### PR TITLE
datree: 0.15.22 -> 1.5.25

### DIFF
--- a/pkgs/development/tools/datree/default.nix
+++ b/pkgs/development/tools/datree/default.nix
@@ -1,30 +1,47 @@
-{ lib, buildGoModule, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
 
 buildGoModule rec {
   pname = "datree";
-  version = "0.15.22";
+  version = "1.5.25";
 
   src = fetchFromGitHub {
     owner = "datreeio";
     repo = "datree";
     rev = version;
-    hash = "sha256-g5u2QQtVmNp01KtUKwC8uoEIuoBDLHsOlRz1Mv0n/y8=";
+    hash = "sha256-OB5o/ouA6a2/OUnhibTKYCskCFmJIuDcXLrNTNWtNEQ=";
   };
 
-  vendorSha256 = "1cvlvlwdk41f145kzifg7rv7ymwhc9k0ck91bn106240rq1igcr0";
+  vendorSha256 = "sha256-6Ve7Ui90KHsFwRs6/uyjqHgRY6U7zFWijSFcVuOXdEM=";
 
   ldflags = [
+    "-extldflags '-static'"
     "-s"
     "-w"
     "-X github.com/datreeio/datree/cmd.CliVersion=${version}"
   ];
 
+  nativeBuildInputs = [ installShellFiles ];
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/datree version | grep ${version} > /dev/null
+  '';
+
+  postInstall = ''
+    for shell in bash fish zsh; do
+      $out/bin/datree completion $shell > datree.$shell
+      installShellCompletion datree.$shell
+    done
+  '';
+
   doCheck = true;
 
   meta = with lib; {
-    description = "CLI tool to ensure K8s manifests and Helm charts follow best practices as well as your organization’s policies";
+    description =
+      "CLI tool to ensure K8s manifests and Helm charts follow best practices as well as your organization’s policies";
     homepage = "https://datree.io/";
     license = [ licenses.asl20 ];
     maintainers = [ maintainers.jceb ];
+    mainProgram = "datree";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15603,7 +15603,9 @@ with pkgs;
 
   cli11 = callPackage ../development/tools/misc/cli11 { };
 
-  datree = callPackage ../development/tools/datree { };
+  datree = callPackage ../development/tools/datree {
+    buildGoModule = buildGo118Module;
+  };
 
   dcadec = callPackage ../development/tools/dcadec { };
 


### PR DESCRIPTION
###### Description of changes

Bump version.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I tested the main functionality, `datree test`, and it worked without issues for me.

Deprecates https://github.com/NixOS/nixpkgs/pull/172311