### PR TITLE
nix-build-profiler: init at unstable-2022-07-09

### DIFF
--- a/pkgs/development/python-modules/gnumake-tokenpool/default.nix
+++ b/pkgs/development/python-modules/gnumake-tokenpool/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+}:
+
+buildPythonPackage {
+  pname = "gnumake-tokenpool";
+  version = "unstable-2022-07-05";
+
+  src = fetchFromGitHub {
+    owner = "milahu";
+    repo = "gnumake-tokenpool";
+    rev = "54435c300e3b660cc75ffd8d63e518df322e6891";
+    sha256 = "uHo5fMY7jsjX56gFod3X/seGVt+p8+lBfodGa/oaRsE=";
+  };
+
+  pythonImportsCheck = [
+    "gnumake_tokenpool"
+  ];
+
+  meta = with lib; {
+    description = "jobclient and jobserver for the GNU make tokenpool protocol";
+    homepage = "https://github.com/milahu/gnumake-tokenpool";
+    license = licenses.mit;
+    maintainers = with maintainers; [ milahu ];
+  };
+}

--- a/pkgs/development/python-modules/nix-build-profiler/default.nix
+++ b/pkgs/development/python-modules/nix-build-profiler/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, psutil
+, prefixed
+, gnumake-tokenpool
+, writeText
+}:
+
+buildPythonPackage rec {
+  pname = "nix-build-profiler";
+  version = "unstable-2022-07-09";
+
+  src = fetchFromGitHub {
+    owner = "milahu";
+    repo = "nix-build-profiler";
+    rev = "24559407783b46a20095813ba1d02ef4ad305089";
+    sha256 = "Iv8TJCFOv7i0+or2ERpgDpEmFbE7Y99UE4ysfv+iGQU=";
+  };
+
+  propagatedBuildInputs = [
+    psutil
+    prefixed
+    gnumake-tokenpool
+  ];
+
+  setupHook = writeText "setup-hook.sh" ''
+    startNixBuildProfiler() {
+      echo "Starting nix-build-profiler"
+      nix-build-profiler &
+    }
+    prePhases+=" startNixBuildProfiler"
+  '';
+
+  meta = with lib; {
+    description = "Profile CPU and memory usage of nix-build";
+    longDescription = ''
+      Usage:
+
+      ```nix
+      mkDerivation {
+        nativeBuildInputs = [ nix-build-profiler ];
+      }
+      ```
+    '';
+    homepage = "https://github.com/milahu/nix-build-profiler";
+    license = licenses.mit;
+    maintainers = with maintainers; [ milahu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34352,6 +34352,10 @@ with pkgs;
 
   nix-simple-deploy = callPackage ../tools/package-management/nix-simple-deploy { };
 
+  nix-build-profiler = callPackage ../development/python-modules/nix-build-profiler {
+    inherit (python3Packages) buildPythonPackage psutil prefixed gnumake-tokenpool;
+  };
+
   alejandra = callPackage ../tools/nix/alejandra { };
 
   nixfmt = haskell.lib.compose.justStaticExecutables haskellPackages.nixfmt;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3553,6 +3553,8 @@ in {
 
   gntp = callPackage ../development/python-modules/gntp { };
 
+  gnumake-tokenpool = callPackage ../development/python-modules/gnumake-tokenpool { };
+
   gnureadline = callPackage ../development/python-modules/gnureadline { };
 
   goalzero = callPackage ../development/python-modules/goalzero { };


### PR DESCRIPTION
###### Description of changes

add `nix-build-profiler` to debug exotic build errors like `segmentation fault`

sometimes, these errors come from overloading (too many build jobs, out of memory errors)
with `nativeBuildInputs = [ nix-build-profiler ];`
nix-build-profiler will print the process tree every second

[the python script](https://github.com/milahu/nix-build-profiler) can be modified to print all kinds of debug info
for example, print the status of the gnumake jobserver (how many tokens are acquired by jobclients?)

this was part of #178171 (unpatched qt6.qtwebengine is aggressively overloading the cpu)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
