### PR TITLE
tintin: restore, 2.02.12 -> 2.02.20, adopt

### DIFF
--- a/pkgs/games/tintin/default.nix
+++ b/pkgs/games/tintin/default.nix
@@ -1,24 +1,21 @@
-{ stdenv, fetchurl, lib, zlib, pcre
+{ stdenv, fetchFromGitHub, lib, zlib, pcre
 , memorymappingHook, memstreamHook
-, tlsSupport ? true, gnutls ? null
-# ^ set { tlsSupport = false; } to reduce closure size by ~= 18.6 MB
+, gnutls
 }:
-
-assert tlsSupport -> gnutls != null;
 
 stdenv.mkDerivation rec {
   pname = "tintin";
-  version = "2.02.12";
+  version = "2.02.20";
 
-  src = fetchurl {
-    url    = "mirror://sourceforge/tintin/tintin-${version}.tar.gz";
-    sha256 = "sha256-tvn9TywefNyM/0Fy16gAFJYbA5Q4DO2RgiCdw014GgA=";
+  src = fetchFromGitHub {
+    owner = "scandum";
+    repo = "tintin";
+    rev = version;
+    hash = "sha256-H9Cjg/GkyV50pgewv77zOJ8/Op78P9sQmZ5LorO4L+A=";
   };
 
-  nativeBuildInputs = lib.optional tlsSupport gnutls.dev;
-  buildInputs = [ zlib pcre ]
-    ++ lib.optionals (stdenv.system == "x86_64-darwin") [ memorymappingHook memstreamHook ]
-    ++ lib.optional tlsSupport gnutls;
+  buildInputs = [ zlib pcre gnutls ]
+    ++ lib.optionals (stdenv.system == "x86_64-darwin") [ memorymappingHook memstreamHook ];
 
   preConfigure = ''
     cd src
@@ -26,9 +23,9 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A free MUD client for macOS, Linux and Windows";
-    homepage    = "http://tintin.sourceforge.net";
-    license     = licenses.gpl2;
-    maintainers = with maintainers; [ lovek323 ];
+    homepage    = "https://tintin.mudhalla.net/index.php";
+    license     = licenses.gpl3Plus;
+    maintainers = with maintainers; [ abathur ];
     mainProgram = "tt++";
     platforms   = platforms.unix;
   };

--- a/pkgs/games/tintin/default.nix
+++ b/pkgs/games/tintin/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl, lib, zlib, pcre
+, memorymappingHook, memstreamHook
+, tlsSupport ? true, gnutls ? null
+# ^ set { tlsSupport = false; } to reduce closure size by ~= 18.6 MB
+}:
+
+assert tlsSupport -> gnutls != null;
+
+stdenv.mkDerivation rec {
+  pname = "tintin";
+  version = "2.02.12";
+
+  src = fetchurl {
+    url    = "mirror://sourceforge/tintin/tintin-${version}.tar.gz";
+    sha256 = "sha256-tvn9TywefNyM/0Fy16gAFJYbA5Q4DO2RgiCdw014GgA=";
+  };
+
+  nativeBuildInputs = lib.optional tlsSupport gnutls.dev;
+  buildInputs = [ zlib pcre ]
+    ++ lib.optionals (stdenv.system == "x86_64-darwin") [ memorymappingHook memstreamHook ]
+    ++ lib.optional tlsSupport gnutls;
+
+  preConfigure = ''
+    cd src
+  '';
+
+  meta = with lib; {
+    description = "A free MUD client for macOS, Linux and Windows";
+    homepage    = "http://tintin.sourceforge.net";
+    license     = licenses.gpl2;
+    maintainers = with maintainers; [ lovek323 ];
+    mainProgram = "tt++";
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33114,7 +33114,7 @@ with pkgs;
 
   tibia = pkgsi686Linux.callPackage ../games/tibia { };
 
-  tintin = throw "tintin has been removed due to lack of maintainers";
+  tintin = callPackage ../games/tintin { };
 
   tinyfugue = callPackage ../games/tinyfugue { };
 


### PR DESCRIPTION
###### Description of changes

- restore tintin, which was removed by maintainer in #170990
- complete the dangling update that was pending in #165797
- adopt the package
- update the homepage (sourceforge redirects to their own site)
- update source to github, which is linked from homepage above

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
