### PR TITLE
python310Packages.types-docutils: 0.18.3 -> 0.19.0

### DIFF
--- a/pkgs/development/python-modules/rstcheck-core/default.nix
+++ b/pkgs/development/python-modules/rstcheck-core/default.nix
@@ -1,0 +1,63 @@
+{ lib
+, buildPythonPackage
+, docutils
+, fetchFromGitHub
+, importlib-metadata
+, mock
+, poetry-core
+, pydantic
+, pytest-mock
+, pytestCheckHook
+, pythonOlder
+, types-docutils
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "rstcheck-core";
+  version = "1.0.2";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "rstcheck";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-XNr+prK9VDP66ZaFvh3Qrx+eJs6mnVO8lvoMC/qrCLs=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    docutils
+    importlib-metadata
+    pydantic
+    types-docutils
+    typing-extensions
+  ];
+
+  checkInputs = [
+    mock
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'types-docutils = ">=0.18, <0.19"' 'types-docutils = ">=0.18"'
+  '';
+
+  pythonImportsCheck = [
+    "rstcheck_core"
+  ];
+
+  meta = with lib; {
+    description = "Library for checking syntax of reStructuredText";
+    homepage = "https://github.com/rstcheck/rstcheck-core";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/rstcheck/default.nix
+++ b/pkgs/development/python-modules/rstcheck/default.nix
@@ -1,26 +1,32 @@
 { lib
 , buildPythonPackage
+, colorama
 , docutils
 , fetchFromGitHub
+, importlib-metadata
 , poetry-core
+, pydantic
 , pytestCheckHook
 , pythonOlder
+, rstcheck-core
+, shellingham
+, typer
 , types-docutils
 , typing-extensions
 }:
 
 buildPythonPackage rec {
   pname = "rstcheck";
-  version = "5.0.0";
+  version = "6.0.0.post1";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
-    owner = "myint";
+    owner = "rstcheck";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-vTUa/eP6/flxRLBuzdHoNoPoGAg6XWwu922az8tLgJM=";
+    hash = "sha256-Ljg1cciT9qKL9xtBxQ8OLygDpV/1yR5XiJOzHrLr6xw=";
   };
 
   nativeBuildInputs = [
@@ -28,14 +34,27 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    colorama
     docutils
+    rstcheck-core
+    shellingham
     types-docutils
     typing-extensions
+    pydantic
+    typer
+  ] ++ lib.optionals (pythonOlder "3.8") [
+    typing-extensions
+    importlib-metadata
   ];
 
   checkInputs = [
     pytestCheckHook
   ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'types-docutils = ">=0.18, <0.19"' 'types-docutils = ">=0.18"'
+  '';
 
   pythonImportsCheck = [
     "rstcheck"

--- a/pkgs/development/python-modules/types-docutils/default.nix
+++ b/pkgs/development/python-modules/types-docutils/default.nix
@@ -5,12 +5,12 @@
 
 buildPythonPackage rec {
   pname = "types-docutils";
-  version = "0.18.3";
+  version = "0.19.0";
   format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-oO+DHcIGNfNQ+pz/WRIxwx0n51dx5Z/WyXm2wMfgMpI=";
+    hash = "sha256-lJNrGWGqzaYexrsKzxFpzXgwtSMLZFhVwdR4m68ZaF4=";
   };
 
   # Module doesn't have tests

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9417,6 +9417,8 @@ in {
 
   rstcheck = callPackage ../development/python-modules/rstcheck { };
 
+  rstcheck-core = callPackage ../development/python-modules/rstcheck-core { };
+
   rtmidi-python = callPackage ../development/python-modules/rtmidi-python {
     inherit (pkgs.darwin.apple_sdk.frameworks) CoreAudio CoreMIDI CoreServices;
   };


### PR DESCRIPTION
###### Description of changes
Update to latest upstream release 0.19.0
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
