### PR TITLE
nixos/aesmd: add qcnl config

### DIFF
--- a/nixos/modules/services/security/aesmd.nix
+++ b/nixos/modules/services/security/aesmd.nix
@@ -30,7 +30,7 @@ in
     debug = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc "Whether to build the PSW package in debug mode.";
+      description = mdDoc "Whether to build the PSW package in debug mode.";
     };
     environment = mkOption {
       type = with types; attrsOf str;
@@ -52,13 +52,13 @@ in
       type = with types; nullOr str;
       default = null;
       example = "http://whitelist.trustedservices.intel.com/SGX/LCWL/Linux/sgx_white_list_cert.bin";
-      description = lib.mdDoc "URL to retrieve authorized Intel SGX enclave signers.";
+      description = mdDoc "URL to retrieve authorized Intel SGX enclave signers.";
     };
     proxy = mkOption {
       type = with types; nullOr str;
       default = null;
       example = "http://proxy_url:1234";
-      description = lib.mdDoc "HTTP network proxy.";
+      description = mdDoc "HTTP network proxy.";
     };
     proxyType = mkOption {
       type = with types; nullOr (enum [ "default" "direct" "manual" ]);
@@ -67,7 +67,7 @@ in
         if (config.services.aesmd.proxy != null) then "manual" else null
       '';
       example = "default";
-      description = lib.mdDoc ''
+      description = mdDoc ''
         Type of proxy to use. The `default` uses the system's default proxy.
         If `direct` is given, uses no proxy.
         A value of `manual` uses the proxy from
@@ -78,29 +78,29 @@ in
       type = with types; nullOr (enum [ "ecdsa_256" "epid_linkable" "epid_unlinkable" ]);
       default = null;
       example = "ecdsa_256";
-      description = lib.mdDoc "Attestation quote type.";
+      description = mdDoc "Attestation quote type.";
     };
     qcnl = mkOption {
-      description = lib.mdDoc "QCNL configuration";
+      description = mdDoc "QCNL configuration";
       default = null;
       type = with types; nullOr (submodule {
         options.pccsUrl = mkOption {
           type = with types; nullOr str;
           default = null;
           example = "https://localhost:8081/sgx/certification/v3/";
-          description = lib.mdDoc "PCCS server address.";
+          description = mdDoc "PCCS server address.";
         };
         options.useSecureCert = mkOption {
           type = with types; nullOr bool;
           default = null;
           example = false;
-          description = lib.mdDoc "To accept insecure HTTPS certificate, set this option to `false`.";
+          description = mdDoc "To accept insecure HTTPS certificate, set this option to `false`.";
         };
         options.collateralService = mkOption {
           type = with types; nullOr str;
           default = null;
           example = "https://api.trustedservices.intel.com/sgx/certification/v3/";
-          description = lib.mdDoc ''
+          description = mdDoc ''
             You can use the Intel PCS or another PCCS to get quote verification collateral.
 
             Retrieval of PCK Certificates will always use the PCCS described in `config.services.aesmd.qcnl.pccsUrl`.
@@ -112,7 +112,7 @@ in
           type = with types; nullOr (enum [ "3.0" "3.1" ]);
           default = null;
           example = "3.1";
-          description = lib.mdDoc ''
+          description = mdDoc ''
             If you use a PCCS service to get the quote verification collateral, you can specify which PCCS API version is to be used.
 
             The legacy 3.0 API will return CRLs in HEX encoded DER format and the sgx_ql_qve_collateral_t.version will be set to 3.0, while
@@ -129,7 +129,7 @@ in
           type = with types; nullOr ints.u32;
           default = null;
           example = 6;
-          description = lib.mdDoc ''
+          description = mdDoc ''
             Maximum retry times for QCNL. When `null` or set to `0`, no retry will be performed.
 
             It will first wait one second and then for all forthcoming retries it will double the waiting time.
@@ -141,7 +141,7 @@ in
           type = with types; nullOr ints.u32;
           default = null;
           example = 10;
-          description = lib.mdDoc ''
+          description = mdDoc ''
             Sleep this amount of seconds before each retry when a transfer has failed with a transient error.
           '';
         };
@@ -149,7 +149,7 @@ in
           type = with types; nullOr str;
           default = null;
           example = "http://localhost:8081/sgx/certification/v3/";
-          description = lib.mdDoc ''
+          description = mdDoc ''
             When not `null`, the QCNL will try to retrieve PCK cert chain from this URL first,
             and failover to {option}`services.aesmd.qcnl.pccsUrl` as in legacy mode.
           '';
@@ -158,7 +158,7 @@ in
           type = with types; nullOr ints.u32;
           default = null;
           example = 168;
-          description = lib.mdDoc ''
+          description = mdDoc ''
             If {option}`services.aesmd.qcnl.localPckUrl` is `null`, the QCNL will cache PCK certificates in memory by default.
             The cached PCK certificates will expire after this many hours.
           '';
@@ -177,7 +177,7 @@ in
               };
             };
           };
-          description = lib.mdDoc ''
+          description = mdDoc ''
             You can add custom request headers and parameters to the get certificate API.
             But the default PCCS implementation just ignores them.
           '';

--- a/nixos/tests/aesmd.nix
+++ b/nixos/tests/aesmd.nix
@@ -7,25 +7,14 @@
   nodes.machine = { lib, ... }: {
     services.aesmd = {
       enable = true;
-      settings = {
-        defaultQuotingType = "ecdsa_256";
-        proxyType = "direct";
-        whitelistUrl = "http://nixos.org";
-      };
-      qcnl.settings = {
-        pccsUrl = "https://localhost:8081/sgx/certification/v3/";
-        customRequestOptions = {
-          get_cert = {
-            headers = {
-              head1 = "value1";
-            };
-            params = {
-              param1 = "value1";
-              param2 = "value2";
-            };
-          };
-        };
-      };
+      defaultQuotingType = "ecdsa_256";
+      proxyType = "direct";
+      whitelistUrl = "http://nixos.org";
+
+      qcnl.pccsUrl = "https://localhost:8081/sgx/certification/v3/";
+      qcnl.customRequestOptions.get_cert.headers.head1 = "value1";
+      qcnl.customRequestOptions.get_cert.params.param1 = "value1";
+      qcnl.customRequestOptions.get_cert.params.param2 = "value2";
     };
 
     # Should have access to the AESM socket

--- a/nixos/tests/aesmd.nix
+++ b/nixos/tests/aesmd.nix
@@ -12,6 +12,20 @@
         proxyType = "direct";
         whitelistUrl = "http://nixos.org";
       };
+      qcnl.settings = {
+        pccsUrl = "https://localhost:8081/sgx/certification/v3/";
+        customRequestOptions = {
+          get_cert = {
+            headers = {
+              head1 = "value1";
+            };
+            params = {
+              param1 = "value1";
+              param2 = "value2";
+            };
+          };
+        };
+      };
     };
 
     # Should have access to the AESM socket
@@ -98,5 +112,9 @@
       with subtest("aesmd.service with quote provider library has set AZDCAP_DEBUG_LOG_LEVEL"):
         azdcp_debug_log_level = machine.succeed(f"xargs -0 -L1 -a /proc/{main_pid}/environ | grep AZDCAP_DEBUG_LOG_LEVEL")
         assert azdcp_debug_log_level == "AZDCAP_DEBUG_LOG_LEVEL=INFO\n", "AZDCAP_DEBUG_LOG_LEVEL is not set to INFO"
-    '';
+
+      with subtest("Writes and binds sgx_default_qcnl.conf in service namespace"):
+        qcnl_config = machine.succeed(f"nsenter -m -t {main_pid} ${pkgs.coreutils}/bin/cat /etc/sgx_default_qcnl.conf")
+        assert qcnl_config == '{"custom_request_options":{"get_cert":{"headers":{"head1":"value1"},"params":{"param1":"value1","param2":"value2"}}},"pccs_url":"https://localhost:8081/sgx/certification/v3/"}'
+  '';
 }


### PR DESCRIPTION
###### Description of changes

QCNL is used by AESMD internally, this allows for configuring the library.

See https://profianinc.github.io/nixpkgs/options.html#opt-services.aesmd.qcnl.settings for rendered doc

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
