### PR TITLE
python3Packages.reorder-python-imports: 3.1.0 -> 3.8.1, python3Packages.classify-imports: init at 4.1.0

### DIFF
--- a/pkgs/development/python-modules/classify-imports/default.nix
+++ b/pkgs/development/python-modules/classify-imports/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "classify-imports";
+  version = "4.1.0";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "asottile";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-w/+Sf2ZVSDmFNPICJfAKzfukcznWyFBhi7hjIELtYGI=";
+  };
+
+  pythonImportsCheck = [
+    "classify_imports"
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Utilities for refactoring imports in python-like syntax";
+    homepage = "https://github.com/asottile/classify-imports";
+    license = licenses.mit;
+    maintainers = with maintainers; [ gador ];
+  };
+}

--- a/pkgs/development/python-modules/reorder-python-imports/default.nix
+++ b/pkgs/development/python-modules/reorder-python-imports/default.nix
@@ -4,21 +4,25 @@
 , pytestCheckHook
 , pythonOlder
 , aspy-refactor-imports
+, classify-imports
 }:
 
 buildPythonPackage rec {
   pname = "reorder-python-imports";
-  version = "3.1.0";
+  version = "3.8.1";
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "asottile";
     repo = "reorder_python_imports";
     rev = "v${version}";
-    hash = "sha256-Ge+VQjK24TqWLMQS19DBX+FFHF3irogK21orlENJx50=";
+    hash = "sha256-CLC9dfNSYqEBZB2fP34jpA/4cxm0HZzjo/e7Yn8XPFc=";
   };
 
-  propagatedBuildInputs = [ aspy-refactor-imports ];
+  propagatedBuildInputs = [
+    aspy-refactor-imports
+    classify-imports
+  ];
 
   pythonImportsCheck = [
     "reorder_python_imports"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1706,6 +1706,8 @@ in {
 
   claripy = callPackage ../development/python-modules/claripy { };
 
+  classify-imports = callPackage ../development/python-modules/classify-imports { };
+
   cld2-cffi = callPackage ../development/python-modules/cld2-cffi { };
 
   cle = callPackage ../development/python-modules/cle { };


### PR DESCRIPTION
###### Description of changes

Update reorder-python-imports. Init classify-imports for this package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
