### PR TITLE
edgedb: init at unstable-2022-06-27

### DIFF
--- a/pkgs/tools/networking/edgedb/0001-dynamically-patchelf-binaries.patch
+++ b/pkgs/tools/networking/edgedb/0001-dynamically-patchelf-binaries.patch
@@ -1,0 +1,34 @@
+diff --git a/src/portable/install.rs b/src/portable/install.rs
+index dc0d932..5394fc1 100644
+--- a/src/portable/install.rs
++++ b/src/portable/install.rs
+@@ -133,8 +133,16 @@ fn unpack_package(cache_file: &Path, target_dir: &Path)
+     for entry in arch.entries()? {
+         let mut entry = entry?;
+         let path = entry.path()?;
++        let is_inside_bin = {
++            let mut path_iter = path.iter();
++            path_iter.next(); // discards first folder
++            path_iter.as_path().starts_with("bin")
++        };
+         if let Some(path) = build_path(&target_dir, &*path)? {
+-            entry.unpack(path)?;
++            entry.unpack(&path)?;
++            if is_inside_bin {
++                nix_patchelf_if_needed(&path);
++            }
+         }
+     }
+     bar.finish_and_clear();
+@@ -203,3 +211,11 @@ pub fn package(pkg_info: &PackageInfo) -> anyhow::Result<InstallInfo> {
+ 
+     Ok(info)
+ }
++
++fn nix_patchelf_if_needed(dest_path: &Path) {
++    let _ = ::std::process::Command::new("@patchelf@/bin/patchelf")
++        .arg("--set-interpreter")
++        .arg("@dynamicLinker@")
++        .arg(dest_path)
++        .output();
++}

--- a/pkgs/tools/networking/edgedb/default.nix
+++ b/pkgs/tools/networking/edgedb/default.nix
@@ -1,0 +1,55 @@
+{ stdenv
+, lib
+, runCommand
+, patchelf
+, fetchFromGitHub
+, rustPlatform
+, makeWrapper
+, pkg-config
+, curl
+, Security
+, CoreServices
+, libiconv
+, xz
+, perl
+, substituteAll
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "edgedb";
+  version = "unstable-2022-06-27";
+
+  src = fetchFromGitHub {
+    owner = "edgedb";
+    repo = "edgedb-cli";
+    rev = "3c65c8bf0a09988356ad477d0ae234182f809b0a";
+    sha256 = "sha256-UqoRa5ZbPJEHo9wyyygrN1ssorgY3cLw/mMrCDXr4gw=";
+  };
+
+  cargoSha256 = "sha256-6HJkkem44+dat5bmVEM+7GSJFjCz1dYZeRIPEoEwNlI=";
+
+  nativeBuildInputs = [ makeWrapper pkg-config perl ];
+
+  buildInputs = [
+    curl
+  ] ++ lib.optionals stdenv.isDarwin [ CoreServices Security libiconv xz ];
+
+  checkFeatures = [ ];
+
+  patches = [
+    (substituteAll {
+      src = ./0001-dynamically-patchelf-binaries.patch;
+      inherit patchelf;
+      dynamicLinker = stdenv.cc.bintools.dynamicLinker;
+    })
+  ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "EdgeDB cli";
+    homepage = "https://www.edgedb.com/docs/cli/index";
+    license = with licenses; [ asl20 /* or */ mit ];
+    maintainers = [ maintainers.ranfdev ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -406,6 +406,10 @@ with pkgs;
 
   eclipse-mat = callPackage ../development/tools/eclipse-mat { };
 
+  edgedb = callPackage ../tools/networking/edgedb {
+    inherit (darwin.apple_sdk.frameworks) CoreServices Security;
+  };
+
   efficient-compression-tool = callPackage ../tools/compression/efficient-compression-tool { };
 
   evans = callPackage ../development/tools/evans { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
