### PR TITLE
plistwatch: init at unstable-2020-12-22

### DIFF
--- a/pkgs/os-specific/darwin/plistwatch/default.nix
+++ b/pkgs/os-specific/darwin/plistwatch/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "plistwatch";
+  version = "unstable-2020-12-22";
+
+  src = fetchFromGitHub {
+    owner = "catilac";
+    repo = "plistwatch";
+    rev = "c3a9afd8d3e5ffa8dcc379770bc4216bae88a671";
+    sha256 = "0a5rfmpy6h06p02z9gdilh7vr3h9cc6n6zzygpjk6zvnqs3mm3vx";
+  };
+
+  vendorSha256 = "sha256-Layg1axFN86OFgxEyNFtIlm6Jtx317jZb/KH6IjJ8e4=";
+
+  #add missing dependencies and hashes
+  patches = [ ./go-modules.patch ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Monitors and prints changes to MacOS plists in real time";
+    homepage = "https://github.com/catilac/plistwatch";
+    maintainers = with maintainers; [ gdinh ];
+    license = licenses.mit;
+    platforms = platforms.darwin;
+  };
+}

--- a/pkgs/os-specific/darwin/plistwatch/go-modules.patch
+++ b/pkgs/os-specific/darwin/plistwatch/go-modules.patch
@@ -1,0 +1,19 @@
+--- a/go.mod
++++ b/go.mod
+@@ -3,1 +3,6 @@
+  go 1.14
++ require(
++   github.com/jessevdk/go-flags v1.5.0
++   howett.net/plist v0.0.0-20200419221736-3b63eb3a43b5
++   gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0 // indirect
++ )
+--- a/go.sum
++++ b/go.sum
+@@ -9,1 +9,7 @@
+  howett.net/plist v0.0.0-20200419221736-3b63eb3a43b5/go.mod h1:vMygbs4qMhSZSc4lCUl2OEE+rDiIIJAIdR4m7MiMcm0=
++ gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0 h1:POO/ycCATvegFmVuPpQzZFJ+pGZeX22Ufu6fibxDVjU=
++ gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0/go.mod h1:WDnlLJ4WF5VGsH/HVa3CI79GS0ol3YnhVnKP89i0kNg=
++ github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=
++ github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
++ golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4 h1:EZ2mChiOa8udjfp6rRmswTbtZN/QzUQp4ptM4rnjHvc=
++ golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25345,6 +25345,8 @@ with pkgs;
 
   osxsnarf = callPackage ../os-specific/darwin/osxsnarf { };
 
+  plistwatch = callPackage ../os-specific/darwin/plistwatch { };
+
   power-calibrate = callPackage ../os-specific/linux/power-calibrate { };
 
   powercap = callPackage ../os-specific/linux/powercap { };


### PR DESCRIPTION
###### Description of changes

Add [plistwatch](https://github.com/catilac/plistwatch) package, which displays changes to preference plists on osx in real time (handy for writing nix-darwin modules).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
