### PR TITLE
ocamlPackages.qcheck: 0.18 → 0.19.1

### DIFF
--- a/pkgs/development/ocaml-modules/qcheck/alcotest.nix
+++ b/pkgs/development/ocaml-modules/qcheck/alcotest.nix
@@ -3,7 +3,7 @@
 buildDunePackage {
   pname = "qcheck-alcotest";
 
-  inherit (qcheck-core) version useDune2 src;
+  inherit (qcheck-core) version src;
 
   propagatedBuildInputs = [ qcheck-core alcotest ];
 

--- a/pkgs/development/ocaml-modules/qcheck/core.nix
+++ b/pkgs/development/ocaml-modules/qcheck/core.nix
@@ -2,9 +2,7 @@
 
 buildDunePackage rec {
   pname = "qcheck-core";
-  version = "0.18";
-
-  useDune2 = true;
+  version = "0.19.1";
 
   minimalOCamlVersion = "4.08";
 
@@ -12,7 +10,7 @@ buildDunePackage rec {
     owner = "c-cube";
     repo = "qcheck";
     rev = "v${version}";
-    sha256 = "1s652hrj2sxqj30dfl300zjvvqk3r62a1bnzqw1hqyf6pi88qn8x";
+    sha256 = "sha256-AZ1Ww6CWt3X1bXXcofMe14rTlMTC9hmohcKdZLUKEvE=";
   };
 
   meta = {

--- a/pkgs/development/ocaml-modules/qcheck/default.nix
+++ b/pkgs/development/ocaml-modules/qcheck/default.nix
@@ -3,7 +3,7 @@
 buildDunePackage {
   pname = "qcheck";
 
-  inherit (qcheck-ounit) version useDune2 src;
+  inherit (qcheck-ounit) version src;
 
   propagatedBuildInputs = [ qcheck-ounit ];
 

--- a/pkgs/development/ocaml-modules/qcheck/ounit.nix
+++ b/pkgs/development/ocaml-modules/qcheck/ounit.nix
@@ -3,7 +3,7 @@
 buildDunePackage {
   pname = "qcheck-ounit";
 
-  inherit (qcheck-core) version useDune2 src;
+  inherit (qcheck-core) version src;
 
   propagatedBuildInputs = [ qcheck-core ounit ];
 


### PR DESCRIPTION
###### Description of changes

Fixes & improvements: https://github.com/c-cube/qcheck/blob/v0.19.1/CHANGELOG.md#0191

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
