### PR TITLE
sile: 0.13.1 → 0.13.2

### DIFF
--- a/pkgs/tools/typesetting/sile/default.nix
+++ b/pkgs/tools/typesetting/sile/default.nix
@@ -44,11 +44,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "sile";
-  version = "0.13.1";
+  version = "0.13.2";
 
   src = fetchurl {
     url = "https://github.com/sile-typesetter/sile/releases/download/v${version}/${pname}-${version}.tar.xz";
-    sha256 = "09mvydgv81pkp2nz9rkz32n3df21cfc2aslpqrivf3svr6sp9hxy";
+    sha256 = "023vxyryk1clkb2lx8n31m8lnfsc27z7h7kvss2vrvqc20i1y2kx";
   };
 
   configureFlags = [


### PR DESCRIPTION
Simple patch release with no changes relevant to Nix build. See [upstream release notes](https://github.com/sile-typesetter/sile/releases/tag/v0.13.2)