### PR TITLE
nixos/openwebrx: add more codecs

### DIFF
--- a/nixos/modules/services/web-apps/openwebrx.nix
+++ b/nixos/modules/services/web-apps/openwebrx.nix
@@ -22,6 +22,7 @@ in
         digiham
         codec2
         js8call
+        m17-cxx-demod
         alsaUtils
         netcat
       ];

--- a/nixos/modules/services/web-apps/openwebrx.nix
+++ b/nixos/modules/services/web-apps/openwebrx.nix
@@ -20,6 +20,8 @@ in
       path = with pkgs; [
         csdr
         digiham
+        codec2
+        js8call
         alsaUtils
         netcat
       ];

--- a/pkgs/applications/radio/m17-cxx-demod/default.nix
+++ b/pkgs/applications/radio/m17-cxx-demod/default.nix
@@ -1,0 +1,24 @@
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, boost, codec2 }:
+
+stdenv.mkDerivation rec {
+  pname = "m17-cxx-demod";
+  version = "2.3";
+
+  src = fetchFromGitHub {
+    owner = "mobilinkd";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-mvppkFBmmPVqvlqIqrbwGrOBih5zS5sZrV/usEhHiws=";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ codec2 boost ];
+
+  meta = with lib; {
+    description = "M17 Demodulator in C++";
+    homepage = "https://github.com/mobilinkd/m17-cxx-demod";
+    license = licenses.gpl3Only;
+    platforms = platforms.unix;
+    maintainers = teams.c3d2.members;
+  };
+}

--- a/pkgs/development/libraries/codec2/default.nix
+++ b/pkgs/development/libraries/codec2/default.nix
@@ -13,6 +13,11 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
+  # Install a binary that is used by openwebrx
+  postInstall = ''
+    install -Dm0755 src/freedv_rx $out/bin/
+  '';
+
   # Swap keyword order to satisfy SWIG parser
   postFixup = ''
     sed -r -i 's/(\<_Complex)(\s+)(float|double)/\3\2\1/' $out/include/$pname/freedv_api.h

--- a/pkgs/development/libraries/codec2/default.nix
+++ b/pkgs/development/libraries/codec2/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   # Install a binary that is used by openwebrx
   postInstall = ''
-    install -Dm0755 src/freedv_rx $out/bin/
+    install -Dm0755 src/freedv_rx -t $out/bin/
   '';
 
   # Swap keyword order to satisfy SWIG parser

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4979,6 +4979,8 @@ with pkgs;
     inherit (gnome) gnome-common;
   };
 
+  m17-cxx-demod = callPackage ../applications/radio/m17-cxx-demod { };
+
   m17n_db = callPackage ../tools/inputmethods/m17n-db { };
 
   m17n_lib = callPackage ../tools/inputmethods/m17n-lib { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
