### PR TITLE
ocamlPackages.mimic: 0.0.4 -> 0.0.5

### DIFF
--- a/pkgs/development/ocaml-modules/mimic/default.nix
+++ b/pkgs/development/ocaml-modules/mimic/default.nix
@@ -5,13 +5,13 @@
 
 buildDunePackage rec {
   pname = "mimic";
-  version = "0.0.4";
+  version = "0.0.5";
 
   minimalOCamlVersion = "4.08";
 
   src = fetchurl {
     url = "https://github.com/dinosaure/mimic/releases/download/${version}/mimic-${version}.tbz";
-    sha256 = "sha256-1Wb2xufgGKp3FJ+FYjK45i9B5+HohdPX+w9Sw0ph5JY=";
+    sha256 = "sha256-3qFjttVLgXKHOsr71550z7aVBcHPYzwdFeMpwHgWPa0=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/mimic/happy-eyeballs.nix
+++ b/pkgs/development/ocaml-modules/mimic/happy-eyeballs.nix
@@ -1,0 +1,23 @@
+{ lib, buildDunePackage, mimic, happy-eyeballs-mirage }:
+
+buildDunePackage {
+  pname = "mimic-happy-eyeballs";
+
+  inherit (mimic) src version;
+
+  minimalOCamlVersion = "4.08";
+
+  strictDeps = true;
+
+  buildInputs = [
+    mimic
+    happy-eyeballs-mirage
+  ];
+  doCheck = false;
+
+  meta = {
+    description = "A happy-eyeballs integration into mimic";
+    maintainers = [ lib.maintainers.ulrikstrid ];
+    inherit (mimic.meta) license homepage;
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -836,6 +836,8 @@ let
 
     mimic = callPackage ../development/ocaml-modules/mimic { };
 
+    mimic-happy-eyeballs = callPackage ../development/ocaml-modules/mimic/happy-eyeballs.nix { };
+
     minisat = callPackage ../development/ocaml-modules/minisat { };
 
     mirage = callPackage ../development/ocaml-modules/mirage { };


### PR DESCRIPTION
###### Description of changes

Updates mimic library and adds mimic-happy-eyeballs

Depends on #180724

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
