### PR TITLE
pulseaudioFull: fix wrapGApp wrapping, fix vm tests

### DIFF
--- a/nixos/modules/config/pulseaudio.nix
+++ b/nixos/modules/config/pulseaudio.nix
@@ -102,7 +102,7 @@ in {
           each user that tries to use the sound system. The server runs
           with user privileges. If true, one system-wide PulseAudio
           server is launched on boot, running as the user "pulse", and
-          only users in the "audio" group will have access to the server.
+          only users in the "pulse-access" group will have access to the server.
           Please read the PulseAudio documentation for more details.
 
           Don't enable this option unless you know what you are doing.
@@ -310,6 +310,7 @@ in {
       };
 
       users.groups.pulse.gid = gid;
+      users.groups.pulse-access = {};
 
       systemd.services.pulseaudio = {
         description = "PulseAudio System-Wide Server";

--- a/nixos/tests/pulseaudio.nix
+++ b/nixos/tests/pulseaudio.nix
@@ -40,7 +40,7 @@ let
             environment.systemPackages = [ testers.testPlay pkgs.pavucontrol ]
               ++ lib.optional pkgs.stdenv.isx86_64 testers.testPlay32;
           } // lib.optionalAttrs systemWide {
-            users.users.alice.extraGroups = [ "audio" ];
+            users.users.alice.extraGroups = [ "pulse-access" ];
             systemd.services.pulseaudio.wantedBy = [ "multi-user.target" ];
           };
 

--- a/nixos/tests/pulseaudio.nix
+++ b/nixos/tests/pulseaudio.nix
@@ -60,6 +60,11 @@ let
           ''}
           machine.screenshot("testPlay")
 
+          ${lib.optionalString (!systemWide) ''
+            machine.send_chars("pacmd info && touch /tmp/pacmd_success\n")
+            machine.wait_for_file("/tmp/pacmd_success")
+          ''}
+
           # Pavucontrol only loads when Pulseaudio is running. If it isn't, the
           # text "Dummy Output" (sound device name) will never show.
           machine.send_chars("pavucontrol\n")

--- a/nixos/tests/pulseaudio.nix
+++ b/nixos/tests/pulseaudio.nix
@@ -1,5 +1,5 @@
 let
-  mkTest = { systemWide ? false }:
+  mkTest = { systemWide ? false , fullVersion ? false }:
     import ./make-test-python.nix ({ pkgs, lib, ... }:
       let
         testFile = pkgs.fetchurl {
@@ -22,7 +22,7 @@ let
           testPlay32 = { inherit (pkgs.pkgsi686Linux) sox alsa-utils; };
         };
       in {
-        name = "pulseaudio${lib.optionalString systemWide "-systemWide"}";
+        name = "pulseaudio${lib.optionalString fullVersion "Full"}${lib.optionalString systemWide "-systemWide"}";
         meta = with pkgs.lib.maintainers; {
           maintainers = [ synthetica ] ++ pkgs.pulseaudio.meta.maintainers;
         };
@@ -35,6 +35,8 @@ let
               enable = true;
               support32Bit = true;
               inherit systemWide;
+            } // lib.optionalAttrs fullVersion {
+              package = pkgs.pulseaudioFull;
             };
 
             environment.systemPackages = [ testers.testPlay pkgs.pavucontrol ]
@@ -66,6 +68,8 @@ let
         '';
       });
 in builtins.mapAttrs (key: val: mkTest val) {
-  user = { systemWide = false; };
-  system = { systemWide = true; };
+  user = { systemWide = false; fullVersion = false; };
+  system = { systemWide = true; fullVersion = false; };
+  userFull = { systemWide = false; fullVersion = true; };
+  systemFull = { systemWide = true; fullVersion = true; };
 }

--- a/nixos/tests/pulseaudio.nix
+++ b/nixos/tests/pulseaudio.nix
@@ -4,7 +4,7 @@ let
       let
         testFile = pkgs.fetchurl {
           url =
-            "https://file-examples-com.github.io/uploads/2017/11/file_example_MP3_700KB.mp3";
+            "https://file-examples.com/storage/fe5947fd2362fc197a3c2df/2017/11/file_example_MP3_700KB.mp3";
           hash = "sha256-+iggJW8s0/LfA/okfXsB550/55Q0Sq3OoIzuBrzOPJQ=";
         };
 

--- a/nixos/tests/pulseaudio.nix
+++ b/nixos/tests/pulseaudio.nix
@@ -59,9 +59,9 @@ let
           machine.screenshot("testPlay")
 
           # Pavucontrol only loads when Pulseaudio is running. If it isn't, the
-          # text "Playback" (one of the tabs) will never show.
+          # text "Dummy Output" (sound device name) will never show.
           machine.send_chars("pavucontrol\n")
-          machine.wait_for_text("Playback")
+          machine.wait_for_text("Dummy Output")
           machine.screenshot("Pavucontrol")
         '';
       });

--- a/pkgs/servers/pulseaudio/default.nix
+++ b/pkgs/servers/pulseaudio/default.nix
@@ -116,6 +116,11 @@ stdenv.mkDerivation rec {
     "-Dsysconfdir=/etc"
     "-Dsysconfdir_install=${placeholder "out"}/etc"
     "-Dudevrulesdir=${placeholder "out"}/lib/udev/rules.d"
+
+    # pulseaudio complains if its binary is moved after installation;
+    # this is needed so that wrapGApp can operate *without*
+    # renaming the unwrapped binaries (see below)
+    "--bindir=${placeholder "out"}/.bin-unwrapped"
   ]
   ++ lib.optional (stdenv.isLinux && useSystemd) "-Dsystemduserunitdir=${placeholder "out"}/lib/systemd/user"
   ++ lib.optionals stdenv.isDarwin [
@@ -133,11 +138,11 @@ stdenv.mkDerivation rec {
   postInstall = lib.optionalString libOnly ''
     find $out/share -maxdepth 1 -mindepth 1 ! -name "vala" -prune -exec rm -r {} \;
     find $out/share/vala -maxdepth 1 -mindepth 1 ! -name "vapi" -prune -exec rm -r {} \;
-    rm -r $out/{bin,etc,lib/pulse-*}
+    rm -r $out/{.bin-unwrapped,etc,lib/pulse-*}
   ''
     + ''
     moveToOutput lib/cmake "$dev"
-    rm -f $out/bin/qpaeq # this is packaged by the "qpaeq" package now, because of missing deps
+    rm -f $out/.bin-unwrapped/qpaeq # this is packaged by the "qpaeq" package now, because of missing deps
   '';
 
   preFixup = lib.optionalString (stdenv.isLinux  && (stdenv.hostPlatform == stdenv.buildPlatform)) ''
@@ -151,6 +156,15 @@ stdenv.mkDerivation rec {
       ln -s "''$file" "''${file%.dylib}.so"
       ln -s "''$file" "$out/lib/pulseaudio/''$(basename ''$file .dylib).so"
     done
+  ''
+  # put symlinks to binaries in `$prefix/bin`;
+  # then wrapGApp will *rename these symlinks* instead of
+  # the original binaries in `$prefix/.bin-unwrapped` (see above);
+  # when pulseaudio is looking for its own binary (it does!),
+  # it will be happy to find it in its original installation location
+  + lib.optionalString (!libOnly) ''
+    mkdir -p $out/bin
+    ln -st $out/bin $out/.bin-unwrapped/*
   '';
 
   passthru = {


### PR DESCRIPTION
Since https://github.com/NixOS/nixpkgs/commit/7a2605e0f3dc99e02cd577634f792f7a4d229378 the pulseaudio build recipe incorporates the `wrapGAppsHook` wrapper setup-hook if `advancedBluetoothCodecs` are enabled.  This wrapper setup-hook -- like most wrappers -- wraps binaries in `$out/bin` by first renaming them, then placing a wrapper script where the original binary was.

Unfortunatelly, pulseaudio doesn't like its binary moved around after installation: It records the binaries path during installation time in https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/blob/e5ad31e873eed62bc580a86a61177047f9e8c491/meson.build#L154 , then checks the path in `/proc/self/exe` and complains

> Jun 16 19:06:48 nixosb pulseaudio[2219]: W: [.pulseaudio-wra] main.c: /proc/self/exe does not point to /nix/store/bqfyzxwpxa2ydmyvh3j32xrm4chxbj22-pulseaudio-15.0/bin/pulseaudio, cannot self execute. Are you playing games?

if they don't match: https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/blob/e5ad31e873eed62bc580a86a61177047f9e8c491/src/daemon/main.c#L577

Somehow, this also results in a real bug: `pacmd` fails to connect to the pulseaudio server, see https://github.com/NixOS/nixpkgs/issues/177915 .

###### Description of changes

To fix this issue, the commit at hand changes the installation directory for binaries to `$out/.bin-unwrapped`.  After the installation, `$out/bin` is created by hand and populated with symlinks to files in `$out/.bin-unwrapped`.  `wrapGAppsHook` doesn't know or care about the `.bin-unwrapped` directory; it just sees all the symlinks in `bin`, renames them and places wrapper scripts beside them.

Effectively, this leaves the original binary in `.bin-unwrapped` unchanged!  So pulseaudio will find itself still in its oritinal place, and "users" of the package can call pulseaudio via the wrapper script in `bin` as usual.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [x] [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - [ ]and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - [ ]or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - [ ]made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### More comments

* I tried `nixpkgs-review` and it attempted a mass rebuild, which I had to abort.  The mass rebuild is likely caused by this pull request also touching `libpulseaudio`.  So it better targets `staging`...
* I tested a minimal (e.g., non-graphical) NixOS installation with `pulseaudioFull` and the patch at hand applied.  After some compiling, the system booted, pulseaudio started, it was able to play some music with `paplay`, and `pacmd info` also worked, i.e., the patch fixes https://github.com/NixOS/nixpkgs/issues/177915 .
* The patch, in particular the new `.bin-unwrapped` directory, feel a bit unorthodox.  It attempts to fix a minor bug in the current implementation and I hope it doesn't introduce new ones.  I can't test this on my productive system as I cannot rebuild everything, but good testing seems to be needed here.

* notifying maintainer: @lovek323
* notifying bug report participant and author of the commit that introduced `wrapGAppsHook`: @schmittlauch 