### PR TITLE
colima: 0.4.2 -> 0.4.4

### DIFF
--- a/pkgs/applications/virtualization/colima/default.nix
+++ b/pkgs/applications/virtualization/colima/default.nix
@@ -55,10 +55,9 @@ buildGoModule rec {
   };
 
   meta = with lib; {
-    description = "Container runtimes on MacOS (and Linux) with minimal setup";
+    description = "Container runtimes with minimal setup";
     homepage = "https://github.com/abiosoft/colima";
     license = licenses.mit;
-    mainProgram = "colima";
     platforms = [ "aarch64-linux" "aarch64-darwin" "x86_64-linux" "x86_64-darwin" ];
     maintainers = with maintainers; [ aaschmid tricktron ];
   };

--- a/pkgs/applications/virtualization/colima/default.nix
+++ b/pkgs/applications/virtualization/colima/default.nix
@@ -58,7 +58,6 @@ buildGoModule rec {
     description = "Container runtimes with minimal setup";
     homepage = "https://github.com/abiosoft/colima";
     license = licenses.mit;
-    platforms = [ "aarch64-linux" "aarch64-darwin" "x86_64-linux" "x86_64-darwin" ];
     maintainers = with maintainers; [ aaschmid tricktron ];
   };
 }

--- a/pkgs/applications/virtualization/colima/default.nix
+++ b/pkgs/applications/virtualization/colima/default.nix
@@ -9,13 +9,13 @@
 
 buildGoModule rec {
   pname = "colima";
-  version = "0.4.3";
+  version = "0.4.4";
 
   src = fetchFromGitHub {
     owner = "abiosoft";
     repo = pname;
     rev = "v${version}";
-    sha256 = "tieQOqcbTT6ODUEcLLwWUD7tDOAb6mklbUecjeVjhRc=";
+    sha256 = "bSBaSS+rVkFqTSdyegdE/F0X5u7yvF/nHslAO3xgD6I=";
     # We need the git revision
     leaveDotGit = true;
     postFetch = ''

--- a/pkgs/applications/virtualization/colima/default.nix
+++ b/pkgs/applications/virtualization/colima/default.nix
@@ -2,12 +2,11 @@
 , buildGo118Module
 , fetchFromGitHub
 , installShellFiles
-, lima
+, lima-unwrapped
 , makeWrapper
 , git
 , perl
 , qemu
-, gvproxy
 , openssl
 }:
 
@@ -16,10 +15,10 @@ buildGo118Module rec {
   version = "0.4.2";
 
   src = fetchFromGitHub {
-    owner = "tricktron";
+    owner = "abiosoft";
     repo = pname;
-    rev = "28099f15bb701ada2a0eecfc195b5b1638a50491";
-    sha256 = "BOb0aqSdW7LWCaJA/PVAjNtvqCRbLwdOgWOM1G5jX6k=";
+    rev = "1cfe5f21ed3769f3248945cb886b73ed3f3f816d";
+    sha256 = "kKLqapQbmwmuJ4Vfgjd9HjCVtFIdHpTORI4FSixJGaw=";
     # We need the git revision
     leaveDotGit = true;
   };
@@ -50,7 +49,7 @@ buildGo118Module rec {
 
   postInstall = ''
     wrapProgram $out/bin/colima \
-      --prefix PATH : ${lib.makeBinPath [ lima qemu gvproxy ]}
+      --prefix PATH : ${lib.makeBinPath [ lima-unwrapped qemu ]}
 
     installShellCompletion --cmd colima \
       --bash <($out/bin/colima completion bash) \

--- a/pkgs/applications/virtualization/colima/default.nix
+++ b/pkgs/applications/virtualization/colima/default.nix
@@ -28,7 +28,7 @@ buildGoModule rec {
 
   vendorSha256 = "jDzDwK7qA9lKP8CfkKzfooPDrHuHI4OpiLXmX9vOpOg=";
 
-  CGO_ENABLED = 0;
+  CGO_ENABLED = 1;
 
   ldflags = [
     "-s"

--- a/pkgs/applications/virtualization/colima/default.nix
+++ b/pkgs/applications/virtualization/colima/default.nix
@@ -31,7 +31,7 @@ buildGo118Module rec {
 
   buildPhase = ''
     runHook preBuild
-    make build VERSION=0.4.2 REVISION=$(git rev-parse --short HEAD)
+    make build VERSION=${version} REVISION=$(git rev-parse --short HEAD)
     runHook postBuild
   '';
 

--- a/pkgs/applications/virtualization/colima/default.nix
+++ b/pkgs/applications/virtualization/colima/default.nix
@@ -59,6 +59,8 @@ buildGoModule rec {
     description = "Container runtimes on MacOS (and Linux) with minimal setup";
     homepage = "https://github.com/abiosoft/colima";
     license = licenses.mit;
+    mainProgram = "colima";
+    platforms = [ "aarch64-linux" "aarch64-darwin" "x86_64-linux" "x86_64-darwin" ];
     maintainers = with maintainers; [ aaschmid tricktron ];
   };
 }

--- a/pkgs/applications/virtualization/colima/default.nix
+++ b/pkgs/applications/virtualization/colima/default.nix
@@ -28,7 +28,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles makeWrapper ];
 
-  vendorSha256 = "jDzDwK7qA9lKP8CfkKzfooPDrHuHI4OpiLXmX9vOpOg=";
+  vendorSha256 = "sha256-jDzDwK7qA9lKP8CfkKzfooPDrHuHI4OpiLXmX9vOpOg=";
 
   CGO_ENABLED = 1;
 

--- a/pkgs/applications/virtualization/colima/default.nix
+++ b/pkgs/applications/virtualization/colima/default.nix
@@ -53,7 +53,7 @@ buildGoModule rec {
   '';
 
   meta = with lib; {
-    description = "Container runtimes on MacOS with minimal setup";
+    description = "Container runtimes on MacOS (and Linux) with minimal setup";
     homepage = "https://github.com/abiosoft/colima";
     license = licenses.mit;
     maintainers = with maintainers; [ aaschmid tricktron ];

--- a/pkgs/applications/virtualization/colima/default.nix
+++ b/pkgs/applications/virtualization/colima/default.nix
@@ -12,13 +12,13 @@
 
 buildGo118Module rec {
   pname = "colima";
-  version = "0.4.2";
+  version = "0.4.3";
 
   src = fetchFromGitHub {
     owner = "abiosoft";
     repo = pname;
-    rev = "1cfe5f21ed3769f3248945cb886b73ed3f3f816d";
-    sha256 = "kKLqapQbmwmuJ4Vfgjd9HjCVtFIdHpTORI4FSixJGaw=";
+    rev = "v${version}";
+    sha256 = "6zF/tDWBirvDJ+l21UVzb/pAwRvLuPOpGnkLdmp6qU0=";
     # We need the git revision
     leaveDotGit = true;
   };

--- a/pkgs/applications/virtualization/colima/default.nix
+++ b/pkgs/applications/virtualization/colima/default.nix
@@ -7,7 +7,6 @@
 , qemu
 , testers
 , colima
-, runCommand
 }:
 
 buildGoModule rec {

--- a/pkgs/applications/virtualization/colima/default.nix
+++ b/pkgs/applications/virtualization/colima/default.nix
@@ -1,5 +1,5 @@
 { lib
-, buildGo118Module
+, buildGoModule
 , fetchFromGitHub
 , installShellFiles
 , lima
@@ -7,7 +7,7 @@
 , qemu
 }:
 
-buildGo118Module rec {
+buildGoModule rec {
   pname = "colima";
   version = "0.4.3";
 

--- a/pkgs/applications/virtualization/colima/default.nix
+++ b/pkgs/applications/virtualization/colima/default.nix
@@ -30,14 +30,9 @@ buildGoModule rec {
 
   CGO_ENABLED = 1;
 
-  ldflags = [
-    "-s"
-    "-w"
-    "-X github.com/abiosoft/colima/config.appVersion=${version}"
-  ];
-
-  preBuild = ''
-    ldflags+=" -X github.com/abiosoft/colima/config.revision=$(cat .git-revision)"
+  preConfigure = ''
+    ldflags="-s -w -X github.com/abiosoft/colima/config.appVersion=${version} \
+    -X github.com/abiosoft/colima/config.revision=$(cat .git-revision)"
   '';
 
   subPackages = [ "cmd/colima" ];

--- a/pkgs/applications/virtualization/colima/default.nix
+++ b/pkgs/applications/virtualization/colima/default.nix
@@ -18,9 +18,13 @@ buildGo118Module rec {
     owner = "abiosoft";
     repo = pname;
     rev = "v${version}";
-    sha256 = "6zF/tDWBirvDJ+l21UVzb/pAwRvLuPOpGnkLdmp6qU0=";
+    sha256 = "tieQOqcbTT6ODUEcLLwWUD7tDOAb6mklbUecjeVjhRc=";
     # We need the git revision
     leaveDotGit = true;
+    postFetch = ''
+       git -C $out rev-parse --short HEAD > $out/.git-revision
+       rm -rf $out/.git
+    '';
   };
 
   nativeBuildInputs = [ installShellFiles makeWrapper git openssl ];
@@ -31,7 +35,7 @@ buildGo118Module rec {
 
   buildPhase = ''
     runHook preBuild
-    make build VERSION=${version} REVISION=$(git rev-parse --short HEAD)
+    make build VERSION=${version} REVISION=$(cat .git-revision)
     runHook postBuild
   '';
 

--- a/pkgs/applications/virtualization/colima/default.nix
+++ b/pkgs/applications/virtualization/colima/default.nix
@@ -5,6 +5,9 @@
 , lima
 , makeWrapper
 , qemu
+, testers
+, colima
+, runCommand
 }:
 
 buildGoModule rec {
@@ -46,6 +49,11 @@ buildGoModule rec {
       --fish <($out/bin/colima completion fish) \
       --zsh <($out/bin/colima completion zsh)
   '';
+
+  passthru.tests.version = testers.testVersion {
+    package = colima;
+    command = "HOME=$(mktemp -d) colima version";
+  };
 
   meta = with lib; {
     description = "Container runtimes on MacOS (and Linux) with minimal setup";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34454,7 +34454,7 @@ with pkgs;
 
   idsk = callPackage ../tools/filesystems/idsk { stdenv = gcc10StdenvCompat; };
 
-  colima = callPackage ../applications/virtualization/colima { };
+  colima = callPackage ../applications/virtualization/colima { buildGoModule = buildGo118Module; };
 
   lima = callPackage ../applications/virtualization/lima { };
 


### PR DESCRIPTION
###### Description of changes
Edit: ~~The colima derivation needs direct access to the lima binary When the pr https://github.com/NixOS/nixpkgs/pull/179521 is merged,~~ then this pr fixes the no internet in vm issue from here: https://github.com/abiosoft/colima/issues/344.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
