### PR TITLE
keyd: init at 2.4.1

### DIFF
--- a/pkgs/tools/inputmethods/keyd/default.nix
+++ b/pkgs/tools/inputmethods/keyd/default.nix
@@ -1,0 +1,43 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, pkg-config
+, systemd
+}:
+
+stdenv.mkDerivation rec {
+  pname = "keyd";
+  version = "2.4.1";
+
+  src = fetchFromGitHub {
+    owner = "rvaiya";
+    repo = "keyd";
+    rev = "v" + version;
+    hash = "sha256-p0f8iGT4QtyWAnlcG4SfOhD94ySNNkQrnVjnGCmQwAk=";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace DESTDIR= DESTDIR=${placeholder "out"} \
+      --replace /usr "" \
+      --replace /var/log/keyd.log /var/log/keyd/keyd.log
+
+    substituteInPlace keyd.service \
+      --replace /usr/bin $out/bin
+  '';
+
+  buildInputs = [ systemd ];
+
+  enableParallelBuilding = true;
+
+  postInstall = ''
+    rm -rf $out/etc
+  '';
+
+  meta = with lib; {
+    description = "keyd";
+    # license = licenses.gpl3;
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/tools/inputmethods/keyd/default.nix
+++ b/pkgs/tools/inputmethods/keyd/default.nix
@@ -36,8 +36,9 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "keyd";
-    # license = licenses.gpl3;
+    description = "A key remapping daemon for linux.";
+    license = licenses.mit;
     maintainers = with maintainers; [ peterhoeg ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4982,6 +4982,8 @@ with pkgs;
 
   evscript = callPackage ../tools/inputmethods/evscript { };
 
+  keyd = callPackage ../tools/inputmethods/keyd { };
+
   gebaar-libinput = callPackage ../tools/inputmethods/gebaar-libinput { stdenv = gcc10StdenvCompat; };
 
   kime = callPackage ../tools/inputmethods/kime { };


### PR DESCRIPTION
###### Description of changes

When I initially made the move from Plasma X11 to Plasma Wayland, I needed a mechanism to handle some key remapping. `keyd` was one of the things I tried out (not the one I ended up using), but I just noticed a request to have it packaged while I was looking for something else, so here goes.

Closes #132474

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
