### PR TITLE
codeowners: add fricklerhandwerk to documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -48,6 +48,7 @@
 /pkgs/build-support/writers @lassulus @Profpatsch
 
 # Nixpkgs documentation
+/doc @fricklerhandwerk
 /maintainers/scripts/db-to-md.sh @jtojnar @ryantm
 /maintainers/scripts/doc @jtojnar @ryantm
 /doc/build-aux/pandoc-filters @jtojnar


### PR DESCRIPTION
See my announcement of the Nix documentation team with @domenkozar and @Mic92 and related meeting notes.
[Applied for commit bit here](https://github.com/NixOS/nixpkgs-committers/issues/60#issuecomment-1175002287).