### PR TITLE
ocrfeeder: Fix launch with patch

### DIFF
--- a/pkgs/applications/graphics/ocrfeeder/default.nix
+++ b/pkgs/applications/graphics/ocrfeeder/default.nix
@@ -48,6 +48,11 @@ stdenv.mkDerivation rec {
       pygobject3
     ]))
   ];
+  patches = [
+    # Compiles, but doesn't launch without this, see:
+    # https://gitlab.gnome.org/GNOME/ocrfeeder/-/issues/83
+    ./fix-launch.diff
+  ];
 
   enginesPath = lib.makeBinPath ([
     tesseract4
@@ -64,7 +69,5 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ doronbehar ];
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    # Compiles, but doesn't launch, see: https://gitlab.gnome.org/GNOME/ocrfeeder/-/issues/83
-    broken = true;
   };
 }

--- a/pkgs/applications/graphics/ocrfeeder/fix-launch.diff
+++ b/pkgs/applications/graphics/ocrfeeder/fix-launch.diff
@@ -1,0 +1,13 @@
+diff --git i/src/ocrfeeder/studio/studioBuilder.py w/src/ocrfeeder/studio/studioBuilder.py
+index 7a2ccdc..7af19d9 100644
+--- i/src/ocrfeeder/studio/studioBuilder.py
++++ w/src/ocrfeeder/studio/studioBuilder.py
+@@ -144,7 +144,7 @@ class Studio:
+         if not self.ocr_engines:
+             engines = self.configuration_manager.getEnginesInSystem()
+             if engines:
+-                add_engines_dialog = widgetPresenter.SystemEnginesDialog(engines)
++                add_engines_dialog = widgetPresenter.SystemEnginesDialog(self.main_window, engines)
+                 response = add_engines_dialog.run()
+                 if response == Gtk.ResponseType.ACCEPT:
+                     for engine in add_engines_dialog.getChosenEngines():


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
