### PR TITLE
kyverno: init at 1.7.0

### DIFF
--- a/pkgs/applications/networking/cluster/kyverno/default.nix
+++ b/pkgs/applications/networking/cluster/kyverno/default.nix
@@ -1,0 +1,49 @@
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles, testers, kyverno }:
+
+buildGoModule rec {
+  pname = "kyverno";
+  version = "1.7.1";
+
+  src = fetchFromGitHub {
+    owner = "kyverno";
+    repo = "kyverno";
+    rev = "v${version}";
+    sha256 = "sha256-MHEVGJNuZozug0l+V1bRIykOe5PGA3aU3wfBV2TH/Lo=";
+  };
+
+  ldflags = [
+    "-s" "-w"
+    "-X github.com/kyverno/kyverno/pkg/version.BuildVersion=v${version}"
+    "-X github.com/kyverno/kyverno/pkg/version.BuildHash=${version}"
+    "-X github.com/kyverno/kyverno/pkg/version.BuildTime=1970-01-01_00:00:00"
+  ];
+
+  vendorSha256 = "sha256-DUe1cy6PgI5qiB9BpDJxnTlBFuy/BmyqCoxRo7Ums1I=";
+
+  subPackages = [ "cmd/cli/kubectl-kyverno" ];
+
+  nativeBuildInputs = [ installShellFiles ];
+  postInstall = ''
+    # we have no integration between krew and kubectl
+    # so better rename binary to kyverno and use as a standalone
+    mv $out/bin/kubectl-kyverno $out/bin/kyverno
+    installShellCompletion --cmd kyverno \
+      --bash <($out/bin/kyverno completion bash) \
+      --zsh <($out/bin/kyverno completion zsh) \
+      --fish <($out/bin/kyverno completion fish)
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = kyverno;
+    command = "kyverno version";
+    inherit version;
+  };
+
+  meta = with lib; {
+    description = "Kubernetes Native Policy Management";
+    homepage = "https://kyverno.io/";
+    changelog = "https://github.com/kyverno/kyverno/releases/tag/v${version}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bryanasdev000 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7777,6 +7777,8 @@ with pkgs;
 
   kytea = callPackage ../tools/text/kytea { };
 
+  kyverno = callPackage ../applications/networking/cluster/kyverno { };
+
   k6 = callPackage ../development/tools/k6 { };
 
   l2md = callPackage ../tools/text/l2md { };


### PR DESCRIPTION
###### Description of changes

kyverno: init at 1.7.0

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
