### PR TITLE
jpegoptim: 1.4.6 -> 1.4.7

### DIFF
--- a/pkgs/applications/graphics/jpegoptim/default.nix
+++ b/pkgs/applications/graphics/jpegoptim/default.nix
@@ -1,12 +1,14 @@
-{ lib, stdenv, fetchurl, libjpeg }:
+{ lib, stdenv, fetchFromGitHub, libjpeg }:
 
 stdenv.mkDerivation rec {
-  version = "1.4.6";
+  version = "1.4.7";
   pname = "jpegoptim";
 
-  src = fetchurl {
-    url = "https://www.kokkonen.net/tjko/src/${pname}-${version}.tar.gz";
-    sha256 = "1dss7907fclfl8zsw0bl4qcw0hhz6fqgi3867w0jyfm3q9jfpcc8";
+  src = fetchFromGitHub {
+    owner = "tjko";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-qae3OEG4CC/OGkmNdHrXFUv9CkoaB1ZJnFHX3RFoxhk=";
   };
 
   # There are no checks, it seems.
@@ -17,7 +19,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Optimize JPEG files";
     homepage = "https://www.kokkonen.net/tjko/projects.html";
-    license = licenses.gpl2;
+    license = licenses.gpl3Plus;
     maintainers = [ maintainers.aristid ];
     platforms = platforms.all;
   };


### PR DESCRIPTION
###### Description of changes
Release [1.4.7](https://github.com/tjko/jpegoptim/releases/tag/v1.4.7) was so far only published on GitHub and not on the [authors website](https://www.kokkonen.net/tjko/projects.html). Therefore we switch to `fetchFromGitHub` for obtaining the source. The license changed from gpl2+ to gpl3+ with commit https://github.com/tjko/jpegoptim/commit/2c0f5f2c2cc3d061249bd6d3aff1c210133cdf69.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).