### PR TITLE
jprofiler-agent: init at 13.0.2

### DIFF
--- a/pkgs/development/tools/java/jprofiler/default.nix
+++ b/pkgs/development/tools/java/jprofiler/default.nix
@@ -1,21 +1,71 @@
 { stdenv
 , lib
+, callPackages
 , fetchurl
 , makeWrapper
 , makeDesktopItem
 , copyDesktopItems
-, undmg
+, autoPatchelfHook
+, callPackage
 , jdk
+, libX11
+, musl
+, component ? "ui"
 }:
 
-let
-  inherit (stdenv.hostPlatform) system;
-  pname = "jprofiler";
+assert lib.asserts.assertOneOf "component" component [ "agent" "ui" ];
 
-  # 11.1.4 is the last version which can be unpacked by undmg
-  # See: https://github.com/matthewbauer/undmg/issues/9
-  version = if stdenv.isLinux then "13.0.2" else "11.1.4";
+let
+  version = "13.0.2";
+  downloadVersion = lib.replaceStrings ["."] ["_"] version;
+
+  artefacts = {
+    agent = rec {
+      x86_64-darwin = {
+        url = "https://download-gcdn.ej-technologies.com/jprofiler/jprofiler_agent_macos_${downloadVersion}.tgz";
+        hash = "sha256-GJYDA6aNP+NYARDhQy7hUy5NduRzz1xpdP9FSWk1XMM=";
+      };
+      aarch64-darwin = x86_64-darwin;
+
+      x86_64-linux = {
+        url = "https://download-gcdn.ej-technologies.com/jprofiler/jprofiler_agent_linux-x86_${downloadVersion}.tar.gz";
+        hash = "sha256-kZ2/ScbOCxeXN++RDf14gdPFrZW8oox+xfK/VUFK+mY=";
+      };
+      i686-linux = x86_64-linux;
+      aarch64-linux = {
+        url = "https://download-gcdn.ej-technologies.com/jprofiler/jprofiler_agent_linux-arm_${downloadVersion}.tar.gz";
+        hash = "sha256-VtGAZuuhyrNL0YM5LR5NKfiIcsv10qy5n8cWlxK+IRk=";
+      };
+      armhf-linux = aarch64-linux;
+    };
+
+    ui = rec {
+      x86_64-darwin = {
+        url = "https://download-gcdn.ej-technologies.com/jprofiler/jprofiler_macos_${downloadVersion}.tgz";
+        hash = "sha256-Fc7inWD5LGenkitk4/2/xHZXfaP9shvmkYvpd/BkHNE=";
+      };
+      aarch64-darwin = x86_64-darwin;
+
+      x86_64-linux = {
+        url = "https://download-gcdn.ej-technologies.com/jprofiler/jprofiler_linux_${downloadVersion}.tar.gz";
+        hash = "sha256-x9I7l2ctquCqUymtlQpFXE6+u0Yg773qE6MvAxvCaEE=";
+      };
+      i686-linux = x86_64-linux;
+      aarch64-linux = x86_64-linux;
+      armhf-linux = x86_64-linux;
+    };
+
+    icon = {
+      url = "https://www.ej-technologies.com/assets/content/header-product-jprofiler@2x-24bc4d84bd2a4eb641a5c8531758ff7c.png";
+      hash = "sha256-XUmuqhnNv7mZ3Gb4A0HLSlfiJd5xbCExVsw3hmXHeVE=";
+    };
+  };
+
   nameApp = "JProfiler";
+
+in stdenv.mkDerivation (finalAttrs: rec {
+  pname = "jprofiler";
+  inherit version;
 
   meta = with lib; {
     description = "JProfiler's intuitive UI helps you resolve performance bottlenecks";
@@ -28,18 +78,14 @@ let
     maintainers = with maintainers; [ catap ];
   };
 
-  src = if stdenv.isLinux then fetchurl {
-    url = "https://download-gcdn.ej-technologies.com/jprofiler/jprofiler_linux_${lib.replaceStrings ["."] ["_"]  version}.tar.gz";
-    sha256 = "sha256-x9I7l2ctquCqUymtlQpFXE6+u0Yg773qE6MvAxvCaEE=";
-  } else fetchurl {
-    url = "https://download-gcdn.ej-technologies.com/jprofiler/jprofiler_macos_${lib.replaceStrings ["."] ["_"]  version}.dmg";
-    sha256 = "sha256-WDMGrDsMdY1//WMHgr+/YKSxHWt6A1dD1Pd/MuDOaz8=";
-  };
+  src = fetchurl artefacts.${component}.${stdenv.hostPlatform.system}
+    or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
-  srcIcon = fetchurl {
-    url = "https://www.ej-technologies.com/assets/content/header-product-jprofiler@2x-24bc4d84bd2a4eb641a5c8531758ff7c.png";
-    sha256 = "sha256-XUmuqhnNv7mZ3Gb4A0HLSlfiJd5xbCExVsw3hmXHeVE=";
-  };
+  nativeBuildInputs = [
+    makeWrapper
+  ] ++ lib.optional stdenv.isLinux [ autoPatchelfHook copyDesktopItems ];
+
+  buildInputs = lib.optional stdenv.isLinux [ libX11 musl ];
 
   desktopItems = makeDesktopItem {
     name = pname;
@@ -51,49 +97,31 @@ let
     categories = [ "Development" ];
   };
 
-  linux = stdenv.mkDerivation {
-    inherit pname version src desktopItems;
+  dontStrip = stdenv.isDarwin;
 
-    nativeBuildInputs = [ makeWrapper copyDesktopItems ];
+  installPhase = ''
+    runHook preInstall
 
-    installPhase = ''
-      runHook preInstall
-      cp -r . $out
+    mv $PWD $out
 
-      rm -f $out/bin/updater
-      rm -rf $out/bin/linux-ppc*
-      rm -rf $out/bin/linux-armhf
-      rm -rf $out/bin/linux-musl*
+    for f in $(find $out/bin $out/.install4j -type f -executable); do
+      wrapProgram $f --set JAVA_HOME "${jdk.home}"
+    done
 
-      for f in $(find $out/bin -type f -executable); do
-        wrapProgram $f --set JAVA_HOME "${jdk.home}"
-      done
-
-      install -Dm644 "${srcIcon}" \
+    ${lib.optionalString (component == "ui") ''
+      install -Dm644 "${fetchurl artefacts.icon}" \
         "$out/share/icons/hicolor/scalable/apps/jprofiler.png"
-      runHook postInstall
-    '';
 
-    meta = meta // { platforms = lib.platforms.linux; };
+      '' + lib.optionalString stdenv.isDarwin ''
+        mkdir -p $out/Applications
+        ln -s $out/bin/${pname}.app $out/Applications/${nameApp}.app
+        ln -s ${jdk.home} $out/.install4j/jre
+      '';
+
+    runHook postInstall
+  '';
+
+  passthru.tests.run = callPackage ./test.nix {
+    jprofiler = finalAttrs.finalPackage;
   };
-
-  darwin = stdenv.mkDerivation {
-    inherit pname version src;
-
-    # Archive extraction via undmg fails for this particular version.
-    nativeBuildInputs = [ makeWrapper undmg ];
-
-    sourceRoot = "${nameApp}.app";
-
-    installPhase = ''
-      runHook preInstall
-      mkdir -p $out/{Applications/${nameApp}.app,bin}
-      cp -R . $out/Applications/${nameApp}.app
-      makeWrapper $out/Applications/${nameApp}.app/Contents/MacOS/JavaApplicationStub $out/bin/${pname}
-      runHook postInstall
-    '';
-
-    meta = meta // { platforms = lib.platforms.darwin; };
-  };
-in
-if stdenv.isDarwin then darwin else linux
+})

--- a/pkgs/development/tools/java/jprofiler/default.nix
+++ b/pkgs/development/tools/java/jprofiler/default.nix
@@ -116,7 +116,7 @@ in stdenv.mkDerivation (finalAttrs: rec {
         mkdir -p $out/Applications
         ln -s $out/bin/${pname}.app $out/Applications/${nameApp}.app
         ln -s ${jdk.home} $out/.install4j/jre
-      '';
+      '' + ''
 
     runHook postInstall
   '';

--- a/pkgs/development/tools/java/jprofiler/test.nix
+++ b/pkgs/development/tools/java/jprofiler/test.nix
@@ -1,0 +1,8 @@
+{ runCommand, jprofiler }:
+
+runCommand "jprofiler-test-run" {
+  nativeBuildInputs = [ jprofiler ];
+} ''
+  diff -U3 --color=auto <((jpcontroller -n -f /dev/null 2>&1 || true) | head -n 1 ) <(echo 'No profiled JVMs found.')
+  touch $out
+''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16881,6 +16881,9 @@ with pkgs;
   jprofiler = callPackage ../development/tools/java/jprofiler {
     jdk = jdk11;
   };
+  jprofiler-agent = jprofiler.override {
+    component = "agent";
+  };
 
   jhiccup = callPackage ../development/tools/java/jhiccup { };
 


### PR DESCRIPTION
###### Description of changes

I've also heavy refactored jprofiler port that makes possible to install the last version for macOS.

An agent is very small library which should be integrated into target application to allow remote debugging.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->