### PR TITLE
scalp: init at unstable-2022-03-15

### DIFF
--- a/pkgs/applications/science/math/scalp/default.nix
+++ b/pkgs/applications/science/math/scalp/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, stdenv
+, fetchgit
+, cmake
+, withGurobi ? false
+, gurobi
+, withCplex ? false
+, cplex
+, withLpsolve ? true
+, lp_solve
+}:
+
+stdenv.mkDerivation rec {
+  pname = "scalp";
+  version = "unstable-2022-03-15";
+
+  src = fetchgit {
+    url = "https://digidev.digi.e-technik.uni-kassel.de/git/scalp.git";
+    # mirrored at https://github.com/wegank/scalp.git
+    rev = "185b84e4ff967f42cf2de5db4db4e6fa0cc18fb8";
+    sha256 = "sha256-NyMZdJwdD3FR6uweYCclJjfcf3Y24Bns1ViwsmJ5izg=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = lib.optionals withGurobi [
+    gurobi
+  ] ++ lib.optionals withCplex [
+    cplex
+  ] ++ lib.optionals withLpsolve [
+    lp_solve
+  ];
+
+  postPatch = lib.optionalString stdenv.isDarwin ''
+    substituteInPlace CMakeLists.txt \
+      --replace "\''$ORIGIN" "\''${CMAKE_INSTALL_PREFIX}/lib"
+  '';
+
+  cmakeFlags = [
+    "-DBUILD_TESTS=${lib.boolToString doCheck}"
+  ] ++ lib.optionals withGurobi [
+    "-DGUROBI_DIR=${gurobi}"
+  ] ++ lib.optionals withCplex [
+    "-DCPLEX_DIR=${cplex}"
+  ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Scalable Linear Programming Library";
+    homepage = "https://digidev.digi.e-technik.uni-kassel.de/scalp/";
+    license = licenses.lgpl3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ wegank ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34259,6 +34259,8 @@ with pkgs;
 
   pynac = callPackage ../applications/science/math/pynac { };
 
+  scalp = callPackage ../applications/science/math/scalp { };
+
   singular = callPackage ../applications/science/math/singular { };
 
   scilab-bin = callPackage ../applications/science/math/scilab-bin {};


### PR DESCRIPTION
###### Description of changes

[ScaLP](https://digidev.digi.e-technik.uni-kassel.de/scalp/) is an open source C++ library that acts as a wrapper for different ILP-solvers and provides a nice interface to the developer which is common for all solvers.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
