### PR TITLE
pinentry-rofi: init at 2.0.3

### DIFF
--- a/pkgs/tools/security/pinentry-rofi/default.nix
+++ b/pkgs/tools/security/pinentry-rofi/default.nix
@@ -1,0 +1,41 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, pkg-config
+, autoreconfHook
+, autoconf-archive
+, guile
+, texinfo
+, rofi
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pinentry-rofi";
+  version = "2.0.3";
+
+  src = fetchFromGitHub {
+    owner = "plattfot";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-EzbeMAhdn9SuSmE+aMHeyuje3s74isIKRDTrFO3bX04=";
+  };
+
+  nativeBuildInputs = [
+    autoconf-archive
+    autoreconfHook
+    pkg-config
+    texinfo
+  ];
+
+  buildInputs = [ guile ];
+
+  propagatedBuildInputs = [ rofi ];
+
+  meta = with lib; {
+    description = "Rofi frontend to pinentry";
+    homepage = "https://github.com/plattfot/pinentry-rofi";
+    license = licenses.gpl3Plus;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ seqizz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9610,6 +9610,8 @@ with pkgs;
 
   pinentry-bemenu = callPackage ../tools/security/pinentry-bemenu { };
 
+  pinentry-rofi = callPackage ../tools/security/pinentry-rofi { };
+
   pingtcp = callPackage ../tools/networking/pingtcp { };
 
   pinnwand = callPackage ../servers/pinnwand { };


### PR DESCRIPTION
###### Description of changes

A new pinentry helper tool, couldn't add to the pinentry flavors so I did what pinentry-bemenu did: Just add the package.

I'd love to be able to change this so we can just give this as kind of "custom" flavor, but I have no idea

Anyway, please ping if I've missed something. Fixes #180728 (thanks to @kilianar).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
