### PR TITLE
Update iosevka-comfy to 0.2.1

### DIFF
--- a/pkgs/data/fonts/iosevka/comfy-private-build-plans.toml
+++ b/pkgs/data/fonts/iosevka/comfy-private-build-plans.toml
@@ -1,5 +1,5 @@
 # The file below is copy/pasted from
-# https://github.com/protesilaos/iosevka-comfy/blob/0.1.0/private-build-plans.toml. It
+# https://raw.githubusercontent.com/protesilaos/iosevka-comfy/0.2.1/private-build-plans.toml. It
 # seems like ofborg will prevent me from using fetchurl to download
 # this file automatically.
 [buildPlans.iosevka-comfy]       # <iosevka-comfy> is your plan name
@@ -303,9 +303,19 @@ serifs = "sans"
 [buildPlans.iosevka-comfy-duo.variants]
 inherits = "buildPlans.iosevka-comfy"
 
-# The short middle leg in 'm' that we need in the narrow monospaced
-# variants is necessary for legibility, especially at small point sizes.
-# Otherwise it is a gimmick, so we remove it in the "wider" builds.
+# The '0' has a forward slash that cuts diagonally through the middle of
+# the circle, connecting the bottom left part to the top right of the
+# oval shape.  Whereas the narrow variants have a dashed forward slash
+# which does not connect the two sides as it is positioned inside the
+# oval shape.
+[buildPlans.iosevka-comfy-duo.variants.design]
+cv71 = 9    # 0 oval forward slash
+
+# The 'm' character has three legs of equal length, insetad of a shorter
+# middle leg.  The short middle leg in the narrow variants is necessary
+# for legibility, especially at small point sizes (otherwise the
+# character's legs visually blend into what appears to be a solid
+# block).
 [buildPlans.iosevka-comfy-duo.variants.upright]
 cv38 = 5    # m earless normal middle leg
 
@@ -371,9 +381,19 @@ serifs = "sans"
 [buildPlans.iosevka-comfy-wide.variants]
 inherits = "buildPlans.iosevka-comfy"
 
-# The short middle leg in 'm' that we need in the narrow monospaced
-# variants is necessary for legibility, especially at small point sizes.
-# Otherwise it is a gimmick, so we remove it in the "wider" builds.
+# The '0' has a forward slash that cuts diagonally through the middle of
+# the circle, connecting the bottom left part to the top right of the
+# oval shape.  Whereas the narrow variants have a dashed forward slash
+# which does not connect the two sides as it is positioned inside the
+# oval shape.
+[buildPlans.iosevka-comfy-wide.variants.design]
+cv71 = 9    # 0 oval forward slash
+
+# The 'm' character has three legs of equal length, insetad of a shorter
+# middle leg.  The short middle leg in the narrow variants is necessary
+# for legibility, especially at small point sizes (otherwise the
+# character's legs visually blend into what appears to be a solid
+# block).
 [buildPlans.iosevka-comfy-wide.variants.upright]
 cv38 = 5    # m earless normal middle leg
 

--- a/pkgs/data/fonts/iosevka/comfy.nix
+++ b/pkgs/data/fonts/iosevka/comfy.nix
@@ -1,10 +1,10 @@
 {stdenv, lib, nodejs, nodePackages, remarshal, ttfautohint-nox, fetchurl}:
 
 let
-  sets = [ "comfy" "comfy-duo" "comfy-wide" "comfy-wide-fixed"];
+  sets = [ "comfy" "comfy-fixed" "comfy-duo" "comfy-wide" "comfy-wide-fixed" ];
   privateBuildPlan = builtins.readFile ./comfy-private-build-plans.toml;
   overrideAttrs = (attrs: {
-    version = "0.1.0";
+    version = "0.2.1";
 
     passthru = {
       updateScript = ./update-comfy.sh;

--- a/pkgs/data/fonts/iosevka/comfy.nix
+++ b/pkgs/data/fonts/iosevka/comfy.nix
@@ -5,6 +5,11 @@ let
   privateBuildPlan = builtins.readFile ./comfy-private-build-plans.toml;
   overrideAttrs = (attrs: {
     version = "0.1.0";
+
+    passthru = {
+      updateScript = ./update-comfy.sh;
+    };
+
     meta = with lib; {
       homepage = "https://github.com/protesilaos/iosevka-comfy";
       description = ''

--- a/pkgs/data/fonts/iosevka/update-comfy.sh
+++ b/pkgs/data/fonts/iosevka/update-comfy.sh
@@ -1,0 +1,33 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p curl jq
+
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+repo=protesilaos/iosevka-comfy
+oldVersion=$(nix-instantiate --eval -E 'with import ../../../.. {}; lib.getVersion iosevka-comfy.comfy' | tr -d \")
+version=$(curl -s https://api.github.com/repos/$repo/tags | jq '.[0].name' | tr -d \")
+buildPlansUrl=https://raw.githubusercontent.com/$repo/$(echo $version)/private-build-plans.toml
+
+if test "$oldVersion" = "$version"; then
+    echo "New version same as old version, nothing to do." >&2
+    exit 0
+fi
+
+sed --in-place "s/$oldVersion/$version/" comfy.nix
+
+cat  > ./comfy-private-build-plans.toml <<EOF
+# The file below is copy/pasted from
+# $buildPlansUrl. It
+# seems like ofborg will prevent me from using fetchurl to download
+# this file automatically.
+EOF
+
+wget --quiet --output-document=- "$buildPlansUrl" >> ./comfy-private-build-plans.toml
+
+sets=$(grep '^\[buildPlans\.iosevka-comfy[^.]*\]' comfy-private-build-plans.toml \
+           | sed 's/^.*iosevka-\(comfy[^]]*\)].*$/"\1" /' \
+           | tr -d '\n' \
+           | sort)
+
+sed --in-place "s/sets = .*$/sets = [ $sets];/" comfy.nix


### PR DESCRIPTION
###### Description of changes

Changelog: https://github.com/protesilaos/iosevka-comfy/releases/tag/0.2.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
