### PR TITLE
python310Packages.hypothesis: run tests

### DIFF
--- a/pkgs/development/python-modules/hypothesis/default.nix
+++ b/pkgs/development/python-modules/hypothesis/default.nix
@@ -4,7 +4,6 @@
 , attrs
 , exceptiongroup
 , pexpect
-, doCheck ? true
 , pytestCheckHook
 , pytest-xdist
 , sortedcontainers
@@ -17,76 +16,86 @@
 , enableDocumentation ? true
 }:
 
-buildPythonPackage rec {
-  pname = "hypothesis";
-  version = "6.68.2";
-  outputs = [ "out" ] ++ lib.optional enableDocumentation "doc";
-  format = "setuptools";
+let
+  self = buildPythonPackage rec {
+    pname = "hypothesis";
+    version = "6.68.2";
+    outputs = [ "out" ] ++ lib.optional enableDocumentation "doc";
+    format = "setuptools";
 
-  disabled = pythonOlder "3.7";
+    disabled = pythonOlder "3.7";
 
-  src = fetchFromGitHub {
-    owner = "HypothesisWorks";
-    repo = "hypothesis";
-    rev = "hypothesis-python-${version}";
-    hash = "sha256-SgX8esTyC3ulFIv9mZJUoBA5hiv7Izr2hyD+NOudkpE=";
+    src = fetchFromGitHub {
+      owner = "HypothesisWorks";
+      repo = "hypothesis";
+      rev = "hypothesis-python-${version}";
+      hash = "sha256-SgX8esTyC3ulFIv9mZJUoBA5hiv7Izr2hyD+NOudkpE=";
+    };
+
+    # I tried to package sphinx-selective-exclude, but it throws
+    # error about "module 'sphinx' has no attribute 'directives'".
+    #
+    # It probably has to do with monkey-patching internals of Sphinx.
+    # On bright side, this extension does not introduces new commands,
+    # only changes "::only" command, so we probably okay with stock
+    # implementation.
+    #
+    # I wonder how upstream of "hypothesis" builds documentation.
+    postPatch = ''
+      sed -i -e '/sphinx_selective_exclude.eager_only/ d' docs/conf.py
+    '';
+
+    sourceRoot = "${src.name}/hypothesis-python";
+
+    nativeBuildInputs = lib.optionals enableDocumentation [
+      sphinxHook
+      sphinx-rtd-theme
+      sphinx-hoverxref
+      sphinx-codeautolink
+    ];
+
+    propagatedBuildInputs = [
+      attrs
+      sortedcontainers
+    ] ++ lib.optionals (pythonOlder "3.11") [
+      exceptiongroup
+    ];
+
+    nativeCheckInputs = [
+      pexpect
+      pytest-xdist
+      pytestCheckHook
+    ];
+
+    # Avoid cyclic dependency with pytest
+    doCheck = false;
+
+    # avoid coverage, and allow for xdist to be used
+    preCheck = ''
+      rm tox.ini
+
+      export HOME=$TMPDIR
+    '';
+
+    pytestFlagsArray = [
+      "tests/cover"
+      "-o cache_dir=$HOME/pytest-cache"
+    ];
+
+    pythonImportsCheck = [
+      "hypothesis"
+    ];
+
+    passthru.tests.hypothesisWithTests = self.overrideAttrs (_: {
+      doCheck = true;
+    });
+
+    meta = with lib; {
+      description = "Library for property based testing";
+      homepage = "https://github.com/HypothesisWorks/hypothesis";
+      changelog = "https://hypothesis.readthedocs.io/en/latest/changes.html#v${lib.replaceStrings [ "." ] [ "-" ] version}";
+      license = licenses.mpl20;
+      maintainers = with maintainers; [ SuperSandro2000 ];
+    };
   };
-
-  # I tried to package sphinx-selective-exclude, but it throws
-  # error about "module 'sphinx' has no attribute 'directives'".
-  #
-  # It probably has to do with monkey-patching internals of Sphinx.
-  # On bright side, this extension does not introduces new commands,
-  # only changes "::only" command, so we probably okay with stock
-  # implementation.
-  #
-  # I wonder how upstream of "hypothesis" builds documentation.
-  postPatch = ''
-    sed -i -e '/sphinx_selective_exclude.eager_only/ d' docs/conf.py
-  '';
-
-  postUnpack = "sourceRoot=$sourceRoot/hypothesis-python";
-
-  nativeBuildInputs = lib.optionals enableDocumentation [
-    sphinxHook
-    sphinx-rtd-theme
-    sphinx-hoverxref
-    sphinx-codeautolink
-  ];
-
-  propagatedBuildInputs = [
-    attrs
-    sortedcontainers
-  ] ++ lib.optionals (pythonOlder "3.11") [
-    exceptiongroup
-  ];
-
-  nativeCheckInputs = [
-    pexpect
-    pytest-xdist
-    pytestCheckHook
-  ];
-
-  inherit doCheck;
-
-  # This file changes how pytest runs and breaks it
-  preCheck = ''
-    rm tox.ini
-  '';
-
-  pytestFlagsArray = [
-    "tests/cover"
-  ];
-
-  pythonImportsCheck = [
-    "hypothesis"
-  ];
-
-  meta = with lib; {
-    description = "Library for property based testing";
-    homepage = "https://github.com/HypothesisWorks/hypothesis";
-    changelog = "https://hypothesis.readthedocs.io/en/latest/changes.html#v${lib.replaceStrings [ "." ] [ "-" ] version}";
-    license = licenses.mpl20;
-    maintainers = with maintainers; [ SuperSandro2000 ];
-  };
-}
+in self


### PR DESCRIPTION
###### Description of changes

~~To reduce the runtime closure of any package which uses hypothesis, avoid having to use a version that exports tests altogether. The test suite will still be ran for PRs, but we can avoid it in normal usage of hypothesis itself.~~

We want to run tests

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
