### PR TITLE
furnace: 0.5.8 -> 0.6pre1

### DIFF
--- a/pkgs/applications/audio/furnace/default.nix
+++ b/pkgs/applications/audio/furnace/default.nix
@@ -7,8 +7,10 @@
 , cmake
 , pkg-config
 , makeWrapper
+, fftw
 , fmt_8
 , libsndfile
+, rtmidi
 , SDL2
 , zlib
 , withJACK ? stdenv.hostPlatform.isUnix
@@ -19,20 +21,15 @@
 
 stdenv.mkDerivation rec {
   pname = "furnace";
-  version = "0.5.8";
+  version = "0.6pre1";
 
   src = fetchFromGitHub {
     owner = "tildearrow";
     repo = "furnace";
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "103ymd3wa1sfsr6qg15vpcs53j350i7zidv3azlf7cynk6k28xim";
+    sha256 = "sha256-7MrzSC8PYQ4X8fyX1hB8mOoSCtLpY+o1x42v9HLdoao=";
   };
-
-  postPatch = ''
-    # rtmidi is not used yet
-    sed -i -e '/add_subdirectory(extern\/rtmidi/d' -e '/DEPENDENCIES_LIBRARIES rtmidi/d' CMakeLists.txt
-  '';
 
   nativeBuildInputs = [
     cmake
@@ -42,8 +39,10 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
+    fftw
     fmt_8
     libsndfile
+    rtmidi
     SDL2
     zlib
   ] ++ lib.optionals withJACK [
@@ -54,10 +53,12 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DBUILD_GUI=${if withGUI then "ON" else "OFF"}"
+    "-DSYSTEM_FFTW=ON"
     "-DSYSTEM_FMT=ON"
     "-DSYSTEM_LIBSNDFILE=ON"
-    "-DSYSTEM_ZLIB=ON"
+    "-DSYSTEM_RTMIDI=ON"
     "-DSYSTEM_SDL2=ON"
+    "-DSYSTEM_ZLIB=ON"
     "-DWITH_JACK=${if withJACK then "ON" else "OFF"}"
     "-DWARNINGS_ARE_ERRORS=ON"
   ];
@@ -85,8 +86,6 @@ stdenv.mkDerivation rec {
     };
     tests.version = testers.testVersion {
       package = furnace;
-      # The command always exits with code 1
-      command = "(furnace --version || [ $? -eq 1 ])";
     };
   };
 


### PR DESCRIPTION
###### Description of changes

Not tested on Darwin yet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).