### PR TITLE
openocd-rp2040: init at version 0.12.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7605,6 +7605,12 @@
     githubId = 8555953;
     name = "Laure Tavard";
   };
+  lu15w1r7h = {
+    email = "lwirth2000@gmail.com";
+    github = "LU15W1R7H";
+    githubId = 37505890;
+    name = "Luis Wirth";
+  };
   luc65r = {
     email = "lucas@ransan.tk";
     github = "luc65r";

--- a/pkgs/development/embedded/openocd-rp2040/default.nix
+++ b/pkgs/development/embedded/openocd-rp2040/default.nix
@@ -1,0 +1,81 @@
+{ lib
+, stdenv
+, fetchgit
+, fetchurl
+, pkg-config
+, hidapi
+, libftdi1
+, libusb1
+, which
+, libtool
+, autoconf
+, automake
+, texinfo
+, git
+, libgpiod
+}:
+
+stdenv.mkDerivation {
+  pname = "openocd-rp2040";
+  version = "0.12.0";
+  src = fetchgit {
+    url = "https://github.com/raspberrypi/openocd";
+    rev = "4d87f6dcae77d3cbcd8ac3f7dc887adf46ffa504";
+    sha256 = "sha256-SYC0qqNx09yO/qeKDDN8dF/9d/dofJ5B1h/PofhG8Jw=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    hidapi
+    libftdi1
+    libusb1
+    which
+    libtool
+    autoconf
+    automake
+    texinfo
+    git
+  ]
+    ++
+    # tracking issue for v2 api changes https://sourceforge.net/p/openocd/tickets/306/
+    lib.optional stdenv.isLinux (libgpiod.overrideAttrs (old: rec {
+      version = "1.6.4";
+      src = fetchurl {
+        url = "https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/snapshot/libgpiod-${version}.tar.gz";
+        sha256 = "sha256-gp1KwmjfB4U2CdZ8/H9HbpqnNssqaKYwvpno+tGXvgo=";
+      };
+    }));
+
+  configurePhase = ''
+    SKIP_SUBMODULE=1 ./bootstrap
+    ./configure --prefix=$out
+  '';
+
+  enableParallelBuilding = true;
+
+  postInstall = lib.optionalString stdenv.isLinux ''
+    mkdir -p "$out/etc/udev/rules.d"
+    rules="$out/share/openocd/contrib/60-openocd.rules"
+    if [ ! -f "$rules" ]; then
+        echo "$rules is missing, must update the Nix file."
+        exit 1
+    fi
+    ln -s "$rules" "$out/etc/udev/rules.d/"
+  '';
+
+  meta = with lib; {
+    description = "OpenOCD fork for rp2040 microcontroller";
+    longDescription = ''
+      This is a fork of OpenOCD by Raspberry Pi,
+      which brings support to the rp2040 microcontroller.
+    '';
+    homepage = "https://github.com/raspberrypi/openocd";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ lu15w1r7h ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16150,6 +16150,8 @@ with pkgs;
 
   openocd = callPackage ../development/embedded/openocd { };
 
+  openocd-rp2040 = callPackage ../development/embedded/openocd-rp2040 { };
+
   oprofile = callPackage ../development/tools/profiling/oprofile {
     libiberty_static = libiberty.override { staticBuild = true; };
   };


### PR DESCRIPTION
###### Description of changes

- add maintainer lu15w1r7h
- add new package openocd-rp2040 v0.12.0

openocd-rp2040 is a Raspberry Pi fork of openocd which supports the rp2040 chip.
It can be found on GitHub [raspberrypi/openocd](https://github.com/raspberrypi/openocd).

This derivation was made based on the standard openocd derivation.

This is my first ever nixos derivation and my first nix related PR.
Thanks for letting me know if anything is not as it should be and for helping
me figure things out.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
