### PR TITLE
corefonts: rename fonts to standard names

### DIFF
--- a/pkgs/data/fonts/corefonts/default.nix
+++ b/pkgs/data/fonts/corefonts/default.nix
@@ -1,29 +1,26 @@
 { lib, stdenv, fetchurl, cabextract }:
 
 let
-
   fonts = [
-    {name = "andale";  sha256 = "0w7927hlwayqf3vvanf8f3qp2g1i404jzqvhp1z3mp0sjm1gw905";}
-    {name = "arial";   sha256 = "1xkqyivbyb3z9dcalzidf8m4npzfpls2g0kldyn8g73f2i6plac5";}
-    {name = "arialb";  sha256 = "1a60zqrg63kjnykh5hz7dbpzvx7lyivn3vbrp7jyv9d1nvzz09d4";}
-    {name = "comic";   sha256 = "0ki0rljjc1pxkbsxg515fwx15yc95bdyaksa3pjd89nyxzzg6vcw";}
-    {name = "courie";  sha256 = "111k3waxki9yyxpjwl2qrdkswvsd2dmvhbjmmrwyipam2s31sldv";}
-    {name = "georgi";  sha256 = "0083jcpd837j2c06kp1q8glfjn9k7z6vg3wi137savk0lv6psb1c";}
-    {name = "impact";  sha256 = "1yyc5z7zmm3s418hmrkmc8znc55afsrz5dgxblpn9n81fhxyyqb0";}
-    {name = "times";   sha256 = "1aq7z3l46vwgqljvq9zfgkii6aivy00z1529qbjkspggqrg5jmnv";}
-    {name = "trebuc";  sha256 = "1jfsgz80pvyqvpfpaiz5pd8zwlcn67rg2jgynjwf22sip2dhssas";}
-    {name = "webdin";  sha256 = "0nnp2znmnmx87ijq9zma0vl0hd46npx38p0cc6lgp00hpid5nnb4";}
-    {name = "verdan";  sha256 = "15mdbbfqbyp25a6ynik3rck3m3mg44plwrj79rwncc9nbqjn3jy1";}
-    {name = "wd97vwr"; sha256 = "1lmkh3zb6xv47k0z2mcwk3vk8jff9m845c9igxm14bbvs6k2c4gn";}
+    { name = "andale";  sha256 = "0w7927hlwayqf3vvanf8f3qp2g1i404jzqvhp1z3mp0sjm1gw905"; }
+    { name = "arial";   sha256 = "1xkqyivbyb3z9dcalzidf8m4npzfpls2g0kldyn8g73f2i6plac5"; }
+    { name = "arialb";  sha256 = "1a60zqrg63kjnykh5hz7dbpzvx7lyivn3vbrp7jyv9d1nvzz09d4"; }
+    { name = "comic";   sha256 = "0ki0rljjc1pxkbsxg515fwx15yc95bdyaksa3pjd89nyxzzg6vcw"; }
+    { name = "courie";  sha256 = "111k3waxki9yyxpjwl2qrdkswvsd2dmvhbjmmrwyipam2s31sldv"; }
+    { name = "georgi";  sha256 = "0083jcpd837j2c06kp1q8glfjn9k7z6vg3wi137savk0lv6psb1c"; }
+    { name = "impact";  sha256 = "1yyc5z7zmm3s418hmrkmc8znc55afsrz5dgxblpn9n81fhxyyqb0"; }
+    { name = "times";   sha256 = "1aq7z3l46vwgqljvq9zfgkii6aivy00z1529qbjkspggqrg5jmnv"; }
+    { name = "trebuc";  sha256 = "1jfsgz80pvyqvpfpaiz5pd8zwlcn67rg2jgynjwf22sip2dhssas"; }
+    { name = "webdin";  sha256 = "0nnp2znmnmx87ijq9zma0vl0hd46npx38p0cc6lgp00hpid5nnb4"; }
+    { name = "verdan";  sha256 = "15mdbbfqbyp25a6ynik3rck3m3mg44plwrj79rwncc9nbqjn3jy1"; }
+    { name = "wd97vwr"; sha256 = "1lmkh3zb6xv47k0z2mcwk3vk8jff9m845c9igxm14bbvs6k2c4gn"; }
   ];
 
   eula = fetchurl {
     url = "http://corefonts.sourceforge.net/eula.htm";
     sha256 = "1aqbcnl032g2hd7iy56cs022g47scb0jxxp3mm206x1yqc90vs1c";
   };
-
 in
-
 stdenv.mkDerivation {
   pname = "corefonts";
   version = "1";
@@ -33,22 +30,53 @@ stdenv.mkDerivation {
     inherit sha256;
   }) fonts;
 
-  nativeBuildInputs = [cabextract];
+  nativeBuildInputs = [ cabextract ];
 
   buildCommand = ''
     for i in $exes; do
-        cabextract --lowercase $i
+      cabextract --lowercase $i
     done
-
     cabextract --lowercase viewer1.cab
+
+    # rename to more standard names
+    mv andalemo.ttf  Andale_Mono.ttf
+    mv ariblk.ttf    Arial_Black.ttf
+    mv arial.ttf     Arial.ttf
+    mv arialbd.ttf   Arial_Bold.ttf
+    mv arialbi.ttf   Arial_Bold_Italic.ttf
+    mv ariali.ttf    Arial_Italic.ttf
+    mv comic.ttf     Comic_Sans_MS.ttf
+    mv comicbd.ttf   Comic_Sans_MS_Bold.ttf
+    mv cour.ttf      Courier_New.ttf
+    mv courbd.ttf    Courier_New_Bold.ttf
+    mv couri.ttf     Courier_New_Italic.ttf
+    mv courbi.ttf    Courier_New_Bold_Italic.ttf
+    mv georgia.ttf   Georgia.ttf
+    mv georgiab.ttf  Georgia_Bold.ttf
+    mv georgiai.ttf  Georgia_Italic.ttf
+    mv georgiaz.ttf  Georgia_Bold_Italic.ttf
+    mv impact.ttf    Impact.ttf
+    mv tahoma.ttf    Tahoma.ttf
+    mv times.ttf     Times_New_Roman.ttf
+    mv timesbd.ttf   Times_New_Roman_Bold.ttf
+    mv timesbi.ttf   Times_New_Roman_Bold_Italic.ttf
+    mv timesi.ttf    Times_New_Roman_Italic.ttf
+    mv trebuc.ttf    Trebuchet_MS.ttf
+    mv trebucbd.ttf  Trebuchet_MS_Bold.ttf
+    mv trebucit.ttf  Trebuchet_MS_Italic.ttf
+    mv trebucbi.ttf  Trebuchet_MS_Italic.ttf
+    mv verdana.ttf   Verdana.ttf
+    mv verdanab.ttf  Verdana_Bold.ttf
+    mv verdanai.ttf  Verdana_Italic.ttf
+    mv verdanaz.ttf  Verdana_Bold_Italic.ttf
+    mv webdings.ttf  Webdings.ttf
 
     install -m444 -Dt $out/share/fonts/truetype *.ttf
 
     # Also put the EULA there to be on the safe side.
     cp ${eula} $out/share/fonts/truetype/eula.html
 
-    # Set up no-op font configs to override any aliases set up by
-    # other packages.
+    # Set up no-op font configs to override any aliases set up by other packages.
     mkdir -p $out/etc/fonts/conf.d
     for name in Andale-Mono Arial-Black Arial Comic-Sans-MS \
                 Courier-New Georgia Impact Times-New-Roman \
@@ -57,10 +85,6 @@ stdenv.mkDerivation {
         --subst-var-by fontname "''${name//-/ }"
     done
   '';
-
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = "089d2m9bvaacj36qdq77pcazji0sbbr796shic3k52cpxkjnzbwh";
 
   meta = with lib; {
     homepage = "http://corefonts.sourceforge.net/";


### PR DESCRIPTION
###### Description of changes

While searching fonts for onlyoffice server I couldn't find the fonts because they had no standard names.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
