### PR TITLE
treewide: fix fallout from 'cmake/setup-hook.sh: Don't skip build-RPATH'

### DIFF
--- a/pkgs/applications/emulators/resim/default.nix
+++ b/pkgs/applications/emulators/resim/default.nix
@@ -17,5 +17,10 @@ stdenv.mkDerivation {
     cp -v vc4emul/vc4emul $out/bin/vc4emul
   '';
 
+  cmakeFlags = [
+    # RPATH of binary /nix/store/.../bin/... contains a forbidden reference to /build/
+    "-DCMAKE_SKIP_BUILD_RPATH=ON"
+  ];
+
   meta.license = lib.licenses.mit;
 }

--- a/pkgs/applications/misc/edgetx/default.nix
+++ b/pkgs/applications/misc/edgetx/default.nix
@@ -29,6 +29,8 @@ mkDerivation rec {
     "-DGTEST_ROOT=${gtest.src}/googletest"
     "-DQT_TRANSLATIONS_DIR=${qttranslations}/translations"
     "-DDFU_UTIL_PATH=${dfu-util}/bin/dfu-util"
+    # file RPATH_CHANGE could not write new RPATH
+    "-DCMAKE_SKIP_BUILD_RPATH=ON"
   ];
 
   meta = with lib; {

--- a/pkgs/applications/misc/opentx/default.nix
+++ b/pkgs/applications/misc/opentx/default.nix
@@ -31,6 +31,9 @@ mkDerivation rec {
     # XXX I would prefer to include these here, though we will need to file a bug upstream to get that changed.
     #"-DDFU_UTIL_PATH=${dfu-util}/bin/dfu-util"
     #"-DAVRDUDE_PATH=${avrdude}/bin/avrdude"
+
+    # file RPATH_CHANGE could not write new RPATH
+    "-DCMAKE_SKIP_BUILD_RPATH=ON"
   ];
 
   meta = with lib; {

--- a/pkgs/applications/science/logic/monosat/default.nix
+++ b/pkgs/applications/science/logic/monosat/default.nix
@@ -47,6 +47,9 @@ let
       "-DBUILD_STATIC=OFF"
       "-DJAVA=${boolToCmake includeJava}"
       "-DGPL=${boolToCmake includeGplCode}"
+
+      # file RPATH_CHANGE could not write new RPATH
+      "-DCMAKE_SKIP_BUILD_RPATH=ON"
     ];
 
     postInstall = optionalString includeJava ''

--- a/pkgs/applications/science/misc/simgrid/default.nix
+++ b/pkgs/applications/science/misc/simgrid/default.nix
@@ -65,6 +65,9 @@ stdenv.mkDerivation rec {
     "-Denable_compile_warnings=off"
     "-Denable_compile_optimizations=${optionOnOff optimize}"
     "-Denable_lto=${optionOnOff optimize}"
+
+    # RPATH of binary /nix/store/.../bin/... contains a forbidden reference to /build/
+    "-DCMAKE_SKIP_BUILD_RPATH=ON"
   ];
   makeFlags = optional debug "VERBOSE=1";
 

--- a/pkgs/development/libraries/fltk/common.nix
+++ b/pkgs/development/libraries/fltk/common.nix
@@ -147,6 +147,9 @@ stdenv.mkDerivation rec {
     "-DOPTION_INSTALL_HTML_DOCUMENTATION=${onOff withDocs}"
     "-DOPTION_INSTALL_PDF_DOCUMENTATION=OFF"
     "-DOPTION_INCLUDE_DRIVER_DOCUMENTATION=${onOff withDocs}"
+
+    # RPATH of binary /nix/store/.../bin/... contains a forbidden reference to /build/
+    "-DCMAKE_SKIP_BUILD_RPATH=ON"
   ];
 
   preBuild = lib.optionalString (withCairo && withShared && stdenv.hostPlatform.isDarwin) ''

--- a/pkgs/development/libraries/libvisio2svg/default.nix
+++ b/pkgs/development/libraries/libvisio2svg/default.nix
@@ -24,6 +24,11 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ libxml2 freetype librevenge libvisio libwmf libemf2svg ];
 
+  cmakeFlags = [
+    # file RPATH_CHANGE could not write new RPATH
+    "-DCMAKE_SKIP_BUILD_RPATH=ON"
+  ];
+
   meta = with lib; {
     description = "Library and tools to convert Microsoft Visio documents (VSS and VSD) to SVG";
     homepage = "https://github.com/kakwa/libvisio2svg";

--- a/pkgs/development/libraries/openhmd/default.nix
+++ b/pkgs/development/libraries/openhmd/default.nix
@@ -37,6 +37,9 @@ stdenv.mkDerivation rec {
     "-DOPENHMD_EXAMPLE_SIMPLE=${examplesOnOff}"
     "-DOPENHMD_EXAMPLE_SDL=${examplesOnOff}"
     "-DOpenGL_GL_PREFERENCE=GLVND"
+
+    # RPATH of binary /nix/store/.../bin/... contains a forbidden reference to /build/
+    "-DCMAKE_SKIP_BUILD_RPATH=ON"
   ];
 
   postInstall = lib.optionalString withExamples ''

--- a/pkgs/development/tools/misc/sipp/default.nix
+++ b/pkgs/development/tools/misc/sipp/default.nix
@@ -18,6 +18,9 @@ stdenv.mkDerivation rec {
     "-DUSE_PCAP=1"
     "-DUSE_SSL=1"
     "-DUSE_SCTP=${if stdenv.isLinux then "1" else "0"}"
+
+    # file RPATH_CHANGE could not write new RPATH
+    "-DCMAKE_SKIP_BUILD_RPATH=ON"
   ];
   enableParallelBuilding = true;
 

--- a/pkgs/servers/geospatial/mapserver/default.nix
+++ b/pkgs/servers/geospatial/mapserver/default.nix
@@ -47,6 +47,9 @@ stdenv.mkDerivation rec {
     "-DWITH_CURL=ON"
     "-DWITH_CLIENT_WMS=ON"
     "-DWITH_CLIENT_WFS=ON"
+
+    # RPATH of binary /nix/store/.../bin/... contains a forbidden reference to /build/
+    "-DCMAKE_SKIP_BUILD_RPATH=ON"
   ] ++ lib.optional withPython "-DWITH_PYTHON=ON";
 
   meta = with lib; {

--- a/pkgs/tools/networking/shadowsocks-libev/default.nix
+++ b/pkgs/tools/networking/shadowsocks-libev/default.nix
@@ -20,7 +20,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake asciidoc xmlto docbook_xml_dtd_45
                         docbook_xsl libxslt ];
 
-  cmakeFlags = [ "-DWITH_STATIC=OFF"  "-DCMAKE_BUILD_WITH_INSTALL_NAME_DIR=ON" ];
+  cmakeFlags = [ "-DWITH_STATIC=OFF"  "-DCMAKE_BUILD_WITH_INSTALL_NAME_DIR=ON"
+    # RPATH of binary /nix/store/.../bin/... contains a forbidden reference to /build/
+    "-DCMAKE_SKIP_BUILD_RPATH=ON"
+  ];
 
   postInstall = ''
     cp lib/* $out/lib


### PR DESCRIPTION
f7414e2

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
