### PR TITLE
qtbase: Fix build for aarch64-darwin

### DIFF
--- a/pkgs/development/libraries/qt-5/5.12/default.nix
+++ b/pkgs/development/libraries/qt-5/5.12/default.nix
@@ -164,7 +164,7 @@ let
         inherit bison cups harfbuzz libGL;
         withGtk3 = !stdenv.isDarwin; inherit dconf gtk3;
         inherit debug developerBuild decryptSslTraffic;
-        inherit (darwin.apple_sdk.frameworks) AGL AppKit ApplicationServices Carbon Cocoa CoreAudio CoreBluetooth
+        inherit (darwin.apple_sdk.frameworks) AGL AppKit ApplicationServices AVFoundation Carbon Cocoa CoreAudio CoreBluetooth
           CoreLocation CoreServices DiskArbitration Foundation OpenGL MetalKit IOKit;
         inherit (darwin) libobjc;
       };

--- a/pkgs/development/libraries/qt-5/5.14/default.nix
+++ b/pkgs/development/libraries/qt-5/5.14/default.nix
@@ -162,7 +162,7 @@ let
         inherit bison cups harfbuzz libGL;
         withGtk3 = !stdenv.isDarwin; inherit dconf gtk3;
         inherit debug developerBuild decryptSslTraffic;
-        inherit (darwin.apple_sdk.frameworks) AGL AppKit ApplicationServices Carbon Cocoa CoreAudio CoreBluetooth
+        inherit (darwin.apple_sdk.frameworks) AGL AppKit ApplicationServices AVFoundation Carbon Cocoa CoreAudio CoreBluetooth
           CoreLocation CoreServices DiskArbitration Foundation OpenGL MetalKit IOKit;
         inherit (darwin) libobjc;
       };

--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -43,6 +43,8 @@ let
       # Patch framework detection to support X.framework/X.tbd,
       # extending the current support for X.framework/X.
       ./qtbase.patch.d/0012-qtbase-tbd-frameworks.patch
+
+      ./qtbase.patch.d/0014-aarch64-darwin.patch
     ] ++ [
       ./qtbase.patch.d/0003-qtbase-mkspecs.patch
       ./qtbase.patch.d/0004-qtbase-replace-libdir.patch
@@ -119,7 +121,7 @@ let
         inherit bison cups harfbuzz libGL;
         withGtk3 = !stdenv.isDarwin; inherit dconf gtk3;
         inherit developerBuild decryptSslTraffic;
-        inherit (darwin.apple_sdk.frameworks) AGL AppKit ApplicationServices Carbon Cocoa CoreAudio CoreBluetooth
+        inherit (darwin.apple_sdk.frameworks) AGL AppKit ApplicationServices AVFoundation Carbon Cocoa CoreAudio CoreBluetooth
           CoreLocation CoreServices DiskArbitration Foundation OpenGL MetalKit IOKit;
         inherit (darwin) libobjc;
       };

--- a/pkgs/development/libraries/qt-5/5.15/qtbase.patch.d/0014-aarch64-darwin.patch
+++ b/pkgs/development/libraries/qt-5/5.15/qtbase.patch.d/0014-aarch64-darwin.patch
@@ -1,0 +1,287 @@
+From abc52460201bc5c7603505bb187138b0c59291aa Mon Sep 17 00:00:00 2001
+From: Mushroom <mushroom@watchingyour.tv>
+Date: Sun, 20 Dec 2020 00:11:41 +0000
+Subject: [PATCH] [QtBase] Split macOS platforms by architecture
+
+Currently macOS only has one platform, which forces the default arch to
+x86_64. This patch splits the platforms by architecture, and defaults to
+the same as the host.
+
+This stops M1-based macs from compiling x64 binaries by default,
+instead making them compile native binaries.
+
+[ChangeLog][QtBase][Platform Specific Changes][OS X] Split macOS
+platforms so it doesn't default to the x64 architecture every time
+
+Change-Id: I34891b107bb24f68371df1c8f087eb0ad5b5dd95
+---
+ configure                                     |  9 +++-
+ .../clang-macx-desktop.conf}                  |  8 ++--
+ mkspecs/common/macx.conf                      |  1 -
+ .../Info.plist.app                            |  0
+ .../Info.plist.dSYM.in                        |  0
+ .../Info.plist.disable_highdpi                |  0
+ .../Info.plist.lib                            |  0
+ mkspecs/macx-clang-arm64/qmake.conf           |  7 ++++
+ .../qplatformdefs.h                           |  0
+ mkspecs/macx-clang-x64/Info.plist.app         | 24 +++++++++++
+ mkspecs/macx-clang-x64/Info.plist.dSYM.in     | 18 ++++++++
+ .../macx-clang-x64/Info.plist.disable_highdpi |  8 ++++
+ mkspecs/macx-clang-x64/Info.plist.lib         | 20 +++++++++
+ mkspecs/macx-clang-x64/qmake.conf             |  7 ++++
+ mkspecs/macx-clang-x64/qplatformdefs.h        | 41 +++++++++++++++++++
+ 15 files changed, 137 insertions(+), 6 deletions(-)
+ rename mkspecs/{macx-clang/qmake.conf => common/clang-macx-desktop.conf} (83%)
+ rename mkspecs/{macx-clang => macx-clang-arm64}/Info.plist.app (100%)
+ rename mkspecs/{macx-clang => macx-clang-arm64}/Info.plist.dSYM.in (100%)
+ rename mkspecs/{macx-clang => macx-clang-arm64}/Info.plist.disable_highdpi (100%)
+ rename mkspecs/{macx-clang => macx-clang-arm64}/Info.plist.lib (100%)
+ create mode 100644 mkspecs/macx-clang-arm64/qmake.conf
+ rename mkspecs/{macx-clang => macx-clang-arm64}/qplatformdefs.h (100%)
+ create mode 100644 mkspecs/macx-clang-x64/Info.plist.app
+ create mode 100644 mkspecs/macx-clang-x64/Info.plist.dSYM.in
+ create mode 100644 mkspecs/macx-clang-x64/Info.plist.disable_highdpi
+ create mode 100644 mkspecs/macx-clang-x64/Info.plist.lib
+ create mode 100644 mkspecs/macx-clang-x64/qmake.conf
+ create mode 100644 mkspecs/macx-clang-x64/qplatformdefs.h
+
+diff --git a/configure b/configure
+index b6c9b462f24..a86f2ceaa5b 100755
+--- a/configure
++++ b/configure
+@@ -556,7 +556,14 @@ PLATFORM_NOTES=
+ if [ -z "$PLATFORM" ]; then
+     case "$UNAME_SYSTEM:$UNAME_RELEASE" in
+      Darwin:*)
+-        PLATFORM=macx-clang
++        case "$UNAME_MACHINE" in
++            arm64)
++                PLATFORM=macx-clang-arm64
++                ;;
++            *)
++                PLATFORM=macx-clang-x64
++                ;;
++        esac
+         ;;
+      AIX:*)
+         #PLATFORM=aix-g++
+diff --git a/mkspecs/macx-clang/qmake.conf b/mkspecs/common/clang-macx-desktop.conf
+similarity index 83%
+rename from mkspecs/macx-clang/qmake.conf
+rename to mkspecs/common/clang-macx-desktop.conf
+index 0cf1f31b60d..042319a2aa3 100644
+--- a/mkspecs/macx-clang/qmake.conf
++++ b/mkspecs/common/clang-macx-desktop.conf
+@@ -24,9 +24,9 @@ QMAKE_LIBS_X11 = -lX11 -lXext -lm
+ QMAKE_LIBDIR_X11 = /opt/X11/lib
+ QMAKE_INCDIR_X11 = /opt/X11/include
+ 
+-include(../common/macx.conf)
+-include(../common/gcc-base-mac.conf)
+-include(../common/clang.conf)
+-include(../common/clang-mac.conf)
++include(macx.conf)
++include(gcc-base-mac.conf)
++include(clang.conf)
++include(clang-mac.conf)
+ 
+ load(qt_config)
+diff --git a/mkspecs/common/macx.conf b/mkspecs/common/macx.conf
+index d16b77acb8e..4ba0a8eaa36 100644
+--- a/mkspecs/common/macx.conf
++++ b/mkspecs/common/macx.conf
+@@ -6,7 +6,6 @@ QMAKE_PLATFORM         += macos osx macx
+ QMAKE_MAC_SDK           = macosx
+ 
+ QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.13
+-QMAKE_APPLE_DEVICE_ARCHS = x86_64
+ 
+ # Should be 10.15, but as long as the CI builds with
+ # older SDKs we have to keep this.
+diff --git a/mkspecs/macx-clang/Info.plist.app b/mkspecs/macx-clang-arm64/Info.plist.app
+similarity index 100%
+rename from mkspecs/macx-clang/Info.plist.app
+rename to mkspecs/macx-clang-arm64/Info.plist.app
+diff --git a/mkspecs/macx-clang/Info.plist.dSYM.in b/mkspecs/macx-clang-arm64/Info.plist.dSYM.in
+similarity index 100%
+rename from mkspecs/macx-clang/Info.plist.dSYM.in
+rename to mkspecs/macx-clang-arm64/Info.plist.dSYM.in
+diff --git a/mkspecs/macx-clang/Info.plist.disable_highdpi b/mkspecs/macx-clang-arm64/Info.plist.disable_highdpi
+similarity index 100%
+rename from mkspecs/macx-clang/Info.plist.disable_highdpi
+rename to mkspecs/macx-clang-arm64/Info.plist.disable_highdpi
+diff --git a/mkspecs/macx-clang/Info.plist.lib b/mkspecs/macx-clang-arm64/Info.plist.lib
+similarity index 100%
+rename from mkspecs/macx-clang/Info.plist.lib
+rename to mkspecs/macx-clang-arm64/Info.plist.lib
+diff --git a/mkspecs/macx-clang-arm64/qmake.conf b/mkspecs/macx-clang-arm64/qmake.conf
+new file mode 100644
+index 00000000000..0cc2361e696
+--- /dev/null
++++ b/mkspecs/macx-clang-arm64/qmake.conf
+@@ -0,0 +1,7 @@
++#
++# qmake configuration for Clang on OS X (arm64)
++#
++
++QMAKE_APPLE_DEVICE_ARCHS=arm64
++
++include(../common/clang-macx-desktop.conf)
+diff --git a/mkspecs/macx-clang/qplatformdefs.h b/mkspecs/macx-clang-arm64/qplatformdefs.h
+similarity index 100%
+rename from mkspecs/macx-clang/qplatformdefs.h
+rename to mkspecs/macx-clang-arm64/qplatformdefs.h
+diff --git a/mkspecs/macx-clang-x64/Info.plist.app b/mkspecs/macx-clang-x64/Info.plist.app
+new file mode 100644
+index 00000000000..fa592af0897
+--- /dev/null
++++ b/mkspecs/macx-clang-x64/Info.plist.app
+@@ -0,0 +1,24 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
++<plist version="1.0">
++<dict>
++	<key>CFBundleExecutable</key>
++	<string>${EXECUTABLE_NAME}</string>
++	<key>CFBundleIconFile</key>
++	<string>${ASSETCATALOG_COMPILER_APPICON_NAME}</string>
++	<key>CFBundleIdentifier</key>
++	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
++	<key>CFBundlePackageType</key>
++	<string>APPL</string>
++	<key>CFBundleSignature</key>
++	<string>${QMAKE_PKGINFO_TYPEINFO}</string>
++	<key>LSMinimumSystemVersion</key>
++	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
++	<key>NOTE</key>
++	<string>This file was generated by Qt/QMake.</string>
++	<key>NSPrincipalClass</key>
++	<string>NSApplication</string>
++	<key>NSSupportsAutomaticGraphicsSwitching</key>
++	<true/>
++</dict>
++</plist>
+diff --git a/mkspecs/macx-clang-x64/Info.plist.dSYM.in b/mkspecs/macx-clang-x64/Info.plist.dSYM.in
+new file mode 100644
+index 00000000000..a8c8d0d4fb5
+--- /dev/null
++++ b/mkspecs/macx-clang-x64/Info.plist.dSYM.in
+@@ -0,0 +1,18 @@
++<?xml version=\"1.0\" encoding=\"UTF-8\"?>
++<!DOCTYPE plist PUBLIC \"-//Apple Computer//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
++<plist version=\"1.0\">
++	<dict>
++		<key>CFBundleIdentifier</key>
++		<string>com.apple.xcode.dsym.$${BUNDLEIDENTIFIER}</string>
++		<key>CFBundlePackageType</key>
++		<string>dSYM</string>
++		<key>CFBundleSignature</key>
++		<string>????</string>
++!!IF !isEmpty(VERSION)
++		<key>CFBundleShortVersionString</key>
++		<string>$${VER_MAJ}.$${VER_MIN}</string>
++		<key>CFBundleVersion</key>
++		<string>$${VER_MAJ}.$${VER_MIN}.$${VER_PAT}</string>
++!!ENDIF
++	</dict>
++</plist>
+diff --git a/mkspecs/macx-clang-x64/Info.plist.disable_highdpi b/mkspecs/macx-clang-x64/Info.plist.disable_highdpi
+new file mode 100644
+index 00000000000..a9b89888ad4
+--- /dev/null
++++ b/mkspecs/macx-clang-x64/Info.plist.disable_highdpi
+@@ -0,0 +1,8 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
++<plist version="1.0">
++<dict>
++	<key>NSHighResolutionCapable</key>
++	<string>NO</string>
++</dict>
++</plist>
+diff --git a/mkspecs/macx-clang-x64/Info.plist.lib b/mkspecs/macx-clang-x64/Info.plist.lib
+new file mode 100644
+index 00000000000..34752ec40d9
+--- /dev/null
++++ b/mkspecs/macx-clang-x64/Info.plist.lib
+@@ -0,0 +1,20 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
++<plist version="1.0">
++<dict>
++	<key>CFBundleExecutable</key>
++	<string>${EXECUTABLE_NAME}</string>
++	<key>CFBundleIdentifier</key>
++	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
++	<key>CFBundlePackageType</key>
++	<string>FMWK</string>
++	<key>CFBundleShortVersionString</key>
++	<string>${QMAKE_SHORT_VERSION}</string>
++	<key>CFBundleSignature</key>
++	<string>${QMAKE_PKGINFO_TYPEINFO}</string>
++	<key>CFBundleVersion</key>
++	<string>${QMAKE_FULL_VERSION}</string>
++	<key>NOTE</key>
++	<string>Please, do NOT change this file -- It was generated by Qt/QMake.</string>
++</dict>
++</plist>
+diff --git a/mkspecs/macx-clang-x64/qmake.conf b/mkspecs/macx-clang-x64/qmake.conf
+new file mode 100644
+index 00000000000..1ac373b53b4
+--- /dev/null
++++ b/mkspecs/macx-clang-x64/qmake.conf
+@@ -0,0 +1,7 @@
++#
++# qmake configuration for Clang on OS X (arm64)
++#
++
++QMAKE_APPLE_DEVICE_ARCHS=x86_64
++
++include(../common/clang-macx-desktop.conf)
+diff --git a/mkspecs/macx-clang-x64/qplatformdefs.h b/mkspecs/macx-clang-x64/qplatformdefs.h
+new file mode 100644
+index 00000000000..063491dd900
+--- /dev/null
++++ b/mkspecs/macx-clang-x64/qplatformdefs.h
+@@ -0,0 +1,41 @@
++/****************************************************************************
++**
++** Copyright (C) 2016 The Qt Company Ltd.
++** Contact: https://www.qt.io/licensing/
++**
++** This file is part of the qmake spec of the Qt Toolkit.
++**
++** $QT_BEGIN_LICENSE:LGPL$
++** Commercial License Usage
++** Licensees holding valid commercial Qt licenses may use this file in
++** accordance with the commercial license agreement provided with the
++** Software or, alternatively, in accordance with the terms contained in
++** a written agreement between you and The Qt Company. For licensing terms
++** and conditions see https://www.qt.io/terms-conditions. For further
++** information use the contact form at https://www.qt.io/contact-us.
++**
++** GNU Lesser General Public License Usage
++** Alternatively, this file may be used under the terms of the GNU Lesser
++** General Public License version 3 as published by the Free Software
++** Foundation and appearing in the file LICENSE.LGPL3 included in the
++** packaging of this file. Please review the following information to
++** ensure the GNU Lesser General Public License version 3 requirements
++** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
++**
++** GNU General Public License Usage
++** Alternatively, this file may be used under the terms of the GNU
++** General Public License version 2.0 or (at your option) the GNU General
++** Public license version 3 or any later version approved by the KDE Free
++** Qt Foundation. The licenses are as published by the Free Software
++** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
++** included in the packaging of this file. Please review the following
++** information to ensure the GNU General Public License requirements will
++** be met: https://www.gnu.org/licenses/gpl-2.0.html and
++** https://www.gnu.org/licenses/gpl-3.0.html.
++**
++** $QT_END_LICENSE$
++**
++****************************************************************************/
++
++#include "../common/mac/qplatformdefs.h"
++

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -4,7 +4,7 @@
 , coreutils, bison, flex, gdb, gperf, lndir, perl, pkg-config, python3
 , which
   # darwin support
-, libiconv, libobjc, xcbuild, AGL, AppKit, ApplicationServices, Carbon, Cocoa, CoreAudio, CoreBluetooth
+, libiconv, libobjc, xcbuild, AGL, AppKit, ApplicationServices, AVFoundation, Carbon, Cocoa, CoreAudio, CoreBluetooth
 , CoreLocation, CoreServices, DiskArbitration, Foundation, OpenGL, MetalKit, IOKit
 
 , dbus, fontconfig, freetype, glib, harfbuzz, icu, libdrm, libX11, libXcomposite
@@ -52,7 +52,7 @@ stdenv.mkDerivation {
   ] ++ (
     if stdenv.isDarwin then [
       # TODO: move to buildInputs, this should not be propagated.
-      AGL AppKit ApplicationServices Carbon Cocoa CoreAudio CoreBluetooth
+      AGL AppKit ApplicationServices AVFoundation Carbon Cocoa CoreAudio CoreBluetooth
       CoreLocation CoreServices DiskArbitration Foundation OpenGL
       libobjc libiconv MetalKit IOKit
     ] else [
@@ -281,7 +281,6 @@ stdenv.mkDerivation {
   ] ++ lib.optional (compareVersion "5.15.0" < 0) "-v"
     ++ (
       if stdenv.isDarwin then [
-      "-platform macx-clang"
       "-no-fontconfig"
       "-qt-freetype"
       "-qt-libpng"
@@ -374,7 +373,7 @@ stdenv.mkDerivation {
     #   error: unknown target CPU 'armv8.3-a+crypto+sha2+aes+crc+fp16+lse+simd+ras+rdm+rcpc'
     #   note: valid target CPU values are: nocona, core2, penryn, ..., znver1, znver2, x86-64
     # it seems the qmake/cmake passes x86_64 as preferred architecture somewhere
-    broken = stdenv.isDarwin && stdenv.isAarch64;
+    broken = stdenv.isDarwin && stdenv.isAarch64 && (compareVersion "5.15.3" < 0);
   };
 
 }

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -120,8 +120,10 @@ impure-cmds // appleSourcePackages // chooseLibs // {
     executable = true;
 
     text = ''
-      CODESIGN_ALLOCATE=${targetPrefix}codesign_allocate \
-        ${self.sigtool}/bin/codesign -f -s - "$linkerOutput"
+      if [ "$linkerOutput" != "/dev/null" ]; then
+        CODESIGN_ALLOCATE=${targetPrefix}codesign_allocate \
+          ${self.sigtool}/bin/codesign -f -s - "$linkerOutput"
+      fi
     '';
   };
 


### PR DESCRIPTION
###### Description of changes

Trying to fix qtbase build on aarch64-darwin platform. There is 2 issues:
- https://github.com/NixOS/nixpkgs/issues/154203 - issue with codesign on aarch64-darwin. I don't think that changes I suggest is a good solution, it is more workaround.
- Issue with aarch64 build on macos mentioned here: https://github.com/NixOS/nixpkgs/blob/235c1c17662bca229537a560b79bd33b5fd3131b/pkgs/development/libraries/qt-5/modules/qtbase.nix#L372-L376. This issue can be fixed with `0002-qtbase-mac-arm64.patch`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
