### PR TITLE
josh: init at 22.06.22

### DIFF
--- a/pkgs/applications/version-management/josh/default.nix
+++ b/pkgs/applications/version-management/josh/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, rustPlatform
+, libgit2
+, openssl
+, pkg-config
+, makeWrapper
+, git
+, darwin
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "josh";
+  version = "22.06.22";
+
+  src = fetchFromGitHub {
+    owner = "esrlabs";
+    repo = "josh";
+    rev = "r" + version;
+    sha256 = "0511qv9zyjvv4zfz6zyi69ssbkrwa24n0ah5w9mb4gzd547as8pq";
+  };
+
+  cargoSha256 = "0zfjjyyz4pxar1mfkkj9aij4dnwqy3asdrmay1iy6ijjn1qd97n4";
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = [
+    libgit2
+    openssl
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    darwin.Security
+  ];
+
+  cargoBuildFlags = [
+    "-p" "josh"
+    "-p" "josh-proxy"
+    # TODO: josh-ui
+  ];
+
+  postInstall = ''
+    wrapProgram "$out/bin/josh-proxy" --prefix PATH : "${git}/bin"
+  '';
+
+  meta = {
+    description = "Just One Single History";
+    homepage = "https://josh-project.github.io/josh/";
+    downloadPage = "https://github.com/josh-project/josh";
+    changelog = "https://github.com/josh-project/josh/releases/tag/${version}";
+    license = lib.licenses.mit;
+    maintainers = [
+      lib.maintainers.sternenseemann
+      lib.maintainers.tazjin
+    ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27268,6 +27268,8 @@ with pkgs;
 
   jmusicbot = callPackage ../applications/audio/jmusicbot { };
 
+  josh = callPackage ../applications/version-management/josh { };
+
   junction = callPackage ../applications/misc/junction { };
 
   lemonade = callPackage ../applications/misc/lemonade { };


### PR DESCRIPTION
###### Description of changes

I want to use josh-filter for converting the cabal2nix repository into a monorepo. Since it takes quite a bit of time to compile, having it cached and in nixpkgs is probably useful.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
