### PR TITLE
sgtpuzzles: bump 2 years, and fix icons

### DIFF
--- a/pkgs/games/sgt-puzzles/default.nix
+++ b/pkgs/games/sgt-puzzles/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   sgt-puzzles-menu = fetchurl {
-    url = "https://raw.githubusercontent.com/Oleh-Kravchenko/portage/master/games-puzzle/sgt-puzzles/files/sgt-puzzles.menu";
+    url = "https://raw.githubusercontent.com/gentoo/gentoo/720e614d0107e86fc1e520bac17726578186843d/games-puzzle/sgt-puzzles/files/sgt-puzzles.menu";
     sha256 = "088w0x9g3j8pn725ix8ny8knhdsfgjr3hpswsh9fvfkz5vlg2xkm";
   };
 

--- a/pkgs/games/sgt-puzzles/default.nix
+++ b/pkgs/games/sgt-puzzles/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Simon Tatham's portable puzzle collection";
     license = licenses.mit;
-    maintainers = [ maintainers.raskin ];
+    maintainers = with maintainers; [ raskin tomfitzhenry ];
     platforms = platforms.linux;
     homepage = "https://www.chiark.greenend.org.uk/~sgtatham/puzzles/";
   };

--- a/pkgs/games/sgt-puzzles/default.nix
+++ b/pkgs/games/sgt-puzzles/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     for i in  $(basename -s $out/bin/*); do
 
       ln -s $out/bin/$i $out/bin/sgt-puzzle-$i
-      install -Dm644 icons/$i-48d24.png -t $out/share/icons/hicolor/48x48/apps/
+      install -Dm644 icons/$i-96d24.png -t $out/share/icons/hicolor/96x96/apps/
 
       # Generate/validate/install .desktop files.
       echo "[Desktop Entry]" > $i.desktop
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
         --set-key Name --set-value $i \
         --set-key Comment --set-value "${meta.description}" \
         --set-key Categories --set-value "Game;LogicGame;X-sgt-puzzles;" \
-        --set-key Icon --set-value $out/share/icons/hicolor/48x48/apps/$i-48d24.png \
+        --set-key Icon --set-value $out/share/icons/hicolor/96x96/apps/$i-96d24.png \
         $i.desktop
     done
 

--- a/pkgs/games/sgt-puzzles/default.nix
+++ b/pkgs/games/sgt-puzzles/default.nix
@@ -1,15 +1,15 @@
 { lib, stdenv, fetchurl, desktop-file-utils
-, gtk3, libX11
-, makeWrapper, pkg-config, perl, autoreconfHook, wrapGAppsHook
+, gtk3, libX11, cmake, imagemagick
+, pkg-config, perl, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
   pname = "sgt-puzzles";
-  version = "20200610.9aa7b7c";
+  version = "20220613.387d323";
 
   src = fetchurl {
     url = "http://www.chiark.greenend.org.uk/~sgtatham/puzzles/puzzles-${version}.tar.gz";
-    sha256 = "0rrd1c77ar91zqy4rr4xp1z7x3ywnshlac99cga4hnrgwb7vwl3f";
+    hash = "sha256-Vcm7gxC9R7vvLkgkHblvEOONGLkYSHGMRfSBktgN/oQ=";
   };
 
   sgt-puzzles-menu = fetchurl {
@@ -17,17 +17,16 @@ stdenv.mkDerivation rec {
     sha256 = "088w0x9g3j8pn725ix8ny8knhdsfgjr3hpswsh9fvfkz5vlg2xkm";
   };
 
-  nativeBuildInputs = [ autoreconfHook desktop-file-utils makeWrapper
-    pkg-config perl wrapGAppsHook ];
+  nativeBuildInputs = [
+    cmake
+    desktop-file-utils
+    imagemagick
+    perl
+    pkg-config
+    wrapGAppsHook
+  ];
 
   buildInputs = [ gtk3 libX11 ];
-
-  makeFlags = [ "prefix=$(out)" "gamesdir=$(out)/bin"];
-
-  preInstall = ''
-    mkdir -p "$out"/{bin,share/doc/sgtpuzzles}
-    cp gamedesc.txt LICENCE README "$out/share/doc/sgtpuzzles"
-  '';
 
   postInstall = ''
     for i in  $(basename -s $out/bin/*); do
@@ -57,12 +56,6 @@ stdenv.mkDerivation rec {
     install -Dm644 ${sgt-puzzles-menu} -t $out/etc/xdg/menus/applications-merged/
   '';
 
-  preConfigure = ''
-    perl mkfiles.pl
-    export NIX_LDFLAGS="$NIX_LDFLAGS -lX11"
-    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -Wno-error"
-    cp Makefile.gtk Makefile
-  '';
   meta = with lib; {
     description = "Simon Tatham's portable puzzle collection";
     license = licenses.mit;

--- a/pkgs/games/sgt-puzzles/default.nix
+++ b/pkgs/games/sgt-puzzles/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
         --set-key Name --set-value $i \
         --set-key Comment --set-value "${meta.description}" \
         --set-key Categories --set-value "Game;LogicGame;X-sgt-puzzles;" \
-        --set-key Icon --set-value $out/share/icons/hicolor/48x48/apps/$i-48d24 \
+        --set-key Icon --set-value $out/share/icons/hicolor/48x48/apps/$i-48d24.png \
         $i.desktop
     done
 


### PR DESCRIPTION
###### Description of changes

* bump sgtpuzzles from a 2020 release to a 2022 release. This required moving to sgtpuzzles' cmake build.
* fix icons, and use higher resolution icons: 48x48 -> 96x96

Tested on x86_64 desktop, and aarch64 phone (PinePhone Pro). I was able to run and play some games!

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).