### PR TITLE
nixos/github-runner: add PAT support

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -296,6 +296,15 @@
       </listitem>
       <listitem>
         <para>
+          <literal>github-runner</literal> gained support for runner
+          registration using a personal access token (PAT) instead of a
+          registration token. See
+          <literal>services.github-runner.tokenFile</literal> for usage
+          instructions.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           A new module was added for the Saleae Logic device family,
           providing the options
           <literal>hardware.saleae-logic.enable</literal> and

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -115,6 +115,8 @@ Use `configure.packages` instead.
 
 - The `xplr` package has been updated from 0.18.0 to 0.19.0, which brings some breaking changes. See the [upstream release notes](https://github.com/sayanarijit/xplr/releases/tag/v0.19.0) for more details.
 
+- `github-runner` gained support for runner registration using a personal access token (PAT) instead of a registration token. See `services.github-runner.tokenFile` for usage instructions.
+
 - A new module was added for the Saleae Logic device family, providing the options `hardware.saleae-logic.enable` and `hardware.saleae-logic.package`.
 
 - The Redis module now disables RDB persistence when `services.redis.servers.<name>.save = []` instead of using the Redis default.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -341,7 +341,7 @@
   ./services/continuous-integration/hail.nix
   ./services/continuous-integration/hercules-ci-agent/default.nix
   ./services/continuous-integration/hydra/default.nix
-  ./services/continuous-integration/github-runner.nix
+  ./services/continuous-integration/github-runner
   ./services/continuous-integration/gitlab-runner.nix
   ./services/continuous-integration/gocd-agent/default.nix
   ./services/continuous-integration/gocd-server/default.nix

--- a/nixos/modules/services/continuous-integration/github-runner/query_registration_token.py
+++ b/nixos/modules/services/continuous-integration/github-runner/query_registration_token.py
@@ -1,0 +1,84 @@
+import argparse
+import json
+import logging
+from urllib.request import urlopen, Request
+from urllib.parse import urlparse
+from urllib.error import HTTPError
+
+
+def new_registration_token_from_pat(url: str, pat: str) -> str:
+    """Queries a new registration token for a github.com repository or organisation"""
+    components = urlparse(url)
+    if components.netloc not in {"github.com", "github.com:443"}:
+        raise ValueError("Only PATs for github.com are supported!")
+
+    path_parts = [x for x in components.path.split("/") if x]
+    if len(path_parts) == 1:
+        logging.debug("Given URL is for a Github organization")
+        endpoint = (
+            "https://api.github.com/orgs/{}/actions/runners/registration-token".format(
+                path_parts[0]
+            )
+        )
+    else:
+        logging.debug("Given URL is for a single Github repository")
+        endpoint = "https://api.github.com/repos/{}/{}/actions/runners/registration-token".format(
+            *path_parts
+        )
+
+    req = Request(
+        endpoint,
+        method="POST",
+        headers={
+            "Authorization": f"token {pat}",
+            "Accept": "application/vnd.github+json",
+        },
+    )
+    logging.debug(f"Performing API call to {endpoint}")
+    try:
+        with urlopen(req) as resp:
+            return json.load(resp)["token"]
+    except HTTPError as err:
+        raise RuntimeError(
+            "Caught unexpected status {err.status} while getting registration token:\n{err.read().decode()}"
+        ) from err
+
+
+def get_registration_token(token_file: str, url: str) -> str:
+    """Return a runner registration token.
+
+    If the given token file contains a PAT, use it to request a new registration token from GitHub.
+    If the file's content is not a PAT, use it as a registration token directly.
+    """
+    with open(token_file) as f:
+        token = f.read().strip()
+
+    is_pat = token.startswith("ghp_")
+    if is_pat:
+        logging.info("Read token file contains a PAT")
+        registration_token = new_registration_token_from_pat(url, token)
+    else:
+        logging.info("Read token file is not a PAT; using as registration token")
+        registration_token = token
+
+    return registration_token
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--token-file",
+        "-t",
+        help="Path to a file which contains either a runner registration token or a PAT suitable to request a new registration token from GitHub",
+    )
+    parser.add_argument("--url", "-u", help="The registration URL of the runner")
+    parser.add_argument("--log-level", "-l", default="INFO")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        format="%(filename)s %(levelname)s: %(message)s", level=args.log_level.upper()
+    )
+
+    registration_token = get_registration_token(args.token_file, args.url)
+
+    print(registration_token, end="")


### PR DESCRIPTION
###### Description of changes

This commit introduces support for runner registrations through a
personal access token (PAT). To use a PAT instead of a registration
token, place an appropriately scoped PAT in `tokenFile`. If the file
contains a PAT, the module queries a new runner registration token from
GitHub. Only github.com is support (i.e., no enterprise setups). Using a
runner registration token directly continues to work as before.

I decided to go for a Python script (without third-party dependencies) as a Bash script was too fragile and cumbersome.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
