### PR TITLE
hplip: 3.21.12 -> 3.22.6

### DIFF
--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, substituteAll
-, pkg-config
+, pkg-config, autoreconfHook
 , cups, zlib, libjpeg, libusb1, python3Packages, sane-backends
 , dbus, file, ghostscript, usbutils
 , net-snmp, openssl, perl, nettools, avahi
@@ -14,16 +14,16 @@
 let
 
   pname = "hplip";
-  version = "3.21.12";
+  version = "3.22.6";
 
   src = fetchurl {
     url = "mirror://sourceforge/hplip/${pname}-${version}.tar.gz";
-    sha256 = "sha256-fvRSPvgbztcVFeHIhA72xoxgJjjBWebdmpJpHO7GT5w=";
+    sha256 = "sha256-J+0NSS/rsLR8ZWI0gg085XOyT/W2Ljv0ssR/goaNa7Q=";
   };
 
   plugin = fetchurl {
     url = "https://developers.hp.com/sites/default/files/${pname}-${version}-plugin.run";
-    sha256 = "sha256-eyYNhuff8mM4IpRfn/fLBjQJ23JrTdsHBQ/EH7Ug0gw=";
+    sha256 = "sha256-MSQCPnSXVLrXS1nPIIvlUx0xshbyU0OlpfLOghZMgvs=";
   };
 
   hplipState = substituteAll {
@@ -71,6 +71,7 @@ python3Packages.buildPythonApplication {
   nativeBuildInputs = [
     pkg-config
     removeReferencesTo
+    autoreconfHook
   ] ++ lib.optional withQt5 qt5.wrapQtAppsHook;
 
   pythonPath = with python3Packages; [
@@ -96,6 +97,15 @@ python3Packages.buildPythonApplication {
     # don't on NixOS).  Add the equivalent NixOS path, /var/lib/cups/path/share.
     # See: https://github.com/NixOS/nixpkgs/issues/21796
     ./hplip-3.20.11-nixos-cups-ppd-search-path.patch
+
+    # Remove all ImageProcessor functionality since that is closed source
+    (fetchurl {
+      url = "https://sources.debian.org/data/main/h/hplip/3.22.4%2Bdfsg0-1/debian/patches/0028-Remove-ImageProcessor-binary-installs.patch";
+      sha256 = "sha256:18njrq5wrf3fi4lnpd1jqmaqr7ph5d7jxm7f15b1wwrbxir1rmml";
+    })
+
+    # Revert changes that break compilation under -Werror=format-security
+    ./revert-snprintf-change.patch
   ];
 
   postPatch = ''
@@ -118,6 +128,8 @@ python3Packages.buildPythonApplication {
       -e s,/usr/share/cups/fonts,${ghostscript}/share/ghostscript/fonts,g \
       -e "s,ExecStart=/usr/bin/python /usr/bin/hp-config_usb_printer,ExecStart=$out/bin/hp-config_usb_printer,g" \
       {} +
+
+    echo 'AUTOMAKE_OPTIONS = foreign' >> Makefile.am
   '';
 
   configureFlags = let out = placeholder "out"; in

--- a/pkgs/misc/drivers/hplip/revert-snprintf-change.patch
+++ b/pkgs/misc/drivers/hplip/revert-snprintf-change.patch
@@ -1,0 +1,61 @@
+commit f103a260215016fc035bc1399c8accabf83b0264
+Author: Claudio Bley <claudio.bley@gmail.com>
+Date:   Fri Jul 1 22:29:05 2022 +0200
+
+    Revert change to hp_ipp.c from 3.22.{4 -> 6}
+    
+    This fails compilation:
+    ```
+    protocol/hp_ipp.c: In function ‘addCupsPrinter’:
+    protocol/hp_ipp.c:113:9: error: format not a string literal and no format arguments [-Werror=format-security]
+      113 |         snprintf( info,sizeof(info), name );
+          |         ^~~~~~~~
+    ```
+
+diff --git a/protocol/hp_ipp.c b/protocol/hp_ipp.c
+index 97d827d..af7013b 100644
+--- a/protocol/hp_ipp.c
++++ b/protocol/hp_ipp.c
+@@ -110,7 +110,7 @@ int addCupsPrinter(char *name, char *device_uri, char *location, char *ppd_file,
+      }
+ 
+      if ( info == NULL )
+-        snprintf( info,sizeof(info), name );
++        strcpy( info, name );
+ 
+      sprintf( printer_uri, "ipp://localhost/printers/%s", name );
+ 
+@@ -511,27 +511,27 @@ int __parsePrinterAttributes(ipp_t *response, printer_t **printer_list)
+ 
+              if ( strcmp(attr_name, "printer-name") == 0 &&
+                                         val_tag == IPP_TAG_NAME ) {
+-                  snprintf(t_printer->name, sizeof(t_printer->name),ippGetString(attr, 0, NULL) );
++                  strcpy(t_printer->name, ippGetString(attr, 0, NULL) );
+              }
+              else if ( strcmp(attr_name, "device-uri") == 0 &&
+                                          val_tag == IPP_TAG_URI ) {
+-                  snprintf(t_printer->device_uri,sizeof(t_printer->device_uri), ippGetString(attr, 0, NULL) );
++                  strcpy(t_printer->device_uri, ippGetString(attr, 0, NULL) );
+              }
+              else if ( strcmp(attr_name, "printer-uri-supported") == 0 &&
+                                                  val_tag == IPP_TAG_URI ) {
+-                  snprintf(t_printer->printer_uri,sizeof(t_printer->printer_uri), ippGetString(attr, 0, NULL) );
++                  strcpy(t_printer->printer_uri, ippGetString(attr, 0, NULL) );
+              }
+              else if ( strcmp(attr_name, "printer-info") == 0 &&
+                                         val_tag == IPP_TAG_TEXT ) {
+-                  snprintf(t_printer->info,sizeof(t_printer->info), ippGetString(attr, 0, NULL) );
++                  strcpy(t_printer->info, ippGetString(attr, 0, NULL) );
+              }
+              else if ( strcmp(attr_name, "printer-location") == 0 &&
+                                            val_tag == IPP_TAG_TEXT ) {
+-                  snprintf(t_printer->location,sizeof(t_printer->location),ippGetString(attr, 0, NULL) );
++                  strcpy(t_printer->location, ippGetString(attr, 0, NULL) );
+              }
+              else if ( strcmp(attr_name, "printer-make-and-model") == 0 &&
+                                                   val_tag == IPP_TAG_TEXT ) {
+-                  snprintf(t_printer->make_model,sizeof(t_printer->make_model),ippGetString(attr, 0, NULL) );
++                  strcpy(t_printer->make_model, ippGetString(attr, 0, NULL) );
+              } 
+              else if ( strcmp(attr_name, "printer-state") == 0 &&
+                                              val_tag == IPP_TAG_ENUM ) {


### PR DESCRIPTION
###### Description of changes

Update the hplip package to the latest release.

* add patch from Debian which removes closed-source binary blobs from the package and fixes the build on aarch64-linux
* add patch that reverts calls of `strcpy` replaced with `snprintf`

Fixes #162141.

The official release notes are not very detailed: https://developers.hp.com/hp-linux-imaging-and-printing/release_notes

They added support for a lot new printers.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


Thank you @simplejack-src for the workaround!