### PR TITLE
libwebsockets: 4.3.1 -> 4.3.2

### DIFF
--- a/pkgs/development/libraries/libwebsockets/default.nix
+++ b/pkgs/development/libraries/libwebsockets/default.nix
@@ -5,13 +5,12 @@
 , openssl
 , zlib
 , libuv
-, fetchpatch
 # External poll is required for e.g. mosquitto, but discouraged by the maintainer.
 , withExternalPoll ? false
 }:
 
 let
-  generic = { version, sha256, patches ? [] }: stdenv.mkDerivation rec {
+  generic = { version, hash, patches ? [] }: stdenv.mkDerivation rec {
     pname = "libwebsockets";
     inherit version;
 
@@ -19,7 +18,7 @@ let
       owner = "warmcat";
       repo = "libwebsockets";
       rev = "v${version}";
-      inherit sha256;
+      inherit hash;
     };
 
     inherit patches;
@@ -63,15 +62,7 @@ let
 
 in {
   libwebsockets_4_3 = generic {
-    version = "4.3.1";
-    sha256 = "sha256-lB3JHh058cQc5rycLnHk3JAOgtku0nRCixN5U6lPKq8=";
-    patches = [
-      # fixes the propagated cmake files, fixing the build of ttyd
-      # see also https://github.com/tsl0922/ttyd/issues/918
-      (fetchpatch {
-        url = "https://github.com/warmcat/libwebsockets/commit/99a8b9c4422bed45c8b7412a1e121056f2a6132a.patch";
-        hash = "sha256-zHBo2ZEayvibM+jzeVaZqySxghaOLUglpSFwuGhl6HM=";
-      })
-    ];
+    version = "4.3.2";
+    hash = "sha256-why8LAcc4XN0JdTJ1JoNWijKENL5mOHBsi9K4wpYr2c=";
   };
 }

--- a/pkgs/development/libraries/libwebsockets/default.nix
+++ b/pkgs/development/libraries/libwebsockets/default.nix
@@ -5,64 +5,54 @@
 , openssl
 , zlib
 , libuv
-# External poll is required for e.g. mosquitto, but discouraged by the maintainer.
+  # External poll is required for e.g. mosquitto, but discouraged by the maintainer.
 , withExternalPoll ? false
 }:
 
-let
-  generic = { version, hash, patches ? [] }: stdenv.mkDerivation rec {
-    pname = "libwebsockets";
-    inherit version;
+stdenv.mkDerivation rec {
+  pname = "libwebsockets";
+  version = "4.3.2";
 
-    src = fetchFromGitHub {
-      owner = "warmcat";
-      repo = "libwebsockets";
-      rev = "v${version}";
-      inherit hash;
-    };
-
-    inherit patches;
-
-    buildInputs = [ openssl zlib libuv ];
-
-    nativeBuildInputs = [ cmake ];
-
-    cmakeFlags = [
-      "-DLWS_WITH_PLUGINS=ON"
-      "-DLWS_WITH_IPV6=ON"
-      "-DLWS_WITH_SOCKS5=ON"
-      "-DDISABLE_WERROR=ON"
-      # Required since v4.2.0
-      "-DLWS_BUILD_HASH=no_hash"
-    ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "-DLWS_WITHOUT_TESTAPPS=ON"
-      ++ lib.optional withExternalPoll "-DLWS_WITH_EXTERNAL_POLL=ON";
-
-    postInstall = ''
-      rm -r ${placeholder "out"}/share/libwebsockets-test-server
-    '';
-
-    # $out/share/libwebsockets-test-server/plugins/libprotocol_*.so refers to crtbeginS.o
-    disallowedReferences = [ stdenv.cc.cc ];
-
-    meta = with lib; {
-      description = "Light, portable C library for websockets";
-      longDescription = ''
-        Libwebsockets is a lightweight pure C library built to
-        use minimal CPU and memory resources, and provide fast
-        throughput in both directions.
-      '';
-      homepage = "https://libwebsockets.org/";
-      # Relicensed from LGPLv2.1+ to MIT with 4.0. Licensing situation
-      # is tricky, see https://github.com/warmcat/libwebsockets/blob/main/LICENSE
-      license = with licenses; [ mit publicDomain bsd3 asl20 ];
-      maintainers = with maintainers; [ mindavi ];
-      platforms = platforms.all;
-    };
-  };
-
-in {
-  libwebsockets_4_3 = generic {
-    version = "4.3.2";
+  src = fetchFromGitHub {
+    owner = "warmcat";
+    repo = "libwebsockets";
+    rev = "v${version}";
     hash = "sha256-why8LAcc4XN0JdTJ1JoNWijKENL5mOHBsi9K4wpYr2c=";
   };
+
+  buildInputs = [ openssl zlib libuv ];
+
+  nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [
+    "-DLWS_WITH_PLUGINS=ON"
+    "-DLWS_WITH_IPV6=ON"
+    "-DLWS_WITH_SOCKS5=ON"
+    "-DDISABLE_WERROR=ON"
+    "-DLWS_BUILD_HASH=no_hash"
+  ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "-DLWS_WITHOUT_TESTAPPS=ON"
+  ++ lib.optional withExternalPoll "-DLWS_WITH_EXTERNAL_POLL=ON";
+
+  postInstall = ''
+    rm -r ${placeholder "out"}/share/libwebsockets-test-server
+  '';
+
+  # $out/share/libwebsockets-test-server/plugins/libprotocol_*.so refers to crtbeginS.o
+  disallowedReferences = [ stdenv.cc.cc ];
+
+  meta = with lib; {
+    description = "Light, portable C library for websockets";
+    longDescription = ''
+      Libwebsockets is a lightweight pure C library built to
+      use minimal CPU and memory resources, and provide fast
+      throughput in both directions.
+    '';
+    homepage = "https://libwebsockets.org/";
+    # Relicensed from LGPLv2.1+ to MIT with 4.0. Licensing situation
+    # is tricky, see https://github.com/warmcat/libwebsockets/blob/main/LICENSE
+    license = with licenses; [ mit publicDomain bsd3 asl20 ];
+    maintainers = with maintainers; [ mindavi ];
+    platforms = platforms.all;
+  };
 }
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8094,9 +8094,7 @@ with pkgs;
 
   librest_1_0 = callPackage ../development/libraries/librest/1.0.nix { };
 
-  inherit (callPackages ../development/libraries/libwebsockets { })
-    libwebsockets_4_3;
-  libwebsockets = libwebsockets_4_3;
+  libwebsockets = callPackage ../development/libraries/libwebsockets { };
 
   licensee = callPackage ../tools/package-management/licensee { };
 


### PR DESCRIPTION
###### Description of changes

Drop the upstreamed patch that was required for fixing ttyd.
Changes: https://github.com/warmcat/libwebsockets/compare/v4.3.1...v4.3.2

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
- [x] Tested ttyd functionality (which uses websockets for its main functionality)


(I should really make a nixos test for this at some point... :smile: )