### PR TITLE
mutt: 2.2.5 -> 2.2.6

### DIFF
--- a/pkgs/applications/networking/mailreaders/mutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/mutt/default.nix
@@ -14,45 +14,37 @@
 , imapSupport  ? true
 , withSidebar  ? true
 , gssSupport   ? true
+, writeScript
 }:
-
-assert headerCache  -> gdbm       != null;
-assert sslSupport   -> openssl    != null;
-assert saslSupport  -> cyrus_sasl != null;
-assert smimeSupport -> openssl    != null;
-assert gpgSupport   -> gnupg      != null;
-assert gpgmeSupport -> gpgme      != null && openssl != null;
-
-with lib;
 
 stdenv.mkDerivation rec {
   pname = "mutt";
-  version = "2.2.5";
+  version = "2.2.6";
   outputs = [ "out" "doc" "info" ];
 
   src = fetchurl {
     url = "http://ftp.mutt.org/pub/mutt/${pname}-${version}.tar.gz";
-    sha256 = "0ivyfld4a4sfzsdiaajqiarvfx4i85g1smbb2b5dqjkrb48pi2zz";
+    sha256 = "/6LZNRfPxgb+Adr/xfEuQgYqHBNNO5r3hITrxUMIiNM=";
   };
 
-  patches = optional smimeSupport (fetchpatch {
+  patches = lib.optional smimeSupport (fetchpatch {
     url = "https://salsa.debian.org/mutt-team/mutt/raw/debian/1.10.1-2/debian/patches/misc/smime.rc.patch";
     sha256 = "0b4i00chvx6zj9pcb06x2jysmrcb2znn831lcy32cgfds6gr3nsi";
   });
 
   buildInputs =
     [ ncurses which perl ]
-    ++ optional headerCache  gdbm
-    ++ optional sslSupport   openssl
-    ++ optional gssSupport   libkrb5
-    ++ optional saslSupport  cyrus_sasl
-    ++ optional gpgmeSupport gpgme;
+    ++ lib.optional headerCache  gdbm
+    ++ lib.optional sslSupport   openssl
+    ++ lib.optional gssSupport   libkrb5
+    ++ lib.optional saslSupport  cyrus_sasl
+    ++ lib.optional gpgmeSupport gpgme;
 
   configureFlags = [
-    (enableFeature headerCache  "hcache")
-    (enableFeature gpgmeSupport "gpgme")
-    (enableFeature imapSupport  "imap")
-    (enableFeature withSidebar  "sidebar")
+    (lib.enableFeature headerCache  "hcache")
+    (lib.enableFeature gpgmeSupport "gpgme")
+    (lib.enableFeature imapSupport  "imap")
+    (lib.enableFeature withSidebar  "sidebar")
     "--enable-smtp"
     "--enable-pop"
     "--with-mailpath="
@@ -67,27 +59,41 @@ stdenv.mkDerivation rec {
     # set by the installer, and removing the need for the group 'mail'
     # I set the value 'mailbox' because it is a default in the configure script
     "--with-homespool=mailbox"
-  ] ++ optional sslSupport  "--with-ssl"
-    ++ optional gssSupport  "--with-gss"
-    ++ optional saslSupport "--with-sasl";
+  ] ++ lib.optional sslSupport  "--with-ssl"
+    ++ lib.optional gssSupport  "--with-gss"
+    ++ lib.optional saslSupport "--with-sasl";
 
-  postPatch = optionalString (smimeSupport || gpgmeSupport) ''
+  postPatch = lib.optionalString (smimeSupport || gpgmeSupport) ''
     sed -i 's#/usr/bin/openssl#${openssl}/bin/openssl#' smime_keys.pl
   '';
 
-  postInstall = optionalString smimeSupport ''
+  postInstall = lib.optionalString smimeSupport ''
     # S/MIME setup
     cp contrib/smime.rc $out/etc/smime.rc
     sed -i 's#openssl#${openssl}/bin/openssl#' $out/etc/smime.rc
     echo "source $out/etc/smime.rc" >> $out/etc/Muttrc
-  '' + optionalString gpgSupport ''
+  '' + lib.optionalString gpgSupport ''
     # GnuPG setup
     cp contrib/gpg.rc $out/etc/gpg.rc
     sed -i 's#\(command="\)gpg #\1${gnupg}/bin/gpg #' $out/etc/gpg.rc
     echo "source $out/etc/gpg.rc" >> $out/etc/Muttrc
   '';
 
-  meta = {
+  passthru = {
+    updateScript = writeScript "update-mutt" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p curl pcre common-updater-scripts
+
+      set -euo pipefail
+
+      # Expect the text in format of "The current stable public release version is 2.2.6."
+      new_version="$(curl -s http://www.mutt.org/download.html |
+          pcregrep -o1 'The current stable public release version is ([0-9.]+).')"
+      update-source-version ${pname} "$new_version"
+    '';
+  };
+
+  meta = with lib; {
     description = "A small but very powerful text-based mail client";
     homepage = "http://www.mutt.org";
     license = licenses.gpl2Plus;


### PR DESCRIPTION
While at it added trivial updater script.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
