### PR TITLE
Use `readlink -m` instead of `readlink -f`

### DIFF
--- a/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
@@ -71,7 +71,7 @@ let
       "pki"
     ];
   in concatStringsSep "\n  "
-  (map (file: "--ro-bind-try $(${coreutils}/bin/readlink -f /etc/${file}) /etc/${file}") files);
+  (map (file: "--ro-bind-try $(${coreutils}/bin/readlink -m /etc/${file}) /etc/${file}") files);
 
   # Create this on the fly instead of linking from /nix
   # The container might have to modify it and re-run ldconfig if there are


### PR DESCRIPTION
###### Description of changes

This change will let certain invalid paths to be passed, avoiding extremely weird and hard to debug behavior. See https://github.com/containers/bubblewrap/issues/520 for what I personally encountered.
```
~
❯ readlink -f stupid

~
❯ readlink -m stupid
/home/keksbg/haha/nonexistent

~
❯ file stupid
stupid: broken symbolic link to haha/nonexistent

~
❯ ls -l
total 2004
drwxr-xr-x 1 keksbg users     74 Jul  7 21:10 Desktop
drwxr-xr-x 1 keksbg users   1622 Jul 15 14:10 Downloads
lrwxrwxrwx 1 keksbg users     68 Jul 15 22:56 Games -> /nix/store/8diigfki448nn52sdpnmkdphm62pfhw3-home-manager-files/Games
lrwxrwxrwx 1 keksbg users     71 Jul 15 22:56 Projects -> /nix/store/8diigfki448nn52sdpnmkdphm62pfhw3-home-manager-files/Projects
drwxr-xr-x 1 keksbg users    736 Jul 15 23:29 bubblewrap
drwxr-xr-x 1 keksbg users    144 Jul 15 23:28 flake
drwxr-xr-x 1 keksbg users      0 Jul  7 23:06 mnt
-rw-r--r-- 1 keksbg users  41013 Jul  7 20:17 Passwords.kdbx
-rw-r--r-- 1 keksbg users   2091 Jul  7 19:59 backup_2022-07-07.sec.pgp
-rw-r--r-- 1 keksbg users  72124 Jul 15 21:13 bwrap.log
-rw------- 1 keksbg users  43329 Jul 15 21:39 callgrind.out.67088
-rw-r--r-- 1 keksbg users 922539 Jul 15 17:46 lutris.log
lrwxrwxrwx 1 keksbg users      6 Jul 16 01:21 notstupid -> stupid
-rw-r--r-- 1 keksbg users 923942 Jul 15 20:02 steam-run.log
-r-xr-xr-x 1 keksbg users   6473 Jul 15 23:46 steam-run.sh
lrwxrwxrwx 1 keksbg users     16 Jul 16 01:22 stupid -> haha/nonexistent
-rwxr-xr-x 1 keksbg users   6538 Jul 15 21:26 test.sh
```
`bwrap` handles nonexistent mounts/symlinks/such just fine.

I have yet to test it more globally but I have no reason to suspect it would function any different, except for this additional change.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).