### PR TITLE
pkgsMusl.colord: fix build

### DIFF
--- a/pkgs/tools/misc/colord/default.nix
+++ b/pkgs/tools/misc/colord/default.nix
@@ -26,6 +26,7 @@
 , docbook_xml_dtd_412
 , gtk-doc
 , libxslt
+, enableDaemon ? !stdenv.hostPlatform.isMusl || stdenv.hostPlatform.isStatic
 }:
 
 stdenv.mkDerivation rec {
@@ -56,6 +57,7 @@ stdenv.mkDerivation rec {
     "-Dlibcolordcompat=true"
     "-Dsane=true"
     "-Dvapi=true"
+    "-Ddaemon=${lib.boolToString enableDaemon}"
     "-Ddaemon_user=colord"
   ];
 
@@ -83,10 +85,11 @@ stdenv.mkDerivation rec {
     gusb
     lcms2
     libgudev
-    polkit
     sane-backends
     sqlite
     systemd
+  ] ++ lib.optionals enableDaemon [
+    polkit
   ];
 
   postInstall = ''

--- a/pkgs/tools/misc/colord/default.nix
+++ b/pkgs/tools/misc/colord/default.nix
@@ -18,7 +18,7 @@
 , ninja
 , vala
 , libgudev
-, wrapGAppsHook
+, wrapGAppsNoGuiHook
 , shared-mime-info
 , sane-backends
 , docbook_xsl
@@ -72,7 +72,7 @@ stdenv.mkDerivation rec {
     pkg-config
     shared-mime-info
     vala
-    wrapGAppsHook
+    wrapGAppsNoGuiHook
   ];
 
   buildInputs = [


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

We can't build the daemon in pkgsMusl, because [rustc does not support dynamic Musl targets][1], which means we can't build Spidermonkey, which means we can't build Polkit.  But it still makes sense to support the rest of colord, because an application should still be able to link against it to talk to a colord daemon built in some other way (e.g. provided by a different distro).

[1]: https://github.com/NixOS/nixpkgs/issues/179242

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
