### PR TITLE
skawarePackages.*: Summer 2022 releases

### DIFF
--- a/pkgs/data/documentation/execline-man-pages/default.nix
+++ b/pkgs/data/documentation/execline-man-pages/default.nix
@@ -2,8 +2,8 @@
 
 buildManPages {
   pname = "execline-man-pages";
-  version = "2.8.3.0.2";
-  sha256 = "0fzv5as81aqgl8llbz8c5bk5n56iyh4g70r54wmj71rh2d1pihk5";
+  version = "2.9.0.0.1";
+  sha256 = "sha256-hT0YsuYJ3XSMYwtlwDR8PGlD8ng8XPky93rCprruHu8=";
   description = "Port of the documentation for the execline suite to mdoc";
   maintainers = [ lib.maintainers.sternenseemann ];
 }

--- a/pkgs/data/documentation/s6-man-pages/default.nix
+++ b/pkgs/data/documentation/s6-man-pages/default.nix
@@ -2,8 +2,8 @@
 
 buildManPages {
   pname = "s6-man-pages";
-  version = "2.11.0.1.1";
-  sha256 = "03gl0vvdaqfb5hs0dfdbs9djxiyq3abcx9vwgkfw22b1rm2fa0r6";
+  version = "2.11.1.1.1";
+  sha256 = "sha256-W1+f65+Su1ZjCtzstn/fqWyU9IlQMThd/1lOg1cbCaE=";
   description = "Port of the documentation for the s6 supervision suite to mdoc";
   maintainers = [ lib.maintainers.sternenseemann ];
 }

--- a/pkgs/data/documentation/s6-networking-man-pages/default.nix
+++ b/pkgs/data/documentation/s6-networking-man-pages/default.nix
@@ -2,8 +2,8 @@
 
 buildManPages {
   pname = "s6-networking-man-pages";
-  version = "2.5.1.0.1";
-  sha256 = "1h87s3wixsms8ys7gvm1s9d8pzn73q5j4sgybpi3gmr55d4cwra4";
+  version = "2.5.1.1.1";
+  sha256 = "sha256-RGXOSCsl1zfiXf5pIgsex/6LWtKh7ne0R7rqHvnQB8E=";
   description = "Port of the documentation for the s6-networking suite to mdoc";
   maintainers = [ lib.maintainers.sternenseemann ];
 }

--- a/pkgs/data/documentation/s6-portable-utils-man-pages/default.nix
+++ b/pkgs/data/documentation/s6-portable-utils-man-pages/default.nix
@@ -1,0 +1,9 @@
+{ lib, buildManPages }:
+
+buildManPages {
+  pname = "s6-portable-utils-man-pages";
+  version = "2.2.5.0.1";
+  sha256 = "sha256-pIh+PKqKJTkaHyYrbWEEzdGDSzEO9E+ekTovu4SVSs4=";
+  description = "Port of the documentation for the s6-portable-utils suite to mdoc";
+  maintainers = [ lib.maintainers.somasis ];
+}

--- a/pkgs/development/libraries/skalibs/default.nix
+++ b/pkgs/development/libraries/skalibs/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "skalibs";
-  version = "2.11.2.0";
-  sha256 = "sha256-ZJzzI2/jED9FNmthlrG80EV8nBfKhvK4AAdpaiuqe3c=";
+  version = "2.12.0.1";
+  sha256 = "sha256-PiKPcvGNiMF/bE4KZogdbTd5Qnt+foifMUK28m2jAoU=";
 
   description = "A set of general-purpose C programming libraries";
 

--- a/pkgs/os-specific/linux/mdevd/default.nix
+++ b/pkgs/os-specific/linux/mdevd/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "mdevd";
-  version = "0.1.5.1";
-  sha256 = "1xch9sk3hklf2v9z3qlw0rfhhmikqp85zkij7qzwbs09g039bkll";
+  version = "0.1.5.2";
+  sha256 = "sha256-RgNys9O6yfNXQVbtfkhhj59KNhy1LESUrZBjJIq0pP8=";
 
   description = "mdev-compatible Linux hotplug manager daemon";
   platforms = lib.platforms.linux;

--- a/pkgs/os-specific/linux/s6-linux-init/default.nix
+++ b/pkgs/os-specific/linux/s6-linux-init/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "s6-linux-init";
-  version = "1.0.7.3";
-  sha256 = "sha256-yQblfr/jANwXz7+5wlSvWZaHYt/RYr/gZLTOK9aVp3Y=";
+  version = "1.0.8.0";
+  sha256 = "sha256-kgVaeWTPZmBAZq2WSiwjku58XmSCG+AxRsE0Hg2MPcY=";
 
   description = "A set of minimalistic tools used to create a s6-based init system, including a /sbin/init binary, on a Linux kernel";
   platforms = lib.platforms.linux;

--- a/pkgs/os-specific/linux/s6-linux-utils/default.nix
+++ b/pkgs/os-specific/linux/s6-linux-utils/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "s6-linux-utils";
-  version = "2.5.1.7";
-  sha256 = "1n6zmnczbybwcchkhg5zqixz8mdk5bfn0sxq0kxifgpi9ggw5a46";
+  version = "2.6.0.0";
+  sha256 = "sha256-bHEyc0oMgocALuaRDEafF1qX12aoAjwMM6+LqSZD7Vk=";
 
   description = "A set of minimalistic Linux-specific system utilities";
   platforms = lib.platforms.linux;
@@ -24,7 +24,7 @@ buildPackage {
 
   postInstall = ''
     # remove all s6 executables from build directory
-    rm $(find -name "s6-*" -type f -mindepth 1 -maxdepth 1 -executable)
+    rm $(find -name "s6-*" -type f -mindepth 1 -maxdepth 1 -executable) rngseed
 
     mv doc $doc/share/doc/s6-linux-utils/html
   '';

--- a/pkgs/tools/misc/execline/default.nix
+++ b/pkgs/tools/misc/execline/default.nix
@@ -2,7 +2,7 @@
 
 with skawarePackages;
 let
-  version = "2.8.3.0";
+  version = "2.9.0.1";
 
   # Maintainer of manpages uses following versioning scheme: for every
   # upstream $version he tags manpages release as ${version}.1, and,
@@ -11,15 +11,15 @@ let
   manpages = fetchFromGitHub {
     owner = "flexibeast";
     repo = "execline-man-pages";
-    rev = "v${version}.2";
-    sha256 = "0fzv5as81aqgl8llbz8c5bk5n56iyh4g70r54wmj71rh2d1pihk5";
+    rev = "v2.9.0.0.1";
+    sha256 = "sha256-hT0YsuYJ3XSMYwtlwDR8PGlD8ng8XPky93rCprruHu8=";
   };
 
 in buildPackage {
   inherit version;
 
   pname = "execline";
-  sha256 = "105dnkw1y6lz0ibqy5b4jarq31y40k7ymhl77i9f10jcb76vwp93";
+  sha256 = "sha256-ASYPyvgP+8oqlKpV6kdN+545swM7VciviBJnkYeVMfY=";
 
   description = "A small scripting language, to be used in place of a shell in non-interactive scripts";
 

--- a/pkgs/tools/misc/s6-portable-utils/default.nix
+++ b/pkgs/tools/misc/s6-portable-utils/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "s6-portable-utils";
-  version = "2.2.4.0";
-  sha256 = "sha256-yx7qifAxEAbwEyqkUyT/lvp3VtEaX0Nmxo0ISDnlpW8=";
+  version = "2.2.5.0";
+  sha256 = "sha256-67OfiTT9NvJdMTUuYbvZTcArHp8EQRhQ0v2WWL2RbjY=";
 
   description = "A set of tiny general Unix utilities optimized for simplicity and small size";
 

--- a/pkgs/tools/networking/s6-dns/default.nix
+++ b/pkgs/tools/networking/s6-dns/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "s6-dns";
-  version = "2.3.5.3";
-  sha256 = "1nknkh2rw7ggf5ncspb11wyp6ldyqc9lf3nmnklwb5fcf5kjzi1a";
+  version = "2.3.5.4";
+  sha256 = "sha256-dq8iJHLEdU+DzcWa01QlXOGx5vaDOgWTKEY/jlH020M=";
 
   description = "A suite of DNS client programs and libraries for Unix systems";
 

--- a/pkgs/tools/networking/s6-networking/default.nix
+++ b/pkgs/tools/networking/s6-networking/default.nix
@@ -19,8 +19,8 @@ assert sslSupportEnabled -> sslLibs ? ${sslSupport};
 
 buildPackage {
   pname = "s6-networking";
-  version = "2.5.1.0";
-  sha256 = "0hgzj68bk17r1gr32ld1dm5s1x1a5x8ac03klykhfbasx8gwa1r5";
+  version = "2.5.1.1";
+  sha256 = "sha256-esedTePZwTUy5ESrdJfE4ErQ+nIp1QKYTZ3H1IqmRBg=";
 
   description = "A suite of small networking utilities for Unix systems";
 

--- a/pkgs/tools/system/s6-rc/default.nix
+++ b/pkgs/tools/system/s6-rc/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "s6-rc";
-  version = "0.5.3.1";
-  sha256 = "sha256-BYxu25KLvihOyUtc1xObrPNEcszF/5YDo65qGNU7PBI=";
+  version = "0.5.3.2";
+  sha256 = "sha256-TySklmpKo1PSvRqK/Km4jHt70pxGs6Gn9TBWhrnW4Dg=";
 
   description = "A service manager for s6-based systems";
   platforms = lib.platforms.unix;

--- a/pkgs/tools/system/s6/default.nix
+++ b/pkgs/tools/system/s6/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "s6";
-  version = "2.11.1.0";
-  sha256 = "sha256-rmTcK6II/4DkrEeSzpDdUmtCvxnJZtx9jrmmhw5Lwjo=";
+  version = "2.11.1.2";
+  sha256 = "sha256-bBR0vj6Inaw5LO4wer4BXNS+DIXHJchOp/GE8ONFA6I=";
 
   description = "skarnet.org's small & secure supervision software suite";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20883,6 +20883,9 @@ with pkgs;
     s6-networking-man-pages = callPackage ../data/documentation/s6-networking-man-pages {
       inherit buildManPages;
     };
+    s6-portable-utils-man-pages = callPackage ../data/documentation/s6-portable-utils-man-pages {
+      inherit buildManPages;
+    };
 
     mdevd = callPackage ../os-specific/linux/mdevd { };
     nsss = callPackage ../development/libraries/nsss { };
@@ -25240,6 +25243,8 @@ with pkgs;
   s6-man-pages = skawarePackages.s6-man-pages;
 
   s6-networking-man-pages = skawarePackages.s6-networking-man-pages;
+
+  s6-portable-utils-man-pages = skawarePackages.s6-portable-utils-man-pages;
 
   scientifica = callPackage ../data/fonts/scientifica { };
 


### PR DESCRIPTION
###### Description of changes

Currently the execline commit is waiting on some action with regards to the [execline-man-pages/execline version mismatch](https://github.com/NixOS/nixpkgs/pull/168341#issuecomment-1170754392). As it stands the manpages [don't *exactly* match the execline-2.9.0.1 documentation](https://github.com/skarnet/execline/commit/28b89edabbd5ee76147a4aa2ccef94ab60d28c0d#diff-f37c36067a01c281dbc085e84557a8da28499206c460d70d565d3629155a4ea2R22).

Additionally, this also creates s6-portable-utils-man-pages.

https://skarnet.org/lists/skaware/1678.html
https://skarnet.org/lists/skaware/1679.html

```
233e92da966 WIP execline: 2.8.3.0 -> 2.9.0.1
23203dda5b9 skalibs: 2.11.2.0 -> 2.12.0.1
9d3fdb8bf5d s6: 2.11.1.0 -> 2.11.1.2
4d4954f5b68 mdevd: 0.1.5.1 -> 0.1.5.2
8e0a7403c0c s6-linux-init: 1.0.7.3 -> 1.0.8.0
b709ce9f389 s6-portable-utils: 2.2.4.0 -> 2.2.5.0
fcfb74fa759 s6-dns: 2.3.5.3 -> 2.3.5.4
be69068cdab s6-networking: 2.5.1.0 -> 2.5.1.1
88c72138b76 s6-rc: 0.5.3.1 -> 0.5.3.2
d99495b4d9c s6-portable-utils-man-pages: init at 2.2.5.0.1
deb7527d9e5 s6-networking-man-pages: 2.5.1.0.1 -> 2.5.1.1.1
a93a907076e s6-man-pages: 2.11.0.1.1 -> 2.11.1.1.1
1e0258ef45a execline-man-pages: 2.8.3.0.2 -> 2.9.0.0.1
fd7947bf92b s6-linux-utils: 2.5.1.7 -> 2.6.0.0
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
