### PR TITLE
searxng: init at unstable-2022-06-29

### DIFF
--- a/pkgs/servers/web-apps/searxng/default.nix
+++ b/pkgs/servers/web-apps/searxng/default.nix
@@ -1,0 +1,62 @@
+{ lib
+, python3
+, python3Packages
+, fetchFromGitHub
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "searxng";
+  version = "unstable-2022-06-29";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "107006515ee9fe9cad9a6f6387db658953d32486";
+    sha256 = "sha256-uV5XiOVuES9wuBx9S8WhM8jhuxRHlSMvW5Ki8WlDwfM=";
+  };
+
+  postPatch = ''
+    sed -i 's/==.*$//' requirements.txt
+  '';
+
+  preBuild = ''
+    export SEARX_DEBUG="true";
+  '';
+
+  propagatedBuildInputs = with python3Packages; [
+    babel
+    certifi
+    python-dateutil
+    flask
+    flaskbabel
+    brotli
+    jinja2
+    langdetect
+    lxml
+    h2
+    pygments
+    pyyaml
+    redis
+    uvloop
+    setproctitle
+    httpx
+    httpx-socks
+    markdown-it-py
+  ];
+
+  # tests try to connect to network
+  doCheck = false;
+
+  postInstall = ''
+    # Create a symlink for easier access to static data
+    mkdir -p $out/share
+    ln -s ../${python3.sitePackages}/searx/static $out/share/
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/searxng/searxng";
+    description = "A fork of Searx, a privacy-respecting, hackable metasearch engine";
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ kranzes ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22970,6 +22970,8 @@ with pkgs;
 
   searx = callPackage ../servers/web-apps/searx { };
 
+  searxng = python3Packages.toPythonModule (callPackage ../servers/web-apps/searxng { });
+
   selfoss = callPackage ../servers/web-apps/selfoss { };
 
   shaarli = callPackage ../servers/web-apps/shaarli { };


### PR DESCRIPTION
###### Description of changes
Fork of SearX with faster development and additional patches/features. The fork only does not release tags, so I picked the latest commit from master.

Tested working on my personal system via `services.searx.package`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
