### PR TITLE
zint: init at 2.11.0

### DIFF
--- a/pkgs/development/libraries/zint/default.nix
+++ b/pkgs/development/libraries/zint/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, wrapQtAppsHook
+, cmake
+, qtbase
+, qttools
+, nix-update-script
+}:
+
+stdenv.mkDerivation rec {
+  pname = "zint";
+  version = "2.11.0";
+
+  src = fetchFromGitHub {
+    owner = "woo-j";
+    repo = "zint";
+    rev = version;
+    sha256 = "sha256-DtfyXBBEDcltGUAutHl/ksRTTYmS7Ll9kjfgD7NmBbA=";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [ cmake wrapQtAppsHook ];
+
+  buildInputs = [ qtbase qttools ];
+
+  postInstall = ''
+    install -Dm644 $src/zint-qt.desktop $out/share/applications/zint-qt.desktop
+    install -Dm644 $src/zint-qt.png $out/share/pixmaps/zint-qt.png
+    install -Dm644 $src/frontend_qt/images/scalable/zint-qt.svg $out/share/icons/hicolor/scalable/apps/zint-qt.svg
+  '';
+
+  passthru.updateScript = nix-update-script {
+    attrPath = pname;
+  };
+
+  meta = with lib; {
+    description = "A barcode generating tool and library";
+    longDescription = ''
+      The Zint project aims to provide a complete cross-platform open source
+      barcode generating solution. The package currently consists of a Qt based
+      GUI, a CLI command line executable and a library with an API to allow
+      developers access to the capabilities of Zint.
+    '';
+    homepage = "http://www.zint.org.uk";
+    changelog = "https://github.com/woo-j/zint/blob/${version}/ChangeLog";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ azahi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12228,6 +12228,8 @@ with pkgs;
 
   zinit = callPackage ../shells/zsh/zinit {} ;
 
+  zint = qt6Packages.callPackage ../development/libraries/zint { };
+
   zs-apc-spdu-ctl = callPackage ../tools/networking/zs-apc-spdu-ctl { };
 
   zs-wait4host = callPackage ../tools/networking/zs-wait4host { };


### PR DESCRIPTION
Fixes: #176559

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
