### PR TITLE
builders/writeHaskell: build with threaded GHC runtime

### DIFF
--- a/pkgs/build-support/writers/default.nix
+++ b/pkgs/build-support/writers/default.nix
@@ -132,12 +132,17 @@ let
     libraries ? [],
     ghc ? pkgs.ghc,
     ghcArgs ? [],
+    threadedRuntime ? true,
     strip ? true
   }:
-    makeBinWriter {
+    let
+      appendIfNotSet = el: list: if elem el list then list else list ++ [ el ];
+      ghcArgs' = if threadedRuntime then appendIfNotSet "-threaded" ghcArgs else ghcArgs;
+
+    in makeBinWriter {
       compileScript = ''
         cp $contentPath tmp.hs
-        ${ghc.withPackages (_: libraries )}/bin/ghc ${lib.escapeShellArgs ghcArgs} tmp.hs
+        ${ghc.withPackages (_: libraries )}/bin/ghc ${lib.escapeShellArgs ghcArgs'} tmp.hs
         mv tmp $out
       '';
       inherit strip;


### PR DESCRIPTION
Some haskell code starts silently hanging when not built with a
threaded runtime, so let’s assume people using `writeHaskell` don’t
care about micro-optimizations like this and do the expected thing.

Some architectures don’t support a threaded runtime, for these we
provide the `threadedRuntime` option to turn it off (it should fail at
build time in that case, easy to detect).

If somebody already passed `"-threaded"` before via ghcArgs, this
will not add the flag a second time. Thus it’s backward-compatible in
this regard.

I tested out both branches (with `-threaded` set and not set before),
on an example I had where the runtime would hang when not compiled
with `-threaded`.
