### PR TITLE
qt6ct: init at 0.5

### DIFF
--- a/pkgs/tools/misc/qt6ct/default.nix
+++ b/pkgs/tools/misc/qt6ct/default.nix
@@ -1,0 +1,40 @@
+{
+  stdenv,
+  lib,
+
+  fetchFromGitHub,
+
+  cmake,
+  wrapQtAppsHook,
+  symlinkJoin,
+
+  qtbase,
+  qttools,
+  qtsvg
+}:
+stdenv.mkDerivation rec {
+  pname = "qt6ct";
+  version = "0.5";
+
+  src = fetchFromGitHub {
+    owner = "trialuser02";
+    repo = "qt6ct";
+    rev = version;
+    sha256 = "sha256-ph3x1c+jlOhm++BKhWYe6LoI7jZaU5J8LoGp/kU54S0=";
+  };
+
+  # the build system tries to detect it with qtpaths, but that does not work on NixOS
+  patches = [ ./fix-qtpaths.diff ];
+  cmakeFlags = [ "-DPLUGINDIR=${placeholder "out"}/${qtbase.qtPluginPrefix}" ];
+
+  nativeBuildInputs = [ cmake wrapQtAppsHook qttools ];
+  buildInputs = [ qtbase qtsvg ];
+
+  meta = with lib; {
+    description = "Qt6 Configuration Tool";
+    homepage = "https://github.com/trialuser02/qt6ct";
+    platforms = platforms.linux;
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ k900 ];
+  };
+}

--- a/pkgs/tools/misc/qt6ct/fix-qtpaths.diff
+++ b/pkgs/tools/misc/qt6ct/fix-qtpaths.diff
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b029931..23d50b7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -39,17 +39,7 @@ else()
+     message(FATAL_ERROR "Could NOT find lrelease executable")
+ endif()
+ 
+-get_filename_component(QT_QTPATHS_EXECUTABLE ${QT_LRELEASE_EXECUTABLE} DIRECTORY)
+-set(QT_QTPATHS_EXECUTABLE ${QT_QTPATHS_EXECUTABLE}/qtpaths)
+-
+-if(EXISTS ${QT_QTPATHS_EXECUTABLE})
+-    message(STATUS "Found qtpaths executable: " ${QT_QTPATHS_EXECUTABLE})
+-else()
+-    message(FATAL_ERROR "Could NOT find qtpaths executable")
+-endif()
+-
+ #execute_process(COMMAND ${QT_QTPATHS_EXECUTABLE} -query QT_INSTALL_PLUGINS OUTPUT_VARIABLE PLUGINDIR OUTPUT_STRIP_TRAILING_WHITESPACE)
+-execute_process(COMMAND ${QT_QTPATHS_EXECUTABLE} --plugin-dir OUTPUT_VARIABLE PLUGINDIR OUTPUT_STRIP_TRAILING_WHITESPACE)
+ message(STATUS "Plugin path: " ${PLUGINDIR})
+ 
+ message(STATUS "Generating translations ...")

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -20,4 +20,6 @@ in
   # LIBRARIES
 
   quazip = callPackage ../development/libraries/quazip { };
+
+  qt6ct = callPackage ../tools/misc/qt6ct { };
 })))


### PR DESCRIPTION
###### Description of changes

Involves a mildly janky patch, but what can you do.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).