### PR TITLE
p4est: fixed versioning

### DIFF
--- a/pkgs/development/libraries/science/math/p4est/default.nix
+++ b/pkgs/development/libraries/science/math/p4est/default.nix
@@ -31,8 +31,10 @@ stdenv.mkDerivation {
   postPatch = ''
     sed -i -e "s:\(^\s*ACLOCAL_AMFLAGS.*\)\s@P4EST_SC_AMFLAGS@\s*$:\1 -I ${p4est-sc}/share/aclocal:" Makefile.am
   '';
-  preConfigure = ''
+  preAutoreconf = ''
     echo "2.8.0" > .tarball-version
+  '';
+  preConfigure = ''
     ${if mpiSupport then "unset CC" else ""}
   '';
 

--- a/pkgs/development/libraries/science/math/p4est/default.nix
+++ b/pkgs/development/libraries/science/math/p4est/default.nix
@@ -1,5 +1,8 @@
-{ lib, stdenv, fetchFromGitHub
-, autoreconfHook, pkg-config
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
 , p4est-withMetis ? true, metis
 , p4est-sc
 }:
@@ -34,8 +37,8 @@ stdenv.mkDerivation {
   preAutoreconf = ''
     echo "2.8.0" > .tarball-version
   '';
-  preConfigure = ''
-    ${if mpiSupport then "unset CC" else ""}
+  preConfigure = lib.optionalString mpiSupport ''
+    unset CC
   '';
 
   configureFlags = p4est-sc.configureFlags


### PR DESCRIPTION
`.tarball_version` generation moved to `autoreconfPhase`: previously it was created during `configurePhase`, i.e. after `build-aux/git-version-gen` was called. It led to `P4EST_VERSION` being `UNKNOWN`, which confused dependent software.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).