### PR TITLE
wkhtmltopdf: unbreak on darwin

### DIFF
--- a/pkgs/tools/graphics/wkhtmltopdf/default.nix
+++ b/pkgs/tools/graphics/wkhtmltopdf/default.nix
@@ -1,8 +1,8 @@
-{ mkDerivation, lib, fetchFromGitHub, qtwebkit, qtsvg, qtxmlpatterns
-, fontconfig, freetype, libpng, zlib, libjpeg
+{ stdenv, lib, fetchFromGitHub, qtwebkit, qtsvg, qtxmlpatterns
+, fontconfig, freetype, libpng, zlib, libjpeg, wrapQtAppsHook
 , openssl, libX11, libXext, libXrender }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   version = "0.12.6";
   pname = "wkhtmltopdf";
 
@@ -12,6 +12,10 @@ mkDerivation rec {
     rev    = version;
     sha256 = "0m2zy986kzcpg0g3bvvm815ap9n5ann5f6bdy7pfj6jv482bm5mg";
   };
+
+  nativeBuildInputs = [
+    wrapQtAppsHook
+  ];
 
   buildInputs = [
     fontconfig freetype libpng zlib libjpeg openssl
@@ -23,6 +27,12 @@ mkDerivation rec {
     for f in src/image/image.pro src/pdf/pdf.pro ; do
       substituteInPlace $f --replace '$(INSTALL_ROOT)' ""
     done
+  '';
+
+  # rewrite library path
+  postInstall = lib.optionalString stdenv.isDarwin ''
+    install_name_tool -change libwkhtmltox.0.dylib $out/lib/libwkhtmltox.0.dylib $out/bin/wkhtmltopdf
+    install_name_tool -change libwkhtmltox.0.dylib $out/lib/libwkhtmltox.0.dylib $out/bin/wkhtmltoimage
   '';
 
   configurePhase = "qmake wkhtmltopdf.pro INSTALLBASE=$out";
@@ -42,6 +52,6 @@ mkDerivation rec {
     '';
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ jb55 ];
-    platforms = with platforms; linux;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Unbreak wkhtmltopdf on darwin by changing dylib paths.

Fixes issue #11861.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
