### PR TITLE
midi-trigger: init at 0.0.4

### DIFF
--- a/pkgs/applications/audio/midi-trigger/default.nix
+++ b/pkgs/applications/audio/midi-trigger/default.nix
@@ -1,0 +1,34 @@
+{ lib, stdenv, fetchFromGitHub, pkg-config, lv2 }:
+
+stdenv.mkDerivation rec {
+  pname = "midi-trigger";
+  version = "0.0.4";
+
+  src = fetchFromGitHub {
+    owner = "unclechu";
+    repo = "MIDI-Trigger";
+    rev = "v${version}";
+    sha256 = "sha256-tMnN8mTd6Bm46ZIDy0JPSVe77xCZws2XwQLQexDWPgU=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ lv2 ];
+
+  makeFlags = [
+    "CXX=cc"
+    "BUILD_DIR=."
+  ];
+
+  installPhase = ''
+    mkdir -p -- "$out/lib/lv2"
+    mv -- "$pname".lv2 "$out/lib/lv2"
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/unclechu/MIDI-Trigger";
+    description = "LV2 plugin which generates MIDI notes by detected audio signal peaks";
+    maintainers = with maintainers; [ unclechu ];
+    license = licenses.gpl3Only;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/audio/midi-trigger/default.nix
+++ b/pkgs/applications/audio/midi-trigger/default.nix
@@ -20,8 +20,8 @@ stdenv.mkDerivation rec {
   ];
 
   installPhase = ''
-    mkdir -p -- "$out/lib/lv2"
-    mv -- "$pname".lv2 "$out/lib/lv2"
+    mkdir -p "$out/lib/lv2"
+    mv midi-trigger.lv2 "$out/lib/lv2"
   '';
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1235,6 +1235,8 @@ with pkgs;
 
   midimonster = callPackage ../tools/audio/midimonster { };
 
+  midi-trigger = callPackage ../applications/audio/midi-trigger { };
+
   mprocs = callPackage ../tools/misc/mprocs { };
 
   nominatim = callPackage ../servers/nominatim { };


### PR DESCRIPTION
###### Description of changes

[MIDI-Trigger](https://github.com/unclechu/MIDI-Trigger): LV2 plugin which generates MIDI notes by detected audio signal peaks.

Tested on NixOS using Ardour 6.

Also it’s tested that it successfully builds on MacOS in the CI:
https://github.com/unclechu/MIDI-Trigger/actions/runs/2693437043

Applied `nixfmt` to `pkgs/applications/audio/midi-trigger/default.nix`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
