### PR TITLE
kdiskmark: init at 2.3.0

### DIFF
--- a/pkgs/tools/filesystems/kdiskmark/default.nix
+++ b/pkgs/tools/filesystems/kdiskmark/default.nix
@@ -1,0 +1,54 @@
+{ stdenv
+, lib
+, wrapQtAppsHook
+, qtbase
+, qttools
+, fio
+, cmake
+, kauth
+, extra-cmake-modules
+, fetchFromGitHub
+}:
+stdenv.mkDerivation rec {
+  name = "kdiskmark";
+  version = "2.3.0";
+
+  src = fetchFromGitHub {
+    owner = "jonmagon";
+    repo = "kdiskmark";
+    rev = version;
+    sha256 = "sha256-9ufRxEbqwcRs+m/YW8D3+1USCJNZEaOUZRec7gvgmtA=";
+  };
+
+  nativeBuildInputs = [ cmake wrapQtAppsHook ];
+
+  buildInputs = [
+    qtbase
+    qttools
+    extra-cmake-modules
+    kauth
+  ];
+
+  postInstall = ''
+    # so that kdiskmark can be used as unpriviledged user even on non-kde
+    # (where kauth is not in environment.systemPackages)
+    ln -s ${kauth}/share/dbus-1/system.d/org.kde.kf5auth.conf $out/share/dbus-1/system.d/00-kdiskmark-needs-org.kde.kf5auth.conf
+  '';
+
+  qtWrapperArgs =
+    [ "--prefix" "PATH" ":" (lib.makeBinPath [ fio ]) ];
+
+  meta = with lib; {
+    description = "HDD and SSD benchmark tool with a friendly graphical user interface";
+    longDescription = ''
+      If kdiskmark is not run as root it can rely on polkit to get the necessary
+      privileges. In this case you must install it with `environment.systemPackages`
+      on NixOS, nix-env will not work.
+    '';
+    homepage = "https://github.com/JonMagon/KDiskMark";
+    maintainers = [ maintainers.symphorien ];
+    license = [ lib.licenses.gpl3Only ];
+    platforms = lib.platforms.linux;
+  };
+}
+

--- a/pkgs/tools/filesystems/kdiskmark/default.nix
+++ b/pkgs/tools/filesystems/kdiskmark/default.nix
@@ -47,8 +47,8 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://github.com/JonMagon/KDiskMark";
     maintainers = [ maintainers.symphorien ];
-    license = [ lib.licenses.gpl3Only ];
-    platforms = lib.platforms.linux;
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
   };
 }
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7691,6 +7691,8 @@ with pkgs;
     buildGoModule = buildGo118Module;
   };
 
+  kdiskmark = libsForQt5.callPackage ../tools/filesystems/kdiskmark { };
+
   keepalived = callPackage ../tools/networking/keepalived { };
 
   kexec-tools = callPackage ../os-specific/linux/kexec-tools { };


### PR DESCRIPTION
###### Description of changes

tested on xfce with and without kauth in environment.systemPackages

Fixes https://github.com/NixOS/nixpkgs/issues/173010

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
