### PR TITLE
tinygo: 0.23.0 -> 0.25.0

### DIFF
--- a/pkgs/development/compilers/tinygo/0001-Makefile.patch
+++ b/pkgs/development/compilers/tinygo/0001-Makefile.patch
@@ -1,11 +1,11 @@
-From fcae473c4b6ac2120ec75c321d6db850d8ecd6a9 Mon Sep 17 00:00:00 2001
+From ef066db7f5cb7f551f88fb218c82fc947e464425 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Mustafa=20=C3=87al=C4=B1=C5=9Fkan?= <muscaln@protonmail.com>
-Date: Sat, 30 Apr 2022 16:37:44 +0300
+Date: Sun, 3 Jul 2022 14:30:51 +0300
 Subject: [PATCH 1/3] Makefile
 
 
 diff --git a/Makefile b/Makefile
-index dc388c21..7efc9901 100644
+index 60a5a574..904d2db5 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -14,11 +14,6 @@ LLVM_VERSIONS = 14 13 12 11
@@ -20,7 +20,7 @@ index dc388c21..7efc9901 100644
  # First search for a custom built copy, then move on to explicitly version-tagged binaries, then just see if the tool is in path with its normal name.
  findLLVMTool = $(call detect,$(1),$(abspath llvm-build/bin/$(1)) $(foreach ver,$(LLVM_VERSIONS),$(call toolSearchPathsVersion,$(1),$(ver))) $(1))
  CLANG ?= $(call findLLVMTool,clang)
-@@ -644,9 +639,8 @@ endif
+@@ -707,9 +702,8 @@ endif
  wasmtest:
  	$(GO) test ./tests/wasm
  
@@ -31,8 +31,13 @@ index dc388c21..7efc9901 100644
  	@mkdir -p build/release/tinygo/lib/CMSIS/CMSIS
  	@mkdir -p build/release/tinygo/lib/macos-minimal-sdk
  	@mkdir -p build/release/tinygo/lib/mingw-w64/mingw-w64-crt/lib-common
-@@ -663,10 +657,6 @@ build/release: tinygo gen-device wasi-libc $(if $(filter 1,$(USE_SYSTEM_BINARYEN
- 	@mkdir -p build/release/tinygo/pkg/thumbv7em-unknown-unknown-eabi-cortex-m4
+@@ -721,15 +715,8 @@ build/release: tinygo gen-device wasi-libc $(if $(filter 1,$(USE_SYSTEM_BINARYEN
+ 	@mkdir -p build/release/tinygo/lib/picolibc/newlib/libc
+ 	@mkdir -p build/release/tinygo/lib/picolibc/newlib/libm
+ 	@mkdir -p build/release/tinygo/lib/wasi-libc
+-	@mkdir -p build/release/tinygo/pkg/thumbv6m-unknown-unknown-eabi-cortex-m0
+-	@mkdir -p build/release/tinygo/pkg/thumbv6m-unknown-unknown-eabi-cortex-m0plus
+-	@mkdir -p build/release/tinygo/pkg/thumbv7em-unknown-unknown-eabi-cortex-m4
  	@echo copying source files
  	@cp -p  build/tinygo$(EXE)           build/release/tinygo/bin
 -ifneq ($(USE_SYSTEM_BINARYEN),1)
@@ -42,7 +47,7 @@ index dc388c21..7efc9901 100644
  	@cp -rp lib/CMSIS/CMSIS/Include      build/release/tinygo/lib/CMSIS/CMSIS
  	@cp -rp lib/CMSIS/README.md          build/release/tinygo/lib/CMSIS
  	@cp -rp lib/macos-minimal-sdk/*      build/release/tinygo/lib/macos-minimal-sdk
-@@ -705,8 +695,7 @@ endif
+@@ -768,16 +755,9 @@ endif
  	@cp -rp lib/picolibc/newlib/libm/common      build/release/tinygo/lib/picolibc/newlib/libm
  	@cp -rp lib/picolibc-stdio.c         build/release/tinygo/lib
  	@cp -rp lib/wasi-libc/sysroot        build/release/tinygo/lib/wasi-libc/sysroot
@@ -51,7 +56,15 @@ index dc388c21..7efc9901 100644
 +	@cp -rp lib/compiler-rt-builtins     build/release/tinygo/lib/compiler-rt-builtins
  	@cp -rp src                          build/release/tinygo/src
  	@cp -rp targets                      build/release/tinygo/targets
- 	./build/tinygo build-library -target=cortex-m0     -o build/release/tinygo/pkg/thumbv6m-unknown-unknown-eabi-cortex-m0/compiler-rt     compiler-rt
+-	./build/release/tinygo/bin/tinygo build-library -target=cortex-m0     -o build/release/tinygo/pkg/thumbv6m-unknown-unknown-eabi-cortex-m0/compiler-rt     compiler-rt
+-	./build/release/tinygo/bin/tinygo build-library -target=cortex-m0plus -o build/release/tinygo/pkg/thumbv6m-unknown-unknown-eabi-cortex-m0plus/compiler-rt compiler-rt
+-	./build/release/tinygo/bin/tinygo build-library -target=cortex-m4     -o build/release/tinygo/pkg/thumbv7em-unknown-unknown-eabi-cortex-m4/compiler-rt    compiler-rt
+-	./build/release/tinygo/bin/tinygo build-library -target=cortex-m0     -o build/release/tinygo/pkg/thumbv6m-unknown-unknown-eabi-cortex-m0/picolibc     picolibc
+-	./build/release/tinygo/bin/tinygo build-library -target=cortex-m0plus -o build/release/tinygo/pkg/thumbv6m-unknown-unknown-eabi-cortex-m0plus/picolibc picolibc
+-	./build/release/tinygo/bin/tinygo build-library -target=cortex-m4     -o build/release/tinygo/pkg/thumbv7em-unknown-unknown-eabi-cortex-m4/picolibc    picolibc
+ 
+ release:
+ 	tar -czf build/release.tar.gz -C build/release tinygo
 -- 
-2.36.0
+2.37.2
 

--- a/pkgs/development/compilers/tinygo/0002-Add-clang-header-path.patch
+++ b/pkgs/development/compilers/tinygo/0002-Add-clang-header-path.patch
@@ -1,14 +1,14 @@
-From 4ee942ccc7cdb06ee51490e9cb44ecb36b25378a Mon Sep 17 00:00:00 2001
+From 301b2d82cdbfaffe4dfba1d2cfed068a4115f730 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Mustafa=20=C3=87al=C4=B1=C5=9Fkan?= <muscaln@protonmail.com>
 Date: Sat, 30 Apr 2022 16:18:31 +0300
 Subject: [PATCH 2/3] Add clang header path
 
 
 diff --git a/builder/builtins.go b/builder/builtins.go
-index 479b541d..b35283c6 100644
+index 121398fa..a589988b 100644
 --- a/builder/builtins.go
 +++ b/builder/builtins.go
-@@ -164,7 +164,7 @@ var aeabiBuiltins = []string{
+@@ -170,7 +170,7 @@ var aeabiBuiltins = []string{
  var CompilerRT = Library{
  	name: "compiler-rt",
  	cflags: func(target, headerPath string) []string {
@@ -31,10 +31,10 @@ index f1b061ae..159f90cf 100644
  			"-I" + picolibcDir + "/tinystdio",
  			"-I" + headerPath,
 diff --git a/compileopts/config.go b/compileopts/config.go
-index b30e653e..7561b3f2 100644
+index a006b673..3a105b49 100644
 --- a/compileopts/config.go
 +++ b/compileopts/config.go
-@@ -288,6 +288,7 @@ func (c *Config) CFlags() []string {
+@@ -279,6 +279,7 @@ func (c *Config) CFlags() []string {
  		path, _ := c.LibcPath("picolibc")
  		cflags = append(cflags,
  			"--sysroot="+path,
@@ -42,7 +42,7 @@ index b30e653e..7561b3f2 100644
  			"-isystem", filepath.Join(path, "include"), // necessary for Xtensa
  			"-isystem", filepath.Join(picolibcDir, "include"),
  			"-isystem", filepath.Join(picolibcDir, "tinystdio"),
-@@ -297,7 +298,6 @@ func (c *Config) CFlags() []string {
+@@ -288,7 +289,6 @@ func (c *Config) CFlags() []string {
  		path, _ := c.LibcPath("musl")
  		arch := MuslArchitecture(c.Triple())
  		cflags = append(cflags,
@@ -51,5 +51,5 @@ index b30e653e..7561b3f2 100644
  			"-isystem", filepath.Join(root, "lib", "musl", "arch", arch),
  			"-isystem", filepath.Join(root, "lib", "musl", "include"),
 -- 
-2.36.0
+2.37.2
 

--- a/pkgs/development/compilers/tinygo/0003-Use-out-path-as-build-id-on-darwin.patch
+++ b/pkgs/development/compilers/tinygo/0003-Use-out-path-as-build-id-on-darwin.patch
@@ -1,0 +1,56 @@
+From e7357c383188dd735592bd9f2202d2afcfffa39d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Mustafa=20=C3=87al=C4=B1=C5=9Fkan?= <muscaln@protonmail.com>
+Date: Sun, 11 Sep 2022 17:08:33 +0300
+Subject: [PATCH 3/3] Use out path as build id on darwin
+
+
+diff --git a/builder/buildid.go b/builder/buildid.go
+index e6527700..65cb08e8 100644
+--- a/builder/buildid.go
++++ b/builder/buildid.go
+@@ -3,8 +3,6 @@ package builder
+ import (
+ 	"bytes"
+ 	"debug/elf"
+-	"debug/macho"
+-	"encoding/binary"
+ 	"fmt"
+ 	"io"
+ 	"os"
+@@ -53,30 +51,9 @@ func ReadBuildID() ([]byte, error) {
+ 			return goID, nil
+ 		}
+ 	case "darwin":
+-		// Read the LC_UUID load command, which contains the equivalent of a
+-		// build ID.
+-		file, err := macho.NewFile(f)
+-		if err != nil {
+-			return nil, err
+-		}
+-		for _, load := range file.Loads {
+-			// Unfortunately, the debug/macho package doesn't support the
+-			// LC_UUID command directly. So we have to read it from
+-			// macho.LoadBytes.
+-			load, ok := load.(macho.LoadBytes)
+-			if !ok {
+-				continue
+-			}
+-			raw := load.Raw()
+-			command := binary.LittleEndian.Uint32(raw)
+-			if command != 0x1b {
+-				// Looking for the LC_UUID load command.
+-				// LC_UUID is defined here as 0x1b:
+-				// https://opensource.apple.com/source/xnu/xnu-4570.71.2/EXTERNAL_HEADERS/mach-o/loader.h.auto.html
+-				continue
+-			}
+-			return raw[4:], nil
+-		}
++		// On darwin, os.Executable() returns broken path in nix build environment
++		// So we are using $out path as build id since its also unique
++		return []byte("OUT_PATH"), nil
+ 	default:
+ 		// On other platforms (such as Windows) there isn't such a convenient
+ 		// build ID. Luckily, Go does have an equivalent of the build ID, which
+-- 
+2.37.2
+

--- a/pkgs/development/compilers/tinygo/default.nix
+++ b/pkgs/development/compilers/tinygo/default.nix
@@ -18,6 +18,7 @@
 , avrdude
 , gdb
 , openocd
+, tinygoTests ? [ "smoketest" ]
 }:
 
 let
@@ -27,17 +28,17 @@ in
 
 buildGoModule rec {
   pname = "tinygo";
-  version = "0.23.0";
+  version = "0.25.0";
 
   src = fetchFromGitHub {
     owner = "tinygo-org";
     repo = "tinygo";
     rev = "v${version}";
-    sha256 = "sha256-YgQGAQJw9Xyw5BF2d9uZTQHfjHsu2evZGo4RV9DtStE=";
+    sha256 = "sha256-Rxdxum1UIaz8tpEAGqpLvKd25nHdj4Se+IoN29EJEHg=";
     fetchSubmodules = true;
   };
 
-  vendorSha256 = "sha256-fK8BlCh+1NtHW6MwW68iSIB+Sw6AK+g3y4lMyMYrXkk=";
+  vendorSha256 = "sha256-QxLY4KT05PtA/W7d1vKxsq5w35YZ6MJL3Lh726b+E9w=";
 
   patches = [
     ./0001-Makefile.patch
@@ -46,17 +47,22 @@ buildGoModule rec {
       src = ./0002-Add-clang-header-path.patch;
       clang_include = "${clang.cc.lib}/lib/clang/${clang.cc.version}/include";
     })
+
+    #TODO(muscaln): Find a better way to fix build ID on darwin
+    ./0003-Use-out-path-as-build-id-on-darwin.patch
   ];
 
   checkInputs = [ avrgcc binaryen ];
-  nativeBuildInputs = [ go makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ llvm clang.cc ]
     ++ lib.optionals stdenv.isDarwin [ zlib ncurses libffi libxml2 xar ];
 
-  doCheck = stdenv.buildPlatform == stdenv.hostPlatform;
+  doCheck = (stdenv.buildPlatform.canExecute stdenv.hostPlatform);
+  inherit tinygoTests;
 
   allowGoReference = true;
   tags = [ "llvm${llvmMajor}" ];
+  ldflags = [ "-X github.com/tinygo-org/tinygo/goenv.TINYGOROOT=${placeholder "out"}/share/tinygo" ];
   subPackages = [ "." ];
 
   # Output contains static libraries for different arm cpus
@@ -83,8 +89,12 @@ buildGoModule rec {
 
     substituteInPlace Makefile \
       --replace "\$(TINYGO)" "$(pwd)/build/tinygo" \
+      --replace "@\$(MD5SUM)" "md5sum" \
       --replace "build/release/tinygo/bin" "$out/bin" \
       --replace "build/release/" "$out/share/"
+
+    substituteInPlace builder/buildid.go \
+      --replace "OUT_PATH" "$out"
 
     # TODO: Fix mingw and darwin
     # Disable windows and darwin cross-compile tests
@@ -103,24 +113,34 @@ buildGoModule rec {
   '';
 
   preBuild = ''
-    export HOME=$TMPDIR
-    export GOCACHE=$TMPDIR/go-cache
-    export GOPATH=$TMPDIR/go
     export PATH=$out/libexec/tinygo:$PATH
+    export HOME=$TMPDIR
   '';
 
-  postBuild = ''
+  postBuild = let
+    tinygoForBuild = if (stdenv.buildPlatform.canExecute stdenv.hostPlatform)
+      then "build/tinygo"
+      else "${buildPackages.tinygo}/bin/tinygo";
+    in ''
     # Move binary
     mkdir -p build
     mv $GOPATH/bin/tinygo build/tinygo
 
     make gen-device
+
+    export TINYGOROOT=$(pwd)
+    finalRoot=$out/share/tinygo
+
+    for target in thumbv6m-unknown-unknown-eabi-cortex-m0 thumbv6m-unknown-unknown-eabi-cortex-m0plus thumbv7em-unknown-unknown-eabi-cortex-m4; do
+      mkdir -p $finalRoot/pkg/$target
+      for lib in compiler-rt picolibc; do
+        ${tinygoForBuild} build-library -target=''${target#*eabi-} -o $finalRoot/pkg/$target/$lib $lib
+      done
+    done
   '';
 
-  checkPhase = ''
-    runHook preCheck
-    make smoketest XTENSA=0
-    runHook postCheck
+  checkPhase = lib.optionalString (tinygoTests != [ ] && tinygoTests != null) ''
+    make ''${tinygoTests[@]} XTENSA=0 ${lib.optionalString stdenv.isDarwin "AVR=0"}
   '';
 
   installPhase = ''
@@ -129,7 +149,6 @@ buildGoModule rec {
     make build/release
 
     wrapProgram $out/bin/tinygo \
-      --set TINYGOROOT $out/share/tinygo \
       --prefix PATH : ${lib.makeBinPath [ go avrdude openocd avrgcc binaryen ]}:$out/libexec/tinygo
 
     runHook postInstall
@@ -142,6 +161,5 @@ buildGoModule rec {
     description = "Go compiler for small places";
     license = licenses.bsd3;
     maintainers = with maintainers; [ Madouura muscaln ];
-    broken = stdenv.isDarwin;
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Bumped version, tried to fix darwin build


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
