### PR TITLE
netdata: update build options, build with jemalloc

### DIFF
--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -7,6 +7,7 @@
 , withIpmi ? (!stdenv.isDarwin), freeipmi
 , withNetfilter ? (!stdenv.isDarwin), libmnl, libnetfilter_acct
 , withCloud ? (!stdenv.isDarwin), json_c
+, withConnPrometheus ? false, snappy
 , withSsl ? true, openssl
 , withDebug ? false
 }:
@@ -37,7 +38,9 @@ in stdenv.mkDerivation rec {
     ++ optionals withDBengine [ judy lz4.dev ]
     ++ optionals withIpmi [ freeipmi ]
     ++ optionals withNetfilter [ libmnl libnetfilter_acct ]
-    ++ optionals withCloud [ json_c protobuf ]
+    ++ optionals withCloud [ json_c ]
+    ++ optionals withConnPrometheus [ snappy ]
+    ++ optionals (withCloud || withConnPrometheus) [ protobuf ]
     ++ optionals withSsl [ openssl.dev ];
 
   patches = [

--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -30,14 +30,14 @@ in stdenv.mkDerivation rec {
   strictDeps = true;
 
   nativeBuildInputs = [ autoreconfHook pkg-config makeWrapper protobuf ];
-  buildInputs = [ curl.dev zlib.dev protobuf libuv ]
+  buildInputs = [ curl.dev zlib.dev libuv ]
     ++ optionals stdenv.isDarwin [ CoreFoundation IOKit libossp_uuid ]
     ++ optionals (!stdenv.isDarwin) [ libcap.dev libuuid.dev ]
     ++ optionals withCups [ cups ]
     ++ optionals withDBengine [ judy lz4.dev ]
     ++ optionals withIpmi [ freeipmi ]
     ++ optionals withNetfilter [ libmnl libnetfilter_acct ]
-    ++ optionals withCloud [ json_c ]
+    ++ optionals withCloud [ json_c protobuf ]
     ++ optionals withSsl [ openssl.dev ];
 
   patches = [
@@ -94,9 +94,8 @@ in stdenv.mkDerivation rec {
     "--disable-ebpf"
   ] ++ optional (!withDBengine) [
     "--disable-dbengine"
-  ] ++ optionals withCloud [
-    "--enable-cloud"
-    "--with-aclk-ng"
+  ] ++ optional (!withCloud) [
+    "--disable-cloud"
   ];
 
   postFixup = ''

--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -7,6 +7,7 @@
 , withIpmi ? (!stdenv.isDarwin), freeipmi
 , withNetfilter ? (!stdenv.isDarwin), libmnl, libnetfilter_acct
 , withCloud ? (!stdenv.isDarwin), json_c
+, withConnPubSub ? false, google-cloud-cpp, grpc
 , withConnPrometheus ? false, snappy
 , withSsl ? true, openssl
 , withDebug ? false
@@ -39,6 +40,7 @@ in stdenv.mkDerivation rec {
     ++ optionals withIpmi [ freeipmi ]
     ++ optionals withNetfilter [ libmnl libnetfilter_acct ]
     ++ optionals withCloud [ json_c ]
+    ++ optionals withConnPubSub [ google-cloud-cpp grpc ]
     ++ optionals withConnPrometheus [ snappy ]
     ++ optionals (withCloud || withConnPrometheus) [ protobuf ]
     ++ optionals withSsl [ openssl.dev ];

--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -1,9 +1,9 @@
 { lib, stdenv, callPackage, fetchFromGitHub, autoreconfHook, pkg-config, makeWrapper
 , CoreFoundation, IOKit, libossp_uuid
 , nixosTests
-, curl, libcap, libuuid, lm_sensors, zlib, protobuf
+, curl, libcap, libuuid, lm_sensors, zlib, protobuf, libuv
 , withCups ? false, cups
-, withDBengine ? true, libuv, lz4, judy
+, withDBengine ? true, judy, lz4
 , withIpmi ? (!stdenv.isDarwin), freeipmi
 , withNetfilter ? (!stdenv.isDarwin), libmnl, libnetfilter_acct
 , withCloud ? (!stdenv.isDarwin), json_c
@@ -30,11 +30,11 @@ in stdenv.mkDerivation rec {
   strictDeps = true;
 
   nativeBuildInputs = [ autoreconfHook pkg-config makeWrapper protobuf ];
-  buildInputs = [ curl.dev zlib.dev protobuf ]
+  buildInputs = [ curl.dev zlib.dev protobuf libuv ]
     ++ optionals stdenv.isDarwin [ CoreFoundation IOKit libossp_uuid ]
     ++ optionals (!stdenv.isDarwin) [ libcap.dev libuuid.dev ]
     ++ optionals withCups [ cups ]
-    ++ optionals withDBengine [ libuv lz4.dev judy ]
+    ++ optionals withDBengine [ judy lz4.dev ]
     ++ optionals withIpmi [ freeipmi ]
     ++ optionals withNetfilter [ libmnl libnetfilter_acct ]
     ++ optionals withCloud [ json_c ]
@@ -92,6 +92,8 @@ in stdenv.mkDerivation rec {
     "--localstatedir=/var"
     "--sysconfdir=/etc"
     "--disable-ebpf"
+  ] ++ optional (!withDBengine) [
+    "--disable-dbengine"
   ] ++ optionals withCloud [
     "--enable-cloud"
     "--with-aclk-ng"

--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -1,7 +1,8 @@
 { lib, stdenv, callPackage, fetchFromGitHub, autoreconfHook, pkg-config, makeWrapper
 , CoreFoundation, IOKit, libossp_uuid
 , nixosTests
-, curl, libcap, libuuid, lm_sensors, zlib, protobuf, libuv
+, curl, jemalloc, libuv, zlib
+, libcap, libuuid, lm_sensors, protobuf
 , withCups ? false, cups
 , withDBengine ? true, judy, lz4
 , withIpmi ? (!stdenv.isDarwin), freeipmi
@@ -32,7 +33,7 @@ in stdenv.mkDerivation rec {
   strictDeps = true;
 
   nativeBuildInputs = [ autoreconfHook pkg-config makeWrapper protobuf ];
-  buildInputs = [ curl.dev zlib.dev libuv ]
+  buildInputs = [ curl.dev jemalloc libuv zlib.dev ]
     ++ optionals stdenv.isDarwin [ CoreFoundation IOKit libossp_uuid ]
     ++ optionals (!stdenv.isDarwin) [ libcap.dev libuuid.dev ]
     ++ optionals withCups [ cups ]
@@ -97,6 +98,7 @@ in stdenv.mkDerivation rec {
     "--localstatedir=/var"
     "--sysconfdir=/etc"
     "--disable-ebpf"
+    "--with-jemalloc=${jemalloc}"
   ] ++ optional (!withDBengine) [
     "--disable-dbengine"
   ] ++ optional (!withCloud) [


### PR DESCRIPTION
###### Description of changes
Updating build configuration.
Now netdata build with jemmaloc memory allocator.
Added options to enable prometheus and pub/sub exporting connectors.

cc @wmertens @SuperSandro2000

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
