### PR TITLE
Revert "release: add tests.packageTestsForChannelBlockers.curl.withCh…

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -156,7 +156,6 @@ in rec {
         (onSystems ["i686-linux"] "nixos.tests.zfs.installer")
         (onFullSupported "nixpkgs.emacs")
         (onFullSupported "nixpkgs.jdk")
-        (onFullSupported "nixpkgs.tests.packageTestsForChannelBlockers.curl.withCheck")
         ["nixpkgs.tarball"]
       ];
     };

--- a/nixos/release-small.nix
+++ b/nixos/release-small.nix
@@ -120,7 +120,6 @@ in rec {
         "nixos.tests.proxy.x86_64-linux"
         "nixos.tests.simple.x86_64-linux"
         "nixpkgs.jdk.x86_64-linux"
-        "nixpkgs.tests.packageTestsForChannelBlockers.curl.withCheck.x86_64-linux"
         "nixpkgs.tarball"
       ];
   };

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -24,14 +24,6 @@ with pkgs;
 
   config = callPackage ./config.nix { };
 
-  # we can't add 'nixpkgs.curl.tests' to hydra jobs due to 'tests' (and 'passthru') being stripped
-  # TODO: add a function in lib-release.nix to get derivations and add `.x86_64-linux` to them
-  # then we can just point release files to nixpkgs.tests.packageTestsForChannelBlockers instead of
-  # nixpkgs.tests.packageTestsForChannelBlockers.curl.withCheck
-  packageTestsForChannelBlockers = recurseIntoAttrs {
-    curl = recurseIntoAttrs pkgs.curl.tests;
-  };
-
   haskell = callPackage ./haskell { };
 
   cc-multilib-gcc = callPackage ./cc-wrapper/multilib.nix { stdenv = gccMultiStdenv; };

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -97,7 +97,6 @@ let
               jobs.lib-tests
               jobs.pkgs-lib-tests
               jobs.stdenv.x86_64-linux
-              jobs.tests.packageTestsForChannelBlockers.curl.withCheck.x86_64-linux
               jobs.cargo.x86_64-linux
               jobs.go.x86_64-linux
               jobs.linux.x86_64-linux
@@ -134,7 +133,6 @@ let
             ++ lib.collect lib.isDerivation jobs.stdenvBootstrapTools
             ++ lib.optionals supportDarwin.x86_64 [
               jobs.stdenv.x86_64-darwin
-              jobs.tests.packageTestsForChannelBlockers.curl.withCheck.x86_64-darwin
               jobs.cargo.x86_64-darwin
               jobs.cachix.x86_64-darwin
               jobs.go.x86_64-darwin


### PR DESCRIPTION
…eck as a channel blocker"

This reverts commit 7141ab0f0b404a95509503e7b16a7f0072a66902.

reverting this for now to unblock staging-next

{UNKNOWN}: aggregate job ‘tested’ failed with the error: nixpkgs.tests.packageTestsForChannelBlockers.curl.withCheck.x86_64-linux: does not exist
 at /nix/store/9i92scfqz5idhmjrmjnqhrvjgyydzfns-hydra-perl-deps/lib/perl5/site_perl/5.34.0/Catalyst/Model/DBIC/Schema.pm line 526

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
