### PR TITLE
nixosTests.mosquitto: disable type checking

### DIFF
--- a/nixos/tests/mosquitto.nix
+++ b/nixos/tests/mosquitto.nix
@@ -59,6 +59,8 @@ in {
     maintainers = with maintainers; [ pennae peterhoeg ];
   };
 
+  skipTypeCheck = true;
+
   nodes = let
     client = { pkgs, ... }: {
       environment.systemPackages = with pkgs; [ mosquitto ];


### PR DESCRIPTION
###### Description of changes

Disable type checking for the mosquitto nixos test.

I'm not very certain how to make the lambda thingey pass the checks,
so let's just disable unless someone has a better idea :).

Caused by https://github.com/NixOS/nixpkgs/pull/171280 (but I like the idea of that in general).

cc @m1-s who maybe knows better how to solve this?

Error log is:

```
testScriptWithTypes:109: error: "wait_for_console_text" of "Machine" does not
return a value
                server.wait_for_console_text("3688cdd7-aa07-42a4-be22-cb93...
                ^
testScriptWithTypes:116: error: "wait_for_console_text" of "Machine" does not
return a value
                server.wait_for_console_text("24ff16a2-ae33-4a51-9098-1b41...
                ^
testScriptWithTypes:135: error: "wait_for_console_text" of "Machine" does not
return a value
                server.wait_for_console_text("fd56032c-d9cb-4813-a3b4-6be0...
                ^
Found 3 errors in 1 file (checked 1 source file)
```


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
