### PR TITLE
libsolv: enable more compression methods

### DIFF
--- a/pkgs/development/libraries/libsolv/default.nix
+++ b/pkgs/development/libraries/libsolv/default.nix
@@ -1,4 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, cmake, ninja, zlib, expat, rpm, db }:
+{ lib, stdenv, fetchFromGitHub, cmake, ninja, pkg-config
+, zlib, lzma, bzip2, zchunk, zstd
+, expat, rpm, db }:
 
 stdenv.mkDerivation rec {
   version  = "0.7.22";
@@ -17,10 +19,15 @@ stdenv.mkDerivation rec {
     "-DENABLE_RPMDB=true"
     "-DENABLE_PUBKEY=true"
     "-DENABLE_RPMDB_BYRPMHEADER=true"
+    "-DENABLE_LZMA_COMPRESSION=true"
+    "-DENABLE_BZIP2_COMPRESSION=true"
+    "-DENABLE_ZSTD_COMPRESSION=true"
+    "-DENABLE_ZCHUNK_COMPRESSION=true"
+    "-DWITH_SYSTEM_ZCHUNK=true"
   ];
 
-  nativeBuildInputs = [ cmake ninja ];
-  buildInputs = [ zlib expat rpm db ];
+  nativeBuildInputs = [ cmake ninja pkg-config ];
+  buildInputs = [ zlib lzma bzip2 zchunk zstd expat rpm db ];
 
   meta = with lib; {
     description = "A free package dependency solver";


### PR DESCRIPTION
###### Description of changes

Compile libsolv with more compression libraries.
Without them microdnf segfaults on any real-world usage attempts,
since real-world repodata is compressed and error handling is lacking.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
