### PR TITLE
python3Packages.cirq-core: 0.14.1 -> 0.15.0

### DIFF
--- a/pkgs/development/python-modules/cirq-core/default.nix
+++ b/pkgs/development/python-modules/cirq-core/default.nix
@@ -31,7 +31,7 @@
 
 buildPythonPackage rec {
   pname = "cirq-core";
-  version = "0.14.1";
+  version = "0.15.0";
 
   disabled = pythonOlder "3.6";
 
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     owner = "quantumlib";
     repo = "cirq";
     rev = "v${version}";
-    sha256 = "sha256-cIDwV3IBXrTJ4jC1/HYmduY3tLe/f6wj8CWZ4cnThG8=";
+    sha256 = "sha256-E36zXpv+9WBNYvv/shItS7Q34gYqUyADlqWd+m4Jpps=";
   };
 
   sourceRoot = "source/${pname}";

--- a/pkgs/development/python-modules/cirq/default.nix
+++ b/pkgs/development/python-modules/cirq/default.nix
@@ -1,5 +1,4 @@
 { buildPythonPackage
-, fetchpatch
 , cirq-aqt
 , cirq-core
 , cirq-google
@@ -7,21 +6,12 @@
 , cirq-pasqal
 , cirq-rigetti
 , cirq-web
-  # test inputs
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "cirq";
   inherit (cirq-core) version src meta;
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/quantumlib/Cirq/commit/b832db606e5f1850b1eda168a6d4a8e77d8ec711.patch";
-      name = "pr-5330-prevent-implicit-packages.patch";
-      sha256 = "sha256-HTEH3fFxPiBedaz5GxZjXayvoiazwHysKZIOzqwZmbg=";
-    })
-  ];
 
   propagatedBuildInputs = [
     cirq-aqt
@@ -34,7 +24,9 @@ buildPythonPackage rec {
   ];
 
   # pythonImportsCheck = [ "cirq" "cirq.Circuit" ];  # cirq's importlib hook doesn't work here
-  checkInputs = [ pytestCheckHook ];
+  checkInputs = [
+    pytestCheckHook
+  ];
 
   # Don't run submodule or development tool tests
   disabledTestPaths = [

--- a/pkgs/development/python-modules/duet/default.nix
+++ b/pkgs/development/python-modules/duet/default.nix
@@ -7,13 +7,13 @@
 
 buildPythonPackage rec {
   pname = "duet";
-  version = "0.2.1";
+  version = "0.2.7";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "duet";
     rev = "v${version}";
-    sha256 = "sha256-hK2Cx7dSm1mGM2z9oCoRogfa2aIsjyJcdpSSfdHhPmw=";
+    sha256 = "sha256-9CTAupAxZI1twoLpgr7VfECw70QunE6pk+SskiT3JDw=";
   };
 
   propagatedBuildInputs = [ typing-extensions ];


### PR DESCRIPTION
###### Description of changes
https://github.com/quantumlib/Cirq/releases/tag/v0.15.0
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
