### PR TITLE
ocamlPackage.odoc: 1.5.3 -> 2.1.1

### DIFF
--- a/pkgs/development/ocaml-modules/odoc/default.nix
+++ b/pkgs/development/ocaml-modules/odoc/default.nix
@@ -1,25 +1,32 @@
 { lib, fetchurl, buildDunePackage, ocaml
 , astring, cmdliner, cppo, fpath, result, tyxml
-, markup, alcotest, yojson, sexplib, jq
+, markup, alcotest, yojson, sexplib0, jq
+, odoc-parser, ppx_expect, bash, fmt
 }:
 
 buildDunePackage rec {
   pname = "odoc";
-  version = "1.5.3";
-
-  minimumOCamlVersion = "4.02";
+  version = "2.1.1";
 
   src = fetchurl {
     url = "https://github.com/ocaml/odoc/releases/download/${version}/odoc-${version}.tbz";
-    sha256 = "0idzidmz7y10xkwcf4aih0mdvkipxk1gzi4anhnbbi2q2s0nzdzj";
+    sha256 = "sha256-9XTb0ozQ/DorlVJcS7ld320fZAi7T+EhV/pTeIT5h/0=";
   };
 
-  useDune2 = true;
+  # dune 3 is required for tests to pass
+  duneVersion = if doCheck then "3" else "2";
 
-  buildInputs = [ astring cmdliner cppo fpath result tyxml ];
+  buildInputs = [ astring cmdliner cppo fpath result tyxml odoc-parser fmt ];
 
-  checkInputs = [ alcotest markup yojson sexplib jq ];
-  doCheck = lib.versionAtLeast ocaml.version "4.05";
+  checkInputs = [ markup yojson sexplib0 jq ppx_expect bash ];
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
+
+  preCheck = ''
+    # some run.t files check the content of patchShebangs-ed scripts, so patch
+    # them as well
+    find test \( -name '*.sh' -o -name 'run.t' \)  -execdir sed 's@#!/bin/sh@#!${bash}/bin/sh@' -i '{}' \;
+    patchShebangs test
+  '';
 
   meta = {
     description = "A documentation generator for OCaml";

--- a/pkgs/development/ocaml-modules/odoc/default.nix
+++ b/pkgs/development/ocaml-modules/odoc/default.nix
@@ -1,6 +1,6 @@
 { lib, fetchurl, buildDunePackage, ocaml
 , astring, cmdliner, cppo, fpath, result, tyxml
-, markup, alcotest, yojson, sexplib0, jq
+, markup, yojson, sexplib0, jq
 , odoc-parser, ppx_expect, bash, fmt
 }:
 


### PR DESCRIPTION
build tested by:
fnix build -f.  ocaml-ng.ocamlPackages_4_{05,06,07,08,09,10,11,12,13,14}.odoc
fnix build -f.  ocaml-ng.ocamlPackages_4_{08,09,10,11,12,13,14}.{odoc,curly,mdx}

curly and mdx are the only reverse dependencies in ocaml-modules
according to grep

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
