### PR TITLE
common-updater-scripts/update-source-version: Add flag required for nix-command

### DIFF
--- a/pkgs/common-updater/scripts/update-source-version
+++ b/pkgs/common-updater/scripts/update-source-version
@@ -196,7 +196,7 @@ tempHash=$(printf '%0*d' "$hashLength" 0)
 if [[ -n "$sri" ]]; then
     # SRI hashes only support base64
     # SRI hashes need to declare the hash type as part of the hash
-    tempHash="$(nix hash to-sri --type "$oldHashAlgo" "$tempHash" 2>/dev/null \
+    tempHash="$(nix --extra-experimental-features nix-command hash to-sri --type "$oldHashAlgo" "$tempHash" 2>/dev/null \
         || nix to-sri --type "$oldHashAlgo" "$tempHash" 2>/dev/null)" \
         || die "Failed to convert hash to SRI representation!"
 fi
@@ -242,7 +242,7 @@ if [[ -z "$newHash" ]]; then
 
     if [[ -n "$sri" ]]; then
         # nix-build preserves the hashing scheme so we can just convert the result to SRI using the old type
-        newHash="$(nix hash to-sri --type "$oldHashAlgo" "$newHash" 2>/dev/null \
+        newHash="$(nix --extra-experimental-features nix-command hash to-sri --type "$oldHashAlgo" "$newHash" 2>/dev/null \
             || nix to-sri --type "$oldHashAlgo" "$newHash" 2>/dev/null)" \
             || die "Failed to convert hash to SRI representation!"
     fi


### PR DESCRIPTION
###### Description of changes

While updating a package, the update script would fail with

```console
update-source-version: error: Failed to convert hash to SRI representation!
```

`update-source-version` tries to run `nix hash`, which needs `--extra-experimental-features nix-command` since Nix 2.4.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
