### PR TITLE
ocamlPackages.happy-eyeballs: 0.1.3 -> 0.3.0

### DIFF
--- a/pkgs/development/ocaml-modules/happy-eyeballs/default.nix
+++ b/pkgs/development/ocaml-modules/happy-eyeballs/default.nix
@@ -4,14 +4,16 @@
 
 buildDunePackage rec {
   pname = "happy-eyeballs";
-  version = "0.1.3";
+  version = "0.3.0";
 
   minimalOCamlVersion = "4.08";
 
   src = fetchurl {
     url = "https://github.com/roburio/happy-eyeballs/releases/download/v${version}/happy-eyeballs-${version}.tbz";
-    sha256 = "sha256:0ns1bxcmx0rkq4am6vl2aargdzkfhria8sfmgnh8dgzvvj93cc1c";
+    sha256 = "17mnid1gvq1ml1zmqzn0m6jmrqw4kqdrjqrdsrphl5kxxyhs03m6";
   };
+
+  strictDeps = true;
 
   propagatedBuildInputs = [
     domain-name
@@ -25,6 +27,6 @@ buildDunePackage rec {
     description = "Connecting to a remote host via IP version 4 or 6";
     homepage = "https://github.com/roburio/happy-eyeballs";
     license = lib.licenses.isc;
-    maintainers = [ lib.maintainers.vbgl ];
+    maintainers = with lib.maintainers; [ vbgl ulrikstrid ];
   };
 }

--- a/pkgs/development/ocaml-modules/happy-eyeballs/lwt.nix
+++ b/pkgs/development/ocaml-modules/happy-eyeballs/lwt.nix
@@ -2,15 +2,32 @@
 , happy-eyeballs
 , cmdliner
 , dns-client
+, duration
+, domain-name
+, ipaddr
+, fmt
 , logs
 , lwt
+, mtime
 }:
 
 buildDunePackage {
   pname = "happy-eyeballs-lwt";
+
   inherit (happy-eyeballs) src version;
 
-  buildInputs = [ cmdliner ];
+  minimalOCamlVersion = "4.08";
+
+  strictDeps = true;
+
+  buildInputs = [
+    cmdliner
+    duration
+    domain-name
+    ipaddr
+    fmt
+    mtime
+  ];
 
   propagatedBuildInputs = [
     dns-client
@@ -19,8 +36,10 @@ buildDunePackage {
     lwt
   ];
 
+  doCheck = true;
+
   meta = happy-eyeballs.meta // {
+    mainProgram = "happy_eyeballs_client";
     description = "Connecting to a remote host via IP version 4 or 6 using Lwt_unix";
   };
-
 }

--- a/pkgs/development/ocaml-modules/happy-eyeballs/mirage.nix
+++ b/pkgs/development/ocaml-modules/happy-eyeballs/mirage.nix
@@ -1,14 +1,36 @@
 { buildDunePackage
 , happy-eyeballs
+, duration
 , dns-client
+, domain-name
+, ipaddr
+, fmt
 , logs
 , lwt
+, mirage-clock
+, mirage-random
+, mirage-time
 , tcpip
 }:
 
 buildDunePackage {
   pname = "happy-eyeballs-mirage";
+
   inherit (happy-eyeballs) src version;
+
+  minimalOCamlVersion = "4.08";
+
+  strictDeps = true;
+
+  buildInputs = [
+    duration
+    ipaddr
+    domain-name
+    fmt
+    mirage-clock
+    mirage-random
+    mirage-time
+  ];
 
   propagatedBuildInputs = [
     dns-client
@@ -18,8 +40,9 @@ buildDunePackage {
     tcpip
   ];
 
+  doCheck = true;
+
   meta = happy-eyeballs.meta // {
     description = "Connecting to a remote host via IP version 4 or 6 using Mirage";
   };
-
 }


### PR DESCRIPTION
###### Description of changes

Update happy-eyeballs and add lwt and mirage packages

Needs https://github.com/NixOS/nixpkgs/pull/192256

Fixes #184393

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->