### PR TITLE
nixpkgs: useRandomLayers option in dockerTools.buildLayeredImage

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -157,6 +157,16 @@
         </para>
       </listitem>
     </itemizedlist>
+    <itemizedlist spacing="compact">
+      <listitem>
+        <para>
+          <literal>pkgs.dockerTools.buildLayeredImage</literal> has a
+          new option <literal>useRandomLayers</literal> that if set then
+          packages are distributed randomly in the image layers, so that
+          layer sizes are more uniform.
+        </para>
+      </listitem>
+    </itemizedlist>
   </section>
   <section xml:id="sec-release-22.11-incompatibilities">
     <title>Backward Incompatibilities</title>

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -66,6 +66,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- `pkgs.dockerTools.buildLayeredImage` has a new option `useRandomLayers` that if set then packages are distributed randomly in the image layers, so that layer sizes are more uniform.
+
 ## Backward Incompatibilities {#sec-release-22.11-incompatibilities}
 
 - The `isCompatible` predicate checking CPU compatibility is no longer exposed


### PR DESCRIPTION
If set then the packages are distributed randomly in the layers instead of a single package in every layer except the last one. This lets the layers be of more uniform size, making pulls from registries faster (pulls are parallelized on layers).

###### Description of changes

A new option, `useRandomLayers`, was added to `pkgs.dockerTools.buildLayeredImage`.

I updated the bash script inside `streamLayeredImage` that copies different packages to layers: instead of creating many single-package layers, I take the list of packages and distribute them into random bins modulo `maxLayers`, and then each bin becomes a layer.

I used `jq` to do the work in order to keep the style and brevity of the existing code.

There was a comment in the code imploring future contributors to check a few edge cases. I checked them and made sure they work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

