### PR TITLE
opam2json: init at v0.2

### DIFF
--- a/pkgs/development/tools/ocaml/opam2json/default.nix
+++ b/pkgs/development/tools/ocaml/opam2json/default.nix
@@ -1,0 +1,25 @@
+{ lib, stdenv, fetchFromGitHub, opam-installer, ocamlPackages }:
+stdenv.mkDerivation rec {
+  pname = "opam2json";
+  version = "0.2";
+
+  src = fetchFromGitHub {
+    owner = "tweag";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "fe8bm/V/4r2iNxgbitT2sXBqDHQ0GBSnSUSBg/1aXoI=";
+  };
+
+  buildInputs = with ocamlPackages; [ yojson opam-file-format cmdliner ];
+  nativeBuildInputs = with ocamlPackages; [ ocaml findlib opam-installer ];
+
+  preInstall = ''export PREFIX="$out"'';
+
+  meta = with lib; {
+    platforms = platforms.all;
+    description = "convert opam file syntax to JSON";
+    maintainers = [ maintainers.balsoft ];
+    license = licenses.gpl3;
+    homepage = "https://github.com/tweag/opam2json";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13938,6 +13938,8 @@ with pkgs;
 
   opam-installer = callPackage ../development/tools/ocaml/opam/installer.nix { };
 
+  opam2json = callPackage ../development/tools/ocaml/opam2json { };
+
   wrapWatcom = callPackage ../development/compilers/open-watcom/wrapper.nix { };
   open-watcom-v2-unwrapped = callPackage ../development/compilers/open-watcom/v2.nix { };
   open-watcom-v2 = wrapWatcom open-watcom-v2-unwrapped { };


### PR DESCRIPTION
###### Description of changes

[opam2json](https://github.com/tweag/opam2json) is a tool for converting files
in opam file format into JSON. It can be useful for use with Nix'
`builtins.fromJSON` to get the contents of opam packages from Nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
