### PR TITLE
tracker: use upstream patch instead of disabling test

### DIFF
--- a/pkgs/development/libraries/tracker/default.nix
+++ b/pkgs/development/libraries/tracker/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , lib
+, fetchpatch
 , fetchurl
 , gettext
 , meson
@@ -37,6 +38,14 @@ stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "Wtb1vJd4Hr9V7NaUfNSuf/QZJRZYDRC9g4Dx3UcZbtI=";
   };
+
+  patches = [
+    ./fix-test-order.patch
+  ];
+
+  postPatch = ''
+    patchShebangs utils/data-generators/cc/generate
+  '';
 
   nativeBuildInputs = [
     meson
@@ -77,11 +86,6 @@ stdenv.mkDerivation rec {
   ];
 
   doCheck = true;
-
-  patches = [ ./drop-sparql-test.patch ];
-  postPatch = ''
-    patchShebangs utils/data-generators/cc/generate
-  '';
 
   preCheck = ''
     # (tracker-store:6194): Tracker-CRITICAL **: 09:34:07.722: Cannot initialize database: Could not open sqlite3 database:'/homeless-shelter/.cache/tracker/meta.db': unable to open database file

--- a/pkgs/development/libraries/tracker/drop-sparql-test.patch
+++ b/pkgs/development/libraries/tracker/drop-sparql-test.patch
@@ -1,9 +1,0 @@
-https://gitlab.gnome.org/GNOME/tracker/-/issues/370
---- a/tests/libtracker-data/meson.build
-+++ b/tests/libtracker-data/meson.build
-@@ -14,5 +14,4 @@
- libtracker_data_slow_tests = [
-     'ontology',
--    'sparql'
- ]
- 

--- a/pkgs/development/libraries/tracker/fix-test-order.patch
+++ b/pkgs/development/libraries/tracker/fix-test-order.patch
@@ -1,0 +1,9 @@
+diff --git a/tests/libtracker-data/algebra/filter-scope-1.rq b/tests/libtracker-data/algebra/filter-scope-1.rq
+index 7ee5a24ad..a8cd89ca9 100644
+--- a/tests/libtracker-data/algebra/filter-scope-1.rq
++++ b/tests/libtracker-data/algebra/filter-scope-1.rq
+@@ -7,3 +7,4 @@ SELECT ?v ?w ?v2
+       OPTIONAL {  :x :p ?v2 FILTER(?v = 1) }
+     }
+ }
++ORDER BY ?v ?w ?v2


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
