### PR TITLE
GNOME updates

### DIFF
--- a/pkgs/development/libraries/gjs/default.nix
+++ b/pkgs/development/libraries/gjs/default.nix
@@ -30,13 +30,13 @@ let
   ];
 in stdenv.mkDerivation rec {
   pname = "gjs";
-  version = "1.72.0";
+  version = "1.72.1";
 
   outputs = [ "out" "dev" "installedTests" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/gjs/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-PvDK9xbjkg3WH3dI9tVuR2zA/Bg1GtBUjn3xoKub3K0=";
+    sha256 = "sha256-F8Cx7D8JZnH/i/q6bku/FBmMcBPGBL/Wd6mFjaB5wKs=";
   };
 
   patches = [

--- a/pkgs/development/libraries/gnome-desktop/default.nix
+++ b/pkgs/development/libraries/gnome-desktop/default.nix
@@ -27,13 +27,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-desktop";
-  version = "42.2";
+  version = "42.3";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-desktop/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-9CsU6sjRRWwr/B+8l+9q/knI3W9XeW6P1f6zkzHtVb0=";
+    sha256 = "sha256-2lBBC48Z/X53WwDR/g26Z/xeEVHe0pkVjcJd2tw/qKk=";
   };
 
   patches = [

--- a/pkgs/development/libraries/librest/1.0.nix
+++ b/pkgs/development/libraries/librest/1.0.nix
@@ -7,20 +7,21 @@
 , gi-docgen
 , glib
 , json-glib
-, libsoup
+, libsoup_3
+, libxml2
 , gobject-introspection
 , gnome
 }:
 
 stdenv.mkDerivation rec {
   pname = "rest";
-  version = "0.9.0";
+  version = "0.9.1";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "hbK8k0ESgTlTm1PuU/BTMxC8ljkv1kWGOgQEELgevmY=";
+    sha256 = "kmalwQ7OOD4ZPft/+we1CcwfUVIauNrXavlu0UISwuM=";
   };
 
   nativeBuildInputs = [
@@ -34,7 +35,8 @@ stdenv.mkDerivation rec {
   buildInputs = [
     glib
     json-glib
-    libsoup
+    libsoup_3
+    libxml2
   ];
 
   mesonFlags = [

--- a/pkgs/development/tools/misc/d-spy/default.nix
+++ b/pkgs/development/tools/misc/d-spy/default.nix
@@ -1,9 +1,9 @@
 { stdenv
 , lib
 , desktop-file-utils
-, fetchpatch
 , fetchurl
 , glib
+, gettext
 , gtk4
 , libadwaita
 , meson
@@ -15,23 +15,14 @@
 
 stdenv.mkDerivation rec {
   pname = "d-spy";
-  version = "1.2.0";
+  version = "1.2.1";
 
   outputs = [ "out" "lib" "dev" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/dspy/${lib.versions.majorMinor version}/dspy-${version}.tar.xz";
-    sha256 = "XKL0z00w0va9m1OfuVq5YJyE1jzeynBxb50jc+O99tQ=";
+    sha256 = "TjnA1to687eJASJd0VEjOFe+Ihtfs62CwdsVhyNrZlI=";
   };
-
-  patches = [
-    # Remove pointless dependencies
-    # https://gitlab.gnome.org/GNOME/d-spy/-/merge_requests/6
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/d-spy/-/commit/5a0ec8d53d006e95e93c6d6e32a381eb248b12a1.patch";
-      sha256 = "jalfdAXcH8GZ50qb2peG+2841cGan4EhwN88z5Ewf+k=";
-    })
-  ];
 
   nativeBuildInputs = [
     meson
@@ -39,6 +30,8 @@ stdenv.mkDerivation rec {
     pkg-config
     desktop-file-utils
     wrapGAppsHook4
+    gettext
+    glib
   ];
 
   buildInputs = [


### PR DESCRIPTION
###### Description of changes

- d-spy: 1.2.0 → 1.2.1
- gjs: 1.72.0 → 1.72.1
- gnome-desktop: 42.2 → 42.3
- librest_1_0: 0.9.0 → 0.9.1

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Closes #180304