### PR TITLE
stdenv: start deprecating non-list cmakeFlags

### DIFF
--- a/pkgs/applications/audio/faust/faust2.nix
+++ b/pkgs/applications/audio/faust/faust2.nix
@@ -58,9 +58,10 @@ let
       cd build
     '';
 
-    cmakeFlags = ''
-      -C ../backends/all.cmake -C  ../targets/all.cmake ..
-    '';
+    cmakeFlags = [
+      "-C../backends/all.cmake"
+      "-C../targets/all.cmake"
+    ];
 
     postInstall = ''
       # syntax error when eval'd directly

--- a/pkgs/applications/office/PageEdit/default.nix
+++ b/pkgs/applications/office/PageEdit/default.nix
@@ -13,7 +13,7 @@ mkDerivation rec {
 
   nativeBuildInputs = [ cmake qttranslations ];
   propagatedBuildInputs = [ qtsvg qtwebengine ];
-  cmakeFlags = "-DINSTALL_BUNDLED_DICTS=0";
+  cmakeFlags = [ "-DINSTALL_BUNDLED_DICTS=0" ];
 
   meta = with lib; {
     description = "ePub XHTML Visual Editor";

--- a/pkgs/applications/video/rtabmap/default.nix
+++ b/pkgs/applications/video/rtabmap/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
   ];
 
   # Disable warnings that are irrelevant to us as packagers
-  cmakeFlags = "-Wno-dev";
+  cmakeFlags = [ "-Wno-dev" ];
 
   # We run one of the executables we build while the build is
   # still running (and patchelf hasn't been invoked) which means

--- a/pkgs/development/libraries/libcef/default.nix
+++ b/pkgs/development/libraries/libcef/default.nix
@@ -88,7 +88,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
-  cmakeFlags = "-DPROJECT_ARCH=${platformInfo.projectArch}";
+  cmakeFlags = [ "-DPROJECT_ARCH=${platformInfo.projectArch}" ];
   makeFlags = [ "libcef_dll_wrapper" ];
   dontStrip = true;
   dontPatchELF = true;


### PR DESCRIPTION
the motivation for this is to simplify stdenv and ease the job of
reviewers due to them needing to tell contributors about the defacto
rule that cmakeFlags should be a list of strings

###### Description of changes


continuation of https://github.com/NixOS/nixpkgs/pull/173172
this is why I made the deprecation release of them `23.05`

meson will be done in a pr after this one is merged

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
