### PR TITLE
halide: 10.0.0 -> 14.0.0

### DIFF
--- a/pkgs/development/compilers/halide/default.nix
+++ b/pkgs/development/compilers/halide/default.nix
@@ -54,6 +54,6 @@ llvmPackages.stdenv.mkDerivation rec {
     homepage = "https://halide-lang.org";
     license = licenses.mit;
     platforms = platforms.all;
-    maintainers = [ maintainers.ck3d ];
+    maintainers = with maintainers; [ ck3d atila ];
   };
 }

--- a/pkgs/development/compilers/halide/default.nix
+++ b/pkgs/development/compilers/halide/default.nix
@@ -15,22 +15,16 @@ assert blas.implementation == "openblas" && lapack.implementation == "openblas";
 
 llvmPackages.stdenv.mkDerivation rec {
   pname = "halide";
-  version = "10.0.0";
+  version = "14.0.0";
 
   src = fetchFromGitHub {
     owner = "halide";
     repo = "Halide";
     rev = "v${version}";
-    sha256 = "0il71rppjp76m7zd420siidvhs76sqiq26h60ywk812sj9mmgxj6";
+    sha256 = "sha256-/7U2TBcpSAKeEyWncAbtW6Vk/cP+rp1CXtbIjvQMmZA=";
   };
 
-  # clang fails to compile intermediate code because
-  # of unused "--gcc-toolchain" option
-  postPatch = ''
-    sed -i "s/-Werror//" src/CMakeLists.txt
-  '';
-
-  cmakeFlags = [ "-DWARNINGS_AS_ERRORS=OFF" "-DWITH_PYTHON_BINDINGS=OFF" ];
+  cmakeFlags = [ "-DWARNINGS_AS_ERRORS=OFF" "-DWITH_PYTHON_BINDINGS=OFF" "-DTARGET_WEBASSEMBLY=OFF" ];
 
   # Note: only openblas and not atlas part of this Nix expression
   # see pkgs/development/libraries/science/math/liblapack/3.5.0.nix

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7310,7 +7310,7 @@ with pkgs;
   halibut = callPackage ../tools/typesetting/halibut { };
 
   halide = callPackage ../development/compilers/halide {
-    llvmPackages = llvmPackages_9;
+    llvmPackages = llvmPackages_14;
   };
 
   harePackages = recurseIntoAttrs (callPackage ../development/compilers/hare { });


### PR DESCRIPTION
###### Description of changes

Major changes [13.0.3](https://github.com/halide/Halide/releases/tag/v13.0.3) -> [14.0.0](https://github.com/halide/Halide/releases/tag/v14.0.0)
`@abadams`
Add ability to pass a user context in JIT mode (https://github.com/halide/Halide/pull/6313)
Reenable warning about unscheduled update definitions (https://github.com/halide/Halide/pull/6602)
`@alexreinking`
Add helper for cross-compiling Halide generators. (https://github.com/halide/Halide/pull/6366)
`@LebedevRI`
Implement SanitizerCoverage support (Refs. https://github.com/halide/Halide/issues/6513) (https://github.com/halide/Halide/pull/6517)
`@steven-johnson`
Expand optional static-typing for Buffer to include dimensionality (https://github.com/halide/Halide/pull/6574)
Deprecate the Generator::build() method (https://github.com/halide/Halide/pull/6580)
Move GeneratorContext into a standalone class (https://github.com/halide/Halide/pull/6618)
Python Bindings didn't allow for zero-D Funcs, ImageParams, Buffers (https://github.com/halide/Halide/pull/6633)
`@zvookin`
Timer based profiler (https://github.com/halide/Halide/pull/6642)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package failed to build:</summary>
  <ul>
    <li>hdr-plus</li>
  </ul>
</details>
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>halide</li>
  </ul>
</details>
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
