### PR TITLE
xu4: init at 1.4.3

### DIFF
--- a/pkgs/by-name/fa/faun/package.nix
+++ b/pkgs/by-name/fa/faun/package.nix
@@ -1,0 +1,49 @@
+{
+  stdenv,
+  lib,
+  fetchFromCodeberg,
+  flac,
+  libpulseaudio,
+  libvorbis,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "faun";
+  version = "0.2.3";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromCodeberg {
+    owner = "WickedSmoke";
+    repo = "faun";
+    tag = "v${version}";
+    hash = "sha256-fUYKrs4nSIh/l3UQ+PA7F0RJ5hPBd99sjhex7LZ/Lik=";
+  };
+
+  buildInputs = [
+    flac
+    libpulseaudio
+    libvorbis
+  ];
+
+  # nonstandard configure script: uses '--prefix <dir>' (space) instead of '--prefix=<dir>'
+  dontAddPrefix = true;
+
+  postPatch = ''
+    patchShebangs configure
+  '';
+
+  configureFlags = [
+    "--prefix"
+    (placeholder "out")
+  ];
+
+  meta = {
+    homepage = "https://codeberg.org/WickedSmoke/faun";
+    description = "High-level C audio library";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ mausch ];
+    platforms = with lib.platforms; unix;
+  };
+}

--- a/pkgs/by-name/xu/xu4/package.nix
+++ b/pkgs/by-name/xu/xu4/package.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  makeWrapper,
+  zlib,
+  libpng,
+  boron,
+  libGL,
+  libx11,
+  libxcursor,
+  faun,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "xu4";
+  version = "1.4.3";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "xu4-engine";
+    repo = "u4";
+    tag = "v${version}";
+    hash = "sha256-0nTnUX2Exka7ytZnFWsjuMIodU4HQ2l/h+z2v550sTU=";
+    fetchSubmodules = true;
+  };
+
+  # this is not a standard Autotools-like `configure` script
+  dontAddPrefix = true;
+
+  preConfigure = ''
+    patchShebangs configure
+  '';
+
+  postConfigure = ''
+    # need to report this upstream
+    substituteInPlace src/Makefile \
+      --replace-fail "-Wall" "-Wall -Wno-error=format-security"
+
+    # disable git submodule init as part of build
+    sed --in-place 's/^\s*git submodule.*//g' src/Makefile.common
+
+    # set binary version (ref https://github.com/NixOS/nixpkgs/commit/571e02812f5da12fd851557ebbacea72fc7b5121#r129407907 )
+    substituteInPlace src/Makefile.common \
+      --replace-fail "DR-1.0" "${version}"
+  '';
+
+  enableParallelBuilding = true;
+
+  buildInputs = [
+    zlib
+    libpng
+    libGL
+    libx11
+    libxcursor
+    faun
+    boron
+  ];
+
+  nativeBuildInputs = [
+    makeWrapper
+    boron
+  ];
+
+  # The `install` target references some files with unknown license
+  installPhase = ''
+    install -D -m 555 src/xu4 $out/libexec/xu4
+    install -D -m 444 Ultima-IV.mod $out/share/Ultima-IV.mod
+    install -D -m 444 U4-Upgrade.mod $out/share/U4-Upgrade.mod
+    install -D -m 444 render.pak $out/share/render.pak
+    install -D -m 444 icons/xu4.png $out/share/icons/hicolor/48x48/apps/xu4.png
+    install -D -m 444 dist/xu4.desktop $out/share/applications/xu4.desktop
+    makeWrapper $out/libexec/xu4 $out/bin/xu4 --chdir $out/share
+  '';
+
+  meta = {
+    homepage = "https://xu4.sourceforge.net/";
+    description = "Remake of the computer game Ultima IV";
+    license = lib.licenses.gpl2Plus;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ mausch ];
+  };
+}


### PR DESCRIPTION
###### Description of changes

http://xu4.sourceforge.net/
XU4 is a remake of the computer game Ultima IV.

It requires the original game files, which are not open source and is available from [GOG](https://www.gog.com/en/game/ultima_4) and some other sites. The zip file then needs to be placed in `~/.local/share/xu4`.

I'll probably make another PR with a separate unfree package getting that and some graphics upgrade patches so users don't need to set things up manually.

cc @WickedSmoke

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
