### PR TITLE
stdenv: start deprecating non-list mesonFlags

### DIFF
--- a/pkgs/applications/audio/speech-denoiser/default.nix
+++ b/pkgs/applications/audio/speech-denoiser/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation  {
   nativeBuildInputs = [ pkg-config meson ninja ];
   buildInputs = [ lv2 rnnoise-nu ];
 
-  mesonFlags = ("--prefix=${placeholder "out"}/lib/lv2");
+  mesonFlags = [ "--prefix=${placeholder "out"}/lib/lv2" ];
 
   postPatch = ''
     substituteInPlace meson.build \

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -361,6 +361,43 @@ else let
         in
           explicitFlags ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) crossFlags;
 
+      mesonFlags =
+        let
+          explicitFlags =
+            if lib.isString mesonFlags then lib.warn
+                "String 'mesonFlags' is deprecated and will be removed in release 23.05. Please use a list of strings. Derivation name: ${derivationArg.name}, file: ${pos.file or "unknown file"}"
+                [mesonFlags]
+            else if mesonFlags == null then
+              lib.warn
+                "Null 'mesonFlags' is deprecated and will be removed in release 23.05. Please use a empty list instead '[]'. Derivation name: ${derivationArg.name}, file: ${pos.file or "unknown file"}"
+                []
+            else
+              mesonFlags;
+
+          # See https://mesonbuild.com/Reference-tables.html#cpu-families
+          cpuFamily = platform: with platform;
+            /**/ if isAarch32 then "arm"
+            else if isAarch64 then "aarch64"
+            else if isx86_32  then "x86"
+            else if isx86_64  then "x86_64"
+            else platform.parsed.cpu.family + builtins.toString platform.parsed.cpu.bits;
+
+          crossFile = builtins.toFile "cross-file.conf" ''
+            [properties]
+            needs_exe_wrapper = true
+
+            [host_machine]
+            system = '${stdenv.targetPlatform.parsed.kernel.name}'
+            cpu_family = '${cpuFamily stdenv.targetPlatform}'
+            cpu = '${stdenv.targetPlatform.parsed.cpu.name}'
+            endian = ${if stdenv.targetPlatform.isLittleEndian then "'little'" else "'big'"}
+
+            [binaries]
+            llvm-config = 'llvm-config-native'
+          '';
+          crossFlags = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [ "--cross-file=${crossFile}" ];
+        in crossFlags ++ explicitFlags;
+
       inherit patches;
 
       inherit doCheck doInstallCheck;
@@ -372,29 +409,6 @@ else let
       # most people won't care about these anyways
       outputHashAlgo = attrs.outputHashAlgo or "sha256";
       outputHashMode = attrs.outputHashMode or "recursive";
-    } // lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform) {
-      mesonFlags = if mesonFlags == null then null else let
-        # See https://mesonbuild.com/Reference-tables.html#cpu-families
-        cpuFamily = platform: with platform;
-          /**/ if isAarch32 then "arm"
-          else if isAarch64 then "aarch64"
-          else if isx86_32  then "x86"
-          else if isx86_64  then "x86_64"
-          else platform.parsed.cpu.family + builtins.toString platform.parsed.cpu.bits;
-        crossFile = builtins.toFile "cross-file.conf" ''
-          [properties]
-          needs_exe_wrapper = true
-
-          [host_machine]
-          system = '${stdenv.targetPlatform.parsed.kernel.name}'
-          cpu_family = '${cpuFamily stdenv.targetPlatform}'
-          cpu = '${stdenv.targetPlatform.parsed.cpu.name}'
-          endian = ${if stdenv.targetPlatform.isLittleEndian then "'little'" else "'big'"}
-
-          [binaries]
-          llvm-config = 'llvm-config-native'
-        '';
-      in [ "--cross-file=${crossFile}" ] ++ mesonFlags;
     } // lib.optionalAttrs (enableParallelBuilding) {
       enableParallelChecking = attrs.enableParallelChecking or true;
     } // lib.optionalAttrs (hardeningDisable != [] || hardeningEnable != [] || stdenv.hostPlatform.isMusl) {


### PR DESCRIPTION
the motivation for this is to simplify stdenv and ease the job of
reviewers due to them needing to tell contributors about the defacto
rule that mesonFlags should be a list of strings

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
