### PR TITLE
fmt_8: 8.0.1 -> 8.1.1

### DIFF
--- a/pkgs/applications/science/electronics/openroad/default.nix
+++ b/pkgs/applications/science/electronics/openroad/default.nix
@@ -8,7 +8,7 @@
 , git
 , python3
 , swig4
-, boost172
+, boost17x
 , cimg
 , eigen
 , lcov
@@ -27,14 +27,14 @@
 
 mkDerivation rec {
   pname = "openroad";
-  version = "2.0";
+  version = "unstable-2022-07-19";
 
   src = fetchFromGitHub {
     owner = "The-OpenROAD-Project";
     repo = "OpenROAD";
-    rev = "v${version}";
+    rev = "2610b3953ef62651825d89fb96917cf5d20af0f1";
     fetchSubmodules = true;
-    sha256 = "1p677xh16wskfj06jnplhpc3glibhdaqxmk0j09832chqlryzwyx";
+    sha256 = "sha256-BP0JSnxl1XyqHzDY4eITaGHevqd+rbjWZy/LAfDfELs=";
   };
 
   nativeBuildInputs = [
@@ -47,7 +47,7 @@ mkDerivation rec {
   ];
 
   buildInputs = [
-    boost172
+    boost17x
     cimg
     eigen
     lcov
@@ -70,7 +70,11 @@ mkDerivation rec {
   '';
 
   # Enable output images from the placer.
-  cmakeFlags = [ "-DUSE_CIMG_LIB=ON" ];
+  cmakeFlags = [
+    "-DUSE_SYSTEM_BOOST=ON"
+    "-DUSE_CIMG_LIB=ON"
+    "-DOPENROAD_VERSION=${src.rev}"
+  ];
 
   # Resynthesis needs access to the Yosys binaries.
   qtWrapperArgs = [ "--prefix PATH : ${lib.makeBinPath [ yosys ]}" ];
@@ -82,6 +86,12 @@ mkDerivation rec {
     # Regression tests must be run from the project root not from within the CMake build directory.
     cd ..
     test/regression
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/openroad -version
+    $out/bin/sta -version
   '';
 
   meta = with lib; {

--- a/pkgs/development/libraries/fmt/default.nix
+++ b/pkgs/development/libraries/fmt/default.nix
@@ -49,7 +49,7 @@ in
   };
 
   fmt_8 = generic {
-    version = "8.0.1";
-    sha256 = "1mnvxqsan034d2jiqnw2yvkljl7lwvhakmj5bscwp1fpkn655bbw";
+    version = "8.1.1";
+    sha256 = "sha256-leb2800CwdZMJRWF5b1Y9ocK0jXpOX/nwo95icDf308=";
   };
 }


### PR DESCRIPTION
nixpkgs-wayland waybar needs this
and nixpkgs waybar will need this

https://github.com/Alexays/Waybar/commit/36aa22189bb0c4cf5f916d89298a39ed730018b8

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
