### PR TITLE
ocamlPackages.chacha: 1.0.0 → 1.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/chacha/default.nix
+++ b/pkgs/development/ocaml-modules/chacha/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildDunePackage
-, fetchurl
+, fetchFromGitHub
+, fetchpatch
 , ocaml
 
 , alcotest
@@ -10,16 +11,22 @@
 
 buildDunePackage rec {
   pname = "chacha";
-  version = "1.0.0";
+  version = "1.1.0";
 
-  src = fetchurl {
-    url = "https://github.com/abeaumont/ocaml-chacha/releases/download/${version}/${pname}-${version}.tbz";
-    sha256 = "sha256-t8dOMQQDpje0QbuOhjSIa3xnXuXcxMVTLENa/rwdgA4=";
+  src = fetchFromGitHub {
+    owner = "abeaumont";
+    repo = "ocaml-chacha";
+    rev = version;
+    sha256 = "sha256-PmeiFloU0k3SqOK1VjaliiCEzDzrzyMSasgnO5fJS1k=";
   };
 
-  useDune2 = true;
+  # Ensure compatibility with cstruct ≥ 6.1.0
+  patches = [ (fetchpatch {
+    url = "https://github.com/abeaumont/ocaml-chacha/commit/fbe4a0a808226229728a68f278adf370251196fd.patch";
+    sha256 = "sha256-y7X9toFDrgdv3qmFmUs7K7QS+Gy45rRLulKy48m7uqc=";
+  })];
 
-  minimumOCamlVersion = "4.02";
+  minimalOCamlVersion = "4.02";
 
   propagatedBuildInputs = [ cstruct mirage-crypto ];
 


### PR DESCRIPTION
###### Description of changes

Compatibility with recent cstruct:
https://github.com/abeaumont/ocaml-chacha/blob/master/CHANGES.md#110-2021-08-03

cc maintainer @fufexan

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
