### PR TITLE
zulip-term: fix tests

### DIFF
--- a/pkgs/applications/networking/instant-messengers/zulip-term/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zulip-term/default.nix
@@ -17,6 +17,10 @@ python3.pkgs.buildPythonApplication rec {
     sha256 = "sha256-ZouUU4p1FSGMxPuzDo5P971R+rDXpBdJn2MqvkJO+Fw=";
   };
 
+  patches = [
+    ./pytest-executable-name.patch
+  ];
+
   propagatedBuildInputs = with python3.pkgs; [
     beautifulsoup4
     lxml
@@ -41,12 +45,6 @@ python3.pkgs.buildPythonApplication rec {
 
   makeWrapperArgs = [
     "--prefix" "PATH" ":" (lib.makeBinPath [ libnotify ])
-  ];
-
-  disabledTests = [
-    # IndexError: list index out of range
-    "test_main_multiple_notify_options"
-    "test_main_multiple_autohide_options"
   ];
 
   meta = with lib; {

--- a/pkgs/applications/networking/instant-messengers/zulip-term/pytest-executable-name.patch
+++ b/pkgs/applications/networking/instant-messengers/zulip-term/pytest-executable-name.patch
@@ -1,0 +1,22 @@
+diff --git a/tests/cli/test_run.py b/tests/cli/test_run.py
+index 1452cfd..0a21c09 100644
+--- a/tests/cli/test_run.py
++++ b/tests/cli/test_run.py
+@@ -240,7 +240,7 @@ def test_main_multiple_autohide_options(
+ 
+     captured = capsys.readouterr()
+     lines = captured.err.strip("\n")
+-    lines = lines.split("pytest: ", 1)[1]
++    lines = lines.split("__main__.py: ", 1)[1]
+     expected = f"error: argument {options[1]}: not allowed with argument {options[0]}"
+     assert lines == expected
+ 
+@@ -277,7 +277,7 @@ def test_main_multiple_notify_options(
+ 
+     captured = capsys.readouterr()
+     lines = captured.err.strip("\n")
+-    lines = lines.split("pytest: ", 1)[1]
++    lines = lines.split("__main__.py: ", 1)[1]
+     expected = f"error: argument {options[1]}: not allowed with argument {options[0]}"
+     assert lines == expected
+ 


### PR DESCRIPTION
###### Description of changes
The patch shouldn't have been removed in https://github.com/NixOS/nixpkgs/pull/180708.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
