### PR TITLE
pipewire: 0.3.52 -> 0.3.54

### DIFF
--- a/nixos/modules/services/desktops/pipewire/daemon/minimal.conf.json
+++ b/nixos/modules/services/desktops/pipewire/daemon/minimal.conf.json
@@ -91,6 +91,7 @@
         "adapter.auto-port-config": {
           "mode": "dsp",
           "monitor": false,
+          "control": false,
           "position": "unknown"
         }
       }
@@ -109,6 +110,7 @@
         "adapter.auto-port-config": {
           "mode": "dsp",
           "monitor": false,
+          "control": false,
           "position": "unknown"
         }
       }

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -2,7 +2,6 @@
 , lib
 , buildPackages
 , fetchFromGitLab
-, fetchpatch
 , removeReferencesTo
 , python3
 , meson
@@ -70,7 +69,7 @@ let
 
   self = stdenv.mkDerivation rec {
     pname = "pipewire";
-    version = "0.3.53";
+    version = "0.3.54";
 
     outputs = [
       "out"
@@ -88,7 +87,7 @@ let
       owner = "pipewire";
       repo = "pipewire";
       rev = version;
-      sha256 = "sha256-mIrBuJ+Lf5kw7xQ6TQ2mRVrdlhyzG0mw0hK9Y7kR1a4=";
+      sha256 = "sha256-EFkx/K5v4f7clFguiU1xFt9VacSHeVksRye73rOjPPI=";
     };
 
     patches = [
@@ -104,14 +103,6 @@ let
       ./0090-pipewire-config-template-paths.patch
       # Place SPA data files in lib output to avoid dependency cycles
       ./0095-spa-data-dir.patch
-
-      # audioconvert: ensure temp buffers are large enough
-      # Fixes a segfault in mpv
-      # Remove when updating past 0.3.53
-      (fetchpatch {
-        url = "https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/9af94508886b19bb398f4e2a777447ca42907c2f.patch";
-        sha256 = "sha256-kmtEAWfA1FrmzSwCcGqvoOreY59kmLRQeByxyrSr8tA=";
-      })
     ];
 
     nativeBuildInputs = [

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -70,7 +70,7 @@ let
 
   self = stdenv.mkDerivation rec {
     pname = "pipewire";
-    version = "0.3.52";
+    version = "0.3.53";
 
     outputs = [
       "out"
@@ -88,7 +88,7 @@ let
       owner = "pipewire";
       repo = "pipewire";
       rev = version;
-      sha256 = "sha256-JWmO36+OF2O9sLB+Z0znwm3TH+O+pEv3cXnuwP6Wy1E=";
+      sha256 = "sha256-mIrBuJ+Lf5kw7xQ6TQ2mRVrdlhyzG0mw0hK9Y7kR1a4=";
     };
 
     patches = [
@@ -104,11 +104,13 @@ let
       ./0090-pipewire-config-template-paths.patch
       # Place SPA data files in lib output to avoid dependency cycles
       ./0095-spa-data-dir.patch
-      # Remove 44.1KHz from allowed rates (multiple regressions reported)
-      # To be removed when 0.3.53 is released
+
+      # audioconvert: ensure temp buffers are large enough
+      # Fixes a segfault in mpv
+      # Remove when updating past 0.3.53
       (fetchpatch {
-        url = "https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/16a7c274989f47b0c0d8ba192a30316b545bd26a.patch";
-        sha256 = "sha256-VZ7ChjcR/PGfmH2DmLxfIhd3mj9668l9zLO4k2KBoqg=";
+        url = "https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/9af94508886b19bb398f4e2a777447ca42907c2f.patch";
+        sha256 = "sha256-kmtEAWfA1FrmzSwCcGqvoOreY59kmLRQeByxyrSr8tA=";
       })
     ];
 


### PR DESCRIPTION
###### Description of changes

https://gitlab.freedesktop.org/pipewire/pipewire/-/releases/0.3.53
https://gitlab.freedesktop.org/pipewire/pipewire/-/releases/0.3.54

###### Things done

Built pipewire itself & tried running the results, didn't try a full system rebuild.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
