### PR TITLE
openfpgaloader: 0.6.0 -> 0.8.0

### DIFF
--- a/pkgs/development/embedded/fpga/openfpgaloader/default.nix
+++ b/pkgs/development/embedded/fpga/openfpgaloader/default.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation rec {
   pname = "openfpgaloader";
-  version = "0.6.0";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "trabucayre";
     repo = "openFPGALoader";
     rev = "v${version}";
-    sha256 = "sha256-gPRBHy7WVra4IlGvzrhNqbEbOQtYtUC+zQ+SnJTMvRA=";
+    sha256 = "sha256-8AP4EJ+msOf1lstahyOyalI5dtS2ri7djN4zdN36Kfg=";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];

--- a/pkgs/development/embedded/fpga/openfpgaloader/default.nix
+++ b/pkgs/development/embedded/fpga/openfpgaloader/default.nix
@@ -6,6 +6,8 @@
 , libftdi1
 , libusb1
 , udev
+, hidapi
+, zlib
 }:
 
 stdenv.mkDerivation rec {
@@ -25,6 +27,8 @@ stdenv.mkDerivation rec {
     libftdi1
     libusb1
     udev
+    hidapi
+    zlib
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

Update to 0.8.0 and add optional dependencies hidapi and zlib. Both of them were already useful in 0.6.0. hidapi is required to support cmsis-dap cables (which is what I am interested in). zlib is required for Altera/Intel devices according to CMakeLists.txt. Both are small so I think that we should add them by default.

Upstream changelogs:
- https://github.com/trabucayre/openFPGALoader/releases/tag/v0.8.0
- https://github.com/trabucayre/openFPGALoader/releases/tag/v0.7.0
- https://github.com/trabucayre/openFPGALoader/releases/tag/v0.6.1

Summary: Bugfixes and support for new cables and boards.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
