### PR TITLE
gnomeExtensions.argos: init at 20220930

### DIFF
--- a/pkgs/desktops/gnome/extensions/argos/default.nix
+++ b/pkgs/desktops/gnome/extensions/argos/default.nix
@@ -1,0 +1,30 @@
+{ fetchFromGitHub, lib, stdenv }:
+
+stdenv.mkDerivation rec {
+  pname = "argos-unstable";
+  version = "20220930";
+
+  src = fetchFromGitHub {
+    owner = "p-e-w";
+    repo = "argos";
+    rev = "f5f6f5bf6ab33dd2d65a490efe8faac5a0c07dc6";
+    hash = "sha256-kI8EpZ68loM5oOS9Dkde+dkldD08mo9VcDqNhecyTOU=";
+  };
+
+  installPhase = ''
+    mkdir -p "$out/share/gnome-shell/extensions"
+    cp -a argos@pew.worldwidemann.com "$out/share/gnome-shell/extensions"
+  '';
+
+  passthru = {
+    extensionUuid = "argos@pew.worldwidemann.com";
+    extensionPortalSlug = "argos";
+  };
+
+  meta = with lib; {
+    description = "Create GNOME Shell extensions in seconds";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ andersk ];
+    homepage = "https://github.com/p-e-w/argos";
+  };
+}

--- a/pkgs/desktops/gnome/extensions/manuallyPackaged.nix
+++ b/pkgs/desktops/gnome/extensions/manuallyPackaged.nix
@@ -1,6 +1,7 @@
 { callPackage }:
 {
   "arcmenu@arcmenu.com" = callPackage ./arcmenu { };
+  "argos@pew.worldwidemann.com" = callPackage ./argos { };
   "clock-override@gnomeshell.kryogenix.org" = callPackage ./clock-override { };
   "dash-to-dock@micxgx.gmail.com" = callPackage ./dash-to-dock { };
   "drop-down-terminal@gs-extensions.zzrough.org" = callPackage ./drop-down-terminal { };


### PR DESCRIPTION
###### Description of changes

Package the [Argos](https://github.com/p-e-w/argos) GNOME shell extension, which lets you add custom information and menus to the panel by writing a script that prints to stdout.

It’s [on the extensions portal](https://extensions.gnome.org/extension/1176/argos/), but the latest Git version is required for GNOME 42 compatibility.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
