### PR TITLE
Add pkgs.callOverlay function

### DIFF
--- a/pkgs/pkgs-lib/default.nix
+++ b/pkgs/pkgs-lib/default.nix
@@ -32,7 +32,7 @@
     Type: callOverlays :: [pkgs -> pkgs -> attrs] -> attrs
 
     Example:
-      evalOverlays [(final: prev: { a = 42; }) (final: prev: { b = 123; })]
+      callOverlays [(final: prev: { a = 42; }) (final: prev: { b = 123; })]
       => { a = 42; b = 123; }
   */
   callOverlays = overlays:

--- a/pkgs/pkgs-lib/default.nix
+++ b/pkgs/pkgs-lib/default.nix
@@ -19,9 +19,12 @@
   */
   callOverlay = overlay:
     let
-      result = overlay (pkgs.extend overlay) pkgs;
+      newPkgs = overlay newPkgs pkgs // {
+        pkgs = newPkgs;
+        callPackage = pkgs.lib.callPackageWith newPkgs;
+      };
     in
-    result;
+    overlay newPkgs pkgs;
 
   /*
     Return attribute set of packages from overlays
@@ -33,6 +36,6 @@
       => { a = 42; b = 123; }
   */
   callOverlays = overlays:
-      pkgs.callOverlay (lib.composeManyExtensions overlays);
+    pkgs.callOverlay (lib.composeManyExtensions overlays);
 }
 

--- a/pkgs/pkgs-lib/default.nix
+++ b/pkgs/pkgs-lib/default.nix
@@ -14,7 +14,7 @@
     Type: callOverlay :: (pkgs -> pkgs -> attrs) -> attrs
 
     Example:
-      evalOverlay (final: prev: { a = 42; })
+      callOverlay (final: prev: { a = 42; })
       => { a = 42 }
   */
   callOverlay = overlay:

--- a/pkgs/pkgs-lib/default.nix
+++ b/pkgs/pkgs-lib/default.nix
@@ -7,5 +7,32 @@
   formats = import ./formats.nix {
     inherit lib pkgs;
   };
+
+  /*
+    Return attribute set of packages from overlay
+
+    Type: callOverlay :: (pkgs -> pkgs -> attrs) -> attrs
+
+    Example:
+      evalOverlay (final: prev: { a = 42; })
+      => { a = 42 }
+  */
+  callOverlay = overlay:
+    let
+      result = overlay (pkgs.extend overlay) pkgs;
+    in
+    result;
+
+  /*
+    Return attribute set of packages from overlays
+
+    Type: callOverlays :: [pkgs -> pkgs -> attrs] -> attrs
+
+    Example:
+      evalOverlays [(final: prev: { a = 42; }) (final: prev: { b = 123; })]
+      => { a = 42; b = 123; }
+  */
+  callOverlays = overlays:
+      pkgs.callOverlay (lib.composeManyExtensions overlays);
 }
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -969,7 +969,7 @@ with pkgs;
   writers = callPackage ../build-support/writers {};
 
   # lib functions depending on pkgs
-  inherit (import ../pkgs-lib { inherit lib pkgs; }) formats;
+  inherit (import ../pkgs-lib { inherit lib pkgs; }) formats callOverlay callOverlays;
 
   testers = callPackage ../build-support/testers {};
 


### PR DESCRIPTION
###### Description of changes

Added `callOverlay` function. This function helps us evaluate overlays without applying them to nixpkgs. Similar idea to `extend` function but does get polluted with a global context.


Boilerplate for reviewers to test this:
```nix
{
  inputs.nixpkgs.url = github:gytis-ivaskevicius/nixpkgs/10e0ac7e0a764e64f967d78869671dda37001160;

  outputs = { self, nixpkgs }:
    let
      system = "x86_64-linux";
      pkgs = nixpkgs.legacyPackages.${system};
    in
    {

      overlays.default = final: prev: {
        a = prev.ruby;
        default = final.callPackage ({a}: a) {};
        inherit (prev) ruby;
      };

      overlays.test = final: prev: {
        a = prev.go;
        c = prev.go;
        d = final.default;
      };

      packages.${system} = pkgs.callOverlays [
        self.overlays.test
        self.overlays.default
      ];

    };
}
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
