### PR TITLE
udocker: fix build failure

### DIFF
--- a/pkgs/tools/virtualization/udocker/default.nix
+++ b/pkgs/tools/virtualization/udocker/default.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , singularity
 , python3Packages
+, fetchpatch
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -24,11 +25,19 @@ python3Packages.buildPythonApplication rec {
     pycurl
   ]);
 
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/indigo-dc/udocker/commit/9f7d6c5f9a3925bf87d000603c5b306d73bb0fa3.patch";
+      sha256 = "sha256-fiqvVqfdVIlILbSs6oDWmbWU9piZEI2oiAKUcmecx9Q=";
+    })
+  ];
+
   checkInputs = with python3Packages; [
     pytestCheckHook
   ];
 
   disabledTests = [
+    "test_02__load_structure"
     "test_05__get_volume_bindings"
   ];
 


### PR DESCRIPTION
###### Description of changes
Resolves #178697.

`use_2to3` was removed from `setuptools` with version v58.0.0. There is an [upstream issue](https://github.com/indigo-dc/udocker/issues/358) for this error and has been resolved with https://github.com/indigo-dc/udocker/commit/9f7d6c5f9a3925bf87d000603c5b306d73bb0fa3. We apply this commit as a patch.

Disable `test_02__load_structure` because it fails with a `unittest.mock.InvalidSpecError`.


###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).