### PR TITLE
python3Packages.afdko: 3.8.3 -> 3.9.0

### DIFF
--- a/pkgs/development/python-modules/afdko/default.nix
+++ b/pkgs/development/python-modules/afdko/default.nix
@@ -5,6 +5,7 @@
 , setuptools-scm, scikit-build
 , cmake
 , antlr4_9
+, libxml2
 , pytestCheckHook
 # Enables some expensive tests, useful for verifying an update
 , runAllTests ? false
@@ -13,13 +14,13 @@
 
 buildPythonPackage rec {
   pname = "afdko";
-  version = "3.8.3";
+  version = "3.9.0";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0mplyla4zcai3qld7is7bl5wn2kzhp87w87yi13wpqnw06i6ij4b";
+    sha256 = "1fjsaz6bp028fbmry6fzfcih78mdzycqmky1wsz5y0bg4kfk4shh";
   };
 
   format = "pyproject";
@@ -32,6 +33,7 @@ buildPythonPackage rec {
 
   buildInputs = [
     antlr4_9.runtime.cpp
+    libxml2.dev
   ];
 
   patches = [
@@ -40,6 +42,8 @@ buildPythonPackage rec {
 
     # Use antlr4 runtime from nixpkgs and link it dynamically
     ./use-dynamic-system-antlr4-runtime.patch
+
+    ./libxml2-cmake-find-package.patch
   ];
 
   # setup.py will always (re-)execute cmake in buildPhase

--- a/pkgs/development/python-modules/afdko/libxml2-cmake-find-package.patch
+++ b/pkgs/development/python-modules/afdko/libxml2-cmake-find-package.patch
@@ -1,0 +1,22 @@
+commit c423d1ddf0345aed7ecaf4c8b9e1fa5108aafc6f
+Author: sternenseemann <sternenseemann@systemli.org>
+Date:   Sat Jul 2 12:35:56 2022 +0200
+
+    Force use of CMake-shipped FindLibXml2 module
+    
+    This is needed to work around a nixpkgs bug:
+    https://github.com/NixOS/nixpkgs/issues/125008
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a75b6fb1..c1408283 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -42,7 +42,7 @@ set(ANTLR4_TAG tags/4.9.3)
+ find_path(ANTLR4_HEADER antlr4-runtime.h PATH_SUFFIXES antlr4-runtime)
+ set(ANTLR4_INCLUDE_DIRS ${ANTLR4_HEADER})
+ 
+-FIND_PACKAGE(LibXml2)
++FIND_PACKAGE(LibXml2 REQUIRED MODULE)
+ IF (NOT ${LibXml2_FOUND})
+    MESSAGE(STATUS "Could not locate LibXml2, will install externally.")
+    set(LIBXML2_TAG tags/v2.9.13)

--- a/pkgs/development/python-modules/afdko/use-dynamic-system-antlr4-runtime.patch
+++ b/pkgs/development/python-modules/afdko/use-dynamic-system-antlr4-runtime.patch
@@ -1,4 +1,4 @@
-commit 1ccbf21a67da0fdbaad881a1f5c2a4df915e8c57
+commit 286b9c6e69691292dce4f2b4beaac8f886da184d
 Author: sternenseemann <sternenseemann@systemli.org>
 Date:   Tue Oct 5 18:16:10 2021 +0200
 
@@ -9,7 +9,7 @@ Date:   Tue Oct 5 18:16:10 2021 +0200
     called antlr4-runtime, not antlr4_static).
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index e9c8c08e..dc3a46da 100644
+index 9ce80598..a75b6fb1 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -36,11 +36,11 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
@@ -24,10 +24,22 @@ index e9c8c08e..dc3a46da 100644
 +find_path(ANTLR4_HEADER antlr4-runtime.h PATH_SUFFIXES antlr4-runtime)
 +set(ANTLR4_INCLUDE_DIRS ${ANTLR4_HEADER})
  
- # sanitizer support
- # work around https://github.com/pypa/setuptools/issues/1928 with environment
+ FIND_PACKAGE(LibXml2)
+ IF (NOT ${LibXml2_FOUND})
+diff --git a/c/makeotf/lib/cffread/CMakeLists.txt b/c/makeotf/lib/cffread/CMakeLists.txt
+index 9a400fde..5452d987 100644
+--- a/c/makeotf/lib/cffread/CMakeLists.txt
++++ b/c/makeotf/lib/cffread/CMakeLists.txt
+@@ -13,6 +13,6 @@ else ()
+     endif()
+ endif()
+ 
+-target_link_libraries(makeotf_cffread PUBLIC antlr4_static)
++target_link_libraries(makeotf_cffread PUBLIC antlr4-runtime)
+ 
+ target_compile_definitions(makeotf_cffread PRIVATE $<$<CONFIG:Debug>:CFF_DEBUG=1> CFF_T13_SUPPORT=0)
 diff --git a/c/makeotf/lib/hotconv/CMakeLists.txt b/c/makeotf/lib/hotconv/CMakeLists.txt
-index 82257bf2..02eb2e30 100644
+index 3cceceea..9695ea21 100644
 --- a/c/makeotf/lib/hotconv/CMakeLists.txt
 +++ b/c/makeotf/lib/hotconv/CMakeLists.txt
 @@ -69,7 +69,7 @@ add_library(hotconv STATIC
@@ -37,5 +49,5 @@ index 82257bf2..02eb2e30 100644
 -target_link_libraries(hotconv PUBLIC antlr4_static)
 +target_link_libraries(hotconv PUBLIC antlr4-runtime)
  
- if ( CMAKE_COMPILER_IS_GNUCC )
-     target_compile_options(hotconv PRIVATE -Wall -Wno-attributes)
+ if (${LibXml2_FOUND})
+     target_link_libraries(hotconv PUBLIC ${LIBXML2_LIBRARY})


### PR DESCRIPTION
3.9.1 is problematic atm because it'll unconditionally use the libxml2
externalproject on linux:
https://github.com/adobe-type-tools/afdko/pull/1527#issuecomment-1172872618

https://github.com/adobe-type-tools/afdko/blob/3.9.0/NEWS.md#390-released-2022-06-23

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
