### PR TITLE
monoid: 2018-06-03 -> 2020-10-26

### DIFF
--- a/pkgs/data/fonts/monoid/default.nix
+++ b/pkgs/data/fonts/monoid/default.nix
@@ -1,25 +1,18 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, python3 }:
+{ lib, stdenv, fetchFromGitHub, python39 }:
 
 stdenv.mkDerivation {
   pname = "monoid";
-  version = "2018-06-03";
+  version = "2020-10-26";
 
   src = fetchFromGitHub {
     owner = "larsenwork";
     repo = "monoid";
-    rev = "a331c7c5f402c449f623e0d0895bd2fd8dc30ccf";
-    sha256 = "sha256-RV6lxv5CjywTMcuPMj6rdjLKrap7zLJ7niaNeF//U1Y=";
+    rev = "0673c8d6728df093faee9f183b6dfa62939df8c0";
+    sha256 = "sha256-u2jwVOC9QM2JHsdAVBuEpqqdiBAVs+IWnpp48A5Xk28=";
   };
 
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/larsenwork/monoid/pull/233/commits/f84f2ed61301ee84dadd16351314394f22ebed2f.patch";
-      sha256 = "sha256-CxfFHlR7TB64pvrfzVfUDkPwuRO2UdGOhXwW98c+oQU=";
-    })
-  ];
-
   nativeBuildInputs = [
-    (python3.withPackages (pp: with pp; [
+    (python39.withPackages (pp: with pp; [
       fontforge
     ]))
   ];
@@ -47,3 +40,4 @@ stdenv.mkDerivation {
     maintainers = [ maintainers.romildo ];
   };
 }
+


### PR DESCRIPTION
###### Description of changes
Manual patch removed since it was merged to `master` branch: https://github.com/larsenwork/monoid/pull/233 .

Locked python3 version to python39 because current python3 maps to python3.10 which breaks the build.
```shell
error: builder for '/nix/store/rzd5nhjr2wmap74v2q0pmkpln5cq4k33-monoid-2020-10-26.drv' failed with exit code 1;                                                                                                                                                                                       
       last 10 log lines:                                                                                                                                                                                                                                                                             
       > Traceback (most recent call last):                                                                                                                                                                                                                                                           
       >   File "/build/source/Scripts/build.py", line 52, in <module>                                                                                                                                                                                                                                
       >     build_batch(output, sys.argv[3], int(sys.argv[1]), int(sys.argv[2]))                                                                                                                                                                                                                     
       >   File "/build/source/Scripts/fontbuilder.py", line 103, in build_batch                                                                                                                                                                                                                      
       >     _build(dstdir, font, list(permutations())[node_number::total_nodes])                                                                                                                                                                                                                     
       >   File "/build/source/Scripts/fontbuilder.py", line 86, in _build                                                                                                                                                                                                                            
       >     oper(fnt)                                                                                                                                                                                                                                                                                
       >   File "/build/source/Scripts/fontbuilder.py", line 123, in bearing_op                                                                                                                                                                                                                       
       >     glyph.right_side_bearing += right                                                                                                                                                                                                                                                        
       > TypeError: 'float' object cannot be interpreted as an integer                                                                                                                                                                                                                                
       For full logs, run 'nix log /nix/store/rzd5nhjr2wmap74v2q0pmkpln5cq4k33-monoid-2020-10-26.drv'.                                                                                                                                                                                                
error: 1 dependencies of derivation '/nix/store/y1d988r3nvskskiyzc6lzkgwvn4vmfpn-review-shell.drv' failed to build
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
