### PR TITLE
dt-shell-color-scripts: unstable-2022-02-22 -> unstable-2022-07-25

### DIFF
--- a/pkgs/tools/misc/dt-shell-color-scripts/default.nix
+++ b/pkgs/tools/misc/dt-shell-color-scripts/default.nix
@@ -1,22 +1,23 @@
 { stdenv
 , lib
 , fetchFromGitLab
+, installShellFiles
 , runtimeShell
 , makeWrapper
 }:
 
 stdenv.mkDerivation {
   pname = "dt-shell-color-scripts";
-  version = "unstable-2022-02-22";
+  version = "unstable-2022-07-25";
 
   src = fetchFromGitLab {
     owner = "dwt1";
     repo = "shell-color-scripts";
-    rev = "fcd013ea2e1ff80e01adbcea9d0eaf9c73db94c0";
-    sha256 = "sha256-bd3NBf99rCiADUKQb6fzCBDaKBmYaZHcO4qokm/39do=";
+    rev = "da2e3c512b94f312ee54a38d5cde131b0511ad01";
+    sha256 = "sha256-cdTgBbtsbJHaJuLIcZh0g0jKOrQyFx3P6QhYNx8hz0U=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper installShellFiles ];
 
   installPhase = ''
     runHook preInstall
@@ -25,6 +26,9 @@ stdenv.mkDerivation {
     mkdir -p $out/bin
     mkdir -p $out/opt/shell-color-scripts/
     cp -r colorscripts $out/opt/shell-color-scripts/colorscripts
+    installManPage colorscript.1
+    installShellCompletion --fish completions/colorscript.fish
+    installShellCompletion --zsh completions/_colorscript
     chmod +x colorscript.sh
     cp colorscript.sh $out/bin/colorscript
     substituteInPlace $out/bin/colorscript \


### PR DESCRIPTION
###### Description of changes
Updated dt-shell-color-scripts!
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
