### PR TITLE
kodi.packages.invidious: init at 0.1.0+matrix.1

### DIFF
--- a/pkgs/applications/video/kodi/addons/invidious/default.nix
+++ b/pkgs/applications/video/kodi/addons/invidious/default.nix
@@ -1,0 +1,32 @@
+{ lib, buildKodiAddon, fetchpatch, fetchzip, addonUpdateScript, requests, inputstream-adaptive, inputstreamhelper }:
+
+buildKodiAddon rec {
+  pname = "invidious";
+  namespace = "plugin.video.invidious";
+  version = "0.1.0+matrix.1";
+
+  src = fetchzip {
+    url = "https://mirrors.kodi.tv/addons/matrix/${namespace}/${namespace}-${version}.zip";
+    sha256 = "sha256-4z2/YTso5KV6JHS/DOXll2lKOoVnW1i5MnpmV6ESXbM=";
+  };
+
+  propagatedBuildInputs = [
+    requests
+    inputstream-adaptive
+    inputstreamhelper
+  ];
+
+  passthru = {
+    pythonPath = "resources/lib";
+    updateScript = addonUpdateScript {
+      attrPath = "kodi.packages.invidious";
+    };
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/TheAssassin/kodi-invidious-plugin";
+    description = "A privacy-friendly way of watching YouTube content";
+    license = licenses.mit;
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -58,6 +58,8 @@ let self = rec {
 
   iagl = callPackage ../applications/video/kodi/addons/iagl { };
 
+  invidious = callPackage ../applications/video/kodi/addons/invidious { };
+
   libretro = callPackage ../applications/video/kodi/addons/libretro { };
 
   libretro-genplus = callPackage ../applications/video/kodi/addons/libretro-genplus { inherit genesis-plus-gx; };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Someone asked for this: https://discourse.nixos.org/t/install-kodi-addons/20094

No harm in a backport either.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
