### PR TITLE
tg: init at 0.19.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/tg/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tg/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonApplication, fetchFromGitHub, pythonOlder, python-telegram }:
+
+buildPythonApplication rec {
+  pname = "tg";
+  version = "0.19.0";
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "paul-nameless";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-apHd26XnOz5nak+Kz8PJPsonQfTWDyPz7Mi/tWf7zwM=";
+  };
+
+  propagatedBuildInputs = [ python-telegram ];
+
+  doCheck = false; # No tests
+
+  meta = with lib; {
+    description = "Terminal client for telegram";
+    homepage = "https://github.com/paul-nameless/tg";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ sikmir ];
+  };
+}

--- a/pkgs/development/python-modules/python-telegram/default.nix
+++ b/pkgs/development/python-modules/python-telegram/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, stdenv
+, fetchpatch
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, setuptools
+, tdlib
+}:
+
+buildPythonPackage rec {
+  pname = "python-telegram";
+  version = "0.15.0";
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-Na2NIiVgYexKbEqjN58hfkgxwFdCTL7Z7D3WEhL4wXA=";
+  };
+
+  patches = [
+    # Search for the system library first, and fallback to the embedded one if the system was not found
+    (fetchpatch {
+      url = "https://github.com/alexander-akhmetov/python-telegram/commit/b0af0985910ebb8940cff1b92961387aad683287.patch";
+      sha256 = "sha256-ZqsntaiC2y9l034gXDMeD2BLO/RcsbBII8FomZ65/24=";
+    })
+  ];
+
+  postPatch = ''
+    # Remove bundled libtdjson
+    rm -fr telegram/lib
+
+    substituteInPlace telegram/tdjson.py \
+      --replace "ctypes.util.find_library(\"libtdjson\")" \
+                "\"${tdlib}/lib/libtdjson${stdenv.hostPlatform.extensions.sharedLibrary}\""
+  '';
+
+  propagatedBuildInputs = [
+    setuptools
+  ];
+
+  pythonImportsCheck = [
+    "telegram.client"
+  ];
+
+  meta = with lib; {
+    description = "Python client for the Telegram's tdlib";
+    homepage = "https://github.com/alexander-akhmetov/python-telegram";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sikmir ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30348,6 +30348,8 @@ with pkgs;
 
   telegram-cli = callPackage ../applications/networking/instant-messengers/telegram/telegram-cli { };
 
+  tg = python3Packages.callPackage ../applications/networking/instant-messengers/telegram/tg { };
+
   telepathy-gabble = callPackage ../applications/networking/instant-messengers/telepathy/gabble { };
 
   telepathy-haze = callPackage ../applications/networking/instant-messengers/telepathy/haze {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8741,6 +8741,8 @@ in {
 
   python-stdnum = callPackage ../development/python-modules/python-stdnum { };
 
+  python-telegram = callPackage ../development/python-modules/python-telegram { };
+
   python-telegram-bot = callPackage ../development/python-modules/python-telegram-bot { };
 
   python-toolbox = callPackage ../development/python-modules/python-toolbox { };


### PR DESCRIPTION
###### Description of changes
**[tg](https://github.com/paul-nameless/tg)** - Telegram terminal client.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
