### PR TITLE
geocode-glib: fix installed tests

### DIFF
--- a/nixos/tests/installed-tests/geocode-glib.nix
+++ b/nixos/tests/installed-tests/geocode-glib.nix
@@ -1,0 +1,13 @@
+{ pkgs, makeInstalledTest, ... }:
+
+makeInstalledTest {
+  testConfig = {
+    i18n.supportedLocales = [
+      "en_US.UTF-8/UTF-8"
+      # The tests require this locale available.
+      "en_GB.UTF-8/UTF-8"
+    ];
+  };
+
+  tested = pkgs.geocode-glib;
+}

--- a/pkgs/development/libraries/geocode-glib/default.nix
+++ b/pkgs/development/libraries/geocode-glib/default.nix
@@ -1,6 +1,7 @@
-{ fetchurl
+{ stdenv
 , lib
-, stdenv
+, fetchurl
+, fetchpatch
 , meson
 , ninja
 , pkg-config
@@ -28,6 +29,20 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./installed-tests-path.patch
+
+    # Install data for pi test.
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/geocode-glib/-/commit/0eb5c21cf4deb2c45aedf5a4393d4208b8dc6d58.patch";
+      sha256 = "DmaPzGEu7f+gjjb2HSZ3+ZMc4EJSsba9ufsVysB0UPA=";
+    })
+    # Fix pi test.
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/geocode-glib/-/commit/464bb3bae5525566a7f41d157f73575cc4f3b5f8.patch";
+      sha256 = "qSjXR8eKl+E38Zp7/Kgge/FxOLHYUJgRSR68okc3No0=";
+      postFetch = ''
+        substituteInPlace $out --replace "LC_MESSAGES" "LC_ALL"
+      '';
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes
Follow up to https://github.com/NixOS/nixpkgs/pull/179849.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
