### PR TITLE
WIP: tree-sitter: update grammars & add tree-sitter-protobuf

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
@@ -30,9 +30,9 @@
   tree-sitter-glimmer = lib.importJSON ./tree-sitter-glimmer.json;
   tree-sitter-glsl = lib.importJSON ./tree-sitter-glsl.json;
   tree-sitter-go = lib.importJSON ./tree-sitter-go.json;
-  tree-sitter-gowork = lib.importJSON ./tree-sitter-gowork.json;
   tree-sitter-godot-resource = lib.importJSON ./tree-sitter-godot-resource.json;
   tree-sitter-gomod = lib.importJSON ./tree-sitter-gomod.json;
+  tree-sitter-gowork = lib.importJSON ./tree-sitter-gowork.json;
   tree-sitter-graphql = lib.importJSON ./tree-sitter-graphql.json;
   tree-sitter-haskell = lib.importJSON ./tree-sitter-haskell.json;
   tree-sitter-hcl = lib.importJSON ./tree-sitter-hcl.json;

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
@@ -63,6 +63,7 @@
   tree-sitter-php = lib.importJSON ./tree-sitter-php.json;
   tree-sitter-pioasm = lib.importJSON ./tree-sitter-pioasm.json;
   tree-sitter-prisma = lib.importJSON ./tree-sitter-prisma.json;
+  tree-sitter-protobuf = lib.importJSON ./tree-sitter-protobuf.json;
   tree-sitter-pug = lib.importJSON ./tree-sitter-pug.json;
   tree-sitter-python = lib.importJSON ./tree-sitter-python.json;
   tree-sitter-ql = lib.importJSON ./tree-sitter-ql.json;

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-beancount.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-beancount.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/polarmutex/tree-sitter-beancount",
-  "rev": "78b8ddca3ab774573a4e3bf64eabd79e9452cea9",
-  "date": "2021-11-11T10:25:06-05:00",
-  "path": "/nix/store/lzvc19ky1wxbc1cjf2zr351hbdfq22mm-tree-sitter-beancount",
-  "sha256": "19s1fgn1vgxz5q6qvcfdr1lqj1vnkjrwlkl9chapbdaliw0dy110",
+  "rev": "b807e0c5255221f5e4baa08b3325d08e2ba56ba2",
+  "date": "2022-07-02T10:33:09-04:00",
+  "path": "/nix/store/9kqvj3rpqlqgxr5nkcc43pkcvs460h14-tree-sitter-beancount",
+  "sha256": "0vh2sz5qjsgkmqlcw0kyq01wj5mxwymhyg9w8hfyd7kd779lfa86",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cmake.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cmake.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/uyha/tree-sitter-cmake",
-  "rev": "5020572408a386d5d2dfac3516584f5edda7a49b",
-  "date": "2022-01-26T22:53:15+01:00",
-  "path": "/nix/store/in8jrkjf5vca2azpnyq2dgmzz9jcvjy6-tree-sitter-cmake",
-  "sha256": "0y49x8d36vdq2lcj67f3ms53qxym3578b3aw9gs2ckibwzrbfbgy",
+  "rev": "13c7c529d7f67641fbd7ae16ce1bd30387853d6f",
+  "date": "2022-07-04T12:48:46+07:00",
+  "path": "/nix/store/m99qhan4pp5zw0z99w0whzi5nqbkjgl6-tree-sitter-cmake",
+  "sha256": "0a03zi4lzzhqsx9xz0v98rih52cgdj1dxiw8vv15q4gjlc8xvhqh",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-embedded-template.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-embedded-template.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-embedded-template",
-  "rev": "d21df11b0ecc6fd211dbe11278e92ef67bd17e97",
-  "date": "2021-12-23T08:53:16-08:00",
-  "path": "/nix/store/zy74brmd1x2q68bpvi5v4z52bhmkcmy8-tree-sitter-embedded-template",
-  "sha256": "0h3nj6fz512riyx2b65pg9pjprkpkasnglwljlzi6s1in9fdig3x",
+  "rev": "1a538da253d73f896b9f6c0c7d79cda58791ac5c",
+  "date": "2022-06-20T17:01:16+02:00",
+  "path": "/nix/store/6mrkhc8bkfnmfaq94a30am9ygh971y97-tree-sitter-embedded-template",
+  "sha256": "0j73jk9byrhwddb4qsh67gf5fwj9fgdz6byphh3jj8f0ajzdxrmx",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fennel.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fennel.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/travonted/tree-sitter-fennel",
-  "rev": "d37fd84a702b78ff0282f223ece83c61ab062a6e",
-  "date": "2022-02-21T08:13:28-05:00",
-  "path": "/nix/store/lafx5rw9r9jp9056sv0sk89kxfjlb9x3-tree-sitter-fennel",
-  "sha256": "1wqvz8v877jh7shv50xbnx1bxvdlnfnpmndwzsb0smidnzx7lbw2",
+  "rev": "517195970428aacca60891b050aa53eabf4ba78d",
+  "date": "2022-06-22T09:39:24-04:00",
+  "path": "/nix/store/v8by7ilv9fyv20rp714xq7vhwwi7vz0g-tree-sitter-fennel",
+  "sha256": "02ja5narbahc02f6gmnr5j2sg5sbjcc71hbny6n0nd57kcnapfgd",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-glimmer.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-glimmer.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/alexlafroscia/tree-sitter-glimmer",
-  "rev": "5ed38d3cba65376e4734b0f1763c2f049ad5a1cf",
-  "date": "2021-09-25T09:50:19-04:00",
-  "path": "/nix/store/z0nhsn3v519mbxrhj5x1y7h7k7giviw2-tree-sitter-glimmer",
-  "sha256": "0whij8420niywdi0lna8w5fizq30vhldz3wssisw91gjfdn8d9mz",
+  "rev": "a23d28de811976f3ca310df735fe09a5d2de16ab",
+  "date": "2022-06-24T09:27:51-04:00",
+  "path": "/nix/store/m0hr0x0s3j7r6dn1kv6c77c9qbl4ggkw-tree-sitter-glimmer",
+  "sha256": "07dzpjyc644clh2x3r48w3mi3i68pkac5mwzha2iaxly9fndm0zk",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-gowork.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-gowork.json
@@ -2,7 +2,7 @@
   "url": "https://github.com/omertuc/tree-sitter-go-work",
   "rev": "6dd9dd79fb51e9f2abc829d5e97b15015b6a8ae2",
   "date": "2021-12-18T20:13:22+01:00",
-  "path": "/nix/store/7a4raw2gi4xgbg858cs0davbplj7m8rq-tree-sitter-gowork",
+  "path": "/nix/store/7a4raw2gi4xgbg858cs0davbplj7m8rq-tree-sitter-go-work",
   "sha256": "1kzrs4rpby3b0h87rbr02k55k3mmkmdy7rvl11q95b3ym0smmyqb",
   "fetchLFS": false,
   "fetchSubmodules": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-haskell",
-  "rev": "ca0a13f1acb60cf32e74cced3cb623b6c70fa77c",
-  "date": "2022-06-06T23:15:37+02:00",
-  "path": "/nix/store/dmq8mc361rkhrpa5s06h1z9k8khkvi78-tree-sitter-haskell",
-  "sha256": "1r3mfnj1f6p2cqriay22jjfggrmyywimidzmzw8h5q84flngdg2s",
+  "rev": "cf394604ae2ec2a5e65b1afbc7dea21258ede403",
+  "date": "2022-07-02T11:46:11+02:00",
+  "path": "/nix/store/04cbp4wc4ga3d36d9xvqz2wy9bdnyapv-tree-sitter-haskell",
+  "sha256": "1kvh5gwg3c59snqhpsg23b690rnbmcya0i38mqq9n1pdmv2pzxyi",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-heex.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-heex.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/connorlay/tree-sitter-heex",
-  "rev": "4d8d646bba27ec11bbf76ea37410a604d2e18bfc",
-  "date": "2022-06-09T17:09:44-05:00",
-  "path": "/nix/store/hcn9zl21asz1h6h2abqjpcc37sr56s6s-tree-sitter-heex",
-  "sha256": "0s38g23npq4k2yfwijmp14wmk7klhlycr4jl9a1hnh8qqihxjbj1",
+  "rev": "961bc4d2937cfd24ceb0a5a6b2da607809f8822e",
+  "date": "2022-06-13T09:15:37-07:00",
+  "path": "/nix/store/5qackjn309ls9qja23wkwhqiid9rc6l3-tree-sitter-heex",
+  "sha256": "1by6c4gcqxy9czvwabbmlfr1hlw8z2w7f623llbag956scp2b9al",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ledger.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ledger.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/cbarrete/tree-sitter-ledger",
-  "rev": "1050a25df55a62878102d10e524b5184b316b7ad",
-  "date": "2022-04-01T08:21:18-04:00",
-  "path": "/nix/store/hfhxv3k8kxpg7m31xzrf56lbaa4ips65-tree-sitter-ledger",
-  "sha256": "0qivr9wjab8m1ha4zisznijpw4x3phv0q0nh8lnsx7bjbz6f7xfx",
+  "rev": "1f864fb2bf6a87fe1b48545cc6adc6d23090adf7",
+  "date": "2022-07-01T10:31:32-04:00",
+  "path": "/nix/store/i07g1rw651hx4wlv44v3bwygsv7x5fm1-tree-sitter-ledger",
+  "sha256": "1qxdad40nladdnq6d2s1z7fxlwjz8llpj85da792pv7p7dwh95vd",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-lua.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-lua.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/MunifTanjim/tree-sitter-lua",
-  "rev": "2b4ffd5a5ffd0c6b4c84f0d9e003050a70db2a37",
-  "date": "2022-04-08T22:29:43+06:00",
-  "path": "/nix/store/gj2bbwc3105djyl3l5b0hjr1y1jg7262-tree-sitter-lua",
-  "sha256": "1l383clymmzk0q9b21kcgnmpww4hsh938yd3z9djpkhagadpqpjs",
+  "rev": "a041a547270c17f3d3aca11cb882f5c8eb88a572",
+  "date": "2022-07-07T14:08:02+06:00",
+  "path": "/nix/store/cs0rf42nnyw4w2rlzhw137iqh06dy5mh-tree-sitter-lua",
+  "sha256": "0db2wjwzzx40i38cs04w8pn0zqqv18ry4m2div0a0b2wgdhzf33f",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-markdown.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-markdown.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/MDeiml/tree-sitter-markdown",
-  "rev": "6d112e7a9c1694504bb78ee0b92dcd509625e0df",
-  "date": "2022-04-26T12:23:01+02:00",
-  "path": "/nix/store/598nrwznzg37r9pskrmzwnhrw3f4knnw-tree-sitter-markdown",
-  "sha256": "03d601dp65p30c88p0r6rx13wlkbg1q3ch11wfn4sa2rhba8zpyk",
+  "rev": "142a5b4a1b092b64c9f5db8f11558f9dd4009a1b",
+  "date": "2022-07-04T10:48:30+02:00",
+  "path": "/nix/store/wac43pvz3wdwl2i6a8a0ik6l99c9lzmq-tree-sitter-markdown",
+  "sha256": "0q1czdv7szw9rk4h9i9xjc29s0g3m1grhsjq6rl5vm70h998fbmg",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ocaml.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ocaml.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-ocaml",
-  "rev": "23d419ba45789c5a47d31448061557716b02750a",
-  "date": "2021-08-26T21:21:27+02:00",
-  "path": "/nix/store/942q4rv9vs77wwvvw46yx0jnqja2cbig-tree-sitter-ocaml",
-  "sha256": "1bh3afd3iix0gf6ldjngf2c65nyfdwvbmsq25gcxm04jwbg9c6k8",
+  "rev": "cc26b1ef111100f26a137bcbcd39fd4e35be9a59",
+  "date": "2022-06-19T21:41:43+02:00",
+  "path": "/nix/store/m5z0cdxb8mg1ff64529p8sfj9afq50l5-tree-sitter-ocaml",
+  "sha256": "1qra2zihw09ff16gxfmpmdmyj0rilvnk1xc9y4wb01j2a4292fc1",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-org-nvim.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-org-nvim.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/milisims/tree-sitter-org",
-  "rev": "7ab140276cff85bf6dd08914e04188f4da1ff0ab",
-  "date": "2022-06-01T13:56:57-04:00",
-  "path": "/nix/store/ig79jii0vihy6vjq5j35ymgpbppjcsgd-tree-sitter-org",
-  "sha256": "0j3520h0bvxn6sm8fg1a400y2rnp0l9jrf31n8rbkq9ri34bzi5x",
+  "rev": "bc8a040492b56754a35b3b00a3052fdb7ba12969",
+  "date": "2022-06-27T11:07:56-04:00",
+  "path": "/nix/store/6xpvk9i1250slzsh2ap3pr0fawmibngw-tree-sitter-org",
+  "sha256": "19z45bd276g4xggg2vqmr6fjwyi88xmpx1ihqq908152pq83zmv6",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-pgn.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-pgn.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/rolandwalker/tree-sitter-pgn",
-  "rev": "e26ee30850f0cb81541480cf1e2c70385bdb013a",
-  "date": "2021-08-25T17:57:38-04:00",
-  "path": "/nix/store/fj882ab2hl3qrz45zvq366na6d2gqv8v-tree-sitter-pgn",
-  "sha256": "1c4602jmq3p7p7splzip76863l1z3rgbjlbksqv0diqjxp7c42gq",
+  "rev": "4c372e9e4d69bdc57701201347afe5f6413f2367",
+  "date": "2021-09-14T07:33:59-04:00",
+  "path": "/nix/store/62pvfyg8qlybxmd8kac8fdpycsypga67-tree-sitter-pgn",
+  "sha256": "0c2iqv93fg2pl7ixa7bby0bgnfnd8djjkjcg7d9bn3y7vpswvbvi",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-php",
-  "rev": "866e4a155739a1374da5247b876e70f8639005f6",
-  "date": "2022-06-06T09:18:54+02:00",
-  "path": "/nix/store/23f9s4z321mnjnqfxjdj75rkcvwv2xpa-tree-sitter-php",
-  "sha256": "11nagsvq2jsinrhsfpnylz1lkp6hiw3jndshnjvzvkjmmpavm1gr",
+  "rev": "ece74b20942a5b23acaf3622512c6d0db1491a7e",
+  "date": "2022-06-24T15:38:28-07:00",
+  "path": "/nix/store/cqqyvb0vfp0q34lf3w5jds5dq4riac9z-tree-sitter-php",
+  "sha256": "0ggx747j3hpgwqw7cjh07n866mvdcyv3mvblffbrb8b1xn3bll84",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-protobuf.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-protobuf.json
@@ -1,0 +1,11 @@
+{
+  "url": "https://github.com/yusdacra/tree-sitter-protobuf",
+  "rev": "5aef38d655f76a6b0d172340eed3766c93b3124c",
+  "date": "2021-08-22T19:21:20+03:00",
+  "path": "/nix/store/hhcv3vn8yahmqjsgyhgmwfglkyp144fy-tree-sitter-protobuf",
+  "sha256": "0cj3352xkp001hzpl19rnmvibl9j4jm2xd46msafjlqi0908vkl7",
+  "fetchLFS": false,
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-python.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-python.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-python",
-  "rev": "dafcef7943229ec9d530b36ed67d758e659f4c6c",
-  "date": "2022-05-31T14:13:03-07:00",
-  "path": "/nix/store/9f82z98jx9jlpb96niav0zd173lxmlla-tree-sitter-python",
-  "sha256": "07dkwp46wp8fnh94qy4rlvn8yq0wzawnmbrz7z1jk14ymr6s5hkh",
+  "rev": "de221eccf9a221f5b85474a553474a69b4b5784d",
+  "date": "2022-06-27T15:09:45-07:00",
+  "path": "/nix/store/r8cac3zd9xd3l3knzl6k98zhq0wshv0n-tree-sitter-python",
+  "sha256": "1mp2rqv6p2nla0sh1s5hprq32b9nkwbj2q21dcpvdcg6gack1sdf",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rst.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rst.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/stsewd/tree-sitter-rst",
-  "rev": "b74770c0166f28c1a0ab293513a78712ca1c338b",
-  "date": "2022-01-22T20:59:44-05:00",
-  "path": "/nix/store/ymhzq6hwq43gf918zyxk7can4qfkz7n1-tree-sitter-rst",
-  "sha256": "0q50vwk72lrgnrdjjn5aj1fjksrwkd0gfmdnrjy59a6cw8m1gmf0",
+  "rev": "d4b6c33ec15a4c22d0003dd37a5b20baa352b843",
+  "date": "2022-06-13T13:46:50-05:00",
+  "path": "/nix/store/scmhiai4dfc8k7nw6f0j1nmdhzv2j1ji-tree-sitter-rst",
+  "sha256": "127g78x2macl5fc1vhkfgkkd3zzj1yv9m2067j53nrivaff3jj8d",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ruby.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ruby.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-ruby",
-  "rev": "fe6a2d634da0e16b11b5aa255cc3df568a4572fd",
-  "date": "2021-03-03T16:54:30-08:00",
-  "path": "/nix/store/ragrvqj7hm98r74v5b3fljvc47gd3nhj-tree-sitter-ruby",
-  "sha256": "0m3h4928rbs300wcb6776h9r88hi32rybbhcaf6rdympl5nzi83v",
+  "rev": "5b305c3cd32db10494cedd2743de6bbe32f1a573",
+  "date": "2022-06-27T12:03:05+02:00",
+  "path": "/nix/store/xvdshaivryvvcfqxz7bmkm4cl9qdbbnm-tree-sitter-ruby",
+  "sha256": "1wzisqhy7grmqn5j8iczg34ma33ips3r3wrb3frij4h09mnjgdmc",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-sql.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-sql.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/m-novikov/tree-sitter-sql",
-  "rev": "2ec2fedbb38d09737e2a1cdd207f6416dc1cb109",
-  "date": "2022-06-11T22:57:56+02:00",
-  "path": "/nix/store/zzx4b5cnsrrdzkb5rbmx5d8vzbyr0rbi-tree-sitter-sql",
-  "sha256": "0dcpdshymyszsr1dflsr3j6ynrnrq0g4qdxqcz7d0anpwh3xw4cs",
+  "rev": "218b672499729ef71e4d66a949e4a1614488aeaa",
+  "date": "2022-06-30T19:50:55+02:00",
+  "path": "/nix/store/rcdcgwb28jblgb65k5zjw5zgmigiqjfl-tree-sitter-sql",
+  "sha256": "1j68h5jzc0d3a44v5mw005lh3zsrh0salfzydl9br1n8byl1awms",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-surface.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-surface.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/connorlay/tree-sitter-surface",
-  "rev": "21b7676859c1187645a27ff301f76738af5dfd44",
-  "date": "2021-08-15T10:33:50-07:00",
-  "path": "/nix/store/7i1klj80jbcvwgad7nrbcs7hvn68f125-tree-sitter-surface",
-  "sha256": "122v1d2zb0w2k5h7xqgm1c42rwfrp59dzyb2lly7kxmylyazmshy",
+  "rev": "f4586b35ac8548667a9aaa4eae44456c1f43d032",
+  "date": "2022-01-18T18:13:51-08:00",
+  "path": "/nix/store/l1nzhnhw1219140vzwvillawr7m9sz22-tree-sitter-surface",
+  "sha256": "085yvq2m4dbhhn51ndhzvgfmpp3hqiwk1a39xpjy4lxgrhbyjzqn",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-svelte.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-svelte.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/Himujjal/tree-sitter-svelte",
-  "rev": "84c90ee15f851e1541c25c86e8a4338f5b4d5af2",
-  "date": "2022-04-13T11:35:15+05:30",
-  "path": "/nix/store/2miakcpw7xgg2pcwdbcg0kl2djijcfbj-tree-sitter-svelte",
-  "sha256": "0hidafgzbnksyigksab8731jdnvj1vqn7fv0jxsc1yfrwrmai6ls",
+  "rev": "ed9fb880972ddcca1b9400e9e7e792fc83c22885",
+  "date": "2022-07-04T18:11:19+05:30",
+  "path": "/nix/store/gad84vhq0xx5vadjb58l8s8d43512jf0-tree-sitter-svelte",
+  "sha256": "1z41zc0blr1r13lz6r4hcky9jsn4s1307jkg9n6f4z86rgdryswk",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-typescript",
-  "rev": "1b3ba31c7538825b05815f4f5bffcca6394edc63",
-  "date": "2022-06-02T09:10:56-07:00",
-  "path": "/nix/store/g3q8azmyclcdns0ihwl5im46qlsfxbfj-tree-sitter-typescript",
-  "sha256": "1iw6823zh2m95gjmly34j49ixga07fhax7z6g2q6px06gj4fm5df",
+  "rev": "49e82b1bce36d6046df911901684cd66b5345d58",
+  "date": "2022-07-06T12:52:21-07:00",
+  "path": "/nix/store/wzkgvx1sj0js8sdkm8cmip4rmsgqy3ij-tree-sitter-typescript",
+  "sha256": "1kgl0dvcjzlbpfbdf1mq9693p5j7kvcqfmxis2w30js2lmrp0wgb",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-vim.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-vim.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/vigoux/tree-sitter-viml",
-  "rev": "4b9d2dda6de64fe5abc9bf96b5727ba73ed08515",
-  "date": "2022-05-07T11:41:23+02:00",
-  "path": "/nix/store/zm2pfjv3fn2qg6iy1s03mn5kjawsy3qg-tree-sitter-viml",
-  "sha256": "0p7fj5vvxxz4d43j91zwv3h8df4m4c26w9gq2qx561vjh5w1q7fn",
+  "rev": "c5425cf06a7002cb28587778a28aa231a3e5e054",
+  "date": "2022-07-06T14:47:43+02:00",
+  "path": "/nix/store/mwvvbmgd6mmzqzx1wkii8qdlpsg1yfp5-tree-sitter-viml",
+  "sha256": "1qajh56005w3i529h95qq93vja1i5s3j551x90i9ydqzwc48mld5",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-zig.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-zig.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/maxxnino/tree-sitter-zig",
-  "rev": "4cff36421dae9c05388b86cd64d2bab4b9ed6676",
-  "date": "2022-04-02T10:33:48+07:00",
-  "path": "/nix/store/ripw74y32a8nzsr9n30jfhh16wjxlxvb-tree-sitter-zig",
-  "sha256": "0k9z0f6vfj1pfz3qkscb41wz2nzjp0xpz9mvm6264q655rq73dlc",
+  "rev": "8d3224c3bd0890fe08358886ebf54fca2ed448a6",
+  "date": "2022-06-25T10:13:16+07:00",
+  "path": "/nix/store/an534h97z3gi6zk5mzysbx2fp8rvy9c4-tree-sitter-zig",
+  "sha256": "0mw4s92qmxkh9a13h9hg6kv9b704vzx3kr4j6dap0c80dffvfjhk",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/update.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/update.nix
@@ -322,6 +322,10 @@ let
       orga = "victorhqc";
       repo = "tree-sitter-prisma";
     };
+    "tree-sitter-protobuf" = {
+      orga = "yusdacra";
+      repo = "tree-sitter-protobuf";
+    };
     "tree-sitter-org-nvim" = {
       orga = "milisims";
       repo = "tree-sitter-org";


### PR DESCRIPTION
###### Description of changes
Updated tree-sitter grammars and added tree-sitter-protobuf.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
