### PR TITLE
python3Packages.nextcord: fix issue with loading libopus

### DIFF
--- a/pkgs/development/python-modules/nextcord/paths.patch
+++ b/pkgs/development/python-modules/nextcord/paths.patch
@@ -7,7 +7,7 @@ index 52e4ddbd..d8b8090b 100644
              _lib = libopus_loader(_filename)
          else:
 -            opus = ctypes.util.find_library("opus")
-+            opus = ctypes.util.find_library("@opus@")
++            opus = "@libopus@"
  
              if opus is None:
                  _lib = None


### PR DESCRIPTION
###### Description of changes

The substitution patch used to point nextcord to the installed location of libopus in nix's store was incorrectly formatted:

* `@opus@` was used while default.nix attempted to substitute instances of
  `@libopus@`.
* `ctypes.util.find_library(<library_name>)` will return a path to a
  library. If we already have the path (provided by the substitution),
  then `find_library` is not necessary to call (nor will it produce the
  desired result).

Before this PR, I would receive the following traceback when attempting to use voice features with nextcord:

```
Traceback (most recent call last):
  File "/home/user/code/my-project/./main.py", line 609, in play_next_song
    active_voice_client.play(
  File "/nix/store/hklg3izid1vqjynscmbfzihppdq6qkpz-python3.10-nextcord-2.0.0/lib/python3.10/site-packages/nextcord/voice_client.py", line 607, in play
    self.encoder = opus.Encoder()
  File "/nix/store/hklg3izid1vqjynscmbfzihppdq6qkpz-python3.10-nextcord-2.0.0/lib/python3.10/site-packages/nextcord/opus.py", line 365, in __init__
    _OpusStruct.get_opus_version()
  File "/nix/store/hklg3izid1vqjynscmbfzihppdq6qkpz-python3.10-nextcord-2.0.0/lib/python3.10/site-packages/nextcord/opus.py", line 358, in get_opus_version
    raise OpusNotLoaded()
nextcord.opus.OpusNotLoaded
```

Broke in 8dbfd523ec9c0dd3c80093875855911666644767.

Not necessary to backport to 22.05 as the above commit has not been backported.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
