### PR TITLE
nixos/amd.sev: init

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -359,6 +359,12 @@
       </listitem>
       <listitem>
         <para>
+          There is a new module for AMD SEV CPU functionality, which
+          grants access to the hardware.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           There is a new module for the <literal>thunar</literal>
           program (the Xfce file manager), which depends on the
           <literal>xfconf</literal> dbus service, and also has a dbus

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -132,6 +132,8 @@ Use `configure.packages` instead.
 
 - The `pass-secret-service` package now includes systemd units from upstream, so adding it to the NixOS `services.dbus.packages` option will make it start automatically as a systemd user service when an application tries to talk to the libsecret D-Bus API.
 
+- There is a new module for AMD SEV CPU functionality, which grants access to the hardware.
+
 - There is a new module for the `thunar` program (the Xfce file manager), which depends on the `xfconf` dbus service, and also has a dbus service and a systemd unit. The option `services.xserver.desktopManager.xfce.thunarPlugins` has been renamed to `programs.thunar.plugins`, and in a future release it may be removed.
 
 - There is a new module for the `xfconf` program (the Xfce configuration storage system), which has a dbus service.

--- a/nixos/modules/hardware/cpu/amd-sev.nix
+++ b/nixos/modules/hardware/cpu/amd-sev.nix
@@ -1,0 +1,51 @@
+{ config, lib, ... }:
+with lib;
+let
+  cfg = config.hardware.cpu.amd.sev;
+  defaultGroup = "sev";
+in
+  with lib; {
+    options.hardware.cpu.amd.sev = {
+      enable = mkEnableOption "access to the AMD SEV device";
+      user = mkOption {
+        description = "Owner to assign to the SEV device.";
+        type = types.str;
+        default = "root";
+      };
+      group = mkOption {
+        description = "Group to assign to the SEV device.";
+        type = types.str;
+        default = defaultGroup;
+      };
+      mode = mkOption {
+        description = "Mode to set for the SEV device.";
+        type = types.str;
+        default = "0660";
+      };
+    };
+
+    config = mkIf cfg.enable {
+      assertions = [
+        {
+          assertion = hasAttr cfg.user config.users.users;
+          message = "Given user does not exist";
+        }
+        {
+          assertion = (cfg.group == defaultGroup) || (hasAttr cfg.group config.users.groups);
+          message = "Given group does not exist";
+        }
+      ];
+
+      boot.extraModprobeConfig = ''
+        options kvm_amd sev=1
+      '';
+
+      users.groups = optionalAttrs (cfg.group == defaultGroup) {
+        "${cfg.group}" = {};
+      };
+
+      services.udev.extraRules = with cfg; ''
+        KERNEL=="sev", OWNER="${user}", GROUP="${group}", MODE="${mode}"
+      '';
+    };
+  }


### PR DESCRIPTION
###### Description of changes

Note, for now this requires a custom kernel (as does Intel SGX module already present in the tree).
At Profian we maintain a patched kernel, which includes both Intel SGX and AMD SEV-SNP support https://github.com/enarx/linux/tree/v5.19-rc5-enarx-5

It's already packaged for `nixpkgs` and is currently based on v5.19-rc5 of upstream kernel. https://github.com/profianinc/nixpkgs/blob/731575e81af9a64d449798ed99943690d18f646c/pkgs/os-specific/linux/kernel/linux-enarx.nix

~I will open a PR for that shortly~(https://github.com/NixOS/nixpkgs/pull/181081)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
