### PR TITLE
Imagemagick: modernize package options

### DIFF
--- a/pkgs/applications/graphics/ImageMagick/6.x.nix
+++ b/pkgs/applications/graphics/ImageMagick/6.x.nix
@@ -1,6 +1,25 @@
 { lib, stdenv, fetchFromGitHub, pkg-config, libtool
-, bzip2, zlib, libX11, libXext, libXt, fontconfig, freetype, ghostscript, libjpeg, djvulibre
-, lcms2, openexr, libpng, liblqr1, librsvg, libtiff, libxml2, openjpeg, libwebp, fftw, libheif, libde265
+, bzip2Support ? true, bzip2
+, zlibSupport ? true, zlib
+, libX11Support ? !stdenv.hostPlatform.isMinGW, libX11
+, libXtSupport ? !stdenv.hostPlatform.isMinGW, libXt
+, fontconfigSupport ? true, fontconfig
+, freetypeSupport ? true, freetype
+, ghostscriptSupport ? false, ghostscript
+, libjpegSupport ? true, libjpeg
+, djvulibreSupport ? true, djvulibre
+, lcms2Support ? true, lcms2
+, openexrSupport ? !stdenv.hostPlatform.isMinGW, openexr
+, libpngSupport ? true, libpng
+, liblqr1Support ? true, liblqr1
+, librsvgSupport ? !stdenv.hostPlatform.isMinGW, librsvg
+, libtiffSupport ? true, libtiff
+, libxml2Support ? true, libxml2
+, openjpegSupport ? !stdenv.hostPlatform.isMinGW, openjpeg
+, libwebpSupport ? !stdenv.hostPlatform.isMinGW, libwebp
+, libheifSupport ? true, libheif
+, libde265Support ? true, libde265
+, fftw
 , ApplicationServices, Foundation
 }:
 
@@ -30,35 +49,47 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  configureFlags =
-    [ "--with-frozenpaths" ]
-    ++ (if arch != null then [ "--with-gcc-arch=${arch}" ] else [ "--without-gcc-arch" ])
-    ++ lib.optional (librsvg != null) "--with-rsvg"
-    ++ lib.optional (liblqr1 != null) "--with-lqr"
-    ++ lib.optionals (ghostscript != null)
-      [ "--with-gs-font-dir=${ghostscript}/share/ghostscript/fonts"
-        "--with-gslib"
-      ]
-    ++ lib.optionals (stdenv.hostPlatform.isMinGW)
-      [ "--enable-static" "--disable-shared" ] # due to libxml2 being without DLLs ATM
-    ;
+  configureFlags = [
+    "--with-frozenpaths"
+    (lib.withFeatureAs (arch != null) "gcc-arch" arch)
+    (lib.withFeature librsvgSupport "rsvg")
+    (lib.withFeature liblqr1Support "lqr")
+    (lib.withFeatureAs ghostscriptSupport "gs-font-dir" "${ghostscript}/share/ghostscript/fonts")
+    (lib.withFeature ghostscriptSupport "gslib")
+  ] ++ lib.optionals stdenv.hostPlatform.isMinGW [
+    # due to libxml2 being without DLLs ATM
+    "--enable-static" "--disable-shared"
+  ];
 
   nativeBuildInputs = [ pkg-config libtool ];
 
-  buildInputs =
-    [ zlib fontconfig freetype ghostscript
-      liblqr1 libpng libtiff libxml2 libheif libde265 djvulibre
-    ]
-    ++ lib.optionals (!stdenv.hostPlatform.isMinGW)
-      [ openexr librsvg openjpeg ]
-    ++ lib.optionals stdenv.isDarwin
-      [ ApplicationServices Foundation ];
+  buildInputs = [ ]
+    ++ lib.optional zlibSupport zlib
+    ++ lib.optional fontconfigSupport fontconfig
+    ++ lib.optional ghostscriptSupport ghostscript
+    ++ lib.optional liblqr1Support liblqr1
+    ++ lib.optional libpngSupport libpng
+    ++ lib.optional libtiffSupport libtiff
+    ++ lib.optional libxml2Support libxml2
+    ++ lib.optional libheifSupport libheif
+    ++ lib.optional libde265Support libde265
+    ++ lib.optional djvulibreSupport djvulibre
+    ++ lib.optional openexrSupport openexr
+    ++ lib.optional librsvgSupport librsvg
+    ++ lib.optional openjpegSupport openjpeg
+    ++ lib.optionals stdenv.isDarwin [
+      ApplicationServices
+      Foundation
+    ];
 
-  propagatedBuildInputs =
-    [ bzip2 freetype libjpeg lcms2 fftw ]
-    ++ lib.optionals (!stdenv.hostPlatform.isMinGW)
-      [ libX11 libXext libXt libwebp ]
-    ;
+  propagatedBuildInputs = [ fftw ]
+    ++ lib.optional bzip2Support bzip2
+    ++ lib.optional freetypeSupport freetype
+    ++ lib.optional libjpegSupport libjpeg
+    ++ lib.optional lcms2Support lcms2
+    ++ lib.optional libX11Support libX11
+    ++ lib.optional libXtSupport libXt
+    ++ lib.optional libwebpSupport libwebp;
 
   doCheck = false; # fails 6 out of 76 tests
 
@@ -72,7 +103,7 @@ stdenv.mkDerivation rec {
       substituteInPlace "$file" --replace ${pkg-config}/bin/pkg-config \
         "PKG_CONFIG_PATH='$dev/lib/pkgconfig' '${pkg-config}/bin/${pkg-config.targetPrefix}pkg-config'"
     done
-  '' + lib.optionalString (ghostscript != null) ''
+  '' + lib.optionalString ghostscriptSupport ''
     for la in $out/lib/*.la; do
       sed 's|-lgs|-L${lib.getLib ghostscript}/lib -lgs|' -i $la
     done

--- a/pkgs/applications/graphics/ImageMagick/default.nix
+++ b/pkgs/applications/graphics/ImageMagick/default.nix
@@ -3,28 +3,27 @@
 , fetchFromGitHub
 , pkg-config
 , libtool
-, bzip2
-, zlib
-, libX11
-, libXext
-, libXt
-, fontconfig
-, freetype
-, ghostscript
-, libjpeg
-, djvulibre
-, lcms2
-, openexr
-, libjxl
-, libpng
-, liblqr1
-, libraw
-, librsvg
-, libtiff
-, libxml2
-, openjpeg
-, libwebp
-, libheif
+, bzip2Support ? true, bzip2
+, zlibSupport ? true, zlib
+, libX11Support ? !stdenv.hostPlatform.isMinGW, libX11
+, libXtSupport ? !stdenv.hostPlatform.isMinGW, libXt
+, fontconfigSupport ? true, fontconfig
+, freetypeSupport ? true, freetype
+, ghostscriptSupport ? false, ghostscript
+, libjpegSupport ? true, libjpeg
+, djvulibreSupport ? true, djvulibre
+, lcms2Support ? true, lcms2
+, openexrSupport ? !stdenv.hostPlatform.isMinGW, openexr
+, libjxlSupport ? true, libjxl
+, libpngSupport ? true, libpng
+, liblqr1Support ? true, liblqr1
+, librawSupport ? true, libraw
+, librsvgSupport ? !stdenv.hostPlatform.isMinGW, librsvg
+, libtiffSupport ? true, libtiff
+, libxml2Support ? true, libxml2
+, openjpegSupport ? !stdenv.hostPlatform.isMinGW, openjpeg
+, libwebpSupport ? !stdenv.hostPlatform.isMinGW, libwebp
+, libheifSupport ? true, libheif
 , potrace
 , curl
 , ApplicationServices
@@ -32,6 +31,8 @@
 , testers
 , imagemagick
 }:
+
+assert libXtSupport -> libX11Support;
 
 let
   arch =
@@ -59,51 +60,49 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  configureFlags =
-    [ "--with-frozenpaths" ]
-    ++ (if arch != null then [ "--with-gcc-arch=${arch}" ] else [ "--without-gcc-arch" ])
-    ++ lib.optional (librsvg != null) "--with-rsvg"
-    ++ lib.optional (liblqr1 != null) "--with-lqr"
-    ++ lib.optional (libjxl != null ) "--with-jxl"
-    ++ lib.optionals (ghostscript != null)
-      [
-        "--with-gs-font-dir=${ghostscript}/share/ghostscript/fonts"
-        "--with-gslib"
-      ]
-    ++ lib.optionals stdenv.hostPlatform.isMinGW
-      [ "--enable-static" "--disable-shared" ] # due to libxml2 being without DLLs ATM
-  ;
+  configureFlags = [
+    "--with-frozenpaths"
+    (lib.withFeatureAs (arch != null) "gcc-arch" arch)
+    (lib.withFeature librsvgSupport "rsvg")
+    (lib.withFeature liblqr1Support "lqr")
+    (lib.withFeature libjxlSupport "jxl")
+    (lib.withFeatureAs ghostscriptSupport "gs-font-dir" "${ghostscript}/share/ghostscript/fonts")
+    (lib.withFeature ghostscriptSupport "gslib")
+  ] ++ lib.optionals stdenv.hostPlatform.isMinGW [
+    # due to libxml2 being without DLLs ATM
+    "--enable-static" "--disable-shared"
+  ];
 
   nativeBuildInputs = [ pkg-config libtool ];
 
-  buildInputs =
-    [
-      zlib
-      fontconfig
-      freetype
-      ghostscript
-      potrace
-      liblqr1
-      libpng
-      libraw
-      libtiff
-      libxml2
-      libheif
-      djvulibre
-      libjxl
-    ]
-    ++ lib.optionals (!stdenv.hostPlatform.isMinGW)
-      [ openexr librsvg openjpeg ]
+  buildInputs = [ potrace ]
+    ++ lib.optional zlibSupport zlib
+    ++ lib.optional fontconfigSupport fontconfig
+    ++ lib.optional ghostscriptSupport ghostscript
+    ++ lib.optional liblqr1Support liblqr1
+    ++ lib.optional libpngSupport libpng
+    ++ lib.optional librawSupport libraw
+    ++ lib.optional libtiffSupport libtiff
+    ++ lib.optional libxml2Support libxml2
+    ++ lib.optional libheifSupport libheif
+    ++ lib.optional djvulibreSupport djvulibre
+    ++ lib.optional libjxlSupport libjxl
+    ++ lib.optional openexrSupport openexr
+    ++ lib.optional librsvgSupport librsvg
+    ++ lib.optional openjpegSupport openjpeg
     ++ lib.optionals stdenv.isDarwin [
       ApplicationServices
       Foundation
     ];
 
-  propagatedBuildInputs =
-    [ bzip2 freetype libjpeg lcms2 curl ]
-    ++ lib.optionals (!stdenv.hostPlatform.isMinGW)
-      [ libX11 libXext libXt libwebp ]
-  ;
+  propagatedBuildInputs = [ curl ]
+    ++ lib.optional bzip2Support bzip2
+    ++ lib.optional freetypeSupport freetype
+    ++ lib.optional libjpegSupport libjpeg
+    ++ lib.optional lcms2Support lcms2
+    ++ lib.optional libX11Support libX11
+    ++ lib.optional libXtSupport libXt
+    ++ lib.optional libwebpSupport libwebp;
 
   postInstall = ''
     (cd "$dev/include" && ln -s ImageMagick* ImageMagick)
@@ -113,7 +112,7 @@ stdenv.mkDerivation rec {
       substituteInPlace "$file" --replace pkg-config \
         "PKG_CONFIG_PATH='$dev/lib/pkgconfig' '${pkg-config}/bin/${pkg-config.targetPrefix}pkg-config'"
     done
-  '' + lib.optionalString (ghostscript != null) ''
+  '' + lib.optionalString ghostscriptSupport ''
     for la in $out/lib/*.la; do
       sed 's|-lgs|-L${lib.getLib ghostscript}/lib -lgs|' -i $la
     done

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27864,35 +27864,33 @@ with pkgs;
   imagemagick6Big = imagemagick6.override { inherit ghostscript; };
 
   imagemagick_light = lowPrio (imagemagick.override {
-    bzip2 = null;
-    zlib = null;
-    libX11 = null;
-    libXext = null;
-    libXt = null;
-    fontconfig = null;
-    freetype = null;
-    ghostscript = null;
-    libjpeg = null;
-    djvulibre = null;
-    lcms2 = null;
-    openexr = null;
-    libjxl = null;
-    libpng = null;
-    liblqr1 = null;
-    librsvg = null;
-    libtiff = null;
-    libxml2 = null;
-    openjpeg = null;
-    libwebp = null;
-    libheif = null;
+    bzip2Support = false;
+    zlibSupport = false;
+    libX11Support = false;
+    libXtSupport = false;
+    fontconfigSupport = false;
+    freetypeSupport = false;
+    libjpegSupport = false;
+    djvulibreSupport = false;
+    lcms2Support = false;
+    openexrSupport = false;
+    libjxlSupport = false;
+    libpngSupport = false;
+    liblqr1Support = false;
+    librsvgSupport = false;
+    libtiffSupport = false;
+    libxml2Support = false;
+    openjpegSupport = false;
+    libwebpSupport = false;
+    libheifSupport = false;
   });
 
-  imagemagick = lowPrio (imagemagickBig.override {
-    ghostscript = null;
-  });
-
-  imagemagickBig = lowPrio (callPackage ../applications/graphics/ImageMagick {
+  imagemagick = lowPrio (callPackage ../applications/graphics/ImageMagick {
     inherit (darwin.apple_sdk.frameworks) ApplicationServices Foundation;
+  });
+
+  imagemagickBig = lowPrio (imagemagick.override {
+    ghostscriptSupport = true;
   });
 
   imagination = callPackage ../applications/video/imagination { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27833,35 +27833,35 @@ with pkgs;
   fiji = callPackage ../applications/graphics/fiji { };
 
   imagemagick6_light = imagemagick6.override {
-    bzip2 = null;
-    zlib = null;
-    libX11 = null;
-    libXext = null;
-    libXt = null;
-    fontconfig = null;
-    freetype = null;
-    ghostscript = null;
-    libjpeg = null;
-    djvulibre = null;
-    lcms2 = null;
-    openexr = null;
-    libpng = null;
-    liblqr1 = null;
-    librsvg = null;
-    libtiff = null;
-    libxml2 = null;
-    openjpeg = null;
-    libwebp = null;
-    libheif = null;
-    libde265 = null;
+    bzip2Support = false;
+    zlibSupport = false;
+    libX11Support = false;
+    libXtSupport = false;
+    fontconfigSupport = false;
+    freetypeSupport = false;
+    ghostscriptSupport = false;
+    libjpegSupport = false;
+    djvulibreSupport = false;
+    lcms2Support = false;
+    openexrSupport = false;
+    libpngSupport = false;
+    liblqr1Support = false;
+    librsvgSupport = false;
+    libtiffSupport = false;
+    libxml2Support = false;
+    openjpegSupport = false;
+    libwebpSupport = false;
+    libheifSupport = false;
+    libde265Support = false;
   };
 
   imagemagick6 = callPackage ../applications/graphics/ImageMagick/6.x.nix {
     inherit (darwin.apple_sdk.frameworks) ApplicationServices Foundation;
-    ghostscript = null;
   };
 
-  imagemagick6Big = imagemagick6.override { inherit ghostscript; };
+  imagemagick6Big = imagemagick6.override {
+    ghostscriptSupport = true;
+  };
 
   imagemagick_light = lowPrio (imagemagick.override {
     bzip2Support = false;


### PR DESCRIPTION
###### Description of changes

Throughout Nixpkgs, we now tend to avoid packages being null outside of bootstrapping, in favour of dedicated options that can have more complex defaults set, e.g. per-platform.  This simplifies and regularizes the imagemagick package definition.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
