### PR TITLE
voms: 2021-05-04 -> 2022-06-14 and fixes & xrootd: 5.4.2 -> 5.4.3

### DIFF
--- a/pkgs/tools/networking/voms/default.nix
+++ b/pkgs/tools/networking/voms/default.nix
@@ -15,13 +15,13 @@
 
 stdenv.mkDerivation rec{
   pname = "voms-unstable";
-  version = "2021-05-04";
+  version = "2022-06-14";
 
   src = fetchFromGitHub {
     owner = "italiangrid";
     repo = "voms";
-    rev = "61563152fce3a4e6860dd8ab8ab6e72b7908d8b8";
-    sha256 = "LNR0G4XrgxqjQmjyaKoZJLNoxtAGiTM93FG3jIU1u+Y=";
+    rev = "8e99bb96baaf197f0f557836e2829084bb1bb00e"; # develop branch
+    hash = "sha256-FG4fHO2lsQ3t/ZaKT9xY+xqdQHfdtzi5ULtxLhdPnss=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/networking/voms/default.nix
+++ b/pkgs/tools/networking/voms/default.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec{
   ];
 
   meta = with lib; {
-    description = "The VOMS native service and APIs";
+    description = "The C/C++ VOMS server, client and APIs v2.x";
     homepage = "https://italiangrid.github.io/voms/";
     changelog = "https://github.com/italiangrid/voms/blob/master/ChangeLog";
     license = licenses.asl20;

--- a/pkgs/tools/networking/voms/default.nix
+++ b/pkgs/tools/networking/voms/default.nix
@@ -11,6 +11,10 @@
 , gsoap
 , openssl
 , zlib
+  # Configuration overridable with .override
+  # If not null, the builder will
+  # move "$out/etc" to "$out/etc.orig" and symlink "$out/etc" to externalEtc.
+, externalEtc ? "/etc"
 }:
 
 stdenv.mkDerivation rec{
@@ -22,6 +26,10 @@ stdenv.mkDerivation rec{
     repo = "voms";
     rev = "8e99bb96baaf197f0f557836e2829084bb1bb00e"; # develop branch
     hash = "sha256-FG4fHO2lsQ3t/ZaKT9xY+xqdQHfdtzi5ULtxLhdPnss=";
+  };
+
+  passthru = {
+    inherit externalEtc;
   };
 
   nativeBuildInputs = [
@@ -58,6 +66,13 @@ stdenv.mkDerivation rec{
   configureFlags = [
     "--with-gsoap-wsdl2h=${gsoap}/bin/wsdl2h"
   ];
+
+  postFixup = ''
+    ${lib.optionalString (externalEtc != null) ''
+      mv "$out"/etc{,.orig}
+      ln -s ${lib.escapeShellArg externalEtc} "$out/etc"
+    ''}
+  '';
 
   meta = with lib; {
     description = "The C/C++ VOMS server, client and APIs v2.x";

--- a/pkgs/tools/networking/xrootd/default.nix
+++ b/pkgs/tools/networking/xrootd/default.nix
@@ -20,14 +20,14 @@
 
 stdenv.mkDerivation rec {
   pname = "xrootd";
-  version = "5.4.2";
+  version = "5.4.3";
 
   src = fetchFromGitHub {
     owner = "xrootd";
     repo = "xrootd";
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "sha256-k6uAJbUhpwnRrSeGn4JQiHDBrGJNQDf5vG2a+je5ByU=";
+    hash = "sha256-BlMYm4ffSpUxqMjlDVZC59KOuLvwsk/BeBB3VBjAwjs=";
   };
 
   outputs = [ "bin" "out" "dev" "man" ];


### PR DESCRIPTION
###### Description of changes

- Contain #180527 that updates voms and xrootd
- Fix package voms:
  - Provide an input argument `externalEtc`, which, if not `null`, will instruct the builder to move "$out/etc" to "$out/etc.orig" and symlink "$out/etc" to `externalEtc`. The default is set to `"/etc"`which is reasonable for most use cases (e.g. on LXPLUS).
  - Make it clear in the meta.description that it is in C/C++ and that its version is 2.x, for the relevant VOMS client is now written in Java, versioned 3.x and hosted in another repository.

The xrootd package still suffers from #169677 and does not work. Suggestions / contributions will be appreciated!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`) (Tested on LXPLUS)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
