### PR TITLE
generic-extlinux-compatible: add `copyKernels` option

### DIFF
--- a/nixos/modules/system/boot/loader/generic-extlinux-compatible/default.nix
+++ b/nixos/modules/system/boot/loader/generic-extlinux-compatible/default.nix
@@ -99,6 +99,14 @@ in
         '';
       };
 
+      copyKernels = mkOption {
+        default = true;
+        type = types.bool;
+        description = ''
+          Whether the builder should copy kernels, initial ramdisks and device
+          trees to `/boot`.
+        '';
+      };
     };
   };
 
@@ -107,7 +115,8 @@ in
       builderArgs =
         "-g ${toString cfg.configurationLimit} -t ${timeoutStr}"
         + lib.optionalString (dtCfg.name != null) " -n ${dtCfg.name}"
-        + lib.optionalString (!cfg.useGenerationDeviceTree) " -r";
+        + lib.optionalString (!cfg.useGenerationDeviceTree) " -r"
+        + lib.optionalString cfg.copyKernels " -k";
       installBootLoader = pkgs.writeScript "install-extlinux-conf.sh" (
         ''
           #!${pkgs.runtimeShell}


### PR DESCRIPTION

###### Description of changes

Add an option to disable copying kernels, initrds and device trees to the target directory (`/boot`). On most systems these days, `extlinux.conf` is on the root partition and there is no need to copy files out of the store. With this patch, the files are still copied by default to maintain backwards compatibility.

This option mirrors those for GRUB and generations-dir.

I considered automatically disabling `copyKernels` if the Nix store is on the same filesystem as the target directory (like GRUB), but I was concerned that this could return the wrong result if a user attempted to build a custom SD image with `extlinux.conf` on a separate partition from the root. At build time, the target directory would be on the same filesystem as the store, but not at runtime.

I tested booting a machine both with the option enabled and with it disabled.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] armv7l-linux
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
