### PR TITLE
tree-sitter: Update grammars and add markdown-inline

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/default.nix
@@ -20,7 +20,7 @@
 , enableShared ? !stdenv.hostPlatform.isStatic
 , enableStatic ? stdenv.hostPlatform.isStatic
 , webUISupport ? false
-, extraGrammars ? {}
+, extraGrammars ? { }
 }:
 
 # TODO: move to carnix or https://github.com/kolloch/crate2nix
@@ -69,9 +69,11 @@ let
         { tree-sitter-ocaml-interface = grammars'.tree-sitter-ocaml // { location = "interface"; }; } //
         { tree-sitter-org-nvim = grammars'.tree-sitter-org-nvim // { language = "org"; }; } //
         { tree-sitter-typescript = grammars'.tree-sitter-typescript // { location = "typescript"; }; } //
-        { tree-sitter-tsx = grammars'.tree-sitter-typescript // { location = "tsx"; }; };
+        { tree-sitter-tsx = grammars'.tree-sitter-typescript // { location = "tsx"; }; } //
+        { tree-sitter-markdown = grammars'.tree-sitter-markdown // { location = "tree-sitter-markdown"; }; } //
+        { tree-sitter-markdown-inline = grammars'.tree-sitter-markdown // { language = "markdown_inline"; location = "tree-sitter-markdown-inline"; }; };
     in
-      lib.mapAttrs change (grammars);
+    lib.mapAttrs change (grammars);
 
   # Usage:
   # pkgs.tree-sitter.withPlugins (p: [ p.tree-sitter-c p.tree-sitter-java ... ])

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
@@ -30,9 +30,9 @@
   tree-sitter-glimmer = lib.importJSON ./tree-sitter-glimmer.json;
   tree-sitter-glsl = lib.importJSON ./tree-sitter-glsl.json;
   tree-sitter-go = lib.importJSON ./tree-sitter-go.json;
-  tree-sitter-gowork = lib.importJSON ./tree-sitter-gowork.json;
   tree-sitter-godot-resource = lib.importJSON ./tree-sitter-godot-resource.json;
   tree-sitter-gomod = lib.importJSON ./tree-sitter-gomod.json;
+  tree-sitter-gowork = lib.importJSON ./tree-sitter-gowork.json;
   tree-sitter-graphql = lib.importJSON ./tree-sitter-graphql.json;
   tree-sitter-haskell = lib.importJSON ./tree-sitter-haskell.json;
   tree-sitter-hcl = lib.importJSON ./tree-sitter-hcl.json;

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-beancount.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-beancount.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/polarmutex/tree-sitter-beancount",
-  "rev": "78b8ddca3ab774573a4e3bf64eabd79e9452cea9",
-  "date": "2021-11-11T10:25:06-05:00",
-  "path": "/nix/store/lzvc19ky1wxbc1cjf2zr351hbdfq22mm-tree-sitter-beancount",
-  "sha256": "19s1fgn1vgxz5q6qvcfdr1lqj1vnkjrwlkl9chapbdaliw0dy110",
+  "rev": "b807e0c5255221f5e4baa08b3325d08e2ba56ba2",
+  "date": "2022-07-02T10:33:09-04:00",
+  "path": "/nix/store/9kqvj3rpqlqgxr5nkcc43pkcvs460h14-tree-sitter-beancount",
+  "sha256": "0vh2sz5qjsgkmqlcw0kyq01wj5mxwymhyg9w8hfyd7kd779lfa86",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-c",
-  "rev": "3ced8d6cd212a6f576cd4ef3d533bcb9c09eface",
-  "date": "2022-05-30T15:48:31+02:00",
-  "path": "/nix/store/hh79856h2fw1i3i4g75a78rbzgi8qk3s-tree-sitter-c",
-  "sha256": "0g43xn98i01cgqzv0ck1inj267y7qjwpxzy5l245kdmxgfg4czm8",
+  "rev": "517bf92b2c5e8baa4241cbb8a49085ed7c3c48d4",
+  "date": "2022-07-08T09:44:02-07:00",
+  "path": "/nix/store/0nz381ay9ybngxvialwxisji9j4gwadb-tree-sitter-c",
+  "sha256": "03klq9mb9jnhjxf8lv0mk02gdp83zcyrvx1bzrqbd9jdza3ji1xl",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cmake.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cmake.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/uyha/tree-sitter-cmake",
-  "rev": "5020572408a386d5d2dfac3516584f5edda7a49b",
-  "date": "2022-01-26T22:53:15+01:00",
-  "path": "/nix/store/in8jrkjf5vca2azpnyq2dgmzz9jcvjy6-tree-sitter-cmake",
-  "sha256": "0y49x8d36vdq2lcj67f3ms53qxym3578b3aw9gs2ckibwzrbfbgy",
+  "rev": "599836393074e4744d78dad76b8b8eb8e1f690ff",
+  "date": "2022-07-08T12:16:35+07:00",
+  "path": "/nix/store/w6nxam1m3kq35faqcx17qmgn250fv461-tree-sitter-cmake",
+  "sha256": "02gbi24rxq4qqlxzl17vi81xjk3d3y41ig6g8w2yc6f2ihiw85na",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-embedded-template.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-embedded-template.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-embedded-template",
-  "rev": "d21df11b0ecc6fd211dbe11278e92ef67bd17e97",
-  "date": "2021-12-23T08:53:16-08:00",
-  "path": "/nix/store/zy74brmd1x2q68bpvi5v4z52bhmkcmy8-tree-sitter-embedded-template",
-  "sha256": "0h3nj6fz512riyx2b65pg9pjprkpkasnglwljlzi6s1in9fdig3x",
+  "rev": "1a538da253d73f896b9f6c0c7d79cda58791ac5c",
+  "date": "2022-06-20T17:01:16+02:00",
+  "path": "/nix/store/6mrkhc8bkfnmfaq94a30am9ygh971y97-tree-sitter-embedded-template",
+  "sha256": "0j73jk9byrhwddb4qsh67gf5fwj9fgdz6byphh3jj8f0ajzdxrmx",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fennel.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fennel.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/travonted/tree-sitter-fennel",
-  "rev": "d37fd84a702b78ff0282f223ece83c61ab062a6e",
-  "date": "2022-02-21T08:13:28-05:00",
-  "path": "/nix/store/lafx5rw9r9jp9056sv0sk89kxfjlb9x3-tree-sitter-fennel",
-  "sha256": "1wqvz8v877jh7shv50xbnx1bxvdlnfnpmndwzsb0smidnzx7lbw2",
+  "rev": "517195970428aacca60891b050aa53eabf4ba78d",
+  "date": "2022-06-22T09:39:24-04:00",
+  "path": "/nix/store/v8by7ilv9fyv20rp714xq7vhwwi7vz0g-tree-sitter-fennel",
+  "sha256": "02ja5narbahc02f6gmnr5j2sg5sbjcc71hbny6n0nd57kcnapfgd",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-glimmer.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-glimmer.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/alexlafroscia/tree-sitter-glimmer",
-  "rev": "5ed38d3cba65376e4734b0f1763c2f049ad5a1cf",
-  "date": "2021-09-25T09:50:19-04:00",
-  "path": "/nix/store/z0nhsn3v519mbxrhj5x1y7h7k7giviw2-tree-sitter-glimmer",
-  "sha256": "0whij8420niywdi0lna8w5fizq30vhldz3wssisw91gjfdn8d9mz",
+  "rev": "a23d28de811976f3ca310df735fe09a5d2de16ab",
+  "date": "2022-06-24T09:27:51-04:00",
+  "path": "/nix/store/m0hr0x0s3j7r6dn1kv6c77c9qbl4ggkw-tree-sitter-glimmer",
+  "sha256": "07dzpjyc644clh2x3r48w3mi3i68pkac5mwzha2iaxly9fndm0zk",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-glsl.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-glsl.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/thehamsta/tree-sitter-glsl",
-  "rev": "a480a02033f8d5c67e798a6f7584ec0d2be568b0",
-  "date": "2022-05-22T00:37:43+02:00",
-  "path": "/nix/store/jw1wnz2wfgibdz9pz0zlxyvs9p3pcayg-tree-sitter-glsl",
-  "sha256": "04yd7s26z4lmjrw325sn68nwma3mj1pl1kj1xvvwzxb9cxb91657",
+  "rev": "57652a006b726251ae4d03862ffecbe39b1515bf",
+  "date": "2022-07-10T20:32:50+02:00",
+  "path": "/nix/store/n3rfnc7z8ps4jzgxyb9hv9kffb2alcmw-tree-sitter-glsl",
+  "sha256": "1iayzjbwfmjbak3igrgms7wpa58syy2xym6n2hpi3369v7rfgsg8",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-gowork.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-gowork.json
@@ -2,7 +2,7 @@
   "url": "https://github.com/omertuc/tree-sitter-go-work",
   "rev": "6dd9dd79fb51e9f2abc829d5e97b15015b6a8ae2",
   "date": "2021-12-18T20:13:22+01:00",
-  "path": "/nix/store/7a4raw2gi4xgbg858cs0davbplj7m8rq-tree-sitter-gowork",
+  "path": "/nix/store/7a4raw2gi4xgbg858cs0davbplj7m8rq-tree-sitter-go-work",
   "sha256": "1kzrs4rpby3b0h87rbr02k55k3mmkmdy7rvl11q95b3ym0smmyqb",
   "fetchLFS": false,
   "fetchSubmodules": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-haskell",
-  "rev": "ca0a13f1acb60cf32e74cced3cb623b6c70fa77c",
-  "date": "2022-06-06T23:15:37+02:00",
-  "path": "/nix/store/dmq8mc361rkhrpa5s06h1z9k8khkvi78-tree-sitter-haskell",
-  "sha256": "1r3mfnj1f6p2cqriay22jjfggrmyywimidzmzw8h5q84flngdg2s",
+  "rev": "cf394604ae2ec2a5e65b1afbc7dea21258ede403",
+  "date": "2022-07-02T11:46:11+02:00",
+  "path": "/nix/store/04cbp4wc4ga3d36d9xvqz2wy9bdnyapv-tree-sitter-haskell",
+  "sha256": "1kvh5gwg3c59snqhpsg23b690rnbmcya0i38mqq9n1pdmv2pzxyi",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-heex.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-heex.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/connorlay/tree-sitter-heex",
-  "rev": "4d8d646bba27ec11bbf76ea37410a604d2e18bfc",
-  "date": "2022-06-09T17:09:44-05:00",
-  "path": "/nix/store/hcn9zl21asz1h6h2abqjpcc37sr56s6s-tree-sitter-heex",
-  "sha256": "0s38g23npq4k2yfwijmp14wmk7klhlycr4jl9a1hnh8qqihxjbj1",
+  "rev": "961bc4d2937cfd24ceb0a5a6b2da607809f8822e",
+  "date": "2022-06-13T09:15:37-07:00",
+  "path": "/nix/store/5qackjn309ls9qja23wkwhqiid9rc6l3-tree-sitter-heex",
+  "sha256": "1by6c4gcqxy9czvwabbmlfr1hlw8z2w7f623llbag956scp2b9al",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ledger.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ledger.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/cbarrete/tree-sitter-ledger",
-  "rev": "1050a25df55a62878102d10e524b5184b316b7ad",
-  "date": "2022-04-01T08:21:18-04:00",
-  "path": "/nix/store/hfhxv3k8kxpg7m31xzrf56lbaa4ips65-tree-sitter-ledger",
-  "sha256": "0qivr9wjab8m1ha4zisznijpw4x3phv0q0nh8lnsx7bjbz6f7xfx",
+  "rev": "47b8971448ce5e9abac865f450c1b14fb3b6eee9",
+  "date": "2022-07-09T09:40:08-04:00",
+  "path": "/nix/store/qzp0n5gcw7hakcv3ahxf1nrqrk8j2l3w-tree-sitter-ledger",
+  "sha256": "0j5fsgmmvc8z0ihsifc38qbvx8xdwd25bxq2a0k6kb8mbbmzk30f",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-lua.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-lua.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/MunifTanjim/tree-sitter-lua",
-  "rev": "2b4ffd5a5ffd0c6b4c84f0d9e003050a70db2a37",
-  "date": "2022-04-08T22:29:43+06:00",
-  "path": "/nix/store/gj2bbwc3105djyl3l5b0hjr1y1jg7262-tree-sitter-lua",
-  "sha256": "1l383clymmzk0q9b21kcgnmpww4hsh938yd3z9djpkhagadpqpjs",
+  "rev": "a041a547270c17f3d3aca11cb882f5c8eb88a572",
+  "date": "2022-07-07T14:08:02+06:00",
+  "path": "/nix/store/cs0rf42nnyw4w2rlzhw137iqh06dy5mh-tree-sitter-lua",
+  "sha256": "0db2wjwzzx40i38cs04w8pn0zqqv18ry4m2div0a0b2wgdhzf33f",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-markdown.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-markdown.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/MDeiml/tree-sitter-markdown",
-  "rev": "6d112e7a9c1694504bb78ee0b92dcd509625e0df",
-  "date": "2022-04-26T12:23:01+02:00",
-  "path": "/nix/store/598nrwznzg37r9pskrmzwnhrw3f4knnw-tree-sitter-markdown",
-  "sha256": "03d601dp65p30c88p0r6rx13wlkbg1q3ch11wfn4sa2rhba8zpyk",
+  "rev": "142a5b4a1b092b64c9f5db8f11558f9dd4009a1b",
+  "date": "2022-07-04T10:48:30+02:00",
+  "path": "/nix/store/wac43pvz3wdwl2i6a8a0ik6l99c9lzmq-tree-sitter-markdown",
+  "sha256": "0q1czdv7szw9rk4h9i9xjc29s0g3m1grhsjq6rl5vm70h998fbmg",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ocaml.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ocaml.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-ocaml",
-  "rev": "23d419ba45789c5a47d31448061557716b02750a",
-  "date": "2021-08-26T21:21:27+02:00",
-  "path": "/nix/store/942q4rv9vs77wwvvw46yx0jnqja2cbig-tree-sitter-ocaml",
-  "sha256": "1bh3afd3iix0gf6ldjngf2c65nyfdwvbmsq25gcxm04jwbg9c6k8",
+  "rev": "cc26b1ef111100f26a137bcbcd39fd4e35be9a59",
+  "date": "2022-06-19T21:41:43+02:00",
+  "path": "/nix/store/m5z0cdxb8mg1ff64529p8sfj9afq50l5-tree-sitter-ocaml",
+  "sha256": "1qra2zihw09ff16gxfmpmdmyj0rilvnk1xc9y4wb01j2a4292fc1",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-org-nvim.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-org-nvim.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/milisims/tree-sitter-org",
-  "rev": "7ab140276cff85bf6dd08914e04188f4da1ff0ab",
-  "date": "2022-06-01T13:56:57-04:00",
-  "path": "/nix/store/ig79jii0vihy6vjq5j35ymgpbppjcsgd-tree-sitter-org",
-  "sha256": "0j3520h0bvxn6sm8fg1a400y2rnp0l9jrf31n8rbkq9ri34bzi5x",
+  "rev": "bc8a040492b56754a35b3b00a3052fdb7ba12969",
+  "date": "2022-06-27T11:07:56-04:00",
+  "path": "/nix/store/6xpvk9i1250slzsh2ap3pr0fawmibngw-tree-sitter-org",
+  "sha256": "19z45bd276g4xggg2vqmr6fjwyi88xmpx1ihqq908152pq83zmv6",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-php",
-  "rev": "866e4a155739a1374da5247b876e70f8639005f6",
-  "date": "2022-06-06T09:18:54+02:00",
-  "path": "/nix/store/23f9s4z321mnjnqfxjdj75rkcvwv2xpa-tree-sitter-php",
-  "sha256": "11nagsvq2jsinrhsfpnylz1lkp6hiw3jndshnjvzvkjmmpavm1gr",
+  "rev": "ece74b20942a5b23acaf3622512c6d0db1491a7e",
+  "date": "2022-06-24T15:38:28-07:00",
+  "path": "/nix/store/cqqyvb0vfp0q34lf3w5jds5dq4riac9z-tree-sitter-php",
+  "sha256": "0ggx747j3hpgwqw7cjh07n866mvdcyv3mvblffbrb8b1xn3bll84",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-python.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-python.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-python",
-  "rev": "dafcef7943229ec9d530b36ed67d758e659f4c6c",
-  "date": "2022-05-31T14:13:03-07:00",
-  "path": "/nix/store/9f82z98jx9jlpb96niav0zd173lxmlla-tree-sitter-python",
-  "sha256": "07dkwp46wp8fnh94qy4rlvn8yq0wzawnmbrz7z1jk14ymr6s5hkh",
+  "rev": "de221eccf9a221f5b85474a553474a69b4b5784d",
+  "date": "2022-06-27T15:09:45-07:00",
+  "path": "/nix/store/r8cac3zd9xd3l3knzl6k98zhq0wshv0n-tree-sitter-python",
+  "sha256": "1mp2rqv6p2nla0sh1s5hprq32b9nkwbj2q21dcpvdcg6gack1sdf",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rst.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rst.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/stsewd/tree-sitter-rst",
-  "rev": "b74770c0166f28c1a0ab293513a78712ca1c338b",
-  "date": "2022-01-22T20:59:44-05:00",
-  "path": "/nix/store/ymhzq6hwq43gf918zyxk7can4qfkz7n1-tree-sitter-rst",
-  "sha256": "0q50vwk72lrgnrdjjn5aj1fjksrwkd0gfmdnrjy59a6cw8m1gmf0",
+  "rev": "d4b6c33ec15a4c22d0003dd37a5b20baa352b843",
+  "date": "2022-06-13T13:46:50-05:00",
+  "path": "/nix/store/scmhiai4dfc8k7nw6f0j1nmdhzv2j1ji-tree-sitter-rst",
+  "sha256": "127g78x2macl5fc1vhkfgkkd3zzj1yv9m2067j53nrivaff3jj8d",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rust.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rust.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-rust",
-  "rev": "36ae187ed6dd3803a8a89dbb54f3124c8ee74662",
-  "date": "2022-05-30T15:48:43+02:00",
-  "path": "/nix/store/h3abmx5hwki3lnymgk1awmkrc070733m-tree-sitter-rust",
-  "sha256": "1x1k4cn8x3my2rp735byn0z1sjiw17vkzaqnm10jr8jg5nxigl7a",
+  "rev": "0f14a10011ac6e56f309fb99a94829c3312b743a",
+  "date": "2022-07-11T12:34:08-04:00",
+  "path": "/nix/store/9767f79glbdja848ri2i0vii41g3z84n-tree-sitter-rust",
+  "sha256": "15js3v1kyl7h34ichy5q6zs5n0sm2b0iwgfdh34jrcgnlbvbgy52",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-sql.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-sql.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/m-novikov/tree-sitter-sql",
-  "rev": "2ec2fedbb38d09737e2a1cdd207f6416dc1cb109",
-  "date": "2022-06-11T22:57:56+02:00",
-  "path": "/nix/store/zzx4b5cnsrrdzkb5rbmx5d8vzbyr0rbi-tree-sitter-sql",
-  "sha256": "0dcpdshymyszsr1dflsr3j6ynrnrq0g4qdxqcz7d0anpwh3xw4cs",
+  "rev": "218b672499729ef71e4d66a949e4a1614488aeaa",
+  "date": "2022-06-30T19:50:55+02:00",
+  "path": "/nix/store/rcdcgwb28jblgb65k5zjw5zgmigiqjfl-tree-sitter-sql",
+  "sha256": "1j68h5jzc0d3a44v5mw005lh3zsrh0salfzydl9br1n8byl1awms",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-typescript",
-  "rev": "1b3ba31c7538825b05815f4f5bffcca6394edc63",
-  "date": "2022-06-02T09:10:56-07:00",
-  "path": "/nix/store/g3q8azmyclcdns0ihwl5im46qlsfxbfj-tree-sitter-typescript",
-  "sha256": "1iw6823zh2m95gjmly34j49ixga07fhax7z6g2q6px06gj4fm5df",
+  "rev": "49e82b1bce36d6046df911901684cd66b5345d58",
+  "date": "2022-07-06T12:52:21-07:00",
+  "path": "/nix/store/wzkgvx1sj0js8sdkm8cmip4rmsgqy3ij-tree-sitter-typescript",
+  "sha256": "1kgl0dvcjzlbpfbdf1mq9693p5j7kvcqfmxis2w30js2lmrp0wgb",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-vim.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-vim.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/vigoux/tree-sitter-viml",
-  "rev": "4b9d2dda6de64fe5abc9bf96b5727ba73ed08515",
-  "date": "2022-05-07T11:41:23+02:00",
-  "path": "/nix/store/zm2pfjv3fn2qg6iy1s03mn5kjawsy3qg-tree-sitter-viml",
-  "sha256": "0p7fj5vvxxz4d43j91zwv3h8df4m4c26w9gq2qx561vjh5w1q7fn",
+  "rev": "2d75bf329e3df6e1c13f81262567b9aeb6c241d1",
+  "date": "2022-07-12T08:30:33+02:00",
+  "path": "/nix/store/l19kbw907jxk26qf5cl5w5nz17sywjf6-tree-sitter-viml",
+  "sha256": "1pc6s2pc4svk64imkc486nz8fkhkpmwamn17gvnblinsjxr8369y",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-zig.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-zig.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/maxxnino/tree-sitter-zig",
-  "rev": "4cff36421dae9c05388b86cd64d2bab4b9ed6676",
-  "date": "2022-04-02T10:33:48+07:00",
-  "path": "/nix/store/ripw74y32a8nzsr9n30jfhh16wjxlxvb-tree-sitter-zig",
-  "sha256": "0k9z0f6vfj1pfz3qkscb41wz2nzjp0xpz9mvm6264q655rq73dlc",
+  "rev": "8d3224c3bd0890fe08358886ebf54fca2ed448a6",
+  "date": "2022-06-25T10:13:16+07:00",
+  "path": "/nix/store/an534h97z3gi6zk5mzysbx2fp8rvy9c4-tree-sitter-zig",
+  "sha256": "0mw4s92qmxkh9a13h9hg6kv9b704vzx3kr4j6dap0c80dffvfjhk",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,


### PR DESCRIPTION
###### Description of changes

Update tree-sitters grammars and add the split for markdown and markdown-inline mentioned in https://github.com/nvim-treesitter/nvim-treesitter/issues/2293#issuecomment-1166574954

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

@Profpatsch @oxalica 
