### PR TITLE
cpm: download from GitHub releases instead of GitHub source code

### DIFF
--- a/pkgs/development/tools/cpm/default.nix
+++ b/pkgs/development/tools/cpm/default.nix
@@ -1,28 +1,25 @@
 { lib
 , stdenvNoCC
-, fetchFromGitHub
+, fetchurl
 }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "cpm";
   version = "0.35.1";
 
-  src = fetchFromGitHub {
-    owner = "cpm-cmake";
-    repo = "CPM.cmake";
-    rev = "v${version}";
-    hash = "sha256-Oon/5iwkUUASsUDvde69iEwLe8/CAzwYKYsyzH5K+V0=";
+  src = fetchurl {
+    url = "https://github.com/cpm-cmake/CPM.cmake/releases/download/v${version}/CPM.cmake";
+    sha256 = "sha256-CMge+NpJRU+G+c+s0tb2EN8UG6E8FE90lIvcULggYXY=";
   };
 
+  dontUnpack = true;
   dontConfigure = true;
-
   dontBuild = true;
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p ${placeholder "out"}/share/cpm/
-    cp ./cmake/CPM.cmake ${placeholder "out"}/share/cpm/
+    install -Dm644 $src $out/share/cpm/CPM.cmake
 
     runHook postInstall
   '';


### PR DESCRIPTION
###### Description of changes

CPM.cmake in GitHub source code does not set the proper version:

https://github.com/cpm-cmake/CPM.cmake/blob/5961f9f9fb6d5d8fa387e26b2dd1b40fa1d77a5c/cmake/CPM.cmake#L31

To use CPM.cmake with the correct version, we must download it from GitHub releases:

https://github.com/cpm-cmake/CPM.cmake/blob/5961f9f9fb6d5d8fa387e26b2dd1b40fa1d77a5c/cmake/get_cpm.cmake#L16

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
