### PR TITLE
Add Mopidy-Bandcamp

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2790,6 +2790,13 @@
     githubId = 1311761;
     name = "Didier J. Devroye";
   };
+  desttinghim = {
+    email = "opensource@louispearson.work";
+    matrix = "@desttinghim:matrix.org";
+    github = "desttinghim";
+    githubId = 10042482;
+    name = "Louis Pearson";
+  };
   devhell = {
     email = ''"^"@regexmail.net'';
     github = "devhell";

--- a/pkgs/applications/audio/mopidy/bandcamp.nix
+++ b/pkgs/applications/audio/mopidy/bandcamp.nix
@@ -1,0 +1,19 @@
+{ lib, python3Packages, mopidy }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "Mopidy-Bandcamp";
+  version = "1.1.5";
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-wg9zcOKfZQRhpyA1Cu5wvdwKpmrlcr2m9mrqBHgUXAQ=";
+  };
+
+  propagatedBuildInputs = with python3Packages; [ mopidy pykka ];
+
+  meta = with lib; {
+    description = "Mopidy extension for playing music from bandcamp";
+    homepage = "https://github.com/impliedchaos/mopidy-bandcamp";
+    license = licenses.mit;
+    maintainers = with maintainers; [ desttinghim ];
+  };
+}

--- a/pkgs/applications/audio/mopidy/default.nix
+++ b/pkgs/applications/audio/mopidy/default.nix
@@ -7,6 +7,8 @@ lib.makeScope newScope (self: with self; {
 
   mopidy = callPackage ./mopidy.nix { };
 
+  mopidy-bandcamp = callPackage ./bandcamp.nix { };
+
   mopidy-iris = callPackage ./iris.nix { };
 
   mopidy-local = callPackage ./local.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26829,6 +26829,7 @@ with pkgs;
 
   inherit (mopidyPackages)
     mopidy
+    mopidy-bandcamp
     mopidy-iris
     mopidy-local
     mopidy-moped


### PR DESCRIPTION
###### Note

This is a port of a derivation I am using in my [home-manager configuration.](https://github.com/desttinghim/nixos-configuration/blob/75c97728000e9e66d9b6776c0b84f335b4f0f036/home.nix#L11)

###### Description of changes

Add myself to the maintainers list.
Add [Mopidy-Bandcamp](https://github.com/impliedchaos/mopidy-bandcamp)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
