### PR TITLE
unzip: no-lchmod build flag

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/openasar.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/openasar.nix
@@ -1,15 +1,5 @@
 { lib, stdenv, fetchFromGitHub, nodejs, bash, nodePackages, unzip }:
 
-let
-  # OpenAsar fails with default unzip, throwing  "lchmod (file attributes) error: Operation not supported"
-  unzipFix =
-    if stdenv.isLinux then
-      unzip.overrideAttrs (oldAttrs: {
-        buildFlags = oldAttrs.buildFlags ++ [ "LOCAL_UNZIP=-DNO_LCHMOD" ];
-      })
-    else
-      unzip;
-in
 stdenv.mkDerivation rec {
   pname = "openasar";
   version = "unstable-2022-06-27";
@@ -24,7 +14,7 @@ stdenv.mkDerivation rec {
   postPatch = ''
     # Hardcode unzip path
     substituteInPlace ./src/updater/moduleUpdater.js \
-      --replace \'unzip\' \'${unzipFix}/bin/unzip\'
+      --replace \'unzip\' \'${unzip}/bin/unzip\'
     # Remove auto-update feature
     echo "module.exports = async () => log('AsarUpdate', 'Removed');" > ./src/asarUpdate.js
   '';

--- a/pkgs/tools/archivers/unzip/default.nix
+++ b/pkgs/tools/archivers/unzip/default.nix
@@ -60,7 +60,10 @@ stdenv.mkDerivation rec {
     "generic"
     "D_USE_BZ2=-DUSE_BZIP2"
     "L_BZ2=-lbz2"
-  ];
+  ]
+  # `lchmod` is not available on Linux, so we remove it to fix "not supported" errors (when the zip file contains symlinks).
+  # Alpine (musl) and Debian (glibc) also add this flag.
+  ++ lib.optionals stdenv.isLinux [ "LOCAL_UNZIP=-DNO_LCHMOD" ];
 
   preConfigure = ''
     sed -i -e 's@CF="-O3 -Wall -I. -DASM_CRC $(LOC)"@CF="-O3 -Wall -I. -DASM_CRC -DLARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 $(LOC)"@' unix/Makefile


### PR DESCRIPTION
###### Description of changes

Adds `-DNO_LCHMOD` to `unzip` to solve `lchmod (file attributes) error: Operation not supported` on Linux, where `lchmod` seems to be a glibc shim. (Debian and Alpine seems to also have this flag)

@fufexan was the first to spot this in https://github.com/NixOS/nixpkgs/pull/178507#issuecomment-1171629376; overrides were used to temporarily fix this in https://github.com/NixOS/nixpkgs/pull/179808

> lchmod is not available on linux, but it's enabled by default. This leads to warnings while unpacking when the zip file contains symlinks
[Source]: https://gitlab.alpinelinux.org/alpine/aports/-/commit/3006365ef443c6c7d6432bd24ed65045341a4182


###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
