### PR TITLE
pkgsStatic.cctz: fix build

### DIFF
--- a/pkgs/development/libraries/cctz/default.nix
+++ b/pkgs/development/libraries/cctz/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, darwin }:
+{ lib, stdenv, fetchFromGitHub, Foundation }:
 
 stdenv.mkDerivation rec {
   pname = "cctz";
@@ -13,9 +13,11 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "PREFIX=$(out)" ];
 
-  buildInputs = lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Foundation;
+  buildInputs = lib.optional stdenv.isDarwin Foundation;
 
-  installTargets = [ "install_hdrs" "install_shared_lib" ];
+  installTargets = [ "install_hdrs" ]
+    ++ lib.optional (!stdenv.targetPlatform.isStatic) "install_shared_lib"
+    ++ lib.optional stdenv.targetPlatform.isStatic "install_lib";
 
   postInstall = lib.optionalString stdenv.isDarwin ''
     install_name_tool -id $out/lib/libcctz.so $out/lib/libcctz.so

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17107,7 +17107,9 @@ with pkgs;
 
   ccrtp = callPackage ../development/libraries/ccrtp { };
 
-  cctz = callPackage ../development/libraries/cctz { };
+  cctz = callPackage ../development/libraries/cctz {
+    inherit (darwin.apple_sdk.frameworks) Foundation;
+  };
 
   celt = callPackage ../development/libraries/celt {};
   celt_0_7 = callPackage ../development/libraries/celt/0.7.nix {};


### PR DESCRIPTION

###### Description of changes

The static build of cctz 
```
nix-build --pure ./nixpkgs -A pkgsStatic.cctz
```
was failing at the installPhase with:
```
install flags: SHELL=/nix/store/pxfxgmas6iyqb6dq7d7d7kvv1vld4r89-bash-interactive-5.1-p16/bin/bash PREFIX=\$\(out\) install_hdrs install_shared_lib
install -d /nix/store/jvrlakd1800qbdcailhxym016p095hi3-cctz-static-x86_64-unknown-linux-musl-2.3/include/cctz
install -m 644 -p include/cctz/civil_time.h include/cctz/civil_time_detail.h include/cctz/time_zone.h include/cctz/zone_info_source.h /nix/store/jvrlakd1800qbdcailhxym016p095hi3-cctz-static-x86_64-unknown-linux-musl-2.3/include/cctz
x86_64-unknown-linux-musl-g++ -O3 -g -Wall -Iinclude -std=c++11  -fPIC -MMD  -O3  -O3 -shared -o libcctz.so civil_time_detail.o time_zone_fixed.o time_zone_format.o time_zone_if.o time_zone_impl.o time_zone_info.o time_zone_libc.o time_zone_lookup.o time_zone_posix.o zone_info_source.o
/nix/store/57mlf0zidj36xx7ikfln9km5ymzgxv1z-x86_64-unknown-linux-musl-binutils-2.38/bin/x86_64-unknown-linux-musl-ld: /nix/store/jnin5hhg78y0cww1ima7d8l9xdh74s71-x86_64-unknown-linux-musl-stage-final-gcc-11.3.0/lib/gcc/x86_64-unknown-linux-musl/11.3.0/crtbeginT.o: relocation R_X86_64_32 against hidden symbol `__TMC_END__' can not be used when making a shared object
/nix/store/57mlf0zidj36xx7ikfln9km5ymzgxv1z-x86_64-unknown-linux-musl-binutils-2.38/bin/x86_64-unknown-linux-musl-ld: failed to set dynamic section sizes: bad value
collect2: error: ld returned 1 exit status

```

The install targets were "install_hdrs" and "install_shared_lib". 
The later is obviously not correct for a static build and was changed to
"install_lib" (corresponds to libcctz.a) for that case.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
