### PR TITLE
zchunk: fix build on darwin

### DIFF
--- a/pkgs/development/libraries/zchunk/0001-meson-fix-argp-standalone.patch
+++ b/pkgs/development/libraries/zchunk/0001-meson-fix-argp-standalone.patch
@@ -1,0 +1,18 @@
+diff --git a/meson.build b/meson.build
+index 1c6b32d..aa7dd25 100644
+--- a/meson.build
++++ b/meson.build
+@@ -58,10 +58,10 @@ endif
+ 
+ # argp-standalone dependency (if required)
+ if build_machine.system() == 'windows' or build_machine.system() == 'darwin' or build_machine.system() == 'freebsd' or not cc.links('#include <argp.h>\nstatic error_t parse_opt (int key, char *arg, struct argp_state *state) { argp_usage(state); return 0; }; void main() {}')
+-    if fs.is_dir(join_paths([get_option('prefix'), 'include']))
+-        inc += include_directories(join_paths([get_option('prefix'), 'include']))
++    argplib = cc.find_library('argp', has_headers : ['argp.h'], required: false)
++    if not argplib.found()
++        argplib = dependency('argp-standalone')
+     endif
+-    argplib = cc.find_library('argp', dirs : join_paths([get_option('prefix'), 'lib']))
+ else
+     argplib = dependency('', required : false)
+ endif

--- a/pkgs/development/libraries/zchunk/default.nix
+++ b/pkgs/development/libraries/zchunk/default.nix
@@ -20,6 +20,11 @@ stdenv.mkDerivation rec {
     hash = "sha256-7H1WF5VkpA65xCdEa0Sw4r4jj+kGhDVCMr5AeE+3Ii4=";
   };
 
+  # unbreak on darwin by finding argp-standalone, based on the patch from
+  # buildroot:
+  #    https://github.com/buildroot/buildroot/raw/master/package/zchunk/0001-meson-fix-argp-standalone-wrap-and-find_library.patch
+  patches = lib.optional stdenv.isDarwin ./0001-meson-fix-argp-standalone.patch;
+
   nativeBuildInputs = [
     meson
     ninja
@@ -47,6 +52,5 @@ stdenv.mkDerivation rec {
     license = licenses.bsd2;
     maintainers = with maintainers; [ AndersonTorres ];
     platforms = platforms.unix;
-    broken = stdenv.isDarwin; # does not find argp-standalone
   };
 }


### PR DESCRIPTION
###### Description of changes

Fix build of zchunk after it was marked broken in #163232 by using the patch from buildroot ([mailing list](https://lore.kernel.org/all/20220604170530.GP427639@scaer/)).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
