### PR TITLE
treewide: fix build with libressl 3.5.x

### DIFF
--- a/pkgs/development/libraries/libssh2/default.nix
+++ b/pkgs/development/libraries/libssh2/default.nix
@@ -11,6 +11,12 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" "devdoc" ];
 
+  patches = [
+    # https://github.com/libssh2/libssh2/pull/700
+    # openssl: add support for LibreSSL 3.5.x
+    ./openssl_add_support_for_libressl_3_5.patch
+  ];
+
   buildInputs = [ openssl zlib ]
     ++ lib.optional stdenv.hostPlatform.isMinGW windows.mingw_w64;
 

--- a/pkgs/development/libraries/libssh2/openssl_add_support_for_libressl_3_5.patch
+++ b/pkgs/development/libraries/libssh2/openssl_add_support_for_libressl_3_5.patch
@@ -1,0 +1,26 @@
+From f0681a4573d7c7f7484d3157ddff7063a200295b Mon Sep 17 00:00:00 2001
+From: Viktor Szakats <commit@vsz.me>
+Date: Thu, 19 May 2022 13:25:06 +0000
+Subject: [PATCH] openssl: add support for LibreSSL 3.5.x
+
+LibreSSL 3.5.0 made more structures opaque, so let's enable existing
+support for that when building against these LibreSSL versions.
+
+Ref: https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.5.0-relnotes.txt
+---
+ src/openssl.h | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/openssl.h b/src/openssl.h
+index 658b040..1733b9e 100644
+--- a/src/openssl.h
++++ b/src/openssl.h
+@@ -58,7 +58,8 @@
+ #include <openssl/rand.h>
+
+ #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
+-    !defined(LIBRESSL_VERSION_NUMBER)
++    !defined(LIBRESSL_VERSION_NUMBER) || \
++    LIBRESSL_VERSION_NUMBER >= 0x3050000fL
+ # define HAVE_OPAQUE_STRUCTS 1
+ #endif


### PR DESCRIPTION
###### Description of changes

Closes #181375

I somehow broke GitHub and can no longer force push onto the branch

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
