### PR TITLE
cnijfilter2: 6.10 -> 6.40

### DIFF
--- a/pkgs/misc/cups/drivers/cnijfilter2/default.nix
+++ b/pkgs/misc/cups/drivers/cnijfilter2/default.nix
@@ -4,11 +4,11 @@
 stdenv.mkDerivation {
   pname = "cnijfilter2";
 
-  version = "6.10";
+  version = "6.40";
 
   src = fetchzip {
-    url = "https://gdlp01.c-wss.com/gds/1/0100010921/01/cnijfilter2-source-6.10-1.tar.gz";
-    sha256 = "0w121issdjxdv5i9ksa5m23if6pz1r9ql8p894f1pqn16w0kw1ix";
+    url = "https://gdlp01.c-wss.com/gds/1/0100011381/01/cnijfilter2-source-6.40-1.tar.gz";
+    sha256 = "3RoG83jLOsdTEmvUkkxb7wa8oBrJA4v1mGtxTGwSowU=";
   };
 
   nativeBuildInputs = [ automake autoconf ];
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
   # $out/lib/cups/filter/libcnbpcnclapicom2.so
   buildPhase = ''
     mkdir -p $out/lib
-    cp com/libs_bin64/* $out/lib
+    cp com/libs_bin_x86_64/* $out/lib
     mkdir -p $out/lib/cups/filter
     ln -s $out/lib/libcnbpcnclapicom2.so $out/lib/cups/filter
 
@@ -47,6 +47,12 @@ stdenv.mkDerivation {
 
     (
       cd cmdtocanonij2
+      ./autogen.sh --prefix=$out
+      make
+    )
+
+    (
+      cd cmdtocanonij3
       ./autogen.sh --prefix=$out
       make
     )
@@ -87,6 +93,11 @@ stdenv.mkDerivation {
 
     (
       cd cmdtocanonij2
+      make install
+    )
+
+    (
+      cd cmdtocanonij3
       make install
     )
 

--- a/pkgs/misc/cups/drivers/cnijfilter2/default.nix
+++ b/pkgs/misc/cups/drivers/cnijfilter2/default.nix
@@ -16,6 +16,10 @@ stdenv.mkDerivation {
     cups glib libxml2 libusb1 libtool
   ];
 
+  patches = [
+    ./patches/get_protocol.patch
+  ];
+
   # lgmon3's --enable-libdir flag is used soley for specifying in which
   # directory the cnnnet.ini cache file should reside.
   # NixOS uses /var/cache/cups, and given the name, it seems like a reasonable

--- a/pkgs/misc/cups/drivers/cnijfilter2/patches/get_protocol.patch
+++ b/pkgs/misc/cups/drivers/cnijfilter2/patches/get_protocol.patch
@@ -1,0 +1,14 @@
+# Resolves the compilation issue reported at https://github.com/NixOS/nixpkgs/pull/180681#issuecomment-1192304711
+# An identical issue was previously reported in Gentoo: https://bugs.gentoo.org/723186
+# This patch is taken from the solution of Alfredo Tupone (https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=24688d64544b43f2c14be54531ad8764419dde09)
+--- a/lgmon3/src/cnijlgmon3.c	2022-07-22 12:44:32.194641628 +0100
++++ b/lgmon3/src/cnijlgmon3.c	2022-07-22 12:43:53.954817724 +0100
+@@ -55,7 +55,7 @@
+ int (*GET_STATUS)(char *, int, int *, int * , char *);
+ int (*GET_STATUS2)(char *, int, char *, int *, int * , char *, char *);
+ int (*GET_STATUS2_MAINTENANCE)(char *, int, char *, int *, int * , char *, char *);
+-int (*GET_PROTOCOL)(char *, size_t);
++static int (*GET_PROTOCOL)(char *, size_t);
+ 
+ 
+  int main(int argc, char *argv[])


### PR DESCRIPTION
###### Description of changes

Update cnijfilter2 to the latest 6.40 package to support newer printers. Canon have added a new binary and renamed a folder, but no changes are breaking.

I've tested this package on my Canon Pixma G650 (which requires >=6.30) and all seems to be working well.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
