### PR TITLE
nixos/modules/flake/source-info: new module

### DIFF
--- a/nixos/doc/manual/configuration/flake-source-info.section.md
+++ b/nixos/doc/manual/configuration/flake-source-info.section.md
@@ -1,0 +1,38 @@
+# Flake Configuration Source Information {#sec-flake-source-info}
+
+Perhaps the most significant advantage of a flake-based configuration
+over a legacy configuration is the ability to record the revision of
+the repository from which a NixOS system is built, as shown in the
+following example:
+
+```
+$ nixos-version --json
+{"configurationRevision":"f25d2e456a5a7b2798620e41e183739fdaf057ed"
+,"nixosVersion":"22.11.20220715.a2ec1c5"
+,"nixpkgsRevision":"a2ec1c5fca5f131a26411dd0c18a59fcda3bc974"}
+```
+
+To enable this feature, set
+[](#opt-system.nixos.configuration.sourceInfo) to the source
+information of the flake:
+
+```nix
+{
+  inputs.nixpkgs.url = ...;
+  outputs = { self, nixpkgs }: {
+    nixosConfigurations = {
+      host = nixpkgs.lib.nixosSystem {
+        modules = [
+          { system.nixos.configuration.sourceInfo = self.sourceInfo; }
+        ] ++ ...;
+      };
+    };
+  };
+}
+```
+
+Note that this feature is not enabled by default.  That is because in
+such a case that the repository changes but a specific system's
+configuration, `host` in the above snippet for example, does not
+change, there could be extra unnecessary generations.  Keep this in
+mind while using it.

--- a/nixos/modules/flake/source-info.nix
+++ b/nixos/modules/flake/source-info.nix
@@ -11,14 +11,26 @@ in
     system.nixos.configuration.sourceInfo = mkOption {
       type = types.attrsOf types.anything;
       default = {};
-      example = "self.sourceInfo";
-      description = ''
+      example = lib.literalExpression ''
+      {
+        inputs.nixpkgs.url = ...;
+        outputs = { self, nixpkgs }: {
+          nixosConfigurations = {
+            host = nixpkgs.lib.nixosSystem {
+              modules = [
+                { system.nixos.configuration.sourceInfo = self.sourceInfo; }
+              ] ++ ...;
+            };
+          };
+        };
+      }
+      '';
+      description = lib.mdDoc ''
         The source information of a flake-based NixOS configuration.
-        If set, the attribute <literal>configurationRevision</literal>
-        will appear properly in the output of
-        <literal>nixos-version --json</literal>.
+        If set, the attribute `configurationRevision` will appear
+        properly in the output of `nixos-version --json`.
 
-        Caution: Setting this option may result in unnecessary
+        **Caution:** Setting this option may result in unnecessary
         re-deployments if the flake repository changes but the
         specific system configuration does not change.
       '';

--- a/nixos/modules/flake/source-info.nix
+++ b/nixos/modules/flake/source-info.nix
@@ -1,0 +1,31 @@
+{ config, lib, ... }:
+
+with lib;
+
+let sourceInfo = config.system.nixos.configuration.sourceInfo;
+
+in
+{
+  options = {
+
+    system.nixos.configuration.sourceInfo = mkOption {
+      type = types.attrsOf types.anything;
+      default = {};
+      example = "self.sourceInfo";
+      description = ''
+        The source information of a flake-based NixOS configuration.
+        If set, the attribute <literal>configurationRevision</literal>
+        will appear properly in the output of
+        <literal>nixos-version --json</literal>.
+
+        Caution: Setting this option may result in unnecessary
+        re-deployments if the flake repository changes but the
+        specific system configuration does not change.
+      '';
+    };
+  };
+
+  config = {
+    system.configurationRevision = mkIf (sourceInfo ? rev) sourceInfo.rev;
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -38,6 +38,7 @@
   ./config/users-groups.nix
   ./config/vte.nix
   ./config/zram.nix
+  ./flake/source-info.nix
   ./hardware/acpilight.nix
   ./hardware/all-firmware.nix
   ./hardware/bladeRF.nix


### PR DESCRIPTION
###### Description of changes

This PR introduces a new module that improves `configurationRevision` handling as discussed in #178837.

This option can be set as in the following example:

```
{
  inputs.nixpkgs.url = ...;
  outputs = { self, nixpkgs }: {
    nixosConfigurations = {
      host1 = nixpkgs.lib.nixosSystem {
        system = ...;
        modules = [
          { system.nixos.configuration.sourceInfo = self.sourceInfo; }
        ] ++ ...;
      };
    };
  };
}
```

See more details in the module description.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
