### PR TITLE
cro-mag-rally: init at 3.0.0

### DIFF
--- a/pkgs/by-name/cr/cro-mag-rally/package.nix
+++ b/pkgs/by-name/cr/cro-mag-rally/package.nix
@@ -1,0 +1,51 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, SDL2
+, cmake
+, makeWrapper
+}:
+
+stdenv.mkDerivation {
+  pname = "CroMagRally";
+  version = "3.0.0-unstable-2023-05-21";
+
+  src = fetchFromGitHub {
+    owner = "jorio";
+    repo = "CroMagRally";
+    rev = "5983de40c180b50bbbec8b04f5f5f1ceccd1901b";
+    hash = "sha256-QbUkrNY7DZQts8xaimE83yXpCweKvnn0uDb1CawLfEE=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+    makeWrapper
+  ];
+  buildInputs = [
+    SDL2
+  ];
+
+  cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out/share/CroMagRally"
+    mv Data ReadMe.txt "$out/share/CroMagRally/"
+    install -Dm755 {.,$out/bin}/CroMagRally
+    wrapProgram $out/bin/CroMagRally --chdir "$out/share/CroMagRally"
+    install -Dm644 $src/packaging/cromagrally.desktop $out/share/applications/cromagrally.desktop
+    install -Dm644 $src/packaging/cromagrally-desktopicon.png $out/share/pixmaps/cromagrally-desktopicon.png
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A port of Cro-Mag Rally, a 2000 Macintosh game by Pangea Software, for modern operating systems";
+    homepage = "https://github.com/jorio/CroMagRally";
+    changelog = "https://github.com/jorio/CroMagRally/releases";
+    license = licenses.cc-by-sa-40;
+    maintainers = with maintainers; [ lux ];
+    platforms = platforms.linux;
+    mainProgram = "CroMagRally";
+  };
+}


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add [Cro-Mag Rally](https://github.com/jorio/CroMagRally) package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
