### PR TITLE
WIP: upgrade faust from qt4 to qt5

### DIFF
--- a/pkgs/applications/audio/faust/faust2alqt.nix
+++ b/pkgs/applications/audio/faust/faust2alqt.nix
@@ -2,6 +2,7 @@
 , alsa-lib
 , qtbase
 , writeText
+, runtimeShell
 }:
 
 faust.wrapWithBuildEnv rec {
@@ -20,7 +21,7 @@ faust.wrapWithBuildEnv rec {
     for p in $FILES; do
       binary=$(basename --suffix=.dsp "$p")
       touch "$binary"-temp-wrap.sh
-      echo '#!/usr/bin/env bash' >> "$binary"-temp-wrap.sh
+      echo '#!${runtimeShell}' >> "$binary"-temp-wrap.sh
       echo 'export QT_PLUGIN_PATH=${qtbase}/${qtbase.qtPluginPrefix}' >> "$binary"-temp-wrap.sh
       echo "./."$binary"-wrapped" >> "$binary"-temp-wrap.sh
       mv "$binary" ."$binary"-wrapped

--- a/pkgs/applications/audio/faust/faust2alqt.nix
+++ b/pkgs/applications/audio/faust/faust2alqt.nix
@@ -1,15 +1,39 @@
 { faust
 , alsa-lib
-, qt4
+, qtbase
+, writeText
 }:
 
-faust.wrapWithBuildEnv {
+faust.wrapWithBuildEnv rec {
 
   baseName = "faust2alqt";
 
   propagatedBuildInputs = [
     alsa-lib
-    qt4
+    qtbase
   ];
 
+  dontWrapQtApps = true;
+
+  # Wrap the binary coming out of the the compilation script, so it knows QT_PLUGIN_PATH
+  wrapBinary = writeText "wrapBinary" ''
+    for p in $FILES; do
+      binary=$(basename --suffix=.dsp "$p")
+      touch "$binary"-temp-wrap.sh
+      echo '#!/usr/bin/env bash' >> "$binary"-temp-wrap.sh
+      echo 'export QT_PLUGIN_PATH=${qtbase}/${qtbase.qtPluginPrefix}' >> "$binary"-temp-wrap.sh
+      echo "./."$binary"-wrapped" >> "$binary"-temp-wrap.sh
+      mv "$binary" ."$binary"-wrapped
+      mv "$binary"-temp-wrap.sh "$binary"
+      chmod +x "$binary"
+    done
+  '';
+
+  # append the wrapping code to the compilation script
+  preFixup = ''
+    for script in "$out"/bin/*; do
+      echo $script
+      cat ${wrapBinary} >> $script
+    done
+  '';
 }

--- a/pkgs/applications/audio/faust/faust2alqt.nix
+++ b/pkgs/applications/audio/faust/faust2alqt.nix
@@ -2,7 +2,7 @@
 , alsa-lib
 , qtbase
 , writeText
-, runtimeShell
+, makeWrapper
 }:
 
 faust.wrapWithBuildEnv rec {
@@ -18,15 +18,12 @@ faust.wrapWithBuildEnv rec {
 
   # Wrap the binary coming out of the the compilation script, so it knows QT_PLUGIN_PATH
   wrapBinary = writeText "wrapBinary" ''
+    source ${makeWrapper}/nix-support/setup-hook
     for p in $FILES; do
       binary=$(basename --suffix=.dsp "$p")
-      touch "$binary"-temp-wrap.sh
-      echo '#!${runtimeShell}' >> "$binary"-temp-wrap.sh
-      echo 'export QT_PLUGIN_PATH=${qtbase}/${qtbase.qtPluginPrefix}' >> "$binary"-temp-wrap.sh
-      echo "./."$binary"-wrapped" >> "$binary"-temp-wrap.sh
-      mv "$binary" ."$binary"-wrapped
-      mv "$binary"-temp-wrap.sh "$binary"
-      chmod +x "$binary"
+      mv $binary ."$binary"-wrapped
+      makeWrapper ./."$binary"-wrapped ."$binary"-temp  --set QT_PLUGIN_PATH "${qtbase}/${qtbase.qtPluginPrefix}"
+      mv ."$binary"-temp $binary
     done
   '';
 

--- a/pkgs/applications/audio/faust/faust2jaqt.nix
+++ b/pkgs/applications/audio/faust/faust2jaqt.nix
@@ -5,6 +5,7 @@
 , alsa-lib
 , which
 , writeText
+, runtimeShell
 }:
 
 faust.wrapWithBuildEnv rec {
@@ -31,7 +32,7 @@ faust.wrapWithBuildEnv rec {
     for p in $FILES; do
       binary=$(basename --suffix=.dsp "$p")
       touch "$binary"-temp-wrap.sh
-      echo '#!/usr/bin/env bash' >> "$binary"-temp-wrap.sh
+      echo '#!${runtimeShell}' >> "$binary"-temp-wrap.sh
       echo 'export QT_PLUGIN_PATH=${qtbase}/${qtbase.qtPluginPrefix}' >> "$binary"-temp-wrap.sh
       echo "./."$binary"-wrapped" >> "$binary"-temp-wrap.sh
       mv "$binary" ."$binary"-wrapped

--- a/pkgs/applications/audio/faust/faust2jaqt.nix
+++ b/pkgs/applications/audio/faust/faust2jaqt.nix
@@ -1,12 +1,13 @@
 { faust
 , jack2
-, qt4
+, qtbase
 , libsndfile
 , alsa-lib
 , which
+, writeText
 }:
 
-faust.wrapWithBuildEnv {
+faust.wrapWithBuildEnv rec {
 
   baseName = "faust2jaqt";
 
@@ -17,10 +18,33 @@ faust.wrapWithBuildEnv {
 
   propagatedBuildInputs = [
     jack2
-    qt4
+    qtbase
     libsndfile
     alsa-lib
     which
   ];
 
+  dontWrapQtApps = true;
+
+  # Wrap the binary coming out of the the compilation script, so it knows QT_PLUGIN_PATH
+  wrapBinary = writeText "wrapBinary" ''
+    for p in $FILES; do
+      binary=$(basename --suffix=.dsp "$p")
+      touch "$binary"-temp-wrap.sh
+      echo '#!/usr/bin/env bash' >> "$binary"-temp-wrap.sh
+      echo 'export QT_PLUGIN_PATH=${qtbase}/${qtbase.qtPluginPrefix}' >> "$binary"-temp-wrap.sh
+      echo "./."$binary"-wrapped" >> "$binary"-temp-wrap.sh
+      mv "$binary" ."$binary"-wrapped
+      mv "$binary"-temp-wrap.sh "$binary"
+      chmod +x "$binary"
+    done
+  '';
+
+  # append the wrapping code to the compilation script
+  preFixup = ''
+    for script in "$out"/bin/*; do
+      echo $script
+      cat ${wrapBinary} >> $script
+    done
+  '';
 }

--- a/pkgs/applications/audio/faust/faust2jaqt.nix
+++ b/pkgs/applications/audio/faust/faust2jaqt.nix
@@ -5,7 +5,7 @@
 , alsa-lib
 , which
 , writeText
-, runtimeShell
+, makeWrapper
 }:
 
 faust.wrapWithBuildEnv rec {
@@ -29,18 +29,14 @@ faust.wrapWithBuildEnv rec {
 
   # Wrap the binary coming out of the the compilation script, so it knows QT_PLUGIN_PATH
   wrapBinary = writeText "wrapBinary" ''
+    source ${makeWrapper}/nix-support/setup-hook
     for p in $FILES; do
       binary=$(basename --suffix=.dsp "$p")
-      touch "$binary"-temp-wrap.sh
-      echo '#!${runtimeShell}' >> "$binary"-temp-wrap.sh
-      echo 'export QT_PLUGIN_PATH=${qtbase}/${qtbase.qtPluginPrefix}' >> "$binary"-temp-wrap.sh
-      echo "./."$binary"-wrapped" >> "$binary"-temp-wrap.sh
-      mv "$binary" ."$binary"-wrapped
-      mv "$binary"-temp-wrap.sh "$binary"
-      chmod +x "$binary"
+      mv $binary ."$binary"-wrapped
+      makeWrapper ./."$binary"-wrapped ."$binary"-temp  --set QT_PLUGIN_PATH "${qtbase}/${qtbase.qtPluginPrefix}"
+      mv ."$binary"-temp $binary
     done
   '';
-
   # append the wrapping code to the compilation script
   preFixup = ''
     for script in "$out"/bin/*; do

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34433,7 +34433,7 @@ with pkgs;
     llvm = llvm_10;
   };
 
-  faust2alqt = callPackage ../applications/audio/faust/faust2alqt.nix { };
+  faust2alqt = libsForQt5.callPackage ../applications/audio/faust/faust2alqt.nix { };
 
   faust2alsa = callPackage ../applications/audio/faust/faust2alsa.nix { };
 
@@ -34445,7 +34445,7 @@ with pkgs;
 
   faust2jackrust = callPackage ../applications/audio/faust/faust2jackrust.nix { };
 
-  faust2jaqt = callPackage ../applications/audio/faust/faust2jaqt.nix { };
+  faust2jaqt = libsForQt5.callPackage ../applications/audio/faust/faust2jaqt.nix { };
 
   faust2ladspa = callPackage ../applications/audio/faust/faust2ladspa.nix { };
 


### PR DESCRIPTION
###### Description of changes
This fixes https://github.com/NixOS/nixpkgs/pull/174634 for faust2alqt and faust2jaqt.
These are compilation scripts, that spit out a program that uses qt.
I changed the script so it wraps the output program so it knows QT_PLUGIN_PATH.
This solution works, but is kinda clunky: you end up with two files, one pointing at the other, which is hidden.
Thanks to @tpwrules who pointed out this solution on IRC 

faust2lv2 on the other hand, spits out an lv2 plugin, to be used inside a DAW, like ardour.
I do not see how I could make the DAW find QT_PLUGIN_PATH.
Any ideas?

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
