### PR TITLE
hopper: update to 5.7.0, add darwin support

### DIFF
--- a/pkgs/development/tools/analysis/hopper/default.nix
+++ b/pkgs/development/tools/analysis/hopper/default.nix
@@ -66,11 +66,14 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://www.hopperapp.com/index.html";
     description = "A macOS and Linux Disassembler";
+    downloadPage = "https://www.hopperapp.com/download.html";
+    changelog = "https://www.hopperapp.com/rss/html_changelog.php";
     license = licenses.unfree;
+    mainProgram = "hopper";
     maintainers = with maintainers; [
       luis
       Enteee
     ];
-    platforms = platforms.linux;
+    platforms = [ "x86_64-linux" /* aarch64-linux is not supported */ ];
   };
 }

--- a/pkgs/development/tools/analysis/hopper/default.nix
+++ b/pkgs/development/tools/analysis/hopper/default.nix
@@ -12,12 +12,12 @@
 
 stdenv.mkDerivation rec {
   pname = "hopper";
-  version = "5.5.3";
+  version = "5.7.0";
   rev = "v4";
 
   src = fetchurl {
     url = "https://d2ap6ypl1xbe4k.cloudfront.net/Hopper-${rev}-${version}-Linux-demo.pkg.tar.xz";
-    hash = "sha256-xq9ZVg1leHm/tq6LYyQLa8p5dDwBd64Jt92uMoE0z58=";
+    hash = "sha256-yvNNt10GRbNCr4ycG3U5kkqe+lVtiTh78iqAdY7Y5WQ=";
   };
 
   sourceRoot = ".";

--- a/pkgs/development/tools/analysis/hopper/default.nix
+++ b/pkgs/development/tools/analysis/hopper/default.nix
@@ -8,60 +8,94 @@
 , libbsd
 , libffi_3_3
 , ncurses6
+, undmg
 }:
-
-stdenv.mkDerivation rec {
-  pname = "hopper";
+let
   version = "5.7.0";
   rev = "v4";
 
-  src = fetchurl {
-    url = "https://d2ap6ypl1xbe4k.cloudfront.net/Hopper-${rev}-${version}-Linux-demo.pkg.tar.xz";
-    hash = "sha256-yvNNt10GRbNCr4ycG3U5kkqe+lVtiTh78iqAdY7Y5WQ=";
+  linux = {
+    src = fetchurl {
+      url = "https://d2ap6ypl1xbe4k.cloudfront.net/Hopper-${rev}-${version}-Linux-demo.pkg.tar.xz";
+      hash = "sha256-yvNNt10GRbNCr4ycG3U5kkqe+lVtiTh78iqAdY7Y5WQ=";
+    };
+
+    nativeBuildInputs = [
+      autoPatchelfHook
+      wrapQtAppsHook
+    ];
+
+    buildInputs = [
+      gnustep.libobjc
+      libbsd
+      libffi_3_3
+      ncurses6
+    ];
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/bin
+      mkdir -p $out/lib
+      mkdir -p $out/share
+
+      cp $sourceRoot/opt/hopper-${rev}/bin/Hopper $out/bin/hopper
+      cp \
+        --archive \
+        $sourceRoot/opt/hopper-${rev}/lib/libBlocksRuntime.so* \
+        $sourceRoot/opt/hopper-${rev}/lib/libdispatch.so* \
+        $sourceRoot/opt/hopper-${rev}/lib/libgnustep-base.so* \
+        $sourceRoot/opt/hopper-${rev}/lib/libHopperCore.so* \
+        $sourceRoot/opt/hopper-${rev}/lib/libkqueue.so* \
+        $sourceRoot/opt/hopper-${rev}/lib/libobjcxx.so* \
+        $sourceRoot/opt/hopper-${rev}/lib/libpthread_workqueue.so* \
+        $out/lib
+
+      cp -r $sourceRoot/usr/share $out
+
+      runHook postInstall
+    '';
+
+    postFixup = ''
+      substituteInPlace "$out/share/applications/hopper-${rev}.desktop" \
+        --replace "Exec=/opt/hopper-${rev}/bin/Hopper" "Exec=$out/bin/hopper"
+    '';
   };
 
+  darwin = {
+    src = fetchurl {
+      url = "https://d2ap6ypl1xbe4k.cloudfront.net/Hopper-${version}-demo.dmg";
+      hash = "sha256-MhquCcgei+wpocKhVOF0uAkPT0U58w9SE5yhYX7Cad0=";
+    };
+    appName = "Hopper Disassembler ${rev}.app";
+
+    nativeBuildInputs = [ undmg ];
+
+    installPhase = ''
+      runHook preInstall
+
+      APP_DIR="$out/Applications/$appName"
+      mkdir -p "$APP_DIR"
+      cp -Tr "$appName" "$APP_DIR"
+
+      mkdir -p "$out/bin"
+      cat << EOF > "$out/bin/hopper"
+      #!${stdenv.shell}
+      exec "$APP_DIR/Contents/MacOS/hopper" "$@"
+      EOF
+      chmod +x "$out/bin/hopper"
+
+      runHook postInstall
+    '';
+  };
+
+  args = if stdenv.targetPlatform.isDarwin then darwin else linux;
+
+in stdenv.mkDerivation ({
+  pname = "hopper";
+  inherit version rev;
+
   sourceRoot = ".";
-
-  nativeBuildInputs = [
-    autoPatchelfHook
-    wrapQtAppsHook
-  ];
-
-  buildInputs = [
-    gnustep.libobjc
-    libbsd
-    libffi_3_3
-    ncurses6
-  ];
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/bin
-    mkdir -p $out/lib
-    mkdir -p $out/share
-
-    cp $sourceRoot/opt/hopper-${rev}/bin/Hopper $out/bin/hopper
-    cp \
-      --archive \
-      $sourceRoot/opt/hopper-${rev}/lib/libBlocksRuntime.so* \
-      $sourceRoot/opt/hopper-${rev}/lib/libdispatch.so* \
-      $sourceRoot/opt/hopper-${rev}/lib/libgnustep-base.so* \
-      $sourceRoot/opt/hopper-${rev}/lib/libHopperCore.so* \
-      $sourceRoot/opt/hopper-${rev}/lib/libkqueue.so* \
-      $sourceRoot/opt/hopper-${rev}/lib/libobjcxx.so* \
-      $sourceRoot/opt/hopper-${rev}/lib/libpthread_workqueue.so* \
-      $out/lib
-
-    cp -r $sourceRoot/usr/share $out
-
-    runHook postInstall
-  '';
-
-  postFixup = ''
-    substituteInPlace "$out/share/applications/hopper-${rev}.desktop" \
-      --replace "Exec=/opt/hopper-${rev}/bin/Hopper" "Exec=$out/bin/hopper"
-  '';
 
   meta = with lib; {
     homepage = "https://www.hopperapp.com/index.html";
@@ -74,6 +108,8 @@ stdenv.mkDerivation rec {
       luis
       Enteee
     ];
-    platforms = [ "x86_64-linux" /* aarch64-linux is not supported */ ];
+    platforms =
+      [ "x86_64-linux" /* aarch64-linux is not supported */ ] ++
+      platforms.darwin;
   };
-}
+} // args)


### PR DESCRIPTION
###### Description of changes

Updates hopper to v5.7.0, adds support for macOS, and marks hopper as unsupported on aarch64-linux (only x86_64 binary releases are [provided](https://www.hopperapp.com/download.html) for Linux).

From the hopper [changelog](https://www.hopperapp.com/rss/html_changelog.php), for 5.5.3 to 5.7.0:

<details>

```
Version 5.7.0 (2022-07-08 16:54:15)

    Improves the decompilation of Objective-C programs extracted from the DYLD cache,
    Fixes the display of 32-bit operands formatted as a float. 

Version 5.6.1 (2022-06-29 17:46:54)

    Improves DYLD cache path discovery on macOS Ventura,
    Slightly improves the decompiler output,
    Fixes a crash on multi-display systems when the computer was awakened,
    Fixes conditional jump instructions on the PowerPC plugin. 

Version 5.6.0 (2022-05-31 12:51:35)

    Adds a decompiler's option which removes (almost) all GOTO statements. This is still considered as beta as it introduces a lot of temporary variables.
    Adds a way to change the fields order of a structure, a union or an enum.
    Adds a way to change the arguments order of a method signature.
    Fixes an issue with the disassembly of the CCMP instruction (AArch64). 
```

</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).