### PR TITLE
pam_mount: 2.17 -> 2.19

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9033,6 +9033,15 @@
     github = "nessdoor";
     githubId = 25993494;
   };
+  netali = {
+    name = "Jennifer Graul";
+    email = "me@netali.de";
+    github = "NetaliDev";
+    githubId = 15304894;
+    keys = [{
+      fingerprint = "F729 2594 6F58 0B05 8FB3  F271 9C55 E636 426B 40A9";
+    }];
+  };
   netcrns = {
     email = "jason.wing@gmx.de";
     github = "netcrns";

--- a/pkgs/os-specific/linux/pam_mount/default.nix
+++ b/pkgs/os-specific/linux/pam_mount/default.nix
@@ -1,12 +1,12 @@
-{ lib, stdenv, fetchurl, autoreconfHook, pkg-config, libtool, pam, libHX, libxml2, pcre, perl, openssl, cryptsetup, util-linux }:
+{ lib, stdenv, fetchurl, autoreconfHook, pkg-config, libtool, pam, libHX, libxml2, pcre2, perl, openssl, cryptsetup, util-linux }:
 
 stdenv.mkDerivation rec {
   pname = "pam_mount";
-  version = "2.17";
+  version = "2.19";
 
   src = fetchurl {
     url = "mirror://sourceforge/pam-mount/pam_mount/${pname}-${version}.tar.xz";
-    sha256 = "1q2n6a2ah6nghdn8i6ad2wj247njwb5nx48cggxknaa6lqxylidy";
+    sha256 = "02m6w04xhgv2yx69yxph8giw0sp39s9lvvlffslyna46fnr64qvb";
   };
 
   patches = [
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook libtool pkg-config ];
 
-  buildInputs = [ pam libHX util-linux libxml2 pcre perl openssl cryptsetup ];
+  buildInputs = [ pam libHX util-linux libxml2 pcre2 perl openssl cryptsetup ];
 
   enableParallelBuilding = true;
 
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     description = "PAM module to mount volumes for a user session";
     homepage = "https://pam-mount.sourceforge.net/";
     license = with licenses; [ gpl2 gpl3 lgpl21 lgpl3 ];
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ netali ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Description of changes

A update for pam_mount over two minor versions. Additionally I have entered myself as maintainer, because there are no maintainers at the moment and I like to take care of this package.

Original changelog:
```
2.19:
Enhancements:

* Added support for LUKS detached headers

2.18:
Import patches from the Debian project.

Changes:

* The build now uses PCRE2 instead of PCRE1.
* Cure mount.crypt recursively executing itself with -t crypt

Enhancements:

* Allow luserconf to be placed outside home directory
* Documentation updates
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
