### PR TITLE
nixos/privacyidea: better secret-handling ldap-proxy & RFC42-style settings for ldap-proxy

### DIFF
--- a/nixos/modules/services/security/privacyidea.nix
+++ b/nixos/modules/services/security/privacyidea.nix
@@ -51,6 +51,16 @@ let
     ${cfg.extraConfig}
   '';
 
+  renderValue = x:
+    if isList x then concatMapStringsSep "," (x: ''"${x}"'') x
+    else if isString x && hasInfix "," x then ''"${x}"''
+    else x;
+
+  ldapProxyConfig = pkgs.writeText "ldap-proxy.ini"
+    (generators.toINI {}
+      (flip mapAttrs cfg.ldap-proxy.settings
+        (const (mapAttrs (const renderValue)))));
+
 in
 
 {
@@ -172,7 +182,8 @@ in
         enable = mkEnableOption "PrivacyIDEA LDAP Proxy";
 
         configFile = mkOption {
-          type = types.path;
+          type = types.nullOr types.path;
+          default = null;
           description = ''
             Path to PrivacyIDEA LDAP Proxy configuration (proxy.ini).
           '';
@@ -188,6 +199,26 @@ in
           type = types.str;
           default = "pi-ldap-proxy";
           description = "Group account under which PrivacyIDEA LDAP proxy runs.";
+        };
+
+        settings = mkOption {
+          type = with types; attrsOf (attrsOf (oneOf [ str bool int (listOf str) ]));
+          default = {};
+          description = ''
+            Attribute-set containing the settings for <package>privacyidea-ldap-proxy</package>.
+            It's possible to pass secrets using env-vars as substitutes and
+            use the option <xref linkend="opt-services.privacyidea.ldap-proxy.environmentFile" />
+            to inject them via <package>envsubst</package>.
+          '';
+        };
+
+        environmentFile = mkOption {
+          default = null;
+          type = types.nullOr types.str;
+          description = ''
+            Environment file containing secrets to be substituted into
+            <xref linkend="opt-services.privacyidea.ldap-proxy.settings" />.
+          '';
         };
       };
     };
@@ -276,6 +307,18 @@ in
 
     (mkIf cfg.ldap-proxy.enable {
 
+      assertions = [
+        { assertion = let
+            xor = a: b: a && !b || !a && b;
+          in xor (cfg.ldap-proxy.settings == {}) (cfg.ldap-proxy.configFile == null);
+          message = "configFile & settings are mutually exclusive for services.privacyidea.ldap-proxy!";
+        }
+      ];
+
+      warnings = mkIf (cfg.ldap-proxy.configFile != null) [
+        "Using services.privacyidea.ldap-proxy.configFile is deprecated! Use the RFC42-style settings option instead!"
+      ];
+
       systemd.services.privacyidea-ldap-proxy = let
         ldap-proxy-env = pkgs.python3.withPackages (ps: [ ps.privacyidea-ldap-proxy ]);
       in {
@@ -284,14 +327,28 @@ in
         serviceConfig = {
           User = cfg.ldap-proxy.user;
           Group = cfg.ldap-proxy.group;
-          ExecStart = ''
+          StateDirectory = "privacyidea-ldap-proxy";
+          EnvironmentFile = mkIf (cfg.ldap-proxy.environmentFile != null)
+            cfg.ldap-proxy.environmentFile;
+          ExecStartPre = mkIf (cfg.ldap-proxy.settings != {})
+            "${pkgs.writeShellScript "substitute-secrets-ldap-proxy" ''
+              set -x
+              ${pkgs.envsubst}/bin/envsubst \
+                -i ${ldapProxyConfig} \
+                -o $STATE_DIRECTORY/ldap-proxy.ini
+            ''}";
+          ExecStart = let
+            configPath = if cfg.ldap-proxy.settings != {}
+              then "%S/privacyidea-ldap-proxy/ldap-proxy.ini"
+              else cfg.ldap-proxy.configFile;
+          in ''
             ${ldap-proxy-env}/bin/twistd \
               --nodaemon \
               --pidfile= \
               -u ${cfg.ldap-proxy.user} \
               -g ${cfg.ldap-proxy.group} \
               ldap-proxy \
-              -c ${cfg.ldap-proxy.configFile}
+              -c ${configPath}
           '';
           Restart = "always";
         };

--- a/nixos/modules/services/security/privacyidea.nix
+++ b/nixos/modules/services/security/privacyidea.nix
@@ -330,9 +330,8 @@ in
           StateDirectory = "privacyidea-ldap-proxy";
           EnvironmentFile = mkIf (cfg.ldap-proxy.environmentFile != null)
             cfg.ldap-proxy.environmentFile;
-          ExecStartPre = mkIf (cfg.ldap-proxy.settings != {})
+          ExecStartPre =
             "${pkgs.writeShellScript "substitute-secrets-ldap-proxy" ''
-              set -x
               ${pkgs.envsubst}/bin/envsubst \
                 -i ${ldapProxyConfig} \
                 -o $STATE_DIRECTORY/ldap-proxy.ini

--- a/nixos/modules/services/security/privacyidea.nix
+++ b/nixos/modules/services/security/privacyidea.nix
@@ -329,7 +329,7 @@ in
           Group = cfg.ldap-proxy.group;
           StateDirectory = "privacyidea-ldap-proxy";
           EnvironmentFile = mkIf (cfg.ldap-proxy.environmentFile != null)
-            cfg.ldap-proxy.environmentFile;
+            [ cfg.ldap-proxy.environmentFile ];
           ExecStartPre =
             "${pkgs.writeShellScript "substitute-secrets-ldap-proxy" ''
               ${pkgs.envsubst}/bin/envsubst \


### PR DESCRIPTION



###### Description of changes
Instead of hard-coding a single `configFile` for
`privacyidea-ldap-proxy.service` which is pretty unmergable with other
declarations it now uses a RFC42-like approach. Also to make sure that
secrets can be handled properly without ending up in the Nix store, it's
possible to inject secrets via envsubst

    {
      services.privacyidea.ldap-proxy = {
        enable = true;
        environmentFile = "/run/secrets/ldap-pw";
        settings = {
          privacyidea.instance = "privacyidea.example.org";
          service-account = {
            dn = "uid=readonly,ou=serviceaccounts,dc=example,dc=org";
            password = "$LDAP_PW";
          };
        };
      };
    }

and the following secret file (at `/run/secrets`):

    LDAP_PW=<super-secret ldap pw>

For backwards-compat the old `configFile`-option is kept, but it throws
a deprecation warning and is mutually exclusive with the
`settings`-attrset. Also, it doesn't support secrets injection with
`envsubst` & `environmentFile`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
