### PR TITLE
hub: 2.14.2 -> unstable-2022-04-04

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/hub/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/hub/default.nix
@@ -1,47 +1,65 @@
-{ lib, buildGoPackage, fetchFromGitHub, git, groff, installShellFiles, unixtools, nixosTests }:
+{ lib
+, buildGoModule
+, fetchpatch
+, fetchFromGitHub
+, git
+, groff
+, installShellFiles
+, makeWrapper
+, unixtools
+, nixosTests
+}:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "hub";
-  version = "2.14.2";
-
-  goPackagePath = "github.com/github/hub";
-
-  # Only needed to build the man-pages
-  excludedPackages = [ "github.com/github/hub/md2roff-bin" ];
+  version = "unstable-2022-04-04";
 
   src = fetchFromGitHub {
     owner = "github";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "1qjab3dpia1jdlszz3xxix76lqrm4zbmqzd9ymld7h06awzsg2vh";
+    rev = "363513a0f822a8bde5b620e5de183702280d4ace";
+    sha256 = "sha256-jipZHmGtPTsztTeVZofaMReU4AEU9k6mdw9YC4KKB1Q=";
   };
 
-  nativeBuildInputs = [ groff installShellFiles unixtools.col ];
-
   postPatch = ''
-    patchShebangs .
-    substituteInPlace git/git.go --replace "cmd.New(\"git\")" "cmd.New(\"${git}/bin/git\")"
-    substituteInPlace commands/args.go --replace "Executable:  \"git\"" "Executable:  \"${git}/bin/git\""
+    patchShebangs script/
   '';
+
+  vendorSha256 = "sha256-wQH8V9jRgh45JGs4IfYS1GtmCIYdo93JG1UjJ0BGxXk=";
+
+  # Only needed to build the man-pages
+  excludedPackages = [ "github.com/github/hub/md2roff-bin" ];
+
+  nativeBuildInputs = [
+    groff
+    installShellFiles
+    makeWrapper
+    unixtools.col
+  ];
 
   postInstall = ''
-    cd go/src/${goPackagePath}
-    installShellCompletion --zsh --name _hub etc/hub.zsh_completion
-    installShellCompletion --bash --name hub etc/hub.bash_completion.sh
-    installShellCompletion --fish --name hub.fish etc/hub.fish_completion
+    installShellCompletion --cmd hub \
+      --bash etc/hub.bash_completion.sh \
+      --fish etc/hub.fish_completion \
+      --zsh etc/hub.zsh_completion
 
-    LC_ALL=C.UTF8 \
-    make man-pages
+    LC_ALL=C.UTF8 make man-pages
     installManPage share/man/man[1-9]/*.[1-9]
+
+    wrapProgram $out/bin/hub \
+      --suffix PATH : ${lib.makeBinPath [ git ]}
   '';
+
+  checkInputs = [
+    git
+  ];
 
   passthru.tests = { inherit (nixosTests) hub; };
 
   meta = with lib; {
     description = "Command-line wrapper for git that makes you better at GitHub";
-    license = licenses.mit;
     homepage = "https://hub.github.com/";
+    license = licenses.mit;
     maintainers = with maintainers; [ globin ];
-    platforms = with platforms; unix;
   };
 }


### PR DESCRIPTION
Fetching https://github.com/github/hub/commit/5d42499f1da717ff39b7b1d4139f06f3a77a0612
didn't turn out to be that easy because the vendor/ directory was
removed in the meantime and we would need to create a custom patch.
Since the last release is  over 2 years ago I opted into bumping it to
the latest version in master instead.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
