### PR TITLE
radioboat: init at 0.2.1

### DIFF
--- a/pkgs/applications/audio/radioboat/default.nix
+++ b/pkgs/applications/audio/radioboat/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, fetchFromGitHub
+, buildGoModule
+, mpv
+, makeWrapper
+, installShellFiles
+, nix-update-script
+, testers
+, radioboat
+}:
+
+buildGoModule rec {
+  pname = "radioboat";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "slashformotion";
+    repo = "radioboat";
+    rev = "v${version}";
+    sha256 = "sha256-ZAKTWmK3hCJxm/578cjtdgMA2ZRhCFtzfGdta0gmuFY=";
+  };
+
+  vendorSha256 = "sha256-X3KiqaiOQYQBfVckh50C+4oxIVN6gXyNuQtBwGvjdFQ=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/slashformotion/radioboat/internal/buildinfo.Version=${version}"
+  ];
+
+  nativeBuildInputs = [ makeWrapper installShellFiles ];
+
+  preFixup = ''
+    wrapProgram $out/bin/radioboat --prefix PATH ":" "${lib.makeBinPath [ mpv ]}";
+  '';
+
+  postInstall = ''
+    installShellCompletion --cmd radioboat \
+      --bash <($out/bin/radioboat completion bash) \
+      --fish <($out/bin/radioboat completion fish) \
+      --zsh <($out/bin/radioboat completion zsh)
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { attrPath = pname; };
+    tests.version = testers.testVersion {
+      package = radioboat;
+      command = "radioboat version";
+      version = version;
+    };
+  };
+
+  meta = with lib; {
+    description = "A terminal web radio client";
+    homepage = "https://github.com/slashformotion/radioboat";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ zendo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29632,6 +29632,8 @@ with pkgs;
 
   roomeqwizard = callPackage ../applications/audio/roomeqwizard { };
 
+  radioboat = callPackage ../applications/audio/radioboat { };
+
   radiotray-ng = callPackage ../applications/audio/radiotray-ng {
     wxGTK = wxGTK30;
   };


### PR DESCRIPTION
###### Description of changes

Radioboat is a terminal web radio client, built with simplicity in mind 

https://github.com/slashformotion/radioboat
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
