### PR TITLE
linuxPackages.bbswitch: 0.8 -> unstable-2021-11-29

### DIFF
--- a/pkgs/os-specific/linux/bbswitch/default.nix
+++ b/pkgs/os-specific/linux/bbswitch/default.nix
@@ -13,6 +13,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "Bumblebee-Project";
     repo = "bbswitch";
+    # https://github.com/Bumblebee-Project/bbswitch/tree/develop
     rev = "23891174a80ea79c7720bcc7048a5c2bfcde5cd9";
     hash = "sha256-50v1Jxem5kaI1dHOKmgBbPLxI82QeYxiaRHhrHpWRzU=";
   };

--- a/pkgs/os-specific/linux/bbswitch/default.nix
+++ b/pkgs/os-specific/linux/bbswitch/default.nix
@@ -2,7 +2,7 @@
 
 let
   baseName = "bbswitch";
-  version = "0.8";
+  version = "unstable-2021-11-29";
   name = "${baseName}-${version}-${kernel.version}";
 
 in
@@ -13,18 +13,14 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "Bumblebee-Project";
     repo = "bbswitch";
-    rev = "v${version}";
-    hash = "sha256-FHC8myKnouNDERVds2QCJj1ZstjHrOzFpb+FDiSBjL4=";
+    rev = "23891174a80ea79c7720bcc7048a5c2bfcde5cd9";
+    hash = "sha256-50v1Jxem5kaI1dHOKmgBbPLxI82QeYxiaRHhrHpWRzU=";
   };
 
   patches = [
     (fetchpatch {
-      url = "https://github.com/Bumblebee-Project/bbswitch/pull/102.patch";
-      sha256 = "1lbr6pyyby4k9rn2ry5qc38kc738d0442jhhq57vmdjb6hxjya7m";
-    })
-    (fetchpatch {
-      url = "https://github.com/Bumblebee-Project/bbswitch/pull/196.patch";
-      sha256 = "02ihy3piws7783qbm9q0mb9s18ipn5ckdy1iar74xn31qjrsn99n";
+      url = "https://raw.githubusercontent.com/archlinux/svntogit-community/0bd986055ba52887b81048de5c61e618eec06eb0/trunk/0003-kernel-5.18.patch";
+      sha256 = "sha256-va62/bR1qyBBMPg0lUwCH7slGG0XijxVCsFa4FCoHEQ=";
     })
   ];
 
@@ -64,6 +60,5 @@ stdenv.mkDerivation {
     homepage = "https://github.com/Bumblebee-Project/bbswitch";
     maintainers = with maintainers; [ abbradar ];
     license = licenses.gpl2Plus;
-    broken = kernel.kernelAtLeast "5.18";
   };
 }


### PR DESCRIPTION
###### Description of changes

Same as closes #175162, with review changes applied.

Switch to the development branch, as it's basically stable at
this point, and pinch Arch's 5.18 compat patch.

Also remove existing patches:
- PR 102 was rejected upstream, the actual issue is
  https://github.com/Bumblebee-Project/bbswitch/issues/112,
  and can be worked around via acpi_osi=Linux
- PR 196 is applied upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
