### PR TITLE
nixos/nginx: allow per-vhost SSL config

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -514,6 +514,16 @@
       </listitem>
       <listitem>
         <para>
+          <literal>services.nginx.virtualHosts.&lt;name&gt;</literal>
+          now supports <literal>sslCiphers</literal>,
+          <literal>sslProtocols</literal> (nullable),
+          <literal>sslDhparam</literal> and
+          <literal>recommendedTlsSettings</literal>, same as
+          <literal>services.nginx</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           There is a new module for the <literal>thunar</literal>
           program (the Xfce file manager), which depends on the
           <literal>xfconf</literal> dbus service, and also has a dbus

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -173,6 +173,8 @@ Use `configure.packages` instead.
 
 - There is a new module for AMD SEV CPU functionality, which grants access to the hardware.
 
+- `services.nginx.virtualHosts.<name>` now supports `sslCiphers`, `sslProtocols` (nullable), `sslDhparam` and `recommendedTlsSettings`, same as `services.nginx`.
+
 - There is a new module for the `thunar` program (the Xfce file manager), which depends on the `xfconf` dbus service, and also has a dbus service and a systemd unit. The option `services.xserver.desktopManager.xfce.thunarPlugins` has been renamed to `programs.thunar.plugins`, and in a future release it may be removed.
 
 - There is a new module for the `xfconf` program (the Xfce configuration storage system), which has a dbus service.

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -406,42 +406,32 @@ in
       recommendedTlsSettings = mkOption {
         default = false;
         type = types.bool;
-        description = lib.mdDoc ''
-          Enable recommended TLS settings.
-        '';
+        description = lib.mdDoc "Enable recommended TLS settings.";
       };
 
       recommendedOptimisation = mkOption {
         default = false;
         type = types.bool;
-        description = lib.mdDoc ''
-          Enable recommended optimisation settings.
-        '';
+        description = lib.mdDoc "Enable recommended optimisation settings.";
       };
 
       recommendedGzipSettings = mkOption {
         default = false;
         type = types.bool;
-        description = lib.mdDoc ''
-          Enable recommended gzip settings.
-        '';
+        description = lib.mdDoc "Enable recommended gzip settings.";
       };
 
       recommendedProxySettings = mkOption {
         default = false;
         type = types.bool;
-        description = lib.mdDoc ''
-          Whether to enable recommended proxy settings if a vhost does not specify the option manually.
-        '';
+        description = lib.mdDoc "Whether to enable recommended proxy settings if a vhost does not specify the option manually.";
       };
 
       proxyTimeout = mkOption {
         type = types.str;
         default = "60s";
         example = "20s";
-        description = lib.mdDoc ''
-          Change the proxy related timeouts in recommendedProxySettings.
-        '';
+        description = lib.mdDoc "Change the proxy related timeouts in recommendedProxySettings.";
       };
 
       defaultListenAddresses = mkOption {
@@ -449,9 +439,7 @@ in
         default = [ "0.0.0.0" ] ++ optional enableIPv6 "[::0]";
         defaultText = literalExpression ''[ "0.0.0.0" ] ++ lib.optional config.networking.enableIPv6 "[::0]"'';
         example = literalExpression ''[ "10.0.0.12" "[2002:a00:1::]" ]'';
-        description = lib.mdDoc ''
-          If vhosts do not specify listenAddresses, use these addresses by default.
-        '';
+        description = lib.mdDoc "If vhosts do not specify listenAddresses, use these addresses by default.";
       };
 
       package = mkOption {

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -424,7 +424,7 @@ in
       recommendedProxySettings = mkOption {
         default = false;
         type = types.bool;
-        description = lib.mdDoc "Whether to enable recommended proxy settings if a vhost does not specify the option manually.";
+        description = lib.mdDoc "Enable recommended proxy settings if a vhost does not specify the option manually.";
       };
 
       proxyTimeout = mkOption {

--- a/nixos/modules/services/web-servers/nginx/vhost-options.nix
+++ b/nixos/modules/services/web-servers/nginx/vhost-options.nix
@@ -180,6 +180,33 @@ with lib;
       description = lib.mdDoc "Path to root SSL certificate for stapling and client certificates.";
     };
 
+    sslCiphers = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384";
+      description = lib.mdDoc "Ciphers to choose from when negotiating TLS handshakes.";
+    };
+
+    sslProtocols = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "TLSv1 TLSv1.1 TLSv1.2 TLSv1.3";
+      description = lib.mdDoc "Allowed TLS protocol versions.";
+    };
+
+    sslDhparam = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = "/path/to/dhparams.pem";
+      description = lib.mdDoc "Path to DH parameters file.";
+    };
+
+    recommendedTlsSettings = mkOption {
+      default = false;
+      type = types.bool;
+      description = lib.mdDoc "Enable recommended TLS settings.";
+    };
+
     http2 = mkOption {
       type = types.bool;
       default = true;


### PR DESCRIPTION
###### Description of changes
Nginx SSL settings are applicable to both `server` and `http` blocks, so added a few SSL-specific options from top-level `nginx` config.
Note, that I made `sslProtocols` nullable to keep the existing configs the same.

See https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols, for example

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
