### PR TITLE
awsebcli: fixup, use more versions from nixpkgs

### DIFF
--- a/pkgs/tools/virtualization/awsebcli/default.nix
+++ b/pkgs/tools/virtualization/awsebcli/default.nix
@@ -16,8 +16,6 @@ let
       self = localPython;
       packageOverrides = self: super: {
         cement = changeVersion super.cement.overridePythonAttrs "2.8.2" "1li2whjzfhbpg6fjb6r1r92fb3967p1xv6hqs3j787865h2ysrc7";
-        botocore = changeVersion super.botocore.overridePythonAttrs "1.23.54" "sha256-S7m6FszO5fWiYCBJvD4ttoZTRrJVBmfzATvfM7CgHOs=";
-        jmespath = changeVersion super.jmespath.overridePythonAttrs "0.10.0" "b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9";
         colorama = changeVersion super.colorama.overridePythonAttrs "0.4.3" "189n8hpijy14jfan4ha9f5n06mnl33cxz7ay92wjqgkr639s0vg9";
         future = changeVersion super.future.overridePythonAttrs "0.16.0" "1nzy1k4m9966sikp0qka7lirh8sqrsyainyf8rk97db7nwdfv773";
         wcwidth = changeVersion super.wcwidth.overridePythonAttrs "0.1.9" "1wf5ycjx8s066rdvr0fgz4xds9a8zhs91c4jzxvvymm1c8l8cwzf";
@@ -50,8 +48,10 @@ with localPython.pkgs; buildPythonApplication rec {
 
   preConfigure = ''
     substituteInPlace setup.py \
-      --replace "six>=1.11.0,<1.15.0" "six" \
-      --replace "requests>=2.20.1,<=2.26" "requests"
+      --replace "six>=1.11.0,<1.15.0" "six==1.16.0" \
+      --replace "requests>=2.20.1,<=2.26" "requests==2.28.1" \
+      --replace "jmespath>=0.7.1,<1.0.0" "jmespath==1.0.1" \
+      --replace "botocore>1.23.41,<1.24.0" "botocore==1.27.31"
   '';
 
   buildInputs = [


### PR DESCRIPTION
###### Description of changes

fixup `awsebcli`

@mweinelt i've decided when replacing dependencies in setup.py to use specific version, that way at least each version bump I can retest the app, Not sure if its a common practice.

alternatively we can also drop version constrains and rely on tests, @mweinelt let me know what you think

I've been also monitoring upstream, they are going to bump all their dependencies in next release
https://github.com/aws/aws-elastic-beanstalk-cli/blob/master/requirements.txt

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
