### PR TITLE
`_module.specialArgs` + unit test for nixos/documentation module

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -266,6 +266,15 @@ rec {
               turned off.
             '';
           };
+
+          _module.specialArgs = mkOption {
+            readOnly = true;
+            internal = true;
+            description = ''
+              Externally provided module arguments that can't be modified from
+              within a configuration, but can be used in module imports.
+            '';
+          };
         };
 
         config = {
@@ -273,6 +282,7 @@ rec {
             inherit extendModules;
             moduleType = type;
           };
+          _module.specialArgs = specialArgs;
         };
       };
 

--- a/nixos/modules/misc/documentation.nix
+++ b/nixos/modules/misc/documentation.nix
@@ -332,10 +332,6 @@ in
       environment.systemPackages = []
         ++ optional cfg.man.enable manual.manpages
         ++ optionals cfg.doc.enable [ manual.manualHTML nixos-help ];
-
-      services.getty.helpLine = mkIf cfg.doc.enable (
-          "\nRun 'nixos-help' for the NixOS manual."
-      );
     })
 
   ]);

--- a/nixos/modules/misc/documentation.nix
+++ b/nixos/modules/misc/documentation.nix
@@ -1,4 +1,4 @@
-{ config, options, lib, pkgs, utils, modules, baseModules, extraModules, modulesPath, ... }:
+{ config, options, lib, pkgs, utils, modules, baseModules, extraModules, modulesPath, specialArgs, ... }:
 
 with lib;
 
@@ -41,7 +41,7 @@ let
           modules = [ {
             _module.check = false;
           } ] ++ docModules.eager;
-          specialArgs = {
+          specialArgs = specialArgs // {
             pkgs = scrubDerivations "pkgs" pkgs;
             # allow access to arbitrary options for eager modules, eg for getting
             # option types from lazy modules

--- a/nixos/modules/misc/documentation.nix
+++ b/nixos/modules/misc/documentation.nix
@@ -142,6 +142,12 @@ in
 
 {
   imports = [
+    ./man-db.nix
+    ./mandoc.nix
+    ./assertions.nix
+    ./meta.nix
+    ../config/system-path.nix
+    ../system/etc/etc.nix
     (mkRenamedOptionModule [ "programs" "info" "enable" ] [ "documentation" "info" "enable" ])
     (mkRenamedOptionModule [ "programs" "man"  "enable" ] [ "documentation" "man"  "enable" ])
     (mkRenamedOptionModule [ "services" "nixosManual" "enable" ] [ "documentation" "nixos" "enable" ])

--- a/nixos/modules/misc/documentation.nix
+++ b/nixos/modules/misc/documentation.nix
@@ -7,9 +7,6 @@ let
   cfg = config.documentation;
   allOpts = options;
 
-  /* Modules for which to show options even when not imported. */
-  extraDocModules = [ ../virtualisation/qemu-vm.nix ];
-
   canCacheDocs = m:
     let
       f = import m;
@@ -23,7 +20,7 @@ let
 
   docModules =
     let
-      p = partition canCacheDocs (baseModules ++ extraDocModules);
+      p = partition canCacheDocs (baseModules ++ cfg.nixos.extraModules);
     in
       {
         lazy = p.right;
@@ -233,6 +230,14 @@ in
           <listitem><para>This includes the HTML manual and the <command>nixos-help</command> command if
                     <option>documentation.doc.enable</option> is set.</para></listitem>
           </itemizedlist>
+        '';
+      };
+
+      nixos.extraModules = mkOption {
+        type = types.listOf types.raw;
+        default = [];
+        description = ''
+          Modules for which to show options even when not imported.
         '';
       };
 

--- a/nixos/modules/misc/documentation/test.nix
+++ b/nixos/modules/misc/documentation/test.nix
@@ -1,0 +1,49 @@
+{ nixosLib, pkgsModule, runCommand }:
+
+let
+  sys = nixosLib.evalModules rec {
+    modules = [
+      pkgsModule
+      ../documentation.nix
+      ../version.nix
+
+      ({ lib, someArg, ... }: {
+        # Make sure imports from specialArgs are respected
+        imports = [ someArg.myModule ];
+
+        # TODO test this
+        meta.doc = ./test-dummy.chapter.xml;
+      })
+
+      {
+        _module.args = {
+          baseModules = [
+            ../documentation.nix
+            ../version.nix
+          ];
+          extraModules = [ ];
+          inherit modules;
+        };
+        documentation.nixos.includeAllModules = true;
+      }
+    ];
+    specialArgs.someArg.myModule = { lib, ... }: {
+      options.foobar = lib.mkOption {
+        type = lib.types.str;
+        description = "The foobar option was added via specialArgs";
+        default = "qux";
+      };
+    };
+  };
+
+in
+runCommand "documentation-check"
+{
+  inherit (sys.config.system.build.manual) optionsJSON;
+} ''
+  json="$optionsJSON/share/doc/nixos/options.json"
+  echo checking $json
+
+  grep 'The foobar option was added via specialArgs' <"$json" >/dev/null
+  touch $out
+''

--- a/nixos/modules/misc/version.nix
+++ b/nixos/modules/misc/version.nix
@@ -45,6 +45,12 @@ in
     (mkRenamedOptionModule [ "system" "nixosLabel" ] [ "system" "nixos" "label" ])
   ];
 
+  options.boot.initrd.osRelease = mkOption {
+    internal = true;
+    readOnly = true;
+    default = initrdRelease;
+  };
+
   options.system = {
 
     nixos.version = mkOption {
@@ -141,11 +147,6 @@ in
       };
 
       "os-release".text = attrsToText osReleaseContents;
-    };
-
-    boot.initrd.systemd.contents = {
-      "/etc/os-release".source = initrdRelease;
-      "/etc/initrd-release".source = initrdRelease;
     };
 
     # We have to use `warnings` because when warning in the default of the option

--- a/nixos/modules/misc/version.nix
+++ b/nixos/modules/misc/version.nix
@@ -38,6 +38,7 @@ let
 in
 {
   imports = [
+    ./label.nix
     (mkRenamedOptionModule [ "system" "nixosVersion" ] [ "system" "nixos" "version" ])
     (mkRenamedOptionModule [ "system" "nixosVersionSuffix" ] [ "system" "nixos" "versionSuffix" ])
     (mkRenamedOptionModule [ "system" "nixosRevision" ] [ "system" "nixos" "revision" ])

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1283,4 +1283,5 @@
   ./virtualisation/waydroid.nix
   ./virtualisation/xen-dom0.nix
   ./virtualisation/xe-guest-utilities.nix
+  { documentation.nixos.extraModules = [ ./virtualisation/qemu-vm.nix ]; }
 ]

--- a/nixos/modules/services/ttys/getty.nix
+++ b/nixos/modules/services/ttys/getty.nix
@@ -104,6 +104,7 @@ in
     # Note: this is set here rather than up there so that changing
     # nixos.label would not rebuild manual pages
     services.getty.greetingLine = mkDefault ''<<< Welcome to NixOS ${config.system.nixos.label} (\m) - \l >>>'';
+    services.getty.helpLine = mkIf (config.documentation.nixos.enable && config.documentation.doc.enable) "\nRun 'nixos-help' for the NixOS manual.";
 
     systemd.services."getty@" =
       { serviceConfig.ExecStart = [

--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -359,6 +359,9 @@ in {
         '';
         "/etc/modprobe.d/debian.conf".source = pkgs.kmod-debian-aliases;
 
+        "/etc/os-release".source = config.boot.initrd.osRelease;
+        "/etc/initrd-release".source = config.boot.initrd.osRelease;
+
       };
 
       storePaths = [

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -127,6 +127,7 @@ in {
   docker-tools-cross = handleTestOn ["x86_64-linux" "aarch64-linux"] ./docker-tools-cross.nix {};
   docker-tools-overlay = handleTestOn ["x86_64-linux"] ./docker-tools-overlay.nix {};
   documize = handleTest ./documize.nix {};
+  documentation = pkgs.callPackage ../modules/misc/documentation/test.nix { inherit nixosLib; };
   doh-proxy-rust = handleTest ./doh-proxy-rust.nix {};
   dokuwiki = handleTest ./dokuwiki.nix {};
   domination = handleTest ./domination.nix {};


### PR DESCRIPTION
###### Description

 - Fixes https://github.com/NixOS/nixpkgs/issues/181009, an infinite recursion.
 - Some pure refactoring of modules
 - New unit test

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
