### PR TITLE
minijail: 17 -> 18

### DIFF
--- a/pkgs/tools/system/minijail/default.nix
+++ b/pkgs/tools/system/minijail/default.nix
@@ -11,24 +11,24 @@ in
 
 stdenv.mkDerivation rec {
   pname = "minijail";
-  version = "17";
+  version = "18";
 
   src = fetchFromGitiles {
     url = "https://android.googlesource.com/platform/external/minijail";
     rev = "linux-v${version}";
-    sha256 = "1j65h50wa39m6qvgnh1pf59fv9jdsdbc6a6c1na7y0rgljxhmdzv";
+    sha256 = "sha256-OpwzISZ5iZNQvJAX7UJJ4gELEaVfcQgY9cqMM0YvBzc=";
   };
 
   nativeBuildInputs =
     lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) qemu;
   buildInputs = [ libcap ];
 
-  makeFlags = [ "LIBDIR=$(out)/lib" ];
+  makeFlags = [ "ECHO=echo" "LIBDIR=$(out)/lib" ];
   dumpConstantsFlags = lib.optional (stdenv.hostPlatform.libc == "glibc")
     "LDFLAGS=-L${glibc.static}/lib";
 
   postPatch = ''
-    substituteInPlace common.mk --replace /bin/echo echo
+    substituteInPlace Makefile --replace /bin/echo echo
     patchShebangs platform2_preinstall.sh
   '';
 

--- a/pkgs/tools/system/minijail/default.nix
+++ b/pkgs/tools/system/minijail/default.nix
@@ -55,6 +55,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://android.googlesource.com/platform/external/minijail/";
     description = "Sandboxing library and application using Linux namespaces and capabilities";
+    changelog = "https://android.googlesource.com/platform/external/minijail/+/refs/tags/linux-v${version}";
     license = licenses.bsd3;
     maintainers = with maintainers; [ pcarrier qyliss ];
     platforms = platforms.linux;


### PR DESCRIPTION
###### Description of changes

https://android.googlesource.com/platform/external/minijail/+/refs/tags/linux-v18

Tested building minijail, minijail-tools, and crosvm.
Unfortunately the crosvm sandbox is broken at the moment due to the Glibc upgrade (ah, seccomp), but it gets just as far as it did with minijail 17, and the release notes look pretty straightforward.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
