### PR TITLE
deno: 1.23.3 -> 1.23.4

### DIFF
--- a/pkgs/development/web/deno/default.nix
+++ b/pkgs/development/web/deno/default.nix
@@ -4,6 +4,8 @@
 , fetchFromGitHub
 , rustPlatform
 , installShellFiles
+, fetchpatch
+, tinycc
 , libiconv
 , libobjc
 , Security
@@ -14,17 +16,38 @@
 , librusty_v8 ? callPackage ./librusty_v8.nix { }
 }:
 
+let
+  libtcc = tinycc.overrideAttrs (oa: {
+    makeFlags = [ "libtcc.a" ];
+    # tests want tcc binary
+    doCheck = false;
+    outputs = [ "out" ];
+    installPhase = ''
+      mkdir -p $out/lib/
+      mv libtcc.a $out/lib/
+    '';
+  });
+in
 rustPlatform.buildRustPackage rec {
   pname = "deno";
-  version = "1.23.3";
+  version = "1.23.4";
 
   src = fetchFromGitHub {
     owner = "denoland";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-kxQZDuqVddooYeelW3gJBbU7N/PnARj/IG7eBVJoAJ8=";
+    sha256 = "sha256-nLQqfLRuh9mhZfjeiPaGpQbi5bXEg7HiGwrwDmaIRWM=";
   };
-  cargoSha256 = "sha256-bQZpE3kBqN5+lPdHWiiUQsWQwuMkvnfHLy3S1HnS4lk=";
+  cargoSha256 = "sha256-l5Ce/ypYXZKEi859OFskwC/Unpo842ZPxIHvp6lCjQc=";
+
+  patches = [
+    # remove after https://github.com/denoland/deno/pull/15193 is in a release
+    (fetchpatch {
+      name = "byo-tcc.patch";
+      url = "https://github.com/denoland/deno/pull/15193/commits/c43698b2b58af1ef69b1558d55c8ebea0268dfea.patch";
+      sha256 = "sha256-YE5mGHyEm20FjFhr8yveBRlrOVL3+qQYxz2xp/IfmJs=";
+    })
+  ];
 
   postPatch = ''
     # upstream uses lld on aarch64-darwin for faster builds
@@ -32,17 +55,20 @@ rustPlatform.buildRustPackage rec {
     substituteInPlace .cargo/config.toml --replace '"-C", "link-arg=-fuse-ld=lld"' ""
   '';
 
-  # Install completions post-install
   nativeBuildInputs = [ installShellFiles ];
-
-  buildAndTestSubdir = "cli";
-
   buildInputs = lib.optionals stdenv.isDarwin
     [ libiconv libobjc Security CoreServices Metal Foundation QuartzCore ];
+
+  buildAndTestSubdir = "cli";
 
   # The v8 package will try to download a `librusty_v8.a` release at build time to our read-only filesystem
   # To avoid this we pre-download the file and export it via RUSTY_V8_ARCHIVE
   RUSTY_V8_ARCHIVE = librusty_v8;
+
+  # The deno_ffi package currently needs libtcc.a on linux and macos and will try to compile it at build time
+  # To avoid this we point it to our copy (dir)
+  # In the future tinycc will be replaced with asm
+  DENO_FFI_LIBTCC = "${libtcc}/lib";
 
   # Tests have some inconsistencies between runs with output integration tests
   # Skipping until resolved

--- a/pkgs/development/web/deno/librusty_v8.nix
+++ b/pkgs/development/web/deno/librusty_v8.nix
@@ -11,11 +11,11 @@ let
   };
 in
 fetch_librusty_v8 {
-  version = "0.44.3";
+  version = "0.45.0";
   shas = {
-    x86_64-linux = "sha256-0l05QWfWICFTStB0AVGMAzB28MFOe4kH7Y5mT6CxvGc=";
-    aarch64-linux = "sha256-G2yZPD1lXHZvEX3CwnijoFyWF2dv6fM07+xK0oYKMVU=";
-    x86_64-darwin = "sha256-f0lBrayYNo7ivCqeJcYF5EMEnmrgH+qHLofMzbUJ+Os=";
-    aarch64-darwin = "sha256-3DG8IIMeniYLk+GyK0znFpx/f3URxFy5SFMusEPzykU=";
+    x86_64-linux = "sha256-yZw6zwEhJyRntqOmyk03N+sHxzIrbY/e67AQ21ePlAU=";
+    aarch64-linux = "sha256-2p21Smm5wZycv9u+yDbyerKTjSTB7yau5WC2aJ+Vr8w=";
+    x86_64-darwin = "sha256-HO287V+iBwdqKZUWhZJnuGJO9RE4wGG4cQMN8CkB7WQ=";
+    aarch64-darwin = "sha256-ekoMhWMQpBUdM7R7i82NWrNtQMNqCujNYy1ijOxT64U=";
   };
 }

--- a/pkgs/development/web/deno/update/librusty_v8.ts
+++ b/pkgs/development/web/deno/update/librusty_v8.ts
@@ -1,3 +1,4 @@
+import * as toml from "https://deno.land/std@0.148.0/encoding/toml.ts";
 import {
   genValueRegExp,
   getExistingVersion,
@@ -6,6 +7,7 @@ import {
   versionRegExp,
   write,
 } from "./common.ts";
+
 
 const log = logger("librusty_v8");
 
@@ -25,7 +27,7 @@ const getLibrustyV8Version = async (
 ) =>
   fetch(`https://github.com/${owner}/${repo}/raw/${version}/core/Cargo.toml`)
     .then((res) => res.text())
-    .then((txt) => txt.match(genValueRegExp("v8", versionRegExp))?.shift());
+    .then((txt) => mod.parse(txt).dependencies.v8.version);
 
 const fetchArchShaTasks = (version: string, arches: Architecture[]) =>
   arches.map(


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Bump deno to `1.23.4`

Now depends on `libtcc.a` which `tinycc` doesn't build

I've just used an override but should this be added to tinycc? should it also be updated?

cc tinycc maintainers: `joachifm` (not cc-ed since status is vacation) @AndersonTorres

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
