### PR TITLE
nixos/systemd: make sure all the device nodes are created in stage1

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -592,6 +592,9 @@ in
     systemd.services.systemd-importd.environment = proxy_env;
     systemd.services.systemd-pstore.wantedBy = [ "sysinit.target" ]; # see #81138
 
+    # NixOS has kernel modules in a different location
+    systemd.services.kmod-static-nodes.unitConfig.ConditionFileNotEmpty = "/run/booted-system/kernel-modules/lib/modules/%v/modules.devname";
+
     # Don't bother with certain units in containers.
     systemd.services.systemd-remount-fs.unitConfig.ConditionVirtualization = "!container";
     systemd.services.systemd-random-seed.unitConfig.ConditionVirtualization = "!container";

--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -420,6 +420,10 @@ in {
       services."systemd-makefs@" = lib.mkIf needMakefs { unitConfig.IgnoreOnIsolate = true; };
       services."systemd-growfs@" = lib.mkIf needGrowfs { unitConfig.IgnoreOnIsolate = true; };
 
+      # make sure all the /dev nodes are set up
+      services.kmod-static-nodes.unitConfig.ConditionFileNotEmpty = "/lib/modules/%v/modules.devname";
+      services.systemd-tmpfiles-setup-dev.wantedBy = ["sysinit.target"];
+
       services.initrd-nixos-activation = {
         after = [ "initrd-fs.target" ];
         requiredBy = [ "initrd.target" ];

--- a/pkgs/os-specific/linux/systemd/0016-kmod-static-nodes.service-Update-ConditionFileNotEmp.patch
+++ b/pkgs/os-specific/linux/systemd/0016-kmod-static-nodes.service-Update-ConditionFileNotEmp.patch
@@ -18,10 +18,9 @@ index 777e82d16b..b6abc2bba0 100644
  Before=sysinit.target systemd-tmpfiles-setup-dev.service
  ConditionCapability=CAP_SYS_MODULE
 -ConditionFileNotEmpty=/lib/modules/%v/modules.devname
-+ConditionFileNotEmpty=/run/booted-system/kernel-modules/lib/modules/%v/modules.devname
- 
+
  [Service]
  Type=oneshot
--- 
+--
 2.34.0
 


### PR DESCRIPTION
###### Description of changes

The ConditionFileNotEmpty override patch wasn't correct for stage1, which does have the modules in /lib. So, remove the condition instead, and set the right path with overrides in both stage1 and the final system.

Also, make sure systemd-tmpfiles-setup-dev is pulled in to create all the necessary symlinks.

Unfortunately requires a systemd rebuild.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
