### PR TITLE
[22.05] hadoop: security updates

### DIFF
--- a/pkgs/applications/networking/cluster/hadoop/default.nix
+++ b/pkgs/applications/networking/cluster/hadoop/default.nix
@@ -26,12 +26,13 @@ with lib;
 assert elem stdenv.system [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
 
 let
-  common = { pname, version, untarDir ? "${pname}-${version}", sha256, jdk, openssl ? null, nativeLibs ? [ ], libPatches ? "", tests }:
+  common = { pname, versions, untarDir ? "${pname}-${version}", hash, jdk, openssl ? null, nativeLibs ? [ ], libPatches ? "", tests, extraMeta ? {} }:
     stdenv.mkDerivation rec {
-      inherit pname version jdk libPatches untarDir openssl;
+      inherit pname jdk libPatches untarDir openssl;
+      version = versions.${stdenv.system} or (throw "Unsupported system: ${stdenv.system}");
       src = fetchurl {
         url = "mirror://apache/hadoop/common/hadoop-${version}/hadoop-${version}" + optionalString stdenv.isAarch64 "-aarch64" + ".tar.gz";
-        sha256 = sha256.${stdenv.system};
+        hash = hash.${stdenv.system};
       };
       doCheck = true;
 
@@ -61,7 +62,7 @@ let
 
       passthru = { inherit tests; };
 
-      meta = {
+      meta = recursiveUpdate {
         homepage = "https://hadoop.apache.org/";
         description = "Framework for distributed processing of large data sets across clusters of computers";
         license = licenses.asl20;
@@ -77,9 +78,9 @@ let
           so delivering a highly-availabile service on top of a cluster of
           computers, each of which may be prone to failures.
         '';
-        maintainers = with maintainers; [ volth illustris ];
-        platforms = attrNames sha256;
-      };
+        maintainers = with maintainers; [ illustris ];
+        platforms = attrNames hash;
+      }  (if hasAttr stdenv.system extraMeta then extraMeta.${stdenv.system} else {});
     };
 in
 {
@@ -87,14 +88,30 @@ in
   # https://cwiki.apache.org/confluence/display/HADOOP/Hadoop+Java+Versions
   hadoop_3_3 = common rec {
     pname = "hadoop";
-    version = "3.3.1";
-    untarDir = "${pname}-${version}";
-    sha256 = rec {
-      x86_64-linux = "1b3v16ihysqaxw8za1r5jlnphy8dwhivdx2d0z64309w57ihlxxd";
+    versions = rec {
+      x86_64-linux = "3.3.3";
       x86_64-darwin = x86_64-linux;
-      aarch64-linux = "00ln18vpi07jq2slk3kplyhcj8ad41n0yl880q5cihilk7daclxz";
+      aarch64-linux = "3.3.1";
       aarch64-darwin = aarch64-linux;
     };
+    untarDir = "${pname}-${version}";
+    hash = rec {
+      x86_64-linux = "sha256-+nHGG7qkJxKa7wn+wCizTdVCxlrZD9zOxefvk9g7h2Q=";
+      x86_64-darwin = x86_64-linux;
+      aarch64-linux = "sha256-v1Om2pk0wsgKBghRD2wgTSHJoKd3jkm1wPKAeDcKlgI=";
+      aarch64-darwin = aarch64-linux;
+    };
+
+    extraMeta = rec {
+      # hadoop-3.3.3 for aarch64 is listed on https://hadoop.apache.org/releases.html
+      # but the links return 404
+      aarch64-linux.knownVulnerabilities = [
+        "CVE-2021-37404"
+        "CVE-2021-33036"
+      ];
+      aarch64-darwin = aarch64-linux;
+    };
+
     jdk = jdk11_headless;
     inherit openssl;
     # TODO: Package and add Intel Storage Acceleration Library
@@ -115,8 +132,8 @@ in
   };
   hadoop_3_2 = common rec {
     pname = "hadoop";
-    version = "3.2.2";
-    sha256.x86_64-linux = "1hxq297cqvkfgz2yfdiwa3l28g44i2abv5921k2d6b4pqd33prwp";
+    versions.x86_64-linux = "3.2.3";
+    hash.x86_64-linux = "sha256-Q2/a1LcKutpJoGySB0qlCcYE2bvC/HoG/dp9nBikuNU=";
     jdk = jdk8_headless;
     # not using native libs because of broken openssl_1_0_2 dependency
     # can be manually overriden
@@ -124,8 +141,8 @@ in
   };
   hadoop2 = common rec {
     pname = "hadoop";
-    version = "2.10.1";
-    sha256.x86_64-linux = "1w31x4bk9f2swnx8qxx0cgwfg8vbpm6cy5lvfnbbpl3rsjhmyg97";
+    versions.x86_64-linux = "2.10.2";
+    hash.x86_64-linux = "sha256-xhA4zxqIRGNhIeBnJO9dLKf/gx/Bq+uIyyZwsIafEyo=";
     jdk = jdk8_headless;
     tests = nixosTests.hadoop2;
   };


### PR DESCRIPTION
(backported from commit 136574f2a3bb8800344cc7e14f21589cb858ecba)

###### Description of changes

backport https://github.com/NixOS/nixpkgs/pull/179461

Package updates:
hadoop 3.3: 3.3.1 -> 3.3.3
hadoop 3.2: 3.2.2 -> 3.2.3
hadoop 2: 2.10.1 -> 2.10.2

Fixes:
CVE-2021-37404
CVE-2021-33036

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
