### PR TITLE
feh: 3.8 -> 3.9

### DIFF
--- a/pkgs/applications/graphics/feh/default.nix
+++ b/pkgs/applications/graphics/feh/default.nix
@@ -1,16 +1,26 @@
-{ lib, stdenv, fetchurl, makeWrapper
-, xorg, imlib2, libjpeg, libpng
+{ lib, stdenv, fetchFromGitHub, makeWrapper
+, xorg, imlib2, libjpeg, libpng, fetchpatch
 , curl, libexif, jpegexiforient, perl
 , enableAutoreload ? !stdenv.hostPlatform.isDarwin }:
 
 stdenv.mkDerivation rec {
   pname = "feh";
-  version = "3.8";
+  version = "3.9";
 
-  src = fetchurl {
-    url = "https://feh.finalrewind.org/${pname}-${version}.tar.bz2";
-    sha256 = "1a9bsq5j9sl2drzkab0hdhnamalpaszw9mz2prz6scrr5dak8g3z";
+  src = fetchFromGitHub {
+    owner = "derf";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-rgNC4M1TJ5EPeWmVHVzgaxTGLY7CYQf7uOsOn5bkwKE=";
   };
+
+  patches = [
+    # fix test failure when magic=0 is set
+    (fetchpatch {
+      url = "https://github.com/derf/feh/commit/3c1076b31e2e4e3429a5c3d334d555e549fb72d2.patch";
+      sha256 = "sha256-F9N+N/BAeclyPHQYlO9ZV1U8S1VWfHl/8dMKUqA7DF8=";
+    })
+  ];
 
   outputs = [ "out" "man" "doc" ];
 


### PR DESCRIPTION
###### Description of changes
Update to the latest upstream release [3.9](https://feh.finalrewind.org/archive/3.9/).
- [View changes on GitHub](https://github.com/derf/feh/compare/3.8...3.9)

Includes some refactoring:
- `fetchFromGitHub` instead of `fetchurl`
- add https://github.com/derf/feh/commit/3c1076b31e2e4e3429a5c3d334d555e549fb72d2 as a patch to fix failing tests

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).