### PR TITLE
ocamlPackages.atdgen: 2.4.1 → 2.9.1

### DIFF
--- a/pkgs/development/ocaml-modules/atd/default.nix
+++ b/pkgs/development/ocaml-modules/atd/default.nix
@@ -1,4 +1,4 @@
-{ lib, atdgen-codec-runtime, menhir, easy-format, buildDunePackage, which, re, nixosTests }:
+{ lib, atdgen-codec-runtime, menhir, easy-format, buildDunePackage, re, yojson, nixosTests }:
 
 buildDunePackage rec {
   pname = "atd";
@@ -6,9 +6,8 @@ buildDunePackage rec {
 
   minimalOCamlVersion = "4.08";
 
-  nativeBuildInputs = [ which menhir ];
-  buildInputs = [ re ];
-  propagatedBuildInputs = [ easy-format ];
+  nativeBuildInputs = [ menhir ];
+  propagatedBuildInputs = [ easy-format re yojson ];
 
   strictDeps = true;
 

--- a/pkgs/development/ocaml-modules/atdgen/codec-runtime.nix
+++ b/pkgs/development/ocaml-modules/atdgen/codec-runtime.nix
@@ -2,11 +2,11 @@
 
 buildDunePackage rec {
   pname = "atdgen-codec-runtime";
-  version = "2.4.1";
+  version = "2.9.1";
 
   src = fetchurl {
-    url = "https://github.com/ahrefs/atd/releases/download/${version}/atdgen-codec-runtime-${version}.tbz";
-    sha256 = "sha256:16888rnvhgh5yxxsnzsj10g5pzs1l4dn27n23kk2f4641dn26s3a";
+    url = "https://github.com/ahrefs/atd/releases/download/${version}/atdts-${version}.tbz";
+    sha256 = "sha256-OdwaUR0Ix0Oz8NDm36nIyvIRzF+r/pKgiej1fhcOmuQ=";
   };
 
   meta = {

--- a/pkgs/development/ocaml-modules/atdgen/default.nix
+++ b/pkgs/development/ocaml-modules/atdgen/default.nix
@@ -1,4 +1,6 @@
-{ buildDunePackage, alcotest, atd, atdgen-codec-runtime, atdgen-runtime, biniou, re, yojson }:
+{ buildDunePackage, alcotest, atd, atdgen-codec-runtime, atdgen-runtime, biniou, re, yojson
+, python3
+}:
 
 buildDunePackage {
   pname = "atdgen";
@@ -9,7 +11,9 @@ buildDunePackage {
   propagatedBuildInputs = [ atdgen-runtime ];
 
   doCheck = true;
-  checkInputs = [ alcotest atdgen-codec-runtime ];
+  checkInputs = [ alcotest atdgen-codec-runtime
+    (python3.withPackages (ps: [ ps.jsonschema ]))
+  ];
 
   meta = (builtins.removeAttrs atd.meta [ "mainProgram" ]) // {
     description = "Generates efficient JSON serializers, deserializers and validators";


### PR DESCRIPTION
###### Description of changes

https://github.com/ahrefs/atd/blob/2.9.1/CHANGES.md#291-2022-06-10

cc maintainer @aij

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
