### PR TITLE
surf: enable audio & video support

### DIFF
--- a/pkgs/applications/networking/browsers/surf/default.nix
+++ b/pkgs/applications/networking/browsers/surf/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchgit
 , pkg-config, wrapGAppsHook
 , glib, gcr, glib-networking, gsettings-desktop-schemas, gtk, libsoup, webkitgtk
-, xorg, dmenu, findutils, gnused, coreutils
+, xorg, dmenu, findutils, gnused, coreutils, gst_all_1
 , patches ? null
 }:
 
@@ -17,7 +17,21 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkg-config wrapGAppsHook ];
-  buildInputs = [ glib gcr glib-networking gsettings-desktop-schemas gtk libsoup webkitgtk ];
+  buildInputs = [
+    glib
+    gcr
+    glib-networking
+    gsettings-desktop-schemas
+    gtk
+    libsoup
+    webkitgtk
+  ] ++ (with gst_all_1; [
+    # Audio & video support for webkitgtk WebView
+    gstreamer
+    gst-plugins-base
+    gst-plugins-good
+    gst-plugins-bad
+  ]);
 
   inherit patches;
 


### PR DESCRIPTION
###### Description of changes
Try it out with surf:
* [HTML audio](https://www.w3schools.com/html/tryit.asp?filename=tryhtml5_audio_all)
* [HTML video](https://www.w3schools.com/html/tryit.asp?filename=tryhtml5_video)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
