### PR TITLE
gamescope: init at 3.11.33-jupiter-3.3-2

### DIFF
--- a/pkgs/applications/window-managers/gamescope/default.nix
+++ b/pkgs/applications/window-managers/gamescope/default.nix
@@ -1,0 +1,91 @@
+{ stdenv
+, fetchFromGitHub
+, meson
+, pkg-config
+, ninja
+, xorg
+, libdrm
+, vulkan-loader
+, wayland
+, wayland-protocols
+, libxkbcommon
+, libcap
+, SDL2
+, pipewire
+, udev
+, pixman
+, libinput
+, libseat
+, xwayland
+, glslang
+, stb
+, wlroots
+, libliftoff
+, lib
+, makeBinaryWrapper
+}:
+let
+  pname = "gamescope";
+  version = "3.11.33-jupiter-3.3-2";
+in
+stdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "Plagman";
+    repo = "gamescope";
+    rev = "refs/tags/${version}";
+    hash = "sha256-6/gTsQGZDQPCdmXe5EI9QcT/MkdTf6odsI2/+g/W7Qc=";
+  };
+
+  patches = [ ./use-pkgconfig.patch ];
+
+  nativeBuildInputs = [
+    meson
+    pkg-config
+    ninja
+    makeBinaryWrapper
+  ];
+
+  buildInputs = [
+    xorg.libXdamage
+    xorg.libXcomposite
+    xorg.libXrender
+    xorg.libXext
+    xorg.libXxf86vm
+    xorg.libXtst
+    xorg.libXres
+    xorg.libXi
+    libdrm
+    libliftoff
+    vulkan-loader
+    glslang
+    SDL2
+    wayland
+    wayland-protocols
+    wlroots
+    xwayland
+    libseat
+    libinput
+    libxkbcommon
+    udev
+    pixman
+    pipewire
+    libcap
+    stb
+  ];
+
+  # --debug-layers flag expects these in the path
+  postInstall = ''
+    wrapProgram "$out/bin/gamescope" \
+     --prefix PATH : ${with xorg; lib.makeBinPath [xprop xwininfo]}
+  '';
+
+  meta = with lib; {
+    description = "SteamOS session compositing window manager";
+    homepage = "https://github.com/Plagman/gamescope";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ nrdxp ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/window-managers/gamescope/use-pkgconfig.patch
+++ b/pkgs/applications/window-managers/gamescope/use-pkgconfig.patch
@@ -1,0 +1,11 @@
+diff --git a/meson.build b/meson.build
+index 1311784..77043ac 100644
+--- a/meson.build
++++ b/meson.build
+@@ -6,7 +6,6 @@ project(
+   default_options: [
+     'cpp_std=c++14',
+     'warning_level=2',
+-    'force_fallback_for=wlroots,libliftoff',
+   ],
+ )

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1185,6 +1185,8 @@ with pkgs;
     libgamemode32 = pkgsi686Linux.gamemode.lib;
   };
 
+  gamescope = callPackage ../applications/window-managers/gamescope { };
+
   gay = callPackage ../tools/misc/gay {  };
 
   elkhound = callPackage ../development/tools/elkhound { };


### PR DESCRIPTION
###### Description of changes

Closes #162562

Based on @samueldr's version https://github.com/NixOS/nixpkgs/issues/162562#issuecomment-1138026849 

All I did was update to the latest tag, ~~add a pkgconfig file for stb~~, and add a small patch to stop meson from trying to load wlroots and libliftoff from it's src directory and instead rely on pkgconfig. That way we don't have to rely on copying sources as in the [original](https://github.com/Jovian-Experiments/Jovian-NixOS/blob/d27526e7917671ad3a64f823f4b95b761f96807d/pkgs/gamescope/default.nix#L72-L87).

I also figured out a way to add the `cap_sys_nice` capbility for NixOS systems to launch steam. But the change may be a bit contentious since I'd have to patch the steam derivation (since bubblewrap will fail without suid bit), so I'll save that for a seprate PR.

**Note**
~~I have not been able to successfully launch gamescope with the DRM backend from a VT. I have only been able to use it from a wayland session so far. Not sure if I just don't know the right flags to pass, or if this is a genuine upstream bug, or if it's an issue with Nvidia on a dual graphics laptop. Likely an upstream bug https://github.com/Plagman/gamescope/issues/498#issuecomment-1186386392~~ It works by passing `--disable-layers` https://github.com/Plagman/gamescope/issues/560

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->