### PR TITLE
[Backport release-22.05] mdbook: 0.4.18 -> 0.4.20

### DIFF
--- a/pkgs/tools/text/mdbook/default.nix
+++ b/pkgs/tools/text/mdbook/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, rustPlatform, CoreServices }:
+{ lib, stdenv, fetchFromGitHub, nix, rustPlatform, CoreServices }:
 
 rustPlatform.buildRustPackage rec {
   pname = "mdbook";
@@ -20,6 +20,12 @@ rustPlatform.buildRustPackage rec {
   # Can be removed when https://github.com/rust-lang/mdBook/pull/1777
   # is released.
   logLevel = "info";
+
+  passthru = {
+    tests = {
+      inherit nix;
+    };
+  };
 
   meta = with lib; {
     description = "Create books from MarkDown";

--- a/pkgs/tools/text/mdbook/default.nix
+++ b/pkgs/tools/text/mdbook/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "mdbook";
-  version = "0.4.17";
+  version = "0.4.20";
 
   src = fetchFromGitHub {
     owner = "rust-lang";
     repo = "mdBook";
     rev = "v${version}";
-    sha256 = "sha256-08ccRiOBXYqueKfyi/Ry39O2xOXUKishgqhn6RdbvUE=";
+    sha256 = "sha256-Cfi9qjY7+G7nGgxt4xNLIkGlpgr6TnvGlFrz3gMKCX8=";
   };
 
-  cargoSha256 = "sha256-vXUjKpCGlHlBvXLtmGkFtHRxxZakiEzuNzReFGEl6dw=";
+  cargoSha256 = "sha256-Ihs5aaruzj/8gbUhg4MmrYmpS9Hi/DohuEV2WtrxUXE=";
 
   buildInputs = lib.optionals stdenv.isDarwin [ CoreServices ];
 


### PR DESCRIPTION
This is a manual backport of #181644 to `release-22.05`.