### PR TITLE
iredis: init at 1.12.0

### DIFF
--- a/pkgs/tools/admin/iredis/default.nix
+++ b/pkgs/tools/admin/iredis/default.nix
@@ -1,0 +1,58 @@
+{ lib, python3Packages }:
+
+with python3Packages;
+
+buildPythonApplication rec {
+  pname = "iredis";
+  version = "1.12.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "c3031094db0aa03d48b6f9be750e32d3e901942a96cc05283029086cb871cd81";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "click>=7.0,<8.0" "click" \
+      --replace "wcwidth==0.1.9" "wcwidth" \
+      --replace "redis>=3.4.0,<4.0.0" "redis" \
+      --replace "mistune>=2.0,<3.0" "mistune"
+  '';
+
+  propagatedBuildInputs = [
+    pygments
+    click
+    configobj
+    importlib-resources
+    mistune_2_0
+    packaging
+    pendulum
+    prompt-toolkit
+    redis
+    wcwidth
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pexpect
+  ];
+
+  pytestFlagsArray = [
+    # Fails on sandbox
+    "--ignore=tests/unittests/test_client.py"
+    "--deselect=tests/unittests/test_render_functions.py::test_render_unixtime_config_raw"
+    "--deselect=tests/unittests/test_render_functions.py::test_render_time"
+    # Only execute unittests, because cli tests require a running Redis
+    "tests/unittests/"
+  ];
+
+  pythonImportsCheck = [ "iredis" ];
+
+  meta = with lib; {
+    description = "A Terminal Client for Redis with AutoCompletion and Syntax Highlighting";
+    changelog = "https://github.com/laixintao/iredis/raw/v${version}/CHANGELOG.md";
+    homepage = "https://iredis.io/";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ marsam ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8144,6 +8144,8 @@ with pkgs;
 
   kea = callPackage ../tools/networking/kea { };
 
+  iredis = callPackage ../tools/admin/iredis { };
+
   ispell = callPackage ../tools/text/ispell {};
 
   iodash = callPackage ../development/libraries/iodash { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add https://github.com/laixintao/iredis
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
