### PR TITLE
lib.types, formats: Introduce a new `secret` type and use it for generalized secret replacements in `pkgs.formats`

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -142,7 +142,8 @@ let
       unknownModule mkOption mkPackageOption mkPackageOptionMD
       mdDoc literalMD;
     inherit (self.types) isType setType defaultTypeMerge defaultFunctor
-      isOptionType mkOptionType;
+      isOptionType mkOptionType isSecret mkSecret mkEncryptedSecret
+      mkSecretFile;
     inherit (self.asserts)
       assertMsg assertOneOf;
     inherit (self.debug) traceIf traceVal traceValFn

--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -44,6 +44,7 @@ rec {
     # here it returns to "", which is even less of a good default
     else if false ==   v then "false"
     else if null  ==   v then "null"
+    else if lib.types.isSecret v then hashString "sha256" v._secret.path
     # if you have lists you probably want to replace this
     else if isList     v then err "lists" v
     # same as for lists, might want to replace

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -104,6 +104,40 @@ rec {
     binOp   = a: b: null;
   };
 
+
+  isSecret = isType "secret";
+  mkSecret = path:
+    assert lib.assertMsg (types.path.check path)
+      "lib.mkSecret: argument must be a path";
+    {
+      _type = "secret";
+      _secret = {
+        type = "file-content";
+        inherit path;
+      };
+    };
+  mkEncryptedSecret = path:
+    assert lib.assertMsg (types.path.check path)
+      "lib.mkEncryptedSecret: argument must be a path";
+    {
+      _type = "secret";
+      _secret = {
+        type = "file-content-encrypted";
+        inherit path;
+      };
+    };
+  mkSecretFile = path:
+    assert lib.assertMsg (types.path.check path)
+      "lib.mkSecretFile: argument must be a path";
+    {
+      _type = "secret";
+      _secret = {
+        type = "file-path";
+        inherit path;
+      };
+    };
+
+
   isOptionType = isType "option-type";
   mkOptionType =
     { # Human-readable representation of the type, should be equivalent to
@@ -272,6 +306,13 @@ rec {
       description = "boolean";
       descriptionClass = "noun";
       check = isBool;
+      merge = mergeEqualOption;
+    };
+
+    secret = mkOptionType {
+      name = "secret";
+      description = "secret";
+      check = isSecret;
       merge = mergeEqualOption;
     };
 

--- a/nixos/modules/services/misc/gitlab.nix
+++ b/nixos/modules/services/misc/gitlab.nix
@@ -165,6 +165,8 @@ let
     };
   };
 
+  configWithSecrets = yaml.configWithSecrets "${cfg.statePath}/config/gitlab.yml" gitlabConfig;
+
   gitlabEnv = cfg.packages.gitlab.gitlabEnv // {
     HOME = "${cfg.statePath}/home";
     PUMA_PATH = "${cfg.statePath}/";
@@ -1354,10 +1356,7 @@ in {
               ''
             }
 
-            ${utils.genJqSecretsReplacementSnippet
-                gitlabConfig
-                "${cfg.statePath}/config/gitlab.yml"
-            }
+            ${configWithSecrets.creationScript}
 
             rm -f '${cfg.statePath}/config/secrets.yml'
 
@@ -1378,7 +1377,7 @@ in {
 
           git config --global core.autocrlf "input"
         '';
-      };
+      } // configWithSecrets.systemdServiceConfig;
     };
 
     systemd.services.gitlab-db-config = {


### PR DESCRIPTION
###### Motivation
The goal of this PR is to generalize secrets handling in a way which accompanies [RFC 0042](https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md) well. 

Currently, it's up to each and every module to handle secrets individually. This is usually done by providing one option for every secret, each accepting a path to a file which should be read at runtime to fetch the secret value. The modules declare these options explicitly and have to implement a way to read the secrets at runtime.

In this PR I'm trying to move the responsibility of implementing secrets handling from the modules to `pkgs.formats`. This means that when these formats are used, for example in freeform modules, any option can be declared secret if the user so wishes. In turn, this renders the third type of value listed in https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md#valuable-options, `Sensitive data, passwords`, unnecessary, as long as the secrets are specified in the configuration file.

###### Implementation

Introduce a new `secret` type and an accompanying `mkSecret` function. Implement handling of secrets in `formats.json`, `formats.ini`, `formats.yaml` and `formats.toml`.

I'm not considering any of this final, hence why it's marked as a draft. I just got it into a working state and figured it was time to ask for opinions before polishing it too much :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
