### PR TITLE
cachix-agent: allow restarts now that deployments are subprocesses

### DIFF
--- a/nixos/modules/services/system/cachix-agent/default.nix
+++ b/nixos/modules/services/system/cachix-agent/default.nix
@@ -52,12 +52,15 @@ in {
       path = [ config.nix.package ];
       wantedBy = [ "multi-user.target" ];
 
-      # don't restart while changing
-      restartIfChanged = false;
+      # Cachix requires $USER to be set
+      environment.USER = "root";
+
+      # don't stop the service if the unit disappears
       unitConfig.X-StopOnRemoval = false;
 
-      environment.USER = "root";
       serviceConfig = {
+        # we don't want to kill children processes as those are deployments
+        KillMode = "process";
         Restart = "on-failure";
         EnvironmentFile = cfg.credentialsFile;
         ExecStart = "${cfg.package}/bin/cachix ${lib.optionalString cfg.verbose "--verbose"} deploy agent ${cfg.name} ${if cfg.profile != null then profile else ""}";


### PR DESCRIPTION
This goes to haskell-updates because it requires cachix 0.8.0