### PR TITLE
quictls: 3.0.3+quick_unstable-2022-05.04 -> 3.0.5+quick_unstable-2022-07.05

### DIFF
--- a/pkgs/development/libraries/quictls/default.nix
+++ b/pkgs/development/libraries/quictls/default.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation rec {
   pname = "quictls";
-  version = "3.0.3+quick_unstable-2022-05.04";
+  version = "3.0.5+quick_unstable-2022-07.05";
 
   src = fetchFromGitHub {
     owner = "quictls";
     repo = "openssl";
-    rev = "368c9d581b17f0bbe425f8dedeaa7b864a7b29ce";
-    sha256 = "sha256-W3bILxhyeziWQNZUHUg/D9eV8LnmHJqEFwyzWjJrRuc=";
+    rev = "75e940831d0570d6b020cfebf128ae500f424867";
+    sha256 = "sha256-1HBGKafcCbM0RZWLvyl3vpSfGBsAcGDgjz1Nm/qclWM=";
   };
 
   patches = [

--- a/pkgs/development/libraries/quictls/default.nix
+++ b/pkgs/development/libraries/quictls/default.nix
@@ -68,6 +68,12 @@ stdenv.mkDerivation rec {
       x86_64-linux = "./Configure linux-x86_64";
       x86_64-solaris = "./Configure solaris64-x86_64-gcc";
       riscv64-linux = "./Configure linux64-riscv64";
+      mips64el-linux =
+        if stdenv.hostPlatform.isMips64n64
+        then "./Configure linux64-mips64"
+        else if stdenv.hostPlatform.isMips64n32
+        then "./Configure linux-mips64"
+        else throw "unsupported ABI for ${stdenv.hostPlatform.system}";
     }.${stdenv.hostPlatform.system} or (
       if stdenv.hostPlatform == stdenv.buildPlatform
         then "./config"


### PR DESCRIPTION
- quictls: 3.0.3+quick_unstable-2022-05.04 -> 3.0.5+quick_unstable-2022-07.05
- quictls: specify the ABI explicitly on mips64
- quictls: disable ct feature in static mode

###### Description of changes
Update quictls to 3.0.4
Cherry picked commits from openssl 3.0.

cc @SuperSandro2000

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
