### PR TITLE
nixos/desktop-manager: Use literal newline to fix shell syntax

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/default.nix
+++ b/nixos/modules/services/x11/desktop-managers/default.nix
@@ -72,7 +72,9 @@ in
         apply = map (d: d // {
           manage = "desktop";
           start = d.start
-          + optionalString (needBGCond d) ''\n\n
+          # literal newline to ensure d.start's last line is not appended to
+          + optionalString (needBGCond d) ''
+
             if [ -e $HOME/.background-image ]; then
               ${pkgs.feh}/bin/feh --bg-${cfg.wallpaper.mode} ${optionalString cfg.wallpaper.combineScreens "--no-xinerama"} $HOME/.background-image
             fi


### PR DESCRIPTION
Running `nixos/tests/keepassxc.nix` shows:
```
machine # [   18.705390] xsession[985]: /nix/store/2g2jx5c6x3p152wbiijr0rmky7byqivc-xsession: line 13: nn: command not found
```

This garbled bash script runs without `set -o errexit` and thus skips
"\n\n" as invalid command:
```
$ cat -n /nix/store/2g2jx5c6x3p152wbiijr0rmky7byqivc-xsession
...
\n\n
            if [ -e $HOME/.background-image ]; then
              /nix/store/wq1d1ph8wj4alpx78akvpbd0a0m9qkd1-feh-3.8/bin/feh --bg-scale  $HOME/.background-image
            fi
...
```

KeePassXC uses it through
`nixos/modules/services/x11/display-managers/default.nix`:
```
...
        # Script responsible for starting the window manager and the desktop manager.
        xsession = dm: wm: pkgs.writeScript "xsession" ''
          #! ${pkgs.bash}/bin/bash

          # Legacy session script used to construct .desktop files from
          # `services.xserver.displayManager.session` entries. Called from
          # `sessionWrapper`.

          # Start the window manager.
          ${wm.start}

          # Start the desktop manager.
          ${dm.start}
...
        '';
...
```

The bogus line was introduced in PR #160752:
```
commit 0bc0dc8090e6609838816f43dc7799e32c674434
Author: Shaw Vrana <shaw@vranix.com>
Date:   Fri Feb 18 11:27:42 2022 -0800

    desktop manager script: start properly

    Adds a missing line feed when X is enabled to the start script name
    and the appended if check. Resolves #160735
```

I have not tried to reproduce the original issue and thus don't know
why "\n\n" apparently gets interpreted fine in one place but remains
literal the `xsession` case.

However, using a literal newline must be valid for all cases and
certainly fixes the warning seen in KeePassXC tests.

Furthermore, starting the nix string (`''`) with a newline as usual also
fixes its overall indentation.

@svrana @infinisil
