### PR TITLE
libfido2: 1.10.0 -> 1.11.0 and refactor to enable NFC support via pcsc

### DIFF
--- a/pkgs/development/libraries/dbus/default.nix
+++ b/pkgs/development/libraries/dbus/default.nix
@@ -5,7 +5,7 @@
 , pkg-config
 , expat
 , enableSystemd ? stdenv.isLinux && !stdenv.hostPlatform.isStatic
-, systemd
+, systemdMinimal
 , audit
 , libapparmor
 , dbus
@@ -75,7 +75,7 @@ stdenv.mkDerivation rec {
       libX11
       libICE
       libSM
-    ]) ++ lib.optional enableSystemd systemd
+    ]) ++ lib.optional enableSystemd systemdMinimal
     ++ lib.optionals stdenv.isLinux [ audit libapparmor ];
   # ToDo: optional selinux?
 
@@ -94,7 +94,7 @@ stdenv.mkDerivation rec {
     "--with-systemduserunitdir=${placeholder "out"}/etc/systemd/user"
   ] ++ lib.optional (!x11Support) "--without-x"
   ++ lib.optionals stdenv.isLinux [ "--enable-apparmor" "--enable-libaudit" ]
-  ++ lib.optionals enableSystemd [ "SYSTEMCTL=${systemd}/bin/systemctl" ];
+  ++ lib.optionals enableSystemd [ "SYSTEMCTL=${systemdMinimal}/bin/systemctl" ];
 
   NIX_CFLAGS_LINK = lib.optionalString (!stdenv.isDarwin) "-Wl,--as-needed";
 

--- a/pkgs/development/libraries/libfido2/default.nix
+++ b/pkgs/development/libraries/libfido2/default.nix
@@ -12,12 +12,12 @@
 
 stdenv.mkDerivation rec {
   pname = "libfido2";
-  version = "1.10.0";
+  version = "1.11.0";
 
   # releases on https://developers.yubico.com/libfido2/Releases/ are signed
   src = fetchurl {
     url = "https://developers.yubico.com/${pname}/Releases/${pname}-${version}.tar.gz";
-    sha256 = "sha256-Um79PVavcGwF0J89IfGO47CxWsDB9cXaGsvCfCcwuZs=";
+    sha256 = "sha256-CDDFhT47RAmalxZuDOxUpltUt/qqwHBxhy93uOTXswI=";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];

--- a/pkgs/development/libraries/libfido2/default.nix
+++ b/pkgs/development/libraries/libfido2/default.nix
@@ -8,6 +8,7 @@
 , openssl
 , udev
 , zlib
+, pcsclite
 }:
 
 stdenv.mkDerivation rec {
@@ -24,7 +25,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libcbor openssl zlib ]
     ++ lib.optionals stdenv.isDarwin [ hidapi ]
-    ++ lib.optionals stdenv.isLinux [ udev ];
+    ++ lib.optionals stdenv.isLinux [ udev pcsclite ];
 
   cmakeFlags = [
     "-DUDEV_RULES_DIR=${placeholder "out"}/etc/udev/rules.d"
@@ -33,6 +34,7 @@ stdenv.mkDerivation rec {
     "-DUSE_HIDAPI=1"
   ] ++ lib.optionals stdenv.isLinux [
     "-DNFC_LINUX=1"
+    "-DUSE_PCSC=1"
   ];
 
   meta = with lib; {

--- a/pkgs/development/libraries/polkit/default.nix
+++ b/pkgs/development/libraries/polkit/default.nix
@@ -22,7 +22,7 @@
 , gtk-doc
 , coreutils
 , useSystemd ? stdenv.isLinux
-, systemd
+, systemdMinimal
 , elogind
 # A few tests currently fail on musl (polkitunixusertest, polkitunixgrouptest, polkitidentitytest segfault).
 # Not yet investigated; it may be due to the "Make netgroup support optional"
@@ -106,7 +106,7 @@ stdenv.mkDerivation rec {
     duktape
   ] ++ lib.optionals stdenv.isLinux [
     # On Linux, fall back to elogind when systemd support is off.
-    (if useSystemd then systemd else elogind)
+    (if useSystemd then systemdMinimal else elogind)
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/python-dbusmock/default.nix
+++ b/pkgs/development/python-modules/python-dbusmock/default.nix
@@ -8,9 +8,17 @@
 , bluez
 , networkmanager
 , setuptools-scm
+, runCommand
 }:
 
-buildPythonPackage rec {
+let
+  # Cannot just add it to path in preCheck since that attribute will be passed to
+  # mkDerivation even with doCheck = false, causing a dependency cycle.
+  pbap-client = runCommand "pbap-client" { } ''
+    mkdir -p "$out/bin"
+    ln -s "${bluez.test}/test/pbap-client" "$out/bin/pbap-client"
+  '';
+in buildPythonPackage rec {
   pname = "python-dbusmock";
   version = "0.28.3";
 
@@ -40,7 +48,7 @@ buildPythonPackage rec {
     dbus
     pygobject3
     bluez
-    (lib.getOutput "test" bluez)
+    pbap-client
     networkmanager
     nose
   ];
@@ -67,7 +75,6 @@ buildPythonPackage rec {
     # Very slow, consider disabling?
     # "test_networkmanager"
   ];
-
 
   checkPhase = ''
     runHook preCheck

--- a/pkgs/os-specific/linux/bluez/default.nix
+++ b/pkgs/os-specific/linux/bluez/default.nix
@@ -12,7 +12,7 @@
 , pkg-config
 , python3
 , readline
-, systemd
+, systemdMinimal
 , udev
 , withExperimental ? false
 }: let
@@ -48,7 +48,7 @@ in stdenv.mkDerivation rec {
     python3.pkgs.wrapPython
   ];
 
-  outputs = [ "out" "dev" ] ++ lib.optional doCheck "test";
+  outputs = [ "out" "dev" "test" ];
 
   patches = [
     # https://github.com/bluez/bluez/commit/0905a06410d4a5189f0be81e25eb3c3e8a2199c5
@@ -63,7 +63,7 @@ in stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace tools/hid2hci.rules \
-      --replace /sbin/udevadm ${systemd}/bin/udevadm \
+      --replace /sbin/udevadm ${systemdMinimal}/bin/udevadm \
       --replace "hid2hci " "$out/lib/udev/hid2hci "
     # Disable some tests:
     # - test-mesh-crypto depends on the following kernel settings:
@@ -107,7 +107,7 @@ in stdenv.mkDerivation rec {
 
   doCheck = stdenv.hostPlatform.isx86_64;
 
-  postInstall = lib.optionalString doCheck ''
+  postInstall = ''
     mkdir -p $test/{bin,test}
     cp -a test $test
     pushd $test/test

--- a/pkgs/tools/security/pcsclite/default.nix
+++ b/pkgs/tools/security/pcsclite/default.nix
@@ -8,7 +8,7 @@
 , python3
 , dbus
 , polkit
-, systemd
+, systemdMinimal
 , IOKit
 }:
 
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook autoconf-archive pkg-config perl ];
 
   buildInputs = [ python3 ]
-    ++ lib.optionals stdenv.isLinux [ dbus polkit systemd ]
+    ++ lib.optionals stdenv.isLinux [ dbus polkit systemdMinimal ]
     ++ lib.optionals stdenv.isDarwin [ IOKit ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

libfido2 supports nfc via pcsc, which could be used to let ssh access a yubikey through an NFC reader. This PR refactors dbus, polkit, python-dbusmock, bluez and pcsclite to remove a dependency loop on systemd, and updates libfido2 to the latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
