### PR TITLE
Create services.mlflow

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -18,6 +18,8 @@
 
 - [Anuko Time Tracker](https://github.com/anuko/timetracker), a simple, easy to use, open source time tracking system. Available as [services.anuko-time-tracker](#opt-services.anuko-time-tracker.enable).
 
+- [mlflow](https://mlflow.org/), an open source platform to manage the ML lifecycle, including experimentation, reproducibility, deployment, and a central model registry. Available as [services.mlflow](options.html#opt-services.mlflow.enable).
+
 - [sitespeed-io](https://sitespeed.io), a tool that can generate metrics (timings, diagnostics) for websites. Available as [services.sitespeed-io](#opt-services.sitespeed-io.enable).
 
 - [Apache Guacamole](https://guacamole.apache.org/), a cross-platform, clientless remote desktop gateway. Available as [services.guacamole-server](#opt-services.guacamole-server.enable) and [services.guacamole-client](#opt-services.guacamole-client.enable) services.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -463,6 +463,8 @@
   ./services/development/hoogle.nix
   ./services/development/jupyter/default.nix
   ./services/development/jupyterhub/default.nix
+  ./services/development/mlflow/default.nix
+  ./services/development/rstudio-server/default.nix
   ./services/development/lorri.nix
   ./services/development/rstudio-server/default.nix
   ./services/development/zammad.nix

--- a/nixos/modules/services/development/mlflow/default.nix
+++ b/nixos/modules/services/development/mlflow/default.nix
@@ -1,0 +1,139 @@
+{ options, config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.mlflow;
+
+  keyToFlag = k: (if lib.stringLength k == 1 then "-" else "--") + k;
+
+  toFlags = k: v:
+    if v == false || v == null then
+      ""
+    else if v == true then
+      keyToFlag k
+    else if lib.isList v then
+      lib.concatMapStringsSep " " (x: toFlags k x) v
+    else
+      "${keyToFlag k} ${toString v}";
+
+  flags = lib.concatStringsSep " " (lib.mapAttrsToList toFlags cfg.settings);
+
+  valueType = with lib.types;
+    oneOf [ bool float int package path port str ];
+
+  settingsType = with lib.types;
+    submodule {
+      freeformType = attrsOf (oneOf [ (nullOr valueType) (listOf valueType) ]);
+      options = {
+        host = lib.mkOption {
+          type = str;
+          default = "127.0.0.1";
+          description = lib.mdDoc ''
+            The IP address the mlflow server should listen on.
+          '';
+        };
+
+        port = lib.mkOption {
+          type = port;
+          default = 5000;
+          description = lib.mdDoc ''
+            The TCP port the mlflow server should listen on.
+          '';
+        };
+
+        default-artifact-root = lib.mkOption {
+          type = str;
+          default = if cfg.settings.serve-artifacts or false then
+            "mlflow-artifacts:/"
+          else
+            "/var/lib/mlflow/mlruns";
+
+          defaultText = lib.literalExpression ''
+            if cfg.settings.serve-artifacts or false then
+              "mlflow-artifacts:/"
+            else
+              "/var/lib/mlflow/mlruns"
+          '';
+
+          description = lib.mdDoc ''
+            Directory in which to store artifacts for any new experiments
+            created. For tracking server backends that rely on SQL, this option
+            is required in order to store artifacts.
+          '';
+        };
+
+        backend-store-uri = lib.mkOption {
+          type = str;
+          default = "sqlite:////var/lib/mlflow/mlruns.db";
+          description = lib.mdDoc ''
+            URI to which to persist experiment and run data.
+
+            Acceptable URIs are SQLAlchemy-compatible database connection
+            strings (e.g. 'sqlite:///path/to/file.db') or local filesystem URIs
+            (e.g. 'file:///absolute/path/to/directory'). Using a SQL-backed
+            store is required for a number of features.
+          '';
+        };
+      };
+    };
+
+in {
+  options.services.mlflow = with lib; {
+    enable = mkEnableOption (lib.mdDoc "the MLflow tracking server");
+
+    settings = mkOption {
+      type = settingsType;
+      default = { };
+      description = lib.mdDoc ''
+        Settings for mlflow server. Each setting is passed as command-line flag
+        to mlflow server. For example: { serve-artifacts = true; port = 9999; }
+        results in "mlflow server --serve-artifacts --port 9999".
+        See https://mlflow.org/docs/latest/cli.html#mlflow-server for possible
+        flags.
+      '';
+
+      example = literalExpression ''
+        {
+          serve-artifacts = true;
+        }
+      '';
+    };
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.python3.pkgs.mlflow;
+      defaultText = "pkgs.python3.pkgs.mlflow";
+      description = lib.mdDoc ''
+        The mlflow package to use.
+      '';
+    };
+
+    autoUpgrade = mkOption {
+      type = types.bool;
+      default = false;
+      description = lib.mdDoc ''
+        Automatically upgrade the mlflow backend store to new schema versions.
+        IMPORTANT: Schema migrations can be slow and are not guaranteed to be
+        transactional - it is recommended to take a backup of your database
+        before running migrations.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.mlflow = {
+      wantedBy = [ "multi-user.target" ];
+      path = [ cfg.package ];
+      serviceConfig = {
+        StateDirectory = "mlflow";
+        DynamicUser = true;
+        WorkingDirectory = "/var/lib/mlflow";
+      };
+
+      script = lib.optionalString cfg.autoUpgrade ''
+        mlflow db upgrade ${cfg.settings.backend-store-uri}
+      '' + ''
+        mlflow server ${flags}
+      '';
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -466,6 +466,7 @@ in {
   miriway = handleTest ./miriway.nix {};
   misc = handleTest ./misc.nix {};
   mjolnir = handleTest ./matrix/mjolnir.nix {};
+  mlflow = handleTest ./mlflow.nix {};
   mod_perl = handleTest ./mod_perl.nix {};
   molly-brown = handleTest ./molly-brown.nix {};
   monica = handleTest ./web-apps/monica.nix {};

--- a/nixos/tests/mlflow.nix
+++ b/nixos/tests/mlflow.nix
@@ -1,0 +1,16 @@
+import ./make-test-python.nix ({ lib, ... }: {
+  name = "mlflow";
+  meta.maintainers = [ lib.teams.lumiguide ];
+
+  nodes.machine = { ... }: {
+    services.mlflow.enable = true;
+  };
+
+  testScript = ''
+    with subtest("Web interface gets ready"):
+        machine.wait_for_unit("mlflow.service")
+        # Wait until server accepts connections
+        machine.wait_until_succeeds("curl -fs localhost:5000")
+  '';
+})
+

--- a/pkgs/development/python-modules/mlflow/default.nix
+++ b/pkgs/development/python-modules/mlflow/default.nix
@@ -92,6 +92,13 @@ buildPythonPackage rec {
     "mlflow"
   ];
 
+  # Some mlflow subcommands like `mlflow server` run the gunicorn binary which
+  # in turn attempts to find the mlflow package again. Gunicorn does not have
+  # mlflow in its closure and won't find it unless we expose it here.
+  makeWrapperArgs = [
+    "--prefix PYTHONPATH : $PYTHONPATH"
+  ];
+
   # no tests in PyPI dist
   # run into https://stackoverflow.com/questions/51203641/attributeerror-module-alembic-context-has-no-attribute-config
   # also, tests use conda so can't run on NixOS without buildFHSEnv

--- a/pkgs/development/python-modules/mlflow/default.nix
+++ b/pkgs/development/python-modules/mlflow/default.nix
@@ -15,6 +15,7 @@
 , importlib-metadata
 , markdown
 , matplotlib
+, nixosTests
 , numpy
 , packaging
 , pandas
@@ -103,6 +104,8 @@ buildPythonPackage rec {
   # run into https://stackoverflow.com/questions/51203641/attributeerror-module-alembic-context-has-no-attribute-config
   # also, tests use conda so can't run on NixOS without buildFHSEnv
   doCheck = false;
+
+  passthru.tests = { inherit (nixosTests) mlflow; };
 
   meta = with lib; {
     description = "Open source platform for the machine learning lifecycle";


### PR DESCRIPTION
###### Description of changes

Create a nixos module for mlflow. Fixes #161049.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).