### PR TITLE
libfprint-tod: 1.90.7+git20210222+tod1 -> 1.94.3+tod1

### DIFF
--- a/pkgs/development/libraries/libfprint-2-tod1-vfs0090/default.nix
+++ b/pkgs/development/libraries/libfprint-2-tod1-vfs0090/default.nix
@@ -38,5 +38,6 @@ stdenv.mkDerivation {
     license = licenses.lgpl21Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ valodim ];
+    broken = true;
   };
 }

--- a/pkgs/development/libraries/libfprint-tod/default.nix
+++ b/pkgs/development/libraries/libfprint-tod/default.nix
@@ -5,32 +5,17 @@
 
 # for the curious, "tod" means "Touch OEM Drivers" meaning it can load
 # external .so's.
-libfprint.overrideAttrs ({ postPatch ? "", mesonFlags ? [], ... }: let
-  version = "1.90.7+git20210222+tod1";
-in  {
+libfprint.overrideAttrs (_: rec {
   pname = "libfprint-tod";
-  inherit version;
+  version = "1.94.3+tod1";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "3v1n0";
     repo = "libfprint";
     rev = "v${version}";
-    sha256 = "0cj7iy5799pchyzqqncpkhibkq012g3bdpn18pfb19nm43svhn4j";
+    sha256 = "sha256-rtkZ1q5A8MxaDjrdVCqLUUuA6v1ob07v95/U9wV+ydk=";
   };
-
-  mesonFlags = [
-    # Include virtual drivers for fprintd tests
-    "-Ddrivers=all"
-    "-Dudev_hwdb_dir=${placeholder "out"}/lib/udev/hwdb.d"
-  ];
-
-
-  postPatch = ''
-    ${postPatch}
-    patchShebangs ./tests/*.py ./tests/*.sh
-  '';
-
 
   meta = with lib; {
     homepage = "https://gitlab.freedesktop.org/3v1n0/libfprint";

--- a/pkgs/tools/security/fprintd/tod.nix
+++ b/pkgs/tools/security/fprintd/tod.nix
@@ -3,19 +3,4 @@
 , libfprint-tod
 }:
 
-(fprintd.override { libfprint = libfprint-tod; }).overrideAttrs (oldAttrs:
-  let
-    pname = "fprintd-tod";
-    version = "1.90.9";
-  in
-  {
-    inherit pname version;
-
-    src = fetchFromGitLab {
-      domain = "gitlab.freedesktop.org";
-      owner = "libfprint";
-      repo = "${oldAttrs.pname}";
-      rev = "v${version}";
-      sha256 = "sha256-rOTVThHOY/Q2IIu2RGiv26UE2V/JFfWWnfKZQfKl5Mg=";
-    };
-  })
+fprintd.override { libfprint = libfprint-tod; }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The versions of fprintd and libfprint-tod have diverged which leads to strange errors when trying to use libfprint-tod with libfprint-2-tod-goodix. A simple version bump is enough to make it work again.

See also https://forum.manjaro.org/t/goodix-fingerprint-sensor-53xc-finally-working-again/110690

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
