### PR TITLE
supabase-cli: init at 0.28.0

### DIFF
--- a/pkgs/development/tools/supabase-cli/default.nix
+++ b/pkgs/development/tools/supabase-cli/default.nix
@@ -1,0 +1,35 @@
+{ lib, buildGo118Module, fetchFromGitHub }:
+
+buildGo118Module rec {
+  pname = "supabase-cli";
+  version = "0.28.0";
+
+  src = fetchFromGitHub {
+    owner = "supabase";
+    repo = "cli";
+    rev = "v${version}";
+    sha256 = "kY4QTtmgi/uU2e86oQrLI9In3A0JykMr5Q4Glc96H6Q=";
+  };
+
+  vendorSha256 = "uV0pAK9TDrDplUJ0NkhG0mtAFhgBQmUI8seizDRxohA=";
+  subPackages = [ "." ];
+
+  postInstall = ''
+    mv $out/bin/cli $out/bin/supabase;
+  '';
+
+  meta = with lib; {
+    description = "Supabase CLI";
+    homepage = "https://github.com/supabase/cli";
+    license = licenses.mit;
+    maintainers = with maintainers; [ morrisonwill ];
+
+    longDescription = ''
+      The Supabase CLI interacts with Supabase projects. Currently, it can do the following:
+       - Run Supabase locally
+       - Manage database migrations
+       - Create and developing Edge Functions
+       - Push your local changes to production
+    '';
+  };
+}


### PR DESCRIPTION
###### Description of changes

New package from https://github.com/supabase/cli/

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).