### PR TITLE
bluetuith: init at 0.0.3

### DIFF
--- a/pkgs/tools/bluetooth/bluetuith/default.nix
+++ b/pkgs/tools/bluetooth/bluetuith/default.nix
@@ -1,0 +1,25 @@
+{ buildGoModule, fetchFromGitHub, lib, stdenv }:
+
+buildGoModule rec {
+  pname = "bluetuith";
+  version = "0.0.3";
+
+  src = fetchFromGitHub {
+    owner = "darkhz";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-7JqpF9iga6RO+/r2JK0N9gjieVRUNkHhGNsfVFfKfRY=";
+  };
+
+  vendorSha256 = "sha256-MsVrhEG2DOFJAXvt5rvfctGUbb3hQsBJ7cjOSzWA+bc=";
+
+  ldflags = [ "-s" "-w" ];
+
+  meta = with lib; {
+    description = "TUI-based bluetooth connection manager";
+    homepage = "https://github.com/darkhz/bluetuith";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ thehedgeh0g ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4701,6 +4701,8 @@ with pkgs;
 
   blueman = callPackage ../tools/bluetooth/blueman { };
 
+  bluetuith = callPackage ../tools/bluetooth/bluetuith { };
+
   bmrsa = callPackage ../tools/security/bmrsa/11.nix { };
 
   bogofilter = callPackage ../tools/misc/bogofilter { };


### PR DESCRIPTION
###### Description of changes
Adds https://github.com/darkhz/bluetuith, a TUI manager for bluetooth devices.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
