### PR TITLE
Update nrfutil and dependencies.

### DIFF
--- a/pkgs/development/libraries/pc-ble-driver/default.nix
+++ b/pkgs/development/libraries/pc-ble-driver/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub
+{ lib, stdenv, fetchpatch, fetchFromGitHub
 , cmake, git
 , asio, catch2, spdlog
 , IOKit, udev
@@ -14,6 +14,14 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "1609x17sbfi668jfwyvnfk9z29w6cgzvgv67xcpvpx5jv0czpcdj";
   };
+
+  patches = [
+     # Fix build with GCC 11
+    (fetchpatch {
+      url = "https://github.com/NordicSemiconductor/pc-ble-driver/commit/37258e65bdbcd0b4369ae448faf650dd181816ec.patch";
+      sha256 = "sha256-gOdzIW8YJQC+PE4FJd644I1+I7CMcBY8wpF6g02eI5g=";
+    })
+  ];
 
   cmakeFlags = [
     "-DNRF_BLE_DRIVER_VERSION=${version}"

--- a/pkgs/development/python-modules/pc-ble-driver-py/default.nix
+++ b/pkgs/development/python-modules/pc-ble-driver-py/default.nix
@@ -16,15 +16,15 @@
 
 buildPythonPackage rec {
   pname = "pc-ble-driver-py";
-  version = "0.16.3";
+  version = "0.17.0";
 
-  disabled = pythonOlder "3.7" || pythonAtLeast "3.10";
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "NordicSemiconductor";
     repo = "pc-ble-driver-py";
     rev = "v${version}";
-    sha256 = "sha256-X21GQsyRZu1xdoTlD9DjceIWKpcuTLdIDf8UahntS3s=";
+    sha256 = "sha256-brC33ar2Jq3R2xdrklvVsQKf6pcnKwD25PO4TIvXgTg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/tools/misc/nrfutil/default.nix
+++ b/pkgs/development/tools/misc/nrfutil/default.nix
@@ -1,41 +1,20 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, pkgs
 , python3
-, python3Packages
 }:
-let
-  py = python3.override {
-    packageOverrides = self: super: {
 
-      libusb1 = super.libusb1.overridePythonAttrs (oldAttrs: rec {
-        version = "1.9.3";
-        src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "0j8p7jb7sibiiib18vyv3w5rrk0f4d2dl99bs18nwkq6pqvwxrk0";
-        };
-
-        postPatch = ''
-          substituteInPlace usb1/libusb1.py --replace \
-            "ctypes.util.find_library(base_name)" \
-            "'${pkgs.libusb1}/lib/libusb-1.0${stdenv.hostPlatform.extensions.sharedLibrary}'"
-        '';
-      });
-    };
-  };
-in
-with py.pkgs;
+with python3.pkgs;
 
 buildPythonApplication rec {
   pname = "nrfutil";
-  version = "6.1.3";
+  version = "6.1.6";
 
   src = fetchFromGitHub {
     owner = "NordicSemiconductor";
     repo = "pc-nrfutil";
     rev = "v${version}";
-    sha256 = "1gpxjdcjn4rjvk649vpkh563c7lx3rrfvamazb1qjii1pxrvvqa7";
+    sha256 = "sha256-UiGNNJxNSpIzpeYMlzocLG2kuetl8xti5A3n6zz0lcY=";
   };
 
   propagatedBuildInputs = [
@@ -60,6 +39,7 @@ buildPythonApplication rec {
 
   postPatch = ''
     mkdir test-reports
+    substituteInPlace requirements.txt --replace "libusb1==1.9.3" "libusb1"
   '';
 
   meta = with lib; {
@@ -68,7 +48,5 @@ buildPythonApplication rec {
     license = licenses.unfreeRedistributable;
     platforms = platforms.unix;
     maintainers = with maintainers; [ gebner ];
-    # libusb1 1.9.3 uses setuptools' 2to3 translation feature, which has been removed in setuptools 58
-    broken = true;
   };
 }


### PR DESCRIPTION
###### Description of changes

`nrfutil` and dependencies were updated to versions that include support for Python 3.10. The `broken` was removed by using the packaged version of `libusb1` instead of the one the project locked.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
