### PR TITLE
unicode-paracode: 2.7 -> 2.9

### DIFF
--- a/pkgs/tools/misc/unicode/default.nix
+++ b/pkgs/tools/misc/unicode/default.nix
@@ -1,19 +1,19 @@
-{ lib, fetchFromGitHub, fetchurl, python3Packages, installShellFiles }:
+{ lib, fetchFromGitHub, fetchurl, python3Packages, installShellFiles, gitUpdater }:
 
 python3Packages.buildPythonApplication rec {
   pname = "unicode";
-  version = "2.7";
+  version = "2.9";
 
   src = fetchFromGitHub {
     owner = "garabik";
     repo = "unicode";
     rev = "v${version}";
-    sha256 = "15d9yvarxsiy0whx1mxzsjnnkrjdm3ga4qv2yy398mk0jh763q9v";
+    sha256 = "sha256-FHAlZ5HID/FE9+YR7Dmc3Uh7E16QKORoD8g9jgTeQdY=";
   };
 
   ucdtxt = fetchurl {
-    url = "https://www.unicode.org/Public/13.0.0/ucd/UnicodeData.txt";
-    sha256 = "1fz8fcd23lxyl97ay8h42zvkcgcg8l81b2dm05nklkddr2zzpgxx";
+    url = "https://www.unicode.org/Public/14.0.0/ucd/UnicodeData.txt";
+    sha256 = "sha256-NgGOaGV/3LNIX2NmMP/oyFMuAcl3cD0oA/W4nWxf6vs=";
   };
 
   nativeBuildInputs = [ installShellFiles ];
@@ -26,6 +26,12 @@ python3Packages.buildPythonApplication rec {
   postInstall = ''
     installManPage paracode.1 unicode.1
   '';
+
+  passthru.updateScript = gitUpdater {
+    inherit version;
+    pname = "unicode-paracode";
+    rev-prefix = "v";
+  };
 
   meta = with lib; {
     description = "Display unicode character properties";


### PR DESCRIPTION
###### Description of changes
Update to latest upstream release [2.9](https://github.com/garabik/unicode/releases/tag/v2.9).

- update unicode data from 13.0.0 to 14.0.0
- add `passthru.updateScript`

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).