### PR TITLE
tgswitch: 0.5.389 -> 0.6.0

### DIFF
--- a/pkgs/applications/networking/cluster/tgswitch/default.nix
+++ b/pkgs/applications/networking/cluster/tgswitch/default.nix
@@ -20,8 +20,7 @@ buildGoModule rec {
   doCheck = false;
 
   meta = with lib; {
-    description =
-      "A command line tool to switch between different versions of terragrunt";
+    description = "Command line tool to switch between different versions of terragrunt";
     homepage = "https://github.com/warrensbox/tgswitch";
     license = licenses.mit;
     maintainers = with maintainers; [ psibi ];

--- a/pkgs/applications/networking/cluster/tgswitch/default.nix
+++ b/pkgs/applications/networking/cluster/tgswitch/default.nix
@@ -1,26 +1,27 @@
 { buildGoModule, lib, fetchFromGitHub }:
 buildGoModule rec {
   pname = "tgswitch";
-  version = "0.5.389";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "warrensbox";
     repo = "tgswitch";
     rev = version;
-    sha256 = "sha256-6hErfI7LEJFgOoJR8IF9jTSBwqbQYeGiwdeJShqxVQ0=";
+    sha256 = "sha256-Q3Cef3B7hfVHLvW8Rx6IdH9g/3luDhpUMZ8TXVpb8gQ=";
   };
 
-  vendorSha256 = null;
+  vendorSha256 = "sha256-PlTdbA8Z2I2SWoG7oYG87VQfczx9zP1SCJx70UWOEog=";
 
   ldflags = [ "-s" "-w" ];
 
   # There are many modifications need to be done to make tests run. For example:
   # 1. Network access
   # 2. Operation on `/var/empty` not permitted on macOS
-  doCheck= false;
+  doCheck = false;
 
   meta = with lib; {
-    description = "A command line tool to switch between different versions of terragrunt";
+    description =
+      "A command line tool to switch between different versions of terragrunt";
     homepage = "https://github.com/warrensbox/tgswitch";
     license = licenses.mit;
     maintainers = with maintainers; [ psibi ];


### PR DESCRIPTION
###### Description of changes

This upgrades tgswitch to new release v0.6.0.
Link to the cahngelog: https://github.com/warrensbox/tgswitch/releases/tag/0.6.0

I've also needed to add back `vendorSha256` as without it I couldn't build this updated package.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

What I've tested is running the new package via `nix-env -f . -iA tgswitch` and veryfing that new functionality (of being able to specify the `bin` path in `~/.tgswitch.toml` file, same as in daughter project - `tfswitch`) works. also of note, that the built binary itself reports wrong version - `0.5.0` - upstream maintainer forgot to update it.

The code is formatted according to `nix-mode` and `nixfmt` default settings,