### PR TITLE
openvdb: 7.0.0 -> 9.1.0

### DIFF
--- a/pkgs/development/libraries/openvdb/default.nix
+++ b/pkgs/development/libraries/openvdb/default.nix
@@ -1,50 +1,26 @@
-{ lib, stdenv, fetchFromGitHub, openexr, boost, jemalloc, c-blosc, ilmbase, tbb }:
+{ lib, stdenv, fetchFromGitHub, cmake, openexr, boost, jemalloc, c-blosc, ilmbase, tbb }:
 
 stdenv.mkDerivation rec
 {
   pname = "openvdb";
-  version = "7.0.0";
+  version = "9.1.0";
 
   src = fetchFromGitHub {
     owner = "dreamworksanimation";
     repo = "openvdb";
     rev = "v${version}";
-    sha256 = "0hhs50f05hkgj1wni53cwbsx2bhn1aam6z65j133356gbid2carl";
+    sha256 = "sha256-OP1xCR1YW60125mhhrW5+8/4uk+EBGIeoWGEU9OiIGY=";
   };
 
-  outputs = [ "out" ];
+  nativeBuildInputs = [ cmake ];
 
   buildInputs = [ openexr boost tbb jemalloc c-blosc ilmbase ];
-
-  setSourceRoot = ''
-    sourceRoot=$(echo */openvdb)
-  '';
-
-  installTargets = [ "install_lib" ];
-
-  enableParallelBuilding = true;
-
-  buildFlags = [
-    "lib"
-    "DESTDIR=$(out)"
-    "HALF_LIB=-lHalf"
-    "TBB_LIB=-ltbb"
-    "BLOSC_LIB=-lblosc"
-    "LOG4CPLUS_LIB="
-    "BLOSC_INCLUDE_DIR=${c-blosc}/include/"
-    "BLOSC_LIB_DIR=${c-blosc}/lib/"
-  ];
-
-  installFlags = [ "DESTDIR=$(out)" ];
-
-  NIX_CFLAGS_COMPILE="-I${openexr.dev}/include/OpenEXR -I${ilmbase.dev}/include/OpenEXR/";
-  NIX_LDFLAGS="-lboost_iostreams";
 
   meta = with lib; {
     description = "An open framework for voxel";
     homepage = "https://www.openvdb.org";
     maintainers = [ maintainers.guibou ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     license = licenses.mpl20;
   };
 }


### PR DESCRIPTION
###### Description of changes

this update seems to be required to build prusa-slicer 2.5.0-alpha2
(of which the appimage doesn't run with appimage-run, hence my attempt to build it)

the currently packaged version is from 2019 while the project is being actively developed and released
(automatic updates seem to have stopped working due to a build system change which i appear to have corrected for)

https://www.openvdb.org/documentation/doxygen/changes.html#v9_1_0_changes

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  - minus blender, that's a bit of a big build
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - prusa-slicer 2.5.0-alpha2 builds and runs using this dependency
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


courtesy ping of possibly affected maintainers for:
this package, @guibou
blender, @cillianderoiste @veprbl
prusa-slicer, @moredread @thorstenweber83
super-slicer, @cab404
bpycv, @lucasew