### PR TITLE
cryptsetup: declare private dependencies for static linking

### DIFF
--- a/pkgs/os-specific/linux/cryptsetup/default.nix
+++ b/pkgs/os-specific/linux/cryptsetup/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   };
 
   # Disable 4 test cases that fail in a sandbox
-  patches = [ ./disable-failing-tests.patch ];
+  patches = [ ./disable-failing-tests.patch ./mr366-static-link.patch ];
 
   postPatch = ''
     patchShebangs tests

--- a/pkgs/os-specific/linux/cryptsetup/mr366-static-link.patch
+++ b/pkgs/os-specific/linux/cryptsetup/mr366-static-link.patch
@@ -1,0 +1,22 @@
+From 836017eb3f443c7133d8d585e093f5eb8653e405 Mon Sep 17 00:00:00 2001
+From: Graham Christensen <graham@grahamc.com>
+Date: Sun, 3 Jul 2022 19:43:45 +0000
+Subject: [PATCH] libcryptsetup.pc: declare private dependencies
+
+Otherwise statically linking against it fails.
+---
+ lib/libcryptsetup.pc.in | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/lib/libcryptsetup.pc.in b/lib/libcryptsetup.pc.in
+index f3d3fb14..2d1378b6 100644
+--- a/lib/libcryptsetup.pc.in
++++ b/lib/libcryptsetup.pc.in
+@@ -8,3 +8,4 @@ Description: cryptsetup library
+ Version: @LIBCRYPTSETUP_VERSION@
+ Cflags: -I${includedir}
+ Libs: -L${libdir} -lcryptsetup
++Requires.private: uuid, json-c, devmapper, libcrypto, blkid
+-- 
+GitLab
+


### PR DESCRIPTION
###### Description of changes


Identified by Kiskae in https://github.com/grahamc/libcryptsetup-static-rust/pull/1/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R30-R37

Applies MR366: https://gitlab.com/cryptsetup/cryptsetup/-/merge_requests/366

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
