### PR TITLE
tinyscheme: fix build on macOS

### DIFF
--- a/pkgs/development/interpreters/tinyscheme/01-remove-macOS-main.patch
+++ b/pkgs/development/interpreters/tinyscheme/01-remove-macOS-main.patch
@@ -1,0 +1,24 @@
+diff --git a/scheme.c b/scheme.c
+index 6186ef0..5a43592 100644
+--- a/scheme.c
++++ b/scheme.c
+@@ -4949,19 +4949,7 @@ pointer scheme_eval(scheme *sc, pointer obj)
+
+ #if STANDALONE
+
+-#if defined(__APPLE__) && !defined (OSX)
+-int main()
+-{
+-     extern MacTS_main(int argc, char **argv);
+-     char**    argv;
+-     int argc = ccommand(&argv);
+-     MacTS_main(argc,argv);
+-     return 0;
+-}
+-int MacTS_main(int argc, char **argv) {
+-#else
+ int main(int argc, char **argv) {
+-#endif
+   scheme sc;
+   FILE *fin;
+   char *file_name=InitFile;

--- a/pkgs/development/interpreters/tinyscheme/02-use-toolchain-env-vars.patch
+++ b/pkgs/development/interpreters/tinyscheme/02-use-toolchain-env-vars.patch
@@ -1,0 +1,26 @@
+diff --git a/makefile b/makefile
+index aeb2fcd..4c111a1 100644
+--- a/makefile
++++ b/makefile
+@@ -18,7 +18,7 @@
+ #AR= echo
+ 
+ # Unix, generally
+-CC = gcc -fpic -pedantic
++CC := $(CC) -fpic -pedantic
+ DEBUG=-g -Wall -Wno-char-subscripts -O
+ Osuf=o
+ SOsuf=so
+@@ -27,10 +27,10 @@ EXE_EXT=
+ LIBPREFIX=lib
+ OUT = -o $@
+ RM= -rm -f
+-AR= ar crs
++AR := $(AR) crs
+ 
+ # Linux
+-LD = gcc
++LD := $(CC)
+ LDFLAGS = -shared
+ DEBUG=-g -Wno-char-subscripts -O
+ SYS_LIBS= -ldl -lm

--- a/pkgs/development/interpreters/tinyscheme/03-macOS-SOsuf.patch
+++ b/pkgs/development/interpreters/tinyscheme/03-macOS-SOsuf.patch
@@ -1,0 +1,13 @@
+diff --git a/makefile b/makefile
+index 4c111a1..8d9e02e 100644
+--- a/makefile
++++ b/makefile
+@@ -21,7 +21,7 @@
+ CC := $(CC) -fpic -pedantic
+ DEBUG=-g -Wall -Wno-char-subscripts -O
+ Osuf=o
+-SOsuf=so
++SOsuf=dylib
+ LIBsuf=a
+ EXE_EXT=
+ LIBPREFIX=lib

--- a/pkgs/development/interpreters/tinyscheme/default.nix
+++ b/pkgs/development/interpreters/tinyscheme/default.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/bin $out/lib
     cp init.scm $out/lib
+    cp libtinyscheme* $out/lib
     cp scheme $out/bin/tinyscheme
   '';
 

--- a/pkgs/development/interpreters/tinyscheme/default.nix
+++ b/pkgs/development/interpreters/tinyscheme/default.nix
@@ -36,6 +36,7 @@ stdenv.mkDerivation rec {
       subset of R5RS as was possible without getting very large and complicated.
     '';
     homepage = "http://tinyscheme.sourceforge.net/";
+    changelog = "http://tinyscheme.sourceforge.net/CHANGES";
     license = licenses.bsdOriginal;
     maintainers = [ maintainers.ebzzry ];
     platforms = platforms.unix;

--- a/pkgs/development/interpreters/tinyscheme/default.nix
+++ b/pkgs/development/interpreters/tinyscheme/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenv, fetchurl, dos2unix }:
 
 stdenv.mkDerivation rec {
   pname = "tinyscheme";
@@ -9,7 +9,15 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-F7Cxv/0i89SdWDPiKhILM5A50s/aC0bW/FHdLwG0B60=";
   };
 
-  patchPhase = ''
+  nativeBuildInputs = [ dos2unix ];
+
+  prePatch = "dos2unix makefile";
+  patches = [
+    # We want to have the makefile pick up $CC, etc. so that we don't have
+    # to unnecessarily tie this package to the GCC stdenv.
+    ./02-use-toolchain-env-vars.patch
+  ];
+  postPatch = ''
     substituteInPlace scheme.c --replace "init.scm" "$out/lib/init.scm"
   '';
 

--- a/pkgs/development/interpreters/tinyscheme/default.nix
+++ b/pkgs/development/interpreters/tinyscheme/default.nix
@@ -75,6 +75,7 @@ stdenv.mkDerivation rec {
     homepage = "http://tinyscheme.sourceforge.net/";
     changelog = "http://tinyscheme.sourceforge.net/CHANGES";
     license = licenses.bsdOriginal;
+    mainProgram = pname;
     maintainers = [ maintainers.ebzzry ];
     platforms = platforms.unix;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14346,9 +14346,7 @@ with pkgs;
     wasi-libc = pkgsCross.wasi32.wasilibc;
   };
 
-  tinyscheme = callPackage ../development/interpreters/tinyscheme {
-    stdenv = gccStdenv;
-  };
+  tinyscheme = callPackage ../development/interpreters/tinyscheme { };
 
   bupc = callPackage ../development/compilers/bupc { };
 


### PR DESCRIPTION
###### Description of changes

Also adds a few tests.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).