### PR TITLE
palemoon: 31.1.0 -> 31.1.1

### DIFF
--- a/pkgs/applications/networking/browsers/palemoon/default.nix
+++ b/pkgs/applications/networking/browsers/palemoon/default.nix
@@ -115,7 +115,7 @@ stdenv.mkDerivation rec {
 
     # Too many cores can lead to build flakiness
     # https://forum.palemoon.org/viewtopic.php?f=5&t=28480
-    export jobs=$(($NIX_BUILD_CORES<=32 ? $NIX_BUILD_CORES : 32))
+    export jobs=$(($NIX_BUILD_CORES<=20 ? $NIX_BUILD_CORES : 20))
     if [ -z "$enableParallelBuilding" ]; then
       jobs=1
     fi

--- a/pkgs/applications/networking/browsers/palemoon/default.nix
+++ b/pkgs/applications/networking/browsers/palemoon/default.nix
@@ -45,15 +45,15 @@ assert with lib.strings; (
 
 stdenv.mkDerivation rec {
   pname = "palemoon";
-  version = "31.1.0";
+  version = "31.1.1";
 
   src = fetchFromGitea {
     domain = "repo.palemoon.org";
     owner = "MoonchildProductions";
     repo = "Pale-Moon";
-    rev = "${version}_Release_build2"; # Remove _build2 when bumping past 31.1.0
+    rev = "${version}_Release";
     fetchSubmodules = true;
-    sha256 = "sha256-x3n4OeZbnJCPCVjsZJW1nBYlsEYn6fXt80voYWQSNq4=";
+    sha256 = "sha256-lKD6+mXHWkNLc1XAX5mJGmwgz60P8mH+zrOi2WoOyJU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/networking/browsers/palemoon/mozconfig
+++ b/pkgs/applications/networking/browsers/palemoon/mozconfig
@@ -19,7 +19,10 @@ ac_add_options --enable-jemalloc
 ac_add_options --enable-strip
 ac_add_options --enable-devtools
 ac_add_options --enable-av1
+ac_add_options --enable-phoenix-extensions
 
+ac_add_options --disable-eme
+ac_add_options --disable-webrtc
 ac_add_options --disable-gamepad
 ac_add_options --disable-tests
 ac_add_options --disable-debug
@@ -34,8 +37,10 @@ export MOZILLA_OFFICIAL=1
 
 ac_add_options --x-libraries=@xlibs@
 
+# MOZ_PKG_SPECIAL is only relevant for upstream's packaging
+
 #
-# NixOS-specific adjustments
+# NixOS-specific additions
 #
 
 ac_add_options --prefix=@prefix@


### PR DESCRIPTION
###### Description of changes

![Bildschirmfoto von 2022-07-07 23-02-25](https://user-images.githubusercontent.com/23431373/177870848-34b9c416-c501-4f78-9204-3ae4aeeb61d3.png)

~~Still building, had to fix `update-source-version` first…~~ All fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
