### PR TITLE
cbmc: init at 5.63.0

### DIFF
--- a/pkgs/applications/science/logic/cbmc/0001-Do-not-download-sources-in-cmake.patch
+++ b/pkgs/applications/science/logic/cbmc/0001-Do-not-download-sources-in-cmake.patch
@@ -1,0 +1,49 @@
+From fbc1488e8da0175e9c9bdf5892f8a65c71f2a266 Mon Sep 17 00:00:00 2001
+From: Jiajie Chen <c@jia.je>
+Date: Fri, 15 Jul 2022 18:33:15 +0800
+Subject: [PATCH] Do not download sources in cmake
+
+---
+ src/solvers/CMakeLists.txt | 20 +-------------------
+ 1 file changed, 1 insertion(+), 19 deletions(-)
+
+diff --git a/src/solvers/CMakeLists.txt b/src/solvers/CMakeLists.txt
+index 744def486..5b719a78a 100644
+--- a/src/solvers/CMakeLists.txt
++++ b/src/solvers/CMakeLists.txt
+@@ -106,31 +106,13 @@ elseif("${sat_impl}" STREQUAL "glucose")
+ elseif("${sat_impl}" STREQUAL "cadical")
+     message(STATUS "Building solvers with cadical")
+ 
+-    download_project(PROJ cadical
+-        URL https://github.com/arminbiere/cadical/archive/rel-1.4.1.tar.gz
+-        PATCH_COMMAND true
+-        COMMAND CXX=${CMAKE_CXX_COMPILER} ./configure -O3 -s CXXFLAGS=-std=c++14
+-        URL_MD5 b44874501a175106424f4bd5de29aa59
+-    )
+-
+     message(STATUS "Building CaDiCaL")
+-    execute_process(COMMAND make -j WORKING_DIRECTORY ${cadical_SOURCE_DIR})
+ 
+     target_compile_definitions(solvers PUBLIC
+         SATCHECK_CADICAL HAVE_CADICAL
+     )
+ 
+-    add_library(cadical STATIC IMPORTED)
+-
+-    set_target_properties(
+-        cadical
+-        PROPERTIES IMPORTED_LOCATION ${cadical_SOURCE_DIR}/build/libcadical.a
+-    )
+-
+-    target_include_directories(solvers
+-      PUBLIC
+-      ${cadical_SOURCE_DIR}/src
+-    )
++    target_include_directories(solvers PUBLIC ${cadical_INCLUDE_DIR})
+ 
+     target_link_libraries(solvers cadical)
+ elseif("${sat_impl}" STREQUAL "ipasir-cadical")
+-- 
+2.35.1
+

--- a/pkgs/applications/science/logic/cbmc/default.nix
+++ b/pkgs/applications/science/logic/cbmc/default.nix
@@ -1,0 +1,82 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, testers
+, bison
+, cadical
+, cbmc
+, cmake
+, flex
+, makeWrapper
+, perl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "cbmc";
+  version = "5.63.0";
+
+  src = fetchFromGitHub {
+    owner = "diffblue";
+    repo = pname;
+    rev = "${pname}-${version}";
+    sha256 = "sha256-4tn3wsmaYdo5/QaZc3MLxVGF0x8dmRKeygF/8A+Ww1o=";
+  };
+
+  nativeBuildInputs = [
+    bison
+    cmake
+    flex
+    perl
+    makeWrapper
+  ];
+
+  buildInputs = [ cadical ];
+
+  # do not download sources
+  # link existing cadical instead
+  patches = [
+    ./0001-Do-not-download-sources-in-cmake.patch
+  ];
+
+  postPatch = ''
+    # do not hardcode gcc
+    substituteInPlace "scripts/bash-autocomplete/extract_switches.sh" \
+      --replace "gcc" "$CC" \
+      --replace "g++" "$CXX"
+    # fix library_check.sh interpreter error
+    patchShebangs .
+  '' + lib.optionalString (!stdenv.cc.isGNU) ''
+    # goto-gcc rely on gcc
+    substituteInPlace "regression/CMakeLists.txt" \
+      --replace "add_subdirectory(goto-gcc)" ""
+  '';
+
+  postInstall = ''
+    # goto-cc expects ls_parse.py in PATH
+    mkdir -p $out/share/cbmc
+    mv $out/bin/ls_parse.py $out/share/cbmc/ls_parse.py
+    chmod +x $out/share/cbmc/ls_parse.py
+    wrapProgram $out/bin/goto-cc \
+      --prefix PATH : "$out/share/cbmc" \
+  '';
+
+  # fix "argument unused during compilation"
+  NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang
+    "-Wno-unused-command-line-argument";
+
+  # TODO: add jbmc support
+  cmakeFlags = [ "-DWITH_JBMC=OFF" "-Dsat_impl=cadical" "-Dcadical_INCLUDE_DIR=${cadical.dev}/include" ];
+
+  passthru.tests.version = testers.testVersion {
+    package = cbmc;
+    command = "cbmc --version";
+  };
+
+  meta = with lib; {
+    description = "CBMC is a Bounded Model Checker for C and C++ programs";
+    homepage = "http://www.cprover.org/cbmc/";
+    license = licenses.bsdOriginal;
+    maintainers = with maintainers; [ jiegec ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34235,6 +34235,8 @@ with pkgs;
 
   boogie = dotnetPackages.Boogie;
 
+  cbmc = callPackage ../applications/science/logic/cbmc { };
+
   cadical = callPackage ../applications/science/logic/cadical {};
 
   inherit (callPackage ./coq-packages.nix {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Cadical is used as sat solver backend.

https://github.com/diffblue/cbmc/releases/tag/cbmc-5.63.0


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
