### PR TITLE
qt6.wrapQtAppsHook: also wrap scripts, pretty error, show hints

### DIFF
--- a/pkgs/development/libraries/qt-6/hooks/wrap-qt-apps-hook.sh
+++ b/pkgs/development/libraries/qt-6/hooks/wrap-qt-apps-hook.sh
@@ -34,7 +34,7 @@ qtHostPathHook() {
         qtWrapperArgs+=(--prefix QML2_IMPORT_PATH : "$qmlDir")
     fi
 }
-addEnvHooks "$hostOffset" qtHostPathHook
+addEnvHooks "$targetOffset" qtHostPathHook
 
 makeQtWrapper() {
     local original="$1"

--- a/pkgs/development/libraries/qt-6/hooks/wrap-qt-apps-hook.sh
+++ b/pkgs/development/libraries/qt-6/hooks/wrap-qt-apps-hook.sh
@@ -85,8 +85,6 @@ wrapQtAppsHook() {
 
         find "$targetDir" ! -type d -executable -print0 | while IFS= read -r -d '' file
         do
-            isELF "$file" || isMachO "$file" || continue
-
             if [ -f "$file" ]
             then
                 echo "wrapping $file"

--- a/pkgs/development/libraries/qt-6/hooks/wrap-qt-apps-hook.sh
+++ b/pkgs/development/libraries/qt-6/hooks/wrap-qt-apps-hook.sh
@@ -22,6 +22,11 @@ qtUnseenHostPath() {
 qtHostPathHook() {
     qtUnseenHostPath "$1" || return 0
 
+    if ! [ -v qtPluginPrefix ]
+    then
+        echo "wrapQtAppsHook qtHostPathHook: qtPluginPrefix is unset. hint: add qt6.qtbase to buildInputs"
+    fi
+
     local pluginDir="$1/${qtPluginPrefix:?}"
     if [ -d "$pluginDir" ]
     then


### PR DESCRIPTION
###### Description of changes

**fix: also wrap scripts**

before this patch, wrapQtAppsHook failed to wrap script files
(bash scripts, python scripts, ...)

the checks `isELF $file` and `isMachO $file` dont make sense here

tested with `python3.pkgs.pyqt6_test` from #177530

**pretty error on missing buildInputs**

wrapQtAppsHook requires `buildInputs = [ qt6.qtbase ]`

before

> ```/nix/store/*-hook/nix-support/setup-hook: line 25: qtPluginPrefix: parameter null or not set```

after

> ```wrapQtAppsHook qtHostPathHook: error: qtPluginPrefix is unset. hint: add qt6.qtbase to nativeBuildInputs```

**show hints on missing nativeBuildInputs**

helpful for packaging qt apps

wrapQtAppsHook does not work when qtbase (etc) are only in buildInputs or propagatedBuildInputs

> ```wrapQtAppsHook makeQtWrapper: qtWrapperArgs is empty. hint: add qt6.qtbase to nativeBuildInputs```
> ```wrapQtAppsHook wrapQtApp: qtWrapperArgs is empty. hint: add qt6.qtbase to nativeBuildInputs```

ping @NickCao @nrdxp @kevincox 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
