### PR TITLE
cjose: 0.6.1 -> 0.6.2 (fork)

### DIFF
--- a/pkgs/development/libraries/cjose/default.nix
+++ b/pkgs/development/libraries/cjose/default.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cjose";
-  version = "0.6.1";
+  version = "0.6.2";
 
   src = fetchFromGitHub {
-    owner = "cisco";
+    owner = "zmartzone";
     repo = "cjose";
-    rev = version;
-    sha256 = "1msyjwmylb5c7jc16ryx3xb9cdwx682ihsm0ni766y6dfwx8bkhp";
+    rev = "v${version}";
+    sha256 = "sha256-FHKuaf4Gg3On7d3UBbGD8k1gA8kGsCOaWtLMohr5woA=";
   };
 
   nativeBuildInputs = [ autoreconfHook pkg-config doxygen ];
@@ -30,9 +30,9 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    homepage = "https://github.com/cisco/cjose";
-    changelog = "https://github.com/cisco/cjose/blob/${version}/CHANGELOG.md";
-    description = "C library for Javascript Object Signing and Encryption";
+    homepage = "https://github.com/zmartzone/cjose";
+    changelog = "https://github.com/zmartzone/cjose/blob/${version}/CHANGELOG.md";
+    description = "C library for Javascript Object Signing and Encryption. This is a maintained fork of the original project";
     license = licenses.mit;
     maintainers = with maintainers; [ midchildan ];
     platforms = platforms.all;


### PR DESCRIPTION
###### Description of changes
supports openssl 3

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).