### PR TITLE
gammu: 1.40.0 -> 1.42.0

### DIFF
--- a/pkgs/applications/misc/gammu/default.nix
+++ b/pkgs/applications/misc/gammu/default.nix
@@ -8,13 +8,13 @@ with lib;
 
 stdenv.mkDerivation rec {
   pname = "gammu";
-  version = "1.40.0";
+  version = "1.42.0";
 
   src = fetchFromGitHub {
     owner = "gammu";
     repo = "gammu";
     rev = version;
-    sha256 = "1jjaa9r3x6i8gv3yn1ngg815s6gsxblsw4wb5ddm77kamn2qyvpf";
+    sha256 = "sha256-aeaGHVxOMiXRU6RHws+oAnzdO9RY1jw/X/xuGfSt76I=";
   };
 
   patches = [ ./bashcomp-dir.patch ./systemd.patch ];

--- a/pkgs/applications/misc/gammu/systemd.patch
+++ b/pkgs/applications/misc/gammu/systemd.patch
@@ -1,8 +1,8 @@
 diff --git a/cmake/templates/gammu.spec.in b/cmake/templates/gammu.spec.in
-index 8302353..e3ca59a 100644
+index 25c08b3d6..86f72d8c7 100644
 --- a/cmake/templates/gammu.spec.in
 +++ b/cmake/templates/gammu.spec.in
-@@ -387,9 +387,9 @@ fi
+@@ -386,9 +386,9 @@ fi
  %doc %{_mandir}/man7/gammu-smsd-run.7*
  %doc %{_mandir}/man7/gammu-smsd-sql.7*
  %doc %{_mandir}/man7/gammu-smsd-tables.7*
@@ -16,13 +16,13 @@ index 8302353..e3ca59a 100644
  %files -n libGammu%{so_ver} -f libgammu.lang
  %defattr(-,root,root,-)
 diff --git a/contrib/CMakeLists.txt b/contrib/CMakeLists.txt
-index 78cc7fc..d674c36 100644
+index 378411086..b871e6525 100644
 --- a/contrib/CMakeLists.txt
 +++ b/contrib/CMakeLists.txt
-@@ -97,7 +97,7 @@ endif (INSTALL_BASH_COMPLETION)
- if (WITH_SYSTEMD)
+@@ -100,7 +100,7 @@ if (WITH_SYSTEMD)
+     configure_file( init/gammu-smsd.service init/gammu-smsd.service )
      install (
-         FILES init/gammu-smsd.service
+         FILES ${CMAKE_CURRENT_BINARY_DIR}/init/gammu-smsd.service
 -        DESTINATION "${SYSTEMD_SERVICES_INSTALL_DIR}"
 +        DESTINATION "${CMAKE_INSTALL_PREFIX}/systemd"
          COMPONENT "systemd"


### PR DESCRIPTION
###### Description of changes
Update to latest upstream release [1.42.0](https://github.com/gammu/gammu/releases/tag/1.42.0).

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).