### PR TITLE
mangareader: init at 2.0.4

### DIFF
--- a/pkgs/applications/graphics/mangareader/default.nix
+++ b/pkgs/applications/graphics/mangareader/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, wrapQtAppsHook
+, extra-cmake-modules
+, cmake
+, kio
+, ki18n
+, kxmlgui
+, kconfig
+, karchive
+, kcoreaddons
+, kconfigwidgets
+, nix-update-script
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mangareader";
+  version = "2.0.4";
+
+  src = fetchFromGitHub {
+    owner = "g-fb";
+    repo = pname;
+    rev = version;
+    hash = "sha256-j5b2O5OgDRaaxNssknTTgVscudk1+mFlGQN5KE6CwcU=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    kio
+    ki18n
+    kxmlgui
+    kconfig
+    karchive
+    kcoreaddons
+    kconfigwidgets
+  ];
+
+  passthru.updateScript = nix-update-script {
+    attrPath = pname;
+  };
+
+  meta = with lib; {
+    description = "Qt manga reader for local files";
+    homepage = "https://github.com/g-fb/mangareader";
+    changelog = "https://github.com/g-fb/mangareader/releases/tag/${src.rev}";
+    platforms = platforms.linux;
+    license = with licenses; [ gpl3Plus cc-by-nc-sa-40 ];
+    maintainers = with maintainers; [ zendo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8489,6 +8489,8 @@ with pkgs;
 
   mandoc = callPackage ../tools/misc/mandoc { };
 
+  mangareader = libsForQt5.callPackage ../applications/graphics/mangareader { };
+
   mangohud = callPackage ../tools/graphics/mangohud {
     libXNVCtrl = linuxPackages.nvidia_x11.settings.libXNVCtrl;
     mangohud32 = pkgsi686Linux.mangohud;


### PR DESCRIPTION
###### Description of changes

Qt manga reader for local files. 
https://github.com/g-fb/mangareader

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
