### PR TITLE
neo4j: 3.5.14 -> 4.4.8

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -374,6 +374,13 @@
       </listitem>
       <listitem>
         <para>
+          Neo4j was updated from version 3 to version 4. See this
+          <link xlink:href="https://neo4j.com/docs/upgrade-migration-guide/current/">migration
+          guide</link> on how to migrate your Neo4j instance.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           Matrix Synapse now requires entries in the
           <literal>state_group_edges</literal> table to be unique, in
           order to prevent accidentally introducing duplicate

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -139,6 +139,8 @@ Use `configure.packages` instead.
 
 - The Redis module now disables RDB persistence when `services.redis.servers.<name>.save = []` instead of using the Redis default.
 
+- Neo4j was updated from version 3 to version 4. See this [migration guide](https://neo4j.com/docs/upgrade-migration-guide/current/) on how to migrate your Neo4j instance.
+
 - Matrix Synapse now requires entries in the `state_group_edges` table to be unique, in order to prevent accidentally introducing duplicate information (for example, because a database backup was restored multiple times). If your Synapse database already has duplicate rows in this table, this could fail with an error and require manual remediation.
 
 - `dockerTools.buildImage` deprecates the misunderstood `contents` parameter, in favor of `copyToRoot`.

--- a/nixos/modules/services/databases/neo4j.nix
+++ b/nixos/modules/services/databases/neo4j.nix
@@ -37,7 +37,7 @@ let
     # General
     dbms.allow_upgrade=${boolToString cfg.allowUpgrade}
     dbms.default_listen_address=${cfg.defaultListenAddress}
-    dbms.read_only=${boolToString cfg.readOnly}
+    dbms.databases.default_to_read_only=${boolToString cfg.readOnly}
     ${optionalString (cfg.workerCount > 0) ''
       dbms.threads.worker_count=${toString cfg.workerCount}
     ''}
@@ -60,6 +60,7 @@ let
     ${optionalString (cfg.http.enable) ''
       dbms.connector.http.enabled=${boolToString cfg.https.enable}
       dbms.connector.http.listen_address=${cfg.http.listenAddress}
+      dbms.connector.http.advertised_address=${cfg.http.listenAddress}
     ''}
     ${optionalString (!cfg.http.enable) ''
       # It is not possible to disable the HTTP connector. To fully prevent
@@ -72,10 +73,12 @@ let
     # HTTPS Connector
     dbms.connector.https.enabled=${boolToString cfg.https.enable}
     dbms.connector.https.listen_address=${cfg.https.listenAddress}
+    dbms.connector.https.advertised_address=${cfg.https.listenAddress}
 
     # BOLT Connector
     dbms.connector.bolt.enabled=${boolToString cfg.bolt.enable}
     dbms.connector.bolt.listen_address=${cfg.bolt.listenAddress}
+    dbms.connector.bolt.advertised_address=${cfg.bolt.listenAddress}
     dbms.connector.bolt.tls_level=${cfg.bolt.tlsLevel}
 
     # SSL Policies

--- a/nixos/modules/services/databases/neo4j.nix
+++ b/nixos/modules/services/databases/neo4j.nix
@@ -647,6 +647,6 @@ in {
     };
 
   meta = {
-    maintainers = with lib.maintainers; [ patternspandemic jonringer ];
+    maintainers = with lib.maintainers; [ patternspandemic jonringer erictapen ];
   };
 }

--- a/nixos/modules/services/databases/neo4j.nix
+++ b/nixos/modules/services/databases/neo4j.nix
@@ -57,7 +57,7 @@ let
 
     # HTTP Connector
     ${optionalString (cfg.http.enable) ''
-      dbms.connector.http.enabled=${boolToString cfg.https.enable}
+      dbms.connector.http.enabled=${boolToString cfg.http.enable}
       dbms.connector.http.listen_address=${cfg.http.listenAddress}
       dbms.connector.http.advertised_address=${cfg.http.listenAddress}
     ''}

--- a/nixos/modules/services/databases/neo4j.nix
+++ b/nixos/modules/services/databases/neo4j.nix
@@ -51,7 +51,6 @@ let
    ''}
 
     # Directories (read and write)
-    dbms.directories.home=${cfg.directories.home}
     dbms.directories.data=${cfg.directories.data}
     dbms.directories.logs=${cfg.directories.home}/logs
     dbms.directories.run=${cfg.directories.home}/run

--- a/nixos/modules/services/databases/neo4j.nix
+++ b/nixos/modules/services/databases/neo4j.nix
@@ -61,13 +61,6 @@ let
       dbms.connector.http.listen_address=${cfg.http.listenAddress}
       dbms.connector.http.advertised_address=${cfg.http.listenAddress}
     ''}
-    ${optionalString (!cfg.http.enable) ''
-      # It is not possible to disable the HTTP connector. To fully prevent
-      # clients from connecting to HTTP, block the HTTP port (7474 by default)
-      # via firewall. listen_address is set to the loopback interface to
-      # prevent remote clients from connecting.
-      dbms.connector.http.listen_address=127.0.0.1
-    ''}
 
     # HTTPS Connector
     dbms.connector.https.enabled=${boolToString cfg.https.enable}
@@ -340,13 +333,10 @@ in {
       enable = mkOption {
         type = types.bool;
         default = true;
-        description = lib.mdDoc ''
-          The HTTP connector is required for Neo4j, and cannot be disabled.
-          Setting this option to `false` will force the HTTP
-          connector's {option}`listenAddress` to the loopback
-          interface to prevent connection of remote clients. To prevent all
-          clients from connecting, block the HTTP port (7474 by default) by
-          firewall.
+        description = ''
+          Enable the HTTP connector for Neo4j. Setting this option to
+          <literal>false</literal> will stop Neo4j from listening for incoming
+          connections on the HTTPS port (7474 by default).
         '';
       };
 

--- a/nixos/modules/services/databases/neo4j.nix
+++ b/nixos/modules/services/databases/neo4j.nix
@@ -36,24 +36,29 @@ let
   serverConfig = pkgs.writeText "neo4j.conf" ''
     # General
     dbms.allow_upgrade=${boolToString cfg.allowUpgrade}
-    dbms.connectors.default_listen_address=${cfg.defaultListenAddress}
+    dbms.default_listen_address=${cfg.defaultListenAddress}
     dbms.read_only=${boolToString cfg.readOnly}
     ${optionalString (cfg.workerCount > 0) ''
       dbms.threads.worker_count=${toString cfg.workerCount}
     ''}
 
-    # Directories
+    # Directories (readonly)
     dbms.directories.certificates=${cfg.directories.certificates}
-    dbms.directories.data=${cfg.directories.data}
-    dbms.directories.logs=${cfg.directories.home}/logs
     dbms.directories.plugins=${cfg.directories.plugins}
+    dbms.directories.lib=${cfg.package}/share/neo4j/lib
     ${optionalString (cfg.constrainLoadCsv) ''
       dbms.directories.import=${cfg.directories.imports}
-    ''}
+   ''}
+
+    # Directories (read and write)
+    dbms.directories.home=${cfg.directories.home}
+    dbms.directories.data=${cfg.directories.data}
+    dbms.directories.logs=${cfg.directories.home}/logs
+    dbms.directories.run=${cfg.directories.home}/run
 
     # HTTP Connector
     ${optionalString (cfg.http.enable) ''
-      dbms.connector.http.enabled=${boolToString cfg.http.enable}
+      dbms.connector.http.enabled=${boolToString cfg.https.enable}
       dbms.connector.http.listen_address=${cfg.http.listenAddress}
     ''}
     ${optionalString (!cfg.http.enable) ''
@@ -67,16 +72,11 @@ let
     # HTTPS Connector
     dbms.connector.https.enabled=${boolToString cfg.https.enable}
     dbms.connector.https.listen_address=${cfg.https.listenAddress}
-    https.ssl_policy=${cfg.https.sslPolicy}
 
     # BOLT Connector
     dbms.connector.bolt.enabled=${boolToString cfg.bolt.enable}
     dbms.connector.bolt.listen_address=${cfg.bolt.listenAddress}
-    bolt.ssl_policy=${cfg.bolt.sslPolicy}
     dbms.connector.bolt.tls_level=${cfg.bolt.tlsLevel}
-
-    # neo4j-shell
-    dbms.shell.enabled=${boolToString cfg.shell.enable}
 
     # SSL Policies
     ${concatStringsSep "\n" sslPolicies}
@@ -95,8 +95,10 @@ let
     dbms.jvm.additional=-Djdk.tls.rejectClientInitiatedRenegotiation=true
     dbms.jvm.additional=-Dunsupported.dbms.udc.source=tarball
 
-    # Usage Data Collector
-    dbms.udc.enabled=${boolToString cfg.udc.enable}
+    #dbms.memory.heap.initial_size=12000m
+    #dbms.memory.heap.max_size=12000m
+    #dbms.memory.pagecache.size=4g
+    #dbms.tx_state.max_off_heap_memory=8000m
 
     # Extra Configuration
     ${cfg.extraServerConfig}
@@ -114,6 +116,8 @@ in {
     (mkRemovedOptionModule [ "services" "neo4j" "port" ] "Use services.neo4j.http.listenAddress instead.")
     (mkRemovedOptionModule [ "services" "neo4j" "boltPort" ] "Use services.neo4j.bolt.listenAddress instead.")
     (mkRemovedOptionModule [ "services" "neo4j" "httpsPort" ] "Use services.neo4j.https.listenAddress instead.")
+    (mkRemovedOptionModule [ "services" "neo4j" "shell" "enabled" ] "shell.enabled was removed upstream")
+    (mkRemovedOptionModule [ "services" "neo4j" "udc" "enabled" ] "udc.enabled was removed upstream")
   ];
 
   ###### interface
@@ -568,19 +572,6 @@ in {
       '';
     };
 
-    udc = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = lib.mdDoc ''
-          Enable the Usage Data Collector which Neo4j uses to collect usage
-          data. Refer to the operations manual section on the
-          [Usage Data Collector](https://neo4j.com/docs/operations-manual/current/configuration/usage-data-collector/)
-          for more information.
-        '';
-      };
-    };
-
   };
 
   ###### implementation
@@ -612,7 +603,7 @@ in {
         wantedBy = [ "multi-user.target" ];
         after = [ "network.target" ];
         environment = {
-          NEO4J_HOME = "${cfg.package}/share/neo4j";
+          NEO4J_HOME = "${cfg.directories.home}";
           NEO4J_CONF = "${cfg.directories.home}/conf";
         };
         serviceConfig = {
@@ -653,6 +644,6 @@ in {
     };
 
   meta = {
-    maintainers = with lib.maintainers; [ patternspandemic ];
+    maintainers = with lib.maintainers; [ patternspandemic jonringer ];
   };
 }

--- a/nixos/tests/neo4j.nix
+++ b/nixos/tests/neo4j.nix
@@ -7,6 +7,9 @@ import ./make-test-python.nix {
 
       {
         services.neo4j.enable = true;
+        # require tls certs to be available
+        services.neo4j.https.enable = false;
+        services.neo4j.bolt.enable = false;
       };
   };
 

--- a/nixos/tests/neo4j.nix
+++ b/nixos/tests/neo4j.nix
@@ -19,7 +19,7 @@ import ./make-test-python.nix {
   testScript = ''
     start_all()
 
-    server.wait_for_unit("neo4j")
+    server.wait_for_unit("neo4j.service")
     server.wait_for_open_port(7474)
     server.succeed("curl -f http://localhost:7474/")
   '';

--- a/nixos/tests/neo4j.nix
+++ b/nixos/tests/neo4j.nix
@@ -6,7 +6,7 @@ import ./make-test-python.nix {
       { ... }:
 
       {
-	# virtualisation.memorySize = 4096;
+	virtualisation.memorySize = 4096;
 	virtualisation.diskSize = 1024;
 
         services.neo4j.enable = true;

--- a/nixos/tests/neo4j.nix
+++ b/nixos/tests/neo4j.nix
@@ -2,10 +2,13 @@ import ./make-test-python.nix {
   name = "neo4j";
 
   nodes = {
-    master =
+    server =
       { ... }:
 
       {
+	# virtualisation.memorySize = 4096;
+	virtualisation.diskSize = 1024;
+
         services.neo4j.enable = true;
         # require tls certs to be available
         services.neo4j.https.enable = false;
@@ -16,8 +19,8 @@ import ./make-test-python.nix {
   testScript = ''
     start_all()
 
-    master.wait_for_unit("neo4j")
-    master.wait_for_open_port(7474)
-    master.succeed("curl -f http://localhost:7474/")
+    server.wait_for_unit("neo4j")
+    server.wait_for_open_port(7474)
+    server.succeed("curl -f http://localhost:7474/")
   '';
 }

--- a/nixos/tests/neo4j.nix
+++ b/nixos/tests/neo4j.nix
@@ -6,8 +6,8 @@ import ./make-test-python.nix {
       { ... }:
 
       {
-	virtualisation.memorySize = 4096;
-	virtualisation.diskSize = 1024;
+        virtualisation.memorySize = 4096;
+        virtualisation.diskSize = 1024;
 
         services.neo4j.enable = true;
         # require tls certs to be available

--- a/pkgs/servers/nosql/neo4j/default.nix
+++ b/pkgs/servers/nosql/neo4j/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A highly scalable, robust (fully ACID) native graph database";
-    homepage = "http://www.neo4j.org/";
+    homepage = "https://neo4j.com/";
     license = licenses.gpl3;
     maintainers = with maintainers; [ jonringer offline ];
     platforms = platforms.unix;

--- a/pkgs/servers/nosql/neo4j/default.nix
+++ b/pkgs/servers/nosql/neo4j/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, makeWrapper, openjdk11, which, gawk }:
+{ stdenv, lib, fetchurl, nixosTests, makeWrapper, openjdk11, which, gawk }:
 
 stdenv.mkDerivation rec {
   pname = "neo4j";
@@ -29,6 +29,8 @@ stdenv.mkDerivation rec {
     # user will be asked to change password on first login
     $out/bin/neo4j-admin set-initial-password neo4j
   '';
+
+  passthru.tests.nixos = nixosTests.neo4j;
 
   meta = with lib; {
     description = "A highly scalable, robust (fully ACID) native graph database";

--- a/pkgs/servers/nosql/neo4j/default.nix
+++ b/pkgs/servers/nosql/neo4j/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "neo4j";
-  version = "4.1.1";
+  version = "4.3.3";
 
   src = fetchurl {
     url = "https://neo4j.com/artifact.php?name=neo4j-community-${version}-unix.tar.gz";
-    sha256 = "0w8jgbk1fxwivjvasj5l63123wrsz4yfnbwpn78dyh7c1d93lrjg";
+    sha256 = "sha256-uzllwY5hPuc48Hrxx8jamFujyoAlBUzmYmY3bG1PcGU=";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/servers/nosql/neo4j/default.nix
+++ b/pkgs/servers/nosql/neo4j/default.nix
@@ -1,14 +1,12 @@
-{ lib, stdenv, fetchurl, makeWrapper, jre, which, gawk }:
-
-with lib;
+{ stdenv, lib, fetchurl, makeWrapper, openjdk11, which, gawk }:
 
 stdenv.mkDerivation rec {
   pname = "neo4j";
-  version = "3.5.14";
+  version = "4.1.1";
 
   src = fetchurl {
     url = "https://neo4j.com/artifact.php?name=neo4j-community-${version}-unix.tar.gz";
-    sha256 = "1zjb6cgk2lpzx6pq1cs5fh65in6b5ccpl1cgfiglgpjc948mnhzv";
+    sha256 = "0w8jgbk1fxwivjvasj5l63123wrsz4yfnbwpn78dyh7c1d93lrjg";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -18,21 +16,25 @@ stdenv.mkDerivation rec {
     cp -R * "$out/share/neo4j"
 
     mkdir -p "$out/bin"
-    for NEO4J_SCRIPT in neo4j neo4j-admin neo4j-import cypher-shell
+    for NEO4J_SCRIPT in neo4j neo4j-admin cypher-shell
     do
+        chmod +x "$out/share/neo4j/bin/$NEO4J_SCRIPT"
         makeWrapper "$out/share/neo4j/bin/$NEO4J_SCRIPT" \
             "$out/bin/$NEO4J_SCRIPT" \
-            --prefix PATH : "${lib.makeBinPath [ jre which gawk ]}" \
-            --set JAVA_HOME "${jre}"
+            --prefix PATH : "${lib.makeBinPath [ openjdk11 which gawk ]}" \
+            --set JAVA_HOME "${openjdk11}"
     done
+
+    patchShebangs $out/share/neo4j/bin/neo4j-admin
+    # user will be asked to change password on first login
+    $out/bin/neo4j-admin set-initial-password neo4j
   '';
 
   meta = with lib; {
     description = "A highly scalable, robust (fully ACID) native graph database";
     homepage = "http://www.neo4j.org/";
     license = licenses.gpl3;
-
-    maintainers = [ maintainers.offline ];
-    platforms = lib.platforms.unix;
+    maintainers = with maintainers; [ jonringer offline ];
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/servers/nosql/neo4j/default.nix
+++ b/pkgs/servers/nosql/neo4j/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "neo4j";
-  version = "4.3.3";
+  version = "4.4.8";
 
   src = fetchurl {
     url = "https://neo4j.com/artifact.php?name=neo4j-community-${version}-unix.tar.gz";
-    sha256 = "sha256-uzllwY5hPuc48Hrxx8jamFujyoAlBUzmYmY3bG1PcGU=";
+    sha256 = "34c8ce7edc2ab9f63a204f74f37621cac3427f12b0aef4c6ef47eaf4c2b90d66";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22995,9 +22995,7 @@ with pkgs;
 
   check_zfs = callPackage ../servers/monitoring/nagios/plugins/zfs.nix { };
 
-  neo4j = callPackage ../servers/nosql/neo4j {
-    jre = jre8_headless;
-  };
+  neo4j = callPackage ../servers/nosql/neo4j { };
 
   neo4j-desktop = callPackage ../applications/misc/neo4j-desktop { };
 


### PR DESCRIPTION
This is a rebase and continuation of #136300.

Tests successfully run. Also it seems like neo4j fully supports disabling http connector (it's well documented, the server makes a loud report if neither http nor https connectors are enabled, and the "loopback" seems outdated).

This pull is mergeable, _but_ at this point neo4j module lacks explicit configuration for TLS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
