### PR TITLE
conserver: init at 8.2.7

### DIFF
--- a/pkgs/tools/misc/conserver/default.nix
+++ b/pkgs/tools/misc/conserver/default.nix
@@ -1,0 +1,62 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, autoreconfHook
+, gssapiSupport ? false
+, libkrb5
+, freeipmiSupport ? false
+, freeipmi
+, ipv6Support ? true
+, opensslSupport ? true
+, openssl
+, trustUdsCredSupport ? false
+, udsSupport ? false
+}:
+
+stdenv.mkDerivation rec {
+  pname = "conserver";
+  version = "8.2.7";
+
+  src = fetchFromGitHub {
+    owner = "bstansell";
+    repo = "conserver";
+    rev = "v${version}";
+    sha256 = "sha256-LiCknqitBoa8E8rNMVgp1004CwkW8G4O5XGKe4NfZI8=";
+  };
+
+  # Remove upon next release since upstream is fixed
+  # https://github.com/bstansell/conserver/pull/82
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/bstansell/conserver/commit/84fc79a459e00dbc87b8cfc943c5045bfcc7aeeb.patch";
+      sha256 = "sha256:1dy8r9z7rv8512fl0rk5gi1vl02hnh7x0i6flvpcc13h6r6fhxyc";
+    })
+  ];
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  buildInputs = [ ]
+    ++ lib.optionals freeipmiSupport [ freeipmi ]
+    ++ lib.optionals gssapiSupport [ libkrb5 ]
+    ++ lib.optionals opensslSupport [ openssl ];
+
+  configureFlags = [ "--with-ccffile=/dev/null" "--with-cffile=/dev/null" ]
+    ++ lib.optionals freeipmiSupport [ "--with-freeipmi=${freeipmi}/include" ]
+    ++ lib.optionals gssapiSupport [ "--with-gssapi=${libkrb5.dev}/include" ]
+    ++ lib.optionals ipv6Support [ "--with-ipv6" ]
+    ++ lib.optionals opensslSupport [ "--with-openssl=${openssl.dev}/include" ]
+    ++ lib.optionals trustUdsCredSupport [ "--with-trust-uds-cred" ]
+    ++ lib.optionals udsSupport [ "--with-uds" ];
+
+  # Disabled due to exist upstream cases failing 8/15 tests
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://www.conserver.com/";
+    description = "An application that allows multiple users to watch a serial console at the same time";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ sarcasticadmin ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -394,6 +394,8 @@ with pkgs;
 
   commix = callPackage ../tools/security/commix { };
 
+  conserver = callPackage ../tools/misc/conserver { };
+
   containerpilot = callPackage ../applications/networking/cluster/containerpilot { };
 
   crc = callPackage ../applications/networking/cluster/crc { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

init conserver is an application that provides the ability for more sophisticated terminal device interactions.

repo: https://github.com/bstansell/conserver  

This package includes 2 binaries (`conserver` and `console`).

```
./result/conserver -h
usage: conserver [-7dDEFhinoRSuvV] [-a type] [-m max] [-M master] [-p port] [-b port] [-c cred] [-C config] [-P passwd] [-L logfile] [-O min] [-U logfile]
	7          strip the high bit off all console data
	a type     set the default access type
	b port     base port for secondary channel (any by default)
	c cred     ignored - encryption not compiled into code
	C config   give a new config file to the server process
	d          become a daemon, redirecting stdout/stderr to logfile
	D          enable debug output, sent to stderr
	E          ignored - encryption not compiled into code
	F          do not automatically reinitialize failed consoles
	h          output this message
	i          initialize console connections on demand
	L logfile  give a new logfile path to the server process
	m max      maximum consoles managed per process
	M master   address to listen on (all addresses by default)
	n          obsolete - see -u
	o          reopen downed console on client connect
	O min      reopen all downed consoles every <min> minutes
	p port     port to listen on
	P passwd   give a new passwd file to the server process
	R          disable automatic client redirection
	S          syntax check of configuration file
	u          copy "unloved" console data to stdout
	U logfile  copy all console data to the "unified" logfile
	v          be verbose on startup
	V          output version info
```

`console`:

```
./result/console -h
usage: console [generic-args] [-aAfFsS] [-e esc] console
       console [generic-args] [-iIuwWx] [console]
       console [generic-args] [-hPqQrRV] [-[bB] message] [-d [user][@console]]
                              [-t [user][@console] message] [-[zZ] cmd]

       generic-args: [-7DEknUv] [-c cred] [-C config] [-M master]
                     [-p port] [-l username]

	7         strip the high bit off all console data
	a(A)      attach politely (and replay last 20 lines)
	b(B)      send broadcast message to all users (on master)
	c cred    ignored - encryption not compiled into code
	C config  override per-user config file
	d         disconnect [user][@console]
	D         enable debug output, sent to stderr
	e esc     set the initial escape characters
	E         ignored - encryption not compiled into code
	f(F)      force read/write connection (and replay)
	h         output this message
	i(I)      display status info in machine-parseable form (on master)
	k         abort connection if the console is not 'up'
	l user    use username instead of current username
	M master  master server to poll first
	n         do not read system-wide config file
	p port    port to connect to
	P         display pids of daemon(s)
	q(Q)      send a quit command to the (master) server
	r(R)      display (master) daemon version (think 'r'emote version)
	s(S)      spy on a console (and replay)
	t         send a text message to [user][@console]
	u         show users on the various consoles
	U         ignored - encryption not compiled into code
	v         be more verbose
	V         show version information
	w(W)      show who is on which console (on master)
	x         examine ports and baud rates
	z(Z) cmd  send a command to the (master) server (think 'z'ap)
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->