### PR TITLE
Revert "ocamlPackages.fmt: 0.8.9 -> 0.9.0"

### DIFF
--- a/pkgs/development/ocaml-modules/fmt/default.nix
+++ b/pkgs/development/ocaml-modules/fmt/default.nix
@@ -5,12 +5,12 @@ then throw "fmt is not available for OCaml ${ocaml.version}"
 else
 
 stdenv.mkDerivation rec {
-  version = "0.9.0";
+  version = "0.8.9";
   pname = "ocaml${ocaml.version}-fmt";
 
   src = fetchurl {
     url = "https://erratique.ch/software/fmt/releases/fmt-${version}.tbz";
-    sha256 = "sha256-8fsggFoi3XWhN9cnBKNw53ic9r32OUjmgX0cImwUEmE=";
+    sha256 = "0gkkkj4x678vxdda4xaw2dd44qjacavsvn5nx8gydfwah6pjbkxk";
   };
 
   nativeBuildInputs = [ ocaml findlib ocamlbuild topkg ];


### PR DESCRIPTION
Reverts NixOS/nixpkgs#165068

Because of: https://github.com/NixOS/nixpkgs/pull/180139#issuecomment-1174242610