### PR TITLE
x-create-mouse-void: init at 0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3744,6 +3744,12 @@
     githubId = 537775;
     name = "Emery Hemingway";
   };
+  eigengrau = {
+    email = "seb@schattenkopie.de";
+    name = "Sebastian Reuße";
+    github = "eigengrau";
+    githubId = 4939947;
+  };
   eikek = {
     email = "eike.kettner@posteo.de";
     github = "eikek";

--- a/pkgs/applications/window-managers/x-create-mouse-void/default.nix
+++ b/pkgs/applications/window-managers/x-create-mouse-void/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, lib, xorg, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "x-create-mouse-void";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "cas--";
+    repo = "XCreateMouseVoid";
+    rev = version;
+    sha256 = "151pv4gmzz9g6nd1xw94hmawlb5z8rgs1jb3x1zpvn3znd7f355c";
+  };
+
+  buildInputs = [ xorg.libX11 ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -pv $out/bin
+    cp -a XCreateMouseVoid $out/bin/x-create-mouse-void
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/cas--/XCreateMouseVoid";
+    description = "Creates an undecorated black window and prevents the mouse from entering that window";
+    platforms = platforms.unix;
+    license = licenses.unfreeRedistributable;
+    maintainers = with maintainers; [ eigengrau ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31703,6 +31703,8 @@ with pkgs;
 
   inherit (xorg) xcompmgr;
 
+  x-create-mouse-void = callPackage ../applications/window-managers/x-create-mouse-void { };
+
   picom = callPackage ../applications/window-managers/picom {};
 
   picom-next = callPackage ../applications/window-managers/picom/picom-next.nix { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

X-Create-Mouse-Void creates an undecorated black window and prevents the mouse from entering that window. This is useful in multi-monitor configurations of Xorg when the monitors have different geometries (e.g., one screen vertical, one horizontal), since it allows constraining the mouse movement to visible parts of the Xorg screen.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
