### PR TITLE
treewide: fix bash exit handlers

### DIFF
--- a/maintainers/scripts/rebuild-amount.sh
+++ b/maintainers/scripts/rebuild-amount.sh
@@ -35,7 +35,7 @@ toRemove=()
 cleanup() {
     rm -rf "${toRemove[@]}"
 }
-trap cleanup EXIT SIGINT SIGQUIT ERR
+trap cleanup EXIT
 
 MKTEMP='mktemp --tmpdir nix-rebuild-amount-XXXXXXXX'
 

--- a/nixos/modules/services/backup/borgbackup.nix
+++ b/nixos/modules/services/backup/borgbackup.nix
@@ -23,12 +23,10 @@ let
     on_exit()
     {
       exitStatus=$?
-      # Reset the EXIT handler, or else we're called again on 'exit' below
-      trap - EXIT
       ${cfg.postHook}
       exit $exitStatus
     }
-    trap 'on_exit' INT TERM QUIT EXIT
+    trap on_exit EXIT
 
     archiveName="${if cfg.archiveBaseName == null then "" else cfg.archiveBaseName + "-"}$(date ${cfg.dateFormat})"
     archiveSuffix="${optionalString cfg.appendFailedSuffix ".failed"}"

--- a/nixos/modules/services/web-apps/keycloak.nix
+++ b/nixos/modules/services/web-apps/keycloak.nix
@@ -569,7 +569,7 @@ in
             shopt -s inherit_errexit
 
             create_role="$(mktemp)"
-            trap 'rm -f "$create_role"' ERR EXIT
+            trap 'rm -f "$create_role"' EXIT
 
             db_password="$(<"$CREDENTIALS_DIRECTORY/db_password")"
             echo "CREATE ROLE keycloak WITH LOGIN PASSWORD '$db_password' CREATEDB" > "$create_role"

--- a/pkgs/applications/editors/vscode/extensions/_maintainers/update-bin-srcs-lib.sh
+++ b/pkgs/applications/editors/vscode/extensions/_maintainers/update-bin-srcs-lib.sh
@@ -39,11 +39,10 @@ prefetchExtensionUnpacked() {
   function rm_tmpdir() {
     1>&2 printf "rm -rf %q\n" "$tmpDir"
     rm -rf "$tmpDir"
-    trap - INT TERM HUP EXIT
   }
   function make_trapped_tmpdir() {
     tmpDir=$(mktemp -d)
-    trap rm_tmpdir INT TERM HUP EXIT
+    trap rm_tmpdir EXIT
   }
 
   1>&2 echo

--- a/pkgs/applications/editors/vscode/extensions/_maintainers/update-bin-srcs-lib.sh
+++ b/pkgs/applications/editors/vscode/extensions/_maintainers/update-bin-srcs-lib.sh
@@ -37,9 +37,8 @@ prefetchExtensionUnpacked() {
   1>&2 echo "zipStorePath='$zipStorePath'"
 
   function rm_tmpdir() {
-    1>&2 printf "rm -rf -- %q\n" "$tmpDir"
-    rm -rf -- "$tmpDir"
-    unset tmpDir
+    1>&2 printf "rm -rf %q\n" "$tmpDir"
+    rm -rf "$tmpDir"
     trap - INT TERM HUP EXIT
   }
   function make_trapped_tmpdir() {

--- a/pkgs/applications/editors/vscode/extensions/cpptools/update_helper.sh
+++ b/pkgs/applications/editors/vscode/extensions/cpptools/update_helper.sh
@@ -44,9 +44,7 @@ extStoreName="${extPublisher}-${extName}"
 
 
 function rm_tmpdir() {
-  #echo "Removing \`tmpDir='$tmpDir'\`"
-  rm -rf -- "$tmpDir"
-  unset tmpDir
+  rm -rf "$tmpDir"
   trap - INT TERM HUP EXIT
 }
 function make_trapped_tmpdir() {

--- a/pkgs/applications/editors/vscode/extensions/cpptools/update_helper.sh
+++ b/pkgs/applications/editors/vscode/extensions/cpptools/update_helper.sh
@@ -45,11 +45,10 @@ extStoreName="${extPublisher}-${extName}"
 
 function rm_tmpdir() {
   rm -rf "$tmpDir"
-  trap - INT TERM HUP EXIT
 }
 function make_trapped_tmpdir() {
   tmpDir=$(mktemp -d)
-  trap rm_tmpdir INT TERM HUP EXIT
+  trap rm_tmpdir EXIT
 }
 
 echo

--- a/pkgs/build-support/fetchcvs/nix-prefetch-cvs
+++ b/pkgs/build-support/fetchcvs/nix-prefetch-cvs
@@ -21,13 +21,11 @@ fi
 
 mkTempDir() {
     tmpPath="$(mktemp -d "${TMPDIR:-/tmp}/nix-prefetch-cvs-XXXXXXXX")"
-    trap removeTempDir EXIT SIGINT SIGQUIT
+    trap removeTempDir EXIT
 }
 
 removeTempDir() {
-    if test -n "$tmpPath"; then
-        rm -rf "$tmpPath" || true
-    fi
+    rm -rf "$tmpPath"
 }
 
 


### PR DESCRIPTION
#### Copy of commit msg

Transform exit handlers of the form
```bash
trap cleanup EXIT [INT] [TERM] [QUIT] [HUP] [ERR]
  (where cleanup is idempotent)
```
to
```bash
trap cleanup EXIT
```

This fixes a common bash antipattern.

Each of the above signals causes the script to exit. For each signal, bash first handles the signal by running `cleanup` and then runs `cleanup` again when handling EXIT. 
(Exception:  `vscode/*` prevents the second run of `cleanup` by removing the trap in cleanup`).

Simplify the cleanup logic by just trapping exit, which is always run when the script exits due to any of the above signals.

Note: In case of borgbackup, the exit handler is not idempotent, but just trapping EXIT guarantees that it's only run once.
