### PR TITLE
[Backport release-22.05] obs-studio-plugins.obs-pipewire-audio-capture: init at 1.0.4 (#179459)

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3709,6 +3709,12 @@
     githubId = 1897147;
     name = "Elijah Caine";
   };
+  Elinvention = {
+    email = "elia@elinvention.ovh";
+    github = "Elinvention";
+    githubId = 5737945;
+    name = "Elia Argentieri";
+  };
   elitak = {
     email = "elitak@gmail.com";
     github = "elitak";

--- a/pkgs/applications/video/obs-studio/plugins/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/default.nix
@@ -9,5 +9,6 @@
   wlrobs = callPackage ./wlrobs.nix {};
   looking-glass-obs = callPackage ./looking-glass-obs.nix {};
   obs-nvfbc = callPackage ./obs-nvfbc.nix {};
+  obs-pipewire-audio-capture = callPackage ./obs-pipewire-audio-capture.nix {};
   obs-vkcapture = callPackage ./obs-vkcapture.nix {};
 }

--- a/pkgs/applications/video/obs-studio/plugins/obs-pipewire-audio-capture.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-pipewire-audio-capture.nix
@@ -1,0 +1,32 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, ninja
+, obs-studio
+, pipewire
+, pkg-config
+}:
+
+stdenv.mkDerivation rec {
+  pname = "obs-pipewire-audio-capture";
+  version = "1.0.4";
+
+  src = fetchFromGitHub {
+    owner = "dimtpap";
+    repo = pname;
+    rev = "${version}";
+    sha256 = "OX27NTUsceEC8kHqlM+oeGjPxguake6lwaXFYsoEqKU=";
+  };
+
+  nativeBuildInputs = [ cmake ninja pkg-config ];
+  buildInputs = [ obs-studio pipewire ];
+
+  meta = with lib; {
+    description = " Audio device and application capture for OBS Studio using PipeWire ";
+    homepage = "https://github.com/dimtpap/obs-pipewire-audio-capture";
+    maintainers = with maintainers; [ Elinvention ];
+    license = licenses.gpl2;
+    platforms = [ "x86_64-linux" "i686-linux" ];
+  };
+}


### PR DESCRIPTION
Co-authored-by: Sandro <sandro.jaeckel@gmail.com>
(cherry picked from commit 22cc20eba8cd24397482305eb50172d5bf3a4c1e)

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
