### PR TITLE
homeassistant: 2022.7.0 -> 2022.7.2

### DIFF
--- a/pkgs/development/python-modules/aioskybell/default.nix
+++ b/pkgs/development/python-modules/aioskybell/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "aioskybell";
-  version = "22.6.1";
+  version = "22.7.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.9";
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "tkdrob";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-VaG8r4ULbjI7LkIPCit3bILZgOi9k7ddRQXwVzplaCM=";
+    hash = "sha256-aBT1fDFtq1vasTvCnAXKV2vmZ6LBLZqRCiepv1HDJ+Q=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/atomicwrites-homeassistant/default.nix
+++ b/pkgs/development/python-modules/atomicwrites-homeassistant/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+}:
+
+let
+  pname = "atomicwrites-homeassistant";
+  version = "1.4.1";
+in
+
+buildPythonPackage {
+  inherit pname version;
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-JWpnIQbxZ0VEUijZZiQLd7VfRqCW0gMFkBpXql0fTC8=";
+  };
+
+  pythonImportsCheck = [
+    "atomicwrites"
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Atomic file writes";
+    homepage = "https://pypi.org/project/atomicwrites-homeassistant/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/development/python-modules/elkm1-lib/default.nix
+++ b/pkgs/development/python-modules/elkm1-lib/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "elkm1-lib";
-  version = "2.0.0";
+  version = "2.0.2";
   format = "pyproject";
 
   disabled = pythonOlder "3.9";
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "gwww";
     repo = "elkm1";
     rev = version;
-    hash = "sha256-o0RQgAP38W7paVJonrfj54y2OhMmTihT9xiipEyNVaM=";
+    hash = "sha256-2UneQL8LT/zm0iusKay9SxeJClGrDi6yL0lRA8ugUms=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/hass-nabucasa/default.nix
+++ b/pkgs/development/python-modules/hass-nabucasa/default.nix
@@ -2,7 +2,7 @@
 , acme
 , aiohttp
 , asynctest
-, atomicwrites
+, atomicwrites-homeassistant
 , attrs
 , buildPythonPackage
 , fetchFromGitHub
@@ -15,13 +15,13 @@
 
 buildPythonPackage rec {
   pname = "hass-nabucasa";
-  version = "0.54.0";
+  version = "0.54.1";
 
   src = fetchFromGitHub {
     owner = "nabucasa";
     repo = pname;
     rev = version;
-    sha256 = "sha256-UL7HPmii65p+WO22y0qv8zq3yICKarRORqE+FK1u7OE=";
+    sha256 = "sha256-usxyONJZQOfLWtfuGUOOHL/Js2ROo7nODqgw++LgTis=";
   };
 
   postPatch = ''
@@ -35,7 +35,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     acme
     aiohttp
-    atomicwrites
+    atomicwrites-homeassistant
     attrs
     pycognito
     snitun

--- a/pkgs/development/python-modules/pydeconz/default.nix
+++ b/pkgs/development/python-modules/pydeconz/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "pydeconz";
-  version = "96";
+  version = "97";
   format = "setuptools";
 
   disabled = pythonOlder "3.9";
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "Kane610";
     repo = "deconz";
     rev = "refs/tags/v${version}";
-    hash = "sha256-6W8GPsIvFlbgXkkN5tJEXyGKsjLfdJzgP8VS07lYZn4=";
+    hash = "sha256-amocjnusTYXkAx1XN+qiMQUQBs97bqVK0wnqy5cIZ9E=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/regenmaschine/default.nix
+++ b/pkgs/development/python-modules/regenmaschine/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "regenmaschine";
-  version = "2022.06.1";
+  version = "2022.07.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "bachya";
     repo = pname;
     rev = "refs/tags/${version}";
-    sha256 = "sha256-Q29e2f/6r0QFN5EPL8Gs1Z4CcvKXrZaYcEMgCJ9uuW8=";
+    sha256 = "sha256-zUef2AMC+vNINUi78xv3rSfBJ9peG7dlDVVmn+WFAsk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2022.7.1";
+  version = "2022.7.2";
   components = {
     "abode" = ps: with ps; [
       abodepy

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2022.7.0";
+  version = "2022.7.1";
   components = {
     "abode" = ps: with ps; [
       abodepy

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -190,7 +190,7 @@ let
   extraPackagesFile = writeText "home-assistant-packages" (lib.concatMapStringsSep "\n" (pkg: pkg.pname) extraBuildInputs);
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "2022.7.1";
+  hassVersion = "2022.7.2";
 
 in python.pkgs.buildPythonApplication rec {
   pname = "homeassistant";
@@ -208,7 +208,7 @@ in python.pkgs.buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = version;
-    hash = "sha256-p5Ht8poSUqaK3pluRuwmyk/tphihYI0H3XNu8YI06R4=";
+    hash = "sha256-POOt5SjDa9jnBqxhD0LUopfAmZ9lpnb7mj7SSVoqTr0=";
   };
 
   # leave this in, so users don't have to constantly update their downstream patch handling
@@ -245,7 +245,7 @@ in python.pkgs.buildPythonApplication rec {
     aiohttp
     astral
     async-timeout
-    atomicwrites
+    atomicwrites-homeassistant
     attrs
     awesomeversion
     bcrypt

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -190,7 +190,7 @@ let
   extraPackagesFile = writeText "home-assistant-packages" (lib.concatMapStringsSep "\n" (pkg: pkg.pname) extraBuildInputs);
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "2022.7.0";
+  hassVersion = "2022.7.1";
 
 in python.pkgs.buildPythonApplication rec {
   pname = "homeassistant";
@@ -208,7 +208,7 @@ in python.pkgs.buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = version;
-    hash = "sha256-DDRut+3wJutXcQVOf2KU+XuHs5XuKkd5R7dQIXwOIrU=";
+    hash = "sha256-p5Ht8poSUqaK3pluRuwmyk/tphihYI0H3XNu8YI06R4=";
   };
 
   # leave this in, so users don't have to constantly update their downstream patch handling

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -4,7 +4,7 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20220706.0";
+  version = "20220707.0";
   format = "wheel";
 
   src = fetchPypi {
@@ -12,7 +12,7 @@ buildPythonPackage rec {
     pname = "home_assistant_frontend";
     dist = "py3";
     python = "py3";
-    sha256 = "sha256-hTdfe+S9D6Grtku5AkRJpCNBvYv2JspSPmXRHHfEPrA=";
+    sha256 = "sha256-ZNaa+YyY77b8Pg462tVewUe+K7ePTflESjZ+ar1cFc4=";
   };
 
   # there is nothing to strip in this package

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -771,6 +771,8 @@ in {
 
   atomicwrites = callPackage ../development/python-modules/atomicwrites { };
 
+  atomicwrites-homeassistant = callPackage ../development/python-modules/atomicwrites-homeassistant { };
+
   atomman = callPackage ../development/python-modules/atomman { };
 
   atpublic = callPackage ../development/python-modules/atpublic { };


### PR DESCRIPTION
###### Description of changes

https://github.com/home-assistant/core/releases/tag/2022.7.1

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
