### PR TITLE
libmd: enable on darwin

### DIFF
--- a/pkgs/development/libraries/libmd/default.nix
+++ b/pkgs/development/libraries/libmd/default.nix
@@ -1,13 +1,25 @@
-{ lib, stdenv, fetchurl, autoreconfHook }:
+{ lib, stdenv, fetchurl, fetchpatch, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   pname = "libmd";
   version = "1.0.4";
 
   src = fetchurl {
-    url = "https://archive.hadrons.org/software/${pname}/${pname}-${version}.tar.xz";
+    urls = [
+      "https://archive.hadrons.org/software/libmd/libmd-${version}.tar.xz"
+      "https://libbsd.freedesktop.org/releases/libmd-${version}.tar.xz"
+    ];
     sha256 = "sha256-9RySEELjS+3e3tS3VVdlZVnPWx8kSAM7TB7sEcB+Uw8=";
   };
+
+  patches = [
+    # Drop aliases for SHA384 functions, because such aliases are not supported on Darwin.
+    (fetchpatch {
+      url = "https://github.com/macports/macports-ports/raw/8332f5dbcaf05a02bc31fbd4ccf735e7d5c9a5b0/devel/libmd/files/patch-symbol-alias.diff";
+      sha256 = "sha256-py5hMpKYKwtBzhWn01lFc2a6+OZN72YCYXyhg1qe6rg=";
+      extraPrefix = "";
+    })
+  ];
 
   nativeBuildInputs = [ autoreconfHook ];
 
@@ -18,6 +30,6 @@ stdenv.mkDerivation rec {
     description = "Message Digest functions from BSD systems";
     license = with licenses; [ bsd3 bsd2 isc beerware publicDomain ];
     maintainers = with maintainers; [ primeos ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Description of changes

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
