### PR TITLE
neofetch: improve detect NixOS version

### DIFF
--- a/pkgs/tools/misc/neofetch/default.nix
+++ b/pkgs/tools/misc/neofetch/default.nix
@@ -25,6 +25,12 @@ stdenvNoCC.mkDerivation rec {
       sha256 = "sha256-F6Q4dUtfmR28VxLbITiLFJ44FjG4T1Cvuz3a0nLisMs=";
       name = "update_old_nixos_logo.patch";
     })
+    # https://github.com/dylanaraps/neofetch/pull/2157
+    (fetchpatch {
+      url = "https://github.com/dylanaraps/neofetch/commit/de253afcf41bab441dc58d34cae654040cab7451.patch";
+      sha256 = "sha256-3i7WnCWNfsRjbenTULmKHft5o/o176imzforNmuoJwo=";
+      name = "improve_detect_nixos_version.patch";
+    })
   ];
 
   outputs = [ "out" "man" ];


### PR DESCRIPTION
###### Description of changes
Improve detect NixOS version

Before PR:
```
neofetch --off --distro_shorthand on | grep OS
OS: nixos 22.11 x86_64

neofetch --off --distro_shorthand tiny | grep OS
OS: nixos x86_64

neofetch --off --distro_shorthand off | grep OS
OS: NixOS 22.11 (Raccoon) x86_64
```

After PR:
```
neofetch --off --distro_shorthand on | grep OS
OS: NixOS 22.11 (Raccoon) x86_64

neofetch --off --distro_shorthand tiny | grep OS
OS: NixOS x86_64

neofetch --off --distro_shorthand off | grep OS
OS: NixOS 22.11.git.31109649164 (Raccoon) x86_64
```

PR in upstream - https://github.com/dylanaraps/neofetch/pull/2157

cc @erikrodrgz @Artturin @rhoriguchi @lilyinstarlight @SuperSandro2000

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
