### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/no-channel.yml
+++ b/.github/workflows/no-channel.yml
@@ -6,8 +6,13 @@ on:
       - 'nixos-**'
       - 'nixpkgs-**'
 
+permissions:
+  contents: read
+
 jobs:
   fail:
+    permissions:
+      contents: none
     name: "This PR is is targeting a channel branch"
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/update-terraform-providers.yml
+++ b/.github/workflows/update-terraform-providers.yml
@@ -5,8 +5,15 @@ on:
     - cron: "14 3 * * 1"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   tf-providers:
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to create branch
+      issues: write  # for peter-evans/create-or-update-comment to create or update comment
+      pull-requests: write  # for peter-evans/create-pull-request to create a PR
     if: github.repository_owner == 'NixOS' && github.ref == 'refs/heads/master' # ensure workflow_dispatch only runs on master
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
