### PR TITLE
yuzu-{ea,mainline}: {2725,1088} -> {2841,1092}

### DIFF
--- a/pkgs/applications/emulators/yuzu/default.nix
+++ b/pkgs/applications/emulators/yuzu/default.nix
@@ -5,23 +5,23 @@
 }:
 
 let
-  # Fetched from https://api.yuzu-emu.org/gamedb, last updated 2022-05-12
+  # Fetched from https://api.yuzu-emu.org/gamedb, last updated 2022-07-14
   # Please make sure to update this when updating yuzu!
   compat-list = fetchurl {
     name = "yuzu-compat-list";
-    url = "https://web.archive.org/web/20220512184801/https://api.yuzu-emu.org/gamedb";
+    url = "https://web.archive.org/web/20220714160745/https://api.yuzu-emu.org/gamedb";
     sha256 = "sha256-anOmO7NscHDsQxT03+YbJEyBkXjhcSVGgKpDwt//GHw=";
   };
 in {
   mainline = libsForQt5.callPackage ./generic.nix rec {
     pname = "yuzu-mainline";
-    version = "1088";
+    version = "1092";
 
     src = fetchFromGitHub {
       owner = "yuzu-emu";
       repo = "yuzu-mainline";
       rev = "mainline-0-${version}";
-      sha256 = "0kjiynv1fwc14w7382qgzayz5j9n2rnzbpbq49zgcywc4wwcxzs2";
+      sha256 = "1avcq924q0r8pfv1s0a88iyii7yixcxpb3yhlj0xg9zqnwp9r23y";
       fetchSubmodules = true;
     };
 
@@ -30,13 +30,13 @@ in {
 
   early-access = libsForQt5.callPackage ./generic.nix rec {
     pname = "yuzu-ea";
-    version = "2725";
+    version = "2841";
 
     src = fetchFromGitHub {
       owner = "pineappleEA";
       repo = "pineapple-src";
       rev = "EA-${version}";
-      sha256 = "1nmcl9y9chr7cdvnra5zs1v42d3i801hmsjdlz3fmp15n04bcjmp";
+      sha256 = "16lrq9drv0x7gs1siq37m4zmh6d2g3vhnw9qcqajr9p0vmlpnh6l";
       fetchSubmodules = true;
     };
 

--- a/pkgs/applications/emulators/yuzu/update.sh
+++ b/pkgs/applications/emulators/yuzu/update.sh
@@ -53,7 +53,7 @@ updateEarlyAccess() {
     OLD_EA_HASH="$(getLocalHash "yuzu-ea")"
 
     NEW_EA_VERSION="$(curl -s ${GITHUB_TOKEN:+"-u \":$GITHUB_TOKEN\""} \
-        "https://api.github.com/repos/pineappleEA/pineapple-src/releases?per_page=1" | jq -r '.[0].name' | cut -d"-" -f2 | cut -d" " -f1)"
+        "https://api.github.com/repos/pineappleEA/pineapple-src/releases?per_page=1" | jq -r '.[0].tag_name' | cut -d"-" -f2 | cut -d" " -f1)"
 
     if [[ "${OLD_EA_VERSION}" = "${NEW_EA_VERSION}" ]]; then
         echo "yuzu-ea is already up to date!"


### PR DESCRIPTION
Upstream added the cast, so the EA version now successfully builds.

This also changes the update script, because pineapple changed their releases which no longer have a name set explicitly.

I did not manage to get archive.org to archive the most recent version of the compatibility database, so I used the most recent one archived there.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->