### PR TITLE
mullvad{,-vpn}: 2022.1 -> 2022.2

### DIFF
--- a/pkgs/applications/networking/mullvad-vpn/default.nix
+++ b/pkgs/applications/networking/mullvad-vpn/default.nix
@@ -43,11 +43,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "mullvad-vpn";
-  version = "2022.1";
+  version = "2022.2";
 
   src = fetchurl {
     url = "https://github.com/mullvad/mullvadvpn-app/releases/download/${version}/MullvadVPN-${version}_amd64.deb";
-    sha256 = "0s12y9j75k59kqkcvfflb1v5p3ny7xgc1m5bd635lvql1bv46c3i";
+    sha256 = "sha256-h/c4aPH6E2TzbXGROpLJgF9uHYcjvKiW5upIobpJM9o=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/networking/mullvad/mullvad.nix
+++ b/pkgs/applications/networking/mullvad/mullvad.nix
@@ -13,29 +13,18 @@
 , openvpn-mullvad
 , shadowsocks-rust
 }:
-let
-  # result of running address_cache as of 02 Mar 2022
-  bootstrap-address-cache = writeText "api-ip-address.txt" ''
-    193.138.218.78:443
-    193.138.218.71:444
-    185.65.134.66:444
-    185.65.135.117:444
-    217.138.254.130:444
-    91.90.44.10:444
-  '';
-in
 rustPlatform.buildRustPackage rec {
   pname = "mullvad";
-  version = "2022.1";
+  version = "2022.2";
 
   src = fetchFromGitHub {
     owner = "mullvad";
     repo = "mullvadvpn-app";
     rev = version;
-    hash = "sha256-bLwuM3Qy2iStbXIvDEWp31vuiihSQThOej297XKo5Xc=";
+    hash = "sha256-ZtQKzbFrkacrfPIkMz/UOfIwQBXQUoVVlFla//jmMwY=";
   };
 
-  cargoHash = "sha256-CBbm8cJHTjyvvzCFQfKmsE5d9N7azEm8nI6KeWLVaa8=";
+  cargoHash = "sha256-J6h3KY1RDCnAc/tQHNGEyOlVQoQNhRqjWbmimPitydQ=";
 
   nativeBuildInputs = [
     pkg-config
@@ -59,26 +48,14 @@ rustPlatform.buildRustPackage rec {
   postFixup =
     # Place all binaries in the 'mullvad-' namespace, even though these
     # specific binaries aren't used in the lifetime of the program.
-    # `address_cache` is used to generate the `api-ip-address.txt` file, which
-    # contains list of Mullvad API servers -- though we provide a "backup" of
-    # the output of this command, it could change at any time, so we want
-    # users to be able to regenerate the list at any time. (The daemon will
-    # refuse to start without this file.)
     ''
-      for bin in address_cache relay_list translations-converter; do
+      for bin in relay_list translations-converter; do
         mv "$out/bin/$bin" "$out/bin/mullvad-$bin"
       done
     '' +
-    # Put distributed assets in-place -- specifically, the
-    # bootstrap-address-cache is necessary; otherwise, the user will have to run
-    # the `address_cache` binary and move the contents into place at
-    # `/var/cache/mullvad-vpn/api-ip-address.txt` manually.
-    ''
-      mkdir -p $out/share/mullvad
-      ln -s ${bootstrap-address-cache} $out/share/mullvad/api-ip-address.txt
-    '' +
     # Files necessary for OpenVPN tunnels to work.
     ''
+      mkdir -p $out/share/mullvad
       cp dist-assets/ca.crt $out/share/mullvad
       ln -s ${openvpn-mullvad}/bin/openvpn $out/share/mullvad
       ln -s ${shadowsocks-rust}/bin/sslocal $out/share/mullvad


### PR DESCRIPTION
###### Description of changes
Update to latest upstream release [2022.2](https://github.com/mullvad/mullvadvpn-app/releases/tag/2022.2). Resolves #180167.
- [View changes on GitHub](https://github.com/mullvad/mullvadvpn-app/compare/2022.1...2022.2)

`address_cache` was removed from upstream with https://github.com/mullvad/mullvadvpn-app/commit/1cd2c994e4a6aff4856de9e89e0ce58d7e51da59.
###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).