### PR TITLE
beamerpresenter: use qt6

### DIFF
--- a/pkgs/applications/office/beamerpresenter/default.nix
+++ b/pkgs/applications/office/beamerpresenter/default.nix
@@ -1,39 +1,28 @@
-{ lib,
-  stdenv,
-  fetchFromGitHub,
-  installShellFiles,
-  pkg-config,
-  cmake,
-  qtbase,
-  qtmultimedia,
-  qttools,
-  wrapQtAppsHook,
-  bash,
-  zlib,
-  gcc,
-  gnumake,
-  coreutils,
-  # only required when using poppler
-  poppler,
-  # only required when using mupdf
-  mupdf,
-  freetype,
-  jbig2dec,
-  openjpeg,
-  gumbo,
-  # choose renderer: mupdf or poppler or both (not recommended)
-  renderer ? "mupdf",
-  # choose major Qt version: "5" or "6" (only 5 is tested)
-  qt_version ? "5"}:
-
-let
-  renderers = {
-    mupdf.buildInputs = [ mupdf freetype jbig2dec openjpeg gumbo ];
-    poppler.buildInputs = [ poppler ];
-  };
-  use_poppler = if "${renderer}" == "poppler" || "${renderer}" == "both" then "ON" else "OFF";
-  use_mupdf = if "${renderer}" == "mupdf" || "${renderer}" == "both" then "ON" else "OFF";
-in
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, wrapGAppsHook
+, wrapQtAppsHook
+, gst_all_1
+, qtbase
+, qtmultimedia
+, qttools
+, qtwayland
+, zlib
+# only required when using poppler
+, poppler
+# only required when using mupdf
+, freetype
+, gumbo
+, jbig2dec
+, mupdf
+, openjpeg
+# choose renderer: mupdf or poppler or both (not recommended)
+, usePoppler ? false
+, useMupdf ? true
+}:
 
 stdenv.mkDerivation rec {
   pname = "beamerpresenter";
@@ -46,25 +35,53 @@ stdenv.mkDerivation rec {
     sha256 = "16v263nnnipih3lxg95rmwz0ihnvpl4n1wlj9r6zavnspzlp9dvb";
   };
 
-  nativeBuildInputs = [ pkg-config installShellFiles wrapQtAppsHook ];
-  buildInputs = [ gcc cmake coreutils gnumake bash zlib qtbase qtmultimedia qttools ] ++ renderers.${renderer}.buildInputs;
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    wrapGAppsHook
+    wrapQtAppsHook
+  ];
+
+  dontWrapGApps = true;
+
+  buildInputs = [
+    gst_all_1.gst-libav
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    zlib
+    qtbase
+    qtmultimedia
+    qttools
+    qtwayland
+  ] ++ lib.optionals useMupdf [
+    freetype
+    gumbo
+    jbig2dec
+    mupdf
+    openjpeg
+  ] ++ lib.optionals usePoppler [
+    poppler
+  ];
 
   cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE='Release'"
     "-DGIT_VERSION=OFF"
-    "-DUSE_POPPLER=${use_poppler}"
-    "-DUSE_MUPDF=${use_mupdf}"
+    "-DUSE_POPPLER=${if usePoppler then "ON" else "OFF"}"
+    "-DUSE_MUPDF=${if useMupdf then "ON" else "OFF"}"
     "-DUSE_MUJS=OFF"
     "-DUSE_GUMBO=ON"
     "-DUSE_TRANSLATIONS=ON"
-    "-DQT_VERSION_MAJOR=${qt_version}"
+    "-DQT_VERSION_MAJOR=${lib.versions.major qtbase.version}"
   ];
+
+  preFixup = ''
+    qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
 
   meta = with lib; {
     description = "Modular multi screen pdf presentation viewer";
     homepage = "https://github.com/stiglers-eponym/BeamerPresenter";
     license = with licenses; [ agpl3 gpl3Plus ];
     platforms = platforms.all;
-    maintainers = with maintainers; [ pacien ];
+    maintainers = with maintainers; [ pacien dotlambda ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4617,7 +4617,7 @@ with pkgs;
 
   bdsync = callPackage ../tools/backup/bdsync { };
 
-  beamerpresenter = libsForQt5.callPackage ../applications/office/beamerpresenter { };
+  beamerpresenter = qt6Packages.callPackage ../applications/office/beamerpresenter { };
 
   beanstalkd = callPackage ../servers/beanstalkd { };
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
cc @stiglers-eponym