### PR TITLE
gourou: init at 0.7.2

### DIFF
--- a/pkgs/development/libraries/gourou/base64.patch
+++ b/pkgs/development/libraries/gourou/base64.patch
@@ -1,0 +1,13 @@
+diff --git a/src/bytearray.cpp b/src/bytearray.cpp
+index 0bfbbabff45e..427f3d275bdd 100644
+--- a/src/bytearray.cpp
++++ b/src/bytearray.cpp
+@@ -18,7 +18,7 @@
+ */
+ #include <string.h>
+ 
+-#include <base64/Base64.h>
++#include <base64.h>
+ 
+ #include <bytearray.h>
+ 

--- a/pkgs/development/libraries/gourou/default.nix
+++ b/pkgs/development/libraries/gourou/default.nix
@@ -1,0 +1,47 @@
+{ lib, stdenv, fetchgit, fetchurl
+, pugixml, updfparser, curl, openssl, libzip }:
+
+let
+  base64 = fetchurl {
+    url = "https://gist.githubusercontent.com/tomykaira/f0fd86b6c73063283afe550bc5d77594/raw/7d5a89229a525452e37504976a73c35fbaf2fe4d/Base64.h";
+    sha256 = "sha256-BKK+6mPEEEd4Y8c6GU2X6UB5fQ+3nPbUbEF8zQ6nGM4=";
+  };
+in stdenv.mkDerivation rec {
+  name = "gourou";
+  version = "0.7.2";
+
+  src = fetchgit {
+    url = "git://soutade.fr/libgourou";
+    rev = "v${version}";
+    sha256 = "sha256-jvvfrCuRggSPk7p/WtEaKRV7kILuZjUB1KEgaE4LStc=";
+  };
+
+  postUnpack = ''
+    cp ${base64} $sourceRoot/include/base64.h
+  '';
+
+  patches = [
+    ./base64.patch # vendor base64 header file
+    ./devendor.patch # devendor pugixml and updfparser
+  ];
+
+  buildInputs = [ pugixml updfparser curl openssl libzip ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dt $out/include include/libgourou*.h
+    install -Dt $out/lib libgourou.so
+    install -Dt $out/bin utils/acsmdownloader
+    install -Dt $out/bin utils/adept_{activate,loan_mgt,remove}
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Implementation of Adobe's ADEPT protocol for ePub/PDF DRM";
+    homepage = "https://indefero.soutade.fr/p/libgourou";
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ McSinyx ];
+    platforms = platforms.all;
+    broken = stdenv.isDarwin;
+  };
+}

--- a/pkgs/development/libraries/gourou/devendor.patch
+++ b/pkgs/development/libraries/gourou/devendor.patch
@@ -1,0 +1,44 @@
+diff --git a/Makefile b/Makefile
+index fac27c2da1db..35439fefd8e1 100644
+--- a/Makefile
++++ b/Makefile
+@@ -2,10 +2,8 @@
+ AR ?= $(CROSS)ar
+ CXX ?= $(CROSS)g++
+ 
+-UPDFPARSERLIB = ./lib/updfparser/libupdfparser.a
+-
+-CXXFLAGS=-Wall -fPIC -I./include -I./lib -I./lib/pugixml/src/ -I./lib/updfparser/include
+-LDFLAGS = $(UPDFPARSERLIB)
++CXXFLAGS=-Wall -fPIC -I./include
++LDFLAGS = -lpugixml -lupdfparser
+ 
+ BUILD_STATIC ?= 0
+ BUILD_SHARED ?= 1
+@@ -36,10 +34,10 @@ TARGETDIR   := bin
+ SRCEXT      := cpp
+ OBJEXT      := o
+ 
+-SOURCES      = src/libgourou.cpp src/user.cpp src/device.cpp src/fulfillment_item.cpp src/loan_token.cpp src/bytearray.cpp src/pugixml.cpp
++SOURCES      = src/libgourou.cpp src/user.cpp src/device.cpp src/fulfillment_item.cpp src/loan_token.cpp src/bytearray.cpp
+ OBJECTS     := $(patsubst $(SRCDIR)/%,$(BUILDDIR)/%,$(SOURCES:.$(SRCEXT)=.$(OBJEXT)))
+ 
+-all: lib obj $(TARGETS)
++all: obj $(TARGETS)
+ 
+ lib:
+ 	mkdir lib
+@@ -56,10 +54,10 @@ $(BUILDDIR)/%.$(OBJEXT): $(SRCDIR)/%.$(SRCEXT)
+ 
+ libgourou: libgourou.a libgourou.so
+ 
+-libgourou.a: $(OBJECTS) $(UPDFPARSERLIB)
+-	$(AR) crs $@ obj/*.o  $(UPDFPARSERLIB)
++libgourou.a: $(OBJECTS)
++	$(AR) crs $@ obj/*.o
+ 
+-libgourou.so: $(OBJECTS) $(UPDFPARSERLIB)
++libgourou.so: $(OBJECTS)
+ 	$(CXX) obj/*.o $(LDFLAGS) -o $@ -shared
+ 
+ build_utils:

--- a/pkgs/development/libraries/updfparser/default.nix
+++ b/pkgs/development/libraries/updfparser/default.nix
@@ -1,0 +1,27 @@
+{ lib, stdenv, fetchgit }:
+
+stdenv.mkDerivation {
+  name = "updfparser";
+  version = "unstable-2022-03-16";
+
+  src = fetchgit {
+    url = "git://soutade.fr/updfparser";
+    rev = "9d56c1d0b1ce81aae4c8db9d99a8b5d1f7967bcf";
+    sha256 = "sha256-9dvibKiUbbI4CrmuAaJzlpntT0XdLvdGeC2/WzjlA5U=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+    install -Dt $out/include include/*.h
+    install -Dt $out/lib libupdfparser.so
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A very simple PDF parser";
+    homepage = "https://indefero.soutade.fr/p/updfparser";
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ McSinyx ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21117,6 +21117,8 @@ with pkgs;
 
   unicon-lang = callPackage ../development/interpreters/unicon-lang {};
 
+  updfparser = callPackage ../development/libraries/updfparser { };
+
   tsocks = callPackage ../development/libraries/tsocks { };
 
   unixODBC = callPackage ../development/libraries/unixODBC { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17889,6 +17889,8 @@ with pkgs;
 
   elementary-cmake-modules = callPackage ../development/libraries/elementary-cmake-modules { };
 
+  gourou = callPackage ../development/libraries/gourou { };
+
   gtk2 = callPackage ../development/libraries/gtk/2.x.nix {
     inherit (darwin.apple_sdk.frameworks) AppKit Cocoa;
   };


### PR DESCRIPTION
###### Description of changes

[libgourou](https://indefero.soutade.fr/p/libgourou) is a library for deDRM'ing Adobe ebooks.  It's working pretty well for me to download and read comics bought from Kobo offline without using any proprietary software.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).