### PR TITLE
xfsdump: fix build against xfsprogs 5.18.0

### DIFF
--- a/pkgs/tools/filesystems/xfsdump/default.nix
+++ b/pkgs/tools/filesystems/xfsdump/default.nix
@@ -33,7 +33,12 @@ stdenv.mkDerivation rec {
     ncurses
   ];
 
-  patchPhase = ''
+  # fixes build against xfsprogs >= 5.18
+  # taken from https://lore.kernel.org/linux-xfs/20220203174540.GT8313@magnolia/
+  # should be included upsteam next release
+  patches = [ ./remove-dmapapi.patch ];
+
+  postPatch = ''
     substituteInPlace Makefile \
       --replace "cp include/install-sh ." "cp -f include/install-sh ."
   '';

--- a/pkgs/tools/filesystems/xfsdump/remove-dmapapi.patch
+++ b/pkgs/tools/filesystems/xfsdump/remove-dmapapi.patch
@@ -1,0 +1,322 @@
+diff --git a/doc/xfsdump.html b/doc/xfsdump.html
+index d4d157f..2c9324b 100644
+--- a/doc/xfsdump.html
++++ b/doc/xfsdump.html
+@@ -1092,7 +1092,6 @@ the size of the hash table.
+         bool_t p_ownerpr - whether to restore directory owner/group attributes
+         bool_t p_fullpr - whether restoring a full level 0 non-resumed dump
+         bool_t p_ignoreorphpr - set if positive subtree or interactive
+-        bool_t p_restoredmpr - restore DMI event settings
+ </pre>
+ <p>
+ The hash table maps the inode number to the tree node. It is a
+diff --git a/po/de.po b/po/de.po
+index 62face8..bdf47d1 100644
+--- a/po/de.po
++++ b/po/de.po
+@@ -3972,11 +3972,6 @@ msgstr ""
+ msgid "no additional media objects needed\n"
+ msgstr "keine zusätzlichen Mediendateien benötigt\n"
+ 
+-#: .././restore/content.c:9547
+-#, c-format
+-msgid "fssetdm_by_handle of %s failed %s\n"
+-msgstr "fssetdm_by_handle von %s fehlgeschlagen %s\n"
+-
+ #: .././restore/content.c:9566
+ #, c-format
+ msgid "%s quota information written to '%s'\n"
+diff --git a/po/pl.po b/po/pl.po
+index 3cba8d6..ba25420 100644
+--- a/po/pl.po
++++ b/po/pl.po
+@@ -3455,11 +3455,6 @@ msgstr "nie są potrzebne dodatkowe obiekty nośnika\n"
+ msgid "path_to_handle of %s failed:%s\n"
+ msgstr "path_to_handle na %s nie powiodło się: %s\n"
+ 
+-#: .././restore/content.c:9723
+-#, c-format
+-msgid "fssetdm_by_handle of %s failed %s\n"
+-msgstr "fssetdm_by_handle na %s nie powiodło się: %s\n"
+-
+ #: .././restore/content.c:9742
+ #, c-format
+ msgid "%s quota information written to '%s'\n"
+diff --git a/restore/content.c b/restore/content.c
+index 6b22965..e9b0a07 100644
+--- a/restore/content.c
++++ b/restore/content.c
+@@ -477,9 +477,6 @@ struct pers {
+ 			/* how many pages following the header page are reserved
+ 			 * for the subtree descriptors
+ 			 */
+-		bool_t restoredmpr;
+-			/* restore DMAPI event settings
+-			 */
+ 		bool_t restoreextattrpr;
+ 			/* restore extended attributes
+ 			 */
+@@ -858,7 +855,6 @@ static void partial_reg(ix_t d_index, xfs_ino_t ino, off64_t fsize,
+                         off64_t offset, off64_t sz);
+ static bool_t partial_check (xfs_ino_t ino, off64_t fsize);
+ static bool_t partial_check2 (partial_rest_t *isptr, off64_t fsize);
+-static int do_fssetdm_by_handle(char *path, fsdmidata_t *fdmp);
+ static int quotafilecheck(char *type, char *dstdir, char *quotafile);
+ 
+ /* definition of locally defined global variables ****************************/
+@@ -894,7 +890,6 @@ content_init(int argc, char *argv[], size64_t vmsz)
+ 	bool_t changepr;/* cmd line overwrite inhibit specification */
+ 	bool_t interpr;	/* cmd line interactive mode requested */
+ 	bool_t ownerpr;	/* cmd line chown/chmod requested */
+-	bool_t restoredmpr; /* cmd line restore dm api attrs specification */
+ 	bool_t restoreextattrpr; /* cmd line restore extended attr spec */
+ 	bool_t sesscpltpr; /* force completion of prev interrupted session */
+ 	ix_t stcnt;	/* cmd line number of subtrees requested */
+@@ -956,7 +951,6 @@ content_init(int argc, char *argv[], size64_t vmsz)
+ 	newerpr = BOOL_FALSE;
+ 	changepr = BOOL_FALSE;
+ 	ownerpr = BOOL_FALSE;
+-	restoredmpr = BOOL_FALSE;
+ 	restoreextattrpr = BOOL_TRUE;
+ 	sesscpltpr = BOOL_FALSE;
+ 	stcnt = 0;
+@@ -1162,8 +1156,11 @@ content_init(int argc, char *argv[], size64_t vmsz)
+ 			tranp->t_noinvupdatepr = BOOL_TRUE;
+ 			break;
+ 		case GETOPT_SETDM:
+-			restoredmpr = BOOL_TRUE;
+-			break;
++			mlog(MLOG_NORMAL | MLOG_ERROR, _(
++			      "-%c option no longer supported\n"),
++			      GETOPT_SETDM);
++			usage();
++			return BOOL_FALSE;
+ 		case GETOPT_ALERTPROG:
+ 			if (!optarg || optarg[0] == '-') {
+ 				mlog(MLOG_NORMAL | MLOG_ERROR, _(
+@@ -1574,12 +1571,6 @@ content_init(int argc, char *argv[], size64_t vmsz)
+ 	}
+ 
+ 	if (persp->a.valpr) {
+-		if (restoredmpr && persp->a.restoredmpr != restoredmpr) {
+-			mlog(MLOG_NORMAL | MLOG_ERROR, _(
+-			     "-%c cannot reset flag from previous restore\n"),
+-			      GETOPT_SETDM);
+-			return BOOL_FALSE;
+-		}
+ 		if (!restoreextattrpr &&
+ 		       persp->a.restoreextattrpr != restoreextattrpr) {
+ 			mlog(MLOG_NORMAL | MLOG_ERROR, _(
+@@ -1734,7 +1725,6 @@ content_init(int argc, char *argv[], size64_t vmsz)
+ 			persp->a.newerpr = newerpr;
+ 			persp->a.newertime = newertime;
+ 		}
+-		persp->a.restoredmpr = restoredmpr;
+ 		if (!persp->a.dstdirisxfspr) {
+ 			restoreextattrpr = BOOL_FALSE;
+ 		}
+@@ -2365,7 +2355,6 @@ content_stream_restore(ix_t thrdix)
+ 					scrhdrp->cih_inomap_nondircnt,
+ 					tranp->t_vmsz,
+ 					fullpr,
+-					persp->a.restoredmpr,
+ 					persp->a.dstdirisxfspr,
+ 					grhdrp->gh_version,
+ 					tranp->t_truncategenpr);
+@@ -7549,12 +7538,6 @@ restore_reg(drive_t *drivep,
+ 		}
+ 	}
+ 
+-	if (persp->a.dstdirisxfspr && persp->a.restoredmpr) {
+-		HsmBeginRestoreFile(bstatp,
+-				     *fdp,
+-				     &strctxp->sc_hsmflags);
+-	}
+-
+ 	return BOOL_TRUE;
+ }
+ 
+@@ -7726,26 +7709,6 @@ restore_complete_reg(stream_context_t *strcxtp)
+ 		      strerror(errno));
+ 	}
+ 
+-	if (persp->a.dstdirisxfspr && persp->a.restoredmpr) {
+-		fsdmidata_t fssetdm;
+-
+-		/* Set the DMAPI Fields. */
+-		fssetdm.fsd_dmevmask = bstatp->bs_dmevmask;
+-		fssetdm.fsd_padding = 0;
+-		fssetdm.fsd_dmstate = bstatp->bs_dmstate;
+-
+-		rval = ioctl(fd, XFS_IOC_FSSETDM, (void *)&fssetdm);
+-		if (rval) {
+-			mlog(MLOG_NORMAL | MLOG_WARNING,
+-			      _("attempt to set DMI attributes of %s "
+-			      "failed: %s\n"),
+-			      path,
+-			      strerror(errno));
+-		}
+-
+-		HsmEndRestoreFile(path, fd, &strcxtp->sc_hsmflags);
+-	}
+-
+ 	/* set any extended inode flags that couldn't be set
+ 	 * prior to restoring the data.
+ 	 */
+@@ -8064,17 +8027,6 @@ restore_symlink(drive_t *drivep,
+ 				      strerror(errno));
+ 			}
+ 		}
+-
+-		if (persp->a.restoredmpr) {
+-		fsdmidata_t fssetdm;
+-
+-		/*	Restore DMAPI fields. */
+-
+-		fssetdm.fsd_dmevmask = bstatp->bs_dmevmask;
+-		fssetdm.fsd_padding = 0;
+-		fssetdm.fsd_dmstate = bstatp->bs_dmstate;
+-		rval = do_fssetdm_by_handle(path, &fssetdm);
+-		}
+ 	}
+ 
+ 	return BOOL_TRUE;
+@@ -8777,7 +8729,7 @@ restore_extattr(drive_t *drivep,
+ 		}
+ 		assert(nread == (int)(recsz - EXTATTRHDR_SZ));
+ 
+-		if (!persp->a.restoreextattrpr && !persp->a.restoredmpr) {
++		if (!persp->a.restoreextattrpr) {
+ 			continue;
+ 		}
+ 
+@@ -8796,19 +8748,6 @@ restore_extattr(drive_t *drivep,
+ 			}
+ 		} else if (isfilerestored && path[0] != '\0') {
+ 			setextattr(path, ahdrp);
+-
+-			if (persp->a.dstdirisxfspr && persp->a.restoredmpr) {
+-				int flag = 0;
+-				char *attrname = (char *)&ahdrp[1];
+-				if (ahdrp->ah_flags & EXTATTRHDR_FLAGS_ROOT)
+-					flag = ATTR_ROOT;
+-				else if (ahdrp->ah_flags & EXTATTRHDR_FLAGS_SECURE)
+-					flag = ATTR_SECURE;
+-
+-				HsmRestoreAttribute(flag,
+-						     attrname,
+-						     &strctxp->sc_hsmflags);
+-			}
+ 		}
+ 	}
+ 	/* NOTREACHED */
+@@ -9709,32 +9648,6 @@ display_needed_objects(purp_t purp,
+ 	}
+ }
+ 
+-static int
+-do_fssetdm_by_handle(
+-	char		*path,
+-	fsdmidata_t	*fdmp)
+-{
+-	void		*hanp;
+-	size_t		hlen=0;
+-	int		rc;
+-
+-	if (path_to_handle(path, &hanp, &hlen)) {
+-		mlog(MLOG_NORMAL | MLOG_WARNING, _(
+-			"path_to_handle of %s failed:%s\n"),
+-			path, strerror(errno));
+-		return -1;
+-	}
+-
+-	rc = fssetdm_by_handle(hanp, hlen, fdmp);
+-	free_handle(hanp, hlen);
+-	if (rc) {
+-		mlog(MLOG_NORMAL | MLOG_WARNING, _(
+-			"fssetdm_by_handle of %s failed %s\n"),
+-			path, strerror(errno));
+-	}
+-	return rc;
+-}
+-
+ static int
+ quotafilecheck(char *type, char *dstdir, char *quotafile)
+ {
+diff --git a/restore/tree.c b/restore/tree.c
+index 0670318..5429b74 100644
+--- a/restore/tree.c
++++ b/restore/tree.c
+@@ -108,9 +108,6 @@ struct treePersStorage {
+ 	bool_t p_ignoreorphpr;
+ 		/* set if positive subtree or interactive
+ 		 */
+-	bool_t p_restoredmpr;
+-		/* restore DMI event settings
+-		 */
+ 	bool_t p_truncategenpr;
+ 		/* truncate inode generation number (for compatibility
+ 		 * with xfsdump format 2 and earlier)
+@@ -348,7 +345,6 @@ tree_init(char *hkdir,
+ 	   size64_t nondircnt,
+ 	   size64_t vmsz,
+ 	   bool_t fullpr,
+-	   bool_t restoredmpr,
+ 	   bool_t dstdirisxfspr,
+ 	   uint32_t dumpformat,
+ 	   bool_t truncategenpr)
+@@ -508,10 +504,6 @@ tree_init(char *hkdir,
+ 	 */
+ 	persp->p_fullpr = fullpr;
+ 
+-	/* record if DMI event settings should be restored
+-	 */
+-	persp->p_restoredmpr = restoredmpr;
+-
+ 	/* record if truncated generation numbers are required
+ 	 */
+ 	if (dumpformat < GLOBAL_HDR_VERSION_3) {
+@@ -2550,31 +2542,6 @@ setdirattr(dah_t dah, char *path)
+ 		}
+ 	}
+ 
+-	if (tranp->t_dstdirisxfspr && persp->p_restoredmpr) {
+-		fsdmidata_t fssetdm;
+-
+-		fssetdm.fsd_dmevmask = dirattr_get_dmevmask(dah);
+-		fssetdm.fsd_padding = 0;	/* not used */
+-		fssetdm.fsd_dmstate = (uint16_t)dirattr_get_dmstate(dah);
+-
+-		/* restore DMAPI event settings etc.
+-		 */
+-		rval = ioctl(fd,
+-			      XFS_IOC_FSSETDM,
+-			      (void *)&fssetdm);
+-		if (rval) {
+-			mlog(errno == EINVAL
+-			      ?
+-			      (MLOG_NITTY + 1) | MLOG_TREE
+-			      :
+-			      MLOG_NITTY | MLOG_TREE,
+-			      "set DMI attributes"
+-			      " of %s failed: %s\n",
+-			      path,
+-			      strerror(errno));
+-		}
+-	}
+-
+ 	utimbuf.actime = dirattr_get_atime(dah);
+ 	utimbuf.modtime = dirattr_get_mtime(dah);
+ 	rval = utime(path, &utimbuf);
+diff --git a/restore/tree.h b/restore/tree.h
+index 4f9ffe8..bf66e3d 100644
+--- a/restore/tree.h
++++ b/restore/tree.h
+@@ -31,7 +31,6 @@ extern bool_t tree_init(char *hkdir,
+ 			 size64_t nondircnt,
+ 			 size64_t vmsz,
+ 			 bool_t fullpr,
+-			 bool_t restoredmpr,
+ 			 bool_t dstdirisxfspr,
+ 			 uint32_t dumpformat,
+ 			 bool_t truncategenpr);


### PR DESCRIPTION
###### Description of changes

Closes #177779

Patch taken from https://lore.kernel.org/linux-xfs/20220203174540.GT8313@magnolia/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
