### PR TITLE
wapiti: remove condition for importlib-metadata

### DIFF
--- a/pkgs/tools/security/wapiti/default.nix
+++ b/pkgs/tools/security/wapiti/default.nix
@@ -15,10 +15,6 @@ python3.pkgs.buildPythonApplication rec {
     sha256 = "sha256-nGAG+7FqEktc55i5Q2urKh52vm/i6kX4kvS2AVUAUjA=";
   };
 
-  nativeBuildInputs = with python3.pkgs; [
-    pytest-runner
-  ];
-
   propagatedBuildInputs = with python3.pkgs; [
     aiocache
     aiosqlite
@@ -30,6 +26,7 @@ python3.pkgs.buildPythonApplication rec {
     httpcore
     httpx
     humanize
+    importlib-metadata
     loguru
     Mako
     markupsafe
@@ -37,10 +34,8 @@ python3.pkgs.buildPythonApplication rec {
     sqlalchemy
     tld
     yaswfp
-  ] ++ lib.optionals (python3.pythonOlder "3.8") [
-    importlib-metadata
   ] ++ httpx.optional-dependencies.brotli
-    ++ httpx.optional-dependencies.socks;
+  ++ httpx.optional-dependencies.socks;
 
   checkInputs = with python3.pkgs; [
     respx
@@ -51,6 +46,8 @@ python3.pkgs.buildPythonApplication rec {
   postPatch = ''
     # Ignore pinned versions
     sed -i -e "s/==[0-9.]*//;s/>=[0-9.]*//" setup.py
+    substituteInPlace setup.py \
+      --replace '"pytest-runner"' ""
     substituteInPlace setup.cfg \
       --replace " --cov --cov-report=xml" ""
   '';
@@ -119,8 +116,9 @@ python3.pkgs.buildPythonApplication rec {
     # TypeError: Expected bytes or bytes-like object got: <class 'str'>
     "test_persister_upload"
   ];
+
   disabledTestPaths = [
-    # requires sslyze
+    # Requires sslyze which is obsolete and was removed
     "tests/attack/test_mod_ssl.py"
   ];
 


### PR DESCRIPTION
###### Description of changes
Fix build (https://hydra.nixos.org/build/182176456)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
