### PR TITLE
libstrangle: use direct nix store path in layer json

### DIFF
--- a/pkgs/tools/X11/libstrangle/default.nix
+++ b/pkgs/tools/X11/libstrangle/default.nix
@@ -24,6 +24,8 @@ stdenv.mkDerivation rec {
     substituteAllInPlace src/stranglevk.sh
   '';
   postInstall = ''
+    substitute $out/share/vulkan/implicit_layer.d/libstrangle_vk.json $out/share/vulkan/implicit_layer.d/libstrangle_vk.x86.json \
+      --replace "libstrangle_vk.so" "$out/lib/libstrangle/lib32/libstrangle_vk.so"
     substituteInPlace $out/share/vulkan/implicit_layer.d/libstrangle_vk.json \
       --replace "libstrangle_vk.so" "$out/lib/libstrangle/lib64/libstrangle_vk.so"
   '';

--- a/pkgs/tools/X11/libstrangle/default.nix
+++ b/pkgs/tools/X11/libstrangle/default.nix
@@ -23,6 +23,10 @@ stdenv.mkDerivation rec {
     substituteAllInPlace src/strangle.sh
     substituteAllInPlace src/stranglevk.sh
   '';
+  postInstall = ''
+    substituteInPlace $out/share/vulkan/implicit_layer.d/libstrangle_vk.json \
+      --replace "libstrangle_vk.so" "$out/lib/libstrangle/lib64/libstrangle_vk.so"
+  '';
 
   meta = with lib; {
     homepage = "https://gitlab.com/torkel104/libstrangle";


### PR DESCRIPTION
This allows you to load libstrangle without setting LD_LIBRARY_PATH to include
it. Only ENABLE_VK_LAYER_TORKEL104_libstrangle=1 is required now, as expected of
an implicit layer.

Previously, you were required to run your VK app via the wrapper:

    STRANGLE_FPS=30 strangle vkcube

Now you can control it via simple environment variables alone:

    ENABLE_VK_LAYER_TORKEL104_libstrangle=1 STRANGLE_FPS=30 vkcube

cc @aske

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
