### PR TITLE
gnomecast: 1.9.11 -> unstable-2022-04-23

### DIFF
--- a/pkgs/applications/video/gnomecast/default.nix
+++ b/pkgs/applications/video/gnomecast/default.nix
@@ -1,19 +1,28 @@
-{ stdenv, lib, python3Packages, gtk3, gobject-introspection, ffmpeg, wrapGAppsHook }:
+{ stdenv, lib, python3Packages, fetchFromGitHub, gtk3, gobject-introspection, ffmpeg, wrapGAppsHook }:
 
 with python3Packages;
 buildPythonApplication rec {
   pname = "gnomecast";
-  version = "1.9.11";
+  version = "unstable-2022-04-23";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "4d8cd7a71f352137252c5a9ee13475bd67fb99594560ecff1efb0f718d8bbaac";
+  src = fetchFromGitHub {
+    owner = "keredson";
+    repo = "gnomecast";
+    rev = "d42d8915838b01c5cadacb322909e08ffa455d4f";
+    sha256 = "sha256-CJpbBuRzEjWb8hsh3HMW4bZA7nyDAwjrERCS5uGdwn8=";
   };
 
   nativeBuildInputs = [ wrapGAppsHook ];
   propagatedBuildInputs = [
-    pychromecast bottle pycaption paste html5lib pygobject3 dbus-python
-    gtk3 gobject-introspection
+    pychromecast
+    bottle
+    pycaption
+    paste
+    html5lib
+    pygobject3
+    dbus-python
+    gtk3
+    gobject-introspection
   ];
 
   # NOTE: gdk-pixbuf setup hook does not run with strictDeps


### PR DESCRIPTION
The gnomecast pypi package is outdated(see: https://github.com/keredson/gnomecast/issues/178) and doesn't work with the PyChromecast version in nixpkgs(https://github.com/keredson/gnomecast/issues/171).
Without this commit gnomecast doesn't work at all, so if this PR is rejected I think gnomecast should be marked as broken.
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
