### PR TITLE
rare: cleanup

### DIFF
--- a/pkgs/games/rare/default.nix
+++ b/pkgs/games/rare/default.nix
@@ -1,39 +1,28 @@
-{ lib, fetchPypi, buildPythonApplication, makeDesktopItem, copyDesktopItems, qt5
-, pillow, psutil, pypresence, pyqt5, python, qtawesome, requests }:
+{ lib, fetchFromGitHub, buildPythonApplication, qt5
+, psutil, pypresence, pyqt5, python, qtawesome, requests }:
 
 buildPythonApplication rec {
   pname = "rare";
   version = "1.8.9";
 
-  src = fetchPypi {
-    inherit version;
-    pname = "Rare";
-    sha256 = "sha256-UEvGwWjr4FCsvyFz6Db3VnhVS6MS3FYzYSucumzOoEA=";
+  src = fetchFromGitHub {
+    owner = "Dummerle";
+    repo = "Rare";
+    rev = version;
+    sha256 = "sha256-2l8Id+bA5Ugb8+3ioiZ78dUtDusU8cvZEAMhmYBcJFc=";
+    fetchSubmodules = true;
   };
 
   nativeBuildInputs = [
-    copyDesktopItems
     qt5.wrapQtAppsHook
   ];
 
   propagatedBuildInputs = [
-    pillow
     psutil
     pypresence
     pyqt5
     qtawesome
     requests
-  ];
-
-  desktopItems = [
-    (makeDesktopItem {
-      name = pname;
-      exec = "rare";
-      icon = "Rare";
-      comment = meta.description;
-      desktopName = "Rare";
-      genericName = "Rare (Epic Games Launcher Open Source Alternative)";
-    })
   ];
 
   dontWrapQtApps = true;
@@ -44,7 +33,8 @@ buildPythonApplication rec {
   '';
 
   postInstall = ''
-    install -Dm644 $out/${python.sitePackages}/rare/resources/images/Rare.png -t $out/share/pixmaps/
+    install -Dm644 misc/rare.desktop -t $out/share/applications/
+    install -Dm644 $out/${python.sitePackages}/rare/resources/images/Rare.png $out/share/pixmaps/rare.png
   '';
 
   preFixup = ''


### PR DESCRIPTION
###### Description of changes
Removed an unneeded dependency, switched to `fetchFromGitHub`, and taken the desktop file from the official repository instead of making a new one (the latter couldn't be done from PyPI). 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
