### PR TITLE
x86_64-darwin: fix packages that won’t build

### DIFF
--- a/pkgs/applications/emulators/bsnes/bsnes-hd/default.nix
+++ b/pkgs/applications/emulators/bsnes/bsnes-hd/default.nix
@@ -44,7 +44,9 @@ stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
-  makeFlags = [ "-C" "bsnes" "hiro=gtk3" "prefix=$(out)" ];
+  makeFlags = [ "-C" "bsnes" "prefix=$(out)" ]
+    ++ lib.optionals stdenv.isLinux [ "hiro=gtk3" ]
+    ++ lib.optionals stdenv.isDarwin [ "hiro=cocoa" ];
 
   # https://github.com/bsnes-emu/bsnes/issues/107
   preFixup = ''
@@ -59,9 +61,6 @@ stdenv.mkDerivation {
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ stevebob ];
     platforms = platforms.unix;
-    # ../nall/traits.hpp:19:14: error: no member named 'is_floating_point_v' in namespace 'std'; did you mean 'is_floating_point'?
-    #   using std::is_floating_point_v;
-    broken = (stdenv.isDarwin && stdenv.isx86_64);
     mainProgram = "bsnes";
   };
 }

--- a/pkgs/applications/graphics/vengi-tools/default.nix
+++ b/pkgs/applications/graphics/vengi-tools/default.nix
@@ -72,7 +72,10 @@ stdenv.mkDerivation rec {
     "-DGAMES=OFF"
     "-DMAPVIEW=OFF"
     "-DAIDEBUG=OFF"
-  ] ++ lib.optional stdenv.isDarwin "-DCORESERVICES_LIB=${CoreServices}";
+  ] ++ lib.optionals stdenv.isDarwin [
+   "-DCORESERVICES_LIB=${CoreServices}"
+   "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.14"
+  ];
 
   # Set the data directory for each executable. We cannot set it at build time
   # with the PKGDATADIR cmake variable because each executable needs a specific
@@ -106,7 +109,5 @@ stdenv.mkDerivation rec {
     license = [ licenses.mit licenses.cc-by-sa-30 ];
     maintainers = with maintainers; [ fgaz ];
     platforms = platforms.all;
-    # Requires SDK 10.14 https://github.com/NixOS/nixpkgs/issues/101229
-    broken = stdenv.isDarwin && stdenv.isx86_64;
   };
 }

--- a/pkgs/applications/misc/stork/default.nix
+++ b/pkgs/applications/misc/stork/default.nix
@@ -30,8 +30,5 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/jameslittle230/stork";
     license = with licenses; [ asl20 ];
     maintainers = with maintainers; [ chuahou ];
-    # TODO: Remove once nixpkgs uses macOS SDK 10.14+ for x86_64-darwin
-    # Undefined symbols for architecture x86_64: "_SecTrustEvaluateWithError"
-    broken = stdenv.isDarwin && stdenv.isx86_64;
   };
 }

--- a/pkgs/applications/science/logic/aspino/default.nix
+++ b/pkgs/applications/science/logic/aspino/default.nix
@@ -20,6 +20,12 @@ stdenv.mkDerivation {
 
   buildInputs = [ zlib boost ];
 
+  patches = [
+    # Fixes the following error when built with Clang:
+    # error: ordered comparison between pointer and zero ('unsigned int *' and 'int')
+    ./pointer-comparison.patch
+  ];
+
   postPatch = ''
     substituteInPlace Makefile \
       --replace "GCC = g++" "GCC = c++"
@@ -47,7 +53,5 @@ stdenv.mkDerivation {
     homepage = "https://alviano.net/software/maxino/";
     # See pkgs/applications/science/logic/glucose/default.nix
     badPlatforms = [ "aarch64-linux" ];
-    # src/MaxSatSolver.cc:280:62: error: ordered comparison between pointer and zero ('unsigned int *' and 'int')
-    broken = (stdenv.isDarwin && stdenv.isx86_64); # broken since 2019-05-07 on hydra
   };
 }

--- a/pkgs/applications/science/logic/aspino/pointer-comparison.patch
+++ b/pkgs/applications/science/logic/aspino/pointer-comparison.patch
@@ -1,0 +1,13 @@
+diff --git a/src/MaxSatSolver.cc b/src/MaxSatSolver.cc
+index 9e32dac..261032d 100644
+--- a/src/MaxSatSolver.cc
++++ b/src/MaxSatSolver.cc
+@@ -277,7 +277,7 @@ void MaxSatSolver::bce() {
+                 else {
+                     for(int j = 0; j < softLiterals.size(); j++) {
+                         if(var(softLiterals[j]) == i) {
+-                            if(occ[i][sign(softLiterals[j])] > 0) {
++                            if(occ[i][sign(softLiterals[j])] > (unsigned int *)0) {
+ //                                cout << "Pure literal: " << mkLit(i, occ[i][1].size() == 0) << endl;
+                                 addClause(mkLit(i, occ[i][1].size() == 0));
+                                 weights[i] = 0;

--- a/pkgs/development/compilers/bigloo/default.nix
+++ b/pkgs/development/compilers/bigloo/default.nix
@@ -54,10 +54,6 @@ stdenv.mkDerivation rec {
     license     = lib.licenses.gpl2Plus;
     platforms   = lib.platforms.unix;
     maintainers = with lib.maintainers; [ thoughtpolice ];
-    # dyld: Library not loaded: /nix/store/w3liqjlrcmzc0sf2kgwjprqgqwqx8z47-libunistring-1.0/lib/libunistring.2.dylib
-    #  Referenced from: /private/tmp/nix-build-bigloo-4.4b.drv-0/bigloo-4.4b/bin/bigloo
-    #  Reason: Incompatible library version: bigloo requires version 5.0.0 or later, but libunistring.2.dylib provides version 4.0.0
-    broken      = (stdenv.isDarwin && stdenv.isx86_64);
 
     longDescription = ''
       Bigloo is a Scheme implementation devoted to one goal: enabling

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -100,7 +100,7 @@ in stdenv.mkDerivation rec {
     "${setHost}.musl-root=${pkgsBuildHost.targetPackages.stdenv.cc.libc}"
   ] ++ optionals stdenv.targetPlatform.isMusl [
     "${setTarget}.musl-root=${pkgsBuildTarget.targetPackages.stdenv.cc.libc}"
-  ] ++ optionals (stdenv.isDarwin && stdenv.isx86_64) [
+  ] ++ optionals (stdenv.isDarwin && stdenv.isx86_64 && (lib.versionOlder stdenv.targetPlatform.darwinSdkVersion "11.0")) [
     # https://github.com/rust-lang/rust/issues/92173
     "--set rust.jemalloc"
   ];

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -299,8 +299,8 @@ in {
     inherit passthruFun;
   };
 
-  rustpython = callPackage ./rustpython/default.nix {
-    inherit (darwin.apple_sdk.frameworks) SystemConfiguration;
+  rustpython = darwin.apple_sdk_11_0.callPackage ./rustpython/default.nix {
+    inherit (darwin.apple_sdk_11_0.frameworks) SystemConfiguration;
   };
 
 })

--- a/pkgs/development/interpreters/python/rustpython/default.nix
+++ b/pkgs/development/interpreters/python/rustpython/default.nix
@@ -4,6 +4,7 @@
 , fetchFromGitHub
 , SystemConfiguration
 , python3
+, fetchpatch
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -16,6 +17,15 @@ rustPlatform.buildRustPackage rec {
     rev = "db3b3127df34ff5dd569301aa36ed71ae5624e4e";
     sha256 = "sha256-YwGfXs3A5L/18mHnnWubPU3Y8EI9uU3keJ2HJnnTwv0=";
   };
+
+  patches = [
+    # Patched needed because this version does not build with recent versions of Rust.
+    # See: https://github.com/RustPython/RustPython/issues/3614
+    (fetchpatch {
+      url = "https://github.com/RustPython/RustPython/commit/61f7d241c0d7acca626a8e932b71e8ac5871362d.patch";
+      hash = "sha256-+2xlu+/etzCxkP/6Z1n+FwsAM6m+uPCriOoYuEI1j1U=";
+    })
+  ];
 
   cargoHash = "sha256-T85kiPG80oZ4mwpb8Ag40wDHKx2Aens+gM7NGXan5lM=";
 
@@ -31,14 +41,5 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://rustpython.github.io";
     license = licenses.mit;
     maintainers = with maintainers; [ prusnak ];
-
-    # TODO: Remove once nixpkgs uses newer SDKs that supports '*at' functions.
-    # Probably macOS SDK 10.13 or later. Check the current version in
-    # .../os-specific/darwin/apple-sdk/default.nix
-    #
-    # From the build logs:
-    #
-    # > Undefined symbols for architecture x86_64: "_utimensat"
-    broken = stdenv.isDarwin && stdenv.isx86_64;
   };
 }

--- a/pkgs/development/libraries/bullet/argument-outside-range.patch
+++ b/pkgs/development/libraries/bullet/argument-outside-range.patch
@@ -1,0 +1,26 @@
+diff --git a/src/Bullet3Common/b3Vector3.h b/src/Bullet3Common/b3Vector3.h
+index 50504c7f7..dee61c400 100644
+--- a/src/Bullet3Common/b3Vector3.h
++++ b/src/Bullet3Common/b3Vector3.h
+@@ -39,7 +39,7 @@ subject to the following restrictions:
+ #endif
+ 
+ 
+-#define B3_SHUFFLE(x,y,z,w) ((w)<<6 | (z)<<4 | (y)<<2 | (x))
++#define B3_SHUFFLE(x, y, z, w) (((w) << 6 | (z) << 4 | (y) << 2 | (x)) & 0xff)
+ //#define b3_pshufd_ps( _a, _mask ) (__m128) _mm_shuffle_epi32((__m128i)(_a), (_mask) )
+ #define b3_pshufd_ps( _a, _mask ) _mm_shuffle_ps((_a), (_a), (_mask) )
+ #define b3_splat3_ps( _a, _i ) b3_pshufd_ps((_a), B3_SHUFFLE(_i,_i,_i, 3) )
+diff --git a/src/LinearMath/btVector3.h b/src/LinearMath/btVector3.h
+index 8d0b73f88..f3be485da 100644
+--- a/src/LinearMath/btVector3.h
++++ b/src/LinearMath/btVector3.h
+@@ -39,7 +39,7 @@ subject to the following restrictions:
+ #endif
+ 
+ 
+-#define BT_SHUFFLE(x,y,z,w) ((w)<<6 | (z)<<4 | (y)<<2 | (x))
++#define BT_SHUFFLE(x, y, z, w) (((w) << 6 | (z) << 4 | (y) << 2 | (x)) & 0xff)
+ //#define bt_pshufd_ps( _a, _mask ) (__m128) _mm_shuffle_epi32((__m128i)(_a), (_mask) )
+ #define bt_pshufd_ps( _a, _mask ) _mm_shuffle_ps((_a), (_a), (_mask) )
+ #define bt_splat3_ps( _a, _i ) bt_pshufd_ps((_a), BT_SHUFFLE(_i,_i,_i, 3) )

--- a/pkgs/development/libraries/bullet/roboschool-fork.nix
+++ b/pkgs/development/libraries/bullet/roboschool-fork.nix
@@ -21,7 +21,12 @@ stdenv.mkDerivation {
   buildInputs = lib.optionals stdenv.isLinux [ libGLU libGL freeglut ]
     ++ lib.optionals stdenv.isDarwin [ Cocoa OpenGL ];
 
-  patches = [ ./gwen-narrowing.patch ];
+  patches = [
+    ./gwen-narrowing.patch
+    # Fixes `error: argument value 10880 is outside the valid range [0, 255] [-Wargument-outside-range]` on Darwin.
+    # Adapted from the fork’s upstream since the fork itself has not been updated.
+    ./argument-outside-range.patch
+  ];
 
   postPatch = lib.optionalString stdenv.isDarwin ''
     sed -i 's/FIND_PACKAGE(OpenGL)//' CMakeLists.txt
@@ -51,8 +56,5 @@ stdenv.mkDerivation {
     homepage = "http://bulletphysics.org";
     license = licenses.zlib;
     platforms = platforms.unix;
-    # /tmp/nix-build-bullet-2019-03-27.drv-0/source/src/Bullet3Common/b3Vector3.h:297:7: error: argument value 10880 is outside the valid range [0, 255] [-Wargument-outside-range]
-    #                 y = b3_splat_ps(y, 0x80);
-    broken = (stdenv.isDarwin && stdenv.isx86_64);
   };
 }

--- a/pkgs/development/tools/rust/cargo-deb/default.nix
+++ b/pkgs/development/tools/rust/cargo-deb/default.nix
@@ -35,15 +35,6 @@ rustPlatform.buildRustPackage rec {
     description = "Generate Debian packages from information in Cargo.toml";
     homepage = "https://github.com/mmstick/cargo-deb";
     license = licenses.mit;
-    # test failures:
-    #   control::tests::generate_scripts_generates_maintainer_scripts_for_unit
-    #   dh_installsystemd::tests::find_units_in_empty_dir_finds_nothing
-    #   dh_lib::tests::apply_with_no_matching_files
-    #   dh_lib::tests::debhelper_script_subst_with_generated_file_only
-    #   dh_lib::tests::debhelper_script_subst_with_no_matching_files
-    #   dh_lib::tests::pkgfile_finds_most_specific_match_without_pkg_file
-    #   dh_lib::tests::pkgfile_finds_most_specific_match_without_unit_file
-    broken = (stdenv.isDarwin && stdenv.isx86_64);
     maintainers = with maintainers; [ Br1ght0ne ];
   };
 }

--- a/pkgs/development/tools/rust/cargo-modules/default.nix
+++ b/pkgs/development/tools/rust/cargo-modules/default.nix
@@ -22,9 +22,6 @@ rustPlatform.buildRustPackage rec {
     description = "A cargo plugin for showing a tree-like overview of a crate's modules";
     homepage = "https://github.com/regexident/cargo-modules";
     license = with licenses; [ mpl20 ];
-    # all tests fail with:
-    # thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: "tests run with disabled concurrency, automatic snapshot name generation is not supported.  Consider using the \"backtrace\" feature of insta which tries to recover test names from the call stack."', /private/tmp/nix-build-cargo-modules-0.5.9.drv-0/cargo-modules-0.5.9-vendor.tar.gz/insta/src/runtime.rs:908:22
-    broken = (stdenv.isDarwin && stdenv.isx86_64);
     maintainers = with maintainers; [ figsoda rvarago ];
   };
 }

--- a/pkgs/os-specific/darwin/apple-sdk-11.0/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/default.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, fetchurl, newScope, lib, pkgs
+{ stdenvNoCC, fetchurl, newScope, lib, pkgs, buildPackages, targetPackages
 , stdenv, overrideCC
 , xar, cpio, python3, pbzx }:
 
@@ -46,7 +46,7 @@ let
     inherit MacOSX-SDK;
 
     Libsystem = callPackage ./libSystem.nix {};
-    LibsystemCross = pkgs.darwin.Libsystem;
+    LibsystemCross = packages.Libsystem;
     libcharset = callPackage ./libcharset.nix {};
     libunwind = callPackage ./libunwind.nix {};
     libnetwork = callPackage ./libnetwork.nix {};
@@ -55,35 +55,8 @@ let
     # questionable aliases
     configd = pkgs.darwin.apple_sdk.frameworks.SystemConfiguration;
     IOKit = pkgs.darwin.apple_sdk.frameworks.IOKit;
-
-    callPackage = newScope (lib.optionalAttrs stdenv.isDarwin rec {
-      inherit (pkgs.darwin.apple_sdk_11_0) stdenv;
-      darwin = pkgs.darwin.overrideScope (_: prev: {
-        inherit (prev.darwin.apple_sdk_11_0) Libsystem LibsystemCross libcharset libunwind objc4 configd IOKit Security;
-        apple_sdk = prev.darwin.apple_sdk_11_0;
-        CF = prev.darwin.apple_sdk_11_0.CoreFoundation;
-      });
-      xcodebuild = pkgs.xcbuild.override {
-        inherit (pkgs.darwin.apple_sdk_11_0.frameworks) CoreServices CoreGraphics ImageIO;
-        inherit stdenv;
-      };
-      xcbuild = xcodebuild;
-    });
-
-    stdenv =
-      let
-        clang = stdenv.cc.override {
-          bintools = stdenv.cc.bintools.override { libc = packages.Libsystem; };
-          libc = packages.Libsystem;
-        };
-      in
-      if stdenv.isAarch64 then stdenv
-      else
-        (overrideCC stdenv clang).override {
-          targetPlatform = stdenv.targetPlatform // {
-            darwinMinVersion = "10.12";
-            darwinSdkVersion = "11.0";
-          };
-        };
+  } // import ./pkg-compatibility.nix {
+    inherit lib pkgs stdenv;
+    darwinPackages = packages;
   };
 in packages

--- a/pkgs/os-specific/darwin/apple-sdk-11.0/pkg-compatibility.nix
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/pkg-compatibility.nix
@@ -1,0 +1,60 @@
+{ darwinPackages
+, lib
+, pkgs
+, stdenv
+}:
+
+# Provides overriden stdenv and gccStdenvs plus a callPackage with additional packages that have
+# been overriden to use this SDK instead of the standard one for the target Darwin architecture.
+# This is set up so it should default to the standard stdenv and package environment on non-Darwin
+# platforms. On platforms where this SDK is the default, it should also pass through.
+let
+  needsOverrides = stdenv.isDarwin && stdenv.isx86_64;
+
+  overrideDarwinVersion = platform: darwinMinVersion: darwinSdkVersion: platform // {
+    inherit darwinMinVersion darwinSdkVersion;
+  };
+
+  overridePlatformDarwinVersions = stdenv: darwinMinVersion: darwinSdkVersion: stdenv.override {
+    buildPlatform = overrideDarwinVersion stdenv.buildPlatform darwinMinVersion darwinSdkVersion;
+    hostPlatform = overrideDarwinVersion stdenv.hostPlatform darwinMinVersion darwinSdkVersion;
+    targetPlatform = overrideDarwinVersion stdenv.targetPlatform darwinMinVersion darwinSdkVersion;
+  };
+
+  nixpkgsFun = newArgs: import ./../../../.. (pkgs // newArgs);
+
+  sdkPkgs =
+    if !needsOverrides then pkgs
+    else
+      nixpkgsFun {
+        overlays = [
+          (_: _: {
+            inherit (darwinPackages) stdenv;
+            darwin = pkgs.darwin.overrideScope (_: prev: {
+              inherit (prev.apple_sdk_11_0) Libsystem LibsystemCross libcharset libunwind objc4 configd IOKit Security;
+              apple_sdk = prev.apple_sdk_11_0;
+              CF = prev.apple_sdk_11_0.CoreFoundation;
+            });
+          })
+        ];
+      };
+in
+{
+  callPackage =
+    pkgs.newScope (lib.optionalAttrs needsOverrides {
+      inherit (sdkPkgs) gccStdenv gcc10Stdenv gcc11Stdenv rustPlatform darwin xcbuild xcodebuild;
+      inherit (darwinPackages) stdenv;
+    });
+
+  inherit (sdkPkgs) gccStdenv gcc10StdenvCompat gcc11Stdenv;
+
+  stdenv =
+    let
+      clang = stdenv.cc.override rec {
+        bintools = stdenv.cc.bintools.override { inherit libc; };
+        libc = darwinPackages.Libsystem;
+      };
+    in
+    if !needsOverrides then stdenv
+    else overridePlatformDarwinVersions (pkgs.overrideCC stdenv clang) "10.12" "11.0";
+}

--- a/pkgs/tools/admin/procs/default.nix
+++ b/pkgs/tools/admin/procs/default.nix
@@ -32,6 +32,5 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/dalance/procs/raw/v${version}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [ Br1ght0ne SuperSandro2000 sciencentistguy ];
-    broken = stdenv.isDarwin && stdenv.isx86_64;
   };
 }

--- a/pkgs/tools/backup/bupstash/default.nix
+++ b/pkgs/tools/backup/bupstash/default.nix
@@ -28,10 +28,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://bupstash.io";
     license = licenses.mit;
     platforms = platforms.unix;
-    # = note: Undefined symbols for architecture x86_64:
-    #           "_utimensat", referenced from:
-    # https://github.com/NixOS/nixpkgs/issues/101229
-    broken = (stdenv.isDarwin && stdenv.isx86_64);
     maintainers = with maintainers; [ andrewchambers ];
   };
 }

--- a/pkgs/tools/filesystems/squashfs-tools-ng/default.nix
+++ b/pkgs/tools/filesystems/squashfs-tools-ng/default.nix
@@ -21,17 +21,5 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ qyliss ];
     platforms = platforms.unix;
-
-    # TODO: Remove once nixpkgs uses newer SDKs that supports '*at' functions.
-    # Probably macOS SDK 10.13 or later. Check the current version in
-    # ../../../../os-specific/darwin/apple-sdk/default.nix
-    #
-    # From the build logs:
-    #
-    # > Undefined symbols for architecture x86_64:
-    # >   "_utimensat", referenced from:
-    # >       _set_attribs in rdsquashfs-restore_fstree.o
-    # > ld: symbol(s) not found for architecture x86_64
-    broken = stdenv.isDarwin && stdenv.isx86_64;
   };
 }

--- a/pkgs/tools/system/bpytop/default.nix
+++ b/pkgs/tools/system/bpytop/default.nix
@@ -45,8 +45,5 @@ stdenv.mkDerivation rec {
     license = licenses.asl20;
     maintainers = with maintainers; [ aw ];
     platforms = with platforms; linux ++ freebsd ++ darwin;
-
-    # https://github.com/NixOS/nixpkgs/pull/94625#issuecomment-668509399
-    broken = stdenv.isDarwin && stdenv.isx86_64;
   };
 }

--- a/pkgs/tools/system/btop/default.nix
+++ b/pkgs/tools/system/btop/default.nix
@@ -28,15 +28,12 @@ stdenv.mkDerivation rec {
     lib.optionals stdenv.isDarwin [
       frameworks.CoreFoundation
       frameworks.IOKit
-    ] ++ lib.optional (stdenv.isDarwin && stdenv.isx86_64) (
-      # Found this explanation for needing to create a header directory for libproc.h alone.
-      # https://github.com/NixOS/nixpkgs/blob/049e5e93af9bbbe06b4c40fd001a4e138ce1d677/pkgs/development/libraries/webkitgtk/default.nix#L154
-      # TL;DR, the other headers in the include path for the macOS SDK is not compatible with the C++ stdlib and causes issues, so we copy
-      # this to avoid those issues
-      runCommand "${pname}_headers" { } ''
-        install -Dm444 "${lib.getDev sdk}"/include/libproc.h "$out"/include/libproc.h
-      ''
-    );
+    ];
+
+  makeFlags = [
+    "ARCH=${stdenv.targetPlatform.darwinArch or stdenv.targetPlatform.uname.processor}"
+    "PLATFORM=${stdenv.targetPlatform.uname.system}"
+  ];
 
   installFlags = [ "PREFIX=$(out)" ];
 

--- a/pkgs/tools/system/plan9port/default.nix
+++ b/pkgs/tools/system/plan9port/default.nix
@@ -103,8 +103,6 @@ stdenv.mkDerivation {
     ];
     mainProgram = "9";
     platforms = platforms.unix;
-    # TODO: revisit this when the sdk situation on x86_64-darwin changes
-    broken = stdenv.isDarwin && stdenv.isx86_64;
   };
 }
 # TODO: investigate the mouse chording support patch

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23485,7 +23485,7 @@ with pkgs;
   htop-vim = callPackage ../tools/system/htop/htop-vim.nix { };
 
   btop = callPackage ../tools/system/btop {
-    stdenv = gcc11Stdenv;
+    stdenv = darwin.apple_sdk_11_0.gcc11Stdenv;
   };
 
   nmon = callPackage ../os-specific/linux/nmon { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33735,7 +33735,7 @@ with pkgs;
   alt-ergo = callPackage ../applications/science/logic/alt-ergo {};
 
   aspino = callPackage ../applications/science/logic/aspino {
-    stdenv = gcc10StdenvCompat;
+    stdenv = darwin.apple_sdk_11_0.gcc10StdenvCompat;
   };
 
   beluga = callPackage ../applications/science/logic/beluga {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10763,7 +10763,7 @@ with pkgs;
 
   squashfsTools = callPackage ../tools/filesystems/squashfs { };
 
-  squashfs-tools-ng = callPackage ../tools/filesystems/squashfs-tools-ng { };
+  squashfs-tools-ng = darwin.apple_sdk_11_0.callPackage ../tools/filesystems/squashfs-tools-ng { };
 
   squashfuse = callPackage ../tools/filesystems/squashfuse { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8609,7 +8609,7 @@ with pkgs;
 
   mkcue = callPackage ../tools/cd-dvd/mkcue { stdenv = gcc10StdenvCompat; };
 
-  mkp224o = callPackage ../tools/security/mkp224o { };
+  mkp224o = darwin.apple_sdk_11_0.callPackage ../tools/security/mkp224o { };
 
   mkpasswd = hiPrio (callPackage ../tools/security/mkpasswd { });
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12567,7 +12567,7 @@ with pkgs;
 
   beekeeper-studio = callPackage ../development/tools/database/beekeeper-studio { };
 
-  bigloo = callPackage ../development/compilers/bigloo { };
+  bigloo = darwin.apple_sdk_11_0.callPackage ../development/compilers/bigloo { };
 
   binaryen = callPackage ../development/compilers/binaryen {
     nodejs = nodejs-slim;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25859,7 +25859,7 @@ with pkgs;
 
   bgpq4 = callPackage ../tools/networking/bgpq4 { };
 
-  blackbox = callPackage ../applications/version-management/blackbox { };
+  blackbox = darwin.apple_sdk_11_0.callPackage ../applications/version-management/blackbox { };
 
   bleachbit = callPackage ../applications/misc/bleachbit { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14027,8 +14027,8 @@ with pkgs;
   cargo-deadlinks = callPackage ../development/tools/rust/cargo-deadlinks {
     inherit (darwin.apple_sdk.frameworks) Security;
   };
-  cargo-deb = callPackage ../development/tools/rust/cargo-deb {
-    inherit (darwin.apple_sdk.frameworks) Security;
+  cargo-deb = darwin.apple_sdk_11_0.callPackage ../development/tools/rust/cargo-deb {
+    inherit (darwin.apple_sdk_11_0.frameworks) Security;
   };
   cargo-deps = callPackage ../development/tools/rust/cargo-deps { };
   cargo-download = callPackage ../development/tools/rust/cargo-download { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4376,8 +4376,8 @@ with pkgs;
 
   pyznap = python3Packages.callPackage ../tools/backup/pyznap {};
 
-  procs = callPackage ../tools/admin/procs {
-    inherit (darwin.apple_sdk.frameworks) Security;
+  procs = darwin.apple_sdk_11_0.callPackage ../tools/admin/procs {
+    inherit (darwin.apple_sdk_11_0.frameworks) Security;
     inherit (darwin) libiconv;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14098,8 +14098,8 @@ with pkgs;
   cargo-make = callPackage ../development/tools/rust/cargo-make {
     inherit (darwin.apple_sdk.frameworks) Security SystemConfiguration;
   };
-  cargo-modules = callPackage ../development/tools/rust/cargo-modules {
-    inherit (darwin.apple_sdk.frameworks) CoreFoundation CoreServices;
+  cargo-modules = darwin.apple_sdk_11_0.callPackage ../development/tools/rust/cargo-modules {
+    inherit (darwin.apple_sdk_11_0.frameworks) CoreFoundation CoreServices;
   };
   cargo-msrv = callPackage ../development/tools/rust/cargo-msrv {
     inherit (darwin.apple_sdk.frameworks) Security;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4716,7 +4716,7 @@ with pkgs;
 
   bup = callPackage ../tools/backup/bup { };
 
-  bupstash = callPackage ../tools/backup/bupstash { };
+  bupstash = darwin.apple_sdk_11_0.callPackage ../tools/backup/bupstash { };
 
   burp = callPackage ../tools/backup/burp { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30724,8 +30724,8 @@ with pkgs;
 
   vdpauinfo = callPackage ../tools/X11/vdpauinfo { };
 
-  vengi-tools = callPackage ../applications/graphics/vengi-tools {
-    inherit (darwin.apple_sdk.frameworks) Carbon CoreServices OpenCL;
+  vengi-tools = darwin.apple_sdk_11_0.callPackage ../applications/graphics/vengi-tools {
+    inherit (darwin.apple_sdk_11_0.frameworks) Carbon CoreServices OpenCL;
   };
 
   verbiste = callPackage ../applications/misc/verbiste {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9628,7 +9628,7 @@ with pkgs;
 
   plantuml-server = callPackage ../tools/misc/plantuml-server { };
 
-  plan9port = callPackage ../tools/system/plan9port { };
+  plan9port = darwin.apple_sdk_11_0.callPackage ../tools/system/plan9port { };
 
   platformioPackages = dontRecurseIntoAttrs (callPackage ../development/embedded/platformio { });
   platformio = platformioPackages.platformio-chrootenv;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34952,7 +34952,7 @@ with pkgs;
 
   sticky = callPackage ../applications/misc/sticky { };
 
-  stork = callPackage ../applications/misc/stork { };
+  stork = darwin.apple_sdk_11_0.callPackage ../applications/misc/stork { };
 
   oclgrind = callPackage ../development/tools/analysis/oclgrind { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2964,7 +2964,7 @@ with pkgs;
 
   bpb = callPackage ../tools/security/bpb { inherit (darwin.apple_sdk.frameworks) Security; };
 
-  bpytop = callPackage ../tools/system/bpytop { };
+  bpytop = darwin.apple_sdk_11_0.callPackage ../tools/system/bpytop { };
 
   brasero-original = lowPrio (callPackage ../tools/cd-dvd/brasero { });
 


### PR DESCRIPTION
###### Description of changes

#176661 allows x86_64-darwin to use the 11.0 SDK. This PR fixes most packages that were flagged as broken on x86_64darwin. It also reworks the MoltenVK derivation to build without needing Xcode (and bumps it because that patch has been sitting in my queue along with the Xcode build change). There are two exceptions:

- Go packages. These are being done in another PR (either #180704 or as part of #179622).
- Qt. The Qt derivation is pretty big, so I left it alone.
- SDL2. This causes a _lot_ of rebuilds. I’m going to submit the fix upstream and reference the patch in a separate PR against staging. Depending on the result of `nixpkgs-review`, I will probably include fixes to broken packages that depend on SDL2.
- MoltenVK. Moved to #180988. That PR will fix broken packages that use Vulkan.

I also updated the SDK-specific `callPackage` to make it more robust. It also now provides a couple of GCC stdenvs and `rustPlatform`.

Sandboxing is set to relaxed. I had to add a `sandboxProfile` to ccl to let it build with sandboxing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
