### PR TITLE
pkgs/data/icons: use stdenvNoCC where possible

### DIFF
--- a/pkgs/data/icons/arc-icon-theme/default.nix
+++ b/pkgs/data/icons/arc-icon-theme/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, gtk3, gnome, moka-icon-theme, gnome-icon-theme, hicolor-icon-theme }:
+{ lib, stdenvNoCC, fetchFromGitHub, autoreconfHook, gtk3, gnome, moka-icon-theme, gnome-icon-theme, hicolor-icon-theme }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "arc-icon-theme";
   version = "2016-11-22";
 

--- a/pkgs/data/icons/beauty-line-icon-theme/default.nix
+++ b/pkgs/data/icons/beauty-line-icon-theme/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchzip, breeze-icons, gtk3, gnome-icon-theme, hicolor-icon-theme, mint-x-icons, pantheon }:
+{ lib, stdenvNoCC, fetchzip, breeze-icons, gtk3, gnome-icon-theme, hicolor-icon-theme, mint-x-icons, pantheon }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "BeautyLine";
   version = "0.0.1";
 

--- a/pkgs/data/icons/bibata-cursors/default.nix
+++ b/pkgs/data/icons/bibata-cursors/default.nix
@@ -1,12 +1,12 @@
 { lib
-, stdenv
+, stdenvNoCC
 , fetchFromGitHub
 , fetchurl
 , clickgen
 , unzip
 }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "bibata-cursors";
   version = "1.1.2";
 

--- a/pkgs/data/icons/bibata-cursors/extra.nix
+++ b/pkgs/data/icons/bibata-cursors/extra.nix
@@ -1,12 +1,12 @@
 { lib
-, stdenv
+, stdenvNoCC
 , fetchFromGitHub
 , fetchurl
 , clickgen
 , unzip
 }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "bibata-extra-cursors";
   version = "1.0.1";
 

--- a/pkgs/data/icons/bibata-cursors/translucent.nix
+++ b/pkgs/data/icons/bibata-cursors/translucent.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "bibata-cursors-translucent";
   version = "1.1.1";
 

--- a/pkgs/data/icons/capitaine-cursors/default.nix
+++ b/pkgs/data/icons/capitaine-cursors/default.nix
@@ -1,7 +1,7 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, makeFontsConf
+{ lib, stdenvNoCC, fetchFromGitHub, fetchpatch, makeFontsConf
 , inkscape, xcursorgen, bc }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "capitaine-cursors";
   version = "4";
 

--- a/pkgs/data/icons/comixcursors/default.nix
+++ b/pkgs/data/icons/comixcursors/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitLab, bc, librsvg, xcursorgen }:
+{ lib, stdenvNoCC, fetchFromGitLab, bc, librsvg, xcursorgen }:
 
 let
   dimensions = {
@@ -16,7 +16,7 @@ let
     # meta.longDescription.)
     map variantName product;
 in
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "comixcursors";
   version = "0.9.2";
 

--- a/pkgs/data/icons/faba-icon-theme/default.nix
+++ b/pkgs/data/icons/faba-icon-theme/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, meson, ninja, python3, gtk3, pantheon, gnome-icon-theme, hicolor-icon-theme }:
+{ lib, stdenvNoCC, fetchFromGitHub, meson, ninja, python3, gtk3, pantheon, gnome-icon-theme, hicolor-icon-theme }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "faba-icon-theme";
   version = "4.3";
 

--- a/pkgs/data/icons/faba-mono-icons/default.nix
+++ b/pkgs/data/icons/faba-mono-icons/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, gtk3, moka-icon-theme, faba-icon-theme, gnome-icon-theme, hicolor-icon-theme }:
+{ lib, stdenvNoCC, fetchFromGitHub, autoreconfHook, gtk3, moka-icon-theme, faba-icon-theme, gnome-icon-theme, hicolor-icon-theme }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "faba-mono-icons";
   version = "2016-04-30";
 

--- a/pkgs/data/icons/gruvbox-dark-icons-gtk/default.nix
+++ b/pkgs/data/icons/gruvbox-dark-icons-gtk/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, gtk3, breeze-icons, gnome-icon-theme, hicolor-icon-theme }:
+{ lib, stdenvNoCC, fetchFromGitHub, gtk3, breeze-icons, gnome-icon-theme, hicolor-icon-theme }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "gruvbox-dark-icons-gtk";
   version = "1.0.0";
 

--- a/pkgs/data/icons/hicolor-icon-theme/default.nix
+++ b/pkgs/data/icons/hicolor-icon-theme/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenvNoCC, fetchurl }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "hicolor-icon-theme";
   version = "0.17";
 

--- a/pkgs/data/icons/iconpack-jade/default.nix
+++ b/pkgs/data/icons/iconpack-jade/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, gtk3, gnome-icon-theme, hicolor-icon-theme }:
+{ lib, stdenvNoCC, fetchFromGitHub, gtk3, gnome-icon-theme, hicolor-icon-theme }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "iconpack-jade";
   version = "1.25";
 

--- a/pkgs/data/icons/iconpack-obsidian/default.nix
+++ b/pkgs/data/icons/iconpack-obsidian/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, gtk3, gnome-icon-theme, mint-x-icons, hicolor-icon-theme }:
+{ lib, stdenvNoCC, fetchFromGitHub, gtk3, gnome-icon-theme, mint-x-icons, hicolor-icon-theme }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "iconpack-obsidian";
   version = "4.15";
 

--- a/pkgs/data/icons/iso-flags/default.nix
+++ b/pkgs/data/icons/iso-flags/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv
+{ lib, stdenvNoCC
 , fetchFromGitHub
 , perl
 , inkscape
@@ -6,7 +6,7 @@
 , targets ? [ "all" ]
 }:
 
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "iso-flags";
   version = "unstable-18012020";
 

--- a/pkgs/data/icons/kora-icon-theme/default.nix
+++ b/pkgs/data/icons/kora-icon-theme/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub , gtk3, adwaita-icon-theme, breeze-icons, hicolor-icon-theme }:
+{ lib, stdenvNoCC, fetchFromGitHub , gtk3, adwaita-icon-theme, breeze-icons, hicolor-icon-theme }:
 
-stdenv.mkDerivation rec  {
+stdenvNoCC.mkDerivation rec  {
   pname = "kora-icon-theme";
   version = "1.5.2";
 

--- a/pkgs/data/icons/la-capitaine-icon-theme/default.nix
+++ b/pkgs/data/icons/la-capitaine-icon-theme/default.nix
@@ -1,5 +1,5 @@
 { lib
-, stdenv
+, stdenvNoCC
 , fetchFromGitHub
 , breeze-icons
 , elementary-icon-theme
@@ -7,7 +7,7 @@
 , hicolor-icon-theme
 }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "la-capitaine-icon-theme";
   version = "0.6.2";
 

--- a/pkgs/data/icons/luna-icons/default.nix
+++ b/pkgs/data/icons/luna-icons/default.nix
@@ -1,5 +1,5 @@
 { lib
-, stdenv
+, stdenvNoCC
 , fetchFromGitHub
 , gtk3
 , breeze-icons
@@ -8,7 +8,7 @@
 , gitUpdater
 }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "luna-icons";
   version = "2.0";
 

--- a/pkgs/data/icons/moka-icon-theme/default.nix
+++ b/pkgs/data/icons/moka-icon-theme/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, meson, ninja, gtk3, python3, faba-icon-theme, hicolor-icon-theme, jdupes }:
+{ lib, stdenvNoCC, fetchFromGitHub, meson, ninja, gtk3, python3, faba-icon-theme, hicolor-icon-theme, jdupes }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "moka-icon-theme";
   version = "unstable-2019-05-29";
 

--- a/pkgs/data/icons/nordzy-cursor-theme/default.nix
+++ b/pkgs/data/icons/nordzy-cursor-theme/default.nix
@@ -1,9 +1,9 @@
-{ stdenv
+{ stdenvNoCC
 , fetchFromGitHub
 , lib
 }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "nordzy-cursor-theme";
   version = "0.1.0";
 

--- a/pkgs/data/icons/numix-cursor-theme/default.nix
+++ b/pkgs/data/icons/numix-cursor-theme/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, inkscape, xcursorgen }:
+{ lib, stdenvNoCC, fetchFromGitHub, inkscape, xcursorgen }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "numix-cursor-theme";
   version = "1.2";
 

--- a/pkgs/data/icons/numix-icon-theme-circle/default.nix
+++ b/pkgs/data/icons/numix-icon-theme-circle/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, gtk3, numix-icon-theme, hicolor-icon-theme }:
+{ lib, stdenvNoCC, fetchFromGitHub, gtk3, numix-icon-theme, hicolor-icon-theme }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "numix-icon-theme-circle";
   version = "22.06.14";
 

--- a/pkgs/data/icons/numix-icon-theme-square/default.nix
+++ b/pkgs/data/icons/numix-icon-theme-square/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, gtk3, numix-icon-theme, hicolor-icon-theme }:
+{ lib, stdenvNoCC, fetchFromGitHub, gtk3, numix-icon-theme, hicolor-icon-theme }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "numix-icon-theme-square";
   version = "22.06.14";
 

--- a/pkgs/data/icons/numix-icon-theme/default.nix
+++ b/pkgs/data/icons/numix-icon-theme/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, gtk3, gnome-icon-theme, hicolor-icon-theme }:
+{ lib, stdenvNoCC, fetchFromGitHub, gtk3, gnome-icon-theme, hicolor-icon-theme }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "numix-icon-theme";
   version = "21.10.31";
 

--- a/pkgs/data/icons/oranchelo-icon-theme/default.nix
+++ b/pkgs/data/icons/oranchelo-icon-theme/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, gtk3, plasma5Packages, hicolor-icon-theme }:
+{ lib, stdenvNoCC, fetchFromGitHub, gtk3, plasma5Packages, hicolor-icon-theme }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "oranchelo-icon-theme";
   version = "0.8.0.1";
 

--- a/pkgs/data/icons/paper-icon-theme/default.nix
+++ b/pkgs/data/icons/paper-icon-theme/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, meson, ninja, gtk3, gnome, gnome-icon-theme, hicolor-icon-theme, jdupes }:
+{ lib, stdenvNoCC, fetchFromGitHub, meson, ninja, gtk3, gnome, gnome-icon-theme, hicolor-icon-theme, jdupes }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "paper-icon-theme";
   version = "unstable-2020-03-12";
 

--- a/pkgs/data/icons/papirus-icon-theme/default.nix
+++ b/pkgs/data/icons/papirus-icon-theme/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, gtk3, pantheon, breeze-icons, gnome-icon-theme, hicolor-icon-theme }:
+{ lib, stdenvNoCC, fetchFromGitHub, gtk3, pantheon, breeze-icons, gnome-icon-theme, hicolor-icon-theme }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "papirus-icon-theme";
   version = "20220606";
 

--- a/pkgs/data/icons/pop-icon-theme/default.nix
+++ b/pkgs/data/icons/pop-icon-theme/default.nix
@@ -1,5 +1,5 @@
 { lib
-, stdenv
+, stdenvNoCC
 , fetchFromGitHub
 , meson
 , ninja
@@ -8,7 +8,7 @@
 , hicolor-icon-theme
 }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "pop-icon-theme";
   version = "2021-11-17";
 

--- a/pkgs/data/icons/vanilla-dmz/default.nix
+++ b/pkgs/data/icons/vanilla-dmz/default.nix
@@ -1,11 +1,11 @@
-{ stdenv
+{ stdenvNoCC
 , lib
 , fetchzip
 , xorg
 , hicolor-icon-theme
 }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "vanilla-dmz";
   version = "0.4.5";
 

--- a/pkgs/data/icons/vimix-icon-theme/default.nix
+++ b/pkgs/data/icons/vimix-icon-theme/default.nix
@@ -1,5 +1,5 @@
 { lib
-, stdenv
+, stdenvNoCC
 , fetchFromGitHub
 , gtk3
 , hicolor-icon-theme
@@ -13,7 +13,7 @@ let
 in
 lib.checkListOfEnum "${pname}: color variants" [ "standard" "Amethyst" "Beryl" "Doder" "Ruby" "Black" "White" ] colorVariants
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   inherit pname;
   version = "2021-11-09";
 

--- a/pkgs/data/icons/zafiro-icons/default.nix
+++ b/pkgs/data/icons/zafiro-icons/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, gtk3, breeze-icons, gnome-icon-theme, numix-icon-theme, numix-icon-theme-circle, hicolor-icon-theme }:
+{ lib, stdenvNoCC, fetchFromGitHub, gtk3, breeze-icons, gnome-icon-theme, numix-icon-theme, numix-icon-theme-circle, hicolor-icon-theme }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "zafiro-icons";
   version = "1.1";
 


### PR DESCRIPTION
###### Description of changes

Most icons themes just copy a bunch of files from the source to the installation directory and therefore work perfectly fine with `stdenvNoCC`.
All themes in `pkgs/data/icons` that still use `stdenv` after this change are failing to build with `stdenvNoCC`.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).