### PR TITLE
i3lock: 2.13 -> 2.14.1

### DIFF
--- a/pkgs/applications/window-managers/i3/lock.nix
+++ b/pkgs/applications/window-managers/i3/lock.nix
@@ -1,25 +1,20 @@
-{ fetchurl, lib, stdenv, which, pkg-config, libxcb, xcbutilkeysyms, xcbutilimage,
+{ stdenv, lib, fetchFromGitHub, meson, ninja, pkg-config, libxcb, xcbutilkeysyms, xcbutilimage,
   xcbutilxrm, pam, libX11, libev, cairo, libxkbcommon, libxkbfile }:
 
 stdenv.mkDerivation rec {
   pname = "i3lock";
-  version = "2.13";
+  version = "2.14.1";
 
-  src = fetchurl {
-    url = "https://i3wm.org/i3lock/${pname}-${version}.tar.bz2";
-    sha256 = "02szjsaz7rqrdkd0r2nwgwa85c4hwfrcskxw7ryk695kmjcfhzv3";
+  src = fetchFromGitHub {
+    owner = "i3";
+    repo = "i3lock";
+    rev = version;
+    sha256 = "sha256-cC908c47fkU6msLqZSxpEbKxO1/PatH81QeuCzBSZGw=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ which libxcb xcbutilkeysyms xcbutilimage xcbutilxrm
+  nativeBuildInputs = [ meson ninja pkg-config ];
+  buildInputs = [ libxcb xcbutilkeysyms xcbutilimage xcbutilxrm
     pam libX11 libev cairo libxkbcommon libxkbfile ];
-
-  makeFlags = [ "all" ];
-  installFlags = [ "PREFIX=\${out}" "SYSCONFDIR=\${out}/etc" ];
-  postInstall = ''
-    mkdir -p $out/share/man/man1
-    cp *.1 $out/share/man/man1
-  '';
 
   meta = with lib; {
     description = "A simple screen locker like slock";


### PR DESCRIPTION
###### Description of changes

<details><summary>Changelog</summary>

```
2022-06-21 i3lock 2.14.1

 • unlock indicator: display only caps lock and num lock,
   not all modifiers like shift (which can leak information
   about your password to bystanders)

2022-05-28 i3lock 2.14

 • Change default background color to #a3a3a3
   See https://github.com/i3/i3lock/pull/300 for extensive
   discussion and rationale for this change.
 • Recommend using xss-lock to start i3lock in the README
   and i3lock.1 man page. xss-lock is the best way to ensure
   your screen truly is locked before your computer suspends.
 • Display modifier key warning before unlocking, too,
   not just on failed attempts like before.
 • Switch build system from autotools to meson.
```
</details>

Biggest change on the packaging side is that upstream switched from autotools to meson. That's great, it means we can switch to fetching from GitHub tags directly instead of relying on source tarballs (which should allow auto-update systems to more easily figure out when a new release is out). It also simplifies a bunch of things on the packaging side, no more postInstall, no more makeFlags, etc.

Also removed the dependency on `which`: it was needed initially in 2.4 when it was added (it's clearly present in the Makefile) but I don't see anything in 2.14.1 that would require it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
