### PR TITLE
copilot-cli: init at 1.19.0

### DIFF
--- a/pkgs/tools/admin/copilot-cli/default.nix
+++ b/pkgs/tools/admin/copilot-cli/default.nix
@@ -1,0 +1,47 @@
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles, testers, copilot-cli }:
+
+buildGoModule rec {
+  pname = "copilot-cli";
+  version = "1.19.0";
+
+  src = fetchFromGitHub {
+    owner = "aws";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-2zF/cBc6TjAcFAI3zJ0yBQrVWDK5nkxYYkb04bjSjgY=";
+  };
+
+  vendorSha256 = "sha256-1UFahXol1Lceccr/f24Mbhtk8bWyh4+Mb5VYZvF6VWs=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  # follow LINKER_FLAGS in Makefile
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/aws/copilot-cli/internal/pkg/version.Version=${version}"
+    "-X github.com/aws/copilot-cli/internal/pkg/cli.binaryS3BucketPath=https://ecs-cli-v2-release.s3.amazonaws.com"
+  ];
+
+  subPackages = [ "./cmd/copilot" ];
+
+  postInstall = ''
+    installShellCompletion --cmd copilot \
+      --bash <($out/bin/copilot completion bash) \
+      --fish <($out/bin/copilot completion fish) \
+      --zsh <($out/bin/copilot completion zsh)
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = copilot-cli;
+    command = "copilot version";
+  };
+
+  meta = with lib; {
+    description = "Build, Release and Operate Containerized Applications on AWS.";
+    homepage = "https://github.com/aws/copilot-cli";
+    changelog = "https://github.com/aws/copilot-cli/releases/tag/v${version}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jiegec ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -386,6 +386,8 @@ with pkgs;
 
   coordgenlibs  = callPackage ../development/libraries/coordgenlibs { };
 
+  copilot-cli = callPackage ../tools/admin/copilot-cli { };
+
   cp437 = callPackage ../tools/misc/cp437 { };
 
   cpm = callPackage ../development/tools/cpm { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The AWS Copilot CLI is a tool for developers to build, release and operate production-ready containerized applications on AWS App Runner or Amazon ECS on AWS Fargate.

https://github.com/aws/copilot-cli/releases/tag/v1.19.0

There was a previous attempt at pr #103255.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
