### PR TITLE
nixos/doc: Fix typo in activation-script.md

### DIFF
--- a/nixos/doc/manual/development/activation-script.section.md
+++ b/nixos/doc/manual/development/activation-script.section.md
@@ -54,7 +54,7 @@ possiblility into account that they have to create them first.
 ## NixOS snippets {#sec-activation-script-nixos-snippets}
 
 There are some snippets NixOS enables by default because disabling them would
-most likely break you system. This section lists a few of them and what they
+most likely break your system. This section lists a few of them and what they
 do:
 
 - `binsh` creates `/bin/sh` which points to the runtime shell

--- a/nixos/doc/manual/from_md/development/activation-script.section.xml
+++ b/nixos/doc/manual/from_md/development/activation-script.section.xml
@@ -73,7 +73,7 @@ system.activationScripts.my-activation-script = {
     <title>NixOS snippets</title>
     <para>
       There are some snippets NixOS enables by default because disabling
-      them would most likely break you system. This section lists a few
+      them would most likely break your system. This section lists a few
       of them and what they do:
     </para>
     <itemizedlist spacing="compact">


### PR DESCRIPTION
###### Description of changes

Fix typo in manual.