### PR TITLE
xmonadctl: init at 0.17.0

### DIFF
--- a/pkgs/applications/window-managers/xmonad/xmonadctl.nix
+++ b/pkgs/applications/window-managers/xmonad/xmonadctl.nix
@@ -1,0 +1,27 @@
+{ stdenv, lib, fetchFromGitHub, ghcWithPackages, ... }:
+
+let xmonadctlEnv = ghcWithPackages (self: [ self.xmonad-contrib self.X11 ]);
+in stdenv.mkDerivation rec {
+  pname = "xmonadctl";
+  version = "0.17.0";
+
+  src = fetchFromGitHub {
+    owner = "xmonad";
+    repo = "xmonad-contrib";
+    rev = "v${version}";
+    sha256 = "142ycg7dammq98drimv6xbih8dla9qindxds9fgkspmrrils3sar";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    ${xmonadctlEnv}/bin/ghc -o $out/bin/xmonadctl \
+      --make scripts/xmonadctl.hs
+  '';
+
+  meta = with lib; {
+    description = "Send commands to a running instance of xmonad";
+    homepage = "https://github.com/xmonad/xmonad-contrib";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.ajgrf ];
+  };
+}

--- a/pkgs/applications/window-managers/xmonad/xmonadctl.nix
+++ b/pkgs/applications/window-managers/xmonad/xmonadctl.nix
@@ -13,12 +13,15 @@ in stdenv.mkDerivation rec {
   };
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     ${xmonadctlEnv}/bin/ghc -o $out/bin/xmonadctl \
       --make scripts/xmonadctl.hs
+    runHook postInstall
   '';
 
   meta = with lib; {
+    platforms = platforms.unix;
     description = "Send commands to a running instance of xmonad";
     homepage = "https://github.com/xmonad/xmonad-contrib";
     license = licenses.bsd3;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31324,6 +31324,10 @@ with pkgs;
     packages = _: [ haskellPackages.xmonad-contrib ];
   };
 
+  xmonadctl = callPackage ../applications/window-managers/xmonad/xmonadctl.nix {
+    inherit (haskellPackages) ghcWithPackages;
+  };
+
   xmonad_log_applet = callPackage ../applications/window-managers/xmonad/log-applet {
     inherit (xfce) libxfce4util xfce4-panel;
   };

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -257,6 +257,7 @@ let
         vaultenv
         wstunnel
         xmobar
+        xmonadctl
         xmonad-with-packages
         yi
         zsh-git-prompt


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add `xmonadctl`, a simple script to send commands to a running instance of xmonad. (Note that XMonad must first be configured to listen for commands using the `XMonad.Hooks.ServerMode` module.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
