### PR TITLE
cairo: upstream fix for macOS Big Sur (or newer) quartz crash

### DIFF
--- a/pkgs/development/libraries/cairo/default.nix
+++ b/pkgs/development/libraries/cairo/default.nix
@@ -55,6 +55,8 @@ in stdenv.mkDerivation rec {
   ] ++ optionals stdenv.hostPlatform.isDarwin [
     # Workaround https://gitlab.freedesktop.org/cairo/cairo/-/issues/121
     ./skip-configure-stderr-check.patch
+    # Backport fix for https://gitlab.freedesktop.org/cairo/cairo/-/issues/420
+    ./patch-cairo-quartz-surfaces.patch
   ];
 
   outputs = [ "out" "dev" "devdoc" ];

--- a/pkgs/development/libraries/cairo/patch-cairo-quartz-surfaces.patch
+++ b/pkgs/development/libraries/cairo/patch-cairo-quartz-surfaces.patch
@@ -1,0 +1,308 @@
+This patch fixes a crash on macOS Big Sur and newer, as reported in:
+https://gitlab.freedesktop.org/cairo/cairo/-/issues/420
+
+The crash has been fixed in cairo:
+https://gitlab.freedesktop.org/cairo/cairo/-/merge_requests/52
+https://gitlab.freedesktop.org/cairo/cairo/-/commit/ba2afdcacf42eccf263b39efc77b85f3a65dcd74
+https://gitlab.freedesktop.org/cairo/cairo/-/merge_requests/119
+https://gitlab.freedesktop.org/cairo/cairo/-/commit/38e486b34d435130f2fb38c429e6016c3c82cd53
+
+This patch file was created by copying a patch in MacPorts, and fixing the file
+paths:
+https://raw.githubusercontent.com/macports/macports-ports/e9fce065c100a6fc78a0c98c151cc9819749f1c1/graphics/cairo/files/patch-cairo-quartz-surfaces.diff
+
+--- a/src/cairo-quartz-image-surface.c
++++ b/src/cairo-quartz-image-surface.c
+@@ -50,10 +50,9 @@
+ #define SURFACE_ERROR_INVALID_FORMAT (_cairo_surface_create_in_error(_cairo_error(CAIRO_STATUS_INVALID_FORMAT)))
+ 
+ static void
+-DataProviderReleaseCallback (void *info, const void *data, size_t size)
++DataProviderReleaseCallback (void *image_info, const void *data, size_t size)
+ {
+-    cairo_surface_t *surface = (cairo_surface_t *) info;
+-    cairo_surface_destroy (surface);
++    free (image_info);
+ }
+ 
+ static cairo_surface_t *
+@@ -88,9 +87,8 @@ _cairo_quartz_image_surface_finish (void *asurface)
+ {
+     cairo_quartz_image_surface_t *surface = (cairo_quartz_image_surface_t *) asurface;
+ 
+-    /* the imageSurface will be destroyed by the data provider's release callback */
+     CGImageRelease (surface->image);
+-
++    cairo_surface_destroy ( (cairo_surface_t*) surface->imageSurface);
+     return CAIRO_STATUS_SUCCESS;
+ }
+ 
+@@ -147,24 +145,29 @@ _cairo_quartz_image_surface_flush (void *asurface,
+     cairo_quartz_image_surface_t *surface = (cairo_quartz_image_surface_t *) asurface;
+     CGImageRef oldImage = surface->image;
+     CGImageRef newImage = NULL;
+-
++    void *image_data;
++    const unsigned int size = surface->imageSurface->height * surface->imageSurface->stride;
+     if (flags)
+ 	return CAIRO_STATUS_SUCCESS;
+ 
+     /* XXX only flush if the image has been modified. */
+ 
+-    /* To be released by the ReleaseCallback */
+-    cairo_surface_reference ((cairo_surface_t*) surface->imageSurface);
++    image_data = _cairo_malloc_ab ( surface->imageSurface->height,
++				    surface->imageSurface->stride);
++    if (unlikely (!image_data))
++	return _cairo_error (CAIRO_STATUS_NO_MEMORY);
+ 
++    memcpy (image_data, surface->imageSurface->data,
++	    surface->imageSurface->height * surface->imageSurface->stride);
+     newImage = CairoQuartzCreateCGImage (surface->imageSurface->format,
+ 					 surface->imageSurface->width,
+ 					 surface->imageSurface->height,
+ 					 surface->imageSurface->stride,
+-					 surface->imageSurface->data,
++					 image_data,
+ 					 TRUE,
+ 					 NULL,
+ 					 DataProviderReleaseCallback,
+-					 surface->imageSurface);
++					 image_data);
+ 
+     surface->image = newImage;
+     CGImageRelease (oldImage);
+@@ -308,7 +311,7 @@ cairo_quartz_image_surface_create (cairo_surface_t *surface)
+     cairo_image_surface_t *image_surface;
+     int width, height, stride;
+     cairo_format_t format;
+-    unsigned char *data;
++    void *image_data;
+ 
+     if (surface->status)
+ 	return surface;
+@@ -321,7 +324,6 @@ cairo_quartz_image_surface_create (cairo_surface_t *surface)
+     height = image_surface->height;
+     stride = image_surface->stride;
+     format = image_surface->format;
+-    data = image_surface->data;
+ 
+     if (!_cairo_quartz_verify_surface_size(width, height))
+ 	return SURFACE_ERROR_INVALID_SIZE;
+@@ -338,20 +340,21 @@ cairo_quartz_image_surface_create (cairo_surface_t *surface)
+ 
+     memset (qisurf, 0, sizeof(cairo_quartz_image_surface_t));
+ 
+-    /* In case the create_cgimage fails, this ref will
+-     * be released via the callback (which will be called in
+-     * case of failure.)
+-     */
+-    cairo_surface_reference (surface);
++    image_data = _cairo_malloc_ab (height, stride);
++    if (unlikely (!image_data)) {
++	free(qisurf);
++	return SURFACE_ERROR_NO_MEMORY;
++    }
+ 
++    memcpy (image_data, image_surface->data, height * stride);
+     image = CairoQuartzCreateCGImage (format,
+ 				      width, height,
+ 				      stride,
+-				      data,
++				      image_data,
+ 				      TRUE,
+ 				      NULL,
+ 				      DataProviderReleaseCallback,
+-				      image_surface);
++				      image_data);
+ 
+     if (!image) {
+ 	free (qisurf);
+@@ -368,7 +371,7 @@ cairo_quartz_image_surface_create (cairo_surface_t *surface)
+     qisurf->height = height;
+ 
+     qisurf->image = image;
+-    qisurf->imageSurface = image_surface;
++    qisurf->imageSurface = (cairo_image_surface_t*) cairo_surface_reference(surface);
+ 
+     return &qisurf->base;
+ }
+@@ -381,7 +384,7 @@ cairo_quartz_image_surface_get_image (cairo_surface_t *asurface)
+ 
+     /* Throw an error for a non-quartz surface */
+     if (! _cairo_surface_is_quartz (asurface)) {
+-        return _cairo_surface_create_in_error (_cairo_error (CAIRO_STATUS_SURFACE_TYPE_MISMATCH));
++        return SURFACE_ERROR_TYPE_MISMATCH;
+     }
+ 
+     return (cairo_surface_t*) surface->imageSurface;
+--- a/src/cairo-quartz-surface.c
++++ b/src/cairo-quartz-surface.c
+@@ -778,20 +778,10 @@ CairoQuartzCreateGradientFunction (const cairo_gradient_pattern_t *gradient,
+ 			     &gradient_callbacks);
+ }
+ 
+-/* Obtain a CGImageRef from a #cairo_surface_t * */
+-
+-typedef struct {
+-    cairo_surface_t *surface;
+-    cairo_image_surface_t *image_out;
+-    void *image_extra;
+-} quartz_source_image_t;
+-
+ static void
+ DataProviderReleaseCallback (void *info, const void *data, size_t size)
+ {
+-    quartz_source_image_t *source_img = info;
+-    _cairo_surface_release_source_image (source_img->surface, source_img->image_out, source_img->image_extra);
+-    free (source_img);
++    free (info);
+ }
+ 
+ static cairo_status_t
+@@ -803,8 +793,9 @@ _cairo_surface_to_cgimage (cairo_surface_t       *source,
+ 			   CGImageRef            *image_out)
+ {
+     cairo_status_t status;
+-    quartz_source_image_t *source_img;
+     cairo_image_surface_t *image_surface;
++    void *image_data, *image_extra;
++    cairo_bool_t acquired = FALSE;
+ 
+     if (source->backend && source->backend->type == CAIRO_SURFACE_TYPE_QUARTZ_IMAGE) {
+ 	cairo_quartz_image_surface_t *surface = (cairo_quartz_image_surface_t *) source;
+@@ -826,19 +817,12 @@ _cairo_surface_to_cgimage (cairo_surface_t       *source,
+ 	}
+     }
+ 
+-    source_img = _cairo_malloc (sizeof (quartz_source_image_t));
+-    if (unlikely (source_img == NULL))
+-	return _cairo_error (CAIRO_STATUS_NO_MEMORY);
+-
+-    source_img->surface = source;
+-
+     if (source->type == CAIRO_SURFACE_TYPE_RECORDING) {
+ 	image_surface = (cairo_image_surface_t *)
+ 	    cairo_image_surface_create (format, extents->width, extents->height);
+ 	if (unlikely (image_surface->base.status)) {
+ 	    status = image_surface->base.status;
+ 	    cairo_surface_destroy (&image_surface->base);
+-	    free (source_img);
+ 	    return status;
+ 	}
+ 
+@@ -848,46 +832,61 @@ _cairo_surface_to_cgimage (cairo_surface_t       *source,
+ 							    NULL);
+ 	if (unlikely (status)) {
+ 	    cairo_surface_destroy (&image_surface->base);
+-	    free (source_img);
+ 	    return status;
+ 	}
+ 
+-	source_img->image_out = image_surface;
+-	source_img->image_extra = NULL;
+-
+ 	cairo_matrix_init_identity (matrix);
+     }
+     else {
+-	status = _cairo_surface_acquire_source_image (source_img->surface,
+-						      &source_img->image_out,
+-						      &source_img->image_extra);
+-	if (unlikely (status)) {
+-	    free (source_img);
++	status = _cairo_surface_acquire_source_image (source, &image_surface,
++						      &image_extra);
++	if (unlikely (status))
+ 	    return status;
+-	}
++	acquired = TRUE;
+     }
+ 
+-    if (source_img->image_out->width == 0 || source_img->image_out->height == 0) {
++    if (image_surface->width == 0 || image_surface->height == 0) {
+ 	*image_out = NULL;
+-	DataProviderReleaseCallback (source_img,
+-				     source_img->image_out->data,
+-				     source_img->image_out->height * source_img->image_out->stride);
+-    } else {
+-	*image_out = CairoQuartzCreateCGImage (source_img->image_out->format,
+-					       source_img->image_out->width,
+-					       source_img->image_out->height,
+-					       source_img->image_out->stride,
+-					       source_img->image_out->data,
+-					       TRUE,
+-					       NULL,
+-					       DataProviderReleaseCallback,
+-					       source_img);
+-
+-	/* TODO: differentiate memory error and unsupported surface type */
+-	if (unlikely (*image_out == NULL))
+-	    status = CAIRO_INT_STATUS_UNSUPPORTED;
++	if (acquired)
++	    _cairo_surface_release_source_image (source, image_surface, image_extra);
++	else
++	    cairo_surface_destroy (&image_surface->base);
++
++	return status;
+     }
+ 
++    image_data = _cairo_malloc_ab (image_surface->height, image_surface->stride);
++    if (unlikely (!image_data))
++    {
++	if (acquired)
++	    _cairo_surface_release_source_image (source, image_surface, image_extra);
++	else
++	    cairo_surface_destroy (&image_surface->base);
++
++	return _cairo_error (CAIRO_STATUS_NO_MEMORY);
++    }
++
++    memcpy (image_data, image_surface->data,
++	    image_surface->height * image_surface->stride);
++    *image_out = CairoQuartzCreateCGImage (image_surface->format,
++					   image_surface->width,
++					   image_surface->height,
++					   image_surface->stride,
++					   image_data,
++					   TRUE,
++					   NULL,
++					   DataProviderReleaseCallback,
++					   image_data);
++
++    /* TODO: differentiate memory error and unsupported surface type */
++    if (unlikely (*image_out == NULL))
++	status = CAIRO_INT_STATUS_UNSUPPORTED;
++
++    if (acquired)
++	_cairo_surface_release_source_image (source, image_surface, image_extra);
++    else
++	cairo_surface_destroy (&image_surface->base);
++
+     return status;
+ }
+ 
+@@ -2273,11 +2272,13 @@ _cairo_quartz_surface_create_internal (CGContextRef cgContext,
+     surface->extents.width = width;
+     surface->extents.height = height;
+     surface->virtual_extents = surface->extents;
++    surface->imageData = NULL;
++    surface->imageSurfaceEquiv = NULL;
++
+ 
+     if (IS_EMPTY (surface)) {
+ 	surface->cgContext = NULL;
+ 	surface->cgContextBaseCTM = CGAffineTransformIdentity;
+-	surface->imageData = NULL;
+ 	surface->base.is_clear = TRUE;
+ 	return surface;
+     }
+@@ -2290,9 +2291,6 @@ _cairo_quartz_surface_create_internal (CGContextRef cgContext,
+     surface->cgContext = cgContext;
+     surface->cgContextBaseCTM = CGContextGetCTM (cgContext);
+ 
+-    surface->imageData = NULL;
+-    surface->imageSurfaceEquiv = NULL;
+-
+     return surface;
+ }
+ 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This adds a patch for two commits from cairo upstream, fixing a crash on macOS Big Sur or
newer that occurs with the Quartz backend. The patch file containing the two
commits was copied from MacPorts.

For the original issue, see:
https://gitlab.freedesktop.org/cairo/cairo/-/issues/420

###### Things done

I manually tested this fix on a GTK 3 application I am trying to patch to get to run on aarch64-darwin (the application in question is `xournalpp`). I can confirm that the cairo patch fixes the crash that occurs on xournalpp.

<details>
<summary>Here is the flake I used to test with:</summary>

Run `nix develop -c xournalpp`

```nix
{
  inputs.flake-utils.url = "github:numtide/flake-utils/v1.0.0";

  outputs = { self, nixpkgs, flake-utils, xournalpp_src }: (
    {
      overlays = {
        default = final: prev: {
          cairo = prev.cairo.overrideAttrs (attrs: {
            patches = attrs.patches ++ [ ./patch-cairo-quartz-surfaces.diff ];
          });
          xournalpp = prev.xournalpp.overrideAttrs (attrs: {
            meta = {};
	    nativeBuildInputs = attrs.nativeBuildInputs ++ [ final.ninja ];
            cmakeFlags = (attrs.cmakeFlags or []) ++ ["-DCMAKE_DISABLE_FIND_PACKAGE_X11=on"];
          }); 
        };
      };
    } //
    (flake-utils.lib.eachDefaultSystem (system:
    let pkgs = import nixpkgs {
      inherit system;
      overlays = [ self.overlays.default ];
    };
    in
    {
      packages = flake-utils.lib.flattenTree {
        xournalpp = pkgs.xournalpp;
        cairo = pkgs.cairo;
        default = pkgs.xournalpp;
      };
      devShells = flake-utils.lib.flattenTree {
        default = pkgs.mkShell {
          nativeBuildInputs = with pkgs; [
            xournalpp hicolor-icon-theme gnome.adwaita-icon-theme
          ];
        };
      };
    }))
  );
}
```

</details>

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
