### PR TITLE
vscode-extensions.chenglou92.rescript-vscode: 1.3.0 -> 1.6.0

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/rescript/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/rescript/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv, vscode-utils, callPackage }:
 let
-  rescript-editor-analysis = (callPackage ./rescript-editor-analysis.nix { });
+  version = "1.6.0";
+  rescript-editor-analysis = callPackage ./rescript-editor-analysis.nix { inherit version; };
   arch =
     if stdenv.isLinux then "linux"
     else if stdenv.isDarwin then "darwin"
@@ -11,8 +12,8 @@ vscode-utils.buildVscodeMarketplaceExtension rec {
   mktplcRef = {
     name = "rescript-vscode";
     publisher = "chenglou92";
-    version = "1.3.0";
-    sha256 = "sha256-Sgi7FFOpI/XOeyPOrDhwZdZ+43ilUz7oQ49yB7tiMXk=";
+    inherit version;
+    sha256 = "sha256-/Nv+uyTkJQVaPKIDRr1P/Z5vsituXpP48/sDn3FUEeA=";
   };
   postPatch = ''
     rm -r ${analysisDir}
@@ -22,7 +23,7 @@ vscode-utils.buildVscodeMarketplaceExtension rec {
   meta = with lib; {
     description = "The official VSCode plugin for ReScript";
     homepage = "https://github.com/rescript-lang/rescript-vscode";
-    maintainers = with maintainers; [ dlip ];
+    maintainers = with maintainers; [ dlip jayesh-bhoot ];
     license = licenses.mit;
   };
 }

--- a/pkgs/applications/editors/vscode/extensions/rescript/rescript-editor-analysis.nix
+++ b/pkgs/applications/editors/vscode/extensions/rescript/rescript-editor-analysis.nix
@@ -1,21 +1,24 @@
-{ lib, stdenv, fetchFromGitHub, bash, ocaml }:
+{ lib, stdenv, fetchFromGitHub, bash, ocaml, dune_3, version }:
 
 stdenv.mkDerivation {
   pname = "rescript-editor-analysis";
-  version = "1.1.3";
+  inherit version;
 
   src = fetchFromGitHub {
     owner = "rescript-lang";
     repo = "rescript-vscode";
-    rev = "8d0412a72307b220b7f5774e2612760a2d429059";
-    sha256 = "rHQtfuIiEWlSPuZvNpEafsvlXCj2Uv1YRR1IfvKfC2s=";
+    rev = version;
+    sha256 = "sha256-O5kZCnhtMcevPTs5UxhIXx124WQf1VvF2WMVHjMEQZc=";
   };
 
-  nativeBuildInputs = [ ocaml ];
+  nativeBuildInputs = [ ocaml dune_3 ];
 
+  # Skip testing phases because they need to download and install node modules
   postPatch = ''
     cd analysis
-    substituteInPlace Makefile --replace "/bin/bash" "${bash}/bin/bash"
+    substituteInPlace Makefile \
+      --replace "build: build-analysis-binary build-reanalyze build-tests" "build: build-analysis-binary" \
+      --replace "test: test-analysis-binary test-reanalyze" "test: test-analysis-binary"
   '';
 
   installPhase = ''
@@ -25,7 +28,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "Analysis binary for the ReScript VSCode plugin";
     homepage = "https://github.com/rescript-lang/rescript-vscode";
-    maintainers = with maintainers; [ dlip ];
+    maintainers = with maintainers; [ dlip jayesh-bhoot ];
     license = licenses.mit;
   };
 }


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/rescript-lang/rescript-vscode/blob/master/CHANGELOG.md#v140

This upgrade also brings the version of the (sub)derivation
rescript-editor-analysis on par with rescript-vscode.

The analysis executable was lagging behind the main rescript-vscode package,
due to which the vscode extension lost a few LSP capabilities, like semanticTokens.
See https://github.com/rescript-lang/rescript-vscode/issues/488 and https://github.com/NixOS/nixpkgs/pull/181254 for more details.

This upgrade brings the analysis binary in sync with the main extension version.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
