### PR TITLE
libuiohook: init at 1.2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -887,6 +887,13 @@
     githubId = 661909;
     name = "Antonio Nuno Monteiro";
   };
+  anoa = {
+    matrix = "@andrewm:amorgan.xyz";
+    email = "andrew@amorgan.xyz";
+    github = "anoadragon453";
+    githubId = 1342360;
+    name = "Andrew Morgan";
+  };
   anpryl = {
     email = "anpryl@gmail.com";
     github = "anpryl";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -279,6 +279,7 @@ in {
   libresprite = handleTest ./libresprite.nix {};
   libreswan = handleTest ./libreswan.nix {};
   librewolf = handleTest ./firefox.nix { firefoxPackage = pkgs.librewolf; };
+  libuiohook = handleTest ./libuiohook.nix {};
   lidarr = handleTest ./lidarr.nix {};
   lightdm = handleTest ./lightdm.nix {};
   limesurvey = handleTest ./limesurvey.nix {};

--- a/nixos/tests/libuiohook.nix
+++ b/nixos/tests/libuiohook.nix
@@ -1,0 +1,21 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
+  name = "libuiohook";
+  meta = with lib.maintainers; { maintainers = [ anoa ]; };
+
+  nodes.client = { nodes, ... }:
+      let user = nodes.client.config.users.users.alice;
+      in {
+        imports = [ ./common/user-account.nix ./common/x11.nix ];
+
+        environment.systemPackages = [ pkgs.libuiohook.test ];
+
+        test-support.displayManager.auto.user = user.name;
+      };
+
+  testScript = { nodes, ... }:
+    let user = nodes.client.config.users.users.alice;
+    in ''
+      client.wait_for_x()
+      client.succeed("su - alice -c ${pkgs.libuiohook.test}/share/uiohook_tests >&2 &")
+    '';
+})

--- a/pkgs/development/libraries/libuiohook/default.nix
+++ b/pkgs/development/libraries/libuiohook/default.nix
@@ -1,0 +1,71 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, nixosTests
+, cmake
+, pkg-config
+, AppKit
+, ApplicationServices
+, Carbon
+, libX11
+, libxkbcommon
+, xinput
+, xorg
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libuiohook";
+  version = "1.2.2";
+
+  src = fetchFromGitHub {
+    owner = "kwhat";
+    repo = pname;
+    rev = version;
+    sha256 = "1qlz55fp4i9dd8sdwmy1m8i4i1jy1s09cpmlxzrgf7v34w72ncm7";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs =
+    if stdenv.isDarwin then [ AppKit ApplicationServices Carbon ]
+    else [
+      libX11
+      libxkbcommon
+      xinput
+    ] ++
+    (with xorg; [
+      libXau
+      libXdmcp
+      libXi
+      libXinerama
+      libXt
+      libXtst
+      libXext
+      libxkbfile
+    ]);
+
+  outputs = [ "out" "test" ];
+
+  # We build the tests, but they're only installed when using the "test" output.
+  # This will produce a "uiohook_tests" binary which can be run to test the
+  # functionality of the library on the current system.
+  # Running the test binary requires a running X11 session.
+  cmakeFlags = [
+    "-DENABLE_TEST:BOOL=ON"
+  ];
+
+  postInstall = ''
+    mkdir -p $test/share
+    cp ./uiohook_tests $test/share
+  '';
+
+  meta = with lib; {
+    description = "A C library to provide global keyboard and mouse hooks from userland";
+    homepage = "https://github.com/kwhat/libuiohook";
+    license = licenses.gpl3Only;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ anoa ];
+  };
+
+  passthru.tests.libuiohook = nixosTests.libuiohook;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19662,6 +19662,10 @@ with pkgs;
 
   libuinputplus = callPackage ../development/libraries/libuinputplus { };
 
+  libuiohook = callPackage ../development/libraries/libuiohook {
+    inherit (darwin.apple_sdk.frameworks) AppKit ApplicationServices Carbon;
+  };
+
   libunistring = callPackage ../development/libraries/libunistring { };
 
   libupnp = callPackage ../development/libraries/pupnp { };


### PR DESCRIPTION
###### Description of changes

[libuiohook](https://github.com/kwhat/libuiohook) is a library that allows capturing of mouse/keyboard input events on an X11 system.

This is my first NixOS package addition!

This PR:

* inits libuiohook at 1.2.2.
* adds `anoa` (myself) as a maintainer of this expression.
* adds a NixOS test at `tests/libuiohook.nix` which runs the compiled `uiohook_tests` binary.

After talking with some folks in [#dev:nixos.org](https://matrix.to/#/!kjdutkOsheZdjqYmqp:nixos.org/$Qq_Z5pM4JthHpycyItTu2WT_j5-8wEtw64yEfoSwnw8?via=nixos.org&via=matrix.org&via=nixos.dev), we concluded that the best way to test this package would be to add a separate "test" output, which would install the `uiohook_tests` binary under `/share`.

The NixOS test could then install the "test" output and run the binary, without the casual user needing to have it installed. The only downside is that the test binary is still built even if the "out" output is specified. But it's fairly quick to build, so hopefully that isn't much concern.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
