### PR TITLE
boron: init at 2.0.8

### DIFF
--- a/pkgs/development/interpreters/boron/default.nix
+++ b/pkgs/development/interpreters/boron/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, stdenv
+, fetchurl
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "boron";
+  version = "2.0.8";
+
+  src = fetchurl {
+    url = "https://sourceforge.net/projects/urlan/files/Boron/boron-${version}.tar.gz";
+    sha256 = "sha256-Ni/LJgOABC2wXDMsg1ZAuZWSQdFT9/Fa4lH4+V0gy8M=";
+  };
+
+  # this is not a standard Autotools-like `configure` script
+  dontAddPrefix = true;
+
+  preConfigure = ''
+    patchShebangs configure
+  '';
+
+  configureFlags = [ "--thread" ];
+
+  makeFlags = [ "DESTDIR=$(out)" ];
+
+  buildInputs = [
+    zlib
+  ];
+
+  installTargets = [ "install" "install-dev" ];
+
+  doCheck = true;
+
+  checkPhase = ''
+    patchShebangs .
+    make -C test
+  '';
+
+  meta = with lib; {
+    homepage = "http://urlan.sourceforge.net/boron/";
+    description = "Scripting language and C library useful for building DSLs";
+    license = licenses.lgpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ mausch ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2166,6 +2166,8 @@ with pkgs;
     stdenv = gcc10StdenvCompat;
   };
 
+  boron = callPackage ../development/interpreters/boron { };
+
   botamusique = callPackage ../tools/audio/botamusique { };
 
   boulder = callPackage ../tools/admin/boulder { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Boron is a scripting language similar to Rebol.
http://urlan.sourceforge.net/boron/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
