### PR TITLE
[22.05] vim: 8.2.4816 -> 8.2.5172

### DIFF
--- a/pkgs/applications/editors/vim/common.nix
+++ b/pkgs/applications/editors/vim/common.nix
@@ -1,12 +1,12 @@
 { lib, fetchFromGitHub }:
 rec {
-  version = "8.2.4816";
+  version = "8.2.5172";
 
   src = fetchFromGitHub {
     owner = "vim";
     repo = "vim";
     rev = "v${version}";
-    sha256 = "1lgqr3ki50hwkz4vhdyaryirrs99qq4kgkhmpx7ygvn6aj2wapg5";
+    sha256 = "sha256-ycp9K7IpXBFLE9DV9/iQ+N1H7EMD/tP/KGv2VOXoDvE=";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Description of changes

Fixes the following CVEs:
https://nvd.nist.gov/vuln/detail/CVE-2022-1927
https://nvd.nist.gov/vuln/detail/CVE-2022-2207
https://nvd.nist.gov/vuln/detail/CVE-2022-2210
https://nvd.nist.gov/vuln/detail/CVE-2022-2175
https://nvd.nist.gov/vuln/detail/CVE-2022-1616
https://nvd.nist.gov/vuln/detail/CVE-2022-1619
https://nvd.nist.gov/vuln/detail/CVE-2022-1621
https://nvd.nist.gov/vuln/detail/CVE-2022-1629
https://nvd.nist.gov/vuln/detail/CVE-2022-1720
https://nvd.nist.gov/vuln/detail/CVE-2022-1733
https://nvd.nist.gov/vuln/detail/CVE-2022-1735
https://nvd.nist.gov/vuln/detail/CVE-2022-1769
https://nvd.nist.gov/vuln/detail/CVE-2022-1785
https://nvd.nist.gov/vuln/detail/CVE-2022-1796
https://nvd.nist.gov/vuln/detail/CVE-2022-1851
https://nvd.nist.gov/vuln/detail/CVE-2022-1886
https://nvd.nist.gov/vuln/detail/CVE-2022-1898
https://nvd.nist.gov/vuln/detail/CVE-2022-1942
https://nvd.nist.gov/vuln/detail/CVE-2022-2124
https://nvd.nist.gov/vuln/detail/CVE-2022-2125
https://nvd.nist.gov/vuln/detail/CVE-2022-2126
https://nvd.nist.gov/vuln/detail/CVE-2022-2129
https://nvd.nist.gov/vuln/detail/CVE-2022-2182
https://nvd.nist.gov/vuln/detail/CVE-2022-2183
https://nvd.nist.gov/vuln/detail/CVE-2022-2206
https://nvd.nist.gov/vuln/detail/CVE-2022-1620
https://nvd.nist.gov/vuln/detail/CVE-2022-1674
https://nvd.nist.gov/vuln/detail/CVE-2022-1771
https://nvd.nist.gov/vuln/detail/CVE-2022-2208

Changes: https://github.com/vim/vim/compare/v8.2.4816...v8.2.5172

9.0.X exists now, but is not officially released yet. Also, since this is stable, I decided to go with a conservative version bump.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
