### PR TITLE
dmidecode: 3.2 -> 3.4

### DIFF
--- a/pkgs/os-specific/linux/dmidecode/default.nix
+++ b/pkgs/os-specific/linux/dmidecode/default.nix
@@ -1,57 +1,13 @@
-{ lib, stdenv, fetchurl, fetchpatch }:
+{ lib, stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
   pname = "dmidecode";
-  version = "3.2";
+  version = "3.4";
 
   src = fetchurl {
     url = "mirror://savannah/dmidecode/dmidecode-${version}.tar.xz";
-    sha256 = "1pcfhcgs2ifdjwp7amnsr3lq95pgxpr150bjhdinvl505px0cw07";
+    sha256 = "sha256-Q8uoUdhGfJl5zNvqsZLrZjjH06aX66Xdt3naiDdUIhI=";
   };
-
-  patches = [
-    # suggested patches for 3.2 according to https://www.nongnu.org/dmidecode/
-    (fetchpatch {
-      name = "0001-fix_redfish_hostname_print_length.patch";
-      url = "https://git.savannah.gnu.org/cgit/dmidecode.git/patch/?id=fde47bb227b8fa817c88d7e10a8eb771c46de1df";
-      sha256 = "133nd0c72p68hnqs5m714167761r1pp6bd3kgbsrsrwdx40jlc3m";
-    })
-    (fetchpatch {
-      name = "0002-add_logical_non-volatile_device_to_memory_device_types.patch";
-      url = "https://git.savannah.gnu.org/cgit/dmidecode.git/patch/?id=74dfb854b8199ddb0a27e89296fa565f4706cb9d";
-      sha256 = "0wdpmlcwmqdyyrsmyis8jb7cx3q6fnqpdpc5xly663dj841jcvwh";
-    })
-    (fetchpatch {
-      name = "0003-only-scan-devmem-for-entry-point-on-x86.patch";
-      url = "https://git.savannah.gnu.org/cgit/dmidecode.git/patch/?id=e12ec26e19e02281d3e7258c3aabb88a5cf5ec1d";
-      sha256 = "1y2858n98bfa49syjinx911vza6mm7aa6xalvzjgdlyirhccs30i";
-    })
-    (fetchpatch {
-      name = "0004-fix_formatting_of_tpm_table_output.patch";
-      url = "https://git.savannah.gnu.org/cgit/dmidecode.git/patch/?id=1d0db85949a5bdd96375f6131d393a11204302a6";
-      sha256 = "11s8jciw7xf2668v79qcq2c9w2gwvm3dkcik8dl9v74p654y1nr8";
-    })
-    (fetchpatch {
-      name = "0005-fix_system-slot_information_for_pcie_ssd.patch";
-      url = "https://git.savannah.gnu.org/cgit/dmidecode.git/patch/?id=fd08479625b5845e4d725ab628628f7ebfccc407";
-      sha256 = "07l61wvsw1d8g14zzf6zm7l0ri9kkqz8j5n4h116qwhg1p2k49y4";
-    })
-    (fetchpatch {
-      name = "0006-print_type_33_name_unconditionally.patch";
-      url = "https://git.savannah.gnu.org/cgit/dmidecode.git/patch/?id=65438a7ec0f4cddccf810136da6f280bd148af71";
-      sha256 = "0gqz576ccxys0c8217spf1qmw9lxi9xalw85jjqwsi2bj1k6vy4n";
-    })
-    (fetchpatch {
-      name = "0007-dont_choke_on_invalid_processor_voltage.patch";
-      url = "https://git.savannah.gnu.org/cgit/dmidecode.git/patch/?id=5bb7eb173b72256f70c6b3f3916d7a444be93340";
-      sha256 = "1dkg4lq9kn2g1w5raz1gssn6zqk078zjqbnh9i32f822f727syhp";
-    })
-    (fetchpatch {
-      name = "0008-fix_the_alignment_of_type_25_name.patch";
-      url = "https://git.savannah.gnu.org/cgit/dmidecode.git/patch/?id=557c3c373a9992d45d4358a6a2ccf53b03276f39";
-      sha256 = "18hc91pk7civyqrlilg3kn2nmp2warhh49xlbzrwqi7hgipyf12z";
-    })
-  ];
 
   makeFlags = [
     "prefix=$(out)"
@@ -63,5 +19,6 @@ stdenv.mkDerivation rec {
     description = "A tool that reads information about your system's hardware from the BIOS according to the SMBIOS/DMI standard";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
+    maintainers = with maintainers; [ delroth ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Update dmidecode to its latest release. We skipped 3.3 (released back in 2020) presumably because there's no maintainer for this package. I adopted the package along the way to try and keep it a bit more up to date in the future.

<details><summary>Changelog</summary>

```
Version 3.4 (Mon Jun 27 2022)
  - Support for SMBIOS 3.4.0. This includes new memory device types, new
    processor upgrades, new slot types and characteristics, decoding of memory
    module extended speed, new system slot types, new processor characteristics
    and new format of Processor ID.
  - Support for SMBIOS 3.5.0. This includes new processor upgrades, BIOS
    characteristics, new slot characteristics, new on-board device types, new
    pointing device interface types, and a new record type (type 45 -
    Firmware Inventory Information).
  - Decode HPE OEM records 194, 199, 203, 236, 237, 238 and 240.
  - Bug fixes:
    Fix OEM vendor name matching
    Fix ASCII filtering of strings
    Fix crash with option -u
  - Minor improvements:
    Skip details of uninstalled memory modules
    Don't display the raw CPU ID in quiet mode
    Improve the formatting of the manual pages

Version 3.3 (Wed Oct 14 2020)
  - [BUILD] Allow overriding build settings from the environment.
  - [COMPATIBILITY] Document how the UUID fields are interpreted.
  - [PORTABILITY] Don't use memcpy on /dev/mem on arm64.
  - [PORTABILITY] Only scan /dev/mem for entry point on x86.
  - Support for SMBIOS 3.3.0. This includes new processor names, new port
    connector types, and new memory device form factors, types and
    technologies.
  - Add bios-revision, firmware-revision and system-sku-number to -s option.
  - Use the most appropriate unit for cache size.
  - Decode system slot base bus width and peers.
  - Important bug fixes:
    Fix Redfish Hostname print length
    Fix formatting of TPM table output
    Fix System Slot Information for PCIe SSD
    Don't choke on invalid processor voltage
  - Use the most appropriate unit for cache size.
```
</details>

<details><summary>Output diff between 3.2 / 3.4 on my system</summary>

```
@@ -1,4 +1,4 @@
-# dmidecode 3.2
+# dmidecode 3.4
 Getting SMBIOS data from sysfs.
 SMBIOS 2.8 present.
 64 structures occupying 3074 bytes.
@@ -73,8 +73,8 @@
 	Configuration: Enabled, Not Socketed, Level 3
 	Operational Mode: Write Back
 	Location: Internal
-	Installed Size: 4096 kB
-	Maximum Size: 4096 kB
+	Installed Size: 4 MB
+	Maximum Size: 4 MB
 	Supported SRAM Types:
 		Synchronous
 	Installed SRAM Type: Synchronous
@@ -159,7 +159,7 @@
 	Error Information Handle: Not Provided
 	Total Width: 64 bits
 	Data Width: 64 bits
-	Size: 8192 MB
+	Size: 8 GB
 	Form Factor: Chip
 	Set: None
 	Locator: ChannelA
@@ -183,7 +183,7 @@
 	Error Information Handle: Not Provided
 	Total Width: 64 bits
 	Data Width: 64 bits
-	Size: 8192 MB
+	Size: 8 GB
 	Form Factor: SODIMM
 	Set: None
 	Locator: ChannelB
```
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
