### PR TITLE
jack-autoconnect: init at unstable-2021-02-01

### DIFF
--- a/pkgs/applications/audio/jack-autoconnect/default.nix
+++ b/pkgs/applications/audio/jack-autoconnect/default.nix
@@ -7,7 +7,7 @@ mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "kripton";
-    repo = "jack_autoconnect";
+    repo = pname;
     rev = "fe0c8f69149e30979e067646f80b9d326341c02b";
     sha256 = "sha256-imvNc498Q2W9RKmiOoNepSoJzIv2tGvFG6hx+seiifw=";
   };

--- a/pkgs/applications/audio/jack-autoconnect/default.nix
+++ b/pkgs/applications/audio/jack-autoconnect/default.nix
@@ -1,0 +1,31 @@
+{ lib, mkDerivation, fetchFromGitHub, pkg-config, qmake, qtbase, libjack2 }:
+mkDerivation rec {
+  pname = "jack_autoconnect";
+
+  # It does not have any versions (yet?)
+  version = "unstable-2021-02-01";
+
+  src = fetchFromGitHub {
+    owner = "kripton";
+    repo = "jack_autoconnect";
+    rev = "fe0c8f69149e30979e067646f80b9d326341c02b";
+    sha256 = "sha256-imvNc498Q2W9RKmiOoNepSoJzIv2tGvFG6hx+seiifw=";
+  };
+
+  buildInputs = [ qtbase libjack2 ];
+  nativeBuildInputs = [ pkg-config qmake ];
+
+  installPhase = ''
+    mkdir -p -- "$out/bin"
+    cp -- jack_autoconnect "$out/bin"
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/kripton/jack_autoconnect";
+    description =
+      "Tiny application that reacts on port registrations by clients and connects them";
+    maintainers = with maintainers; [ unclechu ];
+    license = licenses.gpl2Only;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34693,6 +34693,9 @@ with pkgs;
 
   libjack2 = jack2.override { prefix = "lib"; };
 
+  jack-autoconnect = libsForQt5.callPackage ../applications/audio/jack-autoconnect { };
+  jack_autoconnect = jack-autoconnect;
+
   jacktrip = libsForQt5.callPackage ../applications/audio/jacktrip { };
 
   j2cli = with python3Packages; toPythonApplication j2cli;


### PR DESCRIPTION
###### Description of changes

Applied `nixfmt` against the added module.

Tested on x86_64 and also on aarch64 on Pine64 ROCKPro64.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
