### PR TITLE
python3Packages.torpy: init at 1.1.6

### DIFF
--- a/pkgs/development/python-modules/torpy/default.nix
+++ b/pkgs/development/python-modules/torpy/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, cryptography
+, pytestCheckHook
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "torpy";
+  version = "1.1.6";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "torpyorg";
+    repo = "torpy";
+    rev = "v${version}";
+    sha256 = "sha256-Ni7GcpkxzAMtP4wBOFsi4KnxK+nC0XCZR/2Z/eS/C+w=";
+  };
+
+  propagatedBuildInputs = [
+    cryptography
+    requests
+   ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+
+  disabledTestPaths =[
+    # requires network
+    "tests/integration"
+  ];
+
+  pythonImportsCheck = [
+    "cryptography"
+  ];
+
+  meta = with lib; {
+    description = "Pure python Tor client";
+    homepage = "https://github.com/torpyorg/torpy";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ larsr ];
+  };
+}

--- a/pkgs/development/python-modules/torpy/default.nix
+++ b/pkgs/development/python-modules/torpy/default.nix
@@ -29,8 +29,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-
-  disabledTestPaths =[
+  disabledTestPaths = [
     # requires network
     "tests/integration"
   ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10737,6 +10737,8 @@ in {
   # Used by streamlit, 2021-01-29
   tornado_5 = callPackage ../development/python-modules/tornado/5.nix { };
 
+  torpy = callPackage ../development/python-modules/torpy { };
+
   torrequest = callPackage ../development/python-modules/torrequest { };
 
   total-connect-client = callPackage ../development/python-modules/total-connect-client { };


### PR DESCRIPTION
###### Description of changes

`torpy` is a pure python implementation of a Tor client.  It can
be used as a socks proxy server for aribtrary programs like cur, 
or from a python program.


Here is one way to try it out.  Note how `ifconfig.me` does _not_ return your IP address.

```
nix-shell --pure -p 'python39.withPackages (p:[p.torpy])' cacert \
--command 'python -m torpy --url https://ifconfig.me --header "User-Agent" "curl/7.37.0"'
```

###### Things done

Added python package that fetches source from github.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
