### PR TITLE
rust-bindgen-kernel: init at 0.56.0

### DIFF
--- a/pkgs/development/tools/rust/bindgen/unwrapped-kernel.nix
+++ b/pkgs/development/tools/rust/bindgen/unwrapped-kernel.nix
@@ -1,0 +1,21 @@
+{ fetchFromGitHub, rust-bindgen-unwrapped, clang_13 }:
+
+(rust-bindgen-unwrapped.override {
+  clang = clang_13;
+}).overrideAttrs (old: rec {
+  version = "0.56.0";
+
+  src = fetchFromGitHub {
+    owner = "rust-lang";
+    repo = "rust-bindgen";
+    rev = "v${version}";
+    sha256 = "bqAQrECDz8WMM5wAsAcmZlbeGZ8ngpakvpC1W/AKfCU=";
+  };
+
+  cargoDeps = old.cargoDeps.overrideAttrs (_: {
+    inherit src;
+
+    name = "${old.pname}-${version}-vendor.tar.gz";
+    outputHash = "17hxpakwpxp2nva0bk621h7bn9zjlr5jx3d3m82ncgai44hg77cp";
+  });
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14018,11 +14018,6 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
-  rust-bindgen-kernel-unwrapped = callPackage ../development/tools/rust/bindgen/unwrapped-kernel.nix {};
-  rust-bindgen-kernel = callPackage ../development/tools/rust/bindgen {
-    rust-bindgen-unwrapped = rust-bindgen-kernel-unwrapped;
-  };
-
   rust-script = callPackage ../development/tools/rust/rust-script { };
   rustup = callPackage ../development/tools/rust/rustup {
     inherit (darwin.apple_sdk.frameworks) CoreServices Security;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14017,7 +14017,6 @@ with pkgs;
   rust-cbindgen = callPackage ../development/tools/rust/cbindgen {
     inherit (darwin.apple_sdk.frameworks) Security;
   };
-
   rust-script = callPackage ../development/tools/rust/rust-script { };
   rustup = callPackage ../development/tools/rust/rustup {
     inherit (darwin.apple_sdk.frameworks) CoreServices Security;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14017,6 +14017,12 @@ with pkgs;
   rust-cbindgen = callPackage ../development/tools/rust/cbindgen {
     inherit (darwin.apple_sdk.frameworks) Security;
   };
+
+  rust-bindgen-kernel-unwrapped = callPackage ../development/tools/rust/bindgen/unwrapped-kernel.nix {};
+  rust-bindgen-kernel = callPackage ../development/tools/rust/bindgen {
+    rust-bindgen-unwrapped = rust-bindgen-kernel-unwrapped;
+  };
+
   rust-script = callPackage ../development/tools/rust/rust-script { };
   rustup = callPackage ../development/tools/rust/rustup {
     inherit (darwin.apple_sdk.frameworks) CoreServices Security;

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -438,6 +438,11 @@ in {
 
     rr-zen_workaround = callPackage ../development/tools/analysis/rr/zen_workaround.nix { };
 
+    rust-bindgen-kernel-unwrapped = callPackage ../development/tools/rust/bindgen/unwrapped-kernel.nix {};
+    rust-bindgen-kernel = callPackage ../development/tools/rust/bindgen {
+      rust-bindgen-unwrapped = rust-bindgen-kernel-unwrapped;
+    };
+
     sysdig = callPackage ../os-specific/linux/sysdig {};
 
     systemtap = callPackage ../development/tools/profiling/systemtap { };


### PR DESCRIPTION
This PR includes an override for the `rust-bindgen` package.
This is part of an effort to include rust modules with kernel `5.20`.
This explicit version is needed for kernel compatibility currently.

More information:
- https://discourse.nixos.org/t/help-wanted-packaging-linux-kernel-with-rust-support/19988
- https://www.phoronix.com/scan.php?page=news_item&px=Rust-For-Linux-5.20-Possible
- https://github.com/blitz/nixpkgs/tree/rust-kernel
- https://github.com/Rust-for-Linux/rust-out-of-tree-module

cc @blitz 

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
