### PR TITLE
Split out CoqIDE by default when Coq >= 8.14.

### DIFF
--- a/pkgs/applications/science/logic/coq/default.nix
+++ b/pkgs/applications/science/logic/coq/default.nix
@@ -8,10 +8,10 @@
 { lib, stdenv, fetchzip, writeText, pkg-config, gnumake42
 , customOCamlPackages ? null
 , ocamlPackages_4_05, ocamlPackages_4_09, ocamlPackages_4_10, ocamlPackages_4_12, ncurses
-, buildIde ? true
+, buildIde ? null # default is true for Coq < 8.14 and false for Coq >= 8.14
 , glib, gnome, wrapGAppsHook, makeDesktopItem, copyDesktopItems
 , csdp ? null
-, version, coq-version ? null,
+, version, coq-version ? null
 }@args:
 let lib' = lib; in
 let lib = import ../../../../build-support/coq/extra-lib.nix {lib = lib';}; in
@@ -59,6 +59,7 @@ let
   version = fetched.version;
   coq-version = args.coq-version or (if version != "dev" then versions.majorMinor version else "dev");
   coqAtLeast = v: coq-version == "dev" || versionAtLeast coq-version v;
+  buildIde = args.buildIde or (!coqAtLeast "8.14");
   ideFlags = optionalString (buildIde && !coqAtLeast "8.10")
     "-lablgtkdir ${ocamlPackages.lablgtk}/lib/ocaml/*/site-lib/lablgtk2 -coqide opt";
   csdpPatch = if csdp != null then ''

--- a/pkgs/development/coq-modules/coqide/default.nix
+++ b/pkgs/development/coq-modules/coqide/default.nix
@@ -1,0 +1,61 @@
+{ lib
+, makeDesktopItem
+, copyDesktopItems
+, wrapGAppsHook
+, glib
+, gnome
+, mkCoqDerivation
+, coq
+, version ? null }:
+
+with lib; mkCoqDerivation rec {
+  pname = "coqide";
+  inherit version;
+
+  inherit (coq) src;
+  release."${coq.version}" = {};
+
+  defaultVersion = if versions.isGe "8.14" coq.version then coq.version else null;
+
+  preConfigure = ''
+    patchShebangs dev/tools/
+  '';
+  prefixKey = "-prefix ";
+
+  useDune2 = true;
+
+  buildInputs = [
+    copyDesktopItems
+    wrapGAppsHook
+    coq.ocamlPackages.lablgtk3-sourceview3
+    glib
+    gnome.adwaita-icon-theme
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    dune build -p ${pname} -j $NIX_BUILD_CORES
+    runHook postBuild
+  '';
+  installPhase = ''
+    runHook preInstall
+    dune install --prefix $out ${pname}
+    runHook postInstall
+  '';
+
+  desktopItems = makeDesktopItem {
+    name = "coqide";
+    exec = "coqide";
+    icon = "coq";
+    desktopName = "CoqIDE";
+    comment = "Graphical interface for the Coq proof assistant";
+    categories = [ "Development" "Science" "Math" "IDE" "GTK" ];
+  };
+
+  meta = with lib; {
+    homepage = "https://coq.inria.fr";
+    description = "The CoqIDE user interface for the Coq proof assistant";
+    license = licenses.lgpl21Plus;
+    maintainers = [ maintainers.Zimmi48 ];
+  };
+}

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -36,6 +36,7 @@ let
       coq-record-update = callPackage ../development/coq-modules/coq-record-update { };
       coqeal = callPackage ../development/coq-modules/coqeal {};
       coqhammer = callPackage ../development/coq-modules/coqhammer {};
+      coqide = callPackage ../development/coq-modules/coqide {};
       coqprime = callPackage ../development/coq-modules/coqprime {};
       coqtail-math = callPackage ../development/coq-modules/coqtail-math {};
       coquelicot = callPackage ../development/coq-modules/coquelicot {};


### PR DESCRIPTION
###### Description of changes

This splits out CoqIDE out of the main `coq` derivation, into its own `coqPackages.coqide` derivation, starting with Coq 8.14 (first version where the current code works, because the build of the OCaml files relies on Dune). I have also considered making this change only starting at Coq 8.16 to avoid being too disruptive. The benefit is that the main `coq` derivation becomes smaller.

###### Things done

Probably this kind of change would require a changelog?

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

cc @vbgl @CohenCyril 