### PR TITLE
ocm: 0.1.63 -> 0.1.64

### DIFF
--- a/pkgs/applications/networking/cluster/ocm/default.nix
+++ b/pkgs/applications/networking/cluster/ocm/default.nix
@@ -1,20 +1,22 @@
-{ lib, buildGoModule, fetchFromGitHub, stdenv, testers, ocm }:
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles, stdenv, testers, ocm }:
 
 buildGoModule rec {
   pname = "ocm";
-  version = "0.1.63";
+  version = "0.1.64";
 
   src = fetchFromGitHub {
     owner = "openshift-online";
     repo = "ocm-cli";
     rev = "v${version}";
-    sha256 = "sha256-wBKW2WS1+JmWOFCArmrlVfUTEqFYF7aq1OBrUo7e4ac=";
+    sha256 = "sha256-RMXiEXgf8tAdp2d97kaOzXgFCFVkaMhkJF8AHXIEJm8=";
   };
 
-  vendorSha256 = "sha256-LyQ/F+E0y1gQtpGSyPEB2z2ImorA7mjY3QjrRORakIo=";
+  vendorSha256 = "sha256-4m5Ej2Ql9+wGqrzvXQkY8fL2I9tYE6Tm6s9+qcZBHQI=";
 
   # Strip the final binary.
   ldflags = [ "-s" "-w" ];
+
+  nativeBuildInputs = [ installShellFiles ];
 
   # Tests expect the binary to be located in the root directory.
   preCheck = ''
@@ -23,6 +25,13 @@ buildGoModule rec {
 
   # Tests fail in Darwin sandbox.
   doCheck = !stdenv.isDarwin;
+
+  postInstall = ''
+    installShellCompletion --cmd ocm \
+      --bash <($out/bin/ocm completion bash) \
+      --fish <($out/bin/ocm completion fish) \
+      --zsh <($out/bin/ocm completion zsh)
+  '';
 
   passthru.tests.version = testers.testVersion {
     package = ocm;
@@ -34,5 +43,6 @@ buildGoModule rec {
     license = licenses.asl20;
     homepage = "https://github.com/openshift-online/ocm-cli";
     maintainers = with maintainers; [ stehessel ];
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
