### PR TITLE
nixos/borgbackup: fix env vars not being passed verbatim in job wrappers

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -1753,6 +1753,15 @@ services.github-runner.serviceOverrides.SupplementaryGroups = [
           result, they will be garbage collected more often.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          <literal>services.borgbackup</literal>: In the borg job
+          wrapper, environment variables are now passed verbatim to the
+          borg process, so that its process environment is the same as
+          in the systemd service. Previously, vars were expanded in the
+          Nix build environment for the job wrapper.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
 </section>

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -551,4 +551,6 @@ Available as [services.patroni](options.html#opt-services.patroni.enable).
 
 - `haskellPackages.callHackage` and `haskellPackages.callCabal2nix` (and related functions) no longer keep a reference to the `cabal2nix` call used to generate them. As a result, they will be garbage collected more often.
 
+- `services.borgbackup`: In the borg job wrapper, environment variables are now passed verbatim to the borg process, so that its process environment is the same as in the systemd service. Previously, vars were expanded in the Nix build environment for the job wrapper.
+
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/services/backup/borgbackup.nix
+++ b/nixos/modules/services/backup/borgbackup.nix
@@ -119,7 +119,7 @@ let
       nativeBuildInputs = [ pkgs.makeWrapper ];
     } (with lib; ''
       makeWrapper "${original}" "$out/bin/${name}" \
-        ${concatStringsSep " \\\n " (mapAttrsToList (name: value: ''--set ${name} "${value}"'') set)}
+        ${concatStringsSep " \\\n " (mapAttrsToList (name: value: "--set ${name} ${escapeShellArg value}") set)}
     '');
 
   mkBorgWrapper = name: cfg: mkWrapperDrv {


### PR DESCRIPTION
#### Copy of commit msg
Like in the borg-job systemd service, env var values are now passed verbatim to the borg process.
Previously, the var values were evaluated as bash double quoted strings in the Nix build environment for the job wrapper .

Test this with:
```bash
read -d '' container <<'EOF' || :
{
  containers.borg-test = {
    config = {
      documentation.enable = false;
      services.borgbackup.jobs.main = {
        startAt = [];
        paths = [ "/" ];
        repo = "myrepo";
        encryption.mode = "none";
        environment.BORG_REMOTE_PATH = "$HOME/bin/borg";
      };
    };
  };
}
EOF
extra-container shell --nixpkgs-path /home/main/d/nix-dev/nixpkgs -E "$container" --run c bash -c 'cat $(which borg-job-main)' | grep BORG_REMOTE_PATH
```
Output before this PR:
```
export BORG_REMOTE_PATH='/homeless-shelter/bin/borg'
```
Output after this PR:
```
export BORG_REMOTE_PATH='$HOME/bin/borg'
```