### PR TITLE
wakeonlan: 0.41 -> 0.42

### DIFF
--- a/pkgs/tools/networking/wakeonlan/default.nix
+++ b/pkgs/tools/networking/wakeonlan/default.nix
@@ -2,18 +2,20 @@
 
 perlPackages.buildPerlPackage rec {
   pname = "wakeonlan";
-  version = "0.41";
+  version = "0.42";
 
   src = fetchFromGitHub {
     owner = "jpoliv";
     repo = pname;
-    rev = "wakeonlan-${version}";
-    sha256 = "0m48b39lz0yc5ckx2jx8y2p4c8npjngxl9wy86k43xgsd8mq1g3c";
+    rev = "v${version}";
+    sha256 = "sha256-zCOpp5iNrWwh2knBGWhiEyG9IPAnFRwH5jJLEVLBISM=";
   };
 
   outputs = [ "out" ];
 
   nativeBuildInputs = [ installShellFiles ];
+  # buildInputs = [ perl534Packages.TestPerlCritic perl534Packages.TestPod perl534Packages.TestPodCoverage ];
+  doCheck = false;  # Missing package for https://github.com/genio/test-spelling to run tests
 
   installPhase = ''
     install -Dt $out/bin wakeonlan


### PR DESCRIPTION
###### Description of changes
The current package is of 0.41, which is from 2011 and doesn't work (at least on my end). The current 0.42 version has the same CLI but works and outputs a bit more information.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
