### PR TITLE
beauty-line-icon-theme: 0.0.1 -> 0.0.4

### DIFF
--- a/pkgs/data/icons/beauty-line-icon-theme/default.nix
+++ b/pkgs/data/icons/beauty-line-icon-theme/default.nix
@@ -1,16 +1,32 @@
-{ lib, stdenvNoCC, fetchzip, breeze-icons, gtk3, gnome-icon-theme, hicolor-icon-theme, mint-x-icons, pantheon }:
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, breeze-icons
+, gtk3
+, gnome-icon-theme
+, hicolor-icon-theme
+, mint-x-icons
+, pantheon
+, jdupes
+}:
 
 stdenvNoCC.mkDerivation rec {
   pname = "BeautyLine";
-  version = "0.0.1";
+  version = "0.0.4";
 
-  src = fetchzip {
-    name = "${pname}-${version}";
-    url = "https://github.com/gvolpe/BeautyLine/releases/download/${version}/BeautyLine.tar.gz";
-    sha256 = "030bjk333fr9wm1nc740q8i31rfsgf3vg6cvz36xnvavx3q363l7";
+  src = fetchFromGitHub {
+    owner = "gvolpe";
+    repo = pname;
+    rev = version;
+    sparseCheckout = ''
+      BeautyLine-V3
+    '';
+    sha256 = "sha256-gFqGsni0tb5K/y0dzKmX9BirB3KCvqLkGyopBKf7ZwM=";
   };
 
-  nativeBuildInputs = [ gtk3 ];
+  sourceRoot = "${src.name}/BeautyLine-V3";
+
+  nativeBuildInputs = [ jdupes gtk3 ];
 
   # ubuntu-mono is also required but missing in ubuntu-themes (please add it if it is packaged at some point)
   propagatedBuildInputs = [
@@ -23,10 +39,19 @@ stdenvNoCC.mkDerivation rec {
 
   dontDropIconThemeCache = true;
 
+  dontPatchELF = true;
+  dontRewriteSymlinks = true;
+
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/icons/${pname}
     cp -r * $out/share/icons/${pname}/
     gtk-update-icon-cache $out/share/icons/${pname}
+
+    jdupes --link-soft --recurse $out/share
+
+    runHook postInstall
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes
Update to the latest upstream release [0.0.4](https://github.com/gvolpe/BeautyLine/releases/tag/0.0.4).

Includes some refactoring partly inspired by [tela-circle-icon-theme](https://github.com/NixOS/nixpkgs/blob/522cdaaf0602274d2111e2291fa11282c2adc2a3/pkgs/data/icons/tela-circle-icon-theme/default.nix):
- use `stdenvNoCC` instead of `stdenv`
- use `fetchFromGitHub` instead of `fetchzip` for fetching the release from GitHub
- the newest release is located in the subdirectory `BeautyLine-V3`, so we fetch only this folder via `sparseCheckout` and set it as source root
- run `preInstall` and `postInstall` hooks in the `installPhase`
- deduplicate files with `jdupes`
- set
  ```nix
  dontPatchELF = true;
  dontRewriteSymlinks = true;
  ```
  These fixup steps are slow and unnecessary for this package.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).