### PR TITLE
nixos/wireless: reimplement secrets using ext_password_backend

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -145,6 +145,9 @@
   moved into the top level scope (i.e., `budgie.budgie-desktop` is now
   `budgie-desktop`)
 
+- The method to safely handle secrets in the `networking.wireless` module has been changed to benefit from a [new feature](https://w1.fi/cgit/hostap/commit/?id=e680a51e94a33591f61edb210926bcb71217a21a) of wpa_supplicant.
+  The syntax to refer to secrets has changed slightly and the option `networking.wireless.environmentFile` has been replaced by `networking.wireless.secretsFile`; see the description of the latter for how to upgrade.
+
 - All Cinnamon and XApp packages have been moved to top-level (i.e., `cinnamon.nemo` is now `nemo`).
 
 - `services.cgit` now runs as the cgit user by default instead of root.

--- a/nixos/modules/services/networking/wpa_supplicant.nix
+++ b/nixos/modules/services/networking/wpa_supplicant.nix
@@ -50,15 +50,6 @@ let
     ++ optional cfg.scanOnLowSignal ''bgscan="simple:30:-70:3600"''
     ++ optional (cfg.extraConfig != "") cfg.extraConfig);
 
-  configIsGenerated = with cfg;
-    networks != {} || extraConfig != "" || userControlled.enable;
-
-  # the original configuration file
-  configFile =
-    if configIsGenerated
-      then pkgs.writeText "wpa_supplicant.conf" generatedConfig
-      else "/etc/wpa_supplicant.conf";
-
   # Creates a network block for wpa_supplicant.conf
   mkNetwork = opts:
   let
@@ -90,8 +81,8 @@ let
     let
       deviceUnit = optional (iface != null) "sys-subsystem-net-devices-${utils.escapeSystemdPath iface}.device";
       configStr = if cfg.allowAuxiliaryImperativeNetworks
-        then "-c /etc/wpa_supplicant.conf -I ${configFile}"
-        else "-c ${configFile}";
+        then "-c /etc/wpa_supplicant.conf -I ${pkgs.writeText "wpa_supplicant.conf" generatedConfig}"
+        else "-c /etc/wpa_supplicant.conf";
     in {
       description = "WPA Supplicant instance" + optionalString (iface != null) " for interface ${iface}";
 
@@ -112,12 +103,6 @@ let
 
       script =
       ''
-        ${optionalString (configIsGenerated && !cfg.allowAuxiliaryImperativeNetworks) ''
-          if [ -f /etc/wpa_supplicant.conf ]; then
-            echo >&2 "<3>/etc/wpa_supplicant.conf present but ignored. Generated ${configFile} is used instead."
-          fi
-        ''}
-
         # ensure wpa_supplicant.conf exists, or the daemon will fail to start
         ${optionalString cfg.allowAuxiliaryImperativeNetworks ''
           touch /etc/wpa_supplicant.conf
@@ -530,6 +515,9 @@ in {
     ];
 
     hardware.wirelessRegulatoryDatabase = true;
+
+    environment.etc."wpa_supplicant.conf" =
+      lib.mkIf (!cfg.allowAuxiliaryImperativeNetworks) { text = generatedConfig; };
 
     environment.systemPackages = [ pkgs.wpa_supplicant ];
     services.dbus.packages = optional cfg.dbusControlled pkgs.wpa_supplicant;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1086,7 +1086,7 @@ in {
   without-nix = handleTest ./without-nix.nix {};
   wmderland = handleTest ./wmderland.nix {};
   workout-tracker = handleTest ./workout-tracker.nix {};
-  wpa_supplicant = handleTest ./wpa_supplicant.nix {};
+  wpa_supplicant = import ./wpa_supplicant.nix { inherit pkgs runTest; };
   wordpress = handleTest ./wordpress.nix {};
   wrappers = handleTest ./wrappers.nix {};
   writefreely = handleTest ./web-apps/writefreely.nix {};

--- a/nixos/tests/wpa_supplicant.nix
+++ b/nixos/tests/wpa_supplicant.nix
@@ -123,15 +123,13 @@ in
     };
 
     testScript = ''
+      config_file = "/etc/static/wpa_supplicant.conf"
+
       with subtest("Daemon is running and accepting connections"):
           machine.wait_for_unit("wpa_supplicant.service")
           status = machine.wait_until_succeeds("wpa_cli status")
           assert "Failed to connect" not in status, \
                  "Failed to connect to the daemon"
-
-      # get the configuration file
-      cmdline = machine.succeed("cat /proc/$(pgrep wpa)/cmdline").split('\x00')
-      config_file = cmdline[cmdline.index("-c") + 1]
 
       with subtest("WPA2 fallbacks have been generated"):
           assert int(machine.succeed(f"grep -c sae-only {config_file}")) == 1


### PR DESCRIPTION
###### Description of changes

This replaces the current implementation (splicing the secrets into the
configuration file using environment variavles) with the new built-in
mechanism `ext_password_backend`.

With some minor syntax changes, it works exactly as before, except the
heavy lifting is done by wpa_supplicant and probably less error-prone.

###### Things done

- [x] Tested via `nixosTests.wpa_supplicant`
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc: @lopsided98 