### PR TITLE
make-bootstrap-tools: add pbzx and tbd tools on x86_64-darwin

### DIFF
--- a/pkgs/stdenv/darwin/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/darwin/make-bootstrap-tools.nix
@@ -105,16 +105,16 @@ in rec {
       mkdir $out/include
       cp -rd ${llvmPackages.libcxx.dev}/include/c++     $out/include
 
+      # copy .tbd assembly utils
+      cp -d ${pkgs.darwin.rewrite-tbd}/bin/rewrite-tbd $out/bin
+      cp -d ${lib.getLib pkgs.libyaml}/lib/libyaml*.dylib $out/lib
+
+      # copy package extraction tools
+      cp -d ${pkgs.pbzx}/bin/pbzx $out/bin
+      cp -d ${lib.getLib pkgs.xar}/lib/libxar*.dylib $out/lib
+      cp -d ${pkgs.bzip2.out}/lib/libbz2*.dylib $out/lib
+
       ${lib.optionalString targetPlatform.isAarch64 ''
-        # copy .tbd assembly utils
-        cp -d ${pkgs.darwin.rewrite-tbd}/bin/rewrite-tbd $out/bin
-        cp -d ${lib.getLib pkgs.libyaml}/lib/libyaml*.dylib $out/lib
-
-        # copy package extraction tools
-        cp -d ${pkgs.pbzx}/bin/pbzx $out/bin
-        cp -d ${lib.getLib pkgs.xar}/lib/libxar*.dylib $out/lib
-        cp -d ${pkgs.bzip2.out}/lib/libbz2*.dylib $out/lib
-
         # copy sigtool
         cp -d ${pkgs.darwin.sigtool}/bin/sigtool $out/bin
         cp -d ${pkgs.darwin.sigtool}/bin/codesign $out/bin


### PR DESCRIPTION
###### Description of changes

As part of making the 11.0 SDK stdenv bootstrap on x86_64-darwin, I need to add a couple of things that are already in the aarch64-darwin bootstrap-tools. This change adds those. This is for #180931 but separate due to needing the bootstrap-tools.cpio.bz2 to update stdenv per the script laid out in #151399.

I’ve successfully run `nix-build pkgs/stdenv/darwin/make-bootstrap-tools.nix -A test` on both x86_64-darwin. I also used the bootstrapped tools to build stdenvs for and the packages fixed in #180931.

**Sandbox:** set to relaxed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
