### PR TITLE
foma: fix cross-compilation

### DIFF
--- a/pkgs/tools/misc/foma/default.nix
+++ b/pkgs/tools/misc/foma/default.nix
@@ -11,20 +11,23 @@ stdenv.mkDerivation rec {
     sha256 = "1vf01l18j8cksnavbabcckp9gg692w6v5lg81xrzv6f5v14zp4nr";
   };
 
-  sourceRoot = "source/foma";
+  sourceRoot = "${src.name}/foma";
 
   nativeBuildInputs = [ flex bison ]
     ++ lib.optional stdenv.isDarwin darwin.cctools;
   buildInputs = [ zlib readline ];
 
   makeFlags = [
-    "CC=${stdenv.cc.targetPrefix}cc"
+    "CC:=$(CC)"
+    "RANLIB:=$(RANLIB)"
+    "prefix=$(out)"
+  ] ++ lib.optionals (!stdenv.isDarwin) [
+    "AR:=$(AR)" # libtool is used for darwin
   ];
 
   patchPhase = ''
     substituteInPlace Makefile \
-      --replace '-ltermcap' ' ' \
-      --replace '/usr/local' '$(out)'
+      --replace '-ltermcap' ' '
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes
1. Fix cross-compilation (set proper AR, CC and RANLIB)
2. Fix empty prefix in `libfoma.pc`:
```sh
$ cat result/lib/pkgconfig/libfoma.pc
prefix=
exec_prefix=${prefix}
includedir=${prefix}/include
libdir=${exec_prefix}/lib

Name: foma
Description: The foma library
Version: 0.10.0
Cflags: -I${includedir}
Libs: -L${libdir} -lfoma
```
3. Minor: replace `source` with `${src.name}` in `sourceRoot`, since `source` is just default value for `name` and can be changed:
https://github.com/NixOS/nixpkgs/blob/dcae925ccb731bd89929fa20981332173f2ab2b7/pkgs/build-support/fetchgithub/default.nix#L3

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

