### PR TITLE
geopard: init at 1.2.0

### DIFF
--- a/pkgs/applications/networking/browsers/geopard/default.nix
+++ b/pkgs/applications/networking/browsers/geopard/default.nix
@@ -1,0 +1,72 @@
+{ stdenv
+, glib
+, gtk4
+, libadwaita
+, pango
+, rustPlatform
+, openssl
+, pkg-config
+, lib
+, wrapGAppsHook4
+, meson
+, ninja
+, desktop-file-utils
+, blueprint-compiler
+, appstream-glib
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation rec {
+  pname = "geopard";
+  version = "1.2.0";
+
+  cargoDeps = rustPlatform.importCargoLock {
+    lockFile = "${src}/Cargo.lock";
+    outputHashes = {
+      "cairo-rs-0.16.0" = "sha256-Y0qRUliZRuEYvLje2ld75BDgSM7lHOnWITyuI/RoxwI=";
+      "gdk4-0.5.0" = "sha256-cRZS8csxpPZm6yxyb6MYiGO7rdw207E4w4uiuJqJoaU=";
+      "gio-0.16.0" = "sha256-wENBSDGVUQIa6CK4d5oZ9ih0h1SY1CKWBKVtVcxsXP0=";
+      "libadwaita-0.2.0" = "sha256-+ATfy8QIgpoifSCrcqdoub1ust3pEdU3skjOPfIaDQc=";
+    };
+  };
+
+  src = fetchFromGitHub {
+    owner = "ranfdev";
+    repo = "geopard";
+    rev = "v${version}";
+    sha256 = "sha256-XFuCWe7XugE07k0YnZBCaBfdohx2JTl5NFc6uI9gwcQ=";
+  };
+
+  nativeBuildInputs = [
+    openssl
+    glib # for glib-compile-schemas
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook4
+    blueprint-compiler
+    desktop-file-utils
+    appstream-glib
+    blueprint-compiler
+    rustPlatform.rust.cargo
+    rustPlatform.cargoSetupHook
+    rustPlatform.rust.rustc
+  ];
+
+  buildInputs = [
+    meson
+    ninja
+    desktop-file-utils
+    glib
+    gtk4
+    libadwaita
+    openssl
+  ];
+  meta = with lib; {
+    homepage = "https://github.com/ranfdev/Geopard";
+    description = "Colorful, adaptive gemini browser";
+    maintainers = with maintainers; [ ranfdev ];
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6381,6 +6381,8 @@ with pkgs;
   genmap = callPackage ../applications/science/biology/genmap { };
 
   geonkick = callPackage ../applications/audio/geonkick {};
+    
+  geopard = callPackage ../applications/networking/browsers/geopard {};
 
   gerrit = callPackage ../applications/version-management/gerrit { };
 


### PR DESCRIPTION
###### Description of changes

https://github.com/ranfdev/Geopard

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
