### PR TITLE
untrunc-anthwlock: fix build on darwin and ensure optimized builds

### DIFF
--- a/pkgs/development/libraries/libui/default.nix
+++ b/pkgs/development/libraries/libui/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     ln -s $out/lib/libui.so.0 $out/lib/libui.so
   '' + lib.optionalString stdenv.isDarwin ''
     mv ./out/libui.A.dylib $out/lib/
-    ln -s $out/lib/lubui.A.dylib $out/lib/libui.dylib
+    ln -s $out/lib/libui.A.dylib $out/lib/libui.dylib
   '' + ''
     cp $src/ui.h $out/include
     cp $src/ui_${backend}.h $out/include

--- a/pkgs/tools/video/untrunc-anthwlock/default.nix
+++ b/pkgs/tools/video/untrunc-anthwlock/default.nix
@@ -11,11 +11,13 @@ stdenv.mkDerivation {
     sha256 = "14i2lq68q990hnm2kkfamlsi67bcml85zl8yjsyxc5h8ncc2f3dp";
   };
 
-
   buildInputs = [ ffmpeg libui ];
 
-  postBuild = ''
-    make untrunc-gui
+  buildPhase = ''
+    runHook preBuild
+    make IS_RELEASE=1 untrunc
+    make IS_RELEASE=1 untrunc-gui
+    runHook postBuild
   '';
 
   installPhase = ''

--- a/pkgs/tools/video/untrunc-anthwlock/default.nix
+++ b/pkgs/tools/video/untrunc-anthwlock/default.nix
@@ -27,7 +27,6 @@ stdenv.mkDerivation {
   enableParallelBuilding = true;
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
     description = "Restore a truncated mp4/mov (improved version of ponchio/untrunc)";
     homepage = "https://github.com/anthwlock/untrunc";
     license = licenses.gpl2;


### PR DESCRIPTION
###### Description of changes

Fix a typo in `libui` derivation that was actually causing the package to fail on darwin (it could not find the `ui` library).

Also refactor the build to make it clearer and ensure optimizations are enabled.

Marked as broken by #173671 I think, should be backported.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
