### PR TITLE
u001-font: init at unstable-2016-08-01

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -55,6 +55,12 @@ in mkLicense lset) ({
     fullName = "GNU Affero General Public License v3.0 or later";
   };
 
+  aladdin = {
+    spdxId = "Aladdin";
+    fullName = "Aladdin Free Public License";
+    free = false;
+  };
+
   amazonsl = {
     fullName = "Amazon Software License";
     url = "https://aws.amazon.com/asl/";

--- a/pkgs/data/fonts/u001/default.nix
+++ b/pkgs/data/fonts/u001/default.nix
@@ -1,0 +1,42 @@
+{ lib, stdenvNoCC, fetchzip }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "u001";
+  version = "unstable-2016-08-01"; # date in the zip file, actual creation date unknown
+
+  src = fetchzip {
+    url = "https://fontlibrary.org/assets/downloads/u001/3ea00b3c0c8fa6ce4373e5766fafd651/u001.zip";
+    sha256 = "sha256-7H32pfr0g68XP5B48VUY99e6fbd7rhH6fEnCKNXWEkU=";
+    stripRoot = false;
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    TTF_DIR=$out/share/fonts/truetype
+
+    mkdir -p $TTF_DIR
+
+    # We’ll adjust the nonstandard naming convention here
+    cp u001-reg.ttf $TTF_DIR/U001-Regular.ttf
+    cp u001-ita.ttf $TTF_DIR/U001-Italic.ttf
+    cp u001-bol.ttf $TTF_DIR/U001-Bold.ttf
+    cp u001-bolita.ttf $TTF_DIR/U001-BoldItalic.ttf
+    cp u001con-reg.ttf $TTF_DIR/U001Condensed-Regular.ttf
+    cp u001con-ita.ttf $TTF_DIR/U001Condensed-Italic.ttf
+    cp u001con-bol.ttf $TTF_DIR/U001Condensed-Bold.ttf
+    cp u001con-bolita.ttf $TTF_DIR/U001Condensed-BoldItalic.ttf
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A Univers-like typeface that comes with GhostPDL made by URW++";
+    homepage = "https://fontlibrary.org/en/font/u001";
+    license = licenses.aladdin;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ toastal ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25389,6 +25389,8 @@ with pkgs;
 
   uw-ttyp0 = callPackage ../data/fonts/uw-ttyp0 { inherit (xorg) fonttosfnt mkfontdir; };
 
+  u001-font = callPackage ../data/fonts/u001 { };
+
   vanilla-dmz = callPackage ../data/icons/vanilla-dmz { };
 
   vdrsymbols = callPackage ../data/fonts/vdrsymbols { };


### PR DESCRIPTION
###### Description of changes

Added a Univers-like font that is somewhat lost to time and with a weird, non-free but free-adjacent LICENSE from an earlier time of URW++ and. The Aladdin license is very much against you selling it, but requires you to distribute it--more recently their fonts are AGPL or GPL, but this one doesn't seem to be re-licensed and lives on with its old license.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
