### PR TITLE
python3Packages.pdoc: init at 12.0.2

### DIFF
--- a/pkgs/development/python-modules/pdoc/default.nix
+++ b/pkgs/development/python-modules/pdoc/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, pythonOlder
+, fetchPypi
+, fetchFromGitHub
+, jinja2
+, pygments
+, markupsafe
+, astunparse
+, pytestCheckHook
+, hypothesis
+}:
+
+buildPythonPackage rec {
+  pname = "pdoc";
+  version = "12.0.2";
+  disabled = pythonOlder "3.7";
+
+  # the Pypi version does not include tests
+  src = fetchFromGitHub {
+    owner = "mitmproxy";
+    repo = "pdoc";
+    rev = "v${version}";
+    sha256 = "FVfPO/QoHQQqg7QU05GMrrad0CbRR5AQVYUpBhZoRi0=";
+  };
+
+  propagatedBuildInputs = [
+    jinja2
+    pygments
+    markupsafe
+  ] ++ lib.optional (pythonOlder "3.9") astunparse;
+
+  checkInputs = [
+    pytestCheckHook
+    hypothesis
+  ];
+  disabledTests = [
+    # Failing "test_snapshots" parametrization: Output does not match the stored snapshot
+    # This test seems to be sensitive to ordering of dictionary items and the version of dependencies.
+    # the only difference between the stored snapshot and the produced documentation is a debug javascript comment
+    "html-demopackage_dir"
+  ];
+  pytestFlagsArray = [
+    ''-m "not slow"'' # skip tests marked slow
+  ];
+
+  pythonImportsCheck = [ "pdoc" ];
+
+  meta = with lib; {
+    homepage = "https://pdoc.dev/";
+    description = "API Documentation for Python Projects";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ pbsds ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6406,6 +6406,8 @@ in {
 
   pdm-pep517 = callPackage ../development/python-modules/pdm-pep517 { };
 
+  pdoc = callPackage ../development/python-modules/pdoc { };
+
   pdoc3 = callPackage ../development/python-modules/pdoc3 { };
 
   peaqevcore = callPackage ../development/python-modules/peaqevcore { };


### PR DESCRIPTION
###### Description of changes

This PR adds the pdoc python module, used to generate API documenation of python modules using runtime inspection and static analysis.

We already package the fork known as pdoc3, but it is subject to [a](https://github.com/pdoc3/pdoc/issues/64) [few](https://github.com/google/or-tools/issues/1675) [controversies](https://github.com/pdoc3/pdoc/issues/87).
Nixpkgs favoring pdoc3 over pdoc is unfortunate, hence this PR.
pdoc has since the pdoc3 fork gotten much better, switching from using mako to instead use jinja2.
Currently I myself favor the quality of pdoc, but neither of the two are superior to the other, which is why I recommend we **do not** remove pdoc3 from nixpkgs.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

I ran pdoc on a selection of python packages, the results of which are hosted [here](https://pdoc.noximilien.pbsds.net/).

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

@catern: Would you like to share maintainership between pdoc and pdoc3?