### PR TITLE
aqbanking: 6.3.0 -> 6.5.0; gwenhyfar: 5.6.0 -> 5.9.0; libchipcard: 5.0.4 -> 5.1.6

### DIFF
--- a/pkgs/development/libraries/aqbanking/default.nix
+++ b/pkgs/development/libraries/aqbanking/default.nix
@@ -3,14 +3,14 @@
 }:
 
 let
-  inherit ((import ./sources.nix).aqbanking) sha256 releaseId version;
+  inherit ((import ./sources.nix).aqbanking) hash releaseId version;
 in stdenv.mkDerivation rec {
   pname = "aqbanking";
   inherit version;
 
   src = fetchurl {
     url = "https://www.aquamaniac.de/rdm/attachments/download/${releaseId}/${pname}-${version}.tar.gz";
-    inherit sha256;
+    inherit hash;
   };
 
   # Set the include dir explicitly, this fixes a build error when building

--- a/pkgs/development/libraries/aqbanking/gwenhywfar.nix
+++ b/pkgs/development/libraries/aqbanking/gwenhywfar.nix
@@ -11,14 +11,14 @@
 }:
 
 let
-  inherit ((import ./sources.nix).gwenhywfar) sha256 releaseId version;
+  inherit ((import ./sources.nix).gwenhywfar) hash releaseId version;
 in stdenv.mkDerivation rec {
   pname = "gwenhywfar";
   inherit version;
 
   src = fetchurl {
     url = "https://www.aquamaniac.de/rdm/attachments/download/${releaseId}/${pname}-${version}.tar.gz";
-    inherit sha256;
+    inherit hash;
   };
 
   configureFlags = [

--- a/pkgs/development/libraries/aqbanking/libchipcard.nix
+++ b/pkgs/development/libraries/aqbanking/libchipcard.nix
@@ -1,14 +1,14 @@
 { lib, stdenv, fetchurl, pkg-config, gwenhywfar, pcsclite, zlib }:
 
 let
-  inherit ((import ./sources.nix).libchipcard) sha256 releaseId version;
+  inherit ((import ./sources.nix).libchipcard) hash releaseId version;
 in stdenv.mkDerivation rec {
   pname = "libchipcard";
   inherit version;
 
   src = fetchurl {
     url = "https://www.aquamaniac.de/rdm/attachments/download/${releaseId}/${pname}-${version}.tar.gz";
-    inherit sha256;
+    inherit hash;
   };
 
   nativeBuildInputs = [ pkg-config ];
@@ -16,8 +16,6 @@ in stdenv.mkDerivation rec {
   buildInputs = [ gwenhywfar pcsclite zlib ];
 
   makeFlags = [ "crypttokenplugindir=$(out)/lib/gwenhywfar/plugins/ct" ];
-
-  configureFlags = [ "--with-gwen-dir=${gwenhywfar}" ];
 
   meta = with lib; {
     description = "Library for access to chipcards";

--- a/pkgs/development/libraries/aqbanking/sources.nix
+++ b/pkgs/development/libraries/aqbanking/sources.nix
@@ -5,7 +5,11 @@
   libchipcard.version = "5.0.4";
   libchipcard.sha256 = "0fj2h39ll4kiv28ch8qgzdbdbnzs8gl812qnm660bw89rynpjnnj";
   libchipcard.releaseId = "158";
-  aqbanking.version = "6.3.0";
-  aqbanking.sha256 = "1k2mhdnk0jc0inq1hmp74m3y7azxrjm8r07x5k1pp4ic0yi5vs50";
-  aqbanking.releaseId = "372";
+
+  # https://www.aquamaniac.de/rdm/projects/aqbanking/files
+  aqbanking = {
+    version = "6.5.0";
+    hash = "sha256-TS076ghulq2ntoGSBtTrQWjOt+Mtzppo3Gxuq8yetj4=";
+    releaseId = "435";
+  };
 }

--- a/pkgs/development/libraries/aqbanking/sources.nix
+++ b/pkgs/development/libraries/aqbanking/sources.nix
@@ -2,9 +2,13 @@
   gwenhywfar.version = "5.6.0";
   gwenhywfar.sha256 = "1isbj4a7vdgagp3kkvx2pjcjy8lba6kzjr11fmr06aci1694dbsp";
   gwenhywfar.releaseId = "364";
-  libchipcard.version = "5.0.4";
-  libchipcard.sha256 = "0fj2h39ll4kiv28ch8qgzdbdbnzs8gl812qnm660bw89rynpjnnj";
-  libchipcard.releaseId = "158";
+
+  # https://www.aquamaniac.de/rdm/projects/libchipcard/files
+  libchipcard = {
+    version = "5.1.6";
+    hash = "sha256-bAf1J0F/dWIHT5kBLaTRHrTbr9M/SeZrRCzNbjuM/SA=";
+    releaseId = "382";
+  };
 
   # https://www.aquamaniac.de/rdm/projects/aqbanking/files
   aqbanking = {

--- a/pkgs/development/libraries/aqbanking/sources.nix
+++ b/pkgs/development/libraries/aqbanking/sources.nix
@@ -1,7 +1,10 @@
 {
-  gwenhywfar.version = "5.6.0";
-  gwenhywfar.sha256 = "1isbj4a7vdgagp3kkvx2pjcjy8lba6kzjr11fmr06aci1694dbsp";
-  gwenhywfar.releaseId = "364";
+  # https://www.aquamaniac.de/rdm/projects/gwenhywfar/files
+  gwenhywfar = {
+    version = "5.9.0";
+    hash = "sha256-6Ix9M4Ojy75Gyzsimfcd+55vpWX1oWaLQpc5HIdLDhI=";
+    releaseId = "415";
+  };
 
   # https://www.aquamaniac.de/rdm/projects/libchipcard/files
   libchipcard = {


### PR DESCRIPTION
###### Description of changes

https://www.aquamaniac.de/rdm/news/32
https://www.aquamaniac.de/rdm/news/31
https://www.aquamaniac.de/rdm/news/30

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
