### PR TITLE
python310Packages.bsuite: Enable more tests

### DIFF
--- a/pkgs/development/python-modules/bsuite/default.nix
+++ b/pkgs/development/python-modules/bsuite/default.nix
@@ -22,7 +22,8 @@
 , pytestCheckHook
 , dm-sonnet
 , rlax
-, distrax }:
+, distrax
+}:
 
 let bsuite = buildPythonPackage rec {
   pname = "bsuite";

--- a/pkgs/development/python-modules/bsuite/default.nix
+++ b/pkgs/development/python-modules/bsuite/default.nix
@@ -20,9 +20,11 @@
 , trfl
 , optax
 , pytestCheckHook
-, dm-sonnet }:
+, dm-sonnet
+, rlax
+, distrax }:
 
-buildPythonPackage rec {
+let bsuite = buildPythonPackage rec {
   pname = "bsuite";
   version = "0.3.5";
 
@@ -49,25 +51,18 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
+    distrax
     dm-haiku
     dm-sonnet
     optax
     pytestCheckHook
+    rlax
     tensorflow-probability
     trfl
   ];
 
   pythonImportsCheck = [
     "bsuite"
-  ];
-
-  disabledTestPaths = [
-    # Disabled because tests require module rlax but this results in infinite
-    # recursion error
-    "bsuite/baselines/jax/actor_critic/run_test.py"
-    "bsuite/baselines/jax/actor_critic_rnn/run_test.py"
-    "bsuite/baselines/jax/boot_dqn/run_test.py"
-    "bsuite/baselines/jax/dqn/run_test.py"
   ];
 
   disabledTests = [
@@ -89,6 +84,13 @@ buildPythonPackage rec {
     "test_episode_truncation"
   ];
 
+  # escape infinite recursion with rlax
+  doCheck = false;
+
+  passthru.tests = {
+    check = bsuite.overridePythonAttrs (_: { doCheck = true; });
+  };
+
   meta = with lib; {
     description = ''
       Core RL Behaviour Suite. A collection of reinforcement learning
@@ -98,4 +100,4 @@ buildPythonPackage rec {
     license = licenses.asl20;
     maintainers = with maintainers; [ onny ];
   };
-}
+}; in bsuite


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
