### PR TITLE
cmake: detect libc location at runtime

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/001-search-path.diff
+++ b/pkgs/development/tools/build-managers/cmake/001-search-path.diff
@@ -1,5 +1,5 @@
 diff --git a/Modules/Platform/UnixPaths.cmake b/Modules/Platform/UnixPaths.cmake
-index b9381c3d7d..cecc40a89e 100644
+index b9381c3d7d..5e944640b5 100644
 --- a/Modules/Platform/UnixPaths.cmake
 +++ b/Modules/Platform/UnixPaths.cmake
 @@ -26,9 +26,6 @@ get_filename_component(_CMAKE_INSTALL_DIR "${_CMAKE_INSTALL_DIR}" PATH)
@@ -12,7 +12,7 @@ index b9381c3d7d..cecc40a89e 100644
    # CMake install location
    "${_CMAKE_INSTALL_DIR}"
    )
-@@ -47,24 +44,19 @@ endif()
+@@ -47,48 +44,46 @@ endif()
  
  # Non "standard" but common install prefixes
  list(APPEND CMAKE_SYSTEM_PREFIX_PATH
@@ -22,43 +22,61 @@ index b9381c3d7d..cecc40a89e 100644
    )
  
  # List common include file locations not under the common prefixes.
++if(IS_DIRECTORY $ENV{NIX_CC})
++  file(STRINGS "$ENV{NIX_CC}/nix-support/orig-libc" _nix_cmake_libc)
++  file(STRINGS "$ENV{NIX_CC}/nix-support/orig-libc-dev" _nix_cmake_libc_dev)
++else()
++  set(_nix_cmake_libc @libc_lib@)
++  set(_nix_cmake_libc_dev @libc_dev@)
++endif()
++
  list(APPEND CMAKE_SYSTEM_INCLUDE_PATH
 -  # X11
 -  /usr/include/X11
-+  @libc_dev@/include
++  "${_nix_cmake_libc_dev}/include"
    )
  
  list(APPEND CMAKE_SYSTEM_LIBRARY_PATH
 -  # X11
 -  /usr/lib/X11
-+  @libc_lib@/lib
++  "${_nix_cmake_libc}/lib"
    )
  
  list(APPEND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES
 -  /lib /lib32 /lib64 /usr/lib /usr/lib32 /usr/lib64
-+  @libc_lib@/lib
++  "${_nix_cmake_libc}/lib"
    )
  
- if(CMAKE_SYSROOT_COMPILE)
-@@ -77,15 +69,15 @@ endif()
+-if(CMAKE_SYSROOT_COMPILE)
+-  set(_cmake_sysroot_compile "${CMAKE_SYSROOT_COMPILE}")
+-else()
+-  set(_cmake_sysroot_compile "${CMAKE_SYSROOT}")
+-endif()
+-
+ # Default per-language values.  These may be later replaced after
  # parsing the implicit directory information from compiler output.
  set(_CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES_INIT
    ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES}
 -  "${_cmake_sysroot_compile}/usr/include"
-+  @libc_dev@/include
++  "${_nix_cmake_libc_dev}/include"
    )
  set(_CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES_INIT
    ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES}
 -  "${_cmake_sysroot_compile}/usr/include"
-+  @libc_dev@/include
++  "${_nix_cmake_libc_dev}/include"
    )
  set(_CMAKE_CUDA_IMPLICIT_INCLUDE_DIRECTORIES_INIT
    ${CMAKE_CUDA_IMPLICIT_INCLUDE_DIRECTORIES}
 -  "${_cmake_sysroot_compile}/usr/include"
-+  @libc_dev@/include
++  "${_nix_cmake_libc_dev}/include"
    )
  
- unset(_cmake_sysroot_compile)
+-unset(_cmake_sysroot_compile)
++unset(_nix_cmake_libc)
++unset(_nix_cmake_libc_dev)
+ 
+ # Reminder when adding new locations computed from environment variables
+ # please make sure to keep Help/variable/CMAKE_SYSTEM_PREFIX_PATH.rst
 diff --git a/Modules/Platform/WindowsPaths.cmake b/Modules/Platform/WindowsPaths.cmake
 index b9e2f17979..ab517cd4a7 100644
 --- a/Modules/Platform/WindowsPaths.cmake


### PR DESCRIPTION
###### Description of changes

This PR updates the patch to `Modules/Platform/UnixPaths.cmake` to detect the libc location at runtime, based on the cc-wrapper specified in `$NIX_CC`. If `$NIX_CC` is not (or incorrectly) set, it falls back to the original behavior (ie.: use the libc that was used to build CMake itself).

This allows CMake to automatically pick up an alternate libc in package builds. The alternative would be to do something like `-DCMAKE_SYSTEM_INCLUDE_PATH=${stdenv.cc.libc_dev}/include` in every package build that wants a different libc.

This may sound niche, but I suspect may become a more common thing on Darwin as the option to use different macOS SDKs becomes available. #176661 was recently merged, making a second SDK available for `x86_64-darwin` by doing `darwin.apple_sdk_11_0.callPackage ./my-package { }`, which also swaps in a different stdenv with a different version of libSystem.

I'm specifically working on the Swift build on Darwin, which is picking up the wrong libSystem in a couple of places. A simple one is a call to `find_package(Backtrace)`, which does a `find_path(Backtrace_INCLUDE_DIR "execinfo.h")`. Both calls can be easily tested in isolation.

Besides that, I also tested rebuilding `fish` on Linux with this change in place on `master`. Fish uses CMake, and apparently also pulls in a handful of CMake-using deps. That all worked fine and produced a working build.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
