### PR TITLE
papirus-folders: init at 1.12.0

### DIFF
--- a/pkgs/data/misc/papirus-folders/default.nix
+++ b/pkgs/data/misc/papirus-folders/default.nix
@@ -1,0 +1,27 @@
+{ lib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "papirus-folders";
+  version = "1.12.0";
+
+  src = fetchFromGitHub {
+    owner = "PapirusDevelopmentTeam";
+    repo = "papirus-folders";
+    rev = "v${version}";
+    sha256 = "sha256-ZZMEZCWO+qW76eqa+TgxWGVz69VkSCPcttLoCrH7ppY=";
+  };
+
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  meta = with lib; {
+    description = "A tool to change papirus icon theme color";
+    longDescription = ''
+      papirus-folders is a bash script that allows changing the color of
+      folders in Papirus icon theme and its forks (which based on version 20171007 and newer).
+    '';
+    homepage = "https://github.com/PapirusDevelopmentTeam/papirus-folders";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.aacebedo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25076,6 +25076,8 @@ with pkgs;
     inherit (plasma5Packages) breeze-icons;
   };
 
+  papirus-folders = callPackage ../data/misc/papirus-folders { };
+
   plasma-overdose-kde-theme = callPackage ../data/themes/plasma-overdose-kde-theme { };
 
   papis = with python3Packages; toPythonApplication papis;


### PR DESCRIPTION
###### Description of changes

This package is an official tool from papirus team (https://github.com/PapirusDevelopmentTeam/papirus-folders) enabling to change the color of the folder icons in the papirus icons theme. I add this package in order to be able to add an option to the papirus-icon-theme that will change the color while installing the theme. I'll PR it when this one is merged.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).