### PR TITLE
ftxui: 2.0.0 -> 3.0.0

### DIFF
--- a/pkgs/development/libraries/ftxui/default.nix
+++ b/pkgs/development/libraries/ftxui/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , cmake
 , doxygen
 , graphviz
@@ -8,19 +9,32 @@
 
 stdenv.mkDerivation rec {
   pname = "ftxui";
-  version = "2.0.0";
+  version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "ArthurSonzogni";
-    repo = pname;
+    repo = "ftxui";
     rev = "v${version}";
-    sha256 = "sha256-BfNUk2DbBpKMBEu1tQWl85tgjB/4NAh86VVSS9zAjKo=";
+    sha256 = "sha256-2pCk4drYIprUKcjnrlX6WzPted7MUAp973EmAQX3RIE=";
   };
+
+  patches = [
+    # Can be removed once https://github.com/ArthurSonzogni/FTXUI/pull/403 hits a stable release
+    (fetchpatch {
+      name = "fix-postevent-segfault.patch";
+      url = "https://github.com/ArthurSonzogni/FTXUI/commit/f9256fa132e9d3c50ef1e1eafe2774160b38e063.patch";
+      sha256 = "sha256-0040/gJcCXzL92FQLhZ2dNMJhNqXXD+UHFv4Koc07K0=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake
     doxygen
     graphviz
+  ];
+
+  cmakeFlags = [
+    "-DFTXUI_BUILD_EXAMPLES=OFF"
   ];
 
   # gtest and gbenchmark don't seem to generate any binaries


### PR DESCRIPTION
###### Description of changes
Without the changes from https://github.com/ArthurSonzogni/FTXUI/pull/403 a project of mine segfaulted, so I've patched that in. See [the changelog](https://github.com/ArthurSonzogni/FTXUI/blob/v3.0.0/CHANGELOG.md) for more information.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and “core” functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
