### PR TITLE
Revert "Revert "release: add tests.packageTestsForChannelBlockers.curl.withCh…"

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -156,6 +156,7 @@ in rec {
         (onSystems ["i686-linux"] "nixos.tests.zfs.installer")
         (onFullSupported "nixpkgs.emacs")
         (onFullSupported "nixpkgs.jdk")
+        (onFullSupported "nixpkgs.tests.packageTestsForChannelBlockers.curl.withCheck")
         ["nixpkgs.tarball"]
       ];
     };

--- a/nixos/release-small.nix
+++ b/nixos/release-small.nix
@@ -120,6 +120,7 @@ in rec {
         "nixos.tests.proxy.x86_64-linux"
         "nixos.tests.simple.x86_64-linux"
         "nixpkgs.jdk.x86_64-linux"
+        "nixpkgs.tests.packageTestsForChannelBlockers.curl.withCheck.x86_64-linux"
         "nixpkgs.tarball"
       ];
   };

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -24,6 +24,14 @@ with pkgs;
 
   config = callPackage ./config.nix { };
 
+  # we can't add 'nixpkgs.curl.tests' to hydra jobs due to 'tests' (and 'passthru') being stripped
+  # TODO: add a function in lib-release.nix to get derivations and add `.x86_64-linux` to them
+  # then we can just point release files to nixpkgs.tests.packageTestsForChannelBlockers instead of
+  # nixpkgs.tests.packageTestsForChannelBlockers.curl.withCheck
+  packageTestsForChannelBlockers = recurseIntoAttrs {
+    curl = recurseIntoAttrs pkgs.curl.tests;
+  };
+
   haskell = callPackage ./haskell { };
 
   cc-multilib-gcc = callPackage ./cc-wrapper/multilib.nix { stdenv = gccMultiStdenv; };

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -97,6 +97,7 @@ let
               jobs.lib-tests
               jobs.pkgs-lib-tests
               jobs.stdenv.x86_64-linux
+              jobs.tests.packageTestsForChannelBlockers.curl.withCheck.x86_64-linux
               jobs.cargo.x86_64-linux
               jobs.go.x86_64-linux
               jobs.linux.x86_64-linux
@@ -133,6 +134,7 @@ let
             ++ lib.collect lib.isDerivation jobs.stdenvBootstrapTools
             ++ lib.optionals supportDarwin.x86_64 [
               jobs.stdenv.x86_64-darwin
+              jobs.tests.packageTestsForChannelBlockers.curl.withCheck.x86_64-darwin
               jobs.cargo.x86_64-darwin
               jobs.cachix.x86_64-darwin
               jobs.go.x86_64-darwin


### PR DESCRIPTION
Reverts NixOS/nixpkgs#181214

base branch was wrong

right one in https://github.com/NixOS/nixpkgs/pull/181220