### PR TITLE
starsector: fix jvm compatibility, startup crashes and sound, add passthru.updateScript

### DIFF
--- a/pkgs/games/starsector/default.nix
+++ b/pkgs/games/starsector/default.nix
@@ -1,32 +1,27 @@
 { lib
-, alsa-lib
 , fetchzip
 , libXxf86vm
 , makeWrapper
+, openal
 , openjdk
 , stdenv
 , xorg
 , copyDesktopItems
 , makeDesktopItem
+, writeScript
 }:
 
 stdenv.mkDerivation rec {
   pname = "starsector";
-  version = "0.95.1a-RC5";
+  version = "0.95.1a-RC6";
 
   src = fetchzip {
     url = "https://s3.amazonaws.com/fractalsoftworks/starsector/starsector_linux-${version}.zip";
-    sha256 = "sha256-V8/WQPvPIrF3Tg7JVO+GfeYqWhkWWrnHSVcFXGQqDAA=";
+    sha256 = "sha256-+0zGJHM+SMonx3sytCQNQA/QBgzdPMEfQvOjrCDSOs8=";
   };
 
-  nativeBuildInputs = [
-    copyDesktopItems
-    makeWrapper
-  ];
-  buildInputs = with xorg; [
-    alsa-lib
-    libXxf86vm
-  ];
+  nativeBuildInputs = [ copyDesktopItems makeWrapper ];
+  buildInputs = [ xorg.libXxf86vm openal ];
 
   dontBuild = true;
 
@@ -47,7 +42,7 @@ stdenv.mkDerivation rec {
     runHook preInstall
 
     mkdir -p $out/bin
-    rm -r jre_linux # remove jre7
+    rm -r jre_linux # remove bundled jre7
     rm starfarer.api.zip
     cp -r ./* $out
 
@@ -66,10 +61,13 @@ stdenv.mkDerivation rec {
 
   # it tries to run everything with relative paths, which makes it CWD dependent
   # also point mod, screenshot, and save directory to $XDG_DATA_HOME
+  # additionally, add some GC options to improve performance of the game
   postPatch = ''
     substituteInPlace starsector.sh \
       --replace "./jre_linux/bin/java" "${openjdk}/bin/java" \
-      --replace "./native/linux" "$out/native/linux"
+      --replace "./native/linux" "$out/native/linux" \
+      --replace "=." "=\''${XDG_DATA_HOME:-\$HOME/.local/share}/starsector" \
+      --replace "-XX:+CompilerThreadHintNoPreempt" "-XX:+UnlockDiagnosticVMOptions -XX:-BytecodeVerificationRemote -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:+CMSConcurrentMTEnabled -XX:+DisableExplicitGC"
   '';
 
   meta = with lib; {
@@ -79,4 +77,12 @@ stdenv.mkDerivation rec {
     license = licenses.unfree;
     maintainers = with maintainers; [ bbigras ];
   };
+
+  passthru.updateScript = writeScript "starsector-update-script" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p curl gnugrep common-updater-scripts
+    set -eou pipefail;
+    version=$(curl -s https://fractalsoftworks.com/preorder/ | grep -oP "https://s3.amazonaws.com/fractalsoftworks/starsector/starsector_linux-\K.*?(?=\.zip)" | head -1)
+    update-source-version ${pname} "$version" --file=./pkgs/games/starsector/default.nix
+  '';
 }


### PR DESCRIPTION
###### Description of changes
- Fixed paths for game files (saves, screenshots, mods and logs) to point to `$XDG_DATA_HOME/starsector` with a default value for XDG_DATA_HOME
- Replace `alsa-lib` with `openal` fixing sound - game crashes unless you disable sound in the launcher without this
- Add a few VM options - a couple to fix the game crashing on new openjdk8 versions - they use an outdated obfuscator which produces invalid field/method names leading to bytecode verification failing and crashing the VM. A couple of other options are said by someone knowledgeable (I honestly can't find a citation now lol, maybe will link later) on their forum to noticeably improve the game stability on Java 8. And it was done by replacing a deprecated Solaris-only(!) VM option they had in their script.
- Add a passthru.updateScript - basically identical to the one Discord has so should be fine even though it's scraping
- Also run the aforementioned script successfully to update the version

This is kind of clashes with https://github.com/NixOS/nixpkgs/pull/162738, but it's minimal and they can rebase later if they still want to improve packaging - they did not respond for >1 week so I'm making this PR

I played the game for an hour, with saving/loading working fine (something that has to be additionally fixed if you want jdk11/jdk17).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
