### PR TITLE
doc/builders/fetchers: Add examples, reduce sentence complexity

### DIFF
--- a/doc/builders/fetchers.chapter.md
+++ b/doc/builders/fetchers.chapter.md
@@ -34,7 +34,7 @@ fetchurl {
 
 Hash mismatches generate an error message containing the correct sha256.
 
-A similar problem arises while testing changes to a fetcher's implementation. If the output of the derivation already exists in the nix store or cache, test failures can go undetected. The [`invalidateFetcherByDrvHash`](#tester-invalidateFetcherByDrvHash) function helps prevent reusing cached derivations.
+A similar problem arises while testing changes to a fetcher's implementation. If the output of the derivation already exists in the Nix store, test failures can go undetected. The [`invalidateFetcherByDrvHash`](#tester-invalidateFetcherByDrvHash) function helps prevent reusing cached derivations.
 
 ## `fetchurl` and `fetchzip` {#fetchurl}
 

--- a/doc/builders/fetchers.chapter.md
+++ b/doc/builders/fetchers.chapter.md
@@ -1,6 +1,7 @@
 # Fetchers {#chap-pkgs-fetchers}
 
-Nixpkgs provides fetchers for different protocols and services. Fetchers are functions that simplify downloading files.
+Building software with Nix often requires downloading source code and other files from the internet.
+`nixpkgs` provides *fetchers* for different protocols and services. Fetchers are functions that simplify downloading files.
 
 ## Caveats
 

--- a/doc/builders/fetchers.chapter.md
+++ b/doc/builders/fetchers.chapter.md
@@ -39,7 +39,11 @@ fetchurl {
 
 Use the resulting error message to determine the correct hash.
 
-<error message here>
+```
+error: hash mismatch in fixed-output derivation '/path/to/my.drv':
+         specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+            got:    sha256-RApQUm78dswhBLC/rfU9y0u6pSAzHceIJqgmetRD24E=
+```
 
 A similar problem arises while testing changes to a fetcher's implementation. If the output of the derivation already exists in the Nix store, test failures can go undetected. The [`invalidateFetcherByDrvHash`](#tester-invalidateFetcherByDrvHash) function helps prevent reusing cached derivations.
 

--- a/doc/builders/fetchers.chapter.md
+++ b/doc/builders/fetchers.chapter.md
@@ -14,7 +14,7 @@ For example, consider the following fetcher:
 ```nix
 fetchurl {
   url = "http://www.example.org/hello-1.0.tar.gz";
-  sha256 = "1111111111111111111111111111111111111111111111111111";
+  sha256 = "0v6r3wwnsk5pdjr188nip3pjgn1jrn5pc5ajpcfy6had6b3v4dwm";
 };
 ```
 
@@ -23,7 +23,7 @@ A common mistake is to update a fetcher’s URL, or a version parameter, without
 ```nix
 fetchurl {
   url = "http://www.example.org/hello-1.1.tar.gz";
-  sha256 = "1111111111111111111111111111111111111111111111111111";
+  sha256 = "0v6r3wwnsk5pdjr188nip3pjgn1jrn5pc5ajpcfy6had6b3v4dwm";
 };
 ```
 

--- a/doc/builders/fetchers.chapter.md
+++ b/doc/builders/fetchers.chapter.md
@@ -32,7 +32,9 @@ fetchurl {
 };
 ```
 
-Hash mismatches generate an error message containing the correct sha256.
+Use the resulting error message to determine the correct hash.
+
+<error message here>
 
 A similar problem arises while testing changes to a fetcher's implementation. If the output of the derivation already exists in the Nix store, test failures can go undetected. The [`invalidateFetcherByDrvHash`](#tester-invalidateFetcherByDrvHash) function helps prevent reusing cached derivations.
 

--- a/doc/builders/fetchers.chapter.md
+++ b/doc/builders/fetchers.chapter.md
@@ -23,7 +23,8 @@ fetchurl {
 };
 ```
 
-**This will reuse the old contents**. Remember to invalidate the hash argument by setting the sha256 to an empty string.
+**This will reuse the old contents**.
+Remember to invalidate the hash argument, in this case by setting the `sha256` attribute to an empty string.
 
 ```nix
 fetchurl {

--- a/doc/builders/fetchers.chapter.md
+++ b/doc/builders/fetchers.chapter.md
@@ -5,7 +5,11 @@ Building software with Nix often requires downloading source code and other file
 
 ## Caveats
 
-Fetchers create [_fixed output derivations_](https://nixos.org/manual/nix/stable/#fixed-output-drvs) that downloaded files. Later, Nix can reuse the downloaded files via their hash. While the caching improves performance, it can lead to some confusion. For example, consider the following fetcher:
+Fetchers create [fixed output derivations](https://nixos.org/manual/nix/stable/#fixed-output-drvs) from downloaded files.
+Nix can reuse the downloaded files via the hash of the resulting derivation.
+
+The fact that the hash belongs to the Nix derivation output and not the file itself can lead to confusion.
+For example, consider the following fetcher:
 
 ```nix
 fetchurl {

--- a/doc/builders/fetchers.chapter.md
+++ b/doc/builders/fetchers.chapter.md
@@ -1,10 +1,10 @@
 # Fetchers {#chap-pkgs-fetchers}
 
-Nixpkgs provides fetchers for different protocols and services. Fetcher's are functions that simplify downloading files.
+Nixpkgs provides fetchers for different protocols and services. Fetchers are functions that simplify downloading files.
 
 ## Caveats
 
-Fetcher's store their output in the nix store, or cache, using Nix's [_fixed output derivation_](https://nixos.org/manual/nix/stable/#fixed-output-drvs). Later, Nix can reuse the downloaded contents via their hash. While the caching improves performance, it can lead to some confusion. For example, consider the following fetcher:
+Fetchers store their output in the nix store, or cache, using Nix's [_fixed output derivation_](https://nixos.org/manual/nix/stable/#fixed-output-drvs). Later, Nix can reuse the downloaded contents via their hash. While the caching improves performance, it can lead to some confusion. For example, consider the following fetcher:
 
 ```nix
 fetchurl {

--- a/doc/builders/fetchers.chapter.md
+++ b/doc/builders/fetchers.chapter.md
@@ -4,7 +4,7 @@ Nixpkgs provides fetchers for different protocols and services. Fetchers are fun
 
 ## Caveats
 
-Fetchers store their output in the nix store, or cache, using Nix's [_fixed output derivation_](https://nixos.org/manual/nix/stable/#fixed-output-drvs). Later, Nix can reuse the downloaded contents via their hash. While the caching improves performance, it can lead to some confusion. For example, consider the following fetcher:
+Fetchers create [_fixed output derivations_](https://nixos.org/manual/nix/stable/#fixed-output-drvs) from downloaded files. Later, Nix can reuse the downloaded files via their hash. While the caching improves performance, it can lead to some confusion. For example, consider the following fetcher:
 
 ```nix
 fetchurl {
@@ -33,7 +33,7 @@ fetchurl {
 
 Hash mismatches generate an error message containing the correct sha256.
 
-A similar problem arises when changing a fetcher's implementation. Changes may cause a fixed output derivation to fail. Failures can go undetected if the output of the derivation already exists in the nix store or cache. The [`invalidateFetcherByDrvHash`](#tester-invalidateFetcherByDrvHash) function helps prevent this. It uses the derivation hash in the output's name to invalidate the cache.
+A similar problem arises while testing changes to a fetcher's implementation. If the output of the derivation already exists in the nix store or cache, test failures can go undetected. The [`invalidateFetcherByDrvHash`](#tester-invalidateFetcherByDrvHash) function helps prevent reusing cached derivations.
 
 ## `fetchurl` and `fetchzip` {#fetchurl}
 

--- a/doc/builders/fetchers.chapter.md
+++ b/doc/builders/fetchers.chapter.md
@@ -4,7 +4,7 @@ Nixpkgs provides fetchers for different protocols and services. Fetchers are fun
 
 ## Caveats
 
-Fetchers create [_fixed output derivations_](https://nixos.org/manual/nix/stable/#fixed-output-drvs) from downloaded files. Later, Nix can reuse the downloaded files via their hash. While the caching improves performance, it can lead to some confusion. For example, consider the following fetcher:
+Fetchers create [_fixed output derivations_](https://nixos.org/manual/nix/stable/#fixed-output-drvs) that downloaded files. Later, Nix can reuse the downloaded files via their hash. While the caching improves performance, it can lead to some confusion. For example, consider the following fetcher:
 
 ```nix
 fetchurl {


### PR DESCRIPTION
###### Description of changes

Small updates to the fetcher documentation. [Hemingway](https://hemingwayapp.com/) flagged a majority of the old sentences as either hard or very hard to read. It rated the readability as grade 12. I've tried to simplify and reuse the documentation while adding examples.