### PR TITLE
electron-mail: 4.14.0 -> 5.0.1

### DIFF
--- a/pkgs/applications/networking/mailreaders/electron-mail/default.nix
+++ b/pkgs/applications/networking/mailreaders/electron-mail/default.nix
@@ -2,12 +2,12 @@
 
 let
   pname = "electron-mail";
-  version = "4.14.0";
+  version = "5.0.1";
   name = "ElectronMail-${version}";
 
   src = fetchurl {
     url = "https://github.com/vladimiry/ElectronMail/releases/download/v${version}/electron-mail-${version}-linux-x86_64.AppImage";
-    sha256 = "sha256-sahMEj9m10gsceTBnYk8wkWcQoM5s6s1ek1U6u3PTgw=";
+    sha256 = "sha256-w6ZZPIJnAlA8WhNHtM9gsjr7U6wMYT21fGFmkDDAVJU=";
   };
 
   appimageContents = appimageTools.extract { inherit name src; };
@@ -30,7 +30,7 @@ in appimageTools.wrapType2 {
   meta = with lib; {
     description = "ElectronMail is an Electron-based unofficial desktop client for ProtonMail";
     homepage = "https://github.com/vladimiry/ElectronMail";
-    license = licenses.mit;
+    license = licenses.gpl3;
     maintainers = [ maintainers.princemachiavelli ];
     platforms = [ "x86_64-linux" ];
   };


### PR DESCRIPTION
###### Description of changes
Update to latest upstream release [5.0.1](https://github.com/vladimiry/ElectronMail/releases/tag/v5.0.1). Resolves #181507.
- [view changes on GitHub](https://github.com/vladimiry/ElectronMail/compare/v4.14.0...v5.0.1)

The license was already changed from mit to gpl3 a year ago.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).