### PR TITLE
gnumake: unconditionally disable guileSupport on bootstrap

### DIFF
--- a/pkgs/development/tools/build-managers/gnumake/default.nix
+++ b/pkgs/development/tools/build-managers/gnumake/default.nix
@@ -1,4 +1,16 @@
-{ lib, stdenv, fetchurl, guileSupport ? false, pkg-config, guile }:
+{ lib
+, stdenv
+, fetchurl
+, guileSupport ? false, guile
+# avoid guile depend on bootstrap to prevent dependency cycles
+, inBootstrap ? false
+, pkg-config
+, gnumake
+}:
+
+let
+  guileEnabled = guileSupport && !inBootstrap;
+in
 
 stdenv.mkDerivation rec {
   pname = "gnumake";
@@ -19,10 +31,10 @@ stdenv.mkDerivation rec {
     ./0002-remove-impure-dirs.patch
   ];
 
-  nativeBuildInputs = lib.optionals guileSupport [ pkg-config ];
-  buildInputs = lib.optionals guileSupport [ guile ];
+  nativeBuildInputs = lib.optionals guileEnabled [ pkg-config ];
+  buildInputs = lib.optionals guileEnabled [ guile ];
 
-  configureFlags = lib.optional guileSupport "--with-guile"
+  configureFlags = lib.optional guileEnabled "--with-guile"
 
     # Make uses this test to decide whether it should keep track of
     # subseconds. Apple made this possible with APFS and macOS 10.13.
@@ -35,6 +47,11 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "man" "info" ];
   separateDebugInfo = true;
+
+  passthru.tests = {
+    # make sure that the override doesn't break bootstrapping
+    gnumakeWithGuile = gnumake.override { guileSupport = true; };
+  };
 
   meta = with lib; {
     description = "A tool to control the generation of non-source files from sources";

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -356,6 +356,10 @@ in
       #   stage5.gcc -> stage4.coreutils -> stage3.glibc -> bootstrap
       gmp = lib.makeOverridable (super.gmp.override { stdenv = self.stdenv; }).overrideAttrs (a: { pname = "${a.pname}-stage4"; });
 
+      # To allow users' overrides inhibit dependencies too heavy for
+      # bootstrap, like guile: https://github.com/NixOS/nixpkgs/issues/181188
+      gnumake = super.gnumake.override { inBootstrap = true; };
+
       gcc = lib.makeOverridable (import ../../build-support/cc-wrapper) {
         nativeTools = false;
         nativeLibc = false;
@@ -446,7 +450,7 @@ in
       overrides = self: super: {
         inherit (prevStage)
           gzip bzip2 xz bash coreutils diffutils findutils gawk
-          gnumake gnused gnutar gnugrep gnupatch patchelf
+          gnused gnutar gnugrep gnupatch patchelf
           attr acl zlib pcre libunistring;
         ${localSystem.libc} = getLibc prevStage;
 
@@ -457,6 +461,7 @@ in
           inherit (self) stdenv runCommandLocal patchelf libunistring;
         };
 
+        gnumake = super.gnumake.override { inBootstrap = false; };
       } // lib.optionalAttrs (super.stdenv.targetPlatform == localSystem) {
         # Need to get rid of these when cross-compiling.
         inherit (prevStage) binutils binutils-unwrapped;


### PR DESCRIPTION
Before the change an attempt to use `gnumake.override { guileSupport = true; }`
caused recursion in bootstrap stages as guileSupport pulls in guile and it's
dependencies.

To restore the bootstrap the change unconditionally sets
`guileSupport = false;` for `gnumake`.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
