### PR TITLE
criterion: 2.3.3 -> 2.4.1, used prebuilt packge

### DIFF
--- a/pkgs/development/libraries/criterion/default.nix
+++ b/pkgs/development/libraries/criterion/default.nix
@@ -1,4 +1,5 @@
-{ stdenv
+{ lib
+, stdenv
 , fetchurl
 , autoPatchelfHook
 }:
@@ -25,4 +26,14 @@ stdenv.mkDerivation rec {
     mkdir $out
     cp -r criterion-${version}/* $out/
   '';
+  meta = with lib; {
+    description = "A cross-platform C and C++ unit testing framework for the 21th century";
+    homepage = "https://github.com/Snaipe/Criterion";
+    license = licenses.mit;
+    maintainers = with maintainers; [
+      thesola10
+      Yumasi
+    ];
+    platforms = platforms.unix;
+  };
 }

--- a/pkgs/development/libraries/criterion/default.nix
+++ b/pkgs/development/libraries/criterion/default.nix
@@ -1,47 +1,28 @@
-{ lib, stdenv, fetchFromGitHub, boxfort, cmake, libcsptr, pkg-config, gettext
-, dyncall , nanomsg, python3Packages }:
+{ stdenv
+, fetchurl
+, autoPatchelfHook
+}:
 
 stdenv.mkDerivation rec {
-  version = "2.3.3";
+
+  version = "2.4.1";
   pname = "criterion";
 
-  src = fetchFromGitHub {
-    owner = "Snaipe";
-    repo = "Criterion";
-    rev = "v${version}";
-    sha256 = "0y1ay8is54k3y82vagdy0jsa3nfkczpvnqfcjm5n9iarayaxaq8p";
-    fetchSubmodules = true;
+  src = fetchurl {
+    url = "https://github.com/Snaipe/Criterion/releases/download/v${version}/criterion-${version}-linux-x86_64.tar.xz";
+    sha256 = "0907r10bk8wp1pmb0ndsndn5qxaj5nyk8zb6jnwi0vqg0g46p5id";
   };
 
-  nativeBuildInputs = [ cmake pkg-config ];
+  outputs = [ "out" ];
 
-  buildInputs = [
-    boxfort.dev
-    dyncall
-    gettext
-    libcsptr
-    nanomsg
+  nativeBuildInputs = [
+    autoPatchelfHook
   ];
 
-  checkInputs = with python3Packages; [ cram ];
+  sourceRoot = ".";
 
-  cmakeFlags = [ "-DCTESTS=ON" ];
-  doCheck = true;
-  preCheck = ''
-    export LD_LIBRARY_PATH=`pwd`''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH
+  installPhase = ''
+    mkdir $out
+    cp -r criterion-${version}/* $out/
   '';
-  checkTarget = "criterion_tests test";
-
-  outputs = [ "dev" "out" ];
-
-  meta = with lib; {
-    description = "A cross-platform C and C++ unit testing framework for the 21th century";
-    homepage = "https://github.com/Snaipe/Criterion";
-    license = licenses.mit;
-    maintainers = with maintainers; [
-      thesola10
-      Yumasi
-    ];
-    platforms = platforms.unix;
-  };
 }


### PR DESCRIPTION
The criterion package was suffering of bad includes but that is
now fixed using the tarball that is build on the Release page on
Github. This commit also bumps the version from 2.3.3 to 2.4.1.

###### Description of changes

Changed the version and the package is now not built from the sources anymore.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin 
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).