### PR TITLE
sonic-pi: 3.3.1 -> 4.0.3

### DIFF
--- a/pkgs/applications/audio/sonic-pi/default.nix
+++ b/pkgs/applications/audio/sonic-pi/default.nix
@@ -1,115 +1,185 @@
-{ mkDerivation
+{ stdenv
 , lib
-, qtbase
 , fetchFromGitHub
-, ruby
-, erlang
-, aubio
-, alsa-lib
-, rtmidi
-, libsndfile
+, wrapQtAppsHook
+, makeDesktopItem
+, copyDesktopItems
 , cmake
 , pkg-config
+, catch2_3
+, qtbase
+, qtsvg
+, qttools
+, qwt
+, qscintilla
+, kissfftFloat
+, crossguid
+, reproc
+, platform-folders
+, ruby
+, erlang
+, elixir
+, beamPackages
+, alsa-lib
+, rtmidi
 , boost
-, bash
+, aubio
 , jack2
 , supercollider-with-sc3-plugins
-, qwt
+, parallel
+
+, withTauWidget ? false
+, qtwebengine
+
+, withImGui ? false
+, gl3w
+, SDL2
+, fmt
 }:
 
-let
+stdenv.mkDerivation rec {
   pname = "sonic-pi";
-  version = "3.3.1";
+  version = "4.0.3";
+
   src = fetchFromGitHub {
     owner = "sonic-pi-net";
-    repo = "sonic-pi";
+    repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-AE7iuSNnW1SAtBMplReGzXKcqD4GG23i10MIAWnlcPo=";
+    hash = "sha256-kTuW+i/kdPhyG3L6SkgQTE9UvADY49KahJcw3+5Uz4k=";
   };
 
-  # sonic pi uses it's own aubioonset with hardcoded parameters but will compile a whole aubio for it
-  # let's just build the aubioonset instead and link against aubio from nixpkgs
-  aubioonset = mkDerivation {
-    name = "aubioonset";
-    src = src;
-    sourceRoot = "source/app/external/aubio/examples";
-    buildInputs = [jack2 aubio libsndfile];
-    patchPhase = ''
-      sed -i "s@<aubio.h>@<aubio/aubio.h>@" jackio.c utils.h
-    '';
-    buildPhase = ''
-      gcc -o aubioonset -laubio jackio.c utils.c aubioonset.c
-    '';
-    installPhase = ''
-      install -D aubioonset $out/aubioonset
-    '';
+  mixFodDeps = beamPackages.fetchMixDeps {
+    inherit version;
+    pname = "mix-deps-${pname}";
+    mixEnv = "test";
+    src = "${src}/app/server/beam/tau";
+    sha256 = "sha256-MvwUyVTS23vQKLpGxz46tEVCs/OyYk5dDaBlv+kYg1M=";
   };
 
-in
+  strictDeps = true;
 
-mkDerivation rec {
-  inherit pname version src;
+  nativeBuildInputs = [
+    wrapQtAppsHook
+    copyDesktopItems
 
-  nativeBuildInputs = [ cmake ];
-  buildInputs = [
-    bash
+    cmake
     pkg-config
-    qtbase
-    qwt
-    ruby
-    aubio
-    supercollider-with-sc3-plugins
-    boost
+
     erlang
-    alsa-lib
-    rtmidi
+    elixir
+    beamPackages.hex
   ];
 
-  dontUseCmakeConfigure = true;
+  buildInputs = [
+    qtbase
+    qtsvg
+    qttools
+    qwt
+    qscintilla
+    kissfftFloat
+    catch2_3
+    crossguid
+    reproc
+    platform-folders
+    ruby
+    alsa-lib
+    rtmidi
+    boost
+    aubio
+  ] ++ lib.optionals withTauWidget [
+    qtwebengine
+  ] ++ lib.optionals withImGui [
+    gl3w
+    SDL2
+    fmt
+  ];
 
-  prePatch = ''
-    sed -i '/aubio/d' app/external/linux_build_externals.sh
-    sed -i '/aubio/d' app/linux-prebuild.sh
-    patchShebangs app
+  checkInputs = [
+    parallel
+    ruby
+    supercollider-with-sc3-plugins
+    jack2
+  ];
+
+  cmakeFlags = [
+    "-DUSE_SYSTEM_LIBS=ON"
+    "-DBUILD_IMGUI_INTERFACE=${if withImGui then "ON" else "OFF"}"
+    "-DWITH_QT_GUI_WEBENGINE=${if withTauWidget then "ON" else "OFF"}"
+  ];
+
+  doCheck = true;
+
+  postPatch = ''
+    # Fix shebangs on files in app and bin scripts
+    patchShebangs app bin
   '';
 
-  configurePhase = ''
-    runHook preConfigure
+  preConfigure = ''
+    # Set build environment
+    export SONIC_PI_HOME="$TMPDIR/spi"
 
-    ./app/linux-prebuild.sh
-    ./app/linux-config.sh
+    export HEX_HOME="$TEMPDIR/hex"
+    export HEX_OFFLINE=1
+    export MIX_REBAR3='${beamPackages.rebar3}/bin/rebar3'
+    export REBAR_GLOBAL_CONFIG_DIR="$TEMPDIR/rebar3"
+    export REBAR_CACHE_DIR="$TEMPDIR/rebar3.cache"
+    export MIX_HOME="$TEMPDIR/mix"
+    export MIX_DEPS_PATH="$TEMPDIR/deps"
+    export MIX_ENV=prod
 
-    runHook postConfigure
+    # Copy Mix dependency sources
+    echo 'Copying ${mixFodDeps} to Mix deps'
+    cp --no-preserve=mode -R '${mixFodDeps}' "$MIX_DEPS_PATH"
+
+    # Change to project base directory
+    cd app
+
+    # Prebuild Ruby vendored dependencies and Qt docs
+    ./linux-prebuild.sh -o
+
+    # Append CMake flag depending on the value of $out
+    cmakeFlags+=" -DAPP_INSTALL_ROOT=$out/app"
   '';
 
-  buildPhase = ''
-    runHook preBuild
+  postBuild = ''
+    # Build BEAM server
+    ../linux-post-tau-prod-release.sh -o
+  '';
 
-    pushd app/build
-    cmake --build . --config Release
+  checkPhase = ''
+    runHook preCheck
+
+    # BEAM tests
+    pushd ../server/beam/tau
+      MIX_ENV=test TAU_ENV=test mix test
     popd
 
-    runHook postBuild
+    # Ruby tests
+    pushd ../server/ruby
+      rake test
+    popd
+
+    # API tests
+    pushd api-tests
+      # run JACK parallel to tests and quit both when one exits
+      SONIC_PI_ENV=test parallel --no-notice -j2 --halt now,done=1 ::: 'jackd -rd dummy' 'ctest --verbose'
+    popd
+
+    runHook postCheck
   '';
 
   installPhase = ''
     runHook preInstall
 
+    # Run Linux release script
+    ../linux-release.sh
+
+    # Copy dist directory to output
     mkdir $out
-    cp -r {bin,etc} $out/
+    cp -r linux_dist/* $out/
 
-    # Copy server whole.
-    mkdir -p $out/app
-    cp -r app/server $out/app/
-
-    # We didn't build this during linux-prebuild.sh so copy from the separate derivation
-    cp ${aubioonset}/aubioonset $out/app/server/native/
-
-    # Copy only necessary files for the gui app.
-    mkdir -p $out/app/gui/qt
-    cp -r app/gui/qt/{book,fonts,help,html,images,image_source,info,lang,theme} $out/app/gui/qt/
-    mkdir -p $out/app/build/gui/qt
-    cp app/build/gui/qt/sonic-pi $out/app/build/gui/qt/sonic-pi
+    # Copy icon
+    install -Dm644 ../gui/qt/images/icon-smaller.png $out/share/icons/hicolor/256x256/apps/sonic-pi.png
 
     runHook postInstall
   '';
@@ -117,19 +187,42 @@ mkDerivation rec {
   # $out/bin/sonic-pi is a shell script, and wrapQtAppsHook doesn't wrap them.
   dontWrapQtApps = true;
   preFixup = ''
-    wrapQtApp "$out/bin/sonic-pi" \
-      --prefix PATH : ${lib.makeBinPath [ bash jack2 ruby supercollider-with-sc3-plugins erlang] }
-    makeWrapper \
-      $out/app/server/ruby/bin/sonic-pi-server.rb \
-      $out/bin/sonic-pi-server \
-      --prefix PATH : ${lib.makeBinPath [ bash jack2 ruby supercollider-with-sc3-plugins erlang ] }
+    # Wrap Qt GUI (distributed binary)
+    wrapQtApp $out/bin/sonic-pi \
+      --prefix PATH : ${lib.makeBinPath [ ruby supercollider-with-sc3-plugins jack2 ]}
+
+    # If ImGui was built
+    if [ -e $out/app/build/gui/imgui/sonic-pi-imgui ]; then
+      # Wrap ImGui into bin
+      makeWrapper $out/app/build/gui/imgui/sonic-pi-imgui $out/bin/sonic-pi-imgui \
+        --inherit-argv0 \
+        --prefix PATH : ${lib.makeBinPath [ ruby supercollider-with-sc3-plugins jack2 ]}
+    fi
+
+    # Remove runtime Erlang references
+    for file in $(grep -FrIl '${erlang}/lib/erlang' $out/app/server/beam/tau); do
+      substituteInPlace "$file" --replace '${erlang}/lib/erlang' $out/app/server/beam/tau/_build/prod/rel/tau
+    done
   '';
 
-  meta = {
+  stripDebugList = [ "app" "bin" ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "sonic-pi";
+      exec = "sonic-pi";
+      icon = "sonic-pi";
+      desktopName = "Sonic Pi";
+      comment = meta.description;
+      categories = [ "Audio" "AudioVideo" "Education" ];
+    })
+  ];
+
+  meta = with lib; {
     homepage = "https://sonic-pi.net/";
     description = "Free live coding synth for everyone originally designed to support computing and music lessons within schools";
-    license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ Phlogistique kamilchm c0deaddict sohalt lilyinstarlight ];
-    platforms = lib.platforms.linux;
+    license = licenses.mit;
+    maintainers = with maintainers; [ Phlogistique kamilchm c0deaddict sohalt lilyinstarlight ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/crossguid/default.nix
+++ b/pkgs/development/libraries/crossguid/default.nix
@@ -1,0 +1,24 @@
+{ lib, stdenv, fetchFromGitHub, cmake, libuuid }:
+
+stdenv.mkDerivation rec {
+  pname = "crossguid";
+  version = "unstable-2019-05-29";
+
+  src = fetchFromGitHub {
+    owner = "graeme-hill";
+    repo = pname;
+    rev = "ca1bf4b810e2d188d04cb6286f957008ee1b7681";
+    hash = "sha256-37tKPDo4lukl/aaDWWSQYfsBNEnDjE7t6OnEZjBhcvQ=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = lib.optional stdenv.isLinux libuuid;
+
+  meta = with lib; {
+    description = "Lightweight cross platform C++ GUID/UUID library";
+    license = licenses.mit;
+    homepage = "https://github.com/graeme-hill/crossguid";
+    maintainers = with maintainers; [ lilyinstarlight ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/gl3w/default.nix
+++ b/pkgs/development/libraries/gl3w/default.nix
@@ -1,0 +1,37 @@
+{ lib, stdenv, fetchFromGitHub, python3, cmake, libglvnd, libGLU }:
+
+stdenv.mkDerivation rec {
+  pname = "gl3w";
+  version = "unstable-2022-03-24";
+
+  src = fetchFromGitHub {
+    owner = "skaslev";
+    repo = pname;
+    rev = "5f8d7fd191ba22ff2b60c1106d7135bb9a335533";
+    hash = "sha256-qV/PZmaP5iCHhIzTA2bE4d1RMB6LzRbTsB5gWVvi9bU=";
+  };
+
+  nativeBuildInputs = [ python3 cmake ];
+  # gl3w installs a CMake config that when included expects to be able to
+  # build and link against both of these libraries
+  # (the gl3w generated C file gets compiled into the downstream target)
+  propagatedBuildInputs = [ libglvnd libGLU ];
+
+  dontUseCmakeBuildDir = true;
+
+  # These files must be copied rather than linked since they are considered
+  # outputs for the custom command, and CMake expects to be able to touch them
+  preConfigure = ''
+    mkdir -p include/{GL,KHR}
+    cp ${libglvnd.dev}/include/GL/glcorearb.h include/GL/glcorearb.h
+    cp ${libglvnd.dev}/include/KHR/khrplatform.h include/KHR/khrplatform.h
+  '';
+
+  meta = with lib; {
+    description = "Simple OpenGL core profile loading";
+    homepage = "https://github.com/skaslev/gl3w";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ lilyinstarlight ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/platform-folders/default.nix
+++ b/pkgs/development/libraries/platform-folders/default.nix
@@ -1,0 +1,27 @@
+{ lib, stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "platform-folders";
+  version = "4.2.0";
+
+  src = fetchFromGitHub {
+    owner = "sago007";
+    repo = "PlatformFolders";
+    rev = version;
+    hash = "sha256-ruhAP9kjwm6pIFJ5a6oy6VE5W39bWQO3qSrT5IUtiwA=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=${if stdenv.hostPlatform.isStatic then "OFF" else "ON"}"
+  ];
+
+  meta = with lib; {
+    description = "A C++ library to look for standard platform directories so that you do not need to write platform-specific code";
+    homepage = "https://github.com/sago007/PlatformFolders";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lilyinstarlight ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17887,6 +17887,8 @@ with pkgs;
   # A GMP fork
   mpir = callPackage ../development/libraries/mpir {};
 
+  gl3w = callPackage ../development/libraries/gl3w { };
+
   gnatcoll-core = callPackage ../development/libraries/ada/gnatcoll/core.nix { };
 
   # gnatcoll-bindings repository

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17262,6 +17262,8 @@ with pkgs;
 
   croaring = callPackage ../development/libraries/croaring { };
 
+  crossguid = callPackage ../development/libraries/crossguid { };
+
   cryptopp = callPackage ../development/libraries/crypto++ { };
 
   cryptominisat = callPackage ../applications/science/logic/cryptominisat { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20417,6 +20417,8 @@ with pkgs;
 
   place-cursor-at = haskell.lib.compose.justStaticExecutables haskellPackages.place-cursor-at;
 
+  platform-folders = callPackage ../development/libraries/platform-folders { };
+
   plib = callPackage ../development/libraries/plib { };
 
   poco = callPackage ../development/libraries/poco { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20692,6 +20692,9 @@ with pkgs;
   rtrlib = callPackage ../development/libraries/rtrlib { };
 
   kissfft = callPackage ../development/libraries/kissfft { };
+  kissfftFloat = kissfft.override {
+    datatype = "float";
+  };
 
   lambdabot = callPackage ../development/tools/haskell/lambdabot {
     haskellLib = haskell.lib.compose;


### PR DESCRIPTION
###### Description of changes

This is a big update to the Sonic Pi package incorporating all of the changes I've made for dev versions in my personal overlay over the last year and my work with upstream as part of the core team to make Linux packaging a bit better (though that is still very much a work-in-progress)

Now that v4.0.0's been released, I'm pushing the Nix package I've been using from my personal overlay for v4.0.0 development and all of the dependencies I've had to package as well

Some notes about the changes:

* greatly reduced closure size
  - no more erlang references or dev dependencies
* ~~uses vendored aubio (for now)~~
  - ~~I plan on making an upstream PR to devendor that dependency and will post a PR here to `fetchpatch` it once I've done that~~
  - the aubio patch has been made ~~and is waiting on another upstream PR before the aubio PR will be opened~~
* no more `sonic-pi-server` command
  - this is incompatible with new daemon booter in v4 (sorry @kraem! I'm currently developing a new tool to run Sonic Pi headless that I'll release and package soon)
* desktop file included now
* optional support for imgui interface and tau widget
  - both are more for development purposes at the moment and can be removed from this PR if necessary
* slightly better follows standard build phases
  - unfortunately the Ruby vendored dependecies and qt docs generation need to be built in `preConfigure` since they're one monolithic script and are required before doing `cmake`
  - there is now a check phase which runs the same checks as Sonic Pi's CI
  - the check phase uses GNU parallel to run a temporary JACK server which obviously feels a bit sketchy but I'm not sure how best to ensure it only runs a limited-lifetime JACK server for the test
* added new dependencies
  - there is an existing `libcrossguid` package that needs to be on an old version for Kodi and Sonic Pi needs the new version hence the different name `crossguid`

cc: @c0deaddict @Sohalt @kraem

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### nixpkgs-review

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>5 packages built:</summary>
  <ul>
    <li>crossguid</li>
    <li>gl3w</li>
    <li>kissfftFloat</li>
    <li>platform-folders</li>
    <li>sonic-pi</li>
  </ul>
</details>