### PR TITLE
rapid-photo-downloader: 0.9.18 -> 0.9.33

### DIFF
--- a/pkgs/applications/graphics/rapid-photo-downloader/default.nix
+++ b/pkgs/applications/graphics/rapid-photo-downloader/default.nix
@@ -6,11 +6,11 @@
 
 mkDerivationWith python3Packages.buildPythonApplication rec {
   pname = "rapid-photo-downloader";
-  version = "0.9.18";
+  version = "0.9.33";
 
   src = fetchurl {
     url = "https://launchpad.net/rapid/pyqt/${version}/+download/${pname}-${version}.tar.gz";
-    sha256 = "15p7sssg6vmqbm5xnc4j5dr89d7gl7y5qyq44a240yl5aqkjnybw";
+    sha256 = "1hhcv8v1k8xl9c5mbfs41bznqz4i3f6asim2dklvmi7q6ngmrqsp";
   };
 
   # Disable version check and fix install tests
@@ -47,6 +47,8 @@ mkDerivationWith python3Packages.buildPythonApplication rec {
   ];
 
   propagatedBuildInputs = with python3Packages; [
+    babel
+    packaging
     pyqt5
     pygobject3
     gphoto2
@@ -64,6 +66,7 @@ mkDerivationWith python3Packages.buildPythonApplication rec {
     requests
     colorlog
     pyprind
+    show-in-file-manager
     tenacity
   ];
 

--- a/pkgs/development/python-modules/show-in-file-manager/default.nix
+++ b/pkgs/development/python-modules/show-in-file-manager/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildPythonPackage, fetchPypi, pyxdg, packaging }:
+
+buildPythonPackage rec {
+  pname = "show-in-file-manager";
+  version = "1.1.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1nrsmdms4zhhkqyggqs5srm4l340qclz00ld0dxj37jvhx56xl8m";
+  };
+
+  buildInputs = [ pyxdg packaging ];
+
+  meta = with lib; {
+    homepage = "https://github.com/damonlynch/showinfilemanager/";
+    description = "A library to open the system file manager and optionally select files in it";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jfrankenau ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -547,6 +547,8 @@ in {
 
   ansicolor = callPackage ../development/python-modules/ansicolor { };
 
+  show-in-file-manager = callPackage ../development/python-modules/show-in-file-manager { };
+
   ansicolors = callPackage ../development/python-modules/ansicolors { };
 
   ansiconv = callPackage ../development/python-modules/ansiconv { };


### PR DESCRIPTION
###### Description of changes


rapid-photo-downloader was failing at start with: 

```
typeError: setInterval(self, int): argument 1 has unexpected type 'float'
```

bumping version resolved the issue.

https://damonlynch.net/rapid/changelog.html

@jfrankenau 

###### Things done

- Built on platform(s)
  - [ x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

