### PR TITLE
zafiro-icons: 1.1 -> 1.2

### DIFF
--- a/pkgs/data/icons/zafiro-icons/default.nix
+++ b/pkgs/data/icons/zafiro-icons/default.nix
@@ -1,18 +1,19 @@
-{ lib, stdenv, fetchFromGitHub, gtk3, breeze-icons, gnome-icon-theme, numix-icon-theme, numix-icon-theme-circle, hicolor-icon-theme }:
+{ lib, stdenvNoCC, fetchFromGitHub, gtk3, breeze-icons, gnome-icon-theme, numix-icon-theme, numix-icon-theme-circle, hicolor-icon-theme, jdupes }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "zafiro-icons";
-  version = "1.1";
+  version = "1.2";
 
   src = fetchFromGitHub {
     owner = "zayronxio";
     repo = pname;
     rev = version;
-    sha256 = "05h8qm9izjbp8pnl9jpbw3y9sddhp0zmg94fm1k4d4hhdqnakqhv";
+    sha256 = "sha256-Awc5Sw4X25pXEd4Ob0u6A6Uu0e8FYfwp0fEl90vrsUE=";
   };
 
   nativeBuildInputs = [
     gtk3
+    jdupes
   ];
 
   propagatedBuildInputs = [
@@ -26,10 +27,23 @@ stdenv.mkDerivation rec {
 
   dontDropIconThemeCache = true;
 
+  dontPatchELF = true;
+  dontRewriteSymlinks = true;
+
   installPhase = ''
+    runHook preInstall
+
+    # remove copy file, as it is there clearly by mistake
+    rm "apps/scalable/android-sdk (copia 1).svg"
+
     mkdir -p $out/share/icons/Zafiro-icons
     cp -a * $out/share/icons/Zafiro-icons
-    gtk-update-icon-cache "$out"/share/icons/Zafiro-icons
+
+    gtk-update-icon-cache $out/share/icons/Zafiro-icons
+
+    jdupes --link-soft --recurse $out/share
+
+    runHook postInstall
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes
Update to the latest upstream release [1.2](https://github.com/zayronxio/Zafiro-icons/releases/tag/1.2).

Includes some refactoring:
- use `stdenvNoCC` instead of `stdenv`
- run `preInstall` and `postInstall` hooks in the `installPhase`
- deduplicate files with `jdupes`
- set `dontPatchELF` and `dontRewriteSymlinks` to true. These fixup steps are slow and unnecessary for this package.
- remove whitespace from icon names, because they cause `gtk-update-icon-cache` to fail

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).