### PR TITLE
sgrep: init at 1.94a

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3744,6 +3744,12 @@
     githubId = 537775;
     name = "Emery Hemingway";
   };
+  eigengrau = {
+    email = "seb@schattenkopie.de";
+    name = "Sebastian Reuße";
+    github = "eigengrau";
+    githubId = 4939947;
+  };
   eikek = {
     email = "eike.kettner@posteo.de";
     github = "eikek";

--- a/pkgs/tools/text/sgrep/default.nix
+++ b/pkgs/tools/text/sgrep/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, lib, m4, makeWrapper }:
+{ stdenv, sgrep, fetchurl, runCommand, lib, m4, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "sgrep";
@@ -14,6 +14,14 @@ stdenv.mkDerivation rec {
   postInstall = ''
     wrapProgram $out/bin/sgrep \
       --prefix PATH : ${lib.makeBinPath [ m4 ]}
+  '';
+
+  passthru.tests.smokeTest = runCommand "test-sgrep" { } ''
+    expr='"<foo>" __ "</foo>"'
+    data="<foo>1</foo><bar>2</bar>"
+    ${sgrep}/bin/sgrep "$expr" <<<$data >$out
+    read result <$out
+    [[ $result = 1 ]]
   '';
 
   meta = with lib; {

--- a/pkgs/tools/text/sgrep/default.nix
+++ b/pkgs/tools/text/sgrep/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, lib, m4, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  pname = "sgrep";
+  version = "1.94a";
+
+  src = fetchurl {
+    url = "https://www.cs.helsinki.fi/pub/Software/Local/Sgrep/sgrep-${version}.tar.gz";
+    sha256 = "sha256-1bFkeOOrRHNeJCg9LYldLJyAE5yVIo3zvbKsRGOV+vk=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    wrapProgram $out/bin/sgrep \
+      --prefix PATH : ${lib.makeBinPath [ m4 ]}
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.cs.helsinki.fi/u/jjaakkol/sgrep.html";
+    description = "A grep for structured text formats such as XML";
+    longDescription = ''
+      sgrep (structured grep) is a tool for searching and indexing text,
+      SGML, XML and HTML files and filtering text streams using
+      structural criteria.
+    '';
+    platforms = platforms.unix;
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ eigengrau ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1296,6 +1296,8 @@ with pkgs;
 
   sdlookup = callPackage ../tools/security/sdlookup { };
 
+  sgrep = callPackage ../tools/text/sgrep { };
+
   smbscan = callPackage ../tools/security/smbscan { };
 
   spectre-cli = callPackage ../tools/security/spectre-cli { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[sgrep](http://www.cs.helsinki.fi/~jjaakkol/sgrep.html) is a grep for structured text formats such as XML.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
