### PR TITLE
ndi: 4 -> 5.5.1

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/obs-ndi.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-ndi.nix
@@ -16,7 +16,15 @@ stdenv.mkDerivation rec {
 
   patches = [ ./fix-search-path.patch ./hardcode-ndi-path.patch ];
 
-  postPatch = "sed -i -e s,@NDI@,${ndi},g src/obs-ndi.cpp";
+  postPatch = ''
+    # Add path (variable added in hardcode-ndi-path.patch)
+    sed -i -e s,@NDI@,${ndi},g src/obs-ndi.cpp
+
+    # Replace bundled NDI SDK with the upstream version
+    # (This fixes soname issues)
+    rm -rf lib/ndi
+    ln -s ${ndi}/include lib/ndi
+  '';
 
   cmakeFlags = [
     "-DLIBOBS_INCLUDE_DIR=${obs-studio}/include/obs"

--- a/pkgs/development/libraries/ndi/update.py
+++ b/pkgs/development/libraries/ndi/update.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i python -p "python3.withPackages (ps: with ps; [ ps.absl-py ps.requests ])"
+
+import hashlib
+import io
+import json
+import os.path
+import tarfile
+
+import requests
+from absl import app, flags
+
+BASE_NAME = "Install_NDI_SDK_v5_Linux"
+NDI_SDK_URL = f"https://downloads.ndi.tv/SDK/NDI_SDK_Linux/{BASE_NAME}.tar.gz"
+NDI_EXEC = f"{BASE_NAME}.sh"
+
+NDI_ARCHIVE_MAGIC = b"__NDI_ARCHIVE_BEGIN__\n"
+
+FLAG_out = flags.DEFINE_string("out", None, "Path to read/write version.json from/to.")
+
+
+def find_version_json() -> str:
+    if FLAG_out.value:
+        return FLAG_out.value
+    try_paths = ["pkgs/development/libraries/ndi/version.json", "version.json"]
+    for path in try_paths:
+        if os.path.exists(path):
+            return path
+    raise Exception(
+        "Couldn't figure out where to write version.json; try specifying --out"
+    )
+
+
+def fetch_tarball() -> bytes:
+    r = requests.get(NDI_SDK_URL)
+    r.raise_for_status()
+    return r.content
+
+
+def read_version(tarball: bytes) -> str:
+    # Find the inner script.
+    outer_tarfile = tarfile.open(fileobj=io.BytesIO(tarball), mode="r:gz")
+    eula_script = outer_tarfile.extractfile(NDI_EXEC).read()
+
+    # Now find the archive embedded within the script.
+    archive_start = eula_script.find(NDI_ARCHIVE_MAGIC) + len(NDI_ARCHIVE_MAGIC)
+    inner_tarfile = tarfile.open(
+        fileobj=io.BytesIO(eula_script[archive_start:]), mode="r:gz"
+    )
+
+    # Now find Version.txt...
+    version_txt = (
+        inner_tarfile.extractfile("NDI SDK for Linux/Version.txt")
+        .read()
+        .decode("utf-8")
+    )
+    _, _, version = version_txt.strip().partition(" v")
+    return version
+
+
+def main(argv):
+    tarball = fetch_tarball()
+
+    sha256 = hashlib.sha256(tarball).hexdigest()
+    version = {
+        "hash": f"sha256:{sha256}",
+        "version": read_version(tarball),
+    }
+
+    out_path = find_version_json()
+    with open(out_path, "w") as f:
+        json.dump(version, f)
+        f.write("\n")
+
+
+if __name__ == "__main__":
+    app.run(main)

--- a/pkgs/development/libraries/ndi/version.json
+++ b/pkgs/development/libraries/ndi/version.json
@@ -1,0 +1,1 @@
+{"hash": "sha256:24ed671e140ee62ebe96a494b3f0e3a3e5ba005364a0a6ad8ebf89b3494b7644", "version": "5.5.1"}


### PR DESCRIPTION
###### Description of changes

Bump the NDI SDK from v4 to v5.1.4, which is the version currently available on the ndi.tv website.

This includes a patch to obs-ndi, which AFAIK is the only user of NDI in nixpkgs, to allow it to find the NDI v5 libraries. The option of swapping the headers for the ones in the v5 SDK was preferred to the approach of patching the library discovery simply because it guarantees that the API will be in sync with what the ABI of the so we have is (in so far as we can guarantee that with a binary blob library).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
