### PR TITLE
hackneyed: init at 0.8.2

### DIFF
--- a/pkgs/data/icons/hackneyed/default.nix
+++ b/pkgs/data/icons/hackneyed/default.nix
@@ -1,0 +1,34 @@
+{ lib, fetchzip, stdenvNoCC, fetchFromGitLab, xcursorgen, imagemagick6, inkscape }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "hackneyed";
+  version = "0.8.2";
+
+  src = fetchFromGitLab {
+    owner = "Enthymeme";
+    repo = "hackneyed-x11-cursors";
+    rev = version;
+    sha256 = "sha256-Wtrw/EzxCj4cAyfdBp0OJE4+c6FouW7+b6nFTLxdXNY=";
+  };
+
+  buildInputs = [ imagemagick6 inkscape xcursorgen ];
+
+  postPatch = ''
+    patchShebangs *.sh
+    substituteInPlace make-png.sh \
+      --replace /usr/bin/inkscape ${inkscape}/bin/inkscape
+  '';
+
+  enableParallelBuilding = true;
+
+  makeFlags = [ "PREFIX=$(out)" ];
+  buildFlags = [ "theme" "theme.left" ];
+
+  meta = with lib; {
+    homepage = "https://gitlab.com/Enthymeme/hackneyed-x11-cursors";
+    description = "A scalable cursor theme that resembles Windows 3.x/NT 3.x cursors";
+    platforms = platforms.all;
+    license = licenses.mit;
+    maintainers = with maintainers; [ somasis ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7271,6 +7271,8 @@ with pkgs;
 
   hackertyper = callPackage ../tools/misc/hackertyper { };
 
+  hackneyed = callPackage ../data/icons/hackneyed { };
+
   haveged = callPackage ../tools/security/haveged { };
 
   habitat = callPackage ../applications/networking/cluster/habitat { };


### PR DESCRIPTION
###### Description of changes

Hackneyed is a set of X11 cursors that somewhat resemble Windows 3.x/NT-style cursors.
https://gitlab.com/Enthymeme/hackneyed-x11-cursors

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
