### PR TITLE
[Backport release-22.05] libuiohook: init at 1.2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -856,6 +856,13 @@
     githubId = 661909;
     name = "Antonio Nuno Monteiro";
   };
+  anoa = {
+    matrix = "@andrewm:amorgan.xyz";
+    email = "andrew@amorgan.xyz";
+    github = "anoadragon453";
+    githubId = 1342360;
+    name = "Andrew Morgan";
+  };
   anpryl = {
     email = "anpryl@gmail.com";
     github = "anpryl";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -277,6 +277,7 @@ in
   libreddit = handleTest ./libreddit.nix {};
   libresprite = handleTest ./libresprite.nix {};
   libreswan = handleTest ./libreswan.nix {};
+  libuiohook = handleTest ./libuiohook.nix {};
   lidarr = handleTest ./lidarr.nix {};
   lightdm = handleTest ./lightdm.nix {};
   limesurvey = handleTest ./limesurvey.nix {};

--- a/nixos/tests/libuiohook.nix
+++ b/nixos/tests/libuiohook.nix
@@ -1,0 +1,21 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
+  name = "libuiohook";
+  meta = with lib.maintainers; { maintainers = [ anoa ]; };
+
+  nodes.client = { nodes, ... }:
+      let user = nodes.client.config.users.users.alice;
+      in {
+        imports = [ ./common/user-account.nix ./common/x11.nix ];
+
+        environment.systemPackages = [ pkgs.libuiohook.test ];
+
+        test-support.displayManager.auto.user = user.name;
+      };
+
+  testScript = { nodes, ... }:
+    let user = nodes.client.config.users.users.alice;
+    in ''
+      client.wait_for_x()
+      client.succeed("su - alice -c ${pkgs.libuiohook.test}/share/uiohook_tests >&2 &")
+    '';
+})

--- a/pkgs/development/libraries/libuiohook/default.nix
+++ b/pkgs/development/libraries/libuiohook/default.nix
@@ -1,0 +1,71 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, nixosTests
+, cmake
+, pkg-config
+, AppKit
+, ApplicationServices
+, Carbon
+, libX11
+, libxkbcommon
+, xinput
+, xorg
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libuiohook";
+  version = "1.2.2";
+
+  src = fetchFromGitHub {
+    owner = "kwhat";
+    repo = pname;
+    rev = version;
+    sha256 = "1qlz55fp4i9dd8sdwmy1m8i4i1jy1s09cpmlxzrgf7v34w72ncm7";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs =
+    if stdenv.isDarwin then [ AppKit ApplicationServices Carbon ]
+    else [
+      libX11
+      libxkbcommon
+      xinput
+    ] ++
+    (with xorg; [
+      libXau
+      libXdmcp
+      libXi
+      libXinerama
+      libXt
+      libXtst
+      libXext
+      libxkbfile
+    ]);
+
+  outputs = [ "out" "test" ];
+
+  # We build the tests, but they're only installed when using the "test" output.
+  # This will produce a "uiohook_tests" binary which can be run to test the
+  # functionality of the library on the current system.
+  # Running the test binary requires a running X11 session.
+  cmakeFlags = [
+    "-DENABLE_TEST:BOOL=ON"
+  ];
+
+  postInstall = ''
+    mkdir -p $test/share
+    cp ./uiohook_tests $test/share
+  '';
+
+  meta = with lib; {
+    description = "A C library to provide global keyboard and mouse hooks from userland";
+    homepage = "https://github.com/kwhat/libuiohook";
+    license = licenses.gpl3Only;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ anoa ];
+  };
+
+  passthru.tests.libuiohook = nixosTests.libuiohook;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19320,6 +19320,10 @@ with pkgs;
 
   libuinputplus = callPackage ../development/libraries/libuinputplus { };
 
+  libuiohook = callPackage ../development/libraries/libuiohook {
+    inherit (darwin.apple_sdk.frameworks) AppKit ApplicationServices Carbon;
+  };
+
   libunistring = callPackage ../development/libraries/libunistring { };
 
   libupnp = callPackage ../development/libraries/pupnp { };


### PR DESCRIPTION
This is a manual backport of #181660 to `release-22.05`.