### PR TITLE
fsrx: 1.0.0 -> 1.0.2

### DIFF
--- a/pkgs/tools/misc/fsrx/default.nix
+++ b/pkgs/tools/misc/fsrx/default.nix
@@ -1,23 +1,19 @@
-{ lib, fetchFromGitHub, rustPlatform, gitUpdater, testers, fsrx }:
+{ lib, fetchFromGitHub, rustPlatform, testers, fsrx }:
 
 rustPlatform.buildRustPackage rec {
   pname = "fsrx";
-  version = "1.0.0";
+  version = "1.0.2";
 
   src = fetchFromGitHub {
-    owner = "coloradocolby";
+    owner = "thatvegandev";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-pKdxYO8Rhck3UYxqiWHDlrlPS4cAPe5jLUu5Dajop/k=";
+    sha256 = "sha256-hzfpjunP20WCt3erYu7AO7A3nz+UMKdFzWUA5jASbVA=";
   };
 
-  cargoSha256 = "sha256-5h+ou9FLCG/WWMEQPsCTa1q+PovxUJs+6lzQ0L2bKIs=";
+  cargoSha256 = "sha256-bRStmz2sJnhCKpvoQfc/ZP9B2ZdNHYNEHd+wZErdS1Y=";
 
   passthru = {
-    updateScript = gitUpdater {
-      inherit pname version;
-      rev-prefix = "v";
-    };
     tests.version = testers.testVersion {
       package = fsrx;
     };
@@ -25,7 +21,7 @@ rustPlatform.buildRustPackage rec {
 
   meta = with lib; {
     description = "A flow state reader in the terminal";
-    homepage = "https://github.com/coloradocolby/fsrx";
+    homepage = "https://github.com/thatvegandev/fsrx";
     license = licenses.mit;
     maintainers = with maintainers; [ MoritzBoehme ];
   };


### PR DESCRIPTION
###### Description of changes

Updates `fsrx` to latest version.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
