### PR TITLE
rofi-top: init at unstable-2017-10-16

### DIFF
--- a/pkgs/applications/misc/rofi-top/0001-Patch-plugindir-to-output.patch
+++ b/pkgs/applications/misc/rofi-top/0001-Patch-plugindir-to-output.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.ac b/configure.ac
+index 4d2df69..3260910 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -54,7 +54,7 @@ dnl ---------------------------------------------------------------------
+ PKG_CHECK_MODULES([glib],     [glib-2.0 >= 2.40 gio-unix-2.0 gmodule-2.0 libgtop-2.0])
+ PKG_CHECK_MODULES([rofi],     [rofi])
+ 
+-[rofi_PLUGIN_INSTALL_DIR]="`$PKG_CONFIG --variable=pluginsdir rofi`"
++[rofi_PLUGIN_INSTALL_DIR]="`echo $out/lib/rofi`"
+ AC_SUBST([rofi_PLUGIN_INSTALL_DIR])
+ 
+ LT_INIT([disable-static])

--- a/pkgs/applications/misc/rofi-top/0002-Patch-add-cairo.patch
+++ b/pkgs/applications/misc/rofi-top/0002-Patch-add-cairo.patch
@@ -1,0 +1,25 @@
+diff --git a/Makefile.am b/Makefile.am
+index 24c1a85..cfabbbf 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -6,6 +6,6 @@ plugin_LTLIBRARIES = top.la
+ top_la_SOURCES=\
+ 		 src/top.c
+ 
+-top_la_CFLAGS= @glib_CFLAGS@ @rofi_CFLAGS@
+-top_la_LIBADD= @glib_LIBS@ @rofi_LIBS@
++top_la_CFLAGS= @glib_CFLAGS@ @rofi_CFLAGS@ @cairo_CFLAGS@
++top_la_LIBADD= @glib_LIBS@ @rofi_LIBS@ @cairo_LIBS@
+ top_la_LDFLAGS= -module -avoid-version
+diff --git a/configure.ac b/configure.ac
+index 4d2df69..f340a7a 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -53,6 +53,7 @@ dnl PKG_CONFIG based dependencies
+ dnl ---------------------------------------------------------------------
+ PKG_CHECK_MODULES([glib],     [glib-2.0 >= 2.40 gio-unix-2.0 gmodule-2.0 libgtop-2.0])
+ PKG_CHECK_MODULES([rofi],     [rofi])
++PKG_CHECK_MODULES([cairo],    [cairo cairo-xcb])
+ 
+ [rofi_PLUGIN_INSTALL_DIR]="`$PKG_CONFIG --variable=pluginsdir rofi`"
+ AC_SUBST([rofi_PLUGIN_INSTALL_DIR])

--- a/pkgs/applications/misc/rofi-top/default.nix
+++ b/pkgs/applications/misc/rofi-top/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, cairo
+, glib
+, gobject-introspection
+, libgtop
+, pkg-config
+, rofi-unwrapped
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rofi-top";
+  version = "unstable-2017-10-16";
+
+  src = fetchFromGitHub {
+    owner = "davatorium";
+    repo = pname;
+    rev = "9416addf91dd1bd25dfd5a8c5f1c7297c444408e";
+    sha256 = "sha256-lNsmx1xirepITpUD30vpcs5slAQYQcvDW8FkA2K9JtU=";
+  };
+
+  patches = [
+    ./0001-Patch-plugindir-to-output.patch
+    ./0002-Patch-add-cairo.patch
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    gobject-introspection
+    pkg-config
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    cairo
+    glib
+    libgtop
+    rofi-unwrapped
+  ];
+
+  meta = with lib; {
+    description = "A plugin for rofi that emulates top behaviour";
+    homepage = "https://github.com/davatorium/rofi-top";
+    license = licenses.mit;
+    maintainers = with maintainers; [ aacebedo ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28727,6 +28727,8 @@ with pkgs;
 
   rofi-rbw = python3Packages.callPackage ../applications/misc/rofi-rbw { };
 
+  rofi-top = callPackage ../applications/misc/rofi-top { };
+
   rofi-vpn = callPackage ../applications/networking/rofi-vpn { };
 
   ympd = callPackage ../applications/audio/ympd { };


### PR DESCRIPTION
###### Description of changes
Adding the plugin rofi-top.


###### Things done
- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).