### PR TITLE
gitlab: 15.1.0 -> 15.1.1

### DIFF
--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -1,14 +1,14 @@
 {
-  "version": "15.1.0",
-  "repo_hash": "sha256-vOPI9kxdJlQNmI/DZueFcbvZPy2/0d+2CYM/RBAkIcU=",
+  "version": "15.1.1",
+  "repo_hash": "sha256-wCO0Ksi5c8kgerpK/O3IkI6CJARQbQj9nWmnxBVhBIM=",
   "yarn_hash": "19df16gk0vpvdi1idqaakaglf11cic93i5njw0x4m2cnsznhpvz4",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v15.1.0-ee",
+  "rev": "v15.1.1-ee",
   "passthru": {
-    "GITALY_SERVER_VERSION": "15.1.0",
+    "GITALY_SERVER_VERSION": "15.1.1",
     "GITLAB_PAGES_VERSION": "1.59.0",
     "GITLAB_SHELL_VERSION": "14.7.4",
-    "GITLAB_WORKHORSE_VERSION": "15.1.0"
+    "GITLAB_WORKHORSE_VERSION": "15.1.1"
   }
 }

--- a/pkgs/applications/version-management/gitlab/gitaly/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/default.nix
@@ -11,7 +11,7 @@ let
     gemdir = ./.;
   };
 
-  version = "15.1.0";
+  version = "15.1.1";
   package_version = "v${lib.versions.major version}";
   gitaly_package = "gitlab.com/gitlab-org/gitaly/${package_version}";
 in
@@ -24,7 +24,7 @@ buildGoModule {
     owner = "gitlab-org";
     repo = "gitaly";
     rev = "v${version}";
-    sha256 = "sha256-rhMQRskum4c5bQL1sE7O4gMxIGX7q3bntuV1HkttA8M=";
+    sha256 = "sha256-JMKB6lrmQBbBgXSKinL2shlXRXhZrf4QwoJrm+VpKdE=";
   };
 
   vendorSha256 = "sha256-0JWJ2mpf79gJdnNRdlQLi0oDvnj6VmibkW2XcPnaCww=";

--- a/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
@@ -5,7 +5,7 @@ in
 buildGoModule rec {
   pname = "gitlab-workhorse";
 
-  version = "15.1.0";
+  version = "15.1.1";
 
   src = fetchFromGitLab {
     owner = data.owner;


### PR DESCRIPTION
###### Description of changes
https://about.gitlab.com/releases/2022/06/30/critical-security-release-gitlab-15-1-1-released/

Fixes [CVE-2022-2185](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-2185) 
Fixes [CVE-2022-2235 ](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-2235)
Fixes [CVE-2022-2230](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-2230)
Fixes [CVE-2022-2229](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-2229)
Fixes [CVE-2022-1983](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1983)
Fixes [CVE-2022-1963](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1963)
Fixes [CVE-2022-2228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-2228)
Fixes [CVE-2022-1981](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1981)
Fixes [CVE-2022-2243](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-2243)
Fixes [CVE-2022-2244](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-2244)
Fixes [CVE-2022-1954](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1954)
Fixes [CVE-2022-2270](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-2270)
Fixes [CVE-2022-2250](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-2250)
Fixes [CVE-2022-1999](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1999)
Fixes [CVE-2022-2281](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-2281)
Fixes [CVE-2022-2227](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-2227)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
