### PR TITLE
nixos/test-driver: use attrname from nodes to refer to machines

### DIFF
--- a/nixos/lib/test-driver/test_driver/machine.py
+++ b/nixos/lib/test-driver/test_driver/machine.py
@@ -215,11 +215,14 @@ class NixStartScript(StartCommand):
     (Admittedly a _very_ implicit contract, evtl. TODO fix)
     """
 
-    def __init__(self, script: str):
+    def __init__(self, name: Optional[str], script: str):
         self._cmd = script
+        self._name = name
 
     @property
     def machine_name(self) -> str:
+        if self._name is not None:
+            return self._name
         match = re.search("run-(.+)-vm$", self._cmd)
         name = "machine"
         if match:

--- a/nixos/lib/testing-python.nix
+++ b/nixos/lib/testing-python.nix
@@ -157,9 +157,9 @@ rec {
         # set defaults through environment
         # see: ./test-driver/test-driver.py argparse implementation
         wrapProgram $out/bin/nixos-test-driver \
-          --set startScripts "${lib.concatStringsSep "," (lib.mapAttrsToList
-            (name: machine: "${name}=${machine.config.system.build.vm}/bin/run-${machine.config.system.name}-vm")
-            nodes)}" \
+          --set startScripts ${lib.escapeShellArg (builtins.toJSON (lib.mapAttrs
+            (name: machine: "${machine.config.system.build.vm}/bin/run-${machine.config.system.name}-vm")
+            nodes))} \
           --set testScript "$out/test-script" \
           --set vlans '${toString vlans}' \
           ${lib.optionalString (interactive) "--add-flags --interactive"}


### PR DESCRIPTION
###### Description of changes

The NixOS test-driver sets up VMs as specified by the `nodes` attrset passed to `makeTest`. The VMs can then be interacted with from the python `testScript` using variables named after `system.name` of the VM. This breaks tests when `system.name` changes (e.g. because you like to add a git SHA to the name).

This change makes it possible to refer to machines by the attrname for the
config in the `nodes` attrset as opposed to the `system.name`, e.g.

```
makeTest = {
    nodes = {
        foo = { pkgs, ... }: {
            ...
        };
        bar = { pkgs, ... }: {
            ...
        };
    };
    testScript = ''
        foo.start()
        bar.start()
        ...
    '';
}
```

I think this way is strictly better, because the attrnames in `nodes` are guaranteed to be unique, they are usually defined right next to the `testScript` and they are completely independent from other parts of the module system (i.e. only the test-driver uses them).

The code is not very clean and not backwards compatible. I just want to have a starting point for discussion.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
