### PR TITLE
nixpkgs-basic-release-checks: check for case-insensitive path conflicts

### DIFF
--- a/pkgs/top-level/nixpkgs-basic-release-checks.nix
+++ b/pkgs/top-level/nixpkgs-basic-release-checks.nix
@@ -19,6 +19,14 @@ pkgs.runCommand "nixpkgs-release-checks" { src = nixpkgs; buildInputs = [nix]; }
         exit 1
     fi
 
+    # Make sure that no paths collide on case-preserving or case-insensitive filesysytems.
+    conflictingPaths=$(find $src | awk '{ print $1 " " tolower($1) }' | sort -k2 | uniq -D -f 1 | cut -d ' ' -f 1)
+    if [[ -n $conflictingPaths ]]; then
+        echo "Files in nixpkgs must not vary only by case"
+        echo "The offending paths: $conflictingPaths"
+        exit 1
+    fi
+
     src2=$TMPDIR/foo
     cp -rd $src $src2
 


### PR DESCRIPTION
###### Description of changes

There was an issue recently in nixpkgs (#179272) where a file was added to `pkgs/x11` instead of `pkgs/X11` (#178509). This caused the nixpkgs hash to vary depending on if the filesystem is case-sensitive, or case-insensitive (or more accurately case-preserving). This caused failures evaluating flakes depending on which filesystem type generated the hash in `flake.lock`.

To avoid this situation in the future, @domenkozar suggested adding a check https://github.com/NixOS/nix/issues/1885#issuecomment-1171706533

The check lowercases all paths and looks for entries that occur twice. It preserves the original paths throughout the check to print the actual paths that caused the problem.

###### Things done

Tested by reverting aae0476728516c6a2ce78638fbc13436c4f4fa19

```
❯ nix-build pkgs/top-level/release.nix -A tarball.nixpkgs-basic-release-checks
this derivation will be built:
  /nix/store/cbbla3irciprxd55zliwv3hx0vk5iz62-nixpkgs-release-checks.drv
building '/nix/store/cbbla3irciprxd55zliwv3hx0vk5iz62-nixpkgs-release-checks.drv'...
Files in nixpkgs must not vary only by case
The offending paths: /nix/store/2w808gsp1apvwfx0s2vrvdv0ihcgdbkm-source/pkgs/tools/X11
/nix/store/2w808gsp1apvwfx0s2vrvdv0ihcgdbkm-source/pkgs/tools/x11
```

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
