### PR TITLE
django: fix build with gdal and use correct geos version

### DIFF
--- a/pkgs/development/python-modules/django/3.nix
+++ b/pkgs/development/python-modules/django/3.nix
@@ -3,7 +3,7 @@
 , buildPythonPackage
 , fetchPypi
 , substituteAll
-, geos
+, geos39
 , gdal
 , asgiref
 , pytz
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   patches = lib.optional withGdal
     (substituteAll {
       src = ./django_3_set_geos_gdal_lib.patch;
-      inherit geos;
+      inherit geos39;
       inherit gdal;
       extension = stdenv.hostPlatform.extensions.sharedLibrary;
     });

--- a/pkgs/development/python-modules/django/django_3_set_geos_gdal_lib.patch
+++ b/pkgs/development/python-modules/django/django_3_set_geos_gdal_lib.patch
@@ -18,7 +18,7 @@ diff -Nur a/django/contrib/gis/geos/libgeos.py b/django/contrib/gis/geos/libgeos
          lib_path = settings.GEOS_LIBRARY_PATH
      except (AttributeError, ImportError, ImproperlyConfigured, OSError):
 -        lib_path = None
-+        lib_path = "@geos@/lib/libgeos_c@extension@"
++        lib_path = "@geos39@/lib/libgeos_c@extension@"
 
      # Setting the appropriate names for the GEOS-C library.
      if lib_path:


### PR DESCRIPTION
###### Description of changes

With the update of geos from 3.9 to 3.10, the use of django with gdal
broke since django 3 does not support geos 3.10.
https://docs.djangoproject.com/en/3.2/ref/contrib/gis/install/geolibs/

geos 3.10 is supported starting django 4.
https://docs.djangoproject.com/en/4.0/ref/contrib/gis/install/geolibs/


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
