### PR TITLE
weechatScripts.weechat-autosort: add to maintainers, 3.8 -> 3.9

### DIFF
--- a/pkgs/applications/networking/irc/weechat/scripts/weechat-autosort/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/weechat-autosort/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "weechat-autosort";
-  version = "3.8";
+  version = "3.9";
 
   src = fetchFromGitHub {
     owner = "de-vri-es";
     repo = pname;
-    rev = version;
-    sha256 = "0a2gc8nhklvlivradhqy2pkymsqyy01pvzrmwg60cln8snmcqpd5";
+    rev = "d62fa8633015ebc2676060fcdae88c402977be46";
+    sha256 = "sha256-doYDRIWiuHam2i3r3J3BZuWEhopoN4jms/xPXGyypok=";
   };
 
   passthru.scripts = [ "autosort.py" ];

--- a/pkgs/applications/networking/irc/weechat/scripts/weechat-autosort/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/weechat-autosort/default.nix
@@ -20,6 +20,6 @@ stdenv.mkDerivation rec {
     description = "Autosort is a weechat script to automatically or manually keep your buffers sorted";
     homepage = "https://github.com/de-vri-es/weechat-autosort";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ emily ];
+    maintainers = with maintainers; [ emily flokli ];
   };
 }

--- a/pkgs/applications/networking/irc/weechat/scripts/weechat-autosort/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/weechat-autosort/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Autosort is a weechat script to automatically or manually keep your buffers sorted";
     homepage = "https://github.com/de-vri-es/weechat-autosort";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ emily flokli ];
   };
 }


### PR DESCRIPTION
It looks like upstream didn't push a tag, but the referenced commit updates the `SCRIPT_VERSION` variable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
