### PR TITLE
gobject-introspection: override pkg-config variables in a setup hook

### DIFF
--- a/pkgs/development/libraries/gobject-introspection/default.nix
+++ b/pkgs/development/libraries/gobject-introspection/default.nix
@@ -124,16 +124,6 @@ stdenv.mkDerivation (finalAttrs: {
     rm $out/lib/libregress-1.0${stdenv.targetPlatform.extensions.sharedLibrary}
   '';
 
-  # when cross-compiling and using the wrapper then when a package looks up the g_ir_X
-  # variable with pkg-config they'll get the host version which can't be run
-  # switch the variables to use g_ir_X from path instead of an absolute path
-  postFixup = lib.optionalString (!lib.hasSuffix "wrapped" finalAttrs.pname) ''
-    find "''${!outputDev}/lib/pkgconfig" -name '*.pc' | while read pc; do
-        substituteInPlace "$pc" \
-          --replace '=''${bindir}/g-ir' '=g-ir'
-    done
-  '';
-
   setupHook = ./setup-hook.sh;
 
   passthru = {

--- a/pkgs/development/libraries/gobject-introspection/wrapper.nix
+++ b/pkgs/development/libraries/gobject-introspection/wrapper.nix
@@ -28,5 +28,22 @@ gobject-introspection-unwrapped.overrideAttrs (previousAttrs: {
       chmod +x "$dev/bin/g-ir-compiler"
       chmod +x "$dev/bin/g-ir-scanner"
     )
+  ''
+  # when cross-compiling and using the wrapper then when a package looks up the g_ir_X
+  # variable with pkg-config they'll get the host version which can't be run
+  # override the variable to use the absolute path to g_ir_X in PATH which can be run
+  + ''
+    cat >> $dev/nix-support/setup-hook <<-'EOF'
+      override-pkg-config-gir-variables() {
+        PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_G_IR_SCANNER="$(type -p g-ir-scanner)"
+        PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_G_IR_COMPILER="$(type -p g-ir-compiler)"
+        PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_G_IR_GENERATE="$(type -p g-ir-generate)"
+        export PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_G_IR_SCANNER
+        export PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_G_IR_COMPILER
+        export PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_G_IR_GENERATE
+      }
+
+      preConfigureHooks+=(override-pkg-config-gir-variables)
+    EOF
   '';
 })


### PR DESCRIPTION
instead of substituteInPlace

fixes gtk2 because it needs g_ir_scanner to be a path

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
