### PR TITLE
gitlab-triage: 1.20.0 -> 1.23.1

### DIFF
--- a/pkgs/applications/version-management/gitlab-triage/Gemfile.lock
+++ b/pkgs/applications/version-management/gitlab-triage/Gemfile.lock
@@ -1,36 +1,38 @@
 GEM
+  specs:
+
+GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.6)
+    activesupport (7.0.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-    concurrent-ruby (1.1.9)
-    gitlab-triage (1.20.0)
-      activesupport (~> 5.1)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    concurrent-ruby (1.1.10)
+    gitlab-triage (1.23.1)
+      activesupport (>= 5.1)
       globalid (~> 0.4)
       graphql-client (~> 0.16)
       httparty (~> 0.17)
-    globalid (0.5.2)
+    globalid (0.6.0)
       activesupport (>= 5.0)
-    graphql (1.12.14)
-    graphql-client (0.16.0)
+    graphql (2.0.11)
+    graphql-client (0.18.0)
       activesupport (>= 3.0)
-      graphql (~> 1.8)
-    httparty (0.18.1)
+      graphql
+    httparty (0.20.0)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    i18n (1.8.10)
+    i18n (1.10.0)
       concurrent-ruby (~> 1.0)
-    mime-types (3.3.1)
+    mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2021.0704)
-    minitest (5.14.4)
+    mime-types-data (3.2022.0105)
+    minitest (5.16.2)
     multi_xml (0.6.0)
-    thread_safe (0.3.6)
-    tzinfo (1.2.9)
-      thread_safe (~> 0.1)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
 
 PLATFORMS
   ruby
@@ -40,4 +42,4 @@ DEPENDENCIES
   gitlab-triage!
 
 BUNDLED WITH
-   2.1.4
+   2.3.9

--- a/pkgs/applications/version-management/gitlab-triage/default.nix
+++ b/pkgs/applications/version-management/gitlab-triage/default.nix
@@ -1,9 +1,11 @@
-{ lib, bundlerApp }:
+{ lib, bundlerApp, bundlerUpdateScript }:
 
 bundlerApp {
   pname = "gitlab-triage";
   gemdir = ./.;
   exes = [ "gitlab-triage" ];
+
+  passthru.updateScript = bundlerUpdateScript "gitlab-triage";
 
   meta = with lib; {
     description = "GitLab's issues and merge requests triage, automated!";

--- a/pkgs/applications/version-management/gitlab-triage/gemset.nix
+++ b/pkgs/applications/version-management/gitlab-triage/gemset.nix
@@ -5,20 +5,20 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1vybx4cj42hr6m8cdwbrqq2idh98zms8c11kr399xjczhl9ywjbj";
+      sha256 = "0z05zyc57f8ywvdvls6nx93vrhyyzzpgz729mwampz1qb8vvcspj";
       type = "gem";
     };
-    version = "5.2.6";
+    version = "7.0.3";
   };
   concurrent-ruby = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0nwad3211p7yv9sda31jmbyw6sdafzmdi2i2niaz6f0wk5nq9h0f";
+      sha256 = "0s4fpn3mqiizpmpy2a24k4v365pv75y50292r8ajrv4i1p5b2k14";
       type = "gem";
     };
-    version = "1.1.9";
+    version = "1.1.10";
   };
   gitlab-triage = {
     dependencies = ["activesupport" "globalid" "graphql-client" "httparty"];
@@ -26,10 +26,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "sha256-sg/YgRnp1+EcTcBqsm8vZrV0YuHTSJEFk/whhW8An6g=";
+      sha256 = "1vs120wyqm12xy66nv0723cy3m66g5lhhdd37izbc9qwyq03m729";
       type = "gem";
     };
-    version = "1.20.0";
+    version = "1.23.1";
   };
   globalid = {
     dependencies = ["activesupport"];
@@ -37,20 +37,20 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0k6ww3shk3mv119xvr9m99l6ql0czq91xhd66hm8hqssb18r2lvm";
+      sha256 = "1xk28839pi36yzlqgh7k5wqmiphz7wg2c2r2wzfvs2s7g63hy3nv";
       type = "gem";
     };
-    version = "0.5.2";
+    version = "0.6.0";
   };
   graphql = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "sha256-iweRDvp7EWY02B52iwbebEpiwL7Mj9E9RyeHYMuqc/o=";
+      sha256 = "18k3wh73mb7rs469wfn4m10d1rlg2v9chd89nf7vy8z3yjbf9nl4";
       type = "gem";
     };
-    version = "1.12.14";
+    version = "2.0.11";
   };
   graphql-client = {
     dependencies = ["activesupport" "graphql"];
@@ -58,10 +58,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0g971rccyrs3rk8812r6az54p28g66m4ngdcbszg31mvddjaqkr4";
+      sha256 = "02r5qvfr176n051mp1c79xbpjhjqm92kk4118r0fbp131y0xralq";
       type = "gem";
     };
-    version = "0.16.0";
+    version = "0.18.0";
   };
   httparty = {
     dependencies = ["mime-types" "multi_xml"];
@@ -69,10 +69,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "17gpnbf2a7xkvsy20jig3ljvx8hl5520rqm9pffj2jrliq1yi3w7";
+      sha256 = "0rs8c5wga6f1acyaj90d2hlv307gh2flfpb8y48wdk2si812l3a9";
       type = "gem";
     };
-    version = "0.18.1";
+    version = "0.20.0";
   };
   i18n = {
     dependencies = ["concurrent-ruby"];
@@ -80,10 +80,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0g2fnag935zn2ggm5cn6k4s4xvv53v2givj1j90szmvavlpya96a";
+      sha256 = "0b2qyvnk4yynlg17ymkq4g5xgr275637fhl1mjh0valw3cb1fhhg";
       type = "gem";
     };
-    version = "1.8.10";
+    version = "1.10.0";
   };
   mime-types = {
     dependencies = ["mime-types-data"];
@@ -91,30 +91,30 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1zj12l9qk62anvk9bjvandpa6vy4xslil15wl6wlivyf51z773vh";
+      sha256 = "0ipw892jbksbxxcrlx9g5ljq60qx47pm24ywgfbyjskbcl78pkvb";
       type = "gem";
     };
-    version = "3.3.1";
+    version = "3.4.1";
   };
   mime-types-data = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0dlxwc75iy0dj23x824cxpvpa7c8aqcpskksrmb32j6m66h5mkcy";
+      sha256 = "003gd7mcay800k2q4pb2zn8lwwgci4bhi42v2jvlidm8ksx03i6q";
       type = "gem";
     };
-    version = "3.2021.0704";
+    version = "3.2022.0105";
   };
   minitest = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "19z7wkhg59y8abginfrm2wzplz7py3va8fyngiigngqvsws6cwgl";
+      sha256 = "14a9ign0hj3z3j4cpfplj2djaskx3skzyx4fl3x53d7saxmhrgn1";
       type = "gem";
     };
-    version = "5.14.4";
+    version = "5.16.2";
   };
   multi_xml = {
     groups = ["default"];
@@ -126,25 +126,15 @@
     };
     version = "0.6.0";
   };
-  thread_safe = {
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "0nmhcgq6cgz44srylra07bmaw99f5271l0dpsvl5f75m44l0gmwy";
-      type = "gem";
-    };
-    version = "0.3.6";
-  };
   tzinfo = {
-    dependencies = ["thread_safe"];
+    dependencies = ["concurrent-ruby"];
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0zwqqh6138s8b321fwvfbywxy00lw1azw4ql3zr0xh1aqxf8cnvj";
+      sha256 = "10qp5x7f9hvlc0psv9gsfbxg4a7s0485wsbq1kljkxq94in91l4z";
       type = "gem";
     };
-    version = "1.2.9";
+    version = "2.0.4";
   };
 }


### PR DESCRIPTION
###### Description of changes
Update to latest upstream release [1.23.1](https://gitlab.com/gitlab-org/ruby/gems/gitlab-triage/-/tags/v1.23.1) and set
```
passthru.updateScript = bundlerUpdateScript "gitlab-triage";
```
for easier updates.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).