### PR TITLE
criterion: 2.3.3 -> 2.4.1

### DIFF
--- a/pkgs/development/libraries/boxfort/default.nix
+++ b/pkgs/development/libraries/boxfort/default.nix
@@ -1,14 +1,14 @@
 { lib, stdenv, fetchFromGitHub, meson, ninja, python3Packages }:
 
 stdenv.mkDerivation rec {
-  version = "unstable-2019-10-09";
   pname = "boxfort";
+  version = "0.1.4";
 
   src = fetchFromGitHub {
     owner = "Snaipe";
     repo = "BoxFort";
-    rev = "356f047db08b7344ea7980576b705e65b9fc8772";
-    sha256 = "1p0llz7n0p5gzpvqszmra9p88vnr0j88sp5ixhgbfz89bswg62ss";
+    rev = "v${version}";
+    sha256 = "jmtWTOkOlqVZ7tFya3IrQjr714Y8TzAVY5Cq+RzDuRs=";
   };
 
   nativeBuildInputs = [ meson ninja ];
@@ -29,7 +29,5 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     maintainers = with maintainers; [ thesola10 Yumasi ];
     platforms = platforms.unix;
-    # Upstream currently broken for macOS https://cirrus-ci.com/build/5624937369042944
-    broken = stdenv.targetPlatform.isDarwin;
   };
 }

--- a/pkgs/development/libraries/criterion/default.nix
+++ b/pkgs/development/libraries/criterion/default.nix
@@ -1,19 +1,20 @@
-{ lib, stdenv, fetchFromGitHub, boxfort, cmake, libcsptr, pkg-config, gettext
-, dyncall , nanomsg, python3Packages }:
+{ lib, stdenv, fetchFromGitHub, boxfort, meson, libcsptr, pkg-config, gettext
+, cmake, ninja, protobuf, libffi, libgit2, dyncall, nanomsg, nanopbMalloc
+, python3Packages }:
 
 stdenv.mkDerivation rec {
-  version = "2.3.3";
   pname = "criterion";
+  version = "2.4.1";
 
   src = fetchFromGitHub {
     owner = "Snaipe";
     repo = "Criterion";
     rev = "v${version}";
-    sha256 = "0y1ay8is54k3y82vagdy0jsa3nfkczpvnqfcjm5n9iarayaxaq8p";
+    sha256 = "KT1XvhT9t07/ubsqzrVUp4iKcpVc1Z+saGF4pm2RsgQ=";
     fetchSubmodules = true;
   };
 
-  nativeBuildInputs = [ cmake pkg-config ];
+  nativeBuildInputs = [ meson ninja cmake pkg-config protobuf ];
 
   buildInputs = [
     boxfort.dev
@@ -21,13 +22,19 @@ stdenv.mkDerivation rec {
     gettext
     libcsptr
     nanomsg
+    nanopbMalloc
+    libgit2
+    libffi
   ];
 
   checkInputs = with python3Packages; [ cram ];
 
-  cmakeFlags = [ "-DCTESTS=ON" ];
   doCheck = true;
-  checkTarget = "criterion_tests test";
+  checkTarget = "test";
+
+  postPatch = ''
+    patchShebangs ci/isdir.py src/protocol/gen-pb.py
+  '';
 
   outputs = [ "dev" "out" ];
 

--- a/pkgs/development/libraries/nanopb/default.nix
+++ b/pkgs/development/libraries/nanopb/default.nix
@@ -6,6 +6,7 @@
 , python3
 , stdenv
 , buildPackages
+, mallocBuild ? false
 }:
 
 stdenv.mkDerivation rec {
@@ -27,7 +28,7 @@ stdenv.mkDerivation rec {
     "-DBUILD_SHARED_LIBS=ON" # generate $out/lib/libprotobuf-nanopb.so{.0,}
     "-DBUILD_STATIC_LIBS=ON" # generate $out/lib/libprotobuf-nanopb.a
     "-Dnanopb_PROTOC_PATH=${buildPackages.protobuf}/bin/protoc"
-  ];
+  ] ++ lib.optional mallocBuild "-DCMAKE_C_FLAGS=-DPB_ENABLE_MALLOC 1";
 
   postInstall = ''
     mkdir -p $out/share/nanopb/generator/proto

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20818,6 +20818,7 @@ with pkgs;
   flatbuffers = callPackage ../development/libraries/flatbuffers { };
 
   nanopb = callPackage ../development/libraries/nanopb { };
+  nanopbMalloc = callPackage ../development/libraries/nanopb { mallocBuild = true; };
 
   gnupth = callPackage ../development/libraries/pth { };
   pth = if stdenv.hostPlatform.isMusl then npth else gnupth;


### PR DESCRIPTION
###### Description of changes

Updated criterion and boxfort packages, and added option for malloc-enabled builds of nanopb.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
