### PR TITLE
Eval fixes for cross-compilation

### DIFF
--- a/pkgs/applications/virtualization/appvm/default.nix
+++ b/pkgs/applications/virtualization/appvm/default.nix
@@ -32,7 +32,7 @@ buildGoModule rec {
 
   vendorSha256 = "sha256-8eU+Mf5dxL/bAMMShXvj8I1Kdd4ysBTWvgYIXwLStPI=";
 
-  buildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
 
   postFixup = ''
     wrapProgram $out/bin/appvm \

--- a/pkgs/applications/virtualization/arion/default.nix
+++ b/pkgs/applications/virtualization/arion/default.nix
@@ -3,6 +3,7 @@
 , haskellPackages
 , haskell
 , runCommand
+, buildPackages
 }:
 
 let
@@ -32,7 +33,7 @@ let
   inherit (haskellPackages) arion-compose;
 
   cabalOverrides = o: {
-    buildTools = (o.buildTools or []) ++ [pkgs.makeWrapper];
+    buildTools = (o.buildTools or []) ++ [buildPackages.makeWrapper];
     passthru = (o.passthru or {}) // {
       inherit eval build;
     };

--- a/pkgs/development/compilers/chicken/4/chicken.nix
+++ b/pkgs/development/compilers/chicken/4/chicken.nix
@@ -39,11 +39,13 @@ stdenv.mkDerivation {
     ./0001-Introduce-CHICKEN_REPOSITORY_EXTRA.patch
   ];
 
-  buildInputs = [
+  nativeBuildInputs = [
     makeWrapper
-  ] ++ (lib.optionals (bootstrap-chicken != null) [
+  ];
+
+  buildInputs = lib.optionals (bootstrap-chicken != null) [
     bootstrap-chicken
-  ]);
+  ];
 
   preBuild = lib.optionalString (bootstrap-chicken != null) ''
     # Backup the build* files - those are generated from hostname,

--- a/pkgs/development/compilers/chicken/5/chicken.nix
+++ b/pkgs/development/compilers/chicken/5/chicken.nix
@@ -31,11 +31,13 @@ stdenv.mkDerivation rec {
     "C_COMPILER=$(CC)"
   ]);
 
-  buildInputs = [
+  nativeBuildInputs = [
     makeWrapper
-  ] ++ (lib.optionals (bootstrap-chicken != null) [
+  ];
+
+  buildInputs = lib.optionals (bootstrap-chicken != null) [
     bootstrap-chicken
-  ]);
+  ];
 
   postInstall = ''
     for f in $out/bin/*

--- a/pkgs/development/interpreters/acl2/default.nix
+++ b/pkgs/development/interpreters/acl2/default.nix
@@ -10,7 +10,7 @@ let
   # ACL2 system itself; see
   # https://www.cs.utexas.edu/users/moore/acl2/current/HTML/installation/requirements.html#Obtaining-SBCL
   sbcl' = args.sbcl.override { disableImmobileSpace = true; };
-  sbcl = runCommandLocal args.sbcl.name { buildInputs = [ makeWrapper ]; } ''
+  sbcl = runCommandLocal args.sbcl.name { nativeBuildInputs = [ makeWrapper ]; } ''
     makeWrapper ${sbcl'}/bin/sbcl $out/bin/sbcl \
       --add-flags "--dynamic-space-size 2000"
   '';
@@ -40,12 +40,14 @@ in stdenv.mkDerivation rec {
     libcrypto = "${lib.getLib openssl}/lib/libcrypto${stdenv.hostPlatform.extensions.sharedLibrary}";
   })];
 
+  nativeBuildInputs = lib.optional certifyBooks makeWrapper;
+
   buildInputs = [
     # ACL2 itself only needs a Common Lisp compiler/interpreter:
     sbcl
   ] ++ lib.optionals certifyBooks [
     # To build community books, we need Perl and a couple of utilities:
-    which perl hostname makeWrapper
+    which perl hostname
     # Some of the books require one or more of these external tools:
     glucose minisat abc-verifier libipasir
     z3 (python2.withPackages (ps: [ ps.z3 ]))

--- a/pkgs/development/interpreters/cling/default.nix
+++ b/pkgs/development/interpreters/cling/default.nix
@@ -94,7 +94,7 @@ let
 in
 
 runCommand "cling-${unwrapped.version}" {
-  buildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
   inherit unwrapped flags compilerIncludeFlags;
   inherit (unwrapped) meta;
 } ''

--- a/pkgs/development/tools/azure-functions-core-tools/default.nix
+++ b/pkgs/development/tools/azure-functions-core-tools/default.nix
@@ -23,13 +23,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-NdTEFQaG8eFengjzQr51ezehIHFvQZqmrjpjWk4vZKo=";
   };
 
-  buildInputs = [
+  nativeBuildInputs = [
     unzip
     makeWrapper
     dotnetbuildhelpers
-  ];
-
-  nativeBuildInputs = [
     icu
     libunwind
     curl

--- a/pkgs/development/tools/misc/asls/default.nix
+++ b/pkgs/development/tools/misc/asls/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "05kp44p4q4sdykfw0b4k9j3qdp0qvwgjbs48ncmnd0ass0xrmi3s";
   };
 
-  buildInputs = [ erlangR22 ];
+  nativeBuildInputs = [ erlangR22 ];
   installPhase = "install -Dm755 -t $out/bin asls";
 
   meta = with lib; {

--- a/pkgs/servers/http/couchdb/3.nix
+++ b/pkgs/servers/http/couchdb/3.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, erlang, icu, openssl, spidermonkey_91
-, coreutils, bash, makeWrapper, python3, nixosTests }:
+, coreutils, bash, python3, nixosTests }:
 
 stdenv.mkDerivation rec {
   pname = "couchdb";
@@ -13,7 +13,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-acn9b4ATNVf2igLpLdpypP1kbWRvQp9Fu4Mpow+C8g4=";
   };
 
-  buildInputs = [ erlang icu openssl spidermonkey_91 (python3.withPackages(ps: with ps; [ requests ]))];
+  nativeBuildInputs = [
+    erlang
+  ];
+  buildInputs = [ icu openssl spidermonkey_91 (python3.withPackages(ps: with ps; [ requests ]))];
   postPatch = ''
     substituteInPlace src/couch/rebar.config.script --replace '/usr/include/mozjs-91' "${spidermonkey_91.dev}/include/mozjs-91"
     patchShebangs bin/rebar

--- a/pkgs/servers/nosql/apache-jena/binary.nix
+++ b/pkgs/servers/nosql/apache-jena/binary.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
     url = "https://dlcdn.apache.org/jena/binaries/apache-jena-${version}.tar.gz";
     sha256 = "sha256-/KHjhMNnqac2HG/yvHJa0MwdReX6XuexojaMgRFdaWo=";
   };
-  buildInputs = [
+  nativeBuildInputs = [
     makeWrapper
   ];
   installPhase = ''

--- a/pkgs/servers/nosql/apache-jena/fuseki-binary.nix
+++ b/pkgs/servers/nosql/apache-jena/fuseki-binary.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
     url = "https://dlcdn.apache.org/jena/binaries/apache-jena-fuseki-${version}.tar.gz";
     sha256 = "1r0vfa7d55lzw22yfx46mxxmz8x8pkr666vggqw2m1rzzj52z9nx";
   };
-  buildInputs = [
+  nativeBuildInputs = [
     makeWrapper
   ];
   installPhase = ''

--- a/pkgs/servers/varnish/default.nix
+++ b/pkgs/servers/varnish/default.nix
@@ -14,9 +14,9 @@ let
 
       passthru.python = python3;
 
-      nativeBuildInputs = with python3.pkgs; [ pkg-config docutils sphinx ];
+      nativeBuildInputs = with python3.pkgs; [ pkg-config docutils sphinx makeWrapper];
       buildInputs = [
-        libxslt groff ncurses readline libedit makeWrapper python3
+        libxslt groff ncurses readline libedit python3
       ]
       ++ lib.optional (lib.versionOlder version "7") pcre
       ++ lib.optional (lib.versionAtLeast version "7") pcre2

--- a/pkgs/tools/package-management/conda/default.nix
+++ b/pkgs/tools/package-management/conda/default.nix
@@ -42,7 +42,7 @@ let
         zlib # libz.so.1
       ];
     in
-      runCommand "conda-install" { buildInputs = [ makeWrapper zlib]; }
+      runCommand "conda-install" { nativeBuildInputs = [ makeWrapper ]; buildInputs = [ zlib]; }
         # on line 10, we have 'unset LD_LIBRARY_PATH'
         # we have to comment it out however in a way that the number of bytes in the
         # file does not change. So we replace the 'u' in the line with a '#'

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22332,7 +22332,7 @@ with pkgs;
   codeowners = callPackage ../development/tools/codeowners { };
 
   couchdb3 = callPackage ../servers/http/couchdb/3.nix {
-    erlang = erlangR22;
+    erlang = buildPackages.erlangR22;
   };
 
   dcnnt = python3Packages.callPackage ../servers/dcnnt { };


### PR DESCRIPTION
###### Description of changes

Fix evaluation of `nix-env -f . -qaP --attr pkgsCross.aarch64-multiplatform --out-path --show-trace` for a bunch of packages. It still doesn't fully evaluate, unfortunately.

Improves progress for https://github.com/NixOS/nixpkgs/issues/116207.

###### Things done

- Tried evaluating nixpkgs with the above function


Opening as draft for now since I'm still working at it, but I like sharing it already :)