### PR TITLE
zig: fix compilation on Darwin AArch64

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -373,9 +373,7 @@ stdenv.mkDerivation {
     ''
     + optionalString (libcxx.isLLVM or false) (''
       echo "-isystem ${lib.getDev libcxx}/include/c++/v1" >> $out/nix-support/libcxx-cxxflags
-      echo "-stdlib=libc++" >> $out/nix-support/libcxx-ldflags
-    '' + lib.optionalString stdenv.targetPlatform.isLinux ''
-      echo "-lc++abi" >> $out/nix-support/libcxx-ldflags
+      echo "-stdlib=libc++ -lc++abi" >> $out/nix-support/libcxx-ldflags
     '')
 
     ##

--- a/pkgs/development/compilers/zig/default.nix
+++ b/pkgs/development/compilers/zig/default.nix
@@ -52,6 +52,6 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     maintainers = with maintainers; [ andrewrk AndersonTorres ];
     platforms = platforms.unix;
-    broken = stdenv.isDarwin; # See https://github.com/NixOS/nixpkgs/issues/86299
+    broken = stdenv.isDarwin && !stdenv.isAarch64; # See https://github.com/NixOS/nixpkgs/issues/86299
   };
 }


### PR DESCRIPTION
On macOS AArch64, Zig's zig0 build is failing with the following error:

    Undefined symbols for architecture arm64:
      "operator delete[](void*)", referenced from:
          lld::elf::Configuration::~Configuration() in liblldELF.a(Driver.cpp.o)
          ...
      "operator delete(void*)", referenced from:
          _ZigLLVMGetNativeFeatures in libzigcpp.a(zig_llvm.cpp.o)
          ...
      "operator new[](unsigned long)", referenced from:
          bigint_unsigned_division(BigInt const*, BigInt const*, BigInt*, BigInt*) in libzigstage1.a(bigint.cpp.o)
          ...
      "operator new(unsigned long)", referenced from:
          _ZigLLVMTargetMachineEmitToFile in libzigcpp.a(zig_llvm.cpp.o)
          ...
      "operator new(unsigned long, std::nothrow_t const&)", referenced from:
          _ZigLLVMTargetMachineEmitToFile in libzigcpp.a(zig_llvm.cpp.o)
          ...
    ld: symbol(s) not found for architecture arm64
    clang-13: error: linker command failed with exit code 1 (use -v to see invocation)

This is because libc++ is selected during linking, but the libc++abi
isn't linked. Link libc++abi to fix the errors.

I think macOS x86_64 is still failing for a different reason.

###### Description of changes

HELP: Do I need to document somewhere that libc++abi was added to all libc++-using builds? This patch affects more than just the zig package.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
