### PR TITLE
lima: add wrapper and lima-unwrapped

### DIFF
--- a/pkgs/applications/virtualization/lima/default.nix
+++ b/pkgs/applications/virtualization/lima/default.nix
@@ -2,7 +2,6 @@
 , buildGoModule
 , fetchFromGitHub
 , installShellFiles
-, qemu
 , makeWrapper
 }:
 
@@ -36,8 +35,6 @@ buildGoModule rec {
     runHook preInstall
     mkdir -p $out
     cp -r _output/* $out
-    wrapProgram $out/bin/limactl \
-      --prefix PATH : ${lib.makeBinPath [ qemu ]}
     installShellCompletion --cmd limactl \
       --bash <($out/bin/limactl completion bash) \
       --fish <($out/bin/limactl completion fish) \

--- a/pkgs/applications/virtualization/lima/wrapper.nix
+++ b/pkgs/applications/virtualization/lima/wrapper.nix
@@ -1,0 +1,37 @@
+{ lib
+, runCommand
+, makeWrapper
+, lima-unwrapped
+, qemu
+, extraPackages ? [ ]
+}:
+
+let
+  lima = lima-unwrapped;
+
+  binPath = lib.makeBinPath (
+    [
+      qemu
+    ]
+    ++ extraPackages
+  );
+
+in
+runCommand lima.name
+{
+  name = "${lima.pname}-wrapper-${lima.version}";
+
+  inherit (lima) pname version passthru;
+
+  preferLocalBuild = true;
+
+  meta = builtins.removeAttrs lima.meta [ "outputsToInstall" ];
+
+  nativeBuildInputs = [ makeWrapper ];
+}
+  ''
+    mkdir -p $out/bin
+    ln -s ${lima-unwrapped}/share $out/share
+    makeWrapper ${lima-unwrapped}/bin/limactl $out/bin/limactl \
+      --prefix PATH : ${binPath}
+  ''

--- a/pkgs/applications/virtualization/lima/wrapper.nix
+++ b/pkgs/applications/virtualization/lima/wrapper.nix
@@ -1,5 +1,5 @@
 { lib
-, runCommand
+, runCommandLocal
 , makeWrapper
 , lima-unwrapped
 , qemu
@@ -17,13 +17,11 @@ let
   );
 
 in
-runCommand lima.name
+runCommandLocal lima.name
 {
   name = "${lima.pname}-wrapper-${lima.version}";
 
   inherit (lima) pname version passthru;
-
-  preferLocalBuild = true;
 
   meta = builtins.removeAttrs lima.meta [ "outputsToInstall" ];
 
@@ -33,5 +31,5 @@ runCommand lima.name
     mkdir -p $out/bin
     ln -s ${lima-unwrapped}/share $out/share
     makeWrapper ${lima-unwrapped}/bin/limactl $out/bin/limactl \
-      --prefix PATH : ${binPath}
+      --prefix PATH : ${lib.escapeShellArg binPath}
   ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34441,7 +34441,9 @@ with pkgs;
 
   colima = callPackage ../applications/virtualization/colima { };
 
-  lima = callPackage ../applications/virtualization/lima { };
+  lima = callPackage ../applications/virtualization/lima/wrapper.nix { };
+
+  lima-unwrapped = callPackage ../applications/virtualization/lima { };
 
   logtop = callPackage ../tools/misc/logtop { };
 


### PR DESCRIPTION
###### Description of changes

colima `0.4.1` on master is currently broken because the vm has no internet access: https://github.com/abiosoft/colima/issues/344 

colima needs direct access to the unwrapped lima binary to fix it. This pr adds the lima-unwrapped derivation for it.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
