### PR TITLE
python3Packages.debugpy: 1.6.0 → 1.6.2

### DIFF
--- a/pkgs/development/python-modules/debugpy/default.nix
+++ b/pkgs/development/python-modules/debugpy/default.nix
@@ -59,12 +59,12 @@ buildPythonPackage rec {
     cd src/debugpy/_vendored/pydevd/pydevd_attach_to_process
     rm *.so *.dylib *.dll *.exe *.pdb
     ${stdenv.cc}/bin/c++ linux_and_mac/attach.cpp -Ilinux_and_mac -fPIC -nostartfiles ${{
-      "x86_64-linux"   = "-shared -m64 -o attach_linux_amd64.so";
-      "i686-linux"     = "-shared -m32 -o attach_linux_x86.so";
+      "x86_64-linux"   = "-shared -o attach_linux_amd64.so";
+      "i686-linux"     = "-shared -o attach_linux_x86.so";
       "aarch64-linux"  = "-shared -o attach_linux_arm64.so";
-      "x86_64-darwin"  = "-std=c++11 -lc -D_REENTRANT -dynamiclib -arch x86_64 -o attach_x86_64.dylib";
-      "i686-darwin"    = "-std=c++11 -lc -D_REENTRANT -dynamiclib -arch i386 -o attach_x86.dylib";
-      "aarch64-darwin" = "-std=c++11 -lc -D_REENTRANT -dynamiclib -arch arm64 -o attach_arm64.dylib";
+      "x86_64-darwin"  = "-std=c++11 -lc -D_REENTRANT -dynamiclib -o attach_x86_64.dylib";
+      "i686-darwin"    = "-std=c++11 -lc -D_REENTRANT -dynamiclib -o attach_x86.dylib";
+      "aarch64-darwin" = "-std=c++11 -lc -D_REENTRANT -dynamiclib -o attach_arm64.dylib";
     }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}")}
   )'';
 

--- a/pkgs/development/python-modules/debugpy/fix-test-pythonpath.patch
+++ b/pkgs/development/python-modules/debugpy/fix-test-pythonpath.patch
@@ -1,8 +1,8 @@
 diff --git a/tests/debug/session.py b/tests/debug/session.py
-index 101492fc..4ee7cfbe 100644
+index af242877..30b21a1e 100644
 --- a/tests/debug/session.py
 +++ b/tests/debug/session.py
-@@ -630,6 +630,7 @@ class Session(object):
+@@ -622,6 +622,7 @@ class Session(object):
          if "PYTHONPATH" in self.config.env:
              # If specified, launcher will use it in lieu of PYTHONPATH it inherited
              # from the adapter when spawning debuggee, so we need to adjust again.

--- a/pkgs/development/python-modules/debugpy/hardcode-gdb.patch
+++ b/pkgs/development/python-modules/debugpy/hardcode-gdb.patch
@@ -1,5 +1,5 @@
 diff --git a/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/add_code_to_python_process.py b/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/add_code_to_python_process.py
-index 3c0e1b94..e995a20f 100644
+index 462feae9..eb2aa945 100644
 --- a/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/add_code_to_python_process.py
 +++ b/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/add_code_to_python_process.py
 @@ -399,7 +399,7 @@ def run_python_code_linux(pid, python_code, connect_debugger_tracing=False, show

--- a/pkgs/development/python-modules/debugpy/hardcode-version.patch
+++ b/pkgs/development/python-modules/debugpy/hardcode-version.patch
@@ -1,5 +1,5 @@
 diff --git a/setup.py b/setup.py
-index e7487100..10d36520 100644
+index 5fc40070..775a08ec 100644
 --- a/setup.py
 +++ b/setup.py
 @@ -12,7 +12,6 @@ import sys
@@ -26,24 +26,22 @@ index e7487100..10d36520 100644
          description="An implementation of the Debug Adapter Protocol for Python",  # noqa
          long_description=long_description,
          long_description_content_type="text/markdown",
-diff --git a/src/debugpy/__init__.py b/src/debugpy/__init__.py
-index baa5a7c5..53553272 100644
---- a/src/debugpy/__init__.py
-+++ b/src/debugpy/__init__.py
-@@ -27,7 +27,6 @@ __all__ = [
- import codecs
- import os
+diff --git a/src/debugpy/public_api.py b/src/debugpy/public_api.py
+index 3c800898..27743245 100644
+--- a/src/debugpy/public_api.py
++++ b/src/debugpy/public_api.py
+@@ -7,8 +7,6 @@ from __future__ import annotations
+ import functools
+ import typing
  
 -from debugpy import _version
- from debugpy.common import compat
+-
+ 
+ # Expose debugpy.server API from subpackage, but do not actually import it unless
+ # and until a member is invoked - we don't want the server package loaded in the
+@@ -182,4 +180,4 @@ def trace_this_thread(__should_trace: bool):
+     """
  
  
-@@ -204,7 +203,7 @@ def trace_this_thread(should_trace):
-     return api.trace_this_thread(should_trace)
- 
- 
--__version__ = _version.get_versions()["version"]
-+__version__ = "@version@"
- 
- # Force absolute path on Python 2.
- __file__ = os.path.abspath(__file__)
+-__version__: str = _version.get_versions()["version"]
++__version__: str = "@version@"


### PR DESCRIPTION
###### Description of changes

Update to the latest version: https://github.com/microsoft/debugpy/releases/tag/v1.6.2

This includes a new patch to fix compiling the attach library from source, see https://github.com/microsoft/debugpy/pull/978

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).