### PR TITLE
bazel-watcher: 0.14.0 -> 0.17.0 & fix on Darwin

### DIFF
--- a/pkgs/development/tools/bazel-watcher/default.nix
+++ b/pkgs/development/tools/bazel-watcher/default.nix
@@ -29,13 +29,13 @@ let
 in
 buildBazelPackage rec {
   pname = "bazel-watcher";
-  version = "0.16.2";
+  version = "0.17.0";
 
   src = fetchFromGitHub {
     owner = "bazelbuild";
     repo = "bazel-watcher";
     rev = "v${version}";
-    sha256 = "sha256-yRXta6pPhgIonTL0q9GSzNQg/jHMIeC7xvfVYrZMmnc=";
+    sha256 = "sha256-aK18Q2nYxYajk9f/EEmtV7YJ8cYqbamR7vh3BTgu53Q=";
   };
 
   nativeBuildInputs = [ go git python3 ];
@@ -81,7 +81,7 @@ buildBazelPackage rec {
       rm -rf $bazelOut/external/com_google_protobuf
     '';
 
-    sha256 = "sha256-QjMsWTIHCy6Mbbphk5eK2wIiw900AvmyA0ZV9Be7nPI=";
+    sha256 = "sha256-R+Hc9ldYcKgAXETKr2+Hk7IrjJ93WkrjyJ1SQRoM9V4=";
   };
 
   buildAttrs = {

--- a/pkgs/development/tools/bazel-watcher/default.nix
+++ b/pkgs/development/tools/bazel-watcher/default.nix
@@ -1,4 +1,5 @@
 { buildBazelPackage
+, bazel_5
 , fetchFromGitHub
 , git
 , go
@@ -13,18 +14,19 @@ let
 in
 buildBazelPackage rec {
   pname = "bazel-watcher";
-  version = "0.14.0";
+  version = "0.16.2";
 
   src = fetchFromGitHub {
     owner = "bazelbuild";
     repo = "bazel-watcher";
     rev = "v${version}";
-    sha256 = "0gigl1lg8sb4bj5crvj54329ws4yirldbncs15f96db6vhp0ig7r";
+    sha256 = "sha256-yRXta6pPhgIonTL0q9GSzNQg/jHMIeC7xvfVYrZMmnc=";
   };
 
   nativeBuildInputs = [ go git python3 ];
   removeRulesCC = false;
 
+  bazel = bazel_5;
   bazelTarget = "//ibazel";
 
   fetchAttrs = {
@@ -32,6 +34,8 @@ buildBazelPackage rec {
 
     preBuild = ''
       patchShebangs .
+
+      echo ${bazel_5.version} > .bazelversion
     '';
 
     preInstall = ''
@@ -56,7 +60,7 @@ buildBazelPackage rec {
       sed -e '/^FILE:@bazel_gazelle_go_repository_tools.*/d' -i $bazelOut/external/\@*.marker
     '';
 
-    sha256 = "1j175z3d4fbi4pl35py7yjq7ywrvwin6id131jv32hx0ck4g1m46";
+    sha256 = "sha256-vij20VMBlKTBOACjH+XP4Z15BOmXYvlmErkVgjOln3M=";
   };
 
   buildAttrs = {
@@ -66,10 +70,11 @@ buildBazelPackage rec {
       patchShebangs .
 
       substituteInPlace ibazel/BUILD --replace '{STABLE_GIT_VERSION}' ${version}
+      echo ${bazel_5.version} > .bazelversion
     '';
 
     installPhase = ''
-      install -Dm755 bazel-bin/ibazel/*_pure_stripped/ibazel $out/bin/ibazel
+      install -Dm755 bazel-bin/ibazel/ibazel_/ibazel $out/bin/ibazel
     '';
   };
 

--- a/pkgs/development/tools/bazel-watcher/default.nix
+++ b/pkgs/development/tools/bazel-watcher/default.nix
@@ -46,6 +46,7 @@ buildBazelPackage rec {
   bazelBuildFlags = lib.optionals stdenv.cc.isClang [ "--cxxopt=-x" "--cxxopt=c++" "--host_cxxopt=-x" "--host_cxxopt=c++" ];
   bazelTarget = "//ibazel";
 
+  fetchConfigured = false; # we want to fetch all dependencies, regardless of the current system
   fetchAttrs = {
     inherit patches;
 
@@ -75,9 +76,12 @@ buildBazelPackage rec {
       # should be equivalent.
       rm -rf $bazelOut/external/{bazel_gazelle_go_repository_tools,\@bazel_gazelle_go_repository_tools.marker}
       sed -e '/^FILE:@bazel_gazelle_go_repository_tools.*/d' -i $bazelOut/external/\@*.marker
+
+      # remove com_google_protobuf because it had files with different permissions on linux and darwin
+      rm -rf $bazelOut/external/com_google_protobuf
     '';
 
-    sha256 = "sha256-Tkmq5/vrakWeIsnTQ9o0h2XhT/Ot+r6LRSCE5c6PSEk=";
+    sha256 = "sha256-QjMsWTIHCy6Mbbphk5eK2wIiw900AvmyA0ZV9Be7nPI=";
   };
 
   buildAttrs = {

--- a/pkgs/development/tools/bazel-watcher/default.nix
+++ b/pkgs/development/tools/bazel-watcher/default.nix
@@ -84,6 +84,7 @@ buildBazelPackage rec {
     description = "Tools for building Bazel targets when source files change";
     license = licenses.asl20;
     maintainers = with maintainers; [ kalbasit ];
+    mainProgram = "ibazel";
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/tools/bazel-watcher/default.nix
+++ b/pkgs/development/tools/bazel-watcher/default.nix
@@ -27,6 +27,7 @@ buildBazelPackage rec {
   removeRulesCC = false;
 
   bazel = bazel_5;
+  bazelBuildFlags = lib.optionals stdenv.cc.isClang [ "--cxxopt=-x" "--cxxopt=c++" "--host_cxxopt=-x" "--host_cxxopt=c++" ];
   bazelTarget = "//ibazel";
 
   fetchAttrs = {
@@ -84,7 +85,5 @@ buildBazelPackage rec {
     license = licenses.asl20;
     maintainers = with maintainers; [ kalbasit ];
     platforms = platforms.all;
-    # broken on darwin, see https://github.com/NixOS/nixpkgs/issues/105573
-    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/tools/bazel-watcher/use-go-in-path.patch
+++ b/pkgs/development/tools/bazel-watcher/use-go-in-path.patch
@@ -6,7 +6,7 @@ index 51273b6..fcf9ffb 100644
  
  go_rules_dependencies()
  
--go_register_toolchains()
+-go_register_toolchains(version = "1.17.6")
 +go_register_toolchains(go_version = "host")
  
  load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")

--- a/pkgs/development/tools/build-managers/bazel/bazel_3/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_3/default.nix
@@ -110,7 +110,9 @@ let
   # and libraries path.
   # We prefetch it, patch it, and override it in a global bazelrc.
   system = if stdenv.hostPlatform.isDarwin then "darwin" else "linux";
-  arch = stdenv.hostPlatform.parsed.cpu.name;
+
+  # on aarch64 Darwin, `uname -m` returns "arm64"
+  arch = with stdenv.hostPlatform; if isDarwin && isAarch64 then "arm64" else parsed.cpu.name;
 
   remote_java_tools = stdenv.mkDerivation {
     name = "remote_java_tools_${system}";

--- a/pkgs/development/tools/build-managers/bazel/bazel_4/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_4/default.nix
@@ -135,7 +135,9 @@ let
   # and libraries path.
   # We prefetch it, patch it, and override it in a global bazelrc.
   system = if stdenv.hostPlatform.isDarwin then "darwin" else "linux";
-  arch = stdenv.hostPlatform.parsed.cpu.name;
+
+  # on aarch64 Darwin, `uname -m` returns "arm64"
+  arch = with stdenv.hostPlatform; if isDarwin && isAarch64 then "arm64" else parsed.cpu.name;
 
   remote_java_tools = stdenv.mkDerivation {
     name = "remote_java_tools_${system}";

--- a/pkgs/development/tools/build-managers/bazel/bazel_5/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_5/default.nix
@@ -126,7 +126,9 @@ let
   platforms = lib.platforms.linux ++ lib.platforms.darwin;
 
   system = if stdenv.hostPlatform.isDarwin then "darwin" else "linux";
-  arch = stdenv.hostPlatform.parsed.cpu.name;
+
+  # on aarch64 Darwin, `uname -m` returns "arm64"
+  arch = with stdenv.hostPlatform; if isDarwin && isAarch64 then "arm64" else parsed.cpu.name;
 
   bazelRC = writeTextFile {
     name = "bazel-rc";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15398,7 +15398,9 @@ with pkgs;
 
   bazel-remote = callPackage ../development/tools/build-managers/bazel/bazel-remote { };
 
-  bazel-watcher = callPackage ../development/tools/bazel-watcher { };
+  bazel-watcher = callPackage ../development/tools/bazel-watcher {
+    go = go_1_18;
+  };
 
   bazel-gazelle = callPackage ../development/tools/bazel-gazelle { };
 


### PR DESCRIPTION
###### Description of changes

Upgrade bazel-watcher to version ~0.16.2~ [0.17.0](https://github.com/bazelbuild/bazel-watcher/releases/tag/v0.17.0).

Fixes the build on Darwin, by providing explicit C++ flags, just like https://github.com/NixOS/nixpkgs/pull/145149/files

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
