### PR TITLE
mongodb: fix darwin build

### DIFF
--- a/pkgs/servers/nosql/mongodb/4.4.nix
+++ b/pkgs/servers/nosql/mongodb/4.4.nix
@@ -10,5 +10,6 @@ buildMongoDB {
   sha256 = "sha256-ebg3R6P+tjRvizDzsl7mZzhTfqIaRJPfHBu0IfRvtS8=";
   patches = [
     ./forget-build-dependencies-4-4.patch
+    ./fix-build-with-boost-1.79-4_4.patch
   ] ++ lib.optionals stdenv.isDarwin [ ./asio-no-experimental-string-view-4-4.patch ];
 }

--- a/pkgs/servers/nosql/mongodb/5.0.nix
+++ b/pkgs/servers/nosql/mongodb/5.0.nix
@@ -22,5 +22,6 @@ buildMongoDB {
     ./forget-build-dependencies-4-4.patch
     ./asio-no-experimental-string-view-4-4.patch
     ./fix-build-with-boost-1.79-5_0.patch
+    ./fix-gcc-Wno-exceptions-5.0.patch
   ];
 }

--- a/pkgs/servers/nosql/mongodb/5.0.nix
+++ b/pkgs/servers/nosql/mongodb/5.0.nix
@@ -21,5 +21,6 @@ buildMongoDB {
   patches = [
     ./forget-build-dependencies-4-4.patch
     ./asio-no-experimental-string-view-4-4.patch
+    ./fix-build-with-boost-1.79-5_0.patch
   ];
 }

--- a/pkgs/servers/nosql/mongodb/fix-build-with-boost-1.79-4_4.patch
+++ b/pkgs/servers/nosql/mongodb/fix-build-with-boost-1.79-4_4.patch
@@ -1,0 +1,64 @@
+From 72103f5e888b3bbe697e3d5fa3e76c0c872752f1 Mon Sep 17 00:00:00 2001
+From: Et7f3 <cadeaudeelie@gmail.com>
+Date: Tue, 19 Jul 2022 22:11:11 +0200
+Subject: [PATCH] build: Upgrade boost to 1.79.0
+
+We can see in src/third_party/boost-1.70.0/boost/version.hpp that vendored
+version of boost is BOOST_LIB_VERSION "1_70"
+
+We can also see the doc desbribe 2 headers to use filesystems lib: One is
+src/third_party/boost/boost/filesystem/fstream.hpp that contains (175-177)
+  typedef basic_ifstream<char> ifstream;
+  typedef basic_ofstream<char> ofstream;
+  typedef basic_fstream<char> fstream;
+
+So this mean they mostly forgot to include a header and include-what-you-use
+would catch this error.
+
+In upstream they fixed in a simmilar way
+https://github.com/mongodb/mongo/commit/13389dc222fc372442be8c147e09685bb9a26a3a
+---
+ src/mongo/db/storage/storage_repair_observer.cpp    | 1 +
+ src/mongo/db/storage/wiredtiger/wiredtiger_util.cpp | 1 +
+ src/mongo/shell/shell_utils_extended.cpp            | 1 +
+ 3 files changed, 3 insertions(+)
+
+diff --git a/src/mongo/db/storage/storage_repair_observer.cpp b/src/mongo/db/storage/storage_repair_observer.cpp
+index 22b76a6a39c..453f48229cd 100644
+--- a/src/mongo/db/storage/storage_repair_observer.cpp
++++ b/src/mongo/db/storage/storage_repair_observer.cpp
+@@ -42,6 +42,7 @@
+ #endif
+ 
+ #include <boost/filesystem/path.hpp>
++#include <boost/filesystem/fstream.hpp>
+ 
+ #include "mongo/db/dbhelpers.h"
+ #include "mongo/db/operation_context.h"
+diff --git a/src/mongo/db/storage/wiredtiger/wiredtiger_util.cpp b/src/mongo/db/storage/wiredtiger/wiredtiger_util.cpp
+index 85121941458..7464022fb28 100644
+--- a/src/mongo/db/storage/wiredtiger/wiredtiger_util.cpp
++++ b/src/mongo/db/storage/wiredtiger/wiredtiger_util.cpp
+@@ -37,6 +37,7 @@
+ 
+ #include <boost/filesystem.hpp>
+ #include <boost/filesystem/path.hpp>
++#include <boost/filesystem/fstream.hpp>
+ 
+ #include "mongo/base/simple_string_data_comparator.h"
+ #include "mongo/bson/bsonobjbuilder.h"
+diff --git a/src/mongo/shell/shell_utils_extended.cpp b/src/mongo/shell/shell_utils_extended.cpp
+index 8cd7f035f1d..cd672eb513f 100644
+--- a/src/mongo/shell/shell_utils_extended.cpp
++++ b/src/mongo/shell/shell_utils_extended.cpp
+@@ -37,6 +37,7 @@
+ #endif
+ 
+ #include <boost/filesystem.hpp>
++#include <boost/filesystem/fstream.hpp>
+ #include <fstream>
+ 
+ #include "mongo/bson/bson_validate.h"
+-- 
+2.32.1 (Apple Git-133)
+

--- a/pkgs/servers/nosql/mongodb/fix-build-with-boost-1.79-4_4.patch
+++ b/pkgs/servers/nosql/mongodb/fix-build-with-boost-1.79-4_4.patch
@@ -1,4 +1,4 @@
-From 72103f5e888b3bbe697e3d5fa3e76c0c872752f1 Mon Sep 17 00:00:00 2001
+From 9a4c7b33e49cdf121ff9dee858539568d009fc27 Mon Sep 17 00:00:00 2001
 From: Et7f3 <cadeaudeelie@gmail.com>
 Date: Tue, 19 Jul 2022 22:11:11 +0200
 Subject: [PATCH] build: Upgrade boost to 1.79.0
@@ -21,7 +21,9 @@ https://github.com/mongodb/mongo/commit/13389dc222fc372442be8c147e09685bb9a26a3a
  src/mongo/db/storage/storage_repair_observer.cpp    | 1 +
  src/mongo/db/storage/wiredtiger/wiredtiger_util.cpp | 1 +
  src/mongo/shell/shell_utils_extended.cpp            | 1 +
- 3 files changed, 3 insertions(+)
+ src/mongo/util/processinfo_linux.cpp                | 2 +-
+ src/mongo/util/stacktrace_threads.cpp               | 1 +
+ 5 files changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/src/mongo/db/storage/storage_repair_observer.cpp b/src/mongo/db/storage/storage_repair_observer.cpp
 index 22b76a6a39c..453f48229cd 100644
@@ -59,6 +61,31 @@ index 8cd7f035f1d..cd672eb513f 100644
  #include <fstream>
  
  #include "mongo/bson/bson_validate.h"
+diff --git a/src/mongo/util/processinfo_linux.cpp b/src/mongo/util/processinfo_linux.cpp
+index de4b84bca5a..7fa9d5d128e 100644
+--- a/src/mongo/util/processinfo_linux.cpp
++++ b/src/mongo/util/processinfo_linux.cpp
+@@ -33,7 +33,7 @@
+ 
+ #include "processinfo.h"
+ 
+-#include <iostream>
++#include <fstream>
+ #include <malloc.h>
+ #include <pcrecpp.h>
+ #include <sched.h>
+diff --git a/src/mongo/util/stacktrace_threads.cpp b/src/mongo/util/stacktrace_threads.cpp
+index 4667a261ab7..73a36015bd6 100644
+--- a/src/mongo/util/stacktrace_threads.cpp
++++ b/src/mongo/util/stacktrace_threads.cpp
+@@ -36,6 +36,7 @@
+ #include <array>
+ #include <atomic>
+ #include <boost/filesystem.hpp>
++#include <boost/filesystem/fstream.hpp>
+ #include <cctype>
+ #include <cstdint>
+ #include <cstdlib>
 -- 
 2.32.1 (Apple Git-133)
 

--- a/pkgs/servers/nosql/mongodb/fix-build-with-boost-1.79-5_0.patch
+++ b/pkgs/servers/nosql/mongodb/fix-build-with-boost-1.79-5_0.patch
@@ -1,0 +1,64 @@
+From 5c872a02501cad670d5b7f4f153ae856732a605e Mon Sep 17 00:00:00 2001
+From: Et7f3 <cadeaudeelie@gmail.com>
+Date: Tue, 19 Jul 2022 22:01:56 +0200
+Subject: [PATCH] build: Upgrade boost to 1.79.0
+
+We can see in src/third_party/boost/boost/version.hpp that vendored version of
+boost is BOOST_LIB_VERSION "1_76"
+
+We can also see the doc desbribe 2 headers to use filesystems lib: One is
+src/third_party/boost/boost/filesystem/fstream.hpp that contains (175-177)
+  typedef basic_ifstream<char> ifstream;
+  typedef basic_ofstream<char> ofstream;
+  typedef basic_fstream<char> fstream;
+
+So this mean they mostly forgot to include a header and include-what-you-use
+would catch this error.
+
+In upstream they fixed in a simmilar way
+https://github.com/mongodb/mongo/commit/13389dc222fc372442be8c147e09685bb9a26a3a
+---
+ src/mongo/db/storage/storage_repair_observer.cpp    | 1 +
+ src/mongo/db/storage/wiredtiger/wiredtiger_util.cpp | 1 +
+ src/mongo/shell/shell_utils_extended.cpp            | 1 +
+ 3 files changed, 3 insertions(+)
+
+diff --git a/src/mongo/db/storage/storage_repair_observer.cpp b/src/mongo/db/storage/storage_repair_observer.cpp
+index 22b76a6a39c..453f48229cd 100644
+--- a/src/mongo/db/storage/storage_repair_observer.cpp
++++ b/src/mongo/db/storage/storage_repair_observer.cpp
+@@ -42,6 +42,7 @@
+ #endif
+ 
+ #include <boost/filesystem/path.hpp>
++#include <boost/filesystem/fstream.hpp>
+ 
+ #include "mongo/db/dbhelpers.h"
+ #include "mongo/db/operation_context.h"
+diff --git a/src/mongo/db/storage/wiredtiger/wiredtiger_util.cpp b/src/mongo/db/storage/wiredtiger/wiredtiger_util.cpp
+index 07fabadd634..2924a2c74af 100644
+--- a/src/mongo/db/storage/wiredtiger/wiredtiger_util.cpp
++++ b/src/mongo/db/storage/wiredtiger/wiredtiger_util.cpp
+@@ -37,6 +37,7 @@
+ 
+ #include <boost/filesystem.hpp>
+ #include <boost/filesystem/path.hpp>
++#include <boost/filesystem/fstream.hpp>
+ 
+ #include "mongo/base/simple_string_data_comparator.h"
+ #include "mongo/bson/bsonobjbuilder.h"
+diff --git a/src/mongo/shell/shell_utils_extended.cpp b/src/mongo/shell/shell_utils_extended.cpp
+index fbdddc1318d..e37d4c93a11 100644
+--- a/src/mongo/shell/shell_utils_extended.cpp
++++ b/src/mongo/shell/shell_utils_extended.cpp
+@@ -37,6 +37,7 @@
+ #endif
+ 
+ #include <boost/filesystem.hpp>
++#include <boost/filesystem/fstream.hpp>
+ #include <fmt/format.h>
+ #include <fstream>
+ 
+-- 
+2.32.1 (Apple Git-133)
+

--- a/pkgs/servers/nosql/mongodb/fix-build-with-boost-1.79-5_0.patch
+++ b/pkgs/servers/nosql/mongodb/fix-build-with-boost-1.79-5_0.patch
@@ -1,4 +1,4 @@
-From 5c872a02501cad670d5b7f4f153ae856732a605e Mon Sep 17 00:00:00 2001
+From fb846bdbd07cc3b8ada6179dccd974072c2b69da Mon Sep 17 00:00:00 2001
 From: Et7f3 <cadeaudeelie@gmail.com>
 Date: Tue, 19 Jul 2022 22:01:56 +0200
 Subject: [PATCH] build: Upgrade boost to 1.79.0
@@ -21,7 +21,9 @@ https://github.com/mongodb/mongo/commit/13389dc222fc372442be8c147e09685bb9a26a3a
  src/mongo/db/storage/storage_repair_observer.cpp    | 1 +
  src/mongo/db/storage/wiredtiger/wiredtiger_util.cpp | 1 +
  src/mongo/shell/shell_utils_extended.cpp            | 1 +
- 3 files changed, 3 insertions(+)
+ src/mongo/util/processinfo_linux.cpp                | 1 +
+ src/mongo/util/stacktrace_threads.cpp               | 1 +
+ 5 files changed, 5 insertions(+)
 
 diff --git a/src/mongo/db/storage/storage_repair_observer.cpp b/src/mongo/db/storage/storage_repair_observer.cpp
 index 22b76a6a39c..453f48229cd 100644
@@ -59,6 +61,30 @@ index fbdddc1318d..e37d4c93a11 100644
  #include <fmt/format.h>
  #include <fstream>
  
+diff --git a/src/mongo/util/processinfo_linux.cpp b/src/mongo/util/processinfo_linux.cpp
+index eae0e9b7764..d5cd40f6039 100644
+--- a/src/mongo/util/processinfo_linux.cpp
++++ b/src/mongo/util/processinfo_linux.cpp
+@@ -52,6 +52,7 @@
+ #endif
+ 
+ #include <boost/filesystem.hpp>
++#include <boost/filesystem/fstream.hpp>
+ #include <boost/none.hpp>
+ #include <boost/optional.hpp>
+ #include <fmt/format.h>
+diff --git a/src/mongo/util/stacktrace_threads.cpp b/src/mongo/util/stacktrace_threads.cpp
+index d2ee29d24b4..d485fa22367 100644
+--- a/src/mongo/util/stacktrace_threads.cpp
++++ b/src/mongo/util/stacktrace_threads.cpp
+@@ -36,6 +36,7 @@
+ #include <array>
+ #include <atomic>
+ #include <boost/filesystem.hpp>
++#include <boost/filesystem/fstream.hpp>
+ #include <cstdint>
+ #include <cstdlib>
+ #include <dirent.h>
 -- 
 2.32.1 (Apple Git-133)
 

--- a/pkgs/servers/nosql/mongodb/fix-gcc-Wno-exceptions-5.0.patch
+++ b/pkgs/servers/nosql/mongodb/fix-gcc-Wno-exceptions-5.0.patch
@@ -1,0 +1,44 @@
+From e78b2bf6eaa0c43bd76dbb841add167b443d2bb0 Mon Sep 17 00:00:00 2001
+From: Mark Benvenuto <mark.benvenuto@mongodb.com>
+Date: Mon, 21 Jun 2021 11:36:56 -0400
+Subject: [PATCH] SERVER-57688 Fix debug gcc 11 and clang 12 builds on Fedora
+ 34
+
+---
+ SConstruct                              | 4 ----
+ src/mongo/db/query/plan_summary_stats.h | 4 +++-
+ src/mongo/util/shim_boost_assert.cpp    | 1 +
+ 3 files changed, 4 insertions(+), 5 deletions(-)
+
+diff --git a/SConstruct b/SConstruct
+index 25fd4a248d0c..23cff6f9da53 100644
+--- a/SConstruct
++++ b/SConstruct
+@@ -3108,10 +3108,6 @@ def doConfigure(myenv):
+         # harmful to capture unused variables we are suppressing for now with a plan to fix later.
+         AddToCCFLAGSIfSupported(myenv, "-Wno-unused-lambda-capture")
+ 
+-        # This warning was added in clang-5 and incorrectly flags our implementation of
+-        # exceptionToStatus(). See https://bugs.llvm.org/show_bug.cgi?id=34804
+-        AddToCCFLAGSIfSupported(myenv, "-Wno-exceptions")
+-
+         # Enable sized deallocation support.
+         AddToCXXFLAGSIfSupported(myenv, '-fsized-deallocation')
+ 
+diff --git a/src/mongo/db/query/plan_summary_stats.h b/src/mongo/db/query/plan_summary_stats.h
+index 58677ab20d25..cfaa2053d16f 100644
+--- a/src/mongo/db/query/plan_summary_stats.h
++++ b/src/mongo/db/query/plan_summary_stats.h
+@@ -29,9 +29,11 @@
+ 
+ #pragma once
+ 
+-#include "mongo/util/container_size_helper.h"
++#include <optional>
+ #include <string>
+ 
++#include "mongo/util/container_size_helper.h"
++
+ namespace mongo {
+ 
+ /**

--- a/pkgs/servers/nosql/mongodb/mongodb.nix
+++ b/pkgs/servers/nosql/mongodb/mongodb.nix
@@ -72,6 +72,7 @@ in stdenv.mkDerivation rec {
         --replace "env = Environment(" "env = Environment(ENV = os.environ,"
   '' + lib.optionalString stdenv.isDarwin ''
     substituteInPlace src/third_party/mozjs-${variants.mozjsVersion}/extract/js/src/jsmath.cpp --replace '${variants.mozjsReplace}' 0
+  '' + lib.optionalString (stdenv.isDarwin && versionOlder version "3.6") ''
     substituteInPlace src/third_party/s2/s1angle.cc --replace drem remainder
     substituteInPlace src/third_party/s2/s1interval.cc --replace drem remainder
     substituteInPlace src/third_party/s2/s2cap.cc --replace drem remainder

--- a/pkgs/servers/nosql/mongodb/mongodb.nix
+++ b/pkgs/servers/nosql/mongodb/mongodb.nix
@@ -70,6 +70,13 @@ in stdenv.mkDerivation rec {
     # fix environment variable reading
     substituteInPlace SConstruct \
         --replace "env = Environment(" "env = Environment(ENV = os.environ,"
+   '' + lib.optionalString (versionAtLeast version "4.4" && versionOlder version "4.6") ''
+    # Fix debug gcc 11 and clang 12 builds on Fedora
+    # https://github.com/mongodb/mongo/commit/e78b2bf6eaa0c43bd76dbb841add167b443d2bb0.patch
+    substituteInPlace src/mongo/db/query/plan_summary_stats.h --replace '#include <string>' '#include <optional>
+    #include <string>'
+    substituteInPlace src/mongo/db/exec/plan_stats.h --replace '#include <string>' '#include <optional>
+    #include <string>'
   '' + lib.optionalString stdenv.isDarwin ''
     substituteInPlace src/third_party/mozjs-${variants.mozjsVersion}/extract/js/src/jsmath.cpp --replace '${variants.mozjsReplace}' 0
   '' + lib.optionalString (stdenv.isDarwin && versionOlder version "3.6") ''

--- a/pkgs/servers/nosql/mongodb/v3_6.nix
+++ b/pkgs/servers/nosql/mongodb/v3_6.nix
@@ -13,7 +13,6 @@ in buildMongoDB {
   sha256 = "sha256-EJpIerW4zcGJvHfqJ65fG8yNsLRlUnRkvYfC+jkoFJ4=";
   patches = [ ./forget-build-dependencies.patch ]
     ++ lib.optionals stdenv.isDarwin [
-      ./asio-no-experimental-string-view.patch
       (fetchpatch {
         name = "fix double link of isNamedError.";
         url = "https://github.com/mongodb/mongo/commit/9c6751b9765d269b667324bb2efe1ca76a916d20.patch";

--- a/pkgs/servers/nosql/mongodb/v3_6.nix
+++ b/pkgs/servers/nosql/mongodb/v3_6.nix
@@ -1,4 +1,4 @@
-{ stdenv, callPackage, lib, sasl, boost, Security, CoreFoundation, cctools }:
+{ stdenv, callPackage, fetchpatch, lib, sasl, boost, Security, CoreFoundation, cctools }:
 
 let
   buildMongoDB = callPackage ./mongodb.nix {
@@ -12,5 +12,12 @@ in buildMongoDB {
   version = "3.6.23";
   sha256 = "sha256-EJpIerW4zcGJvHfqJ65fG8yNsLRlUnRkvYfC+jkoFJ4=";
   patches = [ ./forget-build-dependencies.patch ]
-    ++ lib.optionals stdenv.isDarwin [ ./asio-no-experimental-string-view.patch ];
+    ++ lib.optionals stdenv.isDarwin [
+      ./asio-no-experimental-string-view.patch
+      (fetchpatch {
+        name = "fix double link of isNamedError.";
+        url = "https://github.com/mongodb/mongo/commit/9c6751b9765d269b667324bb2efe1ca76a916d20.patch";
+        sha256 = "sha256-4mcafqhBh7039ocEI9d/gXWck51X68PqtWtz4dapwwI=";
+       })
+      ];
 }

--- a/pkgs/servers/nosql/mongodb/v4_0.nix
+++ b/pkgs/servers/nosql/mongodb/v4_0.nix
@@ -21,5 +21,12 @@ in buildMongoDB {
       sha256 = "sha256-RvfCP462RG+ZVjcb23DgCuxCdfPl2/UgH8N7FgCghGI=";
     })
   ]
-    ++ lib.optionals stdenv.isDarwin [ ./asio-no-experimental-string-view.patch ];
+    ++ lib.optionals stdenv.isDarwin [
+      ./asio-no-experimental-string-view.patch
+      (fetchpatch {
+        name = "fix double link of isNamedError.";
+        url = "https://github.com/mongodb/mongo/commit/9c6751b9765d269b667324bb2efe1ca76a916d20.patch";
+        sha256 = "sha256-4mcafqhBh7039ocEI9d/gXWck51X68PqtWtz4dapwwI=";
+       })
+    ];
 }

--- a/pkgs/servers/nosql/mongodb/v4_0.nix
+++ b/pkgs/servers/nosql/mongodb/v4_0.nix
@@ -22,7 +22,6 @@ in buildMongoDB {
     })
   ]
     ++ lib.optionals stdenv.isDarwin [
-      ./asio-no-experimental-string-view.patch
       (fetchpatch {
         name = "fix double link of isNamedError.";
         url = "https://github.com/mongodb/mongo/commit/9c6751b9765d269b667324bb2efe1ca76a916d20.patch";


### PR DESCRIPTION
###### Description of changes

I removed patch on Darwin because in failed with 2 of 2 hunk failed to apply (I haven't checked if they can be adapted because they were already no-op and nobody fixed those. I don't know how to setup `sandbox = true` I added in ~/.config/nix/nix.conf but nix-info still can't find it 🤷‍♂️.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
