### PR TITLE
zig: build on darwin

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -417,6 +417,12 @@
     githubId = 4732885;
     name = "Ivan Jager";
   };
+  aiotter = {
+    email = "git@aiotter.com";
+    github = "aiotter";
+    githubId = 37664775;
+    name = "Yuto Oguchi";
+  };
   airwoodix = {
     email = "airwoodix@posteo.me";
     github = "airwoodix";

--- a/pkgs/development/compilers/zig/default.nix
+++ b/pkgs/development/compilers/zig/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , fetchFromGitHub
 , cmake
 , llvmPackages
@@ -6,9 +7,6 @@
 , zlib
 }:
 
-let
-  inherit (llvmPackages) stdenv;
-in
 stdenv.mkDerivation rec {
   pname = "zig";
   version = "0.9.1";
@@ -52,6 +50,5 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     maintainers = with maintainers; [ andrewrk AndersonTorres ];
     platforms = platforms.unix;
-    broken = stdenv.isDarwin; # See https://github.com/NixOS/nixpkgs/issues/86299
   };
 }

--- a/pkgs/development/compilers/zig/default.nix
+++ b/pkgs/development/compilers/zig/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     description =
       "General-purpose programming language and toolchain for maintaining robust, optimal, and reusable software";
     license = licenses.mit;
-    maintainers = with maintainers; [ andrewrk AndersonTorres ];
+    maintainers = with maintainers; [ aiotter andrewrk AndersonTorres ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21678,6 +21678,7 @@ with pkgs;
   libzra = callPackage ../development/libraries/libzra { };
 
   zig = callPackage ../development/compilers/zig {
+    stdenv = if stdenv.isDarwin then darwin.apple_sdk_11_0.stdenv else stdenv;
     llvmPackages = llvmPackages_13;
   };
 


### PR DESCRIPTION
###### Description of changes
Using `darwin.apple_sdk_11_0.callPackage` or overriding stdenv to `darwin.apple_sdk_11_0.stdenv` enables building zig on macOS with now merged #176661.

For example (flake.nix):
```nix
{
  inputs = {
    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
    flake-utils.url = "github:numtide/flake-utils";
    flake-compat = {
      url = "github:edolstra/flake-compat";
      flake = false;
    };
  };

  outputs = {nixpkgs, flake-utils, ...}: flake-utils.lib.eachDefaultSystem (system:
    let
      pkgs = nixpkgs.legacyPackages.${system};
      callPackage = if pkgs.stdenv.isDarwin then pkgs.darwin.apple_sdk_11_0.callPackage else pkgs.callPackage;
    in
      {
         devShells.default = pkgs.mkShell {
           packages = [
             (callPackage <nixpkgs/pkgs/development/compilers/zig> { llvmPackages = pkgs.llvmPackages_13; })
           ];
         };
      }
  );
}
```

I'm not sure it's okay to mark it as not broken because just installing it with nix-env is still failing. The users must modify the stdenv to build it.
And I don't understand why @AndersonTorres moved `stdenv` from argument to let-in expression. Is this for ensuring LLVM13? I don't know why the current package definition runs without specifying LLVM versions.

Anyway I'm a newbie for packaging nix. Please let me know of better implementation, or I'll just close the PR so please continue it if you have better idea.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

