### PR TITLE
ocamlPackages.mirage-console: 4.0.0 → 5.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/mirage-console/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-console/default.nix
@@ -1,21 +1,19 @@
 { lib, fetchurl, buildDunePackage
-, lwt, mirage-device, mirage-flow
+, lwt, mirage-flow
 }:
 
 buildDunePackage rec {
   pname = "mirage-console";
-  version = "4.0.0";
+  version = "5.1.0";
 
-  minimumOCamlVersion = "4.08";
-
-  useDune2 = true;
+  minimalOCamlVersion = "4.08";
 
   src = fetchurl {
-    url = "https://github.com/mirage/mirage-console/releases/download/v${version}/mirage-console-v${version}.tbz";
-    sha256 = "11nwfd4kmmdzkrkhbakdi3cxhk8vi98l17960rgcf85c602gw6vp";
+    url = "https://github.com/mirage/mirage-console/releases/download/v${version}/mirage-console-${version}.tbz";
+    sha256 = "sha256-mjYRisbNOJbYoSuWaGoPueXakmqAwmWh0ATvLLsvpNM=";
   };
 
-  propagatedBuildInputs = [ lwt mirage-device mirage-flow ];
+  propagatedBuildInputs = [ lwt mirage-flow ];
 
   meta = {
     description = "Implementations of Mirage console devices";

--- a/pkgs/development/ocaml-modules/mirage-console/unix.nix
+++ b/pkgs/development/ocaml-modules/mirage-console/unix.nix
@@ -3,7 +3,7 @@
 buildDunePackage {
   pname = "mirage-console-unix";
 
-  inherit (mirage-console) version src useDune2 minimumOCamlVersion;
+  inherit (mirage-console) version src;
 
   propagatedBuildInputs = [
     mirage-console


### PR DESCRIPTION
###### Description of changes

Compatibility with recent `cstruct`: https://github.com/mirage/mirage-console/blob/v5.1.0/CHANGES.md#v500-2021-11-15

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
