### PR TITLE
Install all training data for libpostal fix #38024

### DIFF
--- a/pkgs/development/libraries/libpostal/default.nix
+++ b/pkgs/development/libraries/libpostal/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook }:
+{ lib, stdenv, fetchzip, fetchFromGitHub, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   pname = "libpostal";
@@ -11,9 +11,41 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-gQTD2LQibaB2TK0SbzoILAljAGExURvDcF3C/TfDXqk=";
   };
 
+  languageClassifier = fetchzip {
+    url = "https://github.com/openvenues/libpostal/releases/download/v1.0.0/language_classifier.tar.gz";
+    sha256 = "sha256-/Gn931Nx4UDBaiFUgGqC/NJUIKQ5aZT/+OYSlcfXva8=";
+    stripRoot = false;
+  };
+
+  libpostalData = fetchzip {
+    url = "https://github.com/openvenues/libpostal/releases/download/v1.0.0/libpostal_data.tar.gz";
+    sha256 = "sha256-FpGCkkRhVzyr08YcO0/iixxw0RK+3Of0sv/DH3GbbME=";
+    stripRoot = false;
+  };
+
+  parser = fetchzip {
+    url = "https://github.com/openvenues/libpostal/releases/download/v1.0.0/parser.tar.gz";
+    sha256 = "sha256-OHETb3e0GtVS2b4DgklKDlrE/8gxF7XZ3FwmCTqZbqQ=";
+    stripRoot = false;
+  };
+
+  data = stdenv.mkDerivation {
+    name = "libpostal-data";
+    buildCommand = ''
+      mkdir -p $out/data/libpostal
+
+      ln -s ${languageClassifier}/language_classifier   $out/data/libpostal/languageClassifier
+      ln -s ${libpostalData}/transliteration            $out/data/libpostal/transliteration
+      ln -s ${libpostalData}/numex                      $out/data/libpostal/numex
+      ln -s ${libpostalData}/address_expansions         $out/data/libpostal/address_expansions
+      ln -s ${parser}/address_parser                    $out/data/libpostal/address_parser
+    '';
+  };
+
   nativeBuildInputs = [ autoreconfHook ];
 
   configureFlags = [
+    "--datadir=${data}/data"
     "--disable-data-download"
   ] ++ lib.optionals stdenv.hostPlatform.isAarch64 [ "--disable-sse2" ];
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Tested with the following:

```c
#include <stdio.h>
#include <stdlib.h>
#include <libpostal/libpostal.h>

int main(int argc, char **argv) {
    // Setup (only called once at the beginning of your program)
    if (!libpostal_setup() || !libpostal_setup_parser()) {
        exit(EXIT_FAILURE);
    }

    libpostal_address_parser_options_t options = libpostal_get_address_parser_default_options();
    libpostal_address_parser_response_t *parsed = libpostal_parse_address("781 Franklin Ave Crown Heights Brooklyn NYC NY 11216 USA", options);

    for (size_t i = 0; i < parsed->num_components; i++) {
        printf("%s: %s\n", parsed->labels[i], parsed->components[i]);
    }

    // Free parse result
    libpostal_address_parser_response_destroy(parsed);

    // Teardown (only called once at the end of your program)
    libpostal_teardown();
    libpostal_teardown_parser();
}
```

```nix
let
  pkgs = import <nixpkgs> {};
  stdenv = pkgs.stdenv;
in rec {
  libpostal = pkgs.callPackage "/etc/nixos/libpostal.nix" {};

  dev = stdenv.mkDerivation rec {
    name = "clang-env";
    shellHook = ''
    alias cls=clear
    '';
    
    buildInputs = with pkgs; [
      pkg-config
      libpostal
      stdenv
      # clang
    ];

    nativeBuilInputs = with pkgs; [
    ];
  };
} 
```

```
nix-shell run.nix -A dev
cc -lpostal test.c 
./a.out
# small delay
house_number: 781
road: franklin ave
suburb: crown heights
city_district: brooklyn
city: nyc
state: ny
postcode: 11216
country: usa

```