### PR TITLE
authelia: init at 4.36.2

### DIFF
--- a/pkgs/servers/authelia/default.nix
+++ b/pkgs/servers/authelia/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, lib, fetchzip, autoPatchelfHook, ... }:
+
+let
+  name = "authelia";
+  pname = "${name}-bin";
+  version = "4.36.2";
+
+  inherit (stdenv.hostPlatform) system;
+  throwSystem = throw "Unsupported system: ${system}";
+
+  platform = {
+    x86_64-linux = "linux-amd64";
+    aarch64-linux = "linux-arm64";
+  }.${system} or throwSystem;
+
+  sha256 = {
+    x86_64-linux = "l7VKO28mcGqho2WiMzvRSmQ9PZaKKZs+vLOigVhqCjk=";
+    aarch64-linux = "8oQlGjaiLTuWq9KR4TQQYs3QZmK4pZlm/Omcpu/h/Yo=";
+  }.${system} or throwSystem;
+in
+stdenv.mkDerivation {
+  inherit pname;
+  inherit version;
+
+  src = fetchzip {
+    url = "https://github.com/${name}/${name}/releases/download/v${version}/${name}-v${version}-${platform}.tar.gz";
+    inherit sha256;
+    stripRoot = false;
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  installPhase = ''
+    install -m 755 -D ${name}-${platform} $out/bin/authelia
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.authelia.com/";
+    description = "The Single Sign-On Multi-Factor portal for web apps";
+    license = licenses.asl20;
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21950,6 +21950,8 @@ with pkgs;
   atlassian-crowd = callPackage ../servers/atlassian/crowd.nix { };
   atlassian-jira = callPackage ../servers/atlassian/jira.nix { };
 
+  authelia-bin = callPackage ../servers/authelia { };
+
   cadvisor = callPackage ../servers/monitoring/cadvisor { };
 
   cassandra_2_1 = callPackage ../servers/nosql/cassandra/2.1.nix {


### PR DESCRIPTION
###### Description of changes

Authelia is an authentication and authorization server providing multi-factor authentication and single sign-on via a web portal. I have been using this package on my NixOS server for couple weeks now and it works as expeted. Authelia's build process is kind of complicated and I could not figure out how to build it from source with Nix. Instead I am just pulling the binary release and patching ELF.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
