### PR TITLE
pdfstudio / pdfstudioviewer: 2021.1.3 -> 2021.2.0

### DIFF
--- a/pkgs/applications/misc/pdfstudio/default.nix
+++ b/pkgs/applications/misc/pdfstudio/default.nix
@@ -12,7 +12,7 @@ in
   pdfstudio = callPackage ./common.nix rec {
     pname = program;
     year = "2021";
-    version = "${year}.1.3";
+    version = "${year}.2.0";
     desktopName = "PDF Studio";
     longDescription = ''
       PDF Studio is an easy to use, full-featured PDF editing software. This is the standard/pro edition, which requires a license. For the free PDF Studio Viewer see the package pdfstudioviewer.
@@ -22,21 +22,21 @@ in
     ];
     src = fetchurl {
       url = makeurl { inherit pname year version; };
-      sha256 = "sha256-2az8/slWeLY7l7dCwyTaT18KFfvsO71vJFDZEvbDHGM=";
+      sha256 = "sha256-wQgVWz2kS+XkrqvCAUishizfDrCwGyVDAAU4Yzj4uYU=";
     };
   };
 
   pdfstudioviewer = callPackage ./common.nix rec {
     pname = program;
     year = "2021";
-    version = "${year}.1.3";
+    version = "${year}.2.0";
     desktopName = "PDF Studio Viewer";
     longDescription = ''
       PDF Studio Viewer is an easy to use, full-featured PDF editing software. This is the free edition. For the standard/pro edition, see the package pdfstudio.
     '';
     src = fetchurl {
       url = makeurl { inherit pname year version; };
-      sha256 = "sha256-kd+rQruBL0fudmc30agRO/XV97l/6unqU0GK25yhOzI=";
+      sha256 = "sha256-RjVfl3wRK4bqNwSZr2R0CNx4urHTL0QLmKdogEnySWU=";
     };
   };
 }.${program}


### PR DESCRIPTION
###### Description of changes
Update pdfstudio / pdfstudioviewer from version 2021.1.3 to 2021.2.0. This also fixes https://github.com/NixOS/nixpkgs/issues/179490, because the download link for 2021.1.3 does not exist anymore.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
