### PR TITLE
bottles: 2022.5.28-trento-3 -> 2022.7.28-brescia-2

### DIFF
--- a/pkgs/applications/misc/bottles/default.nix
+++ b/pkgs/applications/misc/bottles/default.nix
@@ -1,10 +1,10 @@
-{ lib, fetchFromGitHub, gitUpdater
+{ lib, fetchFromGitHub, fetchFromGitLab, gitUpdater
 , meson, ninja, pkg-config, wrapGAppsHook
-, desktop-file-utils, gsettings-desktop-schemas, libnotify, libhandy, webkitgtk
+, desktop-file-utils, gsettings-desktop-schemas, libadwaita, libnotify, webkitgtk
 , python3Packages, gettext
-, appstream-glib, gdk-pixbuf, glib, gobject-introspection, gspell, gtk3, gtksourceview4, gnome
+, appstream-glib, gdk-pixbuf, glib, gobject-introspection, gspell, gtk4, gtksourceview5, gnome
 , steam, xdg-utils, pciutils, cabextract
-, freetype, p7zip, gamemode, mangohud
+, freetype, p7zip, gamemode, mangohud, xdpyinfo, imagemagick
 , wine
 , bottlesExtraLibraries ? pkgs: [ ] # extra packages to add to steam.run multiPkgs
 , bottlesExtraPkgs ? pkgs: [ ] # extra packages to add to steam.run targetPkgs
@@ -18,16 +18,27 @@ let
     extraPkgs = pkgs: [ ]
       ++ bottlesExtraPkgs pkgs;
   }).run;
+  # require libadwaita >= 1.2 see https://github.com/bottlesdevs/Bottles/wiki/Packaging
+  libadwaita-git = libadwaita.overrideAttrs (oldAttrs: rec {
+    version = "1.2.alpha";
+    src = fetchFromGitLab {
+      domain = "gitlab.gnome.org";
+      owner = "GNOME";
+      repo = "libadwaita";
+      rev = version;
+      hash = "sha256-JMxUeIOUPp9k5pImQqWLVkQ2GHaKvopvg6ol9pvA+Bk=";
+    };
+  });
 in
 python3Packages.buildPythonApplication rec {
   pname = "bottles";
-  version = "2022.5.28-trento-3";
+  version = "2022.7.28-brescia-2";
 
   src = fetchFromGitHub {
     owner = "bottlesdevs";
     repo = pname;
     rev = version;
-    sha256 = "sha256-KIDLRqDLFTsVAczRpTchnUtKJfVHqbYzf8MhIR5UdYY=";
+    sha256 = "sha256-fg0i0fVbUWieksBv4k4ujLzyHyM6UShwRt7fN/KunJg=";
   };
 
   postPatch = ''
@@ -56,9 +67,9 @@ python3Packages.buildPythonApplication rec {
     gobject-introspection
     gsettings-desktop-schemas
     gspell
-    gtk3
-    gtksourceview4
-    libhandy
+    gtk4
+    gtksourceview5
+    libadwaita-git
     libnotify
     webkitgtk
     gnome.adwaita-icon-theme
@@ -76,7 +87,17 @@ python3Packages.buildPythonApplication rec {
     liblarch
     patool
     markdown
+    icoextract
+    fvs
+    pefile
+    urllib3
+    chardet
+    certifi
+    idna
+    pillow
+    orjson
   ] ++ [
+    imagemagick
     steam-run
     xdg-utils
     pciutils
@@ -86,6 +107,7 @@ python3Packages.buildPythonApplication rec {
     p7zip
     gamemode # programs.gamemode.enable
     mangohud
+    xdpyinfo
   ];
 
   format = "other";

--- a/pkgs/development/python-modules/fvs/default.nix
+++ b/pkgs/development/python-modules/fvs/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchPypi, orjson}:
+
+buildPythonPackage rec {
+  pname = "fvs";
+  version = "0.3.4";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "FVS";
+    extension = "tar.gz";
+    sha256 = "sha256-yYd0HzdwbqB9kexJjBRRYmdsoWtZtcjCNRz0ZJVM5CI=";
+  };
+
+  propagatedBuildInputs = [
+    orjson
+  ];
+
+  # no tests in src
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "fvs"
+  ];
+
+  meta = with lib; {
+    description = "File Versioning System with hash comparison and data storage to create unlinked states that can be deleted";
+    homepage = "https://github.com/mirkobrombin/FVS";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bryanasdev000 ];
+  };
+}

--- a/pkgs/development/python-modules/icoextract/default.nix
+++ b/pkgs/development/python-modules/icoextract/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchPypi, pefile, pillow}:
+
+buildPythonPackage rec {
+  pname = "icoextract";
+  version = "0.1.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "tar.gz";
+    sha256 = "sha256-orpFBnTByeS6I5gY1tkh5Xm8lvUjEm7IVrf82TA+9n4=";
+  };
+
+  propagatedBuildInputs = [
+    pefile
+    pillow
+  ];
+
+  # tests expect mingw and multiarch
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "icoextract"
+  ];
+
+  meta = with lib; {
+    description = "Extract icons from Windows PE files";
+    homepage = "https://github.com/jlu5/icoextract";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bryanasdev000 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3409,6 +3409,8 @@ in {
 
   fuzzywuzzy = callPackage ../development/python-modules/fuzzywuzzy { };
 
+  fvs = callPackage ../development/python-modules/fvs { };
+
   fx2 = callPackage ../development/python-modules/fx2 { };
 
   galario = toPythonModule (pkgs.galario.override {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4218,6 +4218,8 @@ in {
 
   idasen = callPackage ../development/python-modules/idasen { };
 
+  icoextract = callPackage ../development/python-modules/icoextract { };
+
   icontract = callPackage ../development/python-modules/icontract { };
 
   identify = callPackage ../development/python-modules/identify { };


### PR DESCRIPTION
###### Description of changes

- Update bottles to 2022.7.14-brescia-3
- Update deps to bottles per AUR package and build logs
- Init icoextract for use with bottles
- Update libadwaita

Issues that need to be addressed before merge:

- Override libadwaita version for only bottles since it requires git version (based on AUR package)
- Verifiy overral slowness with new GTK4 version for use with bottles.
- Core section in preferences does not open.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
