### PR TITLE
nixos/label: add  validation for system.nixos.label

### DIFF
--- a/nixos/modules/misc/label.nix
+++ b/nixos/modules/misc/label.nix
@@ -19,9 +19,8 @@ in
         If you ever wanted to influence the labels in your GRUB menu,
         this is the option for you.
 
-        It can't be any text, so it's expected to have only letters, numbers
-        and the following symbols: <literal>:</literal>, <literal>_</literal>,
-        <literal>.</literal> and <literal>-</literal>.
+        It can only contain letters, numbers and the following symbols:
+        <literal>:</literal>, <literal>_</literal>, <literal>.</literal> and <literal>-</literal>.
 
         The default is <option>system.nixos.tags</option> separated by
         "-" + "-" + <envar>NIXOS_LABEL_VERSION</envar> environment

--- a/nixos/modules/misc/label.nix
+++ b/nixos/modules/misc/label.nix
@@ -11,13 +11,17 @@ in
   options.system = {
 
     nixos.label = mkOption {
-      type = types.str;
+      type = types.strMatching "[a-zA-Z0-9:_\\.-]*";
       description = ''
         NixOS version name to be used in the names of generated
         outputs and boot labels.
 
         If you ever wanted to influence the labels in your GRUB menu,
         this is the option for you.
+
+        It can't be any text, so it's expected to have only letters, numbers
+        and the following symbols: <literal>:</literal>, <literal>_</literal>,
+        <literal>.</literal> and <literal>-</literal>.
 
         The default is <option>system.nixos.tags</option> separated by
         "-" + "-" + <envar>NIXOS_LABEL_VERSION</envar> environment


### PR DESCRIPTION
Signed-off-by: lucasew <lucas59356@gmail.com>

###### Description of changes
Add validation for the option `system.nixos.label` in a effort to solve a sneaky bug I stumbled.

An accidental "/" f up with the build of a GCP NixOS image, I found the problem but I think it should be more "fail fast".
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
- nix-repl
```nix
t = pkgs.lib.types.strMatching "[a-zA-Z0-9:_\\.-]*"
t.check "nix/nix"
```
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
