### PR TITLE
ocamlPackages.duff: 0.4 → 0.5

### DIFF
--- a/pkgs/development/ocaml-modules/duff/default.nix
+++ b/pkgs/development/ocaml-modules/duff/default.nix
@@ -1,22 +1,20 @@
-{ lib, fetchurl, buildDunePackage, fetchpatch
-, stdlib-shims, bigarray-compat, fmt
+{ lib, fetchurl, buildDunePackage, ocaml
+, fmt
 , alcotest, hxd, crowbar, bigstringaf
 }:
 
 buildDunePackage rec {
   pname = "duff";
-  version = "0.4";
-
-  useDune2 = true;
+  version = "0.5";
 
   src = fetchurl {
-    url = "https://github.com/mirage/duff/releases/download/v${version}/duff-v${version}.tbz";
-    sha256 = "4795e8344a2c2562e0ef6c44ab742334b5cd807637354715889741b20a461da4";
+    url = "https://github.com/mirage/duff/releases/download/v${version}/duff-${version}.tbz";
+    sha256 = "sha256-0eqpfPWNOHYjkcjXRnZUTUFF0/L9E+TNoOqKCETN5hI=";
   };
 
-  propagatedBuildInputs = [ stdlib-shims bigarray-compat fmt ];
+  propagatedBuildInputs = [ fmt ];
 
-  doCheck = true;
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
   checkInputs = [
     alcotest
     crowbar


### PR DESCRIPTION
###### Description of changes

Small update (required for updating `carton`): https://github.com/mirage/duff/releases/tag/v0.5

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
