### PR TITLE
bpftrace/bpftool: libelf -> elfutils dependency update

### DIFF
--- a/pkgs/os-specific/linux/bpftools/default.nix
+++ b/pkgs/os-specific/linux/bpftools/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv
-, libopcodes, libbfd, libelf, readline
+, libopcodes, libbfd, elfutils, readline
 , linuxPackages_latest, zlib
 , python3, bison, flex
 }:
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   inherit (linuxPackages_latest.kernel) version src;
 
   nativeBuildInputs = [ python3 bison flex ];
-  buildInputs = [ libopcodes libbfd libelf zlib readline ];
+  buildInputs = [ libopcodes libbfd elfutils zlib readline ];
 
   preConfigure = ''
     patchShebangs scripts/bpf_doc.py

--- a/pkgs/os-specific/linux/bpftrace/default.nix
+++ b/pkgs/os-specific/linux/bpftrace/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub
 , cmake, pkg-config, flex, bison
 , llvmPackages, elfutils
-, libelf, libbfd, libbpf, libopcodes, bcc
+, libbfd, libbpf, libopcodes, bcc
 , cereal, asciidoctor
 , nixosTests
 , util-linux
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = with llvmPackages;
     [ llvm libclang
-      elfutils libelf bcc
+      elfutils bcc
       libbpf libbfd libopcodes
       cereal asciidoctor
     ];


### PR DESCRIPTION
###### Description of changes

follow up on https://github.com/NixOS/nixpkgs/pull/178256#issuecomment-1181042758 : libelf is no longer maintained, and the library itself is provided by elfutils... cc @vcunat 

I'm focusing on linux specific packages as I have no idea if elfutils is compatible with darwin, and these happen to be things I can test :)


In this case:
 - bpftrace already had elfutils as dependency, I'm not sure how it worked but it managed to link with both libelf.so.0 from libelf and libelf.so.1 from elfutils... Removing libelf builds fine and works from quick test
 - bpftool didn't have elfutils, just replaced & tested ok.

Since we changed libelf -> elfutils for libbpf, and dpdk uses libbpf and libelf, it might be worth updating dpdk and odp-dpdk. I don't know / can't test them though -- ccing their maintainers @magenbluten  @orivej @Mic92 @zhaofengli @abuibrahim  happy to do the change here if you'd like to test?

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
