### PR TITLE
nixosTests.nar-serve: fix failure

### DIFF
--- a/nixos/tests/nar-serve.nix
+++ b/nixos/tests/nar-serve.nix
@@ -27,6 +27,7 @@ import ./make-test-python.nix (
         };
       };
     testScript = ''
+      import os
       start_all()
 
       # Create a fake cache with Nginx service the static files
@@ -41,7 +42,7 @@ import ./make-test-python.nix (
       drvHash = drvName.split("-")[0]
       server.wait_for_unit("nar-serve.service")
       server.succeed(
-          "curl -o hello -f http://localhost:8383/nix/store/{}/bin/hello".format(drvHash)
+          "curl -o hello -f http://localhost:8383/{}/bin/hello".format(drvHash)
       )
     '';
   }


### PR DESCRIPTION
###### Description of changes

The python library `os` was used without being imported causing the [test to fail](https://hydra.nixos.org/build/181598369):
```
testScriptWithTypes:55: error: Name "os" is not defined
    drvName = os.path.basename("/nix/store/cv79b81pjmva78whwwpr66l5mfj4pij...
              ^
Found 1 error in 1 file (checked 1 source file)
```
Furthermore a path that returned a 404 was queried with curl.

###### Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).