### PR TITLE
mesa-demos: 8.4.0 -> 8.5.0

### DIFF
--- a/pkgs/tools/graphics/mesa-demos/default.nix
+++ b/pkgs/tools/graphics/mesa-demos/default.nix
@@ -1,19 +1,27 @@
-{ lib, stdenv, fetchurl, freeglut, glew, libGL, libGLU, libX11, libXext, mesa, pkg-config, wayland }:
+{ lib, stdenv, fetchurl, freeglut, glew, libGL, libGLU, libX11, libXext, mesa
+, meson, ninja, pkg-config, wayland, wayland-protocols }:
 
 stdenv.mkDerivation rec {
   pname = "mesa-demos";
-  version = "8.4.0";
+  version = "8.5.0";
 
   src = fetchurl {
-    url = "ftp://ftp.freedesktop.org/pub/mesa/demos/${pname}-${version}.tar.bz2";
-    sha256 = "0zgzbz55a14hz83gbmm0n9gpjnf5zadzi2kjjvkn6khql2a9rs81";
+    url = "https://archive.mesa3d.org/demos/${version}/${pname}-${version}.tar.bz2";
+    sha256 = "sha256-zqLfCoDwmjD2NcTrGmcr+Qxd3uC4539NcAQWaO9xqsE=";
   };
 
-  buildInputs = [ freeglut glew libX11 libXext libGL libGLU mesa mesa.osmesa wayland ];
-  nativeBuildInputs = [ pkg-config ];
+  patches = [
+    # https://gitlab.freedesktop.org/mesa/demos/-/merge_requests/83
+    ./demos-data-dir.patch
+  ];
 
-  configureFlags = [ "--with-system-data-files" ];
-  enableParallelBuilding = true;
+  buildInputs = [
+    freeglut glew libX11 libXext libGL libGLU mesa mesa.osmesa wayland
+    wayland-protocols
+  ];
+  nativeBuildInputs = [ meson ninja pkg-config ];
+
+  mesonFlags = [ "-Dwith-system-data-files=true" ];
 
   meta = with lib; {
     description = "Collection of demos and test programs for OpenGL and Mesa";

--- a/pkgs/tools/graphics/mesa-demos/demos-data-dir.patch
+++ b/pkgs/tools/graphics/mesa-demos/demos-data-dir.patch
@@ -1,0 +1,13 @@
+diff --git a/meson.build b/meson.build
+index 282c39629da54ba6d7e1e380ffcf70da15e48d83..0c15274bff62b43f95ca7d7c5e29cc2dbd3cc42f 100644
+--- a/meson.build
++++ b/meson.build
+@@ -29,7 +29,7 @@ null_dep = dependency('', required : false)
+ 
+ demos_data_dir = '../data/'
+ if get_option('with-system-data-files')
+-  demos_data_dir = get_option('datadir') / 'mesa-demos'
++  demos_data_dir = get_option('prefix') / get_option('datadir') / 'mesa-demos/'
+ endif
+ add_project_arguments(
+   '-DDEMOS_DATA_DIR="@0@"'.format(demos_data_dir),


### PR DESCRIPTION
###### Description of changes

* Changes upstream mirror URL, the current FTP mirror doesn't include the latest mesa-demos release (and doesn't seem to be the primary mirror these days).
* Upstream switched from autotools to meson and the ./configure errors out unless a special backwards compatibility flag is provided. No reason not to use meson, if anything it's easier!
* New dependency on wayland-protocols.

Note: didn't test *all* binary files (some of them were already broken in 8.4.0, due to build system issues upstream not installing required data files). The ones that worked in 8.4.0 in my testing still work in 8.5.0. Importantly, glxinfo and glxgears are both happy.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
