### PR TITLE
voms: 2021-05-04 -> 2022-06-14 & xrootd: 5.4.2 -> 5.4.3

### DIFF
--- a/pkgs/tools/networking/voms/default.nix
+++ b/pkgs/tools/networking/voms/default.nix
@@ -15,13 +15,13 @@
 
 stdenv.mkDerivation rec{
   pname = "voms-unstable";
-  version = "2021-05-04";
+  version = "2022-06-14";
 
   src = fetchFromGitHub {
     owner = "italiangrid";
     repo = "voms";
-    rev = "61563152fce3a4e6860dd8ab8ab6e72b7908d8b8";
-    sha256 = "LNR0G4XrgxqjQmjyaKoZJLNoxtAGiTM93FG3jIU1u+Y=";
+    rev = "8e99bb96baaf197f0f557836e2829084bb1bb00e"; # develop branch
+    hash = "sha256-FG4fHO2lsQ3t/ZaKT9xY+xqdQHfdtzi5ULtxLhdPnss=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/networking/xrootd/default.nix
+++ b/pkgs/tools/networking/xrootd/default.nix
@@ -20,14 +20,14 @@
 
 stdenv.mkDerivation rec {
   pname = "xrootd";
-  version = "5.4.2";
+  version = "5.4.3";
 
   src = fetchFromGitHub {
     owner = "xrootd";
     repo = "xrootd";
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "sha256-k6uAJbUhpwnRrSeGn4JQiHDBrGJNQDf5vG2a+je5ByU=";
+    hash = "sha256-BlMYm4ffSpUxqMjlDVZC59KOuLvwsk/BeBB3VBjAwjs=";
   };
 
   outputs = [ "bin" "out" "dev" "man" ];


### PR DESCRIPTION
###### Description of changes

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).