### PR TITLE
darkman: init at 1.3.1

### DIFF
--- a/pkgs/applications/misc/darkman/default.nix
+++ b/pkgs/applications/misc/darkman/default.nix
@@ -31,7 +31,7 @@ buildGoModule rec {
 
   installPhase = ''
     runHook preInstall
-    make DESTDIR=$out PREFIX=/ install
+    make PREFIX=$out install
     runHook postInstall
   '';
 

--- a/pkgs/applications/misc/darkman/default.nix
+++ b/pkgs/applications/misc/darkman/default.nix
@@ -3,7 +3,6 @@
 buildGoModule rec {
   pname = "darkman";
   version = "1.3.1";
-  nativeBuildInputs = [ scdoc ];
 
   src = fetchFromGitLab {
     owner = "WhyNotHugo";
@@ -13,6 +12,8 @@ buildGoModule rec {
   };
 
   vendorSha256 = "09rjqw6v1jaf0mhmycw9mcay9q0y1fya2azj8216gdgkl48ics08";
+
+  nativeBuildInputs = [ scdoc ];
 
   postPatch = ''
     substituteInPlace darkman.service \
@@ -40,8 +41,7 @@ buildGoModule rec {
   };
 
   meta = with lib; {
-    description =
-      "Framework for dark-mode and light-mode transitions on Linux desktop";
+    description = "Framework for dark-mode and light-mode transitions on Linux desktop";
     homepage = "https://gitlab.com/WhyNotHugo/darkman";
     license = licenses.isc;
     maintainers = [ maintainers.ajgrf ];

--- a/pkgs/applications/misc/darkman/default.nix
+++ b/pkgs/applications/misc/darkman/default.nix
@@ -1,0 +1,41 @@
+{ lib, fetchFromGitLab, buildGoModule, scdoc }:
+
+buildGoModule rec {
+  pname = "darkman";
+  version = "1.3.1";
+  nativeBuildInputs = [ scdoc ];
+
+  src = fetchFromGitLab {
+    owner = "WhyNotHugo";
+    repo = "darkman";
+    rev = "v${version}";
+    sha256 = "09iwc9cwwc88c6yrf6a552nbsnf1w8cnlra9axsar2p0k21v5yl1";
+  };
+
+  vendorSha256 = "09rjqw6v1jaf0mhmycw9mcay9q0y1fya2azj8216gdgkl48ics08";
+
+  postPatch = ''
+    substituteInPlace darkman.service \
+      --replace "/usr/bin/darkman" "$out/bin/darkman"
+    substituteInPlace contrib/dbus/nl.whynothugo.darkman.service \
+      --replace "/usr/bin/darkman" "$out/bin/darkman"
+    substituteInPlace contrib/dbus/org.freedesktop.impl.portal.desktop.darkman.service \
+      --replace "/usr/bin/darkman" "$out/bin/darkman"
+  '';
+
+  buildPhase = ''
+    make build
+  '';
+
+  installPhase = ''
+    make DESTDIR=$out PREFIX=/ install
+  '';
+
+  meta = with lib; {
+    description =
+      "Framework for dark-mode and light-mode transitions on Linux desktop";
+    homepage = "https://gitlab.com/WhyNotHugo/darkman";
+    license = licenses.isc;
+    maintainers = [ maintainers.ajgrf ];
+  };
+}

--- a/pkgs/applications/misc/darkman/default.nix
+++ b/pkgs/applications/misc/darkman/default.nix
@@ -24,11 +24,15 @@ buildGoModule rec {
   '';
 
   buildPhase = ''
+    runHook preBuild
     make build
+    runHook postBuild
   '';
 
   installPhase = ''
+    runHook preInstall
     make DESTDIR=$out PREFIX=/ install
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/applications/misc/darkman/default.nix
+++ b/pkgs/applications/misc/darkman/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitLab, buildGoModule, scdoc }:
+{ lib, fetchFromGitLab, buildGoModule, scdoc, nix-update-script }:
 
 buildGoModule rec {
   pname = "darkman";
@@ -34,6 +34,10 @@ buildGoModule rec {
     make DESTDIR=$out PREFIX=/ install
     runHook postInstall
   '';
+
+  passthru.updateScript = nix-update-script {
+    attrPath = pname;
+  };
 
   meta = with lib; {
     description =

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26205,6 +26205,8 @@ with pkgs;
 
   darcs-to-git = callPackage ../applications/version-management/git-and-tools/darcs-to-git { };
 
+  darkman = callPackage ../applications/misc/darkman { };
+
   darktable = callPackage ../applications/graphics/darktable {
     lua = lua5_4;
     pugixml = pugixml.override { shared = true; };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add [darkman](https://gitlab.com/WhyNotHugo/darkman), a framework for automatically switching to dark themes at night. Useful for users of standalone window managers who want this feature from GNOME or KDE.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
