### PR TITLE
btdu: 0.4.0 -> 0.4.1

### DIFF
--- a/pkgs/tools/misc/btdu/default.nix
+++ b/pkgs/tools/misc/btdu/default.nix
@@ -1,23 +1,23 @@
 {stdenv, lib, fetchurl, dub, ncurses, ldc, zlib, removeReferencesTo }:
 
 let
-    _d_ae_ver              = "0.0.3141";
+    _d_ae_ver              = "0.0.3184";
     _d_btrfs_ver           = "0.0.12";
     _d_ncurses_ver         = "0.0.149";
     _d_emsi_containers_ver = "0.9.0";
 in
 stdenv.mkDerivation rec {
     pname = "btdu";
-    version = "0.4.0";
+    version = "0.4.1";
 
     srcs = [
       (fetchurl {
         url = "https://github.com/CyberShadow/${pname}/archive/v${version}.tar.gz";
-        sha256 = "1377d2ee14367deed6f0b17407a0de437450a4f381819265d98c38fbc05f792f";
+        sha256 = "265c63ee82067f6b5dc44b47c9ec58be5e13c654f31035c60a7e375ffa4082c9";
       })
       (fetchurl {
         url = "https://github.com/CyberShadow/ae/archive/v${_d_ae_ver}.tar.gz";
-        sha256 = "5ae60c637050c11733da8a67735a43e16d6082d18b74ce64b04e24e42d8f5f5f";
+        sha256 = "74c17146ecde7ec4ba159eae4f88c74a5ef40cc200eabf97a0648f5abb5fde5e";
       })
       (fetchurl {
         url = "https://github.com/CyberShadow/d-btrfs/archive/v${_d_btrfs_ver}.tar.gz";


### PR DESCRIPTION
###### Description of changes

Move <ERROR>/logical ino/ENOENT results to <SLACK>
Allow choosing [size metric](https://github.com/CyberShadow/btdu/blob/master/CONCEPTS.md#size-metrics) in --expert mode
Allow sorting by and display of average query duration
Don't suggest mounting filesystems under /tmp
Don't freeze when data is collected faster than it is ingested (https://github.com/CyberShadow/btdu/issues/12)
Add and improve explanations for various error nodes
Improve display of file/directory sizes
Full Changelog: [0.4.0...v0.4.1](https://github.com/CyberShadow/btdu/compare/v0.4.0...v0.4.1)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>btdu</li>
  </ul>
</details>
