### PR TITLE
qt6.qtwebengine: fix build

### DIFF
--- a/pkgs/development/libraries/qt-6/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwebengine.nix
@@ -3,6 +3,7 @@
 , qtwebchannel
 , qtpositioning
 , qtwebsockets
+, buildPackages
 , bison
 , coreutils
 , flex
@@ -104,6 +105,9 @@ qtModule rec {
         --replace "/usr/bin/env -S deno" "/usr/bin/deno" || true
       patchShebangs .
     )
+
+    substituteInPlace cmake/Functions.cmake \
+      --replace "/bin/bash" "${buildPackages.bash}/bin/bash"
 
     sed -i -e '/lib_loader.*Load/s!"\(libudev\.so\)!"${lib.getLib systemd}/lib/\1!' \
       src/3rdparty/chromium/device/udev_linux/udev?_loader.cc


### PR DESCRIPTION
###### Description of changes

I am still able to build this from time to time,
but I also see:

```
[112/235] Building CXX object src/core/api/CMakeFiles/WebEngineCore.dir/qwebengineurlrequestjob.cpp.o
[113/235] Building CXX object src/core/api/CMakeFiles/WebEngineCore.dir/qwebenginehttprequest.cpp.o
[114/235] Building CXX object src/core/api/CMakeFiles/WebEngineCore.dir/qwebengineurlrequestinfo.cpp.o
[115/235] Building CXX object src/core/api/CMakeFiles/WebEngineCore.dir/qwebenginenewwindowrequest.cpp.o
[116/235] Building CXX object src/core/api/CMakeFiles/WebEngineCore.dir/qwebenginescriptcollection.cpp.o
[117/235] Building CXX object src/core/api/CMakeFiles/WebEngineCore.dir/qwebengineprofile.cpp.o
[118/235] Building CXX object src/core/api/CMakeFiles/WebEngineCore.dir/qwebenginepage.cpp.o
[119/235] Linking CXX shared library lib/libQt6WebEngineCore.so.6.3.1
FAILED: lib/libQt6WebEngineCore.so.6.3.1 
: && /build/qtwebengine-everywhere-src-6.3.1/build/linker_ulimit.sh /nix/store/d7d0ccp06rblhwk9sqnqn4lynijbjgv6-gcc-wrapper-11.3.0/bin/g++ -fPIC -DNDEBUG -O2  -Wl,-Bsymbolic-functions -Wl,--no-undefined @/build/qtwebengine-everywhere-src-6.3.1/build/src/core/Release/x86_64/QtWebEngineCore_objects.rsp -Wl,--enable-new-dtags -shared -Wl,-soname,libQt6WebEngineCore.so.6 -o lib/libQt6WebEngineCore.so.6.3.1 src/core/api/CMakeFiles/WebEngineCore.dir/WebEngineCore_autogen/mocs_compilation.cpp.o src/core/api/CMakeFiles/WebEngineCore.dir/qtwebenginecoreglobal.cpp.o src/core/api/CMakeFiles/WebEngineCore.dir/qwebenginecertificateerror.cpp.o src/core/api/CMakeFiles/WebEngineCore.dir/qwebengineclientcertificateselection.cpp.o src/core/api/CMakeFiles/WebEngineCore.dir/qwebengineclientcertificatestore.cpp.o src/core/api/CMakeFiles/WebEngineCore.dir/qwebenginecontextmenurequest.cpp.o src/core/api/CMakeFiles/WebEngineCore.dir/qwebenginecookiestore.cpp.o src/core/api/CMakeFiles/WebEngineCore.dir/qwebenginedownloadrequest.cpp.o src/core/api/CMakeFiles/WebEngineCore.dir/qwebenginefindtextresult.cpp.o src/core/api/CMakeFiles/WebEngineCore.dir/qwebenginefullscreenrequest.cpp.o src/core/api/CMakeFiles/WebEngineCore.dir/qwebenginehistory.cpp.o src/core/api/CMakeFiles/WebEngineCore.dir/qwebenginehttprequest.cpp.o src/core/api/CMakeFiles/WebEngineCore.dir/qwebengineloadinginfo.cpp.o src/core/api/CMakeFiles/WebEngineCore.dir/qwebenginemessagepumpscheduler.cpp.o src/core/api/CMakeFiles/WebEngineCore.dir/qwebenginenavigationrequest.cpp.o src/core/api/CMakeFiles/WebEngineCore.dir/qwebenginenewwindowrequest.cpp.o src/core/api/CMakeFiles/WebEngineCore.dir/qwebenginenotification.cpp.o src/core/api/CMakeFiles/WebEngineCore.dir/qwebenginepage.cpp.o src/core/api/CMakeFiles/WebEngineCore.dir/qwebengineprofile.cpp.o src/core/api/CMakeFiles/WebEngineCore.dir/qwebenginequotarequest.cpp.o src/core/api/CMakeFiles/WebEngineCore.dir/qwebengineregisterprotocolhandlerrequest.cpp.o src/core/api/CMakeFiles/WebEngineCore.dir/qwebenginescript.cpp.o src/core/api/CMakeFiles/WebEngineCore.dir/qwebenginescriptcollection.cpp.o src/core/api/CMakeFiles/WebEngineCore.dir/qwebenginesettings.cpp.o src/core/api/CMakeFiles/WebEngineCore.dir/qwebengineurlrequestinfo.cpp.o src/core/api/CMakeFiles/WebEngineCore.dir/qwebengineurlrequestjob.cpp.o src/core/api/CMakeFiles/WebEngineCore.dir/qwebengineurlscheme.cpp.o src/core/api/CMakeFiles/WebEngineCore.dir/qwebengineurlschemehandler.cpp.o  -Wl,-rpath,:::::::  -Wl,--start-group @/build/qtwebengine-everywhere-src-6.3.1/build/src/core/Release/x86_64/QtWebEngineCore_archives.rsp -Wl,--end-group  -Wl,--no-fatal-warnings @/build/qtwebengine-everywhere-src-6.3.1/build/src/core/Release/x86_64/QtWebEngineCore_libs.rsp -Wl,--no-fatal-warnings  /nix/store/w9ls9zkcpzx28nzm3sdpgr56l6ibzjv8-libxkbcommon-1.4.1/lib/libxkbcommon.so  /nix/store/rbqh774d8vdgb67cvancv6zrr8hhb1pm-qtdeclarative-6.3.1/lib/libQt6Quick.so.6.3.1  /nix/store/98x78cdz8259f6g3fldzp26ddisqipg4-qtbase-6.3.1/lib/libQt6OpenGL.so.6.3.1  /nix/store/98x78cdz8259f6g3fldzp26ddisqipg4-qtbase-6.3.1/lib/libQt6Gui.so.6.3.1  /nix/store/4lfzpa37cps2apm1khj8wngcp76sjgv3-libGL-1.4.0/lib/libGLX.so  /nix/store/4lfzpa37cps2apm1khj8wngcp76sjgv3-libGL-1.4.0/lib/libOpenGL.so  /nix/store/rbqh774d8vdgb67cvancv6zrr8hhb1pm-qtdeclarative-6.3.1/lib/libQt6QmlModels.so.6.3.1  /nix/store/q3wpns8dly7302y037jm9fhkanpxn9fh-qtwebchannel-6.3.1/lib/libQt6WebChannel.so.6.3.1  /nix/store/rbqh774d8vdgb67cvancv6zrr8hhb1pm-qtdeclarative-6.3.1/lib/libQt6Qml.so.6.3.1  /nix/store/98x78cdz8259f6g3fldzp26ddisqipg4-qtbase-6.3.1/lib/libQt6Network.so.6.3.1  /nix/store/3vdkynbgcx24ghry2gaia8nv5b1qadn6-qtpositioning-6.3.1/lib/libQt6Positioning.so.6.3.1  /nix/store/98x78cdz8259f6g3fldzp26ddisqipg4-qtbase-6.3.1/lib/libQt6Core.so.6.3.1 && :
/bin/sh: /build/qtwebengine-everywhere-src-6.3.1/build/linker_ulimit.sh: not found
ninja: build stopped: subcommand failed.
```

on hydra: https://hydra.nixos.org/build/183115717/nixlog/1

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
