### PR TITLE
cachix-agent: properly handle not restarting the service

### DIFF
--- a/nixos/modules/services/system/cachix-agent/default.nix
+++ b/nixos/modules/services/system/cachix-agent/default.nix
@@ -45,8 +45,11 @@ in {
       after = ["network-online.target"];
       path = [ config.nix.package ];
       wantedBy = [ "multi-user.target" ];
+
       # don't restart while changing
-      reloadIfChanged = true;
+      restartIfChanged = false;
+      unitConfig.X-StopOnRemoval = false;
+
       environment.USER = "root";
       serviceConfig = {
         Restart = "on-failure";


### PR DESCRIPTION
This fixed a bug that would otherwise trigger:



reloading the following units: cachix-agent.service
Failed to reload cachix-agent.service: Job type reload is not applicable for unit cachix-agent.service.