### PR TITLE
wipefreespace: init at 2.5

### DIFF
--- a/pkgs/tools/filesystems/jfsutils/default.nix
+++ b/pkgs/tools/filesystems/jfsutils/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.1.15";
 
   src = fetchurl {
-    url = "http://jfs.sourceforge.net/project/pub/jfsutils-${version}.tar.gz";
+    url = "mirror://sourceforge/jfs/jfsutils-${version}.tar.gz";
     sha256 = "0kbsy2sk1jv4m82rxyl25gwrlkzvl3hzdga9gshkxkhm83v1aji4";
   };
 
@@ -30,6 +30,14 @@ stdenv.mkDerivation rec {
   #     ld: extract.o:/build/jfsutils-1.1.15/fscklog/extract.c:67: multiple definition of
   #       `xchklog_buffer'; display.o:/build/jfsutils-1.1.15/fscklog/display.c:57: first defined here
   NIX_CFLAGS_COMPILE = "-fcommon";
+
+  # this required for wipefreespace
+  postInstall = ''
+    mkdir -p $out/include
+    cp include/*.h $out/include
+    mkdir -p $out/lib
+    cp ./libfs/libfs.a $out/lib
+  '';
 
   meta = with lib; {
     description = "IBM JFS utilities";

--- a/pkgs/tools/filesystems/reiser4progs/default.nix
+++ b/pkgs/tools/filesystems/reiser4progs/default.nix
@@ -21,6 +21,12 @@ stdenv.mkDerivation rec {
     substituteInPlace Makefile --replace ./run-ldconfig true
   '';
 
+  # this required for wipefreespace
+  postInstall = ''
+    mkdir -p $out/lib
+    cp ./libmisc/.libs/libmisc.a $out/lib/libreiser4misc.a.la
+  '';
+
   meta = with lib; {
     inherit version;
     homepage = "https://sourceforge.net/projects/reiser4/";

--- a/pkgs/tools/filesystems/wipefreespace/default.nix
+++ b/pkgs/tools/filesystems/wipefreespace/default.nix
@@ -1,0 +1,54 @@
+{ stdenv
+, pkgs
+, lib
+, fetchurl
+, e2fsprogs
+, ntfs3g
+, xfsprogs
+, reiser4progs
+, libaal
+, jfsutils
+, libuuid
+, texinfo
+}:
+
+stdenv.mkDerivation rec {
+  pname = "wipefreespace";
+  version = "2.5";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/project/wipefreespace/wipefreespace/${version}/wipefreespace-${version}.tar.gz";
+    hash = "sha256-wymV6G4Et5TCoIztZfdb3xuzjdBHFyB5OmI4EcsJKwQ=";
+  };
+
+  nativeBuildInputs = [
+    texinfo
+  ];
+
+  # missed: Reiser3 FAT12/16/32 MinixFS HFS+ OCFS
+  buildInputs = [
+    e2fsprogs
+    ntfs3g
+    xfsprogs
+    reiser4progs
+    libaal
+    jfsutils
+    libuuid
+  ];
+
+  strictDeps = true;
+
+  preConfigure = ''
+    export PATH=$PATH:${xfsprogs}/bin
+    export CFLAGS=-I${jfsutils}/include
+    export LDFLAGS="-L${jfsutils}/lib -L${reiser4progs}/lib"
+  '';
+
+  meta = with lib; {
+    description = "A program which will securely wipe the free space";
+    homepage = "https://wipefreespace.sourceforge.io";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ catap ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11971,6 +11971,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Foundation IOBluetooth;
   };
 
+  wipefreespace = callPackage ../tools/filesystems/wipefreespace {};
+
   woeusb = callPackage ../tools/misc/woeusb { };
 
   woeusb-ng = callPackage ../tools/misc/woeusb-ng { };


### PR DESCRIPTION
###### Description of changes

This is a nice utilite to secure wipe free space on the disk or fill it by zeros. This is quite useful when run NixOS inside virtual machine that allows to save tons of disk by compressing them.

Homepage: https://wipefreespace.sourceforge.io/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
