### PR TITLE
webex: init at 42.8.0.22907

### DIFF
--- a/pkgs/applications/networking/instant-messengers/webex/default.nix
+++ b/pkgs/applications/networking/instant-messengers/webex/default.nix
@@ -1,0 +1,175 @@
+{ lib
+, writeScript
+, stdenv
+, fetchurl
+, alsaLib
+, at-spi2-atk
+, at-spi2-core
+, atk
+, cairo
+, cups
+, dbus
+, expat
+, fontconfig
+, freetype
+, gdk-pixbuf
+, glib
+, gtk3
+, harfbuzz
+, libdrm
+, libgcrypt
+, libglvnd
+, libkrb5
+, libpulseaudio
+, libsecret
+, udev
+, libxcb
+, libxkbcommon
+, lshw
+, mesa
+, nspr
+, nss
+, pango
+, zlib
+, libX11
+, libXcomposite
+, libXcursor
+, libXdamage
+, libXext
+, libXfixes
+, libXi
+, libXrandr
+, libXrender
+, libXtst
+, libxshmfence
+, xcbutil
+, xcbutilimage
+, xcbutilkeysyms
+, xcbutilrenderutil
+, xcbutilwm
+, p7zip
+, wayland
+, libXScrnSaver
+}:
+
+stdenv.mkDerivation rec {
+  pname = "webex";
+  version = "42.8.0.22907";
+
+  src = fetchurl {
+    url = "https://binaries.webex.com/WebexDesktop-Ubuntu-Blue/20220712081040/Webex_ubuntu.7z";
+    sha256 = "b83950cdcf978a3beda93de27b25b70554fc82fcf072a5a7ea858d2ce0d176ac";
+  };
+
+  buildInputs = [
+    alsaLib
+    at-spi2-atk
+    at-spi2-core
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    freetype
+    glib
+    gdk-pixbuf
+    gtk3
+    harfbuzz
+    lshw
+    mesa
+    nspr
+    nss
+    pango
+    zlib
+    libdrm
+    libgcrypt
+    libglvnd
+    libkrb5
+    libpulseaudio
+    libsecret
+    udev
+    libxcb
+    libxkbcommon
+    libX11
+    libXcomposite
+    libXcursor
+    libXdamage
+    libXext
+    libXfixes
+    libXi
+    libXrandr
+    libXrender
+    libXtst
+    libxshmfence
+    xcbutil
+    xcbutilimage
+    libXScrnSaver
+    xcbutilkeysyms
+    xcbutilrenderutil
+    xcbutilwm
+    p7zip
+    wayland
+  ];
+
+  libPath = "$out/opt/Webex/lib:$out/opt/Webex/bin:${lib.makeLibraryPath buildInputs}";
+
+  unpackPhase = ''
+    7z x $src
+    mv Webex_ubuntu/opt .
+  '';
+
+  postPatch = ''
+    substituteInPlace opt/Webex/bin/webex.desktop --replace /opt $out/opt
+  '';
+
+  dontPatchELF = true;
+
+  buildPhase = ''
+    patchelf \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath "${libPath}" \
+      opt/Webex/bin/CiscoCollabHost \
+      opt/Webex/bin/CiscoCollabHostCef \
+      opt/Webex/bin/CiscoCollabHostCefWM \
+      opt/Webex/bin/WebexFileSelector \
+      opt/Webex/bin/pxgsettings
+    for each in $(find opt/Webex -type f | grep \\.so); do
+      patchelf --set-rpath "${libPath}" "$each"
+    done
+  '';
+
+  installPhase = ''
+    mkdir -p "$out/bin" "$out/share/applications"
+    cp -r opt "$out"
+
+    ln -s "$out/opt/Webex/bin/CiscoCollabHost" "$out/bin/webex"
+    chmod +x $out/bin/webex
+
+    mv "$out/opt/Webex/bin/webex.desktop" "$out/share/applications/webex.desktop"
+  '';
+
+  passthru.updateScript = writeScript "webex-update-script" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p curl jq common-updater-scripts
+    set -eou pipefail;
+
+    channel=blue
+    manifest=$(curl -s "https://client-upgrade-a.wbx2.com/client-upgrade/api/v1/webexteamsdesktop/upgrade/@me?channel=$channel&model=ubuntu" | jq '.manifest')
+
+    url=$(jq -r '.packageLocation' <<< "$manifest")
+    version=$(jq -r '.version' <<< "$manifest")
+    hash=$(jq -r '.checksum' <<< "$manifest")
+
+    update-source-version ${pname} "$version" "$hash" "$url" --file=./pkgs/applications/networking/instant-messengers/webex/default.nix
+  '';
+
+  meta = with lib; {
+    description = "The all-in-one app to call, meet, message, and get work done";
+    homepage = "https://webex.com/";
+    downloadPage = "https://www.webex.com/downloads.html";
+    license = licenses.unfree;
+    maintainers = with lib.maintainers; [ uvnikita ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31030,6 +31030,8 @@ with pkgs;
 
   webcamoid = libsForQt5.callPackage ../applications/video/webcamoid { };
 
+  webex = callPackage ../applications/networking/instant-messengers/webex {};
+
   webmacs = libsForQt5.callPackage ../applications/networking/browsers/webmacs {};
 
   webssh = with python3Packages; toPythonApplication webssh;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Picking up efforts from #129851.

Seems like there are three channels:

- gold: 42.6.0.22565
- green: 42.7.0.22904
- blue: 42.8.0.22907

I selected the **blue** channel for now (chat rendering in wayland was fixed in this version for me), but let me know if you think we should use another one.

`update.sh` script is used to get newest package version from the channel. Please let me know if there is a way to integrate it with @r-ryantm so that we don't have to run the script manually. @ryantm

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
