### PR TITLE
visidata: add runtime dependency of clipboard commands

### DIFF
--- a/pkgs/applications/misc/visidata/default.nix
+++ b/pkgs/applications/misc/visidata/default.nix
@@ -22,6 +22,7 @@
 , setuptools
 , git
 , withPcap ? true, dpkt, dnslib
+, withXclip ? stdenv.isLinux, xclip
 }:
 buildPythonApplication rec {
   pname = "visidata";
@@ -63,7 +64,8 @@ buildPythonApplication rec {
     zstandard
     odfpy
     setuptools
-  ] ++ lib.optionals withPcap [ dpkt dnslib ];
+  ] ++ lib.optionals withPcap [ dpkt dnslib ]
+  ++ lib.optional withXclip xclip;
 
   checkInputs = [
     git


### PR DESCRIPTION
###### Description of changes

VisiData’s system clipboard commands (e.g. Edit → Copy → to system clipboard) currently fail with:

```plain
FileNotFoundError: [Errno 2] No such file or directory: 'xclip'
```

This can be corrected in the user’s configuration, and for e.g. Wayland you might prefer to specify different commands anyway—

```nix
{
  home.file.".visidatarc".text = ''
    options.clipboard_copy_cmd = '${wl-clipboard}/bin/wl-copy'
    options.clipboard_paste_cmd = '${wl-clipboard}/bin/wl-paste --no-newline'
  '';
}
```

—but it would be nice if the defaults worked out of the box.

https://github.com/saulpw/visidata/blob/v2.8/visidata/clipboard.py#L18-L19

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
- [x] Tested compilation of all packages that depend on this change using `nixpkgs-review rev visidata/xclip`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
