### PR TITLE
offpunk: init at 1.4

### DIFF
--- a/pkgs/applications/networking/browsers/offpunk/default.nix
+++ b/pkgs/applications/networking/browsers/offpunk/default.nix
@@ -1,0 +1,67 @@
+{
+  fetchFromGitea,
+  less,
+  lib,
+  makeWrapper,
+  offpunk,
+  python3,
+  ripgrep,
+  stdenv,
+  testVersion,
+  timg,
+  xdg-utils,
+  xsel,
+}:
+
+let
+  pythonDependencies = with python3.pkgs; [
+    beautifulsoup4
+    cryptography
+    feedparser
+    pillow
+    readability-lxml
+    requests
+    setproctitle
+  ];
+  otherDependencies = [
+    less
+    ripgrep
+    timg
+    xdg-utils
+    xsel
+  ];
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "offpunk";
+  version = "1.4";
+
+  src = fetchFromGitea {
+    domain = "notabug.org";
+    owner = "ploum";
+    repo = "offpunk";
+    rev = "v${finalAttrs.version}";
+    sha256 = "04dzkzsan1cnrslsvfgn1whpwald8xy34wqzvq81hd2mvw9a2n69";
+  };
+
+  buildInputs = [ makeWrapper ] ++ otherDependencies ++ pythonDependencies;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D ./offpunk.py $out/bin/offpunk
+
+    wrapProgram $out/bin/offpunk \
+        --set PYTHONPATH "$PYTHONPATH" \
+        --set PATH ${lib.makeBinPath otherDependencies}
+
+   runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "An Offline-First browser for the smolnet ";
+    homepage = "https://notabug.org/ploum/offpunk";
+    maintainers = with maintainers; [ DamienCassou ];
+    platforms = platforms.linux;
+    license = licenses.bsd2;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27506,6 +27506,8 @@ with pkgs;
 
   mt32emu-smf2wav = callPackage ../applications/audio/munt/mt32emu-smf2wav.nix { };
 
+  offpunk = callPackage ../applications/networking/browsers/offpunk { };
+
   p2pool = callPackage ../applications/misc/p2pool { };
 
   pass2csv = python3Packages.callPackage ../tools/security/pass2csv {};


### PR DESCRIPTION
###### Description of changes

> A command-line and offline-first smolnet browser/feed reader for Gemini, Gopher, Spartan and 
> Web by [Ploum](https://ploum.net/).
> The goal of Offpunk is to be able to synchronize your content once (a day, a week, a month)
> and then browse/organize it while staying disconnected.

https://notabug.org/ploum/offpunk

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
