### PR TITLE
terraform-providers: switch to go_1_18

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -18,7 +18,7 @@ let
      , rev
      , version
      , sha256
-     , vendorSha256 ? throw "vendorSha256 missing: please use `buildGoModule`" /* added 2022/01 */
+     , vendorSha256
      , deleteVendor ? false
      , proxyVendor ? false
      , mkProviderGoModule ? buildGoModule

--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -1,7 +1,7 @@
 { lib
 , stdenv
 , buildGoModule
-, buildGo118Module
+, buildGo117Module
 , fetchFromGitHub
 , callPackage
 , config
@@ -59,13 +59,22 @@ let
   # These are the providers that don't fall in line with the default model
   special-providers =
     {
-      brightbox = automated-providers.brightbox.override { mkProviderGoModule = buildGo118Module; };
-      hcloud = automated-providers.hcloud.override { mkProviderGoModule = buildGo118Module; };
-      # mkisofs needed to create ISOs holding cloud-init data,
-      # and wrapped to terraform via deecb4c1aab780047d79978c636eeb879dd68630
+      # go-module vendor fails with 1.18
+      buildkite = automated-providers.buildkite.override { mkProviderGoModule = buildGo117Module; };
+      # go-module vendor fails with 1.18
+      checkly = automated-providers.checkly.override { mkProviderGoModule = buildGo117Module; };
+      # mkisofs needed to create ISOs holding cloud-init data and wrapped to terraform via deecb4c1aab780047d79978c636eeb879dd68630
       libvirt = automated-providers.libvirt.overrideAttrs (_: { propagatedBuildInputs = [ cdrtools ]; });
-      linode = automated-providers.linode.override { mkProviderGoModule = buildGo118Module; };
-      utils = automated-providers.utils.override { mkProviderGoModule = buildGo118Module; };
+      # fails to build on x86_64-darwin with 1.18
+      lxd = automated-providers.lxd.override { mkProviderGoModule = buildGo117Module; };
+      # fails to build on x86_64-darwin with 1.18
+      netlify = automated-providers.netlify.override { mkProviderGoModule = buildGo117Module; };
+      # fails to build on x86_64-darwin with 1.18
+      pass = automated-providers.pass.override { mkProviderGoModule = buildGo117Module; };
+      # fails to build on x86_64-darwin with 1.18
+      skytap = automated-providers.skytap.override { mkProviderGoModule = buildGo117Module; };
+      # fails to build on x86_64-{darwin,linux} with 1.18
+      tencentcloud = automated-providers.tencentcloud.override { mkProviderGoModule = buildGo117Module; };
     };
 
   # Put all the providers we not longer support in this list.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35224,7 +35224,9 @@ with pkgs;
   terraform-full = terraform.full;
 
   terraform-providers = recurseIntoAttrs (
-    callPackage ../applications/networking/cluster/terraform-providers { }
+    callPackage ../applications/networking/cluster/terraform-providers {
+      buildGoModule = buildGo118Module;
+    }
   );
 
   terraforming = callPackage ../applications/networking/cluster/terraforming { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
