### PR TITLE
openasar: add unzip; remove autoupdater; unstable-2022-06-10 -> unstable-2022-06-27

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/darwin.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/darwin.nix
@@ -1,4 +1,4 @@
-{ pname, version, src, openasar, meta, stdenv, binaryName, desktopName, lib, undmg }:
+{ pname, version, src, openasar, meta, stdenv, binaryName, desktopName, lib, undmg, withOpenASAR }:
 
 stdenv.mkDerivation {
   inherit pname version src meta;
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  postInstall = lib.strings.optionalString (openasar != null) ''
+  postInstall = lib.strings.optionalString withOpenASAR ''
     cp -f ${openasar} $out/Applications/${desktopName}.app/Contents/Resources/app.asar
   '';
 }

--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -62,10 +62,15 @@ let
   };
   package = if stdenv.isLinux then ./linux.nix else ./darwin.nix;
 
-  openasar = if withOpenASAR then callPackage ./openasar.nix { } else null;
+  openasar = callPackage ./openasar.nix { };
 
   packages = (builtins.mapAttrs
-    (_: value: callPackage package (value // { inherit src version openasar; meta = meta // { mainProgram = value.binaryName; }; }))
+    (_: value: callPackage package
+      (value // {
+        inherit src version openasar withOpenASAR;
+        meta = meta // { mainProgram = value.binaryName; };
+      })
+    )
     {
       stable = rec {
         pname = "discord";

--- a/pkgs/applications/networking/instant-messengers/discord/linux.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/linux.nix
@@ -5,7 +5,7 @@
 , libXScrnSaver, libXcomposite, libXcursor, libXdamage, libXext, libXfixes
 , libXi, libXrandr, libXrender, libXtst, libxcb, libxshmfence, mesa, nspr, nss
 , pango, systemd, libappindicator-gtk3, libdbusmenu, writeScript
-, common-updater-scripts }:
+, common-updater-scripts, withOpenASAR }:
 
 stdenv.mkDerivation rec {
   inherit pname version src meta;
@@ -101,7 +101,7 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  postInstall = lib.strings.optionalString (openasar != null) ''
+  postInstall = lib.strings.optionalString withOpenASAR ''
     cp -f ${openasar} $out/opt/${binaryName}/resources/app.asar
   '';
 


### PR DESCRIPTION
###### Description of changes

- Hardcodes unzip to solve [the issue @fufexan found](https://github.com/NixOS/nixpkgs/pull/178507#issuecomment-1171629376);
- Removes the auto-updaters since we're using our own build in a read-only directory;
- Bump the version, though that does not change anything on linux/darwin (there are just fixes for win32).


###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
