### PR TITLE
qogir-theme: 2022-05-29 -> 2022-07-17

### DIFF
--- a/pkgs/data/themes/qogir/default.nix
+++ b/pkgs/data/themes/qogir/default.nix
@@ -38,8 +38,11 @@ stdenv.mkDerivation rec {
     gtk-engine-murrine # murrine engine for Gtk2
   ];
 
+  postPatch = ''
+    patchShebangs install.sh clean-old-theme.sh
+  '';
+
   installPhase = ''
-    patchShebangs .
     mkdir -p $out/share/themes
     name= HOME="$TMPDIR" ./install.sh -t all -d $out/share/themes
     mkdir -p $out/share/doc/${pname}

--- a/pkgs/data/themes/qogir/default.nix
+++ b/pkgs/data/themes/qogir/default.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation rec {
   pname = "qogir-theme";
-  version = "2022-05-29";
+  version = "2022-07-17";
 
   src = fetchFromGitHub {
     owner = "vinceliuice";
     repo = pname;
     rev = version;
-    sha256 = "z8o/1Qc7XmefX9CuVr0Gq2MmKw2NlkUk+5Lz0Z593do=";
+    sha256 = "NGgTToaSJBwmHnZjWbJ3dSJg9Mmfchj3W0xgK0CMb9M=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/data/themes/qogir/default.nix
+++ b/pkgs/data/themes/qogir/default.nix
@@ -43,6 +43,8 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/themes
     name= HOME="$TMPDIR" ./install.sh -t all -d $out/share/themes
     mkdir -p $out/share/doc/${pname}
@@ -50,6 +52,8 @@ stdenv.mkDerivation rec {
     rm $out/share/themes/*/{AUTHORS,COPYING}
 
     jdupes --link-soft --recurse $out/share
+
+    runHook postInstall
   '';
 
   passthru.updateScript = gitUpdater { inherit pname version; };

--- a/pkgs/data/themes/qogir/default.nix
+++ b/pkgs/data/themes/qogir/default.nix
@@ -1,13 +1,14 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, gitUpdater
 , gdk-pixbuf
 , gnome-themes-extra
 , gtk-engine-murrine
+, jdupes
 , librsvg
 , sassc
 , which
-, gitUpdater
 }:
 
 stdenv.mkDerivation rec {
@@ -22,6 +23,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
+    jdupes
     sassc
     which
   ];
@@ -43,6 +45,8 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share/doc/${pname}
     cp -a src/firefox $out/share/doc/${pname}
     rm $out/share/themes/*/{AUTHORS,COPYING}
+
+    jdupes --link-soft --recurse $out/share
   '';
 
   passthru.updateScript = gitUpdater { inherit pname version; };


### PR DESCRIPTION
###### Description of changes

- Update to version [2022-07-17](https://github.com/vinceliuice/Qogir-theme/releases/tag/2022-07-17)
- Replace duplicate files with links
- Move `patchShebangs` to post patch phase
- Run pre and post install hooks
- Add optional arguments

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
