### PR TITLE
rspamd: fix crashes by disabling pcre2 jit

### DIFF
--- a/pkgs/servers/mail/rspamd/default.nix
+++ b/pkgs/servers/mail/rspamd/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, cmake, perl
-, glib, luajit, openssl, pcre2, pkg-config, sqlite, ragel, icu
+, glib, luajit, openssl, pcre, pkg-config, sqlite, ragel, icu
 , hyperscan, jemalloc, blas, lapack, lua, libsodium
 , withBlas ? true
 , withHyperscan ? stdenv.isx86_64
@@ -23,12 +23,14 @@ stdenv.mkDerivation rec {
   hardeningEnable = [ "pie" ];
 
   nativeBuildInputs = [ cmake pkg-config perl ];
-  buildInputs = [ glib openssl pcre2 sqlite ragel icu jemalloc libsodium ]
+  buildInputs = [ glib openssl pcre sqlite ragel icu jemalloc libsodium ]
     ++ lib.optional withHyperscan hyperscan
     ++ lib.optionals withBlas [ blas lapack ]
     ++ lib.optional withLuaJIT luajit ++ lib.optional (!withLuaJIT) lua;
 
   cmakeFlags = [
+    # pcre2 jit seems to cause crashes: https://github.com/NixOS/nixpkgs/pull/181908
+    "-DENABLE_PCRE2=OFF"
     "-DDEBIAN_BUILD=ON"
     "-DRUNDIR=/run/rspamd"
     "-DDBDIR=/var/lib/rspamd"


### PR DESCRIPTION
###### Description of changes

Since https://github.com/NixOS/nixpkgs/pull/179444 we now have pcre2 jit enabled.
However doing so now crashes rspamd2 quite frequently.
This is serious because it can take down mail delivery.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I have seen a lot of crashes like this:

```
#0  0x00007fbc5165020b in sljit_free_exec () from /nix/store/hzxgmfrn5niii8pvaxf4za2k59jbhlj6-pcre2-10.40/lib/libpcre2-8.so.0
#1  0x00007fbc51682163 in _pcre2_jit_free_8 () from /nix/store/hzxgmfrn5niii8pvaxf4za2k59jbhlj6-pcre2-10.40/lib/libpcre2-8.so.0
#2  0x00007fbc5163b0ca in pcre2_code_free_8 () from /nix/store/hzxgmfrn5niii8pvaxf4za2k59jbhlj6-pcre2-10.40/lib/libpcre2-8.so.0
#3  0x00007fbc51b46368 in rspamd_regexp_dtor () from /nix/store/2zaxxdh1y3wkhm2zrjzwnshx23v7yvg4-rspamd-3.2/lib/rspamd/librspamd-server.so
#4  0x00007fbc51b9d2dc in rspamd_re_cache_elt_dtor () from /nix/store/2zaxxdh1y3wkhm2zrjzwnshx23v7yvg4-rspamd-3.2/lib/rspamd/librspamd-server.so
#5  0x00007fbc4e4f56d0 in ptr_array_free () from /nix/store/i4k2ahrb0rzr7f2ni02nljcffawvpqpg-glib-2.72.3/lib/libglib-2.0.so.0
#6  0x00007fbc51b9d4b5 in rspamd_re_cache_destroy () from /nix/store/2zaxxdh1y3wkhm2zrjzwnshx23v7yvg4-rspamd-3.2/lib/rspamd/librspamd-server.so
#7  0x00007fbc51b691da in rspamd_config_free () from /nix/store/2zaxxdh1y3wkhm2zrjzwnshx23v7yvg4-rspamd-3.2/lib/rspamd/librspamd-server.so
#8  0x000055fdbfb8fe66 in main ()
```

After applying my disabling the jit in pcre2, they were disappeared.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
