### PR TITLE
khal: 0.10.4 -> 0.10.5

### DIFF
--- a/pkgs/applications/misc/khal/default.nix
+++ b/pkgs/applications/misc/khal/default.nix
@@ -1,12 +1,12 @@
-{ lib, stdenv, pkgs, python3, fetchpatch, glibcLocales }:
+{ lib, stdenv, pkgs, python3, fetchpatch, glibcLocales, installShellFiles }:
 
 with python3.pkgs; buildPythonApplication rec {
   pname = "khal";
-  version = "0.10.4";
+  version = "0.10.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "3fdb980a9a61c0206d7a82b16f77b408a4f341a2b866b9c9fcf6a641850d129f";
+    sha256 = "sha256-Tu+3rDAqJthgbbOSgXWHpO2UwnoVvy6iEWFKRk/PDHY=";
   };
 
   propagatedBuildInputs = [
@@ -26,7 +26,7 @@ with python3.pkgs; buildPythonApplication rec {
     pkginfo
     freezegun
   ];
-  nativeBuildInputs = [ setuptools-scm sphinx sphinxcontrib_newsfeed ];
+  nativeBuildInputs = [ setuptools-scm sphinx sphinxcontrib_newsfeed installShellFiles ];
   checkInputs = [
     glibcLocales
     pytestCheckHook
@@ -34,8 +34,11 @@ with python3.pkgs; buildPythonApplication rec {
   LC_ALL = "en_US.UTF-8";
 
   postInstall = ''
-    # zsh completion
-    install -D misc/__khal $out/share/zsh/site-functions/__khal
+    # shell completions
+    installShellCompletion --cmd khal \
+      --bash <(_KHAL_COMPLETE=bash_source $out/bin/khal) \
+      --fish <(_KHAL_COMPLETE=zsh_source $out/bin/khal) \
+      --zsh <(_KHAL_COMPLETE=fish_source $out/bin/khal)
 
     # man page
     PATH="${python3.withPackages (ps: with ps; [ sphinx sphinxcontrib_newsfeed ])}/bin:$PATH" \
@@ -47,14 +50,6 @@ with python3.pkgs; buildPythonApplication rec {
   '';
 
   doCheck = !stdenv.isAarch64;
-
-  disabledTests = [
-    # This test is failing due to https://github.com/pimutils/khal/issues/1065
-    "test_print_ics_command"
-
-    # Mocking breaks in this testcase
-    "test_import_from_stdin"
-  ];
 
   meta = with lib; {
     broken = stdenv.isDarwin;


### PR DESCRIPTION
###### Description of changes
https://github.com/pimutils/khal/releases
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
