### PR TITLE
rbfeeder: init at 1.0.8

### DIFF
--- a/pkgs/applications/radio/rbfeeder/default.nix
+++ b/pkgs/applications/radio/rbfeeder/default.nix
@@ -1,0 +1,71 @@
+{ lib, stdenv
+, fetchFromGitHub
+, pkg-config
+, curl
+, glib
+, jansson
+, ncurses
+, protobuf
+, protobufc
+, hackrf
+, libbladeRF
+, libusb1
+, rtl-sdr
+, limesuite
+, DarwinTools
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rbfeeder";
+  version = "1.0.8";
+
+  src = fetchFromGitHub {
+    owner = "airnavsystems";
+    repo = pname;
+    rev = "17a5f65da1b9ca1a01c636eb728ea6db9010b708";
+    sha256 = "sha256-kvgS9d9nCnsuY21WvJyW/GmgPZsU8tuySNaBLP7yQZs=";
+  };
+
+  nativeBuildInputs = [ pkg-config protobufc ] ++ lib.optionals stdenv.isDarwin [ DarwinTools ];
+
+  buildInputs = [
+    curl
+    glib
+    jansson
+    ncurses
+    protobuf
+    hackrf
+    libbladeRF
+    libusb1
+    rtl-sdr
+  ] ++ lib.optional stdenv.isLinux limesuite;
+
+  doCheck = true;
+
+  # make wildcard expansion doesn't seem to notice the
+  # 'rbfeeder.pb-c.c' file generated in 'proto'
+  # so we need to use two make runs
+  preBuild = ''
+    make proto
+  '';
+
+  buildFlags = [ "rbfeeder" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp -v rbfeeder $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "ADS-B client software used by AirNav to decode Mode S messages and send to their processing servers";
+    homepage = "https://github.com/airnavsystems/rbfeeder";
+    license = licenses.gpl2Plus;
+    platforms = platforms.unix;
+    broken = stdenv.isDarwin;
+    maintainers = with maintainers; [ snicket2100 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10015,6 +10015,10 @@ with pkgs;
 
   ratt = callPackage ../applications/misc/ratt { };
 
+  rbfeeder = callPackage ../applications/radio/rbfeeder {
+    inherit (darwin) DarwinTools;
+  };
+
   rc = callPackage ../shells/rc { };
 
   rcon = callPackage ../tools/networking/rcon { };


### PR DESCRIPTION
###### Description of changes

`rbfeeder` is a client for providing ADS-B data to radarbox.com (operated by AirNav). https://github.com/airnavsystems/rbfeeder

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
