### PR TITLE
spdlog: enable static build through arguments

### DIFF
--- a/pkgs/development/libraries/spdlog/default.nix
+++ b/pkgs/development/libraries/spdlog/default.nix
@@ -1,4 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, cmake, fmt_8 }:
+{ lib, stdenv, fetchFromGitHub, cmake, fmt_8
+, staticBuild ? stdenv.hostPlatform.isStatic
+}:
 
 let
   generic = { version, sha256 }:
@@ -18,8 +20,8 @@ let
       propagatedBuildInputs = lib.optional (lib.versionAtLeast version "1.3") fmt_8;
 
       cmakeFlags = [
-        "-DSPDLOG_BUILD_SHARED=${if stdenv.hostPlatform.isStatic then "OFF" else "ON"}"
-        "-DSPDLOG_BUILD_STATIC=${if stdenv.hostPlatform.isStatic then "ON" else "OFF"}"
+        "-DSPDLOG_BUILD_SHARED=${if staticBuild then "OFF" else "ON"}"
+        "-DSPDLOG_BUILD_STATIC=${if staticBuild then "ON" else "OFF"}"
         "-DSPDLOG_BUILD_EXAMPLE=OFF"
         "-DSPDLOG_BUILD_BENCH=OFF"
         "-DSPDLOG_BUILD_TESTS=ON"


### PR DESCRIPTION
###### Description of changes

Like [OpenSSL](https://github.com/NixOS/nixpkgs/blob/bfae31c89d4e2d46c0addcda97d242d79609435c/pkgs/development/libraries/openssl/default.nix#L5) and [libgit2](https://github.com/NixOS/nixpkgs/blob/2815ff97dd5384da30a928addf8ca6563e33b034/pkgs/development/libraries/libgit2/default.nix#L14), I would like to make spdlog support the `staticBuild` argument.

Related to https://github.com/NixOS/nixpkgs/pull/181754, https://github.com/NixOS/nixpkgs/pull/178258, and https://github.com/NixOS/nixpkgs/pull/178258/checks?check_run_id=7373649988. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
