### PR TITLE
fprintd-tod: fix build

### DIFF
--- a/pkgs/tools/security/fprintd/tod.nix
+++ b/pkgs/tools/security/fprintd/tod.nix
@@ -1,21 +1,51 @@
-{ fetchFromGitLab
+{ lib
+, fetchFromGitLab
+, fetchpatch
 , fprintd
 , libfprint-tod
 }:
 
-(fprintd.override { libfprint = libfprint-tod; }).overrideAttrs (oldAttrs:
-  let
+(fprintd.override { libfprint = libfprint-tod; }).overrideAttrs (oldAttrs: rec {
     pname = "fprintd-tod";
     version = "1.90.9";
-  in
-  {
-    inherit pname version;
 
     src = fetchFromGitLab {
       domain = "gitlab.freedesktop.org";
       owner = "libfprint";
-      repo = "${oldAttrs.pname}";
+      repo = "fprintd";
       rev = "v${version}";
       sha256 = "sha256-rOTVThHOY/Q2IIu2RGiv26UE2V/JFfWWnfKZQfKl5Mg=";
+    };
+
+    patches = oldAttrs.patches or [] ++ [
+      (fetchpatch {
+        name = "use-more-idiomatic-correct-embedded-shell-scripting";
+        url = "https://gitlab.freedesktop.org/libfprint/fprintd/-/commit/f4256533d1ffdc203c3f8c6ee42e8dcde470a93f.patch";
+        sha256 = "sha256-4uPrYEgJyXU4zx2V3gwKKLaD6ty0wylSriHlvKvOhek=";
+      })
+      (fetchpatch {
+        name = "remove-pointless-copying-of-files-into-build-directory";
+        url = "https://gitlab.freedesktop.org/libfprint/fprintd/-/commit/2c34cef5ef2004d8479475db5523c572eb409a6b.patch";
+        sha256 = "sha256-2pZBbMF1xjoDKn/jCAIldbeR2JNEVduXB8bqUrj2Ih4=";
+      })
+      (fetchpatch {
+        name = "build-Do-not-use-positional-arguments-in-i18n.merge_file";
+        url = "https://gitlab.freedesktop.org/libfprint/fprintd/-/commit/50943b1bd4f18d103c35233f0446ce7a31d1817e.patch";
+        sha256 = "sha256-ANkAq6fr0VRjkS0ckvf/ddVB2mH4b2uJRTI4H8vPPes=";
+      })
+    ];
+
+    postPatch = oldAttrs.postPatch or "" + ''
+      # part of "remove-pointless-copying-of-files-into-build-directory" but git-apply doesn't handle renaming
+      mv src/device.xml src/net.reactivated.Fprint.Device.xml
+      mv src/manager.xml src/net.reactivated.Fprint.Manager.xml
+    '';
+
+    meta = {
+      homepage = "https://fprint.freedesktop.org/";
+      description = "fprintd built with libfprint-tod to support Touch OEM Drivers";
+      license = lib.licenses.gpl2Plus;
+      platforms = lib.platforms.linux;
+      maintainers = with lib.maintainers; [ hmenke ];
     };
   })


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Next attempt at fixes #175212.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
