### PR TITLE
Revert "linux-kernel: disable BTF on 32-bit platforms on kernels 5.15+"

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -44,8 +44,7 @@ let
       # Reduced debug info conflict with BTF and have been enabled in
       # aarch64 defconfig since 5.13
       DEBUG_INFO_REDUCED        = whenAtLeast "5.13" (option no);
-      # Disabled on 32-bit platforms, fails to build on 5.15+ with `Failed to parse base BTF 'vmlinux': -22`
-      DEBUG_INFO_BTF            = whenAtLeast "5.2" (option (if stdenv.hostPlatform.is32bit && (versionAtLeast version "5.15") then no else yes));
+      DEBUG_INFO_BTF            = whenAtLeast "5.2" (option yes);
       BPF_LSM                   = whenAtLeast "5.7" (option yes);
       DEBUG_KERNEL              = yes;
       DEBUG_DEVRES              = no;


### PR DESCRIPTION
This reverts commit 79e05fb16b1af292e50cc0c479809cc66b47b087.

broken 32bit BTF builds got fixed in #175467 by switching libbpf from libelf to elfutils, as a side-product of the upgrade, so we don't need this anymore.

This slows down kernel builds a tiny bit so if the status quo is that nobody cares we might be just as well with it off though, I just mostly want to get ofborg to test a kernel build to confirm