### PR TITLE
pivy: 0.6.6 -> 0.6.7

### DIFF
--- a/pkgs/development/python-modules/pivy/default.nix
+++ b/pkgs/development/python-modules/pivy/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "pivy";
-  version = "0.6.6";
+  version = "0.6.7";
 
   src = fetchFromGitHub {
     owner = "coin3d";
     repo = "pivy";
     rev = version;
-    sha256 = "1xlynrbq22pb252r37r80b3myzap8hzhvknz4zfznfrsg9ykh8k2";
+    sha256 = "mU3QRDJd56gGDWqwcxAN3yUCkAkABP/I9gIBMH2MOXA=";
   };
 
   dontUseCmakeConfigure = true;


### PR DESCRIPTION
When attempting to do certain operations in FreeCAD, I ran into this
error:

    12:24:32  Traceback (most recent call last):
    12:24:32    File "/nix/store/y43dl4mv61lvzpdvwpwpsazj6b3ii87l-freecad-0.20/Mod/Image/ImageTools/_CommandImageScaling.py", line 181, in getmousepoint
    12:24:32      event = event_cb.getEvent()
    12:24:32    File "/nix/store/dq8yly6isjzq6imm0i0qjxkang5rcq84-python3.10-pivy-0.6.6/lib/python3.10/site-packages/pivy/coin.py", line 49384, in getEvent
    12:24:32      return _coin.SoEventCallback_getEvent(self)
    12:24:32  SystemError: <built-in function SoEventCallback_getEvent> returned a result with an exception set
    12:24:33  <class 'SystemError'>
    12:24:33  SystemError: PY_SSIZE_T_CLEAN macro must be defined for '#' formats
    12:24:33
    The above exception was the direct cause of the following exception:

This macro was defined in
https://github.com/coin3d/pivy/commit/2f049c19200ab4a3a1e4740268450496c12359f9,
well after 0.6.6 was released, implying that FreeCAD depends on 0.6.7.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

@gebner 