### PR TITLE
xf86videointel: Use the `crocus` and `iris` DRI drivers

### DIFF
--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -870,6 +870,7 @@ self: super:
     buildInputs = attrs.buildInputs ++ [ self.libXScrnSaver self.libXfixes self.libXv self.pixman ];
     nativeBuildInputs = attrs.nativeBuildInputs ++ [autoreconfHook self.utilmacros];
     configureFlags = [ "--with-default-dri=3" "--enable-tools" ];
+    patches = [ ./use_crocus_and_iris.patch ];
 
     meta = attrs.meta // {
       platforms = ["i686-linux" "x86_64-linux"];

--- a/pkgs/servers/x11/xorg/use_crocus_and_iris.patch
+++ b/pkgs/servers/x11/xorg/use_crocus_and_iris.patch
@@ -1,0 +1,28 @@
+--- a/src/uxa/intel_dri.c
++++ b/src/uxa/intel_dri.c
+@@ -1540,8 +1540,10 @@
+ 			return has_i830_dri() ? "i830" : "i915";
+ 		else if (INTEL_INFO(intel)->gen < 040)
+ 			return "i915";
++		else if (INTEL_INFO(intel)->gen < 0100)
++			return "crocus";
+ 		else
+-			return "i965";
++			return "iris";
+ 	}
+ 
+ 	return s;
+--- a/src/sna/sna_dri2.c
++++ b/src/sna/sna_dri2.c
+@@ -3707,8 +3707,10 @@
+ 			return has_i830_dri() ? "i830" : "i915";
+ 		else if (sna->kgem.gen < 040)
+ 			return "i915";
++		else if (sna->kgem.gen < 0100)
++			return "crocus";
+ 		else
+-			return "i965";
++			return "iris";
+ 	}
+ 
+ 	return s;


### PR DESCRIPTION
The `i965` DRI driver was removed in Mesa 22, but the `xf86videointel` driver hasn't been updated to reflect this. This leads to the following error when used with the affected hardware:

```
(EE) AIGLX error: dlopen of /run/opengl-driver/lib/dri/i965_dri.so failed (/run/opengl-driver/lib/dri/i965_dri.so: cannot open shared object file: No such file or directory)
(EE) AIGLX error: unable to load driver i965
```

It's been reported upstream [here](https://gitlab.freedesktop.org/xorg/driver/xf86-video-intel/-/issues/219).

To fix this, add a patch which makes the driver return the appropriate DRI driver name from Mesa 22, i.e. `crocus` for older GPUs and `iris` for newer.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - tested on affected hardware
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
