### PR TITLE
[22.05] curl: add patches for multiple CVEs

### DIFF
--- a/pkgs/tools/networking/curl/CVE-2022-32205.patch
+++ b/pkgs/tools/networking/curl/CVE-2022-32205.patch
@@ -1,0 +1,171 @@
+From 48d7064a49148f03942380967da739dcde1cdc24 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Sun, 26 Jun 2022 11:00:48 +0200
+Subject: [PATCH] cookie: apply limits
+
+- Send no more than 150 cookies per request
+- Cap the max length used for a cookie: header to 8K
+- Cap the max number of received Set-Cookie: headers to 50
+
+Bug: https://curl.se/docs/CVE-2022-32205.html
+CVE-2022-32205
+Reported-by: Harry Sintonen
+Closes #9048
+---
+ lib/cookie.c  | 14 ++++++++++++--
+ lib/cookie.h  | 21 +++++++++++++++++++--
+ lib/http.c    | 13 +++++++++++--
+ lib/urldata.h |  1 +
+ 4 files changed, 43 insertions(+), 6 deletions(-)
+
+diff --git a/lib/cookie.c b/lib/cookie.c
+index a308346a777bc..a1ab89532033b 100644
+--- a/lib/cookie.c
++++ b/lib/cookie.c
+@@ -482,6 +482,10 @@ Curl_cookie_add(struct Curl_easy *data,
+   (void)data;
+ #endif
+ 
++  DEBUGASSERT(MAX_SET_COOKIE_AMOUNT <= 255); /* counter is an unsigned char */
++  if(data->req.setcookies >= MAX_SET_COOKIE_AMOUNT)
++    return NULL;
++
+   /* First, alloc and init a new struct for it */
+   co = calloc(1, sizeof(struct Cookie));
+   if(!co)
+@@ -821,7 +825,7 @@ Curl_cookie_add(struct Curl_easy *data,
+       freecookie(co);
+       return NULL;
+     }
+-
++    data->req.setcookies++;
+   }
+   else {
+     /*
+@@ -1375,7 +1379,8 @@ static struct Cookie *dup_cookie(struct Cookie *src)
+  *
+  * It shall only return cookies that haven't expired.
+  */
+-struct Cookie *Curl_cookie_getlist(struct CookieInfo *c,
++struct Cookie *Curl_cookie_getlist(struct Curl_easy *data,
++                                   struct CookieInfo *c,
+                                    const char *host, const char *path,
+                                    bool secure)
+ {
+@@ -1430,6 +1435,11 @@ struct Cookie *Curl_cookie_getlist(struct CookieInfo *c,
+             mainco = newco;
+ 
+             matches++;
++            if(matches >= MAX_COOKIE_SEND_AMOUNT) {
++              infof(data, "Included max number of cookies (%u) in request!",
++                    matches);
++              break;
++            }
+           }
+           else
+             goto fail;
+diff --git a/lib/cookie.h b/lib/cookie.h
+index 453dfced8a342..abc0a2e8a01ad 100644
+--- a/lib/cookie.h
++++ b/lib/cookie.h
+@@ -83,10 +83,26 @@ struct CookieInfo {
+ */
+ #define MAX_COOKIE_LINE 5000
+ 
+-/* This is the maximum length of a cookie name or content we deal with: */
++/* Maximum length of an incoming cookie name or content we deal with. Longer
++   cookies are ignored. */
+ #define MAX_NAME 4096
+ #define MAX_NAME_TXT "4095"
+ 
++/* Maximum size for an outgoing cookie line libcurl will use in an http
++   request. This is the default maximum length used in some versions of Apache
++   httpd. */
++#define MAX_COOKIE_HEADER_LEN 8190
++
++/* Maximum number of cookies libcurl will send in a single request, even if
++   there might be more cookies that match. One reason to cap the number is to
++   keep the maximum HTTP request within the maximum allowed size. */
++#define MAX_COOKIE_SEND_AMOUNT 150
++
++/* Maximum number of Set-Cookie: lines accepted in a single response. If more
++   such header lines are received, they are ignored. This value must be less
++   than 256 since an unsigned char is used to count. */
++#define MAX_SET_COOKIE_AMOUNT 50
++
+ struct Curl_easy;
+ /*
+  * Add a cookie to the internal list of cookies. The domain and path arguments
+@@ -99,7 +115,8 @@ struct Cookie *Curl_cookie_add(struct Curl_easy *data,
+                                const char *domain, const char *path,
+                                bool secure);
+ 
+-struct Cookie *Curl_cookie_getlist(struct CookieInfo *c, const char *host,
++struct Cookie *Curl_cookie_getlist(struct Curl_easy *data,
++                                   struct CookieInfo *c, const char *host,
+                                    const char *path, bool secure);
+ void Curl_cookie_freelist(struct Cookie *cookies);
+ void Curl_cookie_clearall(struct CookieInfo *cookies);
+diff --git a/lib/http.c b/lib/http.c
+index 5284475ba92c4..258722a602e40 100644
+--- a/lib/http.c
++++ b/lib/http.c
+@@ -2711,12 +2711,14 @@ CURLcode Curl_http_bodysend(struct Curl_easy *data, struct connectdata *conn,
+ }
+ 
+ #if !defined(CURL_DISABLE_COOKIES)
++
+ CURLcode Curl_http_cookies(struct Curl_easy *data,
+                            struct connectdata *conn,
+                            struct dynbuf *r)
+ {
+   CURLcode result = CURLE_OK;
+   char *addcookies = NULL;
++  bool linecap = FALSE;
+   if(data->set.str[STRING_COOKIE] &&
+      !Curl_checkheaders(data, STRCONST("Cookie")))
+     addcookies = data->set.str[STRING_COOKIE];
+@@ -2734,7 +2736,7 @@ CURLcode Curl_http_cookies(struct Curl_easy *data,
+         !strcmp(host, "127.0.0.1") ||
+         !strcmp(host, "[::1]") ? TRUE : FALSE;
+       Curl_share_lock(data, CURL_LOCK_DATA_COOKIE, CURL_LOCK_ACCESS_SINGLE);
+-      co = Curl_cookie_getlist(data->cookies, host, data->state.up.path,
++      co = Curl_cookie_getlist(data, data->cookies, host, data->state.up.path,
+                                secure_context);
+       Curl_share_unlock(data, CURL_LOCK_DATA_COOKIE);
+     }
+@@ -2748,6 +2750,13 @@ CURLcode Curl_http_cookies(struct Curl_easy *data,
+             if(result)
+               break;
+           }
++          if((Curl_dyn_len(r) + strlen(co->name) + strlen(co->value) + 1) >=
++             MAX_COOKIE_HEADER_LEN) {
++            infof(data, "Restricted outgoing cookies due to header size, "
++                  "'%s' not sent", co->name);
++            linecap = TRUE;
++            break;
++          }
+           result = Curl_dyn_addf(r, "%s%s=%s", count?"; ":"",
+                                  co->name, co->value);
+           if(result)
+@@ -2758,7 +2767,7 @@ CURLcode Curl_http_cookies(struct Curl_easy *data,
+       }
+       Curl_cookie_freelist(store);
+     }
+-    if(addcookies && !result) {
++    if(addcookies && !result && !linecap) {
+       if(!count)
+         result = Curl_dyn_addn(r, STRCONST("Cookie: "));
+       if(!result) {
+diff --git a/lib/urldata.h b/lib/urldata.h
+index 17fe25720be33..bcb4d460c2fe6 100644
+--- a/lib/urldata.h
++++ b/lib/urldata.h
+@@ -698,6 +698,7 @@ struct SingleRequest {
+ #ifndef CURL_DISABLE_DOH
+   struct dohdata *doh; /* DoH specific data for this request */
+ #endif
++  unsigned char setcookies;
+   BIT(header);        /* incoming data has HTTP header */
+   BIT(content_range); /* set TRUE if Content-Range: was found */
+   BIT(upload_done);   /* set to TRUE when doing chunked transfer-encoding

--- a/pkgs/tools/networking/curl/CVE-2022-32206.patch
+++ b/pkgs/tools/networking/curl/CVE-2022-32206.patch
@@ -1,0 +1,48 @@
+From 3a09fbb7f264c67c438d01a30669ce325aa508e2 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Mon, 16 May 2022 16:28:13 +0200
+Subject: [PATCH] content_encoding: return error on too many compression steps
+
+The max allowed steps is arbitrarily set to 5.
+
+Bug: https://curl.se/docs/CVE-2022-32206.html
+CVE-2022-32206
+Reported-by: Harry Sintonen
+Closes #9049
+---
+ lib/content_encoding.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/lib/content_encoding.c b/lib/content_encoding.c
+index c5591ca48ac78..95ba48a2dd563 100644
+--- a/lib/content_encoding.c
++++ b/lib/content_encoding.c
+@@ -1028,12 +1028,16 @@ static const struct content_encoding *find_encoding(const char *name,
+   return NULL;
+ }
+ 
++/* allow no more than 5 "chained" compression steps */
++#define MAX_ENCODE_STACK 5
++
+ /* Set-up the unencoding stack from the Content-Encoding header value.
+  * See RFC 7231 section 3.1.2.2. */
+ CURLcode Curl_build_unencoding_stack(struct Curl_easy *data,
+                                      const char *enclist, int maybechunked)
+ {
+   struct SingleRequest *k = &data->req;
++  int counter = 0;
+ 
+   do {
+     const char *name;
+@@ -1068,6 +1072,11 @@ CURLcode Curl_build_unencoding_stack(struct Curl_easy *data,
+       if(!encoding)
+         encoding = &error_encoding;  /* Defer error at stack use. */
+ 
++      if(++counter >= MAX_ENCODE_STACK) {
++        failf(data, "Reject response due to %u content encodings",
++              counter);
++        return CURLE_BAD_CONTENT_ENCODING;
++      }
+       /* Stack the unencoding stage. */
+       writer = new_unencoding_writer(data, encoding, k->writer_stack);
+       if(!writer)

--- a/pkgs/tools/networking/curl/CVE-2022-32207.patch
+++ b/pkgs/tools/networking/curl/CVE-2022-32207.patch
@@ -1,0 +1,476 @@
+As well as the upstream patch (which follows), we also need to
+propagate its changes to the generated autotools files because
+we build from the release tarball:
+
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -795,6 +795,7 @@ LIB_CFILES = \
+   escape.c           \
+   file.c             \
+   fileinfo.c         \
++  fopen.c            \
+   formdata.c         \
+   ftp.c              \
+   ftplistparser.c    \
+@@ -928,6 +929,7 @@ LIB_HFILES = \
+   escape.h           \
+   file.h             \
+   fileinfo.h         \
++  fopen.h            \
+   formdata.h         \
+   ftp.h              \
+   ftplistparser.h    \
+--- a/configure
++++ b/configure
+@@ -44823,7 +44823,7 @@ fi
+ 
+ 
+ 
+-  for ac_func in fnmatch geteuid getpass_r getppid getpwuid getpwuid_r getrlimit gettimeofday if_nametoindex mach_absolute_time pipe setlocale setmode setrlimit usleep utime utimes
++  for ac_func in fnmatch fchmod geteuid getpass_r getppid getpwuid getpwuid_r getrlimit gettimeofday if_nametoindex mach_absolute_time pipe setlocale setmode setrlimit usleep utime utimes
+ do :
+   as_ac_var=`printf "%s\n" "ac_cv_func_$ac_func" | $as_tr_sh`
+ ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+--- a/lib/Makefile.in
++++ b/lib/Makefile.in
+@@ -205,7 +205,7 @@ am__objects_1 = libcurl_la-altsvc.lo libcurl_la-amigaos.lo \
+ 	libcurl_la-doh.lo libcurl_la-dotdot.lo libcurl_la-dynbuf.lo \
+ 	libcurl_la-easy.lo libcurl_la-easygetopt.lo \
+ 	libcurl_la-easyoptions.lo libcurl_la-escape.lo \
+-	libcurl_la-file.lo libcurl_la-fileinfo.lo \
++	libcurl_la-file.lo libcurl_la-fileinfo.lo libcurl_la-fopen.lo \
+ 	libcurl_la-formdata.lo libcurl_la-ftp.lo \
+ 	libcurl_la-ftplistparser.lo libcurl_la-getenv.lo \
+ 	libcurl_la-getinfo.lo libcurl_la-gopher.lo libcurl_la-h2h3.lo \
+@@ -294,23 +294,23 @@ am__objects_9 = libcurlu_la-altsvc.lo libcurlu_la-amigaos.lo \
+ 	libcurlu_la-easy.lo libcurlu_la-easygetopt.lo \
+ 	libcurlu_la-easyoptions.lo libcurlu_la-escape.lo \
+ 	libcurlu_la-file.lo libcurlu_la-fileinfo.lo \
+-	libcurlu_la-formdata.lo libcurlu_la-ftp.lo \
+-	libcurlu_la-ftplistparser.lo libcurlu_la-getenv.lo \
+-	libcurlu_la-getinfo.lo libcurlu_la-gopher.lo \
+-	libcurlu_la-h2h3.lo libcurlu_la-hash.lo libcurlu_la-headers.lo \
+-	libcurlu_la-hmac.lo libcurlu_la-hostasyn.lo \
+-	libcurlu_la-hostip.lo libcurlu_la-hostip4.lo \
+-	libcurlu_la-hostip6.lo libcurlu_la-hostsyn.lo \
+-	libcurlu_la-hsts.lo libcurlu_la-http.lo libcurlu_la-http2.lo \
+-	libcurlu_la-http_chunks.lo libcurlu_la-http_digest.lo \
+-	libcurlu_la-http_negotiate.lo libcurlu_la-http_ntlm.lo \
+-	libcurlu_la-http_proxy.lo libcurlu_la-http_aws_sigv4.lo \
+-	libcurlu_la-idn_win32.lo libcurlu_la-if2ip.lo \
+-	libcurlu_la-imap.lo libcurlu_la-inet_ntop.lo \
+-	libcurlu_la-inet_pton.lo libcurlu_la-krb5.lo \
+-	libcurlu_la-ldap.lo libcurlu_la-llist.lo libcurlu_la-md4.lo \
+-	libcurlu_la-md5.lo libcurlu_la-memdebug.lo libcurlu_la-mime.lo \
+-	libcurlu_la-mprintf.lo libcurlu_la-mqtt.lo \
++	libcurlu_la-fopen.lo libcurlu_la-formdata.lo \
++	libcurlu_la-ftp.lo libcurlu_la-ftplistparser.lo \
++	libcurlu_la-getenv.lo libcurlu_la-getinfo.lo \
++	libcurlu_la-gopher.lo libcurlu_la-h2h3.lo libcurlu_la-hash.lo \
++	libcurlu_la-headers.lo libcurlu_la-hmac.lo \
++	libcurlu_la-hostasyn.lo libcurlu_la-hostip.lo \
++	libcurlu_la-hostip4.lo libcurlu_la-hostip6.lo \
++	libcurlu_la-hostsyn.lo libcurlu_la-hsts.lo libcurlu_la-http.lo \
++	libcurlu_la-http2.lo libcurlu_la-http_chunks.lo \
++	libcurlu_la-http_digest.lo libcurlu_la-http_negotiate.lo \
++	libcurlu_la-http_ntlm.lo libcurlu_la-http_proxy.lo \
++	libcurlu_la-http_aws_sigv4.lo libcurlu_la-idn_win32.lo \
++	libcurlu_la-if2ip.lo libcurlu_la-imap.lo \
++	libcurlu_la-inet_ntop.lo libcurlu_la-inet_pton.lo \
++	libcurlu_la-krb5.lo libcurlu_la-ldap.lo libcurlu_la-llist.lo \
++	libcurlu_la-md4.lo libcurlu_la-md5.lo libcurlu_la-memdebug.lo \
++	libcurlu_la-mime.lo libcurlu_la-mprintf.lo libcurlu_la-mqtt.lo \
+ 	libcurlu_la-multi.lo libcurlu_la-netrc.lo \
+ 	libcurlu_la-nonblock.lo libcurlu_la-openldap.lo \
+ 	libcurlu_la-parsedate.lo libcurlu_la-pingpong.lo \
+@@ -413,6 +413,7 @@ am__depfiles_remade = ./$(DEPDIR)/libcurl_la-altsvc.Plo \
+ 	./$(DEPDIR)/libcurl_la-escape.Plo \
+ 	./$(DEPDIR)/libcurl_la-file.Plo \
+ 	./$(DEPDIR)/libcurl_la-fileinfo.Plo \
++	./$(DEPDIR)/libcurl_la-fopen.Plo \
+ 	./$(DEPDIR)/libcurl_la-formdata.Plo \
+ 	./$(DEPDIR)/libcurl_la-ftp.Plo \
+ 	./$(DEPDIR)/libcurl_la-ftplistparser.Plo \
+@@ -530,6 +531,7 @@ am__depfiles_remade = ./$(DEPDIR)/libcurl_la-altsvc.Plo \
+ 	./$(DEPDIR)/libcurlu_la-escape.Plo \
+ 	./$(DEPDIR)/libcurlu_la-file.Plo \
+ 	./$(DEPDIR)/libcurlu_la-fileinfo.Plo \
++	./$(DEPDIR)/libcurlu_la-fopen.Plo \
+ 	./$(DEPDIR)/libcurlu_la-formdata.Plo \
+ 	./$(DEPDIR)/libcurlu_la-ftp.Plo \
+ 	./$(DEPDIR)/libcurlu_la-ftplistparser.Plo \
+@@ -1132,6 +1134,7 @@ LIB_CFILES = \
+   escape.c           \
+   file.c             \
+   fileinfo.c         \
++  fopen.c            \
+   formdata.c         \
+   ftp.c              \
+   ftplistparser.c    \
+@@ -1265,6 +1268,7 @@ LIB_HFILES = \
+   escape.h           \
+   file.h             \
+   fileinfo.h         \
++  fopen.h            \
+   formdata.h         \
+   ftp.h              \
+   ftplistparser.h    \
+@@ -1683,6 +1687,7 @@ distclean-compile:
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libcurl_la-escape.Plo@am__quote@ # am--include-marker
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libcurl_la-file.Plo@am__quote@ # am--include-marker
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libcurl_la-fileinfo.Plo@am__quote@ # am--include-marker
++@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libcurl_la-fopen.Plo@am__quote@ # am--include-marker
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libcurl_la-formdata.Plo@am__quote@ # am--include-marker
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libcurl_la-ftp.Plo@am__quote@ # am--include-marker
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libcurl_la-ftplistparser.Plo@am__quote@ # am--include-marker
+@@ -1803,6 +1808,7 @@ distclean-compile:
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libcurlu_la-escape.Plo@am__quote@ # am--include-marker
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libcurlu_la-file.Plo@am__quote@ # am--include-marker
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libcurlu_la-fileinfo.Plo@am__quote@ # am--include-marker
++@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libcurlu_la-fopen.Plo@am__quote@ # am--include-marker
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libcurlu_la-formdata.Plo@am__quote@ # am--include-marker
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libcurlu_la-ftp.Plo@am__quote@ # am--include-marker
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libcurlu_la-ftplistparser.Plo@am__quote@ # am--include-marker
+@@ -2260,6 +2266,13 @@ libcurl_la-fileinfo.lo: fileinfo.c
+ @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+ @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libcurl_la_CPPFLAGS) $(CPPFLAGS) $(libcurl_la_CFLAGS) $(CFLAGS) -c -o libcurl_la-fileinfo.lo `test -f 'fileinfo.c' || echo '$(srcdir)/'`fileinfo.c
+ 
++libcurl_la-fopen.lo: fopen.c
++@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libcurl_la_CPPFLAGS) $(CPPFLAGS) $(libcurl_la_CFLAGS) $(CFLAGS) -MT libcurl_la-fopen.lo -MD -MP -MF $(DEPDIR)/libcurl_la-fopen.Tpo -c -o libcurl_la-fopen.lo `test -f 'fopen.c' || echo '$(srcdir)/'`fopen.c
++@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/libcurl_la-fopen.Tpo $(DEPDIR)/libcurl_la-fopen.Plo
++@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='fopen.c' object='libcurl_la-fopen.lo' libtool=yes @AMDEPBACKSLASH@
++@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
++@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libcurl_la_CPPFLAGS) $(CPPFLAGS) $(libcurl_la_CFLAGS) $(CFLAGS) -c -o libcurl_la-fopen.lo `test -f 'fopen.c' || echo '$(srcdir)/'`fopen.c
++
+ libcurl_la-formdata.lo: formdata.c
+ @am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libcurl_la_CPPFLAGS) $(CPPFLAGS) $(libcurl_la_CFLAGS) $(CFLAGS) -MT libcurl_la-formdata.lo -MD -MP -MF $(DEPDIR)/libcurl_la-formdata.Tpo -c -o libcurl_la-formdata.lo `test -f 'formdata.c' || echo '$(srcdir)/'`formdata.c
+ @am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/libcurl_la-formdata.Tpo $(DEPDIR)/libcurl_la-formdata.Plo
+@@ -3352,6 +3365,13 @@ libcurlu_la-fileinfo.lo: fileinfo.c
+ @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+ @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libcurlu_la_CPPFLAGS) $(CPPFLAGS) $(libcurlu_la_CFLAGS) $(CFLAGS) -c -o libcurlu_la-fileinfo.lo `test -f 'fileinfo.c' || echo '$(srcdir)/'`fileinfo.c
+ 
++libcurlu_la-fopen.lo: fopen.c
++@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libcurlu_la_CPPFLAGS) $(CPPFLAGS) $(libcurlu_la_CFLAGS) $(CFLAGS) -MT libcurlu_la-fopen.lo -MD -MP -MF $(DEPDIR)/libcurlu_la-fopen.Tpo -c -o libcurlu_la-fopen.lo `test -f 'fopen.c' || echo '$(srcdir)/'`fopen.c
++@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/libcurlu_la-fopen.Tpo $(DEPDIR)/libcurlu_la-fopen.Plo
++@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='fopen.c' object='libcurlu_la-fopen.lo' libtool=yes @AMDEPBACKSLASH@
++@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
++@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libcurlu_la_CPPFLAGS) $(CPPFLAGS) $(libcurlu_la_CFLAGS) $(CFLAGS) -c -o libcurlu_la-fopen.lo `test -f 'fopen.c' || echo '$(srcdir)/'`fopen.c
++
+ libcurlu_la-formdata.lo: formdata.c
+ @am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libcurlu_la_CPPFLAGS) $(CPPFLAGS) $(libcurlu_la_CFLAGS) $(CFLAGS) -MT libcurlu_la-formdata.lo -MD -MP -MF $(DEPDIR)/libcurlu_la-formdata.Tpo -c -o libcurlu_la-formdata.lo `test -f 'formdata.c' || echo '$(srcdir)/'`formdata.c
+ @am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/libcurlu_la-formdata.Tpo $(DEPDIR)/libcurlu_la-formdata.Plo
+@@ -4357,6 +4377,7 @@ distclean: distclean-am
+ 	-rm -f ./$(DEPDIR)/libcurl_la-escape.Plo
+ 	-rm -f ./$(DEPDIR)/libcurl_la-file.Plo
+ 	-rm -f ./$(DEPDIR)/libcurl_la-fileinfo.Plo
++	-rm -f ./$(DEPDIR)/libcurl_la-fopen.Plo
+ 	-rm -f ./$(DEPDIR)/libcurl_la-formdata.Plo
+ 	-rm -f ./$(DEPDIR)/libcurl_la-ftp.Plo
+ 	-rm -f ./$(DEPDIR)/libcurl_la-ftplistparser.Plo
+@@ -4477,6 +4498,7 @@ distclean: distclean-am
+ 	-rm -f ./$(DEPDIR)/libcurlu_la-escape.Plo
+ 	-rm -f ./$(DEPDIR)/libcurlu_la-file.Plo
+ 	-rm -f ./$(DEPDIR)/libcurlu_la-fileinfo.Plo
++	-rm -f ./$(DEPDIR)/libcurlu_la-fopen.Plo
+ 	-rm -f ./$(DEPDIR)/libcurlu_la-formdata.Plo
+ 	-rm -f ./$(DEPDIR)/libcurlu_la-ftp.Plo
+ 	-rm -f ./$(DEPDIR)/libcurlu_la-ftplistparser.Plo
+@@ -4714,6 +4736,7 @@ maintainer-clean: maintainer-clean-am
+ 	-rm -f ./$(DEPDIR)/libcurl_la-escape.Plo
+ 	-rm -f ./$(DEPDIR)/libcurl_la-file.Plo
+ 	-rm -f ./$(DEPDIR)/libcurl_la-fileinfo.Plo
++	-rm -f ./$(DEPDIR)/libcurl_la-fopen.Plo
+ 	-rm -f ./$(DEPDIR)/libcurl_la-formdata.Plo
+ 	-rm -f ./$(DEPDIR)/libcurl_la-ftp.Plo
+ 	-rm -f ./$(DEPDIR)/libcurl_la-ftplistparser.Plo
+@@ -4834,6 +4857,7 @@ maintainer-clean: maintainer-clean-am
+ 	-rm -f ./$(DEPDIR)/libcurlu_la-escape.Plo
+ 	-rm -f ./$(DEPDIR)/libcurlu_la-file.Plo
+ 	-rm -f ./$(DEPDIR)/libcurlu_la-fileinfo.Plo
++	-rm -f ./$(DEPDIR)/libcurlu_la-fopen.Plo
+ 	-rm -f ./$(DEPDIR)/libcurlu_la-formdata.Plo
+ 	-rm -f ./$(DEPDIR)/libcurlu_la-ftp.Plo
+ 	-rm -f ./$(DEPDIR)/libcurlu_la-ftplistparser.Plo
+
+## Upstream patch follows:
+
+From 20f9dd6bae50b7223171b17ba7798946e74f877f Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Wed, 25 May 2022 10:09:53 +0200
+Subject: [PATCH] fopen: add Curl_fopen() for better overwriting of files
+
+Bug: https://curl.se/docs/CVE-2022-32207.html
+CVE-2022-32207
+Reported-by: Harry Sintonen
+Closes #9050
+---
+ CMakeLists.txt          |   1 +
+ configure.ac            |   1 +
+ lib/Makefile.inc        |   2 +
+ lib/cookie.c            |  19 ++-----
+ lib/curl_config.h.cmake |   3 ++
+ lib/fopen.c             | 113 ++++++++++++++++++++++++++++++++++++++++
+ lib/fopen.h             |  30 +++++++++++
+ 7 files changed, 154 insertions(+), 15 deletions(-)
+ create mode 100644 lib/fopen.c
+ create mode 100644 lib/fopen.h
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 45d763d5a9c1d..ad20777f3d688 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1067,6 +1067,7 @@ elseif(HAVE_LIBSOCKET)
+   set(CMAKE_REQUIRED_LIBRARIES socket)
+ endif()
+ 
++check_symbol_exists(fchmod        "${CURL_INCLUDES}" HAVE_FCHMOD)
+ check_symbol_exists(basename      "${CURL_INCLUDES}" HAVE_BASENAME)
+ check_symbol_exists(socket        "${CURL_INCLUDES}" HAVE_SOCKET)
+ check_symbol_exists(select        "${CURL_INCLUDES}" HAVE_SELECT)
+diff --git a/configure.ac b/configure.ac
+index b0245b99a669f..de2dee5a484ed 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -3438,6 +3438,7 @@ AC_CHECK_DECLS([getpwuid_r], [], [AC_DEFINE(HAVE_DECL_GETPWUID_R_MISSING, 1, "Se
+ 
+ 
+ AC_CHECK_FUNCS([fnmatch \
++  fchmod \
+   geteuid \
+   getpass_r \
+   getppid \
+diff --git a/lib/Makefile.inc b/lib/Makefile.inc
+index 533e16df97020..9bd8e324bd1c1 100644
+--- a/lib/Makefile.inc
++++ b/lib/Makefile.inc
+@@ -137,6 +137,7 @@ LIB_CFILES =         \
+   escape.c           \
+   file.c             \
+   fileinfo.c         \
++  fopen.c            \
+   formdata.c         \
+   ftp.c              \
+   ftplistparser.c    \
+@@ -270,6 +271,7 @@ LIB_HFILES =         \
+   escape.h           \
+   file.h             \
+   fileinfo.h         \
++  fopen.h            \
+   formdata.h         \
+   ftp.h              \
+   ftplistparser.h    \
+diff --git a/lib/cookie.c b/lib/cookie.c
+index a1ab89532033b..cb57b86387191 100644
+--- a/lib/cookie.c
++++ b/lib/cookie.c
+@@ -99,8 +99,8 @@ Example set of cookies:
+ #include "curl_get_line.h"
+ #include "curl_memrchr.h"
+ #include "parsedate.h"
+-#include "rand.h"
+ #include "rename.h"
++#include "fopen.h"
+ 
+ /* The last 3 #include files should be in this order */
+ #include "curl_printf.h"
+@@ -1641,20 +1641,9 @@ static CURLcode cookie_output(struct Curl_easy *data,
+     use_stdout = TRUE;
+   }
+   else {
+-    unsigned char randsuffix[9];
+-
+-    if(Curl_rand_hex(data, randsuffix, sizeof(randsuffix)))
+-      return 2;
+-
+-    tempstore = aprintf("%s.%s.tmp", filename, randsuffix);
+-    if(!tempstore)
+-      return CURLE_OUT_OF_MEMORY;
+-
+-    out = fopen(tempstore, FOPEN_WRITETEXT);
+-    if(!out) {
+-      error = CURLE_WRITE_ERROR;
++    error = Curl_fopen(data, filename, &out, &tempstore);
++    if(error)
+       goto error;
+-    }
+   }
+ 
+   fputs("# Netscape HTTP Cookie File\n"
+@@ -1701,7 +1690,7 @@ static CURLcode cookie_output(struct Curl_easy *data,
+   if(!use_stdout) {
+     fclose(out);
+     out = NULL;
+-    if(Curl_rename(tempstore, filename)) {
++    if(tempstore && Curl_rename(tempstore, filename)) {
+       unlink(tempstore);
+       error = CURLE_WRITE_ERROR;
+       goto error;
+diff --git a/lib/curl_config.h.cmake b/lib/curl_config.h.cmake
+index cd4b568d89948..eb2c62b971453 100644
+--- a/lib/curl_config.h.cmake
++++ b/lib/curl_config.h.cmake
+@@ -159,6 +159,9 @@
+ /* Define to 1 if you have the <assert.h> header file. */
+ #cmakedefine HAVE_ASSERT_H 1
+ 
++/* Define to 1 if you have the `fchmod' function. */
++#cmakedefine HAVE_FCHMOD 1
++
+ /* Define to 1 if you have the `basename' function. */
+ #cmakedefine HAVE_BASENAME 1
+ 
+diff --git a/lib/fopen.c b/lib/fopen.c
+new file mode 100644
+index 0000000000000..ad3691ba9d158
+--- /dev/null
++++ b/lib/fopen.c
+@@ -0,0 +1,113 @@
++/***************************************************************************
++ *                                  _   _ ____  _
++ *  Project                     ___| | | |  _ \| |
++ *                             / __| | | | |_) | |
++ *                            | (__| |_| |  _ <| |___
++ *                             \___|\___/|_| \_\_____|
++ *
++ * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
++ *
++ * This software is licensed as described in the file COPYING, which
++ * you should have received as part of this distribution. The terms
++ * are also available at https://curl.se/docs/copyright.html.
++ *
++ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
++ * copies of the Software, and permit persons to whom the Software is
++ * furnished to do so, under the terms of the COPYING file.
++ *
++ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
++ * KIND, either express or implied.
++ *
++ * SPDX-License-Identifier: curl
++ *
++ ***************************************************************************/
++
++#include "curl_setup.h"
++
++#if !defined(CURL_DISABLE_COOKIES) || !defined(CURL_DISABLE_ALTSVC) ||  \
++  !defined(CURL_DISABLE_HSTS)
++
++#ifdef HAVE_FCNTL_H
++#include <fcntl.h>
++#endif
++
++#include "urldata.h"
++#include "rand.h"
++#include "fopen.h"
++/* The last 3 #include files should be in this order */
++#include "curl_printf.h"
++#include "curl_memory.h"
++#include "memdebug.h"
++
++/*
++ * Curl_fopen() opens a file for writing with a temp name, to be renamed
++ * to the final name when completed. If there is an existing file using this
++ * name at the time of the open, this function will clone the mode from that
++ * file.  if 'tempname' is non-NULL, it needs a rename after the file is
++ * written.
++ */
++CURLcode Curl_fopen(struct Curl_easy *data, const char *filename,
++                    FILE **fh, char **tempname)
++{
++  CURLcode result = CURLE_WRITE_ERROR;
++  unsigned char randsuffix[9];
++  char *tempstore = NULL;
++  struct_stat sb;
++  int fd = -1;
++  *tempname = NULL;
++
++  if(stat(filename, &sb) == -1 || !S_ISREG(sb.st_mode)) {
++    /* a non-regular file, fallback to direct fopen() */
++    *fh = fopen(filename, FOPEN_WRITETEXT);
++    if(*fh)
++      return CURLE_OK;
++    goto fail;
++  }
++
++  result = Curl_rand_hex(data, randsuffix, sizeof(randsuffix));
++  if(result)
++    goto fail;
++
++  tempstore = aprintf("%s.%s.tmp", filename, randsuffix);
++  if(!tempstore) {
++    result = CURLE_OUT_OF_MEMORY;
++    goto fail;
++  }
++
++  result = CURLE_WRITE_ERROR;
++  fd = open(tempstore, O_WRONLY | O_CREAT | O_EXCL, 0600);
++  if(fd == -1)
++    goto fail;
++
++#ifdef HAVE_FCHMOD
++  {
++    struct_stat nsb;
++    if((fstat(fd, &nsb) != -1) &&
++       (nsb.st_uid == sb.st_uid) && (nsb.st_gid == sb.st_gid)) {
++      /* if the user and group are the same, clone the original mode */
++      if(fchmod(fd, sb.st_mode) == -1)
++        goto fail;
++    }
++  }
++#endif
++
++  *fh = fdopen(fd, FOPEN_WRITETEXT);
++  if(!*fh)
++    goto fail;
++
++  *tempname = tempstore;
++  return CURLE_OK;
++
++fail:
++  if(fd != -1) {
++    close(fd);
++    unlink(tempstore);
++  }
++
++  free(tempstore);
++
++  *tempname = NULL;
++  return result;
++}
++
++#endif /* ! disabled */
+diff --git a/lib/fopen.h b/lib/fopen.h
+new file mode 100644
+index 0000000000000..289e55f2afd24
+--- /dev/null
++++ b/lib/fopen.h
+@@ -0,0 +1,30 @@
++#ifndef HEADER_CURL_FOPEN_H
++#define HEADER_CURL_FOPEN_H
++/***************************************************************************
++ *                                  _   _ ____  _
++ *  Project                     ___| | | |  _ \| |
++ *                             / __| | | | |_) | |
++ *                            | (__| |_| |  _ <| |___
++ *                             \___|\___/|_| \_\_____|
++ *
++ * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
++ *
++ * This software is licensed as described in the file COPYING, which
++ * you should have received as part of this distribution. The terms
++ * are also available at https://curl.se/docs/copyright.html.
++ *
++ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
++ * copies of the Software, and permit persons to whom the Software is
++ * furnished to do so, under the terms of the COPYING file.
++ *
++ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
++ * KIND, either express or implied.
++ *
++ * SPDX-License-Identifier: curl
++ *
++ ***************************************************************************/
++
++CURLcode Curl_fopen(struct Curl_easy *data, const char *filename,
++                    FILE **fh, char **tempname);
++
++#endif

--- a/pkgs/tools/networking/curl/CVE-2022-32208.patch
+++ b/pkgs/tools/networking/curl/CVE-2022-32208.patch
@@ -1,0 +1,64 @@
+From 6ecdf5136b52af747e7bda08db9a748256b1cd09 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Thu, 9 Jun 2022 09:27:24 +0200
+Subject: [PATCH] krb5: return error properly on decode errors
+
+Bug: https://curl.se/docs/CVE-2022-32208.html
+CVE-2022-32208
+Reported-by: Harry Sintonen
+Closes #9051
+---
+ lib/krb5.c | 18 +++++++++++-------
+ 1 file changed, 11 insertions(+), 7 deletions(-)
+
+diff --git a/lib/krb5.c b/lib/krb5.c
+index e289595c9e1dd..517491c4658bf 100644
+--- a/lib/krb5.c
++++ b/lib/krb5.c
+@@ -142,11 +142,8 @@ krb5_decode(void *app_data, void *buf, int len,
+   enc.value = buf;
+   enc.length = len;
+   maj = gss_unwrap(&min, *context, &enc, &dec, NULL, NULL);
+-  if(maj != GSS_S_COMPLETE) {
+-    if(len >= 4)
+-      strcpy(buf, "599 ");
++  if(maj != GSS_S_COMPLETE)
+     return -1;
+-  }
+ 
+   memcpy(buf, dec.value, dec.length);
+   len = curlx_uztosi(dec.length);
+@@ -508,6 +505,7 @@ static CURLcode read_data(struct connectdata *conn,
+ {
+   int len;
+   CURLcode result;
++  int nread;
+ 
+   result = socket_read(fd, &len, sizeof(len));
+   if(result)
+@@ -516,7 +514,10 @@ static CURLcode read_data(struct connectdata *conn,
+   if(len) {
+     /* only realloc if there was a length */
+     len = ntohl(len);
+-    buf->data = Curl_saferealloc(buf->data, len);
++    if(len > CURL_MAX_INPUT_LENGTH)
++      len = 0;
++    else
++      buf->data = Curl_saferealloc(buf->data, len);
+   }
+   if(!len || !buf->data)
+     return CURLE_OUT_OF_MEMORY;
+@@ -524,8 +525,11 @@ static CURLcode read_data(struct connectdata *conn,
+   result = socket_read(fd, buf->data, len);
+   if(result)
+     return result;
+-  buf->size = conn->mech->decode(conn->app_data, buf->data, len,
+-                                 conn->data_prot, conn);
++  nread = conn->mech->decode(conn->app_data, buf->data, len,
++                             conn->data_prot, conn);
++  if(nread < 0)
++    return CURLE_RECV_ERROR;
++  buf->size = (size_t)nread;
+   buf->index = 0;
+   return CURLE_OK;
+ }

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -78,6 +78,10 @@ stdenv.mkDerivation rec {
     # quiche: support ca-fallback
     # https://github.com/curl/curl/commit/fdb5e21b4dd171a96cf7c002ee77bb08f8e58021
     ./7.83.1-quiche-support-ca-fallback.patch
+    ./CVE-2022-32205.patch
+    ./CVE-2022-32206.patch
+    ./CVE-2022-32207.patch
+    ./CVE-2022-32208.patch
   ] ++ lib.optional patchNetrcRegression ./netrc-regression.patch;
 
   outputs = [ "bin" "dev" "out" "man" "devdoc" ];


### PR DESCRIPTION
###### Description of changes

https://curl.se/docs/CVE-2022-32205.html
https://curl.se/docs/CVE-2022-32206.html
https://curl.se/docs/CVE-2022-32207.html
https://curl.se/docs/CVE-2022-32208.html

See  #179314 for master.

CVE-2022-32207's patch needed to have the propagated autoreconf changes included else we'd have to make curl depend on autotools.

~(still doing the builds for this...)~ Built `passthru.tests` for the indicated platforms which all pass apart from `nginx-http3` which seems to have trouble on my system.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
