### PR TITLE
unifi-protect-backup: init at 0.7.1

### DIFF
--- a/pkgs/applications/backup/unifi-protect-backup/default.nix
+++ b/pkgs/applications/backup/unifi-protect-backup/default.nix
@@ -1,0 +1,41 @@
+{ fetchFromGitHub, python3, lib }:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "unifi-protect-backup";
+  version = "0.7.1";
+
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "ep1cman";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-HAiyNFWLs1McrlAB48me/iI15LssO8ec7BiWuJbRlbs=";
+  };
+
+  preBuild = ''
+    sed -i 's_click = "8.0.1"_click = "^8"_' pyproject.toml
+    sed -i 's_pyunifiprotect = .*_pyunifiprotect = "*"_' pyproject.toml
+  '';
+
+  nativeBuildInputs = with python3.pkgs; [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    aiocron
+    click
+    pyunifiprotect
+  ];
+
+  checkInputs = with python3.pkgs; [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Python tool to backup unifi event clips in realtime";
+    homepage = "https://github.com/ep1cman/unifi-protect-backup";
+    maintainers = with maintainers; [ ajs124 ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23120,6 +23120,8 @@ with pkgs;
 
   unifi = unifi7;
 
+  unifi-protect-backup = callPackage ../applications/backup/unifi-protect-backup { };
+
   unifi-video = callPackage ../servers/unifi-video { };
 
   unpackerr = callPackage ../servers/unpackerr {


### PR DESCRIPTION
###### Description of changes

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).