### PR TITLE
linux_enarx: init at 5.19-rc5-enarx-5 

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-enarx.nix
+++ b/pkgs/os-specific/linux/kernel/linux-enarx.nix
@@ -1,0 +1,57 @@
+# Adapted from linux-testing
+{ lib, buildLinux, ... } @ args:
+
+with lib;
+
+buildLinux (args // rec {
+  version = "5.19-rc5-enarx-5";
+  modDirVersion = "5.19.0-rc5-next-20220706";
+  extraMeta.branch = lib.versions.majorMinor version;
+  extraMeta.maintainers = with lib.maintainers; [ rvolosatovs ];
+
+  src = builtins.fetchTarball {
+    url = "https://github.com/enarx/linux/archive/refs/tags/v${version}.tar.gz";
+    sha256 = "sha256-MSlkHprFP2HDV/xZxfqYFxXuiclpypq27wKDrbzG6YM=";
+  };
+
+  structuredExtraConfig = with lib.kernel; {
+    "64BIT" = yes;
+    ACPI = yes;
+    AMD_IOMMU_V2 = yes;
+    AMD_MEM_ENCRYPT = yes;
+    CRYPTO = yes;
+    CRYPTO_DEV_CCP = yes;
+    CRYPTO_DEV_CCP_CRYPTO = module;
+    CRYPTO_DEV_CCP_DD = module;
+    CRYPTO_DEV_SP_CCP = yes;
+    CRYPTO_DEV_SP_PSP = yes;
+    DMADEVICES = yes;
+    GART_IOMMU = yes;
+    HIGH_RES_TIMERS = yes;
+    INIT_ON_ALLOC_DEFAULT_ON = yes;
+    INTEGRITY_ASYMMETRIC_KEYS = yes;
+    INTEGRITY_SIGNATURE = yes;
+    INTEL_IOMMU_SVM = yes;
+    INTEL_TURBO_MAX_3 = yes;
+    INTEL_TXT = yes;
+    IOMMU_HELPER = yes;
+    IOMMU_SVA = yes;
+    KVM = yes;
+    KVM_AMD = module;
+    KVM_AMD_SEV = yes;
+    KVM_INTEL = module;
+    MEMORY_FAILURE = yes;
+    MODVERSIONS = yes;
+    PACKET = yes;
+    PCI = yes;
+    RETPOLINE = yes;
+    SECURITY_DMESG_RESTRICT = yes;
+    SECURITY_NETWORK_XFRM=yes;
+    SEV_GUEST = yes;
+    VIRTUALIZATION = yes;
+    X86_CPU_RESCTRL = yes;
+    X86_MCE = yes;
+    X86_SGX = yes;
+    X86_SGX_KVM = yes;
+  };
+ } // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -114,7 +114,8 @@ let
       patches =
         map (p: p.patch) kernelPatches
         # Required for deterministic builds along with some postPatch magic.
-        ++ optional (lib.versionAtLeast version "4.13") ./randstruct-provide-seed.patch
+        ++ optional (lib.versionAtLeast version "4.13" && lib.versionOlder version "5.19") ./randstruct-provide-seed.patch
+        ++ optional (lib.versionAtLeast version "5.19") ./randstruct-provide-seed-5.19.patch
         # Fixes determinism by normalizing metadata for the archive of kheaders
         ++ optional (lib.versionAtLeast version "5.2" && lib.versionOlder version "5.4") ./gen-kheaders-metadata.patch;
 

--- a/pkgs/os-specific/linux/kernel/randstruct-provide-seed-5.19.patch
+++ b/pkgs/os-specific/linux/kernel/randstruct-provide-seed-5.19.patch
@@ -1,0 +1,13 @@
+diff --git a/scripts/gen-randstruct-seed.sh b/scripts/gen-randstruct-seed.sh
+index 61017b36c464..7bb494dd2e18 100755
+--- a/scripts/gen-randstruct-seed.sh
++++ b/scripts/gen-randstruct-seed.sh
+@@ -1,7 +1,7 @@
+ #!/bin/sh
+ # SPDX-License-Identifier: GPL-2.0
+ 
+-SEED=$(od -A n -t x8 -N 32 /dev/urandom | tr -d ' \n')
++SEED="NIXOS_RANDSTRUCT_SEED"
+ echo "$SEED" > "$1"
+ HASH=$(echo -n "$SEED" | sha256sum | cut -d" " -f1)
+ echo "#define RANDSTRUCT_HASHED_SEED \"$HASH\"" > "$2"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23722,6 +23722,9 @@ with pkgs;
   linuxPackages_xanmod_latest = linuxKernel.packages.linux_xanmod_latest;
   linux_xanmod_latest = linuxKernel.kernels.linux_xanmod_latest;
 
+  # Enarx kernel
+  linuxPackages_enarx = linuxKernel.packages.linux_enarx;
+
   linux-doc = callPackage ../os-specific/linux/kernel/htmldocs.nix { };
 
   cryptodev = linuxKernel.packages.linux_4_9.cryptodev;

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -218,6 +218,13 @@ in {
       ];
     }).lqx;
 
+    linux_enarx = callPackage ../os-specific/linux/kernel/linux-enarx.nix {
+      kernelPatches = [
+        kernelPatches.bridge_stp_helper
+        kernelPatches.request_key_helper
+      ];
+    };
+
     # This contains both the STABLE and EDGE variants of the XanMod kernel
     xanmodKernels = callPackage ../os-specific/linux/kernel/xanmod-kernels.nix;
 
@@ -565,6 +572,8 @@ in {
     linux_lqx = recurseIntoAttrs (packagesFor kernels.linux_lqx);
     linux_xanmod = recurseIntoAttrs (packagesFor kernels.linux_xanmod);
     linux_xanmod_latest = recurseIntoAttrs (packagesFor kernels.linux_xanmod_latest);
+
+    linux_enarx = recurseIntoAttrs (packagesFor kernels.linux_enarx);
 
     hardkernel_4_14 = recurseIntoAttrs (packagesFor kernels.linux_hardkernel_4_14);
 


### PR DESCRIPTION
###### Things done

Package https://github.com/enarx/linux, which includes patches for Intel SGX (already in-tree, but requires the patch-set to actually be used) and AMD SEV-SNP (#181079)

This has been built on top of 22.05, not on top of latest `master`, but I assume that should be fine.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
