### PR TITLE
mpvScripts.youtube-quality: replace with mpvScripts.quality-menu v3.0.1

### DIFF
--- a/pkgs/applications/video/mpv/scripts/quality-menu.nix
+++ b/pkgs/applications/video/mpv/scripts/quality-menu.nix
@@ -5,14 +5,14 @@
 }:
 
 stdenvNoCC.mkDerivation rec {
-  pname = "mpv-youtube-quality";
-  version = "unstable-2020-02-11";
+  pname = "mpv-quality-menu";
+  version = "3.0.1";
 
   src = fetchFromGitHub {
-    owner = "jgreco";
-    repo = "mpv-youtube-quality";
-    rev = "1f8c31457459ffc28cd1c3f3c2235a53efad7148";
-    sha256 = "voNP8tCwCv8QnAZOPC9gqHRV/7jgCAE63VKBd/1s5ic=";
+    owner = "christoph-heinrich";
+    repo = "mpv-quality-menu";
+    rev = "v${version}";
+    sha256 = "sha256-6bZxi+4ZNWL6o/5HnjNnyxag0TWSI+X3MpU9FLXWR7c=";
   };
 
   dontBuild = true;
@@ -20,19 +20,19 @@ stdenvNoCC.mkDerivation rec {
   installPhase = ''
     runHook preInstall
     mkdir -p $out/share/mpv/scripts
-    cp youtube-quality.lua $out/share/mpv/scripts
+    cp quality-menu.lua $out/share/mpv/scripts
   '' + lib.optionalString oscSupport ''
-    cp youtube-quality-osc.lua $out/share/mpv/scripts
+    cp quality-menu-osc.lua $out/share/mpv/scripts
   '' + ''
     runHook postInstall
   '';
 
-  passthru.scriptName = "youtube-quality.lua";
+  passthru.scriptName = "quality-menu.lua";
 
   meta = with lib; {
     description = "A userscript for MPV that allows you to change youtube video quality (ytdl-format) on the fly";
-    homepage = "https://github.com/jgreco/mpv-youtube-quality";
-    license = licenses.unfree;
+    homepage = "https://github.com/christoph-heinrich/mpv-quality-menu";
+    license = licenses.gpl2Only;
     platforms = platforms.all;
     maintainers = with maintainers; [ lunik1 ];
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28691,12 +28691,13 @@ with pkgs;
     mpris = callPackage ../applications/video/mpv/scripts/mpris.nix {};
     mpv-playlistmanager = callPackage ../applications/video/mpv/scripts/mpv-playlistmanager.nix {};
     mpvacious = callPackage ../applications/video/mpv/scripts/mpvacious.nix {};
+    quality-menu = callPackage ../applications/video/mpv/scripts/quality-menu.nix { };
     simple-mpv-webui = callPackage ../applications/video/mpv/scripts/simple-mpv-webui.nix {};
     sponsorblock = callPackage ../applications/video/mpv/scripts/sponsorblock.nix {};
     thumbnail = callPackage ../applications/video/mpv/scripts/thumbnail.nix { };
     vr-reversal = callPackage ../applications/video/mpv/scripts/vr-reversal.nix {};
-    youtube-quality = callPackage ../applications/video/mpv/scripts/youtube-quality.nix { };
     cutter = callPackage ../applications/video/mpv/scripts/cutter.nix { };
+    youtube-quality = throw "youtube-quality is no longer maintained, use quality-menu instead"; # added 2022-12-26
   };
 
   mrpeach = callPackage ../applications/audio/pd-plugins/mrpeach { };


### PR DESCRIPTION
###### Description of changes

This replaces [`mpvScripts.youtube-quality`](https://github.com/jgreco/mpv-youtube-quality) with the maintained fork, [`mpvScripts.quality-menu`](https://github.com/christoph-heinrich/mpv-quality-menu)

I am not sure how to update `aliases.nix` such that an error noting the change is thrown when a user attempts to install `mpvScripts.youtube-quality`. Adding an entry for `mpvScripts.youtube-quality` causes `error: Alias mpvScripts is still in all-packages.nix` to be thrown when _any_ package under mpvScripts is built. Assistance is appreciated, and I am marking this PR as a draft until that issue is resolved.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
