### PR TITLE
glusterfs: patch around SSL_CERT_PATH detection

### DIFF
--- a/pkgs/tools/filesystems/glusterfs/default.nix
+++ b/pkgs/tools/filesystems/glusterfs/default.nix
@@ -65,6 +65,17 @@ in stdenv.mkDerivation rec {
   };
   inherit buildInputs propagatedBuildInputs;
 
+  patches = [
+    # Upstream invokes `openssl version -d` to derive the canonical system path
+    # for certificates, which resolves to a nix store path, so this patch
+    # statically sets the configure.ac value. There's probably a less-brittle
+    # way to do this! (this will likely fail on a version bump)
+    # References:
+    # - https://github.com/gluster/glusterfs/issues/3234
+    # - https://github.com/gluster/glusterfs/commit/a7dc43f533ad4b8ff68bf57704fefc614da65493
+    ./ssl_cert_path.patch
+  ];
+
   postPatch = ''
     sed -e '/chmod u+s/d' -i contrib/fuse-util/Makefile.am
     substituteInPlace libglusterfs/src/glusterfs/lvm-defaults.h \

--- a/pkgs/tools/filesystems/glusterfs/ssl_cert_path.patch
+++ b/pkgs/tools/filesystems/glusterfs/ssl_cert_path.patch
@@ -1,0 +1,23 @@
+diff --git a/configure.ac b/configure.ac
+index fb8db11e9e..4c40683057 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -766,14 +766,10 @@ AS_IF([test "x$enable_fuse_notifications" != "xno"], [
+ 
+ dnl Find out OpenSSL trusted certificates path
+ AC_MSG_CHECKING([for OpenSSL trusted certificates path])
+-SSL_CERT_PATH=$(openssl version -d | sed -e 's|OPENSSLDIR: "\(.*\)".*|\1|')
+-if test -d $SSL_CERT_PATH 1>/dev/null 2>&1; then
+-   AC_MSG_RESULT([$SSL_CERT_PATH])
+-   AC_DEFINE_UNQUOTED(SSL_CERT_PATH, ["$SSL_CERT_PATH"], [Path to OpenSSL trusted certificates.])
+-   AC_SUBST(SSL_CERT_PATH)
+-else
+-   AC_MSG_ERROR([Unable to detect path to OpenSSL trusted certificates])
+-fi
++SSL_CERT_PATH=/etc/ssl
++AC_MSG_RESULT([$SSL_CERT_PATH])
++AC_DEFINE_UNQUOTED(SSL_CERT_PATH, ["$SSL_CERT_PATH"], [Path to OpenSSL trusted certificates.])
++AC_SUBST(SSL_CERT_PATH)
+ 
+ AC_CHECK_LIB([ssl], TLS_method, [HAVE_OPENSSL_1_1="yes"], [HAVE_OPENSSL_1_1="no"])
+ if test "x$HAVE_OPENSSL_1_1" = "xyes"; then


### PR DESCRIPTION
###### Description of changes

Well, this was a pain to debug and fix, but I think it's correct.

[The upstream configure.ac invokes `openssl version -d` in order to find the system path for certificates](https://github.com/gluster/glusterfs/blob/c27bdbeb107eb2c786f64857189d08cb674b4eb8/configure.ac#L800-L809). This is problematic for us since that resolves to the nix store and lots of other mechanisms (including the glusterfs module) expect `/etc/ssl` to be the place for certificates, so this addition patches the file to set the value manually.

Here's what an example _failing_ log line looks like when trying to get certificates working:

```
[2022-07-16 21:10:40.479001 +0000] E [socket.c:4403:ssl_setup_connection_params] 0-glusterfs: could not load our cert at /nix/store/ypq5ii7vlp18ckcb32lsynxcmwpp9041-openssl-1.1.1o/etc/ssl/glusterfs.pem
```

Whoopsie! The [upstream issue](https://github.com/gluster/glusterfs/issues/3234) even cites that this new `SSL_CERT_PATH` detection is broken such that glusterfs 10.1's SSL mechansism just... doesn't work in accordance with the docs. This seems to suggest to me that this is something upstream glusterfs will fix, but in its current state, it's just plain broken, so it'd be nice to fix it regardless until that happens.

If there's a better way to patch around this (is there a way to force a variable when autotools renders the `configure.ac` template? I couldn't find anything) then I'd love to know about it because this is pretty brittle - for example, the patch fails against glusterfs's current `master` `configure.ac`.

I dunno if this warrant any documentation/release notes additions but I can do that if it should happen.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - ~[ ] (Package updates) Added a release notes entry if the change is major or breaking~
  - ~[ ] (Module updates) Added a release notes entry if the change is significant~
  - ~[ ] (Module addition) Added a release notes entry if adding a new NixOS module~
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
