### PR TITLE
zafiro-icons: 1.2 -> 1.3

### DIFF
--- a/pkgs/data/icons/zafiro-icons/default.nix
+++ b/pkgs/data/icons/zafiro-icons/default.nix
@@ -13,13 +13,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "zafiro-icons";
-  version = "1.2";
+  version = "1.3";
 
   src = fetchFromGitHub {
     owner = "zayronxio";
     repo = pname;
     rev = version;
-    sha256 = "sha256-Awc5Sw4X25pXEd4Ob0u6A6Uu0e8FYfwp0fEl90vrsUE=";
+    sha256 = "sha256-IbFnlUOSADYMNMfvRuRPndxcQbnV12BqMDb9bJRjnoU=";
   };
 
   nativeBuildInputs = [
@@ -44,13 +44,20 @@ stdenvNoCC.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    # remove copy file, as it is there clearly by mistake
-    rm "apps/scalable/android-sdk (copia 1).svg"
+    mkdir -p $out/share/icons
 
-    mkdir -p $out/share/icons/Zafiro-icons
-    cp -a * $out/share/icons/Zafiro-icons
+    for theme in Dark Light; do
+      cp -a $theme $out/share/icons/Zafiro-icons-$theme
 
-    gtk-update-icon-cache $out/share/icons/Zafiro-icons
+      # remove unneeded files
+      rm $out/share/icons/Zafiro-icons-$theme/_config.yml
+
+      # remove files with non-ascii characters in name
+      # https://github.com/zayronxio/Zafiro-icons/issues/111
+      rm $out/share/icons/Zafiro-icons-$theme/apps/scalable/βTORRENT.svg
+
+      gtk-update-icon-cache $out/share/icons/Zafiro-icons-$theme
+    done
 
     jdupes --link-soft --recurse $out/share
 

--- a/pkgs/data/icons/zafiro-icons/default.nix
+++ b/pkgs/data/icons/zafiro-icons/default.nix
@@ -1,4 +1,15 @@
-{ lib, stdenvNoCC, fetchFromGitHub, gtk3, breeze-icons, gnome-icon-theme, numix-icon-theme, numix-icon-theme-circle, hicolor-icon-theme, jdupes }:
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, gtk3
+, breeze-icons
+, gnome-icon-theme
+, numix-icon-theme
+, numix-icon-theme-circle
+, hicolor-icon-theme
+, jdupes
+, gitUpdater
+}:
 
 stdenvNoCC.mkDerivation rec {
   pname = "zafiro-icons";
@@ -45,6 +56,8 @@ stdenvNoCC.mkDerivation rec {
 
     runHook postInstall
   '';
+
+  passthru.updateScript = gitUpdater { inherit pname version; };
 
   meta = with lib; {
     description = "Icon pack flat with light colors";


### PR DESCRIPTION
###### Description of changes

Update to version [1.3](https://github.com/zayronxio/Zafiro-icons/releases/tag/1.3)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
