### PR TITLE
ocamlPackages.dns: 5.0.1 → 6.1.4 & related updates

### DIFF
--- a/pkgs/development/ocaml-modules/cohttp/async.nix
+++ b/pkgs/development/ocaml-modules/cohttp/async.nix
@@ -7,6 +7,7 @@
 , async_unix
 , cohttp
 , conduit-async
+, core_unix
 , uri
 , uri-sexp
 , logs
@@ -25,8 +26,6 @@ buildDunePackage {
   inherit (cohttp)
     version
     src
-    minimumOCamlVersion
-    useDune2
     ;
 
   buildInputs = [ ppx_sexp_conv ];
@@ -38,6 +37,7 @@ buildDunePackage {
     async_unix
     async
     base
+    core_unix
     magic-mime
     logs
     fmt

--- a/pkgs/development/ocaml-modules/cohttp/default.nix
+++ b/pkgs/development/ocaml-modules/cohttp/default.nix
@@ -1,27 +1,26 @@
 { lib, fetchurl, buildDunePackage
 , ppx_sexp_conv, base64, jsonm, re, stringext, uri-sexp
 , ocaml, fmt, alcotest
+, crowbar
 }:
 
 buildDunePackage rec {
   pname = "cohttp";
-  version = "4.0.0";
+  version = "5.0.0";
 
-  useDune2 = true;
-
-  minimumOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.08";
 
   src = fetchurl {
-    url = "https://github.com/mirage/ocaml-cohttp/releases/download/v${version}/cohttp-v${version}.tbz";
-    sha256 = "bd7aa4cd2c82744990ed7c49e3ee7a40324c64cb3d8509804809155e2bacd1d2";
+    url = "https://github.com/mirage/ocaml-cohttp/releases/download/v${version}/cohttp-${version}.tbz";
+    sha256 = "sha256-/W/0uGyBg1XWGzoIYoWW2/UX1qfabo7exIG7BlPKWgU=";
   };
 
   buildInputs = [ jsonm ppx_sexp_conv ];
 
   propagatedBuildInputs = [ base64 re stringext uri-sexp ];
 
-  doCheck = lib.versionAtLeast ocaml.version "4.05";
-  checkInputs = [ fmt alcotest ];
+  doCheck = true;
+  checkInputs = [ fmt alcotest crowbar ];
 
   meta = {
     description = "HTTP(S) library for Lwt, Async and Mirage";

--- a/pkgs/development/ocaml-modules/cohttp/lwt-unix.nix
+++ b/pkgs/development/ocaml-modules/cohttp/lwt-unix.nix
@@ -9,8 +9,6 @@ buildDunePackage {
   pname = "cohttp-lwt-unix";
   inherit (cohttp-lwt) version src;
 
-  useDune2 = true;
-
   buildInputs = [ cmdliner ppx_sexp_conv ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/cohttp/lwt.nix
+++ b/pkgs/development/ocaml-modules/cohttp/lwt.nix
@@ -1,18 +1,16 @@
-{ lib, buildDunePackage, cohttp, ocaml_lwt, uri, ppx_sexp_conv, logs, sexplib0 }:
+{ lib, buildDunePackage, cohttp, lwt, uri, ppx_sexp_conv, logs, sexplib0 }:
 
 buildDunePackage {
   pname = "cohttp-lwt";
   inherit (cohttp)
     version
     src
-    useDune2
-    minimumOCamlVersion
     ;
 
   buildInputs = [ ppx_sexp_conv ];
 
   propagatedBuildInputs = [
-    cohttp ocaml_lwt logs sexplib0 uri
+    cohttp lwt logs sexplib0 uri
   ];
 
   meta = cohttp.meta // {

--- a/pkgs/development/ocaml-modules/cohttp/mirage.nix
+++ b/pkgs/development/ocaml-modules/cohttp/mirage.nix
@@ -8,7 +8,7 @@
 buildDunePackage {
   pname = "cohttp-mirage";
 
-  inherit (cohttp) version src minimumOCamlVersion useDune2;
+  inherit (cohttp) version src;
 
   nativeBuildInputs = [ ppx_sexp_conv ];
 

--- a/pkgs/development/ocaml-modules/conduit/async.nix
+++ b/pkgs/development/ocaml-modules/conduit/async.nix
@@ -7,8 +7,6 @@ buildDunePackage {
   inherit (conduit)
     version
     src
-    minimumOCamlVersion
-    useDune2
     ;
 
   buildInputs = [ ppx_sexp_conv ppx_here ];

--- a/pkgs/development/ocaml-modules/conduit/default.nix
+++ b/pkgs/development/ocaml-modules/conduit/default.nix
@@ -1,21 +1,20 @@
 { lib, fetchurl, buildDunePackage
-, ppx_sexp_conv, sexplib, astring, uri, logs
+, ppx_sexp_conv, sexplib, astring, uri
 , ipaddr, ipaddr-sexp
 }:
 
 buildDunePackage rec {
   pname = "conduit";
-  version = "4.0.2";
-  useDune2 = true;
+  version = "5.1.0";
 
-  minimumOCamlVersion = "4.03";
+  minimalOCamlVersion = "4.03";
 
   src = fetchurl {
-    url = "https://github.com/mirage/ocaml-conduit/releases/download/v${version}/conduit-v${version}.tbz";
-    sha256 = "2a37ffaa352a1e145ef3d80ac28661213c69a741b238623e59f29e3d5a12c537";
+    url = "https://github.com/mirage/ocaml-conduit/releases/download/v${version}/conduit-${version}.tbz";
+    sha256 = "sha256-5RyMPoecu+ngmYmwBZUJODLchmQgiAcuA+Wlmiojkc0=";
   };
 
-  propagatedBuildInputs = [ astring ipaddr ipaddr-sexp sexplib uri logs ppx_sexp_conv ];
+  propagatedBuildInputs = [ astring ipaddr ipaddr-sexp sexplib uri ppx_sexp_conv ];
 
   meta = {
     description = "A network connection establishment library";

--- a/pkgs/development/ocaml-modules/conduit/lwt-unix.nix
+++ b/pkgs/development/ocaml-modules/conduit/lwt-unix.nix
@@ -1,17 +1,17 @@
 { buildDunePackage
-, conduit-lwt, ppx_sexp_conv, ocaml_lwt, uri, ipaddr, ipaddr-sexp, ca-certs, logs
+, conduit-lwt, ppx_sexp_conv, lwt, uri, ipaddr, ipaddr-sexp, ca-certs, logs
 , lwt_ssl, tls, lwt_log, ssl
 }:
 
 buildDunePackage {
   pname = "conduit-lwt-unix";
-  inherit (conduit-lwt) version src minimumOCamlVersion useDune2;
+  inherit (conduit-lwt) version src;
 
   buildInputs = [ ppx_sexp_conv ];
 
   propagatedBuildInputs = [
     conduit-lwt
-    ocaml_lwt
+    lwt
     uri
     ipaddr
     ipaddr-sexp

--- a/pkgs/development/ocaml-modules/conduit/lwt.nix
+++ b/pkgs/development/ocaml-modules/conduit/lwt.nix
@@ -1,12 +1,12 @@
-{ buildDunePackage, ppx_sexp_conv, conduit, ocaml_lwt, sexplib }:
+{ buildDunePackage, ppx_sexp_conv, conduit, lwt, sexplib }:
 
 buildDunePackage {
   pname = "conduit-lwt";
-  inherit (conduit) version src useDune2 minimumOCamlVersion;
+  inherit (conduit) version src;
 
   buildInputs = [ ppx_sexp_conv ];
 
-  propagatedBuildInputs = [ conduit ocaml_lwt sexplib ];
+  propagatedBuildInputs = [ conduit lwt sexplib ];
 
   meta = conduit.meta // {
     description = "A network connection establishment library for Lwt";

--- a/pkgs/development/ocaml-modules/conduit/mirage.nix
+++ b/pkgs/development/ocaml-modules/conduit/mirage.nix
@@ -1,5 +1,5 @@
 { buildDunePackage, conduit-lwt
-, ppx_sexp_conv, sexplib, uri, cstruct, mirage-stack, mirage-flow
+, ppx_sexp_conv, sexplib, uri, cstruct, mirage-flow
 , mirage-flow-combinators, mirage-random, mirage-time, mirage-clock
 , dns-client, vchan, xenstore, tls, tls-mirage, ipaddr, ipaddr-sexp
 , tcpip, ca-certs-nss
@@ -8,12 +8,12 @@
 buildDunePackage {
   pname = "conduit-mirage";
 
-  inherit (conduit-lwt) version src minimumOCamlVersion useDune2;
+  inherit (conduit-lwt) version src;
 
   nativeBuildInputs = [ ppx_sexp_conv ];
 
   propagatedBuildInputs = [
-    sexplib uri cstruct mirage-stack mirage-clock mirage-flow
+    sexplib uri cstruct mirage-clock mirage-flow
     mirage-flow-combinators mirage-random mirage-time
     dns-client conduit-lwt vchan xenstore tls tls-mirage
     ipaddr ipaddr-sexp tcpip ca-certs-nss

--- a/pkgs/development/ocaml-modules/dns/certify.nix
+++ b/pkgs/development/ocaml-modules/dns/certify.nix
@@ -1,12 +1,13 @@
 { buildDunePackage, dns, dns-tsig, dns-mirage, randomconv, x509
-, mirage-random, mirage-time, mirage-clock, mirage-stack
+, mirage-random, mirage-time, mirage-clock
 , logs, mirage-crypto-pk, mirage-crypto-rng, mirage-crypto-ec, lwt
+, tcpip
 }:
 
 buildDunePackage {
   pname = "dns-certify";
 
-  inherit (dns) version src useDune2 minimumOCamlVersion;
+  inherit (dns) version src;
 
   propagatedBuildInputs = [
     dns
@@ -17,12 +18,12 @@ buildDunePackage {
     mirage-random
     mirage-time
     mirage-clock
-    mirage-stack
     logs
     mirage-crypto-pk
     mirage-crypto-rng
     mirage-crypto-ec
     lwt
+    tcpip
   ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/dns/cli.nix
+++ b/pkgs/development/ocaml-modules/dns/cli.nix
@@ -1,5 +1,5 @@
 { buildDunePackage, dns, dns-tsig, dns-client, dns-server, dns-certify
-, rresult, bos, cmdliner, fpath, x509, mirage-crypto, mirage-crypto-pk
+, bos, cmdliner, fpath, x509, mirage-crypto, mirage-crypto-pk
 , mirage-crypto-rng, hex, ptime, mtime, logs, fmt, ipaddr, lwt
 , randomconv, alcotest
 }:
@@ -7,9 +7,9 @@
 buildDunePackage {
   pname = "dns-cli";
 
-  minimumOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.08";
 
-  inherit (dns) version src useDune2;
+  inherit (dns) version src;
 
   # no need to propagate as this is primarily
   # an executable package
@@ -19,7 +19,6 @@ buildDunePackage {
     dns-client
     dns-server
     dns-certify
-    rresult
     bos
     cmdliner
     fpath

--- a/pkgs/development/ocaml-modules/dns/client.nix
+++ b/pkgs/development/ocaml-modules/dns/client.nix
@@ -1,15 +1,19 @@
-{ lib, buildDunePackage, dns, ocaml_lwt, mirage-clock, mirage-time
-, mirage-random, mirage-stack, mirage-crypto-rng, mtime, randomconv
-, cstruct, fmt, logs, rresult, domain-name, ipaddr, alcotest }:
+{ lib, buildDunePackage, dns, lwt, mirage-clock, mirage-time
+, mirage-random, mirage-crypto-rng, mtime, randomconv
+, cstruct, fmt, logs, rresult, domain-name, ipaddr, alcotest
+, ca-certs, ca-certs-nss
+, happy-eyeballs
+, tcpip
+, tls, tls-mirage
+}:
 
 buildDunePackage {
   pname = "dns-client";
   inherit (dns) src version;
 
-  useDune2 = true;
-
-  propagatedBuildInputs = [ cstruct fmt logs dns rresult randomconv domain-name ipaddr
-                            ocaml_lwt mirage-stack mirage-random mirage-time mirage-clock
+  propagatedBuildInputs = [ cstruct fmt logs dns randomconv domain-name ipaddr
+                            lwt mirage-random mirage-time mirage-clock
+                            ca-certs ca-certs-nss happy-eyeballs tcpip tls tls-mirage
                             mtime mirage-crypto-rng ];
   checkInputs = [ alcotest ];
   doCheck = true;

--- a/pkgs/development/ocaml-modules/dns/default.nix
+++ b/pkgs/development/ocaml-modules/dns/default.nix
@@ -1,23 +1,22 @@
 { lib, buildDunePackage, fetchurl, alcotest
-, cstruct, domain-name, duration, gmap, ipaddr, logs, lru, metrics, ptime, rresult, astring, fmt
+, cstruct, domain-name, duration, gmap, ipaddr, logs, lru, metrics, ptime, fmt
 }:
 
 buildDunePackage rec {
   pname = "dns";
-  version = "5.0.1";
+  version = "6.1.4";
 
-  useDune2 = true;
-  minimumOCamlVersion = "4.07";
+  minimalOCamlVersion = "4.08";
 
   src = fetchurl {
-    url = "https://github.com/mirage/ocaml-dns/releases/download/v${version}/dns-v${version}.tbz";
-    sha256 = "72c0a1a91c8e409bd448c8e0ea28d16d13177c326aea403ee1c30ddcb5969adc";
+    url = "https://github.com/mirage/ocaml-dns/releases/download/v${version}/dns-${version}.tbz";
+    sha256 = "sha256-nO9hRFOQzm3j57S1xTUC/j8ejSB+aDcsw/pOi893kHY=";
   };
 
-  propagatedBuildInputs = [ rresult astring fmt logs ptime domain-name gmap cstruct ipaddr lru duration metrics ];
+  propagatedBuildInputs = [ fmt logs ptime domain-name gmap cstruct ipaddr lru duration metrics ];
 
   doCheck = true;
-  checkInputs = lib.optional doCheck alcotest;
+  checkInputs = [ alcotest ];
 
   meta = {
     description = "An Domain Name System (DNS) library";

--- a/pkgs/development/ocaml-modules/dns/mirage.nix
+++ b/pkgs/development/ocaml-modules/dns/mirage.nix
@@ -1,15 +1,15 @@
-{ buildDunePackage, dns, mirage-stack, ipaddr, lwt }:
+{ buildDunePackage, dns, ipaddr, lwt, tcpip }:
 
 buildDunePackage {
   pname = "dns-mirage";
 
-  inherit (dns) version src useDune2 minimumOCamlVersion;
+  inherit (dns) version src;
 
   propagatedBuildInputs = [
     dns
-    mirage-stack
     ipaddr
     lwt
+    tcpip
   ];
 
   meta = dns.meta // {

--- a/pkgs/development/ocaml-modules/dns/resolver.nix
+++ b/pkgs/development/ocaml-modules/dns/resolver.nix
@@ -1,12 +1,13 @@
 { buildDunePackage, dns, dns-server, dns-mirage, lru, duration
 , randomconv, lwt, mirage-time, mirage-clock, mirage-random
+, tcpip, tls, tls-mirage
 , alcotest
 }:
 
 buildDunePackage {
   pname = "dns-resolver";
 
-  inherit (dns) version src useDune2 minimumOCamlVersion;
+  inherit (dns) version src;
 
   propagatedBuildInputs = [
     dns
@@ -19,6 +20,9 @@ buildDunePackage {
     mirage-time
     mirage-clock
     mirage-random
+    tcpip
+    tls
+    tls-mirage
   ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/dns/server.nix
+++ b/pkgs/development/ocaml-modules/dns/server.nix
@@ -1,12 +1,12 @@
 { buildDunePackage, dns, dns-mirage, randomconv, duration, lwt
-, mirage-time, mirage-clock, mirage-stack, metrics
+, mirage-time, mirage-clock, metrics
 , alcotest, mirage-crypto-rng, dns-tsig, base64
 }:
 
 buildDunePackage {
   pname = "dns-server";
 
-  inherit (dns) version src useDune2 minimumOCamlVersion;
+  inherit (dns) version src;
 
   propagatedBuildInputs = [
     dns
@@ -16,7 +16,6 @@ buildDunePackage {
     lwt
     mirage-time
     mirage-clock
-    mirage-stack
     metrics
   ];
 

--- a/pkgs/development/ocaml-modules/dns/stub.nix
+++ b/pkgs/development/ocaml-modules/dns/stub.nix
@@ -1,12 +1,12 @@
 { buildDunePackage, dns, dns-client, dns-mirage, dns-resolver, dns-tsig
 , dns-server, duration, randomconv, lwt, mirage-time, mirage-clock
-, mirage-random, mirage-stack, metrics
+, mirage-random, tcpip, metrics
 }:
 
 buildDunePackage {
   pname = "dns-stub";
 
-  inherit (dns) version src useDune2 minimumOCamlVersion;
+  inherit (dns) version src;
 
   propagatedBuildInputs = [
     dns
@@ -21,7 +21,7 @@ buildDunePackage {
     mirage-time
     mirage-clock
     mirage-random
-    mirage-stack
+    tcpip
     metrics
   ];
 

--- a/pkgs/development/ocaml-modules/dns/tsig.nix
+++ b/pkgs/development/ocaml-modules/dns/tsig.nix
@@ -3,7 +3,7 @@
 buildDunePackage {
   pname = "dns-tsig";
 
-  inherit (dns) version src useDune2 minimumOCamlVersion;
+  inherit (dns) version src;
 
   propagatedBuildInputs = [
     mirage-crypto

--- a/pkgs/development/ocaml-modules/happy-eyeballs/default.nix
+++ b/pkgs/development/ocaml-modules/happy-eyeballs/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildDunePackage, fetchurl
+, domain-name, duration, fmt, ipaddr, logs
+}:
+
+buildDunePackage rec {
+  pname = "happy-eyeballs";
+  version = "0.1.3";
+
+  minimalOCamlVersion = "4.08";
+
+  src = fetchurl {
+    url = "https://github.com/roburio/happy-eyeballs/releases/download/v${version}/happy-eyeballs-${version}.tbz";
+    sha256 = "sha256:0ns1bxcmx0rkq4am6vl2aargdzkfhria8sfmgnh8dgzvvj93cc1c";
+  };
+
+  propagatedBuildInputs = [
+    domain-name
+    duration
+    fmt
+    ipaddr
+    logs
+  ];
+
+  meta = {
+    description = "Connecting to a remote host via IP version 4 or 6";
+    homepage = "https://github.com/roburio/happy-eyeballs";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/ocsigen-server/cohttp-5.patch
+++ b/pkgs/development/ocaml-modules/ocsigen-server/cohttp-5.patch
@@ -1,0 +1,31 @@
+diff --git a/src/server/ocsigen_cohttp.ml b/src/server/ocsigen_cohttp.ml
+index 4363cff7..b0cc0c53 100644
+--- a/src/server/ocsigen_cohttp.ml
++++ b/src/server/ocsigen_cohttp.ml
+@@ -14,25 +14,13 @@ exception Ext_http_error of
+ 
+ let _print_request fmt request =
+ 
+-  let print_list print_data out_ch lst =
+-    let rec aux = function
+-      | [] -> ()
+-      | [ x ] -> print_data out_ch x
+-      | x :: r -> print_data out_ch x; aux r
+-    in aux lst
+-  in
+-
+   Format.fprintf fmt "%s [%s/%s]:\n"
+     (Uri.to_string (Cohttp.Request.uri request))
+     Cohttp.(Code.string_of_version (Request.version request))
+     Cohttp.(Code.string_of_method (Request.meth request));
+ 
+   Cohttp.Header.iter
+-    (fun key values ->
+-       (print_list
+-          (fun fmt value -> Format.fprintf fmt "\t%s = %s\n" key value)
+-          fmt
+-          values))
++    (Format.fprintf fmt "\t%s = %s\n")
+     (Cohttp.Request.headers request)
+ 
+ let connections = Hashtbl.create 256

--- a/pkgs/development/ocaml-modules/ocsigen-server/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-server/default.nix
@@ -37,6 +37,8 @@ buildDunePackage rec {
     ocaml_pcre xml-light
   ];
 
+  patches = [ ./cohttp-5.patch ];
+
   configureFlags = [ "--root $(out)" "--prefix /" "--temproot ''" ];
 
   dontAddPrefix = true;

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -507,6 +507,8 @@ let
     hacl-star = callPackage ../development/ocaml-modules/hacl-star { };
     hacl-star-raw = callPackage ../development/ocaml-modules/hacl-star/raw.nix { };
 
+    happy-eyeballs = callPackage ../development/ocaml-modules/happy-eyeballs { };
+
     hashcons = callPackage ../development/ocaml-modules/hashcons { };
 
     herelib = callPackage ../development/ocaml-modules/herelib { };


### PR DESCRIPTION
###### Description of changes

Compatibility with recent `cstruct`.
https://github.com/mirage/ocaml-dns/blob/v6.1.4/CHANGES.md#v614-2022-01-11
https://github.com/mirage/ocaml-conduit/blob/v5.1.0/CHANGES.md#v510-2022-03-02
https://github.com/mirage/ocaml-cohttp/blob/v5.0.0/CHANGES.md#v500-2021-12-15

cc maintainer @alexfmpe (`conduit`)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
