### PR TITLE
archimedes: use latest toolchain, not gcc-6

### DIFF
--- a/pkgs/applications/science/electronics/archimedes/default.nix
+++ b/pkgs/applications/science/electronics/archimedes/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenv, fetchurl, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "archimedes";
@@ -8,6 +8,16 @@ stdenv.mkDerivation rec {
     url = "mirror://gnu/archimedes/archimedes-${version}.tar.gz";
     sha256 = "0jfpnd3pns5wxcxbiw49v5sgpmm5b4v8s4q1a5292hxxk2hzmb3z";
   };
+
+  patches = [
+    # Pull patch pending upstream inclusion to support c99 toolchains:
+    #   https://savannah.gnu.org/bugs/index.php?62703
+    (fetchpatch {
+      name = "c99.patch";
+      url = "https://savannah.gnu.org/bugs/download.php?file_id=53393";
+      sha256 = "1xmy1w4ln1gynldk3srdi2h0fxpx465dsa1yxc3rzrrjpxh6087f";
+    })
+  ];
 
   meta = {
     description = "GNU package for semiconductor device simulations";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33156,9 +33156,7 @@ with pkgs;
 
   astral = callPackage ../applications/science/biology/astral { };
 
-  archimedes = callPackage ../applications/science/electronics/archimedes {
-    stdenv = gcc6Stdenv;
-  };
+  archimedes = callPackage ../applications/science/electronics/archimedes { };
 
   bayescan = callPackage ../applications/science/biology/bayescan { };
 


### PR DESCRIPTION
Without the change archimedes fails to build with latest toolchains as:

    ld: archimedes.c:(.text+0xdac7): undefined reference to `rnd'
    ld: archimedes.c:(.text+0xdeab): undefined reference to `rnd'
    ld: archimedes.c:(.text+0xdf13): undefined reference to `rnd'
    ld: archimedes.c:(.text+0xe3ef): undefined reference to `rnd'
    ld: archimedes.o:archimedes.c:(.text+0xe456): more undefined references to `rnd' follow
    ld: archimedes.o: in function `EMC':
    archimedes.c:(.text+0xf11b): undefined reference to `creation'
    ld: archimedes.c:(.text+0xf5f5): undefined reference to `creation'
    ld: archimedes.c:(.text+0xf826): undefined reference to `creation'
    ld: archimedes.c:(.text+0xf9ce): undefined reference to `creation'

The change happens to fix build against clang as well.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
