### PR TITLE
dotnet-sdk_3: 3.1.420 -> 3.1.422

### DIFF
--- a/pkgs/development/compilers/dotnet/update.sh
+++ b/pkgs/development/compilers/dotnet/update.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -I nixpkgs=../../../../. -i bash -p curl jq nix gnused
+# shellcheck shell=bash
 
 set -euo pipefail
 
@@ -67,6 +68,18 @@ generate_package_list() {
     done
 }
 
+version_older () {
+    cur_version=$1
+    max_version=$2
+    result=$(nix-instantiate -I ../../../../. \
+        --eval -E "(import <nixpkgs> {}).lib.versionOlder \"$cur_version\" \"$max_version\"")
+    if [[ "$result" == "true" ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
 aspnetcore_packages () {
     local version=$1
     # These packages are implicitly references by the build process,
@@ -92,20 +105,27 @@ aspnetcore_packages () {
     # This should not happend in minor or bugfix updates, but probably happens
     # with every new major .NET release.
     local pkgs=( \
-      "Microsoft.AspNetCore.App.Ref" \
       "Microsoft.AspNetCore.App.Runtime.linux-arm" \
       "Microsoft.AspNetCore.App.Runtime.linux-arm64" \
-      "Microsoft.AspNetCore.App.Runtime.linux-musl-arm" \
       "Microsoft.AspNetCore.App.Runtime.linux-musl-arm64" \
       "Microsoft.AspNetCore.App.Runtime.linux-musl-x64" \
       "Microsoft.AspNetCore.App.Runtime.linux-x64" \
-      "Microsoft.AspNetCore.App.Runtime.osx-arm64" \
       "Microsoft.AspNetCore.App.Runtime.osx-x64" \
       "Microsoft.AspNetCore.App.Runtime.win-arm" \
       "Microsoft.AspNetCore.App.Runtime.win-arm64" \
       "Microsoft.AspNetCore.App.Runtime.win-x64" \
       "Microsoft.AspNetCore.App.Runtime.win-x86" \
     )
+
+    # Packages that only apply to .NET 6 and up
+    if ! version_older "$version" "6"; then
+        pkgs+=( \
+          "Microsoft.AspNetCore.App.Ref" \
+          "Microsoft.AspNetCore.App.Runtime.linux-musl-arm" \
+          "Microsoft.AspNetCore.App.Runtime.osx-arm64" \
+        )
+    fi
+
 
     generate_package_list "$version" "${pkgs[@]}"
 }
@@ -135,35 +155,21 @@ sdk_packages () {
     # This should not happend in minor or bugfix updates, but probably happens
     # with every new major .NET release.
     local pkgs=( \
-      "Microsoft.NETCore.App.Composite" \
       "Microsoft.NETCore.App.Host.linux-arm" \
       "Microsoft.NETCore.App.Host.linux-arm64" \
-      "Microsoft.NETCore.App.Host.linux-musl-arm" \
       "Microsoft.NETCore.App.Host.linux-musl-arm64" \
       "Microsoft.NETCore.App.Host.linux-musl-x64" \
       "Microsoft.NETCore.App.Host.linux-x64" \
-      "Microsoft.NETCore.App.Host.osx-arm64" \
       "Microsoft.NETCore.App.Host.osx-x64" \
       "Microsoft.NETCore.App.Host.win-arm" \
       "Microsoft.NETCore.App.Host.win-arm64" \
       "Microsoft.NETCore.App.Host.win-x64" \
       "Microsoft.NETCore.App.Host.win-x86" \
-      "Microsoft.NETCore.App.Ref" \
       "Microsoft.NETCore.App.Runtime.linux-arm" \
       "Microsoft.NETCore.App.Runtime.linux-arm64" \
-      "Microsoft.NETCore.App.Runtime.linux-musl-arm" \
       "Microsoft.NETCore.App.Runtime.linux-musl-arm64" \
       "Microsoft.NETCore.App.Runtime.linux-musl-x64" \
       "Microsoft.NETCore.App.Runtime.linux-x64" \
-      "Microsoft.NETCore.App.Runtime.Mono.linux-arm" \
-      "Microsoft.NETCore.App.Runtime.Mono.linux-arm64" \
-      "Microsoft.NETCore.App.Runtime.Mono.linux-musl-x64" \
-      "Microsoft.NETCore.App.Runtime.Mono.linux-x64" \
-      "Microsoft.NETCore.App.Runtime.Mono.osx-arm64" \
-      "Microsoft.NETCore.App.Runtime.Mono.osx-x64" \
-      "Microsoft.NETCore.App.Runtime.Mono.win-x64" \
-      "Microsoft.NETCore.App.Runtime.Mono.win-x86" \
-      "Microsoft.NETCore.App.Runtime.osx-arm64" \
       "Microsoft.NETCore.App.Runtime.osx-x64" \
       "Microsoft.NETCore.App.Runtime.win-arm" \
       "Microsoft.NETCore.App.Runtime.win-arm64" \
@@ -185,10 +191,6 @@ sdk_packages () {
       "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHost" \
       "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHostPolicy" \
       "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHostResolver" \
-      "runtime.linux-musl-arm.Microsoft.NETCore.DotNetAppHost" \
-      "runtime.linux-musl-arm.Microsoft.NETCore.DotNetHost" \
-      "runtime.linux-musl-arm.Microsoft.NETCore.DotNetHostPolicy" \
-      "runtime.linux-musl-arm.Microsoft.NETCore.DotNetHostResolver" \
       "runtime.linux-musl-x64.Microsoft.NETCore.DotNetAppHost" \
       "runtime.linux-musl-x64.Microsoft.NETCore.DotNetHost" \
       "runtime.linux-musl-x64.Microsoft.NETCore.DotNetHostPolicy" \
@@ -197,10 +199,6 @@ sdk_packages () {
       "runtime.linux-x64.Microsoft.NETCore.DotNetHost" \
       "runtime.linux-x64.Microsoft.NETCore.DotNetHostPolicy" \
       "runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver" \
-      "runtime.osx-arm64.Microsoft.NETCore.DotNetAppHost" \
-      "runtime.osx-arm64.Microsoft.NETCore.DotNetHost" \
-      "runtime.osx-arm64.Microsoft.NETCore.DotNetHostPolicy" \
-      "runtime.osx-arm64.Microsoft.NETCore.DotNetHostResolver" \
       "runtime.osx-x64.Microsoft.NETCore.DotNetAppHost" \
       "runtime.osx-x64.Microsoft.NETCore.DotNetHost" \
       "runtime.osx-x64.Microsoft.NETCore.DotNetHostPolicy" \
@@ -223,8 +221,36 @@ sdk_packages () {
       "runtime.win-x86.Microsoft.NETCore.DotNetHostResolver" \
     )
 
+    # Packages that only apply to .NET 6 and up
+    if ! version_older "$version" "6"; then
+        pkgs+=( \
+          "Microsoft.NETCore.App.Composite" \
+          "Microsoft.NETCore.App.Host.linux-musl-arm" \
+          "Microsoft.NETCore.App.Host.osx-arm64" \
+          "Microsoft.NETCore.App.Runtime.linux-musl-arm" \
+          "Microsoft.NETCore.App.Runtime.osx-arm64" \
+          "Microsoft.NETCore.App.Ref" \
+          "Microsoft.NETCore.App.Runtime.Mono.linux-arm" \
+          "Microsoft.NETCore.App.Runtime.Mono.linux-arm64" \
+          "Microsoft.NETCore.App.Runtime.Mono.linux-musl-x64" \
+          "Microsoft.NETCore.App.Runtime.Mono.linux-x64" \
+          "Microsoft.NETCore.App.Runtime.Mono.osx-arm64" \
+          "Microsoft.NETCore.App.Runtime.Mono.osx-x64" \
+          "Microsoft.NETCore.App.Runtime.Mono.win-x64" \
+          "Microsoft.NETCore.App.Runtime.Mono.win-x86" \
+          "runtime.linux-musl-arm.Microsoft.NETCore.DotNetAppHost" \
+          "runtime.linux-musl-arm.Microsoft.NETCore.DotNetHost" \
+          "runtime.linux-musl-arm.Microsoft.NETCore.DotNetHostPolicy" \
+          "runtime.linux-musl-arm.Microsoft.NETCore.DotNetHostResolver" \
+          "runtime.osx-arm64.Microsoft.NETCore.DotNetAppHost" \
+          "runtime.osx-arm64.Microsoft.NETCore.DotNetHost" \
+          "runtime.osx-arm64.Microsoft.NETCore.DotNetHostPolicy" \
+          "runtime.osx-arm64.Microsoft.NETCore.DotNetHostResolver" \
+        )
+    fi
+
     # Packages that only apply to .NET 7 and up
-    if [[ ! ( "$version" =~ ^[1-6]\. ) ]]; then
+    if ! version_older "$version" "7"; then
         # ILCompiler requires nixpkgs#181373 to be fixed to work properly
         pkgs+=( \
           "runtime.linux-arm64.Microsoft.DotNet.ILCompiler" \

--- a/pkgs/development/compilers/dotnet/versions/3.1.nix
+++ b/pkgs/development/compilers/dotnet/versions/3.1.nix
@@ -4,61 +4,134 @@
 {
   aspnetcore_3_1 = buildAspNetCore {
     inherit icu;
-    version = "3.1.26";
+    version = "3.1.28";
     srcs = {
       x86_64-linux = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/6f72adf7-0e78-48ea-85ef-e72a39a1f8a1/1ec0238c236c3757e5628563a329fdc4/aspnetcore-runtime-3.1.26-linux-x64.tar.gz";
-        sha512  = "8bbf06012cdd2cff23c592e0d3c49d032d77add4dda8fba1d7ba73e6cc4ae97b1676908b14cdc7fc2fe723302e1efd27a44b48190a91d69c0e41bb5edb47501f";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/effaa5bf-0fa7-4e5a-9ce8-9ac04ee86669/5afb2b1c2ad68550cec914d8fb303d20/aspnetcore-runtime-3.1.28-linux-x64.tar.gz";
+        sha512  = "fd66f9c0d0e9ed57abe5f81650c2ff49c694e05927e5280dbbdee1a9eb4299f0710bdc06ae0af0737c0a0584970b24d3eb952434b45ad8984fe3e37ca95cc1b1";
       };
       aarch64-linux = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/6b68a14a-b4dd-4a75-bb32-26c08d19190f/1d6b637e290775f668701f8f6092ab35/aspnetcore-runtime-3.1.26-linux-arm64.tar.gz";
-        sha512  = "757ff6cbc31b1c8743077288d7fa621c73fa7f4d155d636ad100cda6e1f601e31d2f842d5cfef3dec5daa4c8c3efbcf76f02afd1c518cae7b67b2a46a9faab08";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/75b4f8b5-8aeb-4ba1-956d-bfc17ba5d6b3/bb3744801157ebc769808a92eabeee5c/aspnetcore-runtime-3.1.28-linux-arm64.tar.gz";
+        sha512  = "28371a6888d41e938f14cceb6c8a4471a1f0d7b585045e65b914f23ffb894f72a66a4a4cdaaf6d21dfd60063bb35d88c36fce8d4411a89c89b52023807639f82";
       };
       x86_64-darwin = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/33e8be5c-5e6a-4dc2-9aa8-846aaffa6897/fe9d96af1d75f8d5f4cba4bff95f2fae/aspnetcore-runtime-3.1.26-osx-x64.tar.gz";
-        sha512  = "0657d8b11a58357f5374e5d8201b401e55f9f4710794be565f7b9022d10639c2e72aebc6b7433b34fd24a03e8e12541c998fad28b5263de4439b3d31a8252c4c";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/a9ad2468-f18b-4d35-9b9d-f2bccc681bdc/b3100ca07ee0e8dc4ef958921d4adbfa/aspnetcore-runtime-3.1.28-osx-x64.tar.gz";
+        sha512  = "965b23a32a9734c72515430e05d395db506a3a802997a6268ed42e24a700f06e5971cd38102f4ceb9c9d85d8515c1b0d11d4e5fbf8adc00c14060cb503a8faf1";
       };
     };
   };
 
   runtime_3_1 = buildNetRuntime {
     inherit icu;
-    version = "3.1.26";
+    version = "3.1.28";
     srcs = {
       x86_64-linux = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/a14c8e4d-a22b-47f8-953c-bb4337634513/58017d103d432f7106c44b0891936aba/dotnet-runtime-3.1.26-linux-x64.tar.gz";
-        sha512  = "03676885ec4d1f5ba184678a6b774f8e385abfff800a6bcee6f85557b39e9cdde500be49b5d6c956fc95cdfb9f33d31e467548bb498a52bc4fd639b3cb87c8d0";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/9a0b8ff8-d3da-4e77-9b5b-2fb3202afbbe/94dbcaacd4ebf59106a141c8e9e84167/dotnet-runtime-3.1.28-linux-x64.tar.gz";
+        sha512  = "b0760d463b8935a14bc247899b692038ded7d476a0cf2ed262eaac8ee6840350b29738cd1ab4961ba93b05f1802e7aba6e3c5e27e06ec9cb5e244149c52adea4";
       };
       aarch64-linux = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/cb0e8b4b-7b2b-40cc-b7a6-30f0d4fabe6c/f5cb06cbb1b1b5d198792333b3db235a/dotnet-runtime-3.1.26-linux-arm64.tar.gz";
-        sha512  = "574409616f5cbef35a2bd6fd1a2f0bcb3bdaa81457aea3af5e0e237ba768ced5214c51a3045697fe7478e8211e2045fc2072e382d6f456509a8f2923e9b1fc26";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/d71449b4-4504-410b-a805-48b3a6af5182/06abb8b35645e76dbe8cc4d17fdcbf89/dotnet-runtime-3.1.28-linux-arm64.tar.gz";
+        sha512  = "feb65d2926e21df802c600c8c8c060d15cf44458150b2be8a5d9dc42735cb89d1a5e990121f7ba5813d6f8acf88b6e6bae11d078156c84023e1337b917219b17";
       };
       x86_64-darwin = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/6bedea65-b104-45b8-abe9-36cefbeedadf/05f4e472ec2395dad7103fda9ed278b2/dotnet-runtime-3.1.26-osx-x64.tar.gz";
-        sha512  = "7957b5e697db7548964c399197ae8e61cc31f15374df384b6db9b47472a7d6f1b5b3e256c191e203c4d18c18cc8bdb6c4a331c5875bd37bd6415f3c83b8062da";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/ff22de78-4644-4395-a187-3910c27222d6/95c5a5334aa3c861238518a66696efa2/dotnet-runtime-3.1.28-osx-x64.tar.gz";
+        sha512  = "ad6ad23b08460eb09b5019760083906df96d064a5f0a34aa9b31b4e1eb4c8313ee59c1f3717056e3e9f4db8310329f9aed368bea6bba3c0a86c4a4ec7083bbb9";
       };
     };
   };
 
   sdk_3_1 = buildNetSdk {
     inherit icu;
-    version = "3.1.420";
+    version = "3.1.422";
     srcs = {
       x86_64-linux = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/5424da8c-ce12-46de-a51a-8fa61aefdde6/52a9d6b5718ea40863db96901c780d4b/dotnet-sdk-3.1.420-linux-x64.tar.gz";
-        sha512  = "b3bdd964182f9edc3c2976541e657fcc43b0eaf9bc97197597c7ecb8b784d79e3efb9e0405c84e1dcb434cf4cd38ddc4af628c5df486c3d7ae8a23e5254796e3";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/4fd83694-c9ad-487f-bf26-ef80f3cbfd9e/6ca93b498019311e6f7732717c350811/dotnet-sdk-3.1.422-linux-x64.tar.gz";
+        sha512  = "690759982b12cce7a06ed22b9311ec3b375b8de8600bd647c0257c866d2f9c99d7c9add4a506f4c6c37ef01db85c0f7862d9ae3de0d11e9bec60958bd1b3b72c";
       };
       aarch64-linux = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/a84bf296-ee6e-4e66-9694-90d3da7af2b4/b00b2efe2432938e5a19c45d3759d80f/dotnet-sdk-3.1.420-linux-arm64.tar.gz";
-        sha512  = "ac66b1544fe178153bb85c2e5be584464374ce4c036fc95720547c231c2730312018fbdfc735f9071579749415bc54e1f6b8f080cc2b08d5799a0da941e8a5f5";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/fdf76122-e9d5-4f66-b96f-4dd0c64e5bea/d756ca70357442de960db145f9b4234d/dotnet-sdk-3.1.422-linux-arm64.tar.gz";
+        sha512  = "3eb7e066568dfc0135f2b3229d0259db90e1920bb413f7e175c9583570146ad593b50ac39c77fb67dd3f460b4621137f277c3b66c44206767b1d28e27bf47deb";
       };
       x86_64-darwin = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/bb0efe58-450c-4e28-81c1-4081acd6ffa4/1d0eaf8b624dff000c8b10ea0497e731/dotnet-sdk-3.1.420-osx-x64.tar.gz";
-        sha512  = "370cba4685e07d1cdb5d7f9b754812b237802ace679c9b9985c6e5c4dc09f500580f1413679a288615079bd155b68b362adb00151b2b8f5ca7c3718ab9e16194";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/515fcb39-1e67-4cf5-908e-0e00f3cd76b2/6478e6b98726db240cb6b572f9eab97e/dotnet-sdk-3.1.422-osx-x64.tar.gz";
+        sha512  = "9f919e42a692e048405b52cce8938fd4c40e7dcdf9c6c29eaa41940af7846cd2a678b5c43222d1cb988236917e47d85f37212bfe0c2dc6973cd5a8f2799838ff";
       };
     };
     packages = { fetchNuGet }: [
-
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-arm"; version = "3.1.28"; sha256 = "0ssf6qdsaihg86pb39162xi5sfnv6b2na85brk6h3gcw2ydqfgbc"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-arm64"; version = "3.1.28"; sha256 = "0gri8zsq5qk5czfg2ik9fc0a3nscz2jn7g1knsp717qxix31ilaf"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-musl-arm64"; version = "3.1.28"; sha256 = "0wp5nrb63k9p5850bfqjscf0hjyqi5dcw8vsymnfnjdd06zldp6j"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-musl-x64"; version = "3.1.28"; sha256 = "16p8z8n47w7m89wy34wh7zyg8a21hbsv8vswrw3b6gh3r861jg24"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-x64"; version = "3.1.28"; sha256 = "1cvgplsmg6d9bgxr7lnnnh7lhcmwhn3r08cnw4di9x92xaysgzwg"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.osx-x64"; version = "3.1.28"; sha256 = "1zv3vjifjcd56q8xp47998d4016a8ma8x0a2pdlki2kghwjjpmcv"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.win-arm"; version = "3.1.28"; sha256 = "0myfvrwn13z8l6j294jw9qrdzg4ld9dp683jdmy657q30vxqj9ci"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.win-arm64"; version = "3.1.28"; sha256 = "1dhg0p820mg2v0gh9yd4snh062cbz0mg106idrii8mhkn09na698"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.win-x64"; version = "3.1.28"; sha256 = "04ss3gd6frf7p9ipry427a0cw9jh4l1xapq3sc0p33hd9g3ggkp3"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.win-x86"; version = "3.1.28"; sha256 = "07r9gd9gc4b0h7fdswk3c4bf617fkcy5jw9y2y8rm97c1gfxph3p"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-arm"; version = "3.1.28"; sha256 = "186i94wddk4j93pqmwzr6fdrf8vqhlipansjfpp530l8d3zba7zp"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-arm64"; version = "3.1.28"; sha256 = "0asdcnqf2vr9v159brdhg0wmfbvh8gl9n14ynv0h561dkdlps7fr"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-musl-arm64"; version = "3.1.28"; sha256 = "0y5m5azblkr2vi8qba83mnad7irmywn7i1b154yig9r09245plgp"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-musl-x64"; version = "3.1.28"; sha256 = "0bm99w4v4mw9nj400szvywripgv8vk96vyxmpr0vq96fpzkx66wr"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-x64"; version = "3.1.28"; sha256 = "09974p9xl37x3dgclpvv280kiclnlvlwg31id8bkrz7ir8iafwbx"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.osx-x64"; version = "3.1.28"; sha256 = "10rrf9gj81viisb31mc0nq90wr9fbnljzi0vn7bpylj68072sqi2"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.win-arm"; version = "3.1.28"; sha256 = "00wcigwd6pphmcb19pj6krj4p8ydzzclgvjxqj45fdj8ja94d0dq"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.win-arm64"; version = "3.1.28"; sha256 = "1rpj5mscc0b15dr6fphrb6lbkycd58d95n6r4vm40124c17nrp70"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.win-x64"; version = "3.1.28"; sha256 = "15fp5g6334ri43vk4cas50b1fg31y0l7inba1z7fwbcrlf7kj72k"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.win-x86"; version = "3.1.28"; sha256 = "1ac9538bx4l4skk295q6d3hm3yfrf3b57zavhlpy8wpclg97wqmc"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-arm"; version = "3.1.28"; sha256 = "0g2wdkm9dcs3d106r80q84i5plwhgnv34abpda8id993dprjpkg1"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-arm64"; version = "3.1.28"; sha256 = "175195fbgrzxs4zmgnx9xy3mlzdvbd8mrlya2is2s0pa0dz3aw61"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-musl-arm64"; version = "3.1.28"; sha256 = "03n58cibw0dk782yrxargnbcrhwv43pvyiic71hvf2kh6hi282gp"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-musl-x64"; version = "3.1.28"; sha256 = "1xs1x03xmmxpy686wydb2v9b3vwb57lhjdxm4spsh74n0iwgbznq"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-x64"; version = "3.1.28"; sha256 = "0pn000bgrb0lmqy34np3q974n3x4cv6rz1rc0w5n7kfnrlpwl15l"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.osx-x64"; version = "3.1.28"; sha256 = "0hgj4pib1ckl38hd197g9x22dvb2h0302zny6za6156sblizypr4"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.win-arm"; version = "3.1.28"; sha256 = "0irh5riigrpq0wfqsbphf3r1a4w29p547pnml8h5997mmch5ds13"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.win-arm64"; version = "3.1.28"; sha256 = "0fayr4rp3ykn0rp3jir81x9ilvg3hfj8s86raxv19k54x15grqw7"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.win-x64"; version = "3.1.28"; sha256 = "1j4hf84ycjhna8ng8hxl3bmwwbnzcfbsj751widwhlbnsy7vdiy4"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.win-x86"; version = "3.1.28"; sha256 = "0mb5kr8rqgh4m01n20xdw8ji87ixxan9qkbjjr7amiv38x1aimfa"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.DotNetAppHost"; version = "3.1.28"; sha256 = "16jm0pcjhmc83f5c5hk2n40xc73jg9358yw1mwm35jp5z15n9nah"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.DotNetHost"; version = "3.1.28"; sha256 = "184qcjc3h70q1w3mjjbmw7w7fq4j6daw5hk53zgbpicfd928i5fm"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.28"; sha256 = "1vx08xz65mapyjs6ixnn31c95i9b35h8fry4djdz167794zj2w0z"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.DotNetHostResolver"; version = "3.1.28"; sha256 = "18jnw2cp3vpm9zkfbjv51gpl5786hsf5fdm6y89c5m25pckilvgi"; })
+      (fetchNuGet { pname = "runtime.linux-arm64.Microsoft.NETCore.DotNetAppHost"; version = "3.1.28"; sha256 = "0k4qv1srcsyq9c0d0xik5bjrng6sxsl6c1n9f8q0vyar63d4dm6y"; })
+      (fetchNuGet { pname = "runtime.linux-arm64.Microsoft.NETCore.DotNetHost"; version = "3.1.28"; sha256 = "1knlnq8xn3z87h2pwp12rcfiwzv7rf9h9245dhsaq0kv0h2173w5"; })
+      (fetchNuGet { pname = "runtime.linux-arm64.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.28"; sha256 = "11m6hvf56iq7q736mx21yrk14qnbyz4ahm8517pz9amiilwnwdcg"; })
+      (fetchNuGet { pname = "runtime.linux-arm64.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.28"; sha256 = "1hp6cysrhm0fn18bmiicy0plvpcplrjbxn792ps6iipn82hfxlfa"; })
+      (fetchNuGet { pname = "runtime.linux-arm.Microsoft.NETCore.DotNetAppHost"; version = "3.1.28"; sha256 = "1b6rlnazbm9h3rwdz2qglqbn44qxbzny8x0cnj5aqa9wxg0ipkqw"; })
+      (fetchNuGet { pname = "runtime.linux-arm.Microsoft.NETCore.DotNetHost"; version = "3.1.28"; sha256 = "1klfr2a842xflc48mw2zds4cb8s95p1m2yb3w0h58rnpkry4r8cw"; })
+      (fetchNuGet { pname = "runtime.linux-arm.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.28"; sha256 = "01v74s41kyysy8v4q20zbl1ba9n6sc55mizybvgjl869h437bikf"; })
+      (fetchNuGet { pname = "runtime.linux-arm.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.28"; sha256 = "039an5v5yck70pl4y3h3nphf6jga6vl071iiakv5siccvkpg2zcr"; })
+      (fetchNuGet { pname = "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetAppHost"; version = "3.1.28"; sha256 = "03fmzxhhxdvs36zjp38h39g1x4zzabfhfac5k5a80m23kh8zk199"; })
+      (fetchNuGet { pname = "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHost"; version = "3.1.28"; sha256 = "0k7ngxhn39ybx3z64bds7kzwmnpyfzpyx6gyv8l0zw9gzaiakmzx"; })
+      (fetchNuGet { pname = "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.28"; sha256 = "0254fw61xcmvlah2c5fpl4ifslph9vqavba8b7i2b8hjj1ah569x"; })
+      (fetchNuGet { pname = "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.28"; sha256 = "0219z3dqiygl8j8q3khxdvkvpzb4lpk5r76an47lnxpqkw90ip4k"; })
+      (fetchNuGet { pname = "runtime.linux-musl-x64.Microsoft.NETCore.DotNetAppHost"; version = "3.1.28"; sha256 = "0ndcp8b1is2h9rjrkn9hs468n9z619qpbqcnj11algpj0gcs00qn"; })
+      (fetchNuGet { pname = "runtime.linux-musl-x64.Microsoft.NETCore.DotNetHost"; version = "3.1.28"; sha256 = "1fz9r6n018rzqarabfkqdbzm0d6nnprkx1cpyplxl6kmc60gp9f7"; })
+      (fetchNuGet { pname = "runtime.linux-musl-x64.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.28"; sha256 = "19lavwarm8svf725vilh1zzwlx27khy27n7nw9d1cvi40r3vpvfp"; })
+      (fetchNuGet { pname = "runtime.linux-musl-x64.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.28"; sha256 = "0b6wa3a479d4w1zxgk748q70nkcrzs3c2snlxhhciz4bv09mrbd3"; })
+      (fetchNuGet { pname = "runtime.linux-x64.Microsoft.NETCore.DotNetAppHost"; version = "3.1.28"; sha256 = "1pj7i6kdf8k31d9bczkggn6fdjrjigzsrvmh24zfz2n3q48g0grc"; })
+      (fetchNuGet { pname = "runtime.linux-x64.Microsoft.NETCore.DotNetHost"; version = "3.1.28"; sha256 = "0llnj78c9ds5y2cg2f1q1mz1kbmzm9vs35hq942d4lfv1hpxbd4n"; })
+      (fetchNuGet { pname = "runtime.linux-x64.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.28"; sha256 = "1nlxmpzb7qgznx0wmm6zci26y7wvkwndq34d4jm310g8qzrqkxn8"; })
+      (fetchNuGet { pname = "runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.28"; sha256 = "0lbsyn96a3nfy94x9n6k9aka5v7q34hbbjdjd0w0is7njrly1xg4"; })
+      (fetchNuGet { pname = "runtime.osx-x64.Microsoft.NETCore.DotNetAppHost"; version = "3.1.28"; sha256 = "0qyf2n35bn0wp4iy4f2whfm1syl44k42g3md2dbivppdc16qs828"; })
+      (fetchNuGet { pname = "runtime.osx-x64.Microsoft.NETCore.DotNetHost"; version = "3.1.28"; sha256 = "091iff9mpp837vakyy5h7mqh1m90gz9x76ch5n49znq7qf819jz4"; })
+      (fetchNuGet { pname = "runtime.osx-x64.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.28"; sha256 = "0byn4ng5cs54r1gz84wz9g914n0dby643fs4iyx14v5pg9ns7m7y"; })
+      (fetchNuGet { pname = "runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.28"; sha256 = "0jh7kmgxjf4xpsbxyf86yfq4ff0lxrhcykhc9mqizmgsp3kdzg36"; })
+      (fetchNuGet { pname = "runtime.win-arm64.Microsoft.NETCore.DotNetAppHost"; version = "3.1.28"; sha256 = "1x7xkjvx2j7khr6iafl1dvzsfqswr54y79lf17w8m196lbsvn13j"; })
+      (fetchNuGet { pname = "runtime.win-arm64.Microsoft.NETCore.DotNetHost"; version = "3.1.28"; sha256 = "18nqdrm8d2xdf7cq7hcbh5v2fa28kdyx682bb0wb4w06x4gziy55"; })
+      (fetchNuGet { pname = "runtime.win-arm64.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.28"; sha256 = "06gfp66ax9m2jhd07alcn0dp8hyxkyi934wy8asl64y1c08rhh09"; })
+      (fetchNuGet { pname = "runtime.win-arm64.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.28"; sha256 = "01q1vs13ifnbqywpmdli83w7bdhph88njz15dhmx7kxjadcicclc"; })
+      (fetchNuGet { pname = "runtime.win-arm.Microsoft.NETCore.DotNetAppHost"; version = "3.1.28"; sha256 = "1kd6np0i0wfz5kpq2528by8sxmp2q7fdsncks9s7sk9s2am6q6wr"; })
+      (fetchNuGet { pname = "runtime.win-arm.Microsoft.NETCore.DotNetHost"; version = "3.1.28"; sha256 = "1r9j70gykblfqd2cxnnhb0hpj0pidn9kk7c7v20bmnkv0vn8nb27"; })
+      (fetchNuGet { pname = "runtime.win-arm.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.28"; sha256 = "0aqinv4s9n61i66dd499x1adiw64a83iscddjaxml4qzyffp3v2g"; })
+      (fetchNuGet { pname = "runtime.win-arm.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.28"; sha256 = "13n0lshgwpwizz7zqm6cph621bk2ayhkkimfmp60wz0s9mhx78f3"; })
+      (fetchNuGet { pname = "runtime.win-x64.Microsoft.NETCore.DotNetAppHost"; version = "3.1.28"; sha256 = "0ky15gpji8hs8hnibk3ckcqk1fpk20kgsgkvczpvq88qd0nzlp1d"; })
+      (fetchNuGet { pname = "runtime.win-x64.Microsoft.NETCore.DotNetHost"; version = "3.1.28"; sha256 = "03n3ps5y45hgniirr9bb80cvrwsddb9ixj8xzlxzdg349j3cz5mw"; })
+      (fetchNuGet { pname = "runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.28"; sha256 = "0a91gv56gl6j97gn7p0ss0ivpnl7gxhb90sklgbvvwp3601gka6a"; })
+      (fetchNuGet { pname = "runtime.win-x64.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.28"; sha256 = "02i5cphwkqg5z5ariy2lrn8fbx15nbq3pzzw2ncja933zqg145zs"; })
+      (fetchNuGet { pname = "runtime.win-x86.Microsoft.NETCore.DotNetAppHost"; version = "3.1.28"; sha256 = "01xcvlrif0wqq02p1x74sqvm95b9aqm5ada1q2l2xr9yglrzh0lq"; })
+      (fetchNuGet { pname = "runtime.win-x86.Microsoft.NETCore.DotNetHost"; version = "3.1.28"; sha256 = "0j9b8xy9vq7vlgx4fbcrh1g2qypai2q5iar6fwsialrrgp3v599x"; })
+      (fetchNuGet { pname = "runtime.win-x86.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.28"; sha256 = "1pl66sqxiw103bknbwcazf82sr2q6x1fk21h0d5xl7cgpabx53gs"; })
+      (fetchNuGet { pname = "runtime.win-x86.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.28"; sha256 = "1jbg3gpmqrbnhy7rf7xjg84riyzfmlmzl8ixpy2ks59q0mm22vkw"; })
     ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Small bugfix release. See [release notes](https://github.com/dotnet/core/blob/main/release-notes/3.1/3.1.27/3.1.27.md)

Follow up to https://github.com/NixOS/nixpkgs/pull/181512, and requires it merged first.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
