### PR TITLE
pythonPackages.klein: don't mark as broken

### DIFF
--- a/pkgs/development/python-modules/klein/default.nix
+++ b/pkgs/development/python-modules/klein/default.nix
@@ -60,6 +60,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/twisted/klein";
     license = licenses.mit;
     maintainers = with maintainers; [ exarkun ];
-    broken = (stdenv.isLinux && stdenv.isAarch64) || stdenv.isDarwin;
   };
 }


### PR DESCRIPTION
#### Copy of commit msg
The package was fixed for all systems in da4f4e183c1dde9c8481d4719df2c518ea9fa34a.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux