### PR TITLE
krb5: 1.19.3 -> 1.20

### DIFF
--- a/pkgs/development/libraries/kerberos/krb5.nix
+++ b/pkgs/development/libraries/kerberos/krb5.nix
@@ -50,22 +50,29 @@ stdenv.mkDerivation rec {
 
   sourceRoot = "krb5-${version}/src";
 
+  libFolders = [ "util" "include" "lib" "build-tools" ];
+
   buildPhase = optionalString libOnly ''
+    runHook preBuild
+
     MAKE="make -j $NIX_BUILD_CORES -l $NIX_BUILD_CORES"
-    (cd util; $MAKE)
-    (cd include; $MAKE)
-    (cd lib; $MAKE)
-    (cd build-tools; $MAKE)
+    for folder in $libFolders; do
+      $MAKE -C $folder
+    done
+
+    runHook postBuild
   '';
 
   installPhase = optionalString libOnly ''
+    runHook preInstall
+
     mkdir -p "$out"/{bin,sbin,lib/pkgconfig,share/{et,man/man1}} \
       "$dev"/include/{gssapi,gssrpc,kadm5,krb5}
-    (cd util; $MAKE install)
-    (cd include; $MAKE install)
-    (cd lib; $MAKE install)
-    (cd build-tools; $MAKE install)
-    ${postInstall}
+    for folder in $libFolders; do
+      $MAKE -C $folder install
+    done
+
+    runHook postInstall
   '';
 
   # not via outputBin, due to reference from libkrb5.so

--- a/pkgs/development/libraries/kerberos/krb5.nix
+++ b/pkgs/development/libraries/kerberos/krb5.nix
@@ -19,16 +19,16 @@ in
 with lib;
 stdenv.mkDerivation rec {
   pname = "${type}krb5";
-  version = "1.19.3";
+  version = "1.20";
 
   src = fetchurl {
     url = "https://kerberos.org/dist/krb5/${versions.majorMinor version}/krb5-${version}.tar.gz";
-    sha256 = "1l6wp58zav37g03n2ig5qr0pslz38gh5cxgigbmxkjfxrxilil2n";
+    sha256 = "sha256-fgIr3TyFGDAXP5+qoAaiMKDg/a1MlT6Fv/S/DaA24S8";
   };
 
   outputs = [ "out" "dev" ];
 
-  configureFlags = [ "--with-tcl=no" "--localstatedir=/var/lib"]
+  configureFlags = [ "--localstatedir=/var/lib" ]
     # krb5's ./configure does not allow passing --enable-shared and --enable-static at the same time.
     # See https://bbs.archlinux.org/viewtopic.php?pid=1576737#p1576737
     ++ optional staticOnly [ "--enable-static" "--disable-shared" ]

--- a/pkgs/development/libraries/kerberos/krb5.nix
+++ b/pkgs/development/libraries/kerberos/krb5.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     ++ optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.libc != "bionic" && !(stdenv.hostPlatform.useLLVM or false)) [ keyutils ]
     ++ optionals (!libOnly) [ openldap libedit ];
 
-  preConfigure = "cd ./src";
+  sourceRoot = "krb5-${version}/src";
 
   buildPhase = optionalString libOnly ''
     MAKE="make -j $NIX_BUILD_CORES -l $NIX_BUILD_CORES"

--- a/pkgs/development/libraries/kerberos/krb5.nix
+++ b/pkgs/development/libraries/kerberos/krb5.nix
@@ -1,5 +1,6 @@
 { lib, stdenv, fetchurl, pkg-config, perl, bison, bootstrap_cmds
 , openssl, openldap, libedit, keyutils
+, nixosTests
 
 # Extra Arguments
 , type ? ""
@@ -89,5 +90,8 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix ++ platforms.windows;
   };
 
-  passthru.implementation = "krb5";
+  passthru = {
+    implementation = "krb5";
+    tests = { inherit (nixosTests) kerberos; };
+  };
 }


### PR DESCRIPTION
###### Description of changes
see https://github.com/krb5/krb5/blob/krb5-1.20-final/README#L88 for changes

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).