### PR TITLE
lib/types: better error when trying to order submodules and optionTypes

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -580,7 +580,8 @@ rec {
         else let
           # Prepares the type definitions for mergeOptionDecls, which
           # annotates submodules types with file locations
-          optionModules = map ({ value, file }:
+          optionModules = map ({ value, file, priority ? null }@args:
+            lib.throwIf (args ? priority) "optionType definitions cannot be ordered"
             {
               _file = file;
               # There's no way to merge types directly from the module system,
@@ -605,10 +606,12 @@ rec {
       let
         inherit (lib.modules) evalModules;
 
-        allModules = defs: map ({ value, file }:
-          if isAttrs value && shorthandOnlyDefinesConfig
-          then { _file = file; config = value; }
-          else { _file = file; imports = [ value ]; }
+        allModules = defs: map ({ value, file, priority ? null }@args:
+          lib.throwIf (args ? priority) "submodule definitions cannot be ordered" (
+            if isAttrs value && shorthandOnlyDefinesConfig
+            then { _file = file; config = value; }
+            else { _file = file; imports = [ value ]; }
+          )
         ) defs;
 
         base = evalModules {


### PR DESCRIPTION
The following contrived example:

```nix
with lib; (evalModules {
  modules = [ {
    options.foo = mkOption {
      type = types.submodule { };
    };
    config.foo = mkBefore { };
  } ];
}).config.foo
```

currently fails with `error: anonymous function at nixpkgs/lib/types.nix:608:33 called with unexpected argument 'priority'`.

This is because `sortProperties` adds a `priority` attribute to `mkOrder`ed definitions for sorting purposes, but some consumers (here the `submodule` `merge` function) only expect `value` and `file` attributes.

While there is usually no reason to use ordering on submodule definitions, there is no reason it should fail either.

The other solution would be to discard the `priority` after `sortProperties` is done sorting, but I think it's more future-proof to allow definition values to come with arbitrary metadata.