### PR TITLE
blender: fix on darwin

### DIFF
--- a/pkgs/applications/misc/blender/darwin.patch
+++ b/pkgs/applications/misc/blender/darwin.patch
@@ -1,7 +1,19 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1832,7 +1832,7 @@ if(WITH_COMPILER_SHORT_FILE_MACRO)
+   ADD_CHECK_CXX_COMPILER_FLAG(CXX_PREFIX_MAP_FLAGS CXX_MACRO_PREFIX_MAP -fmacro-prefix-map=foo=bar)
+   if(C_MACRO_PREFIX_MAP AND CXX_MACRO_PREFIX_MAP)
+     if(APPLE)
+-      if(XCODE AND ${XCODE_VERSION} VERSION_LESS 12.0)
++      if(FALSE)
+       # Developers may have say LLVM Clang-10.0.1 toolchain (which supports the flag)
+       # with Xcode-11 (the Clang of which doesn't support the flag).
+         message(WARNING
 diff --git a/build_files/cmake/platform/platform_apple.cmake b/build_files/cmake/platform/platform_apple.cmake
 --- a/build_files/cmake/platform/platform_apple.cmake
 +++ b/build_files/cmake/platform/platform_apple.cmake
-@@ -77,7 +77,6 @@ else()
+@@ -60,7 +60,6 @@ else()
    message(STATUS "Using pre-compiled LIBDIR: ${LIBDIR}")
  endif()
  if(NOT EXISTS "${LIBDIR}/")
@@ -9,7 +21,7 @@ diff --git a/build_files/cmake/platform/platform_apple.cmake b/build_files/cmake
  endif()
  
  # Prefer lib directory paths
-@@ -114,10 +113,6 @@ if(WITH_CODEC_SNDFILE)
+@@ -98,10 +97,6 @@ if(WITH_CODEC_SNDFILE)
    find_library(_sndfile_VORBIS_LIBRARY NAMES vorbis HINTS ${LIBDIR}/ffmpeg/lib)
    find_library(_sndfile_VORBISENC_LIBRARY NAMES vorbisenc HINTS ${LIBDIR}/ffmpeg/lib)
    list(APPEND LIBSNDFILE_LIBRARIES
@@ -20,17 +32,26 @@ diff --git a/build_files/cmake/platform/platform_apple.cmake b/build_files/cmake
    )
  
    print_found_status("SndFile libraries" "${LIBSNDFILE_LIBRARIES}")
-@@ -134,7 +129,7 @@ if(WITH_PYTHON)
-     # normally cached but not since we include them with blender
+@@ -118,7 +113,7 @@ if(WITH_PYTHON)
+     # Normally cached but not since we include them with blender.
      set(PYTHON_INCLUDE_DIR "${LIBDIR}/python/include/python${PYTHON_VERSION}")
      set(PYTHON_EXECUTABLE "${LIBDIR}/python/bin/python${PYTHON_VERSION}")
 -    set(PYTHON_LIBRARY ${LIBDIR}/python/lib/libpython${PYTHON_VERSION}.a)
 +    set(PYTHON_LIBRARY ${LIBDIR}/python/lib/libpython${PYTHON_VERSION}.dylib)
      set(PYTHON_LIBPATH "${LIBDIR}/python/lib/python${PYTHON_VERSION}")
-     # set(PYTHON_LINKFLAGS "-u _PyMac_Error")  # won't  build with this enabled
    else()
-@@ -175,9 +170,7 @@ endif()
- if(WITH_CODEC_FFMPEG)
+     # Module must be compiled against Python framework.
+@@ -147,7 +142,7 @@ endif()
+ 
+ # FreeType compiled with Brotli compression for woff2.
+ find_package(Freetype REQUIRED)
+-list(APPEND FREETYPE_LIBRARIES
++message(TRACE APPEND FREETYPE_LIBRARIES
+   ${LIBDIR}/brotli/lib/libbrotlicommon-static.a
+   ${LIBDIR}/brotli/lib/libbrotlidec-static.a)
+ 
+@@ -159,9 +154,7 @@ if(WITH_CODEC_FFMPEG)
+   set(FFMPEG_ROOT_DIR ${LIBDIR}/ffmpeg)
    set(FFMPEG_FIND_COMPONENTS
      avcodec avdevice avformat avutil
 -    mp3lame ogg opus swresample swscale
@@ -40,7 +61,7 @@ diff --git a/build_files/cmake/platform/platform_apple.cmake b/build_files/cmake
    find_package(FFmpeg)
  endif()
  
-@@ -275,7 +268,6 @@ if(WITH_BOOST)
+@@ -270,7 +263,6 @@ if(WITH_BOOST)
  endif()
  
  if(WITH_INTERNATIONAL OR WITH_CODEC_FFMPEG)
@@ -48,12 +69,12 @@ diff --git a/build_files/cmake/platform/platform_apple.cmake b/build_files/cmake
  endif()
  
  if(WITH_PUGIXML)
-@@ -476,7 +468,7 @@ else()
-   set(CMAKE_CXX_FLAGS_RELEASE "-O2 -mdynamic-no-pic")
- endif()
+@@ -399,7 +391,7 @@ endif()
  
--if(${XCODE_VERSION} VERSION_EQUAL 5 OR ${XCODE_VERSION} VERSION_GREATER 5)
-+if(FALSE)
-   # Xcode 5 is always using CLANG, which has too low template depth of 128 for libmv
-   string(APPEND CMAKE_CXX_FLAGS " -ftemplate-depth=1024")
- endif()
+ # CMake FindOpenMP doesn't know about AppleClang before 3.12, so provide custom flags.
+ if(WITH_OPENMP)
+-  if(CMAKE_C_COMPILER_ID MATCHES "Clang")
++  if(FALSE)
+     # Use OpenMP from our precompiled libraries.
+     message(STATUS "Using ${LIBDIR}/openmp for OpenMP")
+     set(OPENMP_CUSTOM ON)

--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -76,9 +76,7 @@ stdenv.mkDerivation rec {
       : > build_files/cmake/platform/platform_apple_xcode.cmake
       substituteInPlace source/creator/CMakeLists.txt \
         --replace '${"$"}{LIBDIR}/python' \
-                  '${python}' \
-        --replace '${"$"}{LIBDIR}/openmp' \
-                  '${llvmPackages.openmp}'
+                  '${python}'
       substituteInPlace build_files/cmake/platform/platform_apple.cmake \
         --replace '${"$"}{LIBDIR}/python' \
                   '${python}' \
@@ -159,8 +157,6 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    # darwin.patch doesn't apply anymore, needs update
-    broken = stdenv.isDarwin;
     description = "3D Creation/Animation/Publishing System";
     homepage = "https://www.blender.org";
     # They comment two licenses: GPLv2 and Blender License, but they

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25838,6 +25838,8 @@ with pkgs;
   bleachbit = callPackage ../applications/misc/bleachbit { };
 
   blender = callPackage  ../applications/misc/blender {
+    # LLVM 11 crashes when compiling GHOST_SystemCocoa.mm
+    stdenv = if stdenv.isDarwin then llvmPackages_10.stdenv else stdenv;
     inherit (darwin.apple_sdk.frameworks) Cocoa CoreGraphics ForceFeedback OpenAL OpenGL;
   };
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
