### PR TITLE
libdwarf_0_4: 0.4.0 -> 0.4.1

### DIFF
--- a/pkgs/development/libraries/libdwarf/0.4.nix
+++ b/pkgs/development/libraries/libdwarf/0.4.nix
@@ -4,4 +4,5 @@ callPackage ./common.nix rec {
   url = "https://www.prevanders.net/libdwarf-${version}.tar.xz";
   sha512 = "793fe487de80fe6878f022b90f49ec334a0d7db071ff22a11902db5e3457cc7f3f853945a9ac74de2c40f7f388277f21c5b2e62745bca92d2bb55c51e9577693";
   buildInputs = [ zlib ];
+  knownVulnerabilities = [];
 }

--- a/pkgs/development/libraries/libdwarf/0.4.nix
+++ b/pkgs/development/libraries/libdwarf/0.4.nix
@@ -1,7 +1,7 @@
 { callPackage, zlib }:
 callPackage ./common.nix rec {
-  version = "0.4.0";
+  version = "0.4.1";
   url = "https://www.prevanders.net/libdwarf-${version}.tar.xz";
-  sha512 = "30e5c6c1fc95aa28a014007a45199160e1d9ba870b196d6f98e6dd21a349e9bb31bba1bd6817f8ef9a89303bed0562182a7d46fcbb36aedded76c2f1e0052e1e";
+  sha512 = "793fe487de80fe6878f022b90f49ec334a0d7db071ff22a11902db5e3457cc7f3f853945a9ac74de2c40f7f388277f21c5b2e62745bca92d2bb55c51e9577693";
   buildInputs = [ zlib ];
 }

--- a/pkgs/development/libraries/libdwarf/common.nix
+++ b/pkgs/development/libraries/libdwarf/common.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, buildInputs, sha512, version, libelf, url }:
+{ lib, stdenv, fetchurl, buildInputs, sha512, version, libelf, url, knownVulnerabilities }:
 
 stdenv.mkDerivation rec {
   pname = "libdwarf";
@@ -19,5 +19,6 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.unix;
     license = lib.licenses.lgpl21Plus;
     maintainers = [ lib.maintainers.atry ];
+    inherit knownVulnerabilities;
   };
 }

--- a/pkgs/development/libraries/libdwarf/default.nix
+++ b/pkgs/development/libraries/libdwarf/default.nix
@@ -4,4 +4,5 @@ callPackage ./common.nix rec {
   url = "https://www.prevanders.net/libdwarf-${version}.tar.gz";
   sha512 = "e0f9c88554053ee6c1b1333960891189e7820c4a4ddc302b7e63754a4cdcfc2acb1b4b6083a722d1204a75e994fff3401ecc251b8c3b24090f8cb4046d90f870";
   buildInputs = [ zlib libelf ];
+  knownVulnerabilities = [ "CVE-2022-32200" ];
 }


### PR DESCRIPTION
#177227 would not be fixed by this PR because all other packages are using `libdwarf`, not this `libdwarf_0_4`.

###### Description of changes

Change log: https://github.com/davea42/libdwarf-code/releases/tag/v0.4.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
