### PR TITLE
gcc: pass --with-build-sysroot=/

### DIFF
--- a/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
@@ -50,6 +50,11 @@ if [[ "${NIX_ENFORCE_PURITY:-}" = 1 && -n "${NIX_STORE:-}"
             n+=1; skip "$p2"
         elif [ "$p" = -dynamic-linker ] && badPath "$p2"; then
             n+=1; skip "$p2"
+        elif [ "$p" = -syslibroot ] && [ $p2 == // ]; then
+            # When gcc is built on darwin --with-build-sysroot=/
+            # produces '-syslibroot //' linker flag. It's a no-op,
+            # which does not introduce impurities.
+            n+=1; skip "$p2"
         elif [ "${p:0:1}" = / ] && badPath "$p"; then
             # We cannot skip this; barf.
             echo "impure path \`$p' used in link" >&2

--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -111,8 +111,30 @@ let
       "--with-mpc=${libmpc}"
     ]
     ++ lib.optional (libelf != null) "--with-libelf=${libelf}"
-    ++ lib.optional (!(crossMingw && crossStageStatic))
-      "--with-native-system-header-dir=${lib.getDev stdenv.cc.libc}/include"
+    ++ lib.optionals (!crossStageStatic) [
+      (if libcCross == null
+       then "--with-native-system-header-dir=${lib.getDev stdenv.cc.libc}/include"
+       else "--with-native-system-header-dir=${lib.getDev libcCross}${libcCross.incdir or "/include"}")
+      # gcc builds for cross-compilers (build != host) or cross-built
+      # gcc (host != target) always apply the offset prefix to disentangle
+      # target headers from build or host headers:
+      #     ${with_build_sysroot}${native_system_header_dir}
+      #  or ${test_exec_prefix}/${target_noncanonical}/sys-include
+      #  or ${with_sysroot}${native_system_header_dir}
+      # While native build (build == host == target) uses passed headers
+      # path as is:
+      #    ${native_system_header_dir}
+      #
+      # Nixpkgs uses flat directory structure for both native and cross
+      # cases. As a result libc headers don't get found for cross case
+      # and many modern features get disabled (libssp is used instead of
+      # target-specific implementations and similar). More details at:
+      #   https://github.com/NixOS/nixpkgs/pull/181802#issuecomment-1186822355
+      #
+      # We pick "/" path to effectively avoid sysroot offset and make it work
+      # as a native case.
+      "--with-build-sysroot=/"
+    ]
 
     # Basic configuration
     ++ [


### PR DESCRIPTION
Without this change cross-built gcc fails to detect stack protector style:

    $ nix log -f pkgs/stdenv/linux/make-bootstrap-tools-cross.nix powerpc64le.bootGCC | fgrep __stack_chk_fail
    checking __stack_chk_fail in target C library... no
    checking __stack_chk_fail in target C library... no

It happens because gcc treats search paths differently:

    https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=gcc/configure.ac;h=446747311a6aec3c810ad6aa4190f7bd383b94f7;hb=HEAD#l2458

     if test x$host != x$target || test "x$TARGET_SYSTEM_ROOT" != x ||
        test x$build != x$host || test "x$with_build_sysroot" != x; then
       ...
       if test "x$with_build_sysroot" != "x"; then
         target_header_dir="${with_build_sysroot}${native_system_header_dir}"
       elif test "x$with_sysroot" = x; then
         target_header_dir="${test_exec_prefix}/${target_noncanonical}/sys-include"
       elif test "x$with_sysroot" = xyes; then
         target_header_dir="${test_exec_prefix}/${target_noncanonical}/sys-root${native_system_header_dir}"
       else
         target_header_dir="${with_sysroot}${native_system_header_dir}"
       fi
     else
       target_header_dir=${native_system_header_dir}
     fi

By passing --with-sysroot=/ we trick cross-case to use
`target_header_dir="${with_sysroot}${native_system_header_dir}"`
which makes it equivalent to non-cross
`target_header_dir=${native_system_header_dir}`

Tested the following setups:
- cross-compiler without libc headers (powerpc64le-static)
- cross-compiler with libc headers (powerpc64le-debug)
- cross-build compiler with libc headers (powerpc64le bootstrapTools)

Before the change only 2 of 3 compilers detected libc headers.
After the change all 3 compilers detected libc headers.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
