### PR TITLE
bun: add update-script

### DIFF
--- a/pkgs/development/web/bun/default.nix
+++ b/pkgs/development/web/bun/default.nix
@@ -42,6 +42,7 @@ stdenvNoCC.mkDerivation rec {
     install -Dm 755 ./bun $out/bin/bun
     runHook postInstall
   '';
+  passthru.updateScript = ./update-script;
 
   meta = with lib; {
     homepage = "https://bun.sh";

--- a/pkgs/development/web/bun/update-script
+++ b/pkgs/development/web/bun/update-script
@@ -1,0 +1,44 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq gawk
+# vim:ft=bash
+
+set -eu -o pipefail
+
+LATEST_VERSION=$(curl https://api.github.com/repos/oven-sh/bun/releases/latest | jq .tag_name -r | sed 's;bun-v\([0-9]*\.[0-9]*\.[0-9]*\);\1;g')
+
+# nix-instantiate --eval --json -E $(
+NIX_DIST=$(cat default.nix | awk '
+BEGIN {
+DIST=0
+}
+
+/dists = / {
+print "{"
+DIST=1
+}
+
+/dist = / {
+DIST=0
+}
+
+DIST==1 {
+    print $0
+}
+
+END {
+print "}"
+}
+')
+echo $NIX_DIST
+DIST_JSON=$(nix-instantiate --eval --json --strict -E "$NIX_DIST")
+echo $DIST_JSON
+
+for target in $(echo $DIST_JSON | jq '.dists | keys | join("\n")' -r); do
+    ARCH=$(echo $DIST_JSON | jq ".dists.\"$target\".arch" -r)
+    OS=$(echo $DIST_JSON | jq ".dists.\"$target\".shortName" -r)
+    SHA256=$(echo $DIST_JSON | jq ".dists.\"$target\".sha256" -r)
+    sed -i "s;$SHA256;$(nix-prefetch-url "https://github.com/Jarred-Sumner/bun-releases-for-updater/releases/download/bun-v$LATEST_VERSION/bun-$OS-$ARCH.zip");g" default.nix
+    echo "$ARCH $OS $SHA256"
+done
+
+sed -i "s;version = \"[^\"]*\";version = \"$LATEST_VERSION\";g" default.nix


### PR DESCRIPTION
Signed-off-by: lucasew <lucas59356@gmail.com>

###### Description of changes
Add update script for bun
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
- [ ] How do I test if it integrates well with r-ryantm?
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

