### PR TITLE
hyprpaper: init at unstable-2022-07-04

### DIFF
--- a/pkgs/tools/wayland/hyprpaper/default.nix
+++ b/pkgs/tools/wayland/hyprpaper/default.nix
@@ -3,7 +3,6 @@
 , fetchFromGitHub
 , cmake
 , pkg-config
-, gitMinimal
 , libjpeg
 , mesa
 , pango
@@ -20,13 +19,11 @@ stdenv.mkDerivation rec {
     owner = "hyprwm";
     repo = pname;
     rev = "e15912e9817d79bb988085c88e313fac5ab60940";
-    leaveDotGit = true;
-    sha256 = "sha256-1P4U6fSaiiUYAvoL8EdFPBbtLh5v/S2RMSuSpbISGFc=";
+    sha256 = "sha256-UZSRcj+CckUDllBtmlIcwA+xXUonpJZl3zC151IV3f0=";
   };
 
   nativeBuildInputs = [
     cmake
-    gitMinimal
     pkg-config
     wayland-scanner
   ];
@@ -39,6 +36,11 @@ stdenv.mkDerivation rec {
     wayland-protocols
   ];
 
+  prePatch = ''
+    substituteInPlace src/main.cpp \
+      --replace GIT_COMMIT_HASH '"${src.rev}"'
+  '';
+
   preConfigure = ''
     make protocols
   '';
@@ -50,7 +52,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     homepage = "https://github.com/hyprwm/hyprpaper";
-    description = "A blazing fast wayland wallpaper utility.";
+    description = "A blazing fast wayland wallpaper utility";
     license = licenses.bsd3;
     platforms = platforms.linux;
     maintainers = with maintainers; [ wozeparrot ];

--- a/pkgs/tools/wayland/hyprpaper/default.nix
+++ b/pkgs/tools/wayland/hyprpaper/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, libjpeg
+, mesa
+, pango
+, wayland
+, wayland-protocols
+, wayland-scanner
+, wlroots
+}:
+
+stdenv.mkDerivation rec {
+  pname = "hyprpaper";
+  version = "unstable-2022-07-04";
+
+  src = fetchFromGitHub {
+    owner = "hyprwm";
+    repo = pname;
+    rev = "e15912e9817d79bb988085c88e313fac5ab60940";
+    sha256 = "sha256-UZSRcj+CckUDllBtmlIcwA+xXUonpJZl3zC151IV3f0=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    libjpeg
+    mesa
+    pango
+    wayland
+    wayland-protocols
+  ];
+
+  preConfigure = ''
+    make protocols
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -m755 ./hyprpaper $out/bin
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/hyprwm/hyprpaper";
+    description = "A blazing fast wayland wallpaper utility.";
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ wozeparrot ];
+  };
+}

--- a/pkgs/tools/wayland/hyprpaper/default.nix
+++ b/pkgs/tools/wayland/hyprpaper/default.nix
@@ -3,13 +3,13 @@
 , fetchFromGitHub
 , cmake
 , pkg-config
+, gitMinimal
 , libjpeg
 , mesa
 , pango
 , wayland
 , wayland-protocols
 , wayland-scanner
-, wlroots
 }:
 
 stdenv.mkDerivation rec {
@@ -20,11 +20,13 @@ stdenv.mkDerivation rec {
     owner = "hyprwm";
     repo = pname;
     rev = "e15912e9817d79bb988085c88e313fac5ab60940";
-    sha256 = "sha256-UZSRcj+CckUDllBtmlIcwA+xXUonpJZl3zC151IV3f0=";
+    leaveDotGit = true;
+    sha256 = "sha256-1P4U6fSaiiUYAvoL8EdFPBbtLh5v/S2RMSuSpbISGFc=";
   };
 
   nativeBuildInputs = [
     cmake
+    gitMinimal
     pkg-config
     wayland-scanner
   ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3216,6 +3216,8 @@ with pkgs;
 
   clipman = callPackage ../tools/wayland/clipman { };
 
+  hyprpaper = callPackage ../tools/wayland/hyprpaper { };
+
   kabeljau = callPackage ../games/kabeljau { };
 
   kanshi = callPackage ../tools/wayland/kanshi { };


### PR DESCRIPTION
###### Description of changes

Adds [hyprpaper](https://github.com/hyprwm/hyprpaper), a blazing fast wayland wallpaper utility. This is supposed to go alongside Hyprland but will work with any wlroots compositor.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
