### PR TITLE
python3Packages.unittest2: unbreak

### DIFF
--- a/pkgs/development/python-modules/unittest2/collections-compat.patch
+++ b/pkgs/development/python-modules/unittest2/collections-compat.patch
@@ -1,0 +1,19 @@
+diff --git a/unittest2/compatibility.py b/unittest2/compatibility.py
+index 9e5f1a5..473957c 100644
+--- a/unittest2/compatibility.py
++++ b/unittest2/compatibility.py
+@@ -1,4 +1,5 @@
+ import collections
++import collections.abc
+ import os
+ import sys
+ 
+@@ -140,7 +141,7 @@ except ImportError:
+ ###  ChainMap (helper for configparser and string.Template)
+ ########################################################################
+ 
+-class ChainMap(collections.MutableMapping):
++class ChainMap(collections.abc.MutableMapping):
+     ''' A ChainMap groups multiple dicts (or other mappings) together
+     to create a single, updateable view.
+ 

--- a/pkgs/development/python-modules/unittest2/default.nix
+++ b/pkgs/development/python-modules/unittest2/default.nix
@@ -15,6 +15,10 @@ buildPythonPackage rec {
     sha256 = "0y855kmx7a8rnf81d3lh5lyxai1908xjp0laf4glwa4c8472m212";
   };
 
+  patches = lib.optionals (pythonAtLeast "3.7") [
+    ./collections-compat.patch
+  ];
+
   propagatedBuildInputs = [ six traceback2 ];
 
   # 1.0.0 and up create a circle dependency with traceback2/pbr
@@ -34,7 +38,5 @@ buildPythonPackage rec {
     description = "A backport of the new features added to the unittest testing framework";
     homepage = "https://pypi.org/project/unittest2/";
     license = licenses.bsd0;
-    # AttributeError: module 'collections' has no attribute 'MutableMapping'
-    broken = pythonAtLeast "3.10";
   };
 }

--- a/pkgs/tools/compression/zfp/default.nix
+++ b/pkgs/tools/compression/zfp/default.nix
@@ -1,4 +1,4 @@
-{ cmake, cudatoolkit, fetchFromGitHub, gfortran, lib, llvmPackages, pythonPackages, stdenv, targetPlatform
+{ cmake, cudatoolkit, fetchFromGitHub, gfortran, lib, llvmPackages, python3Packages, stdenv, targetPlatform
 , enableCfp ? true
 , enableCuda ? false
 , enableExamples ? true
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   buildInputs = lib.optional enableCuda cudatoolkit
     ++ lib.optional enableFortran gfortran
     ++ lib.optional enableOpenMP llvmPackages.openmp
-    ++ lib.optionals enablePython [ pythonPackages.cython pythonPackages.numpy pythonPackages.python ];
+    ++ lib.optionals enablePython (with python3Packages; [ cython numpy python ]);
 
   cmakeFlags = [
     # More tests not enabled by default


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
