### PR TITLE
WIP: llvm-bolt: init at 14.0.1

### DIFF
--- a/pkgs/development/compilers/llvm/14/bolt/default.nix
+++ b/pkgs/development/compilers/llvm/14/bolt/default.nix
@@ -1,0 +1,47 @@
+{ lib, stdenv, llvm_meta
+, buildLlvmTools
+, monorepoSrc, runCommand
+, cmake
+, libxml2
+, libllvm
+, version
+}:
+
+stdenv.mkDerivation rec {
+  pname = "bolt";
+  inherit version;
+
+  # Blank llvm dir just so relative path works
+  src = runCommand "llvm-src-${version}" {} ''
+    mkdir -p "$out"
+    cp -r ${monorepoSrc}/cmake "$out"
+    cp -r ${monorepoSrc}/bolt "$out"
+    mkdir -p "$out/libunwind"
+    cp -r ${monorepoSrc}/libunwind/include "$out/libunwind"
+    mkdir -p "$out/llvm"
+  '';
+
+  sourceRoot = "${src.name}/${pname}";
+
+  patches = [
+    # ./gnu-install-dirs.patch
+    # On Darwin the llvm-config is perhaps not working fine as the
+    # LLVM_MAIN_SRC_DIR is not getting set correctly, and the build fails as
+    # the include path is not correct.
+    # ./fix-root-src-dir.patch
+  ];
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libllvm libxml2 ];
+
+  cmakeFlags = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.llvm}/bin/llvm-tblgen"
+  ];
+
+  outputs = [ "out" "lib" "dev" ];
+
+  meta = llvm_meta // {
+    homepage = "https://github.com/llvm/llvm-project/tree/main/bolt";
+    description = "LLVM post-link optimizer (unwrpped).";
+  };
+}

--- a/pkgs/development/compilers/llvm/14/bolt/fix-root-src-dir.patch
+++ b/pkgs/development/compilers/llvm/14/bolt/fix-root-src-dir.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9bcc135665d0..d38679ed41e9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -74,7 +74,7 @@ if(BOLT_BUILT_STANDALONE)
+
+   set(LLVM_MAIN_INCLUDE_DIR "${MAIN_INCLUDE_DIR}" CACHE PATH "Path to llvm/include")
+   set(LLVM_BINARY_DIR "${LLVM_OBJ_ROOT}" CACHE PATH "Path to LLVM build tree")
+-  set(LLVM_MAIN_SRC_DIR "${MAIN_SRC_DIR}" CACHE PATH "Path to LLVM source tree")
++  set(LLVM_MAIN_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../llvm" CACHE PATH "Path to LLVM source tree")
+
+   find_program(LLVM_TABLEGEN_EXE "llvm-tblgen" ${LLVM_TOOLS_BINARY_DIR}
+     NO_DEFAULT_PATH)

--- a/pkgs/development/compilers/llvm/14/default.nix
+++ b/pkgs/development/compilers/llvm/14/default.nix
@@ -67,6 +67,10 @@ let
       inherit llvm_meta;
     };
 
+    bolt = callPackage ./bolt {
+      inherit llvm_meta;
+    };
+
     # `llvm` historically had the binaries.  When choosing an output explicitly,
     # we need to reintroduce `outputSpecified` to get the expected behavior e.g. of lib.get*
     llvm = tools.libllvm.out // { outputSpecified = false; };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13673,6 +13673,8 @@ with pkgs;
   lld_13 = llvmPackages_13.lld;
   lld_14 = llvmPackages_14.lld;
 
+  bolt_14 = llvmPackages_14.bolt;
+
   lldb = llvmPackages_latest.lldb;
   lldb_5 = llvmPackages_5.lldb;
   lldb_6 = llvmPackages_6.lldb;


### PR DESCRIPTION
###### Description

Unstable implementation of this proposal:
https://github.com/NixOS/nixpkgs/issues/176536

###### Current state

I am not fluent with NIX and I need help to build subproject. Current error:

```text
error: builder for '/nix/store/chjids0zrr42z2jv7z7zc0lfiqqvxmfk-llvm-14.0.1.drv' failed with exit code 1;
       last 10 log lines:
       > -- Detecting CXX compile features
       > -- Detecting CXX compile features - done
       > -- bolt project is enabled
       > CMake Error at CMakeLists.txt:136 (message):
       >   LLVM_ENABLE_PROJECTS requests bolt but directory not found:
       >   /build/llvm-src-14.0.1/llvm/../bolt
       >
       >
       > -- Configuring incomplete, errors occurred!
       > See also "/build/llvm-src-14.0.1/llvm/build/CMakeFiles/CMakeOutput.log".
       For full logs, run 'nix log /nix/store/chjids0zrr42z2jv7z7zc0lfiqqvxmfk-llvm-14.0.1.drv'.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
