### PR TITLE
nvc: init at 1.6.2

### DIFF
--- a/pkgs/applications/science/electronics/nvc/default.nix
+++ b/pkgs/applications/science/electronics/nvc/default.nix
@@ -1,0 +1,67 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, check
+, flex
+, pkg-config
+, which
+, elfutils
+, libelf
+, llvm
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "nvc";
+  version = "1.6.2";
+
+  src = fetchFromGitHub {
+    owner = "nickg";
+    repo = pname;
+    rev = "r${version}";
+    sha256 = "sha256-BtUMpT1MKRFGRlIbCEGo4OBZ/r9es1VRmJdgmk1oZFQ=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    check
+    flex
+    pkg-config
+    which
+  ];
+
+  buildInputs = [
+    llvm
+    zlib
+  ] ++ [
+    (if stdenv.isLinux then elfutils else libelf)
+  ];
+
+  # TODO: remove me on 1.7.0
+  postPatch = ''
+    sed -i "/vests22/d;/vhpi4/d" test/regress/testlist.txt
+  '';
+
+  preConfigure = ''
+    mkdir build
+    cd build
+  '';
+
+  configureScript = "../configure";
+
+  configureFlags = [
+    "--enable-vhpi"
+    "--disable-lto"
+  ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "VHDL compiler and simulator";
+    homepage = "https://www.nickg.me.uk/nvc/";
+    license = licenses.gpl3Plus;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ wegank ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33986,6 +33986,8 @@ with pkgs;
 
   ngspice = callPackage ../applications/science/electronics/ngspice { };
 
+  nvc = callPackage ../applications/science/electronics/nvc { };
+
   openems = callPackage ../applications/science/electronics/openems {
     qcsxcad = libsForQt5.qcsxcad;
   };


### PR DESCRIPTION
###### Description of changes

[NVC](https://github.com/nickg/nvc) is a VHDL compiler and simulator.

NVC supports almost all of VHDL-2002 and it has been successfully used to simulate several real-world designs. Experimental support for VHDL-2008 is under development.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
