### PR TITLE
Add `bash` to netdata service path

### DIFF
--- a/nixos/modules/services/monitoring/netdata.nix
+++ b/nixos/modules/services/monitoring/netdata.nix
@@ -186,7 +186,7 @@ in {
       description = "Real time performance monitoring";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
-      path = (with pkgs; [ curl gawk iproute2 which procps ])
+      path = (with pkgs; [ curl gawk iproute2 which procps bash ])
         ++ lib.optional cfg.python.enable (pkgs.python3.withPackages cfg.python.extraPackages)
         ++ lib.optional config.virtualisation.libvirtd.enable (config.virtualisation.libvirtd.package);
       environment = {


### PR DESCRIPTION
The `bash` binary is needed for running some plugins, notably the alarm notify plugins. If the binary isn't in the path, alarms notifications aren't sent and the netdata error log instead contains `/usr/bin/env: 'bash': No such file or directory`.

I'd like for this change to be backported to 22.05 if possible.
###### Description of changes
Adds the `bash` package to the systemd service path.

###### Things done
I tested this by setting `systemd.services.netdata.path = [ pkgs.bash ];` in my system's `/etc/nixos/configuration.nix`, which should have the same result.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
