### PR TITLE
displaylink: remove nshalman as maintainer

### DIFF
--- a/pkgs/os-specific/linux/displaylink/default.nix
+++ b/pkgs/os-specific/linux/displaylink/default.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "DisplayLink DL-5xxx, DL-41xx and DL-3x00 Driver for Linux";
-    maintainers = with maintainers; [ nshalman abbradar peterhoeg eyjhb ];
+    maintainers = with maintainers; [ abbradar peterhoeg eyjhb ];
     platforms = [ "x86_64-linux" "i686-linux" ];
     license = licenses.unfree;
     homepage = "https://www.displaylink.com/";


### PR DESCRIPTION
###### Description of changes

Removing myself from the maintainer list for displaylink; I haven't actively used a displaylink device with NixOS in years.