### PR TITLE
greetd.tuigreet: 0.7.2 -> 0.8.0

### DIFF
--- a/pkgs/os-specific/linux/tuigreet/default.nix
+++ b/pkgs/os-specific/linux/tuigreet/default.nix
@@ -5,16 +5,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "tuigreet";
-  version = "0.7.2";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "apognu";
     repo = pname;
     rev = version;
-    sha256 = "sha256-Mu4GGlX7ZjBaBECXRD6iJCqDMSzcj17BriJ6Nas0J70=";
+    sha256 = "sha256-8/2I6bk29/GqZ1ACuN9RgBiGAy7yt0iw2fagHfu4/BI=";
   };
 
-  cargoSha256 = "sha256-H5xqk7Yd3M8sFGHlmhAS0fhh3eM4dkvkNQGVxRSXUJs=";
+  cargoSha256 = "sha256-fOs9a0/1c8Kh4JA5up3XSQ+km/FwSYzl0w4UDL4yU4M=";
 
   meta = with lib; {
     description = "Graphical console greeter for greetd";


### PR DESCRIPTION
###### Description of changes

Bump tuigreet to 0.8.0 released in May. Release notes copied below:

> tuigreet version 0.8.0.
> 
>  * Remember last successfully opened session per user
>  * Suppress power command output
>  * Allow customization of time format
>  * Added a user selection list from a defined UID range
>  * Miscellaneous UX improvements
>  * Locales improvements

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### nixpkgs-review

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>greetd.tuigreet</li>
  </ul>
</details>