### PR TITLE
freecad: fix crash when selecting color of a solid

### DIFF
--- a/pkgs/applications/graphics/freecad/default.nix
+++ b/pkgs/applications/graphics/freecad/default.nix
@@ -42,6 +42,7 @@
 , swig
 , vtk
 , wrapQtAppsHook
+, wrapGAppsHook
 , xercesc
 , zlib
 }:
@@ -64,6 +65,7 @@ mkDerivation rec {
     pyside2-tools
     gfortran
     wrapQtAppsHook
+    wrapGAppsHook
   ];
 
   buildInputs = [


### PR DESCRIPTION
FreeCAD crashes when user wants to select color of a solid with
following console message (long lines wrapped):

    $ nix run nixpkgs#freecad
    FreeCAD 0.20, Libs: 0.20RUnknown
    © Juergen Riegel, Werner Mayer, Yorik van Havre and others 2001-2022
    FreeCAD is free and open-source software licensed under the terms of
    LGPL2+ license.
    FreeCAD wouldn't be possible without FreeCAD community.
      #####                 ####  ###   ####
      #                    #      # #   #   #
      #     ##  #### ####  #     #   #  #   #
      ####  # # #  # #  #  #     #####  #   #
      #     #   #### ####  #    #     # #   #
      #     #   #    #     #    #     # #   #  ##  ##  ##
      #     #   #### ####   ### #     # ####   ##  ##  ##

    (freecad:19737): GLib-GIO-ERROR **: 14:33:02.511: Settings schema
    'org.gtk.Settings.ColorChooser' is not installed
    fish: Job 1, 'nix run nixpkgs#freecad' terminated by signal SIGTRAP
    (Trace or breakpoint trap)

This patch adds hooks for GApps to relevant places in order to make
FreeCAD finding the Color Chooser dialog schema effectively preventing
crash from happening.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of ~all binary files (usually in `./result/bin/`)~ `./results/freecad/bin/FreeCAD` by following *Steps To Reproduce* section of [issue#179228](https://github.com/NixOS/nixpkgs/issues/179228)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
