### PR TITLE
python3Packages.sphinx-basic-ng: 0.0.1.a11 -> 0.0.1.a12

### DIFF
--- a/pkgs/development/python-modules/sphinx-basic-ng/default.nix
+++ b/pkgs/development/python-modules/sphinx-basic-ng/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "sphinx-basic-ng";
-  version = "0.0.1.a11";
+  version = "0.0.1.a12";
   disable = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "pradyunsg";
     repo = "sphinx-basic-ng";
     rev = version;
-    sha256 = "sha256-Eur3CadC2NTuBXosG4SN9t2L0qkqN+Q79bcvhvlG/f8=";
+    sha256 = "sha256-3/a/xHPNO96GEMLgWGTLdFoojVsjNyxYgY1gAZr75S0=";
   };
 
   patches = [


### PR DESCRIPTION
###### Description of changes
https://github.com/pradyunsg/sphinx-basic-ng/releases/tag/0.0.1.a12

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).