### PR TITLE
ithc: init at unstable-2022-06-07

### DIFF
--- a/pkgs/os-specific/linux/ithc/default.nix
+++ b/pkgs/os-specific/linux/ithc/default.nix
@@ -1,0 +1,35 @@
+{ lib, stdenv, fetchFromGitHub, kernel }:
+
+stdenv.mkDerivation rec {
+  pname = "ithc";
+  version = "unstable-2022-06-07";
+
+  src = fetchFromGitHub {
+    owner = "quo";
+    repo = "ithc-linux";
+    rev = "5af2a2213d2f3d944b19ec7ccdb96f16d56adddb";
+    hash = "sha256-p4TooWUOWPfNdePE18ESmRJezPDAl9nLb55LQtkJiSg=";
+  };
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  makeFlags = kernel.makeFlags ++ [
+    "VERSION=${version}"
+    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
+
+  postPatch = ''
+    sed -i ./Makefile -e '/depmod/d'
+  '';
+
+  installFlags = [ "INSTALL_MOD_PATH=${placeholder "out"}" ];
+
+  meta = with lib; {
+    description = "Linux driver for Intel Touch Host Controller";
+    homepage = "https://github.com/quo/ithc-linux";
+    license = licenses.publicDomain;
+    maintainers = with maintainers; [ aacebedo ];
+    platforms = platforms.linux;
+    broken = kernel.kernelOlder "5.9";
+  };
+}

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -487,6 +487,8 @@ in {
 
     xpadneo = callPackage ../os-specific/linux/xpadneo { };
 
+    ithc = callPackage ../os-specific/linux/ithc { };
+
     zenpower = callPackage ../os-specific/linux/zenpower { };
 
     inherit (callPackage ../os-specific/linux/zfs {


### PR DESCRIPTION
###### Description of changes
Added the ITHC driver developed for Microsoft Surface driver.

The driver enable single touch on the most recent Surface devices. Multi touch is possible with an modified version of [iptsd](https://github.com/quo/iptsd). I'll update the existing one when modifications are merged in upstream. 

###### Things done
- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).