### PR TITLE
python3Packages.humanize: 4.1.0 -> 4.2.3

### DIFF
--- a/pkgs/development/python-modules/humanize/default.nix
+++ b/pkgs/development/python-modules/humanize/default.nix
@@ -11,7 +11,7 @@
 }:
 
 buildPythonPackage rec {
-  version = "4.1.0";
+  version = "4.2.3";
   pname = "humanize";
   format = "pyproject";
 
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "python-humanize";
     repo = pname;
     rev = version;
-    hash = "sha256-5xL3gfEohDjnF085Pgx/PBXWWM76X4FU2KR+8OGshMw=";
+    hash = "sha256-cAlNtN9sUnDAkCQj2bJfT72B2TQDYRBB4P4NJY9mUU0=";
   };
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;

--- a/pkgs/development/python-modules/humanize/default.nix
+++ b/pkgs/development/python-modules/humanize/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , freezegun
+, gettext
 , importlib-metadata
 , pytestCheckHook
 , pythonOlder
@@ -27,6 +28,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     setuptools-scm
+    gettext
   ];
 
   propagatedBuildInputs = [
@@ -34,6 +36,14 @@ buildPythonPackage rec {
   ] ++ lib.optionals (pythonOlder "3.8") [
     importlib-metadata
   ];
+
+  postBuild = ''
+    scripts/generate-translation-binaries.sh
+  '';
+
+  postInstall = ''
+    cp -r 'src/humanize/locale' "$out/lib/"*'/site-packages/humanize/'
+  '';
 
   checkInputs = [
     freezegun

--- a/pkgs/development/python-modules/humanize/default.nix
+++ b/pkgs/development/python-modules/humanize/default.nix
@@ -48,6 +48,6 @@ buildPythonPackage rec {
     description = "Python humanize utilities";
     homepage = "https://github.com/python-humanize/humanize";
     license = licenses.mit;
-    maintainers = with maintainers; [ rmcgibbo ];
+    maintainers = with maintainers; [ rmcgibbo Luflosi ];
   };
 }


### PR DESCRIPTION
###### Description of changes
https://github.com/python-humanize/humanize/releases/tag/4.2.3
Also generate the translations and include them in the output. See the project's GitHub README for a simple example of how to change the locale.
Also add myself as a maintainer.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).