### PR TITLE
pywinrm: remove optional insecure dependency (kerberos)

### DIFF
--- a/pkgs/development/python-modules/pywinrm/default.nix
+++ b/pkgs/development/python-modules/pywinrm/default.nix
@@ -2,7 +2,6 @@
 , buildPythonPackage
 , fetchPypi
 , pythonOlder
-, kerberos
 , mock
 , pytestCheckHook
 , requests
@@ -27,7 +26,6 @@ buildPythonPackage rec {
     requests
     requests_ntlm
     six
-    kerberos
     xmltodict
   ];
 


### PR DESCRIPTION
###### Description of changes

Remove insecure dependency (kerberos) which according to [pywinrm's documenation](https://pypi.org/project/pywinrm/#description) is optional, as the inclusion of `kerberos` in `pywinrm` causes the packages pywinrm, [pyinfra](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/python-modules/pyinfra/default.nix) and potentially [ansible](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/python-modules/ansible/core.nix) (with windowsSupport enabled) to be marked as insecure due to `CVE-2015-3206` and causes installation of e.g. pyinfra to fail:

```log
error: Package ‘python3.10-kerberos-1.3.1’ in /home/mathym/dev/nixpkgs/pkgs/development/python-modules/kerberos/default.nix:22 is marked as insecure, refusing to evaluate.
```

The mentioned packages build fine without the optional insecure dependency.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

Removed optional dependency kerberos

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
