### PR TITLE
fedora-backgrounds.f36: init at 36.1.2

### DIFF
--- a/pkgs/data/misc/fedora-backgrounds/default.nix
+++ b/pkgs/data/misc/fedora-backgrounds/default.nix
@@ -31,4 +31,13 @@ in {
     patches = [ ./f34-fix-xfce-path.patch ];
   };
 
+  f36 = fedoraBackground rec {
+    version = "36.1.2";
+    src = fetchurl {
+      url = "https://github.com/fedoradesign/backgrounds/releases/download/v${version}/f${lib.versions.major version}-backgrounds-${version}.tar.xz";
+      hash = "sha256-DZr1YHltojl02X/3sErqB/29JBDy/7lDZKnHD+KouHc=";
+    };
+    # Fix broken symlinks in the Xfce background directory.
+    patches = [ ./f36-fix-xfce-path.patch ];
+  };
 }

--- a/pkgs/data/misc/fedora-backgrounds/f36-fix-xfce-path.patch
+++ b/pkgs/data/misc/fedora-backgrounds/f36-fix-xfce-path.patch
@@ -1,0 +1,13 @@
+diff --git a/default/Makefile b/default/Makefile
+index 7207745..35c823a 100644
+--- a/default/Makefile
++++ b/default/Makefile
+@@ -1,7 +1,7 @@
+ WP_NAME=f36
+ WP_BIGNAME=F36
+ WP_DIR=$(DESTDIR)/usr/share/backgrounds/$(WP_NAME)
+-WP_DIR_LN=/usr/share/backgrounds/$(WP_NAME)
++WP_DIR_LN=$(DESTDIR)/usr/share/backgrounds/$(WP_NAME)
+ GNOME_BG_DIR=$(DESTDIR)/usr/share/gnome-background-properties
+ KDE_BG_DIR=$(DESTDIR)/usr/share/wallpapers
+ MATE_BG_DIR=$(DESTDIR)/usr/share/mate-background-properties


### PR DESCRIPTION
###### Description of changes
https://github.com/fedoradesign/backgrounds/tree/v36.1.2
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
