### PR TITLE
blesh: init at 2022-07-24

### DIFF
--- a/pkgs/shells/bash/ble.sh/default.nix
+++ b/pkgs/shells/bash/ble.sh/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenvNoCC, fetchgit, git, runtimeShell }:
+{ lib, stdenvNoCC, fetchgit, git, curl, jq, nix-prefetch, runtimeShell }:
 
 stdenvNoCC.mkDerivation {
   name = "ble.sh";
@@ -13,19 +13,47 @@ stdenvNoCC.mkDerivation {
   };
 
   nativeBuildInputs = [ git ];
+  buildInputs = [ curl jq nix-prefetch ];
 
   doCheck = true;
 
   installFlags = [ "INSDIR=$(out)/share" ];
   postInstall = ''
     mkdir -p "$out/bin"
-    cat <<SCRIPT > "$out/bin/ble.sh-share"
+    cat <<SCRIPT >"$out/bin/ble.sh-share"
     #!${runtimeShell}
     # Run this script to find the ble.sh shared folder
     # where all the shell scripts are living.
     echo "$out/share/ble.sh"
     SCRIPT
     chmod +x "$out/bin/ble.sh-share"
+
+    mkdir -p "$out/share/lib"
+    cat <<SCRIPT >"$out/share/lib/_package.sh"
+    _ble_base_package_type=nix
+
+    function ble/base/package:nix/update {
+      local rev=\$(${curl}/bin/curl -sL 'https://api.github.com/repos/akinomyoga/ble.sh/branches/master' | ${jq}/bin/jq -r '.commit.sha')
+      local hash="\$(${nix-prefetch}/bin/nix-prefetch fetchgit --url 'https://github.com/akinomyoga/ble.sh.git' --branchName master --rev \$rev --leaveDotGit --fetchSubmodules 2>/dev/null)"
+
+      cat <<-EOS >/dev/stderr
+    	You cannot update ble.sh automatically via Nix.
+    	The latest ble.sh from master branch can be installed by overriding nixpkgs like following.
+
+    	  pkgs.ble-sh.overrideAttrs (_: {
+    	    src = pkgs.fetchgit {
+    	      url = "https://github.com/akinomyoga/ble.sh.git";
+    	      rev = "\$rev";
+    	      hash = "\$hash";
+    	      fetchSubmodules = true;
+    	      leaveDotGit = true;
+    	    };
+    	    doCheck = false;
+    	  });
+    	EOS
+      return 1
+    }
+    SCRIPT
   '';
 
   meta = with lib; {

--- a/pkgs/shells/bash/ble.sh/default.nix
+++ b/pkgs/shells/bash/ble.sh/default.nix
@@ -1,27 +1,32 @@
-{ lib, stdenv, git, fetchgit }:
+{ lib, stdenvNoCC, fetchgit, git, runtimeShell }:
 
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   name = "ble.sh";
   version = "0.3.3";
-
-  nativeBuildInputs = [ git ];
 
   src = fetchgit {
     url = "https://github.com/akinomyoga/ble.sh.git";
     rev = "refs/tags/v0.3.3";
     hash = "sha256-Gfo2S1t5Kdy+8TEDS4M5yhyRShvzQIljdE0MQK1CL+4=";
     fetchSubmodules = true;
+    leaveDotGit = true;
   };
+
+  nativeBuildInputs = [ git ];
 
   doCheck = true;
 
+  installFlags = [ "INSDIR=$(out)/share" ];
   postInstall = ''
     mkdir -p "$out/bin"
-    echo 'source "$(dirname "$BASH_SOURCE")/../share/ble.sh"' >"$out/bin/ble.sh"
-    chmod +x "$out/bin/ble.sh"
-    '';
-
-  makeFlags = [ "INSDIR=$(out)/share" ];
+    cat <<SCRIPT > "$out/bin/ble.sh-share"
+    #!${runtimeShell}
+    # Run this script to find the ble.sh shared folder
+    # where all the shell scripts are living.
+    echo "$out/share/ble.sh"
+    SCRIPT
+    chmod +x "$out/bin/ble.sh-share"
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/akinomyoga/ble.sh";

--- a/pkgs/shells/bash/ble.sh/default.nix
+++ b/pkgs/shells/bash/ble.sh/default.nix
@@ -1,0 +1,33 @@
+{ lib, stdenv, git, fetchgit }:
+
+stdenv.mkDerivation {
+  name = "ble.sh";
+  version = "0.3.3";
+
+  nativeBuildInputs = [ git ];
+
+  src = fetchgit {
+    url = "https://github.com/akinomyoga/ble.sh.git";
+    rev = "refs/tags/v0.3.3";
+    hash = "sha256-Gfo2S1t5Kdy+8TEDS4M5yhyRShvzQIljdE0MQK1CL+4=";
+    fetchSubmodules = true;
+  };
+
+  doCheck = true;
+
+  postInstall = ''
+    mkdir -p "$out/bin"
+    echo 'source "$(dirname "$BASH_SOURCE")/../share/ble.sh"' >"$out/bin/ble.sh"
+    chmod +x "$out/bin/ble.sh"
+    '';
+
+  makeFlags = [ "INSDIR=$(out)/share" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/akinomyoga/ble.sh";
+    description = "Bash Line Editor -- a full-featured line editor written in pure Bash";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ aiotter ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/shells/bash/blesh/default.nix
+++ b/pkgs/shells/bash/blesh/default.nix
@@ -35,28 +35,11 @@ stdenvNoCC.mkDerivation rec {
     _ble_base_package_type=nix
 
     function ble/base/package:nix/update {
-      local rev=\$(${curl}/bin/curl -sL 'https://api.github.com/repos/akinomyoga/ble.sh/branches/master' | ${jq}/bin/jq -r '.commit.sha')
-      [[ "\$rev" == "${src.rev}" ]] && return 6
-
-      # We use fetchgit here, because nix-prefetch's fetchFromGitHub is broken
-      local hash="\$(${nix-prefetch}/bin/nix-prefetch fetchgit --url 'https://github.com/akinomyoga/ble.sh.git' --branchName master --rev \$rev --leaveDotGit --fetchSubmodules 2>/dev/null)"
-
-      cat <<STDERR >/dev/stderr
-    You cannot update ble.sh to the latest version with Nix.
-    The latest ble.sh from master branch can be installed by overriding nixpkgs like following.
-
-      pkgs.ble-sh.overrideAttrs (_: {
-        src = pkgs.fetchFromGitHub {
-          owner = "akinomyoga";
-          repo = "ble.sh";
-          rev = "\$rev";
-          hash = "\$hash";
-          fetchSubmodules = true;
-          leaveDotGit = true;
-        };
-      });
-    STDERR
-      return 1
+      if ! nix-env --query ble.sh >/dev/null 2>&1; then
+        echo "Upgrade nix and rebuild the system to update ble.sh" >/dev/stderr
+        return 1
+      fi
+      nix-env --upgrade --attr nixpkgs.blesh
     }
     SCRIPT
   '';

--- a/pkgs/shells/bash/blesh/default.nix
+++ b/pkgs/shells/bash/blesh/default.nix
@@ -8,8 +8,8 @@
 }:
 
 stdenvNoCC.mkDerivation rec {
-  name = "ble.sh";
-  version = "2022-07-24";
+  name = "blesh";
+  version = "unstable-2022-07-24";
 
   src = fetchFromGitHub {
     owner = "akinomyoga";

--- a/pkgs/shells/bash/blesh/default.nix
+++ b/pkgs/shells/bash/blesh/default.nix
@@ -1,47 +1,51 @@
-{ lib, stdenvNoCC, fetchFromGitHub, git, curl, jq, nix-prefetch, bashInteractive, runtimeShell }:
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, git
+, bashInteractive
+, glibcLocales
+, runtimeShell
+}:
 
 stdenvNoCC.mkDerivation rec {
   name = "ble.sh";
-  version = "2022-07-21";
+  version = "2022-07-24";
 
   src = fetchFromGitHub {
     owner = "akinomyoga";
     repo = "ble.sh";
-    rev = "a45077599d5c48d946de6e9b3c4baaaae9fc2633";
-    hash = "sha256-YUfDr3wmv7UGAoDQJBuXve0R34cQua4OyooppYXJIlU=";
+    rev = "0b95d5d900b79a63e7f0834da5aa7276b8332a44";
+    hash = "sha256-s/RQKcAFcCUB3Xd/4uOsIgigOE0lCCeVC9K3dfnP/EQ=";
     fetchSubmodules = true;
     leaveDotGit = true;
   };
 
   nativeBuildInputs = [ git ];
-  buildInputs = [ curl jq nix-prefetch ];
 
   doCheck = true;
-  checkInputs = [ bashInteractive ];
+  checkInputs = [ bashInteractive glibcLocales ];
+  preCheck = "export LC_ALL=en_US.UTF-8";
 
   installFlags = [ "INSDIR=$(out)/share" ];
   postInstall = ''
     mkdir -p "$out/bin"
-    cat <<SCRIPT >"$out/bin/blesh-share"
+    cat <<EOF >"$out/bin/blesh-share"
     #!${runtimeShell}
     # Run this script to find the ble.sh shared folder
     # where all the shell scripts are living.
     echo "$out/share/ble.sh"
-    SCRIPT
+    EOF
     chmod +x "$out/bin/blesh-share"
 
     mkdir -p "$out/share/lib"
-    cat <<SCRIPT >"$out/share/lib/_package.sh"
+    cat <<EOF >"$out/share/lib/_package.sh"
     _ble_base_package_type=nix
 
     function ble/base/package:nix/update {
-      if ! nix-env --query ble.sh >/dev/null 2>&1; then
-        echo "Upgrade nix and rebuild the system to update ble.sh" >/dev/stderr
-        return 1
-      fi
-      nix-env --upgrade --attr nixpkgs.blesh
+      echo "Ble.sh is installed by Nix. You can update it there." >/dev/stderr
+      return 1
     }
-    SCRIPT
+    EOF
   '';
 
   meta = with lib; {

--- a/pkgs/shells/bash/blesh/default.nix
+++ b/pkgs/shells/bash/blesh/default.nix
@@ -22,13 +22,13 @@ stdenvNoCC.mkDerivation rec {
   installFlags = [ "INSDIR=$(out)/share" ];
   postInstall = ''
     mkdir -p "$out/bin"
-    cat <<SCRIPT >"$out/bin/ble.sh-share"
+    cat <<SCRIPT >"$out/bin/blesh-share"
     #!${runtimeShell}
     # Run this script to find the ble.sh shared folder
     # where all the shell scripts are living.
     echo "$out/share/ble.sh"
     SCRIPT
-    chmod +x "$out/bin/ble.sh-share"
+    chmod +x "$out/bin/blesh-share"
 
     mkdir -p "$out/share/lib"
     cat <<SCRIPT >"$out/share/lib/_package.sh"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12378,7 +12378,7 @@ with pkgs;
 
   yarn-bash-completion = callPackage ../shells/bash/yarn-completion { };
 
-  ble-sh = callPackage ../shells/bash/ble.sh { };
+  blesh = callPackage ../shells/bash/blesh { };
 
   undistract-me = callPackage ../shells/bash/undistract-me { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12378,6 +12378,8 @@ with pkgs;
 
   yarn-bash-completion = callPackage ../shells/bash/yarn-completion { };
 
+  ble-sh = callPackage ../shells/bash/ble.sh { };
+
   undistract-me = callPackage ../shells/bash/undistract-me { };
 
   dash = callPackage ../shells/dash { };


### PR DESCRIPTION
###### Description of changes
Adds ~~bre.sh~~[ble.sh](https://github.com/akinomyoga/ble.sh).

Use this package by executing `source ble.sh` on bash.
Users can modify their `~/.bashrc` to have it loaded on login:

```bash
# bashrc

# Add this lines at the top of .bashrc:
[[ $- == *i* ]] && source ble.sh --noattach

# your bashrc settings come here...

# Add this line at the end of .bashrc:
[[ ${BLE_VERSION-} ]] && ble-attach
```

See https://github.com/akinomyoga/ble.sh#13-set-up-bashrc for more detail.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
