### PR TITLE
create_ap: fix path

### DIFF
--- a/pkgs/os-specific/linux/linux-wifi-hotspot/default.nix
+++ b/pkgs/os-specific/linux/linux-wifi-hotspot/default.nix
@@ -14,7 +14,15 @@
 , iproute2
 , flock
 , iptables
-, gawk }:
+, gawk
+, coreutils
+, gnugrep
+, gnused
+, kmod
+, networkmanager
+, procps
+}:
+
 
 stdenv.mkDerivation rec {
   pname = "linux-wifi-hotspot";
@@ -56,7 +64,21 @@ stdenv.mkDerivation rec {
   postInstall = ''
     wrapProgram $out/bin/create_ap \
       --prefix PATH : ${lib.makeBinPath [
-          hostapd getopt iw which dnsmasq iproute2 flock iptables gawk
+          coreutils
+          dnsmasq
+          flock
+          gawk
+          getopt
+          gnugrep
+          gnused
+          hostapd
+          iproute2
+          iptables
+          iw
+          kmod
+          networkmanager
+          procps
+          which
         ]}
 
     wrapProgram $out/bin/wihotspot-gui \


### PR DESCRIPTION
###### Description of changes

Fixed the path for create_ap module using [this script](https://gist.github.com/SCOTT-HAMILTON/63070397f9369c44fa47c26750531803) made for the occasion.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Pinging maintainer: @onny 