### PR TITLE
[Backport staging-22.05] gnupg:  2.3.4 -> 2.3.6, patches for CVE-2022-34903 and compressed sigs, gpgme: fix test

### DIFF
--- a/pkgs/development/libraries/gpgme/default.nix
+++ b/pkgs/development/libraries/gpgme/default.nix
@@ -44,6 +44,9 @@ stdenv.mkDerivation rec {
     ./python-310-detection-without-distutils.patch
     # Find correct version string for Python >= 3.10, https://dev.gnupg.org/D546
     ./python-find-version-string-above-310.patch
+    # Fix a test after disallowing compressed signatures in gpg (PR #180336)
+    ./test_t-verify_double-plaintext.patch
+
     # Disable python tests on Darwin as they use gpg (see configureFlags below)
   ] ++ lib.optional stdenv.isDarwin ./disable-python-tests.patch
   # Fix _AC_UNDECLARED_WARNING for autoconf>=2.70

--- a/pkgs/development/libraries/gpgme/test_t-verify_double-plaintext.patch
+++ b/pkgs/development/libraries/gpgme/test_t-verify_double-plaintext.patch
@@ -9,3 +9,23 @@
      {
        fprintf (stderr, "%s:%i: Double plaintext message not detected\n",
  	       PGM, __LINE__);
+--- a/lang/python/tests/t-verify.py
++++ b/lang/python/tests/t-verify.py
+@@ -142,7 +142,7 @@
+     c.op_verify(sig, None, text)
+ except Exception as e:
+     assert type(e) == gpg.errors.GPGMEError
+-    assert e.getcode() == gpg.errors.BAD_DATA
++    assert e.getcode() != gpg.errors.NO_ERROR
+ else:
+     assert False, "Expected an error but got none."
+ 
+@@ -178,7 +178,7 @@
+     try:
+         c.verify(double_plaintext_sig)
+     except gpg.errors.GPGMEError as e:
+-        assert e.getcode() == gpg.errors.BAD_DATA
++        assert e.getcode() != gpg.errors.NO_ERROR
+     else:
+         assert False, "Expected an error but got none."
+ 

--- a/pkgs/development/libraries/gpgme/test_t-verify_double-plaintext.patch
+++ b/pkgs/development/libraries/gpgme/test_t-verify_double-plaintext.patch
@@ -1,0 +1,11 @@
+--- a/tests/gpg/t-verify.c
++++ b/tests/gpg/t-verify.c
+@@ -304,7 +304,7 @@
+   err = gpgme_data_new (&text);
+   fail_if_err (err);
+   err = gpgme_op_verify (ctx, sig, NULL, text);
+-  if (gpgme_err_code (err) != GPG_ERR_BAD_DATA)
++  if (gpgme_err_code (err) == GPG_ERR_NO_ERROR)
+     {
+       fprintf (stderr, "%s:%i: Double plaintext message not detected\n",
+ 	       PGM, __LINE__);

--- a/pkgs/tools/security/gnupg/23.nix
+++ b/pkgs/tools/security/gnupg/23.nix
@@ -15,11 +15,11 @@ assert guiSupport -> pinentry != null && enableMinimal == false;
 
 stdenv.mkDerivation rec {
   pname = "gnupg";
-  version = "2.3.4";
+  version = "2.3.6";
 
   src = fetchurl {
     url = "mirror://gnupg/gnupg/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-80aOyvsdf5rXtR/R23rr8XzridLvqKBc8vObTUBUAq4=";
+    sha256 = "sha256-Iff+L8XC8hQYSrBQl37HqOME5Yv64qsJj+xp+Pq9qcE=";
   };
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];

--- a/pkgs/tools/security/gnupg/23.nix
+++ b/pkgs/tools/security/gnupg/23.nix
@@ -34,6 +34,9 @@ stdenv.mkDerivation rec {
     ./tests-add-test-cases-for-import-without-uid.patch
     ./allow-import-of-previously-known-keys-even-without-UI.patch
     ./accept-subkeys-with-a-good-revocation-but-no-self-sig.patch
+
+    # Patch from upstream 34c649b36013, https://dev.gnupg.org/T6027
+    ./CVE-2022-34903-g10-fix-garbled-status-messages-in-NOTATION_DATA.patch
   ];
   postPatch = ''
     sed -i 's,\(hkps\|https\)://keyserver.ubuntu.com,hkps://keys.openpgp.org,g' configure configure.ac doc/dirmngr.texi doc/gnupg.info-1

--- a/pkgs/tools/security/gnupg/23.nix
+++ b/pkgs/tools/security/gnupg/23.nix
@@ -37,6 +37,9 @@ stdenv.mkDerivation rec {
 
     # Patch from upstream 34c649b36013, https://dev.gnupg.org/T6027
     ./CVE-2022-34903-g10-fix-garbled-status-messages-in-NOTATION_DATA.patch
+
+    # Patch for DoS vuln from https://seclists.org/oss-sec/2022/q3/27
+    ./v3-0001-Disallow-compressed-signatures-and-certificates.patch
   ];
   postPatch = ''
     sed -i 's,\(hkps\|https\)://keyserver.ubuntu.com,hkps://keys.openpgp.org,g' configure configure.ac doc/dirmngr.texi doc/gnupg.info-1

--- a/pkgs/tools/security/gnupg/CVE-2022-34903-g10-fix-garbled-status-messages-in-NOTATION_DATA.patch
+++ b/pkgs/tools/security/gnupg/CVE-2022-34903-g10-fix-garbled-status-messages-in-NOTATION_DATA.patch
@@ -1,0 +1,45 @@
+commit 34c649b3601383cd11dbc76221747ec16fd68e1b
+Author: Werner Koch <wk@gnupg.org>
+Date:   2022-06-14 11:33:27 +0200
+
+    g10: Fix garbled status messages in NOTATION_DATA
+    
+    * g10/cpr.c (write_status_text_and_buffer): Fix off-by-one
+    --
+    
+    Depending on the escaping and line wrapping the computed remaining
+    buffer length could be wrong.  Fixed by always using a break to
+    terminate the escape detection loop.  Might have happened for all
+    status lines which may wrap.
+    
+    GnuPG-bug-id: T6027
+
+diff --git a/g10/cpr.c b/g10/cpr.c
+index 9bfdd3c34..fa8005d6f 100644
+--- a/g10/cpr.c
++++ b/g10/cpr.c
+@@ -372,20 +372,15 @@ write_status_text_and_buffer (int no, const char *string,
+             }
+           first = 0;
+         }
+-      for (esc=0, s=buffer, n=len; n && !esc; s++, n--)
++      for (esc=0, s=buffer, n=len; n; s++, n--)
+         {
+           if (*s == '%' || *(const byte*)s <= lower_limit
+               || *(const byte*)s == 127 )
+             esc = 1;
+           if (wrap && ++count > wrap)
+-            {
+-              dowrap=1;
+-              break;
+-            }
+-        }
+-      if (esc)
+-        {
+-          s--; n++;
++            dowrap=1;
++          if (esc || dowrap)
++            break;
+         }
+       if (s != buffer)
+         es_fwrite (buffer, s-buffer, 1, statusfp);

--- a/pkgs/tools/security/gnupg/v3-0001-Disallow-compressed-signatures-and-certificates.patch
+++ b/pkgs/tools/security/gnupg/v3-0001-Disallow-compressed-signatures-and-certificates.patch
@@ -1,0 +1,216 @@
+From 459b61fa21db755d6c879c3ef9ab85b3d1786c9f Mon Sep 17 00:00:00 2001
+From: Demi Marie Obenour <demi () invisiblethingslab com>
+Date: Fri, 27 May 2022 19:51:19 -0400
+Subject: [PATCH GnuPG v3] Disallow compressed signatures and certificates
+
+Compressed packets have significant attack surface, due to the potential
+for both denial of service (zip bombs and the like) and for code
+execution via memory corruption vulnerabilities in the decompressor.
+Furthermore, I am not aware of any implementation that uses them in keys
+or detached signatures.  Therefore, disallow their use in such contexts
+entirely.  This includes signatures that are part of a cleartext-signed
+message.
+
+When parsing detached signatures, forbid any packet that is not a
+signature or marker packet.  When parsing keys, return an error when
+encountering a compressed packet, instead of decompressing the packet.
+
+Furthermore, certificates, keys, and signatures are not allowed to
+contain partial-length or indeterminate-length packets.  Reject those in
+parse_packet, rather than activating the partial-length filter code.
+This is not (yet) implemented for cleartext-signed messages, as these
+messages are internally represented as inline-signed messages.
+
+GnuPG-bug-id: T5993
+Signed-off-by: Demi Marie Obenour <demiobenour () gmail com>
+---
+ g10/import.c       | 18 ++----------------
+ g10/mainproc.c     | 24 +++++++++++++++++++++---
+ g10/packet.h       |  2 ++
+ g10/parse-packet.c | 44 +++++++++++++++++++++++++++++++++++++++++++-
+ 4 files changed, 68 insertions(+), 20 deletions(-)
+
+diff --git a/g10/import.c b/g10/import.c
+index bb0bf67934a8316130cde182cd43d56353e0171d..a8136351f6f7dae8c65634ed8e1c242d323e2009 100644
+--- a/g10/import.c
++++ b/g10/import.c
+@@ -1042,22 +1042,8 @@ read_block( IOBUF a, unsigned int options,
+       switch (pkt->pkttype)
+         {
+         case PKT_COMPRESSED:
+-          if (check_compress_algo (pkt->pkt.compressed->algorithm))
+-            {
+-              rc = GPG_ERR_COMPR_ALGO;
+-              goto ready;
+-            }
+-          else
+-            {
+-              compress_filter_context_t *cfx = xmalloc_clear( sizeof *cfx );
+-              pkt->pkt.compressed->buf = NULL;
+-              if (push_compress_filter2 (a, cfx,
+-                                         pkt->pkt.compressed->algorithm, 1))
+-                xfree (cfx); /* e.g. in case of compression_algo NONE.  */
+-            }
+-          free_packet (pkt, &parsectx);
+-          init_packet(pkt);
+-          break;
++          rc = GPG_ERR_UNEXPECTED;
++          goto ready;
+ 
+         case PKT_RING_TRUST:
+           /* Skip those packets unless we are in restore mode.  */
+diff --git a/g10/mainproc.c b/g10/mainproc.c
+index af11877aa257e46662c42b6ff573ee01c3ad1547..3629fc921b742afd131e8d8e2664b201095990f0 100644
+--- a/g10/mainproc.c
++++ b/g10/mainproc.c
+@@ -152,6 +152,7 @@ add_onepass_sig (CTX c, PACKET *pkt)
+ {
+   kbnode_t node;
+ 
++  log_assert(!(c->sigs_only && c->signed_data.used));
+   if (c->list) /* Add another packet. */
+     add_kbnode (c->list, new_kbnode (pkt));
+   else /* Insert the first one.  */
+@@ -1076,8 +1077,16 @@ proc_compressed (CTX c, PACKET *pkt)
+   int rc;
+ 
+   /*printf("zip: compressed data packet\n");*/
+-  if (c->sigs_only)
+-    rc = handle_compressed (c->ctrl, c, zd, proc_compressed_cb, c);
++  if ( literals_seen )
++    {
++      log_error ("Compressed packet follows literal data packet\n");
++      rc = GPG_ERR_UNEXPECTED;
++    }
++  else if ( c->sigs_only )
++    {
++      log_assert(!c->signed_data.used);
++      rc = handle_compressed (c->ctrl, c, zd, proc_compressed_cb, c);
++    }
+   else if( c->encrypt_only )
+     rc = handle_compressed (c->ctrl, c, zd, proc_encrypt_cb, c);
+   else
+@@ -1596,6 +1605,7 @@ do_proc_packets (CTX c, iobuf_t a)
+   c->iobuf = a;
+   init_packet(pkt);
+   init_parse_packet (&parsectx, a);
++  parsectx.sigs_only = c->sigs_only && c->signed_data.used;
+   while ((rc=parse_packet (&parsectx, pkt)) != -1)
+     {
+       any_data = 1;
+@@ -1607,6 +1617,12 @@ do_proc_packets (CTX c, iobuf_t a)
+           if (gpg_err_code (rc) == GPG_ERR_INV_PACKET
+               && opt.list_packets == 0)
+             break;
++
++          if (gpg_err_code (rc) == GPG_ERR_UNEXPECTED)
++            {
++              write_status_text( STATUS_UNEXPECTED, "0" );
++              goto leave;
++            }
+           continue;
+ 	}
+       newpkt = -1;
+@@ -1644,7 +1660,9 @@ do_proc_packets (CTX c, iobuf_t a)
+             case PKT_COMPRESSED:  rc = proc_compressed (c, pkt); break;
+             case PKT_ONEPASS_SIG: newpkt = add_onepass_sig (c, pkt); break;
+             case PKT_GPG_CONTROL: newpkt = add_gpg_control (c, pkt); break;
+-            default: newpkt = 0; break;
++            default:
++	      log_assert(!c->signed_data.used);
++	      newpkt = 0; break;
+ 	    }
+ 	}
+       else if (c->encrypt_only)
+diff --git a/g10/packet.h b/g10/packet.h
+index 5a14015a16c872fe7b0b15468598daf7a05ffc02..82dfe786b46051491e7015e64441678140defa9e 100644
+--- a/g10/packet.h
++++ b/g10/packet.h
+@@ -657,6 +657,7 @@ struct parse_packet_ctx_s
+   int free_last_pkt; /* Indicates that LAST_PKT must be freed.  */
+   int skip_meta;     /* Skip ring trust packets.  */
+   unsigned int n_parsed_packets;	/* Number of parsed packets.  */
++  int sigs_only;     /* Only accept detached signature packets */
+ };
+ typedef struct parse_packet_ctx_s *parse_packet_ctx_t;
+ 
+@@ -667,6 +668,7 @@ typedef struct parse_packet_ctx_s *parse_packet_ctx_t;
+     (a)->free_last_pkt = 0;         \
+     (a)->skip_meta = 0;             \
+     (a)->n_parsed_packets = 0;      \
++    (a)->sigs_only = 0;             \
+   } while (0)
+ 
+ #define deinit_parse_packet(a) do { \
+diff --git a/g10/parse-packet.c b/g10/parse-packet.c
+index cea1f7ebc5daec3863ae963c1ab25500f86796fe..dca66ff427ea6778e536782ec6bda83584877342 100644
+--- a/g10/parse-packet.c
++++ b/g10/parse-packet.c
+@@ -738,6 +738,20 @@ parse (parse_packet_ctx_t ctx, PACKET *pkt, int onlykeypkts, off_t * retpos,
+             case PKT_ENCRYPTED_MDC:
+             case PKT_ENCRYPTED_AEAD:
+             case PKT_COMPRESSED:
++              if (ctx->sigs_only)
++                {
++                  log_error (_("partial length packet of type %d in detached"
++                               " signature\n"), pkttype);
++                  rc = gpg_error (GPG_ERR_UNEXPECTED);
++                  goto leave;
++                }
++              if (onlykeypkts)
++                {
++                  log_error (_("partial length packet of type %d in keyring\n"),
++                             pkttype);
++                  rc = gpg_error (GPG_ERR_UNEXPECTED);
++                  goto leave;
++                }
+               iobuf_set_partial_body_length_mode (inp, c & 0xff);
+               pktlen = 0;	/* To indicate partial length.  */
+               partial = 1;
+@@ -775,6 +789,20 @@ parse (parse_packet_ctx_t ctx, PACKET *pkt, int onlykeypkts, off_t * retpos,
+ 	      rc = gpg_error (GPG_ERR_INV_PACKET);
+ 	      goto leave;
+ 	    }
++	  else if (ctx->sigs_only)
++	    {
++	      log_error (_("indeterminate length packet of type %d in detached"
++                           " signature\n"), pkttype);
++	      rc = gpg_error (GPG_ERR_UNEXPECTED);
++	      goto leave;
++	    }
++	  else if (onlykeypkts)
++	    {
++	      log_error (_("indeterminate length packet of type %d in"
++                           " keyring\n"), pkttype);
++	      rc = gpg_error (GPG_ERR_UNEXPECTED);
++	      goto leave;
++	    }
+ 	}
+       else
+ 	{
+@@ -828,7 +856,21 @@ parse (parse_packet_ctx_t ctx, PACKET *pkt, int onlykeypkts, off_t * retpos,
+       goto leave;
+     }
+ 
+-  if (with_uid && pkttype == PKT_USER_ID)
++  if (ctx->sigs_only)
++    switch (pkttype)
++      {
++      case PKT_SIGNATURE:
++      case PKT_MARKER:
++	break;
++      default:
++        log_error(_("Packet type %d not allowed in detached signature\n"),
++                  pkttype);
++	iobuf_skip_rest (inp, pktlen, partial);
++	*skip = 1;
++	rc = GPG_ERR_UNEXPECTED;
++	goto leave;
++      }
++  else if (with_uid && pkttype == PKT_USER_ID)
+     /* If ONLYKEYPKTS is set to 2, then we never skip user id packets,
+        even if DO_SKIP is set.  */
+     ;
+-- 
+2.36.1
+


### PR DESCRIPTION
###### Description of changes

Backports of:

- https://github.com/NixOS/nixpkgs/pull/180336
- https://github.com/NixOS/nixpkgs/pull/176598
- gpgme: fix test compatibility with compressed sigs patch to gpg
  - db6b3e0 
  - 1fc7604 
  - https://github.com/nixos/nixpkgs/commit/add0201f354284b5447b1bcf6a065a9a50aebea8

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
