### PR TITLE
glances: fix tests on darwin

### DIFF
--- a/pkgs/applications/system/glances/default.nix
+++ b/pkgs/applications/system/glances/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonApplication, fetchFromGitHub, isPyPy, lib
+{ stdenv, buildPythonApplication, fetchFromGitHub, fetchpatch, isPyPy, lib
 , defusedxml, future, packaging, psutil, setuptools
 # Optional dependencies:
 , bottle, pysnmp
@@ -20,7 +20,17 @@ buildPythonApplication rec {
   };
 
   # Some tests fail in the sandbox (they e.g. require access to /sys/class/power_supply):
-  patches = lib.optional (doCheck && stdenv.isLinux) ./skip-failing-tests.patch;
+  patches = lib.optional (doCheck && stdenv.isLinux) ./skip-failing-tests.patch
+    ++ lib.optional (doCheck && stdenv.isDarwin)
+    [
+      # Fix "TypeError: unsupported operand type(s) for +=: 'int' and 'NoneType'" on darwin
+      # https://github.com/nicolargo/glances/pull/2082
+      (fetchpatch {
+        name = "fix-typeerror-when-testing-on-darwin.patch";
+        url = "https://patch-diff.githubusercontent.com/raw/nicolargo/glances/pull/2082.patch";
+        sha256 = "sha256-MIePPywZ2dTTqXjf7EJiHlQ7eltiHzgocqrnLeLJwZ4=";
+      })
+    ];
 
   # On Darwin this package segfaults due to mismatch of pure and impure
   # CoreFoundation. This issues was solved for binaries but for interpreted


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Apply changes from https://github.com/nicolargo/glances/pull/2082.

The tests are broken since glances 3.2.5:

```shell
$ hydra-check --arch aarch64-darwin --channel nixpkgs/nixpkgs-unstable-aarch64-darwin glances
Build Status for glances.aarch64-darwin on nixpkgs/nixpkgs-unstable-aarch64-darwin
✖ (Failed) glances-3.2.6.4 from 2022-07-08 - https://hydra.nixos.org/build/183126382

Last Builds:
✖ (Failed) glances-3.2.6.4 from 2022-06-29 - https://hydra.nixos.org/build/182087380
✖ (Failed) glances-3.2.6.4 from 2022-06-28 - https://hydra.nixos.org/build/180840749
✖ (Failed) glances-3.2.6.4 from 2022-06-16 - https://hydra.nixos.org/build/180591914
✖ (Failed) glances-3.2.5 from 2022-06-08 - https://hydra.nixos.org/build/179752943
✔ glances-3.2.4.2 from 2022-06-03 - https://hydra.nixos.org/build/179151394
✔ glances-3.2.4.2 from 2022-05-24 - https://hydra.nixos.org/build/178146299
✔ glances-3.2.4.2 from 2022-05-17 - https://hydra.nixos.org/build/177193972
✔ glances-3.2.4.2 from 2022-05-09 - https://hydra.nixos.org/build/176162015
✔ glances-3.2.4.2 from 2022-05-02 - https://hydra.nixos.org/build/175375386
$ hydra-check --arch x86_64-darwin --channel nixpkgs/trunk glances
Build Status for glances.x86_64-darwin on nixpkgs/trunk
✖ (Failed) glances-3.2.6.4 from 2022-07-08 - https://hydra.nixos.org/build/183084786

Last Builds:
✖ (Failed) glances-3.2.6.4 from 2022-06-28 - https://hydra.nixos.org/build/181998446
✖ (Failed) glances-3.2.6.4 from 2022-06-19 - https://hydra.nixos.org/build/180732056
✖ (Failed) glances-3.2.6.4 from 2022-06-17 - https://hydra.nixos.org/build/180617234
✖ (Failed) glances-3.2.5 from 2022-06-07 - https://hydra.nixos.org/build/179751466
✔ glances-3.2.4.2 from 2022-06-02 - https://hydra.nixos.org/build/179055285
✔ glances-3.2.4.2 from 2022-05-24 - https://hydra.nixos.org/build/178169603
✔ glances-3.2.4.2 from 2022-05-17 - https://hydra.nixos.org/build/177039363
✔ glances-3.2.4.2 from 2022-05-09 - https://hydra.nixos.org/build/176045964
✔ glances-3.2.4.2 from 2022-05-02 - https://hydra.nixos.org/build/175221812
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
