### PR TITLE
pkgsMusl.gcc12: backport build fix (PR106102)

### DIFF
--- a/pkgs/development/compilers/gcc/12/PR106102-musl-poison-cpp.patch
+++ b/pkgs/development/compilers/gcc/12/PR106102-musl-poison-cpp.patch
@@ -1,0 +1,52 @@
+https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=3b21c21f3f5726823e19728fdd1571a14aae0fb3
+https://gcc.gnu.org/PR106102
+--- a/gcc/cp/mapper-client.cc
++++ b/gcc/cp/mapper-client.cc
+@@ -27,6 +27,7 @@ along with GCC; see the file COPYING3.  If not see
+ #define INCLUDE_STRING
+ #define INCLUDE_VECTOR
+ #define INCLUDE_MAP
++#define INCLUDE_MEMORY
+ #include "system.h"
+ 
+ #include "line-map.h"
+--- a/gcc/cp/mapper-resolver.cc
++++ b/gcc/cp/mapper-resolver.cc
+@@ -25,6 +25,7 @@ along with GCC; see the file COPYING3.  If not see
+ #define INCLUDE_VECTOR
+ #define INCLUDE_ALGORITHM
+ #define INCLUDE_MAP
++#define INCLUDE_MEMORY
+ #include "system.h"
+ 
+ // We don't want or need to be aware of networking
+--- a/gcc/cp/module.cc
++++ b/gcc/cp/module.cc
+@@ -206,6 +206,7 @@ Classes used:
+ 
+ #define _DEFAULT_SOURCE 1 /* To get TZ field of struct tm, if available.  */
+ #include "config.h"
++#define INCLUDE_MEMORY
+ #define INCLUDE_STRING
+ #define INCLUDE_VECTOR
+ #include "system.h"
+--- a/libcc1/libcc1plugin.cc
++++ b/libcc1/libcc1plugin.cc
+@@ -31,6 +31,7 @@
+ #undef PACKAGE_TARNAME
+ #undef PACKAGE_VERSION
+ 
++#define INCLUDE_MEMORY
+ #include "gcc-plugin.h"
+ #include "system.h"
+ #include "coretypes.h"
+--- a/libcc1/libcp1plugin.cc
++++ b/libcc1/libcp1plugin.cc
+@@ -32,6 +32,7 @@
+ #undef PACKAGE_TARNAME
+ #undef PACKAGE_VERSION
+ 
++#define INCLUDE_MEMORY
+ #include "gcc-plugin.h"
+ #include "system.h"
+ #include "coretypes.h"

--- a/pkgs/development/compilers/gcc/12/PR106102-musl-poison-jit.patch
+++ b/pkgs/development/compilers/gcc/12/PR106102-musl-poison-jit.patch
@@ -1,0 +1,67 @@
+https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=49d508065bdd36fb1a9b6aad9666b1edb5e06474
+https://gcc.gnu.org/PR106102
+--- a/gcc/jit/jit-playback.cc
++++ b/gcc/jit/jit-playback.cc
+@@ -19,6 +19,7 @@ along with GCC; see the file COPYING3.  If not see
+ <http://www.gnu.org/licenses/>.  */
+ 
+ #include "config.h"
++#define INCLUDE_PTHREAD_H
+ #include "system.h"
+ #include "coretypes.h"
+ #include "target.h"
+@@ -41,8 +42,6 @@ along with GCC; see the file COPYING3.  If not see
+ #include "diagnostic.h"
+ #include "stmt.h"
+ 
+-#include <pthread.h>
+-
+ #include "jit-playback.h"
+ #include "jit-result.h"
+ #include "jit-builtins.h"
+--- a/gcc/jit/jit-recording.cc
++++ b/gcc/jit/jit-recording.cc
+@@ -19,13 +19,13 @@ along with GCC; see the file COPYING3.  If not see
+ <http://www.gnu.org/licenses/>.  */
+ 
+ #include "config.h"
++#define INCLUDE_PTHREAD_H
+ #include "system.h"
+ #include "coretypes.h"
+ #include "tm.h"
+ #include "pretty-print.h"
+ #include "toplev.h"
+ 
+-#include <pthread.h>
+ 
+ #include "jit-builtins.h"
+ #include "jit-recording.h"
+--- a/gcc/jit/libgccjit.cc
++++ b/gcc/jit/libgccjit.cc
+@@ -19,12 +19,12 @@ along with GCC; see the file COPYING3.  If not see
+ <http://www.gnu.org/licenses/>.  */
+ 
+ #include "config.h"
++#define INCLUDE_PTHREAD_H
+ #include "system.h"
+ #include "coretypes.h"
+ #include "timevar.h"
+ #include "typed-splay-tree.h"
+ #include "cppbuiltin.h"
+-#include <pthread.h>
+ 
+ #include "libgccjit.h"
+ #include "jit-recording.h"
+--- a/gcc/system.h
++++ b/gcc/system.h
+@@ -753,6 +753,10 @@ extern int vsnprintf (char *, size_t, const char *, va_list);
+ #endif
+ #endif
+ 
++#ifdef INCLUDE_PTHREAD_H
++#include <pthread.h>
++#endif
++
+ #ifdef INCLUDE_ISL
+ #ifdef HAVE_isl
+ #include <isl/options.h>

--- a/pkgs/development/compilers/gcc/12/default.nix
+++ b/pkgs/development/compilers/gcc/12/default.nix
@@ -69,6 +69,9 @@ let majorVersion = "12";
         ../gnat-cflags-11.patch
         ../gcc-12-gfortran-driving.patch
         ../ppc-musl.patch
+        # Backports. Should be removed with 12.2.0 release:
+        ./PR106102-musl-poison-cpp.patch
+        ./PR106102-musl-poison-jit.patch
       ] ++ optional (stdenv.isDarwin && stdenv.isAarch64) (fetchpatch {
         url = "https://github.com/fxcoudert/gcc/compare/releases/gcc-11.1.0...gcc-11.1.0-arm-20210504.diff";
         sha256 = "sha256-JqCGJAfbOxSmkNyq49aFHteK/RFsCSLQrL9mzUCnaD0=";


### PR DESCRIPTION
Without the change gcc-12 on musl fails to build due to system headers
poisoning:

    /build/build/./prev-gcc/xg++ ... ../../gcc-13-20220626/gcc/cp/mapper-resolver.cc
        In file included from /<<NIX>>/musl-1.2.3-dev/include/pthread.h:30,
                 from /build/build/prev-x86_64-unknown-linux-musl/libstdc++-v3/include/x86_64-unknown-linux-musl/bits/gthr-default.h:35,
                 ....
                 from /build/build/prev-x86_64-unknown-linux-musl/libstdc++-v3/include/memory:77,
                 from ../../gcc-13-20220626/gcc/../libcody/cody.hh:24,
                 from ../../gcc-13-20220626/gcc/cp/../../c++tools/resolver.h:25,
                 from ../../gcc-13-20220626/gcc/cp/../../c++tools/resolver.cc:23,
                 from ../../gcc-13-20220626/gcc/cp/mapper-resolver.cc:32:
    /<<NIX>>/musl-1.2.3-dev/include/sched.h:84:7: error: attempt to use poisoned "calloc"
       84 | void *calloc(size_t, size_t);
          |       ^
    /<<NIX>>/musl-1.2.3-dev/include/sched.h:124:36: error: attempt to use poisoned "calloc"
      124 | #define CPU_ALLOC(n) ((cpu_set_t *)calloc(1,CPU_ALLOC_SIZE(n)))
          |                                    ^

The change pulls upstream fix as is.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
