### PR TITLE
python310Packages.google-auth: Fix tests after removing pyopenssl

### DIFF
--- a/pkgs/development/python-modules/google-auth/default.nix
+++ b/pkgs/development/python-modules/google-auth/default.nix
@@ -48,8 +48,8 @@ buildPythonPackage rec {
     "google.oauth2"
   ];
 
-  # Disable tests related to pyopenssl
   disabledTestPaths = [
+    # Disable tests related to pyopenssl
     "tests/transport/test__mtls_helper.py"
     "tests/transport/test_requests.py"
     "tests/transport/test_urllib3.py"

--- a/pkgs/development/python-modules/google-auth/default.nix
+++ b/pkgs/development/python-modules/google-auth/default.nix
@@ -4,6 +4,7 @@
 , fetchPypi
 , pytestCheckHook
 , cachetools
+, cryptography
 , flask
 , freezegun
 , mock
@@ -32,6 +33,7 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
+    cryptography
     flask
     freezegun
     mock
@@ -46,21 +48,11 @@ buildPythonPackage rec {
     "google.oauth2"
   ];
 
-  disabledTests = lib.optionals stdenv.isDarwin [
-    "test_request_with_timeout_success"
-    "test_request_with_timeout_failure"
-    "test_request_headers"
-    "test_request_error"
-    "test_request_basic"
-  ] ++ lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [
-    # E MemoryError: Cannot allocate write+execute memory for ffi.callback().
-    # You might be running on a system that prevents this.
-    # For more information, see https://cffi.readthedocs.io/en/latest/using.html#callbacks
-    "test_configure_mtls_channel_with_callback"
-    "test_configure_mtls_channel_with_metadata"
-    "TestDecryptPrivateKey"
-    "TestMakeMutualTlsHttp"
-    "TestMutualTlsAdapter"
+  # Disable tests related to pyopenssl
+  disabledTestPaths = [
+    "tests/transport/test__mtls_helper.py"
+    "tests/transport/test_requests.py"
+    "tests/transport/test_urllib3.py"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

See https://hydra.nixos.org/build/182833696/nixlog/1

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
