### PR TITLE
dolphin-emu-{beta,primehack}: cleanup

### DIFF
--- a/pkgs/applications/emulators/dolphin-emu/master.nix
+++ b/pkgs/applications/emulators/dolphin-emu/master.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchFromGitHub, pkg-config, cmake
-, wrapQtAppsHook, qtbase, bluez, ffmpeg, libao, libGLU, libGL, pcre, gettext
-, libXrandr, libusb1, libpthreadstubs, libXext, libXxf86vm, libXinerama
-, libSM, libXdmcp, readline, openal, udev, libevdev, portaudio, curl, alsa-lib
-, miniupnpc, enet, mbedtls, soundtouch, sfml, xz, writeScript
+, wrapQtAppsHook, qtbase, bluez, ffmpeg
+, libXrandr, libusb1, libXext
+, openal, udev, libevdev, curl, alsa-lib
+, miniupnpc, enet, fmt_8, libGL, libiconv, mbedtls, pugixml, soundtouch, sfml, xxHash, xz, writeScript
 , vulkan-loader ? null, libpulseaudio ? null
 
 # - Inputs used for Darwin
@@ -24,9 +24,9 @@ stdenv.mkDerivation rec {
   ++ lib.optional stdenv.isLinux wrapQtAppsHook;
 
   buildInputs = [
-    curl ffmpeg libao libGLU libGL pcre gettext libpthreadstubs libpulseaudio
-    libXrandr libXext libXxf86vm libXinerama libSM readline openal libXdmcp
-    portaudio libusb1 libpng hidapi miniupnpc enet mbedtls soundtouch sfml xz
+    curl ffmpeg libGL libiconv libpulseaudio
+    libXrandr libXext openal
+    libusb1 libpng hidapi miniupnpc enet fmt_8 mbedtls pugixml soundtouch sfml xxHash xz
     qtbase
   ] ++ lib.optionals stdenv.isLinux [
     bluez udev libevdev alsa-lib vulkan-loader
@@ -35,8 +35,9 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DUSE_SHARED_ENET=ON"
+    "-DDISTRIBUTOR=NixOS"
     "-DENABLE_LTO=ON"
+    "-DUSE_SHARED_ENET=ON"
     "-DDOLPHIN_WC_REVISION=${src.rev}"
     "-DDOLPHIN_WC_DESCRIBE=${version}"
     "-DDOLPHIN_WC_BRANCH=master"
@@ -52,9 +53,7 @@ stdenv.mkDerivation rec {
   ];
 
   # - Allow Dolphin to use nix-provided libraries instead of building them
-  postPatch = ''
-    sed -i -e 's,DISTRIBUTOR "None",DISTRIBUTOR "NixOS",g' CMakeLists.txt
-  '' + lib.optionalString stdenv.isDarwin ''
+  postPatch = lib.optionalString stdenv.isDarwin ''
     sed -i -e 's,if(NOT APPLE),if(true),g' CMakeLists.txt
     sed -i -e 's,if(LIBUSB_FOUND AND NOT APPLE),if(LIBUSB_FOUND),g' \
       CMakeLists.txt

--- a/pkgs/applications/emulators/dolphin-emu/primehack.nix
+++ b/pkgs/applications/emulators/dolphin-emu/primehack.nix
@@ -7,32 +7,24 @@
 , qtbase
 , bluez
 , ffmpeg
-, libao
-, libGLU
-, libGL
-, pcre
-, gettext
 , libXrandr
 , libusb1
-, libpthreadstubs
 , libXext
-, libXxf86vm
-, libXinerama
-, libSM
-, libXdmcp
-, readline
 , openal
 , udev
 , libevdev
-, portaudio
 , curl
 , alsa-lib
 , miniupnpc
 , enet
+, fmt_8
+, libGL
+, libiconv
 , mbedtls
+, pugixml
 , soundtouch
 , sfml
-, fmt
+, xxHash
 , xz
 , vulkan-loader
 , libpulseaudio
@@ -66,31 +58,23 @@ stdenv.mkDerivation rec {
   buildInputs = [
     curl
     ffmpeg
-    libao
-    libGLU
     libGL
-    pcre
-    gettext
-    libpthreadstubs
+    libiconv
     libpulseaudio
     libXrandr
     libXext
-    libXxf86vm
-    libXinerama
-    libSM
-    readline
     openal
-    libXdmcp
-    portaudio
     libusb1
     libpng
     hidapi
     miniupnpc
     enet
+    fmt_8
     mbedtls
+    pugixml
     soundtouch
     sfml
-    fmt
+    xxHash
     xz
     qtbase
   ] ++ lib.optionals stdenv.isLinux [
@@ -107,6 +91,7 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
+    "-DDISTRIBUTOR=NixOS"
     "-DUSE_SHARED_ENET=ON"
     "-DENABLE_LTO=ON"
   ] ++ lib.optionals stdenv.isDarwin [
@@ -121,9 +106,7 @@ stdenv.mkDerivation rec {
   ];
 
   # - Allow Dolphin to use nix-provided libraries instead of building them
-  postPatch = ''
-    substituteInPlace CMakeLists.txt --replace 'DISTRIBUTOR "None"' 'DISTRIBUTOR "NixOS"'
-  '' + lib.optionalString stdenv.isDarwin ''
+  postPatch = lib.optionalString stdenv.isDarwin ''
     substituteInPlace CMakeLists.txt --replace 'if(NOT APPLE)' 'if(true)'
     substituteInPlace CMakeLists.txt --replace 'if(LIBUSB_FOUND AND NOT APPLE)' 'if(LIBUSB_FOUND)'
   '';


### PR DESCRIPTION
###### Description of changes

Cleanups `dolphin-emu-beta` and `dolphin-emu-beta` by removing useless dependencies and adding some that would otherwise be bundled (not all of them are packaged on nixpkgs).
Briefly tested by playing a game, with Vulkan and a Bluetooth gamepad.

Some questions:

- Should all Darwin stuff stay there? Dolphin has been marked broken on it for 4 years.
-  On `primehack.nix` there is one dependency per line. Should I do the same on `master.nix`? (And maybe reordering it too?)
- Should I also remove `-DENABLE_LTO=ON`?
- Finally, I changed the way that "DISTRIBUTOR" ([this thing](https://github.com/dolphin-emu/dolphin/blob/master/CMakeLists.txt#L37)) is set. Since I'm ignorant of CMake, does it work? (Taken from the AUR)

EDIT: Not updating anymore because of #180608.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
