### PR TITLE
ocamlPackages.yaml: 3.0.0 -> 3.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_deriving_yaml/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving_yaml/default.nix
@@ -4,15 +4,13 @@
 
 buildDunePackage rec {
   pname = "ppx_deriving_yaml";
-  version = "0.1.0";
-
-  useDune2 = true;
+  version = "0.1.1";
 
   minimalOCamlVersion = "4.08";
 
   src = fetchurl {
-    url = "https://github.com/patricoferris/ppx_deriving_yaml/releases/download/v${version}/ppx_deriving_yaml-v${version}.tbz";
-    sha256 = "kdonUD4Y8QhVSAFAafIpXBFPkS4pSScYwJbaWMn/6pA=";
+    url = "https://github.com/patricoferris/ppx_deriving_yaml/releases/download/v${version}/ppx_deriving_yaml-${version}.tbz";
+    sha256 = "sha256-nR3568ULM6jaGG4H4+lLBTEJqh/ALHPiJxve40jPUxw=";
   };
 
   propagatedBuildInputs = [ ppxlib ppx_deriving yaml ];

--- a/pkgs/development/ocaml-modules/yaml/default.nix
+++ b/pkgs/development/ocaml-modules/yaml/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, buildDunePackage, ocaml
+{ lib, fetchurl, buildDunePackage
 , dune-configurator
 , bos, ctypes, fmt, logs
 , mdx, alcotest, crowbar, junit_alcotest, ezjsonm

--- a/pkgs/development/ocaml-modules/yaml/default.nix
+++ b/pkgs/development/ocaml-modules/yaml/default.nix
@@ -1,24 +1,24 @@
 { lib, fetchurl, buildDunePackage, ocaml
 , dune-configurator
-, bos, ctypes, fmt, logs, rresult
+, bos, ctypes, fmt, logs
 , mdx, alcotest, crowbar, junit_alcotest, ezjsonm
 }:
 
 buildDunePackage rec {
   pname = "yaml";
-  version = "3.0.0";
-
-  useDune2 = true;
+  version = "3.1.0";
 
   src = fetchurl {
-    url = "https://github.com/avsm/ocaml-yaml/releases/download/v${version}/yaml-v${version}.tbz";
-    sha256 = "1iws6lbnrrd5hhmm7lczfvqp0aidx5xn7jlqk2s5rjfmj9qf4j2c";
+    url = "https://github.com/avsm/ocaml-yaml/releases/download/v${version}/yaml-${version}.tbz";
+    sha256 = "sha256-0KngriGEpp5tcgK/43B9EEOdMacSQYYCNLGfAgRS7Mc=";
   };
 
+  minimalOCamlVersion = "4.13";
+
   buildInputs = [ dune-configurator ];
-  propagatedBuildInputs = [ bos ctypes rresult ];
-  # crowbar is not available for OCaml < 4.08
-  doCheck = lib.versionAtLeast ocaml.version "4.08";
+  propagatedBuildInputs = [ bos ctypes ];
+
+  doCheck = true;
   checkInputs = [ fmt logs mdx.bin alcotest crowbar junit_alcotest ezjsonm ];
 
   meta = {

--- a/pkgs/development/ocaml-modules/yaml/yaml-sexp.nix
+++ b/pkgs/development/ocaml-modules/yaml/yaml-sexp.nix
@@ -3,7 +3,7 @@
 buildDunePackage rec {
   pname = "yaml-sexp";
 
-  inherit (yaml) version src useDune2;
+  inherit (yaml) version src;
 
   propagatedBuildInputs = [ yaml ppx_sexp_conv sexplib ];
 


### PR DESCRIPTION
* ocamlPackages.yaml: 3.0.0 -> 3.1.0
  - Fixes failing build after `rresult` upgrade (#165097)
* ocamlPackages.yaml-sexp: remove useDune2
* ocamlPackages.ppx_deriving_yaml: 0.1.0 -> 0.1.1
  - Fixes failing build after `rresult` upgrade (#165097)