### PR TITLE
Fix hdfview issue 179793 and bump hdfview to 3.1.4

### DIFF
--- a/pkgs/tools/misc/hdfview/0001-Hardcode-isUbuntu-false-to-avoid-hostname-dependency.patch
+++ b/pkgs/tools/misc/hdfview/0001-Hardcode-isUbuntu-false-to-avoid-hostname-dependency.patch
@@ -1,0 +1,38 @@
+From e5eb394458e19ce8f8a231e8b2005c80c64fd426 Mon Sep 17 00:00:00 2001
+From: Jiajie Chen <c@jia.je>
+Date: Fri, 15 Jul 2022 10:13:23 +0800
+Subject: [PATCH] Hardcode isUbuntu=false to avoid hostname dependency.
+
+The original build.xml detects whether the system is ubuntu based on its
+hostname, which is useless in nixpkgs and brings additional dependency.
+
+As suggested by @risicle in #180613, we can simply hardcode isUbuntu to
+false.
+
+Signed-off-by: Jiajie Chen <c@jia.je>
+---
+ build.xml | 8 +++-----
+ 1 file changed, 3 insertions(+), 5 deletions(-)
+
+diff --git a/build.xml b/build.xml
+index c4f0974..15a6078 100644
+--- a/build.xml
++++ b/build.xml
+@@ -143,11 +143,9 @@
+         </and>
+     </condition>
+ 
+-    <exec executable="hostname" outputproperty="computer.hostname"/>
+-
+-    <condition property="isUbuntu">
+-        <contains string="${computer.hostname}" substring="ubuntu" />
+-    </condition>
++    <!-- Since we do not package .deb nor .rpm files, we can safely
++        hardcode isUbuntu = false. -->
++    <property name="isUbuntu" value="false" />
+ 
+     <!-- Build 64-bit binary.
+        Note: os.arch gives the architecture of the JVM, NOT the OS;
+-- 
+2.36.1
+

--- a/pkgs/tools/misc/hdfview/default.nix
+++ b/pkgs/tools/misc/hdfview/default.nix
@@ -63,5 +63,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.free; # BSD-like
     homepage = "https://portal.hdfgroup.org/display/HDFVIEW/HDFView";
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ jiegec ];
   };
 }

--- a/pkgs/tools/misc/hdfview/default.nix
+++ b/pkgs/tools/misc/hdfview/default.nix
@@ -9,10 +9,14 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-iY/NUifU57aX795eWpaUBflrclF/nfvb3OKZEpD9VqA=";
   };
 
+  patches = [
+    # Hardcode isUbuntu=false to avoid calling hostname to detect os
+    ./0001-Hardcode-isUbuntu-false-to-avoid-hostname-dependency.patch
+  ];
+
   nativeBuildInputs = [
     ant
     jdk
-    nettools # "hostname" required
     copyDesktopItems
   ];
 

--- a/pkgs/tools/misc/hdfview/default.nix
+++ b/pkgs/tools/misc/hdfview/default.nix
@@ -41,6 +41,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin $out/lib
     cp -a build/dist/HDFView/bin/HDFView $out/bin/
     cp -a build/dist/HDFView/lib/app $out/lib/
+    cp -a build/dist/HDFView/lib/libapplauncher.so $out/lib/
     ln -s ${jdk}/lib/openjdk $out/lib/runtime
 
     mkdir -p $out/share/applications $out/share/icons/hicolor/32x32/apps

--- a/pkgs/tools/misc/hdfview/default.nix
+++ b/pkgs/tools/misc/hdfview/default.nix
@@ -2,29 +2,34 @@
 
 stdenv.mkDerivation rec {
   pname = "hdfview";
-  version = "3.1.3";
+  version = "3.1.4";
 
   src = fetchurl {
     url = "https://support.hdfgroup.org/ftp/HDF5/releases/HDF-JAVA/${pname}-${version}/src/${pname}-${version}.tar.gz";
-    sha256 = "sha256-VmgHSVMFoy09plU5pSnyaPz8N15toy7QfCtXI7mqDGY=";
+    sha256 = "sha256-iY/NUifU57aX795eWpaUBflrclF/nfvb3OKZEpD9VqA=";
   };
 
   nativeBuildInputs = [
-    ant jdk
-    nettools  # "hostname" required
+    ant
+    jdk
+    nettools # "hostname" required
     copyDesktopItems
   ];
 
   HDFLIBS = (hdf4.override { javaSupport = true; }).out;
   HDF5LIBS = (hdf5.override { javaSupport = true; }).out;
 
-  buildPhase = ''
-    runHook preBuild
+  buildPhase =
+    let
+      arch = if stdenv.isx86_64 then "x86_64" else "aarch64";
+    in
+    ''
+      runHook preBuild
 
-    ant createJPackage
+      ant createJPackage -Dmachine.arch=${arch}
 
-    runHook postBuild
-  '';
+      runHook postBuild
+    '';
 
   desktopItem = makeDesktopItem rec {
     name = "HDFView";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Fix issue #179793 by copying the missing libapplauncher.so
- Update HDFView from 3.1.3 to 3.1.4

I am also willing to maintain this package since there are no maintainers listed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
