### PR TITLE
check_smartmon: init at 1.0.1

### DIFF
--- a/pkgs/servers/monitoring/nagios/plugins/smartmon.nix
+++ b/pkgs/servers/monitoring/nagios/plugins/smartmon.nix
@@ -1,0 +1,42 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, python3
+, smartmontools
+}:
+
+stdenv.mkDerivation rec {
+  pname = "check_smartmon";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner  = "driehuis";
+    repo   = "Nagios_check_smartmon";
+    rev    = version;
+    sha256 = "tiIeFiHdDgqoeznk9XdCE7owIMnnsQ0fmtj8foFoUD8=";
+  };
+
+  buildInputs = [
+    (python3.withPackages (pp: [ pp.psutil ]))
+    smartmontools
+  ];
+
+  postPatch = ''
+    patchShebangs check_smartmon.py
+    substituteInPlace check_smartmon.py \
+      --replace '"/usr/sbin/smartctl"' '"${smartmontools}/bin/smartctl"'
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm 755 check_smartmon.py $out/bin/check_smartmon
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A Nagios-Plugin that uses smartmontools to check disk health status and temperature";
+    homepage = "https://github.com/driehuis/Nagios_check_smartmon";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ mariaa144 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22742,6 +22742,8 @@ with pkgs;
 
   check-openvpn = callPackage ../servers/monitoring/plugins/openvpn.nix { };
 
+  check_smartmon = callPackage ../servers/monitoring/nagios/plugins/smartmon.nix { };
+
   checkSSLCert = callPackage ../servers/monitoring/nagios/plugins/check_ssl_cert.nix { };
 
   check_systemd = callPackage ../servers/monitoring/nagios/plugins/check_systemd.nix { };


### PR DESCRIPTION
###### Description of changes

Adds the check-smartmon package and mariaa144 as a maintainer.

Please let me know if I missed anything.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
