### PR TITLE
rescript-editor-analysis: 1.1.3 -> 1.3.0

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/rescript/rescript-editor-analysis.nix
+++ b/pkgs/applications/editors/vscode/extensions/rescript/rescript-editor-analysis.nix
@@ -1,17 +1,17 @@
-{ lib, stdenv, fetchFromGitHub, bash, ocaml }:
+{ lib, stdenv, fetchFromGitHub, bash, ocaml, dune_3 }:
 
 stdenv.mkDerivation {
   pname = "rescript-editor-analysis";
-  version = "1.1.3";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "rescript-lang";
     repo = "rescript-vscode";
-    rev = "8d0412a72307b220b7f5774e2612760a2d429059";
-    sha256 = "rHQtfuIiEWlSPuZvNpEafsvlXCj2Uv1YRR1IfvKfC2s=";
+    rev = "1.3.0";
+    sha256 = "IL0sn7cpCHbSR19n6HvLyhp5aqit4EfO+EhK0lA9A1A=";
   };
 
-  nativeBuildInputs = [ ocaml ];
+  nativeBuildInputs = [ ocaml dune_3 ];
 
   postPatch = ''
     cd analysis
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "Analysis binary for the ReScript VSCode plugin";
     homepage = "https://github.com/rescript-lang/rescript-vscode";
-    maintainers = with maintainers; [ dlip ];
+    maintainers = with maintainers; [ dlip jayesh-bhoot ];
     license = licenses.mit;
   };
 }


### PR DESCRIPTION
The analysis executable was lagging behind the main rescript-vscode package,
due to which the vscode extension lost a few LSP capabilities, like `semanticTokens`.
See https://github.com/rescript-lang/rescript-vscode/issues/488 for more details.

This upgrade brings the analysis binary in sync with the main extension version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
