### PR TITLE
libphonenumber: 8.12.37 -> 8.12.51

### DIFF
--- a/pkgs/applications/plasma-mobile/plasma-dialer.nix
+++ b/pkgs/applications/plasma-mobile/plasma-dialer.nix
@@ -14,7 +14,6 @@
 , kpeople
 , libphonenumber
 , modemmanager-qt
-, protobuf
 , qtfeedback
 , qtmpris
 , qtquickcontrols2
@@ -39,7 +38,6 @@ mkDerivation rec {
     kpeople
     libphonenumber
     modemmanager-qt
-    protobuf # Needed by libphonenumber
     qtfeedback
     qtmpris
     qtquickcontrols2

--- a/pkgs/applications/plasma-mobile/spacebar.nix
+++ b/pkgs/applications/plasma-mobile/spacebar.nix
@@ -12,7 +12,6 @@
 , libphonenumber
 , libqofono
 , modemmanager-qt
-, protobuf
 , qcoro
 , qtquickcontrols2
 }:
@@ -33,7 +32,6 @@ mkDerivation rec {
     kpeople
     libphonenumber
     modemmanager-qt
-    protobuf # Needed by libphonenumber
     qcoro
     qtquickcontrols2
   ];

--- a/pkgs/development/libraries/libphonenumber/cmake-abseil.patch
+++ b/pkgs/development/libraries/libphonenumber/cmake-abseil.patch
@@ -1,0 +1,47 @@
+diff --git i/cpp/CMakeLists.txt w/cpp/CMakeLists.txt
+index 57261a63..27755707 100644
+--- i/cpp/CMakeLists.txt
++++ w/cpp/CMakeLists.txt
+@@ -126,6 +126,8 @@ if (${USE_BOOST} STREQUAL "OFF" AND ${USE_STDMUTEX} STREQUAL "OFF")
+   find_package (Threads)
+ endif()
+ 
++find_package (absl REQUIRED)
++
+ find_or_build_gtest ()
+ 
+ if (${USE_RE2} STREQUAL "ON")
+diff --git i/tools/cpp/CMakeLists.txt w/tools/cpp/CMakeLists.txt
+index b0941656..c4dc4b20 100644
+--- i/tools/cpp/CMakeLists.txt
++++ w/tools/cpp/CMakeLists.txt
+@@ -26,29 +26,10 @@ project (generate_geocoding_data)
+ # Helper functions dealing with finding libraries and programs this library
+ # depends on.
+ include (gtest.cmake)
+-include (FetchContent)
+-
+-# Downloading the abseil sources.
+-FetchContent_Declare(
+-    abseil-cpp
+-    GIT_REPOSITORY  https://github.com/abseil/abseil-cpp.git
+-    GIT_TAG         origin/master
+-)
+-
+-# Building the abseil binaries
+-FetchContent_GetProperties(abseil-cpp)
+-if (NOT abseil-cpp_POPULATED)
+-    FetchContent_Populate(abseil-cpp)
+-endif ()
+-
+-if (NOT abseil-cpp_POPULATED)
+-   message (FATAL_ERROR "Could not build abseil-cpp binaries.")
+-endif ()
+ 
+ # Safeguarding against any potential link errors as mentioned in
+ # https://github.com/abseil/abseil-cpp/issues/225
+ set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
+-add_subdirectory(${abseil-cpp_SOURCE_DIR} ${abseil-cpp_BINARY_DIR})
+ 
+ find_or_build_gtest ()
+ set (

--- a/pkgs/development/libraries/libphonenumber/default.nix
+++ b/pkgs/development/libraries/libphonenumber/default.nix
@@ -1,31 +1,55 @@
-{ lib, stdenv, fetchFromGitHub, cmake, gtest, boost, pkg-config, protobuf, icu, Foundation }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, git
+, gtest
+, abseil-cpp
+, boost
+, protobuf
+, Foundation
+, icu
+}:
 
 stdenv.mkDerivation rec {
   pname = "phonenumber";
-  version = "8.12.37";
+  version = "8.12.51";
 
   src = fetchFromGitHub {
-    owner = "googlei18n";
+    owner = "google";
     repo = "libphonenumber";
     rev = "v${version}";
-    sha256 = "sha256-xLxadSxVY3DjFDQrqj3BuOvdMaKdFSLjocfzovJCBB0=";
+    hash = "sha256-b03GYBepvQBcTJDg+HsOKbykHpQ8hpHGL5pbeX5jnms=";
   };
+
+  patches = [
+    ./cmake-abseil.patch
+  ];
 
   nativeBuildInputs = [
     cmake
-    gtest
     pkg-config
+    gtest
   ];
 
   buildInputs = [
     boost
-    protobuf
+  ] ++ lib.optionals stdenv.isDarwin [
+    Foundation
+  ];
+
+  propagatedBuildInputs = [
+    abseil-cpp
     icu
-  ] ++ lib.optional stdenv.isDarwin Foundation;
+    protobuf
+  ];
 
   cmakeDir = "../cpp";
 
-  checkPhase = "./libphonenumber_test";
+  doCheck = true;
+
+  checkTarget = "tests";
 
   meta = with lib; {
     description = "Google's i18n library for parsing and using phone numbers";

--- a/pkgs/tools/text/pn/default.nix
+++ b/pkgs/tools/text/pn/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, libphonenumber, icu, protobuf }:
+{ lib, stdenv, fetchFromGitHub, cmake, libphonenumber }:
 
 stdenv.mkDerivation rec {
   pname = "pn";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ libphonenumber icu protobuf ];
+  buildInputs = [ libphonenumber ];
 
   meta = with lib; {
     description = "A libphonenumber command-line wrapper";


### PR DESCRIPTION
###### Description of changes

`libphonenumber` is using Abseil now, but annoyingly they force a source fetch of Abseil's master tree using CMake's `FetchContent` (their "Live at HEAD" motto), so we cannot avoid patching the CMake files now to use our `abseil-cpp` package.

Since the installed headers include Abseil, ICU, Probotuf and Boost headers, I've added `abseil-cpp`, `icu` and `protobuf` to `propagatedBuildInputs` (I am not sure about adding `boost`, since it's too big of a dependency).

Now that they are propagated, I've removed those inputs from derivations using `libphonenumber` that were including them just because `libphonenumber` uses them, at least the obvious ones (see the diff), but there are a few that I didn't know what to do:

- pkgs/applications/networking/instant-messengers/chatty/default.nix (protobuf)
- pkgs/desktops/plasma-5/plasma-mobile/default.nix (protobuf)
- pkgs/desktops/gnome/core/evolution-data-server/default.nix (protobuf, icu, boost)

Also, this needs someone doing a nixpkgs-review on Linux, since I don't have a Linux box.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
