### PR TITLE
nrfconnect: init at 3.11.1

### DIFF
--- a/pkgs/tools/bluetooth/nrfconnect/default.nix
+++ b/pkgs/tools/bluetooth/nrfconnect/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, stdenv
+, fetchurl
+, appimageTools
+}:
+
+let
+  pname = "nrfconnect";
+  version = "3.11.1";
+
+  src = fetchurl {
+    url = "https://nsscprodmedia.blob.core.windows.net/prod/software-and-other-downloads/desktop-software/nrf-connect-for-desktop/${lib.versions.major version}-${lib.versions.minor version}-${lib.versions.patch version}/nrfconnect-${version}-x86_64.appimage";
+    sha256 = "sha256-Q6QAFqTCFEcZBIlH9KaO4oAYiwCExvJ3h1PBtlGbhhA=";
+    name = "${pname}-${version}.AppImage";
+  };
+
+  appimageContents = appimageTools.extractType2 {
+    inherit pname version src;
+  };
+
+in appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraPkgs = pkgs: with pkgs; [
+    segger-jlink
+  ];
+
+  extraInstallCommands = ''
+    mv $out/bin/${pname}-${version} $out/bin/${pname}
+    install -m 444 -D ${appimageContents}/nrfconnect.desktop $out/share/applications/nrfconnect.desktop
+    install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/512x512/apps/nrfconnect.png \
+      $out/share/icons/hicolor/512x512/apps/nrfconnect.png
+    substituteInPlace $out/share/applications/nrfconnect.desktop \
+      --replace 'Exec=AppRun' 'Exec=${pname}'
+  '';
+
+  meta = with lib; {
+    description = "Nordic Semiconductor nRF Connect for Desktop";
+    homepage = "https://www.nordicsemi.com/Products/Development-tools/nRF-Connect-for-desktop";
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ stargate01 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16175,6 +16175,8 @@ with pkgs;
 
   nrf5-sdk = callPackage ../development/libraries/nrf5-sdk { };
 
+  nrfconnect = callPackage ../tools/bluetooth/nrfconnect { };
+
   nrfutil = callPackage ../development/tools/misc/nrfutil { };
 
   obelisk = callPackage ../development/tools/ocaml/obelisk { menhir = ocamlPackages.menhir; };


### PR DESCRIPTION
###### Description of changes

This PR adds the nRF Connect for Desktop application (https://www.nordicsemi.com/Products/Development-tools/nRF-Connect-for-desktop) by extracting and installing the provided AppImage. Desktop entries are installed as well, and `segger-jlink` is specified as a dependency for programming and debugging.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
