### PR TITLE
rcptt: init at 2.5.3

### DIFF
--- a/pkgs/applications/misc/rcptt/default.nix
+++ b/pkgs/applications/misc/rcptt/default.nix
@@ -1,0 +1,81 @@
+{
+  lib
+, pkgs
+, stdenv
+, fetchzip
+, fontconfig
+, freetype
+, glib
+, glib-networking
+, gsettings-desktop-schemas
+, gtk3
+, libsecret
+, makeDesktopItem
+, makeWrapper
+, unzip
+, webkitgtk
+, xorg
+, zlib
+}:
+stdenv.mkDerivation rec {
+  pname = "RCPTT";
+  version = "2.5.3";
+  src = fetchzip {
+    url = "https://download.eclipse.org/rcptt/release/${version}/ide/rcptt.ide-${version}-linux.gtk.x86_64.zip";
+    sha256 = "KofgdIHCmi0AeF7oQjp+kvkvuPX6+D7o2Z9U35qwJLA=";
+  };
+
+  buildInputs = with xorg; [
+    gsettings-desktop-schemas
+    makeWrapper
+  ];
+
+  desktopItem = makeDesktopItem {
+    name = "RCPTT";
+    exec = "rcptt";
+    icon = "rcptt";
+    comment = "RCP Testing Tool is a project for GUI testing automation of Eclipse-based applications.";
+    desktopName = "RCPTT";
+    genericName = "RCP Testing Tool";
+    categories = [ "Development" "IDE" "Java" ];
+  };
+
+  unpackPhase = ''
+    cp -rp $src/ $out/
+  '';
+
+  installPhase = with xorg; ''
+    chmod +w $out
+    interpreter=$(echo ${pkgs.glibc.out}/lib/ld-linux*.so.2)
+    libCairo=$out/eclipse/libcairo-swt.so
+    chmod +w $out/rcptt
+    patchelf --set-interpreter $interpreter $out/rcptt
+    patchelf --set-rpath ${lib.makeLibraryPath [freetype fontconfig gsettings-desktop-schemas libX11 libXrender zlib gtk3 glib-networking webkitgtk]} $out/rcptt
+    productId=${pname}
+    productVersion=${version}
+    export gtk3_version=`echo ${gtk3}  | cut -d '-' -f 3`
+    makeWrapper $out/rcptt $out/bin/rcptt \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [glib gtk3 libX11 libXext libXi libXrender libXtst libsecret webkitgtk zlib]} \
+      --prefix XDG_DATA_DIRS : "$XDG_DATA_DIRS:${gtk3}/share/gsettings-schemas/gtk+3-$gtk3_version" \
+      --prefix GIO_EXTRA_MODULES : "${glib-networking}/lib/gio/modules" \
+      --add-flags "-configuration \$HOME/.eclipse/''${productId}_$productVersion/configuration"
+    mkdir -p $out/share/applications
+    cp ${desktopItem}/share/applications/* $out/share/applications
+    mkdir -p $out/share/pixmaps
+    mv $out/icon.xpm $out/share/pixmaps/rcptt.xpm
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.eclipse.org/rcptt";
+    description = "RCP Testing Tool for Eclipse RCP applications";
+    longDescription = ''
+      RCP Testing Tool is a project for GUI testing automation of Eclipse-based applications.
+      RCPTT is fully aware about Eclipse Platform's internals, hiding this complexity from end users
+      and allowing QA engineers to create highly reliable UI tests at great pace.
+    '';
+    maintainers = with maintainers; [ ngiger ];
+    license = licenses.epl20;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10034,6 +10034,8 @@ with pkgs;
 
   rcon = callPackage ../tools/networking/rcon { };
 
+  rcptt = callPackage ../applications/misc/rcptt { };
+
   rdap = callPackage ../tools/networking/rdap { };
 
   rdbtools = callPackage ../development/tools/rdbtools { python = python3; };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add https://www.eclipse.org/rcptt/ RCP Testing Tool . 

RCP Testing Tool is a project for GUI testing automation of Eclipse-based applications. RCPTT is fully aware about Eclipse Platform's internals, hiding this complexity from end users and allowing QA engineers to create highly reliable UI tests at great pace.

I first tried to package it like an eclipse IDE (e.g. eclipse-rcp). But this would have required quite some changes, therefore I decided to use a separate app under applications/editors/.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
