### PR TITLE
imgcat: 2.3.1 -> 2.5.1

### DIFF
--- a/pkgs/applications/graphics/imgcat/default.nix
+++ b/pkgs/applications/graphics/imgcat/default.nix
@@ -1,14 +1,12 @@
-{ lib, stdenv, fetchFromGitHub, autoconf, automake, libtool, ncurses }:
+{ lib, stdenv, fetchFromGitHub, cimg, ncurses }:
 
 stdenv.mkDerivation rec {
   pname = "imgcat";
-  version = "2.3.1";
+  version = "2.5.1";
 
-  nativeBuildInputs = [ autoconf automake libtool ];
-  buildInputs = [ ncurses ];
+  buildInputs = [ ncurses cimg ];
 
   preConfigure = ''
-    ${autoconf}/bin/autoconf
     sed -i -e "s|-ltermcap|-L ${ncurses}/lib -lncurses|" Makefile
   '';
 
@@ -18,7 +16,7 @@ stdenv.mkDerivation rec {
     owner = "eddieantonio";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0frz40rjwi73nx2dlqvmnn56zwr29bmnngfb11hhwr7v58yfajdi";
+    sha256 = "sha256-EkVE6BgoA1lo4oqlNETTxLILIVvGXspFyXykxpmYk8M=";
   };
 
   NIX_CFLAGS_COMPILE = "-Wno-error";


### PR DESCRIPTION
###### Description of changes
Update to latest upstream release [2.5.1](https://github.com/eddieantonio/imgcat/releases/tag/v2.5.1).
- [View changes on GitHub](https://github.com/eddieantonio/imgcat/compare/v2.3.1...v2.5.1)

The project doesn't use `autoconf` anymore, so we can simplify the package a bit.



###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).