### PR TITLE
warpd: init at 1.3.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5107,6 +5107,12 @@
     githubId = 3656888;
     name = "hhm";
   };
+  hhydraa = {
+    email = "hcurfman@keemail.me";
+    github = "hhydraa";
+    githubId = 58676303;
+    name = "hhydraa";
+  };
   higebu = {
     name = "Yuya Kusakabe";
     email = "yuya.kusakabe@gmail.com";

--- a/pkgs/applications/misc/warpd/default.nix
+++ b/pkgs/applications/misc/warpd/default.nix
@@ -1,0 +1,61 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, git
+, libXi
+, libXinerama
+, libXft
+, libXfixes
+, libXtst
+, libX11
+, libXext
+, waylandSupport ? false, cairo, libxkbcommon, wayland
+}:
+
+stdenv.mkDerivation rec {
+  pname = "warpd";
+  version = "1.3.2";
+
+  src = fetchFromGitHub {
+    owner = "rvaiya";
+    repo = "warpd";
+    rev = "v${version}";
+    sha256 = "AR/uLgNX1VLPEcfUd8cnplMiaoEJlUxQ55Fst62RnbI=";
+    leaveDotGit = true;
+  };
+
+  nativeBuildInputs = [ git ];
+
+  buildInputs =  [
+    libXi
+    libXinerama
+    libXft
+    libXfixes
+    libXtst
+    libX11
+    libXext
+  ] ++ lib.optionals waylandSupport [
+    cairo
+    libxkbcommon
+    wayland
+  ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace '-m644' '-Dm644' \
+      --replace '-m755' '-Dm755' \
+      --replace 'warpd.1.gz $(DESTDIR)' 'warpd.1.gz -t $(DESTDIR)' \
+      --replace 'bin/warpd $(DESTDIR)' 'bin/warpd -t $(DESTDIR)'
+  '';
+
+  meta = with lib; {
+    description = "A modal keyboard driven interface for mouse manipulation.";
+    homepage = "https://github.com/rvaiya/warpd";
+    changelog = "https://github.com/rvaiya/warpd/blob/${src.rev}/CHANGELOG.md";
+    maintainers = with maintainers; [ hhydraa ];
+    license = licenses.mit;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30984,6 +30984,8 @@ with pkgs;
 
   warp = callPackage ../applications/networking/warp { };
 
+  warpd = callPackage ../applications/misc/warpd { };
+
   w3m = callPackage ../applications/networking/browsers/w3m { };
 
   # Should always be the version with the most features


### PR DESCRIPTION
###### Description of changes

Adds warpd, "A modal keyboard driven interface for mouse manipulation."

Link to GitHub repo: https://github.com/rvaiya/warpd

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
