### PR TITLE
julia: build julia_17-bin on aarch64-darwin

### DIFF
--- a/pkgs/development/compilers/julia/1.7-bin.nix
+++ b/pkgs/development/compilers/julia/1.7-bin.nix
@@ -1,4 +1,4 @@
-{ autoPatchelfHook, fetchurl, lib, stdenv, fixDarwinDylibNames }:
+{ autoPatchelfHook, fetchurl, lib, stdenv }:
 
 stdenv.mkDerivation rec {
   pname = "julia-bin";

--- a/pkgs/development/compilers/julia/1.7-bin.nix
+++ b/pkgs/development/compilers/julia/1.7-bin.nix
@@ -62,6 +62,8 @@ stdenv.mkDerivation rec {
   preInstallCheck = ''
     # Some tests require read/write access to $HOME.
     export HOME="$TMPDIR"
+    # Libgit2 complains with our custom CA cert
+    export JULIA_SSL_CA_ROOTS_PATH=""
   '';
   installCheckPhase = ''
     runHook preInstallCheck

--- a/pkgs/development/compilers/julia/patches/1.7-bin/0005-nix-Disable-https-tests.patch
+++ b/pkgs/development/compilers/julia/patches/1.7-bin/0005-nix-Disable-https-tests.patch
@@ -1,0 +1,20 @@
+diff --git a/test/download_exec.jl b/test/download_exec.jl
+index 777fb67..a081fa3 100644
+--- a/test/download_exec.jl
++++ b/test/download_exec.jl
+@@ -5,6 +5,7 @@ module TestDownload
+ using Test
+ 
+ mktempdir() do temp_dir
++#= Disable impure tests
+     # Download a file
+     file = joinpath(temp_dir, "ip")
+     @test download("https://httpbin.julialang.org/ip", file) == file
+@@ -22,6 +23,7 @@ mktempdir() do temp_dir
+     missing_file = joinpath(temp_dir, "missing")
+     @test_throws Exception download("https://httpbin.julialang.org/status/404", missing_file)
+     @test !isfile(missing_file)
++=#
+ 
+     # Use a TEST-NET (192.0.2.0/24) address which shouldn't be bound
+     invalid_host_file = joinpath(temp_dir, "invalid_host")


### PR DESCRIPTION
###### Description of changes

Expand `julia_17-bin` to aarch64-darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
