### PR TITLE
Fix building of libbluray with java support

### DIFF
--- a/pkgs/development/libraries/libbluray/BDJ-JARFILE-path.patch
+++ b/pkgs/development/libraries/libbluray/BDJ-JARFILE-path.patch
@@ -1,11 +1,10 @@
-diff --git a/configure.ac b/configure.ac
-index 5fd3c8de..7ae343e0 100644
---- a/configure.ac
-+++ b/configure.ac
-@@ -228,6 +228,10 @@ if test "x$use_bdjava_jar" = "xyes" && test "x$HAVE_ANT" = "xno"; then
-     AC_MSG_ERROR([BD-J requires ANT, but ant was not found. Please install it.])
- fi
- 
+diff -ur a/configure.ac b/configure.ac
+--- a/configure.ac	2022-03-03 09:05:27.000000000 -0800
++++ b/configure.ac	2022-06-04 00:35:32.154279066 -0700
+@@ -279,6 +279,10 @@
+     AS_IF([test "x$with_java12" = "xyes" -a "$BDJ_TYPE" != "j2me"], [java_code_version=1.7])
+ ])
+
 +if test "x$use_bdjava_jar" = "xyes"; then
 +  CPPFLAGS="${CPPFLAGS} -DJARDIR='\"\$(datadir)/java\"'"
 +fi
@@ -13,15 +12,14 @@ index 5fd3c8de..7ae343e0 100644
  AC_DEFINE_UNQUOTED([JAVA_ARCH], ["$java_arch"], ["Defines the architecture of the java vm."])
  AC_DEFINE_UNQUOTED([JDK_HOME], ["$JDK_HOME"], [""])
  AM_CONDITIONAL([USING_BDJAVA_BUILD_JAR], [ test $use_bdjava_jar = "yes" ])
-diff --git a/src/libbluray/bdj/bdj.c b/src/libbluray/bdj/bdj.c
-index 511ad533..e273b9e0 100644
---- a/src/libbluray/bdj/bdj.c
-+++ b/src/libbluray/bdj/bdj.c
-@@ -478,6 +478,7 @@ static const char *_find_libbluray_jar(BDJ_STORAGE *storage)
-     // pre-defined search paths for libbluray.jar
-     static const char * const jar_paths[] = {
- #ifndef _WIN32
+diff -ur a/src/libbluray/bdj/bdj.c b/src/libbluray/bdj/bdj.c
+--- a/src/libbluray/bdj/bdj.c	2022-03-03 09:05:27.000000000 -0800
++++ b/src/libbluray/bdj/bdj.c	2022-06-04 00:39:33.259603941 -0700
+@@ -533,6 +533,7 @@
+ #  ifdef __FreeBSD__
+         "/usr/local/share/java/" BDJ_JARFILE,
+ #  else
 +        JARDIR "/" BDJ_JARFILE,
          "/usr/share/java/" BDJ_JARFILE,
          "/usr/share/libbluray/lib/" BDJ_JARFILE,
- #endif
+ #  endif

--- a/pkgs/development/libraries/libbluray/Fix-build-failure-after-Oracle-Java-CPU-for-April-2022.patch
+++ b/pkgs/development/libraries/libbluray/Fix-build-failure-after-Oracle-Java-CPU-for-April-2022.patch
@@ -1,0 +1,34 @@
+From 8f26777b1ce124ff761f80ef52d6be10bcea323e Mon Sep 17 00:00:00 2001
+From: Fridrich Strba <fstrba@suse.com>
+Date: Mon, 25 Apr 2022 14:28:58 +0300
+Subject: [PATCH] Fix build failure after Oracle Java CPU for April 2022
+
+---
+ src/libbluray/bdj/java/java/io/BDFileSystem.java | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/src/libbluray/bdj/java/java/io/BDFileSystem.java b/src/libbluray/bdj/java/java/io/BDFileSystem.java
+index 03add5d1..fabe57bc 100644
+--- a/src/libbluray/bdj/java/java/io/BDFileSystem.java
++++ b/src/libbluray/bdj/java/java/io/BDFileSystem.java
+@@ -227,6 +227,17 @@ public abstract class BDFileSystem extends FileSystem {
+         return fs.isAbsolute(f);
+     }
+ 
++    public boolean isInvalid(File f) {
++        try {
++            Method m = fs.getClass().getDeclaredMethod("isInvalid", new Class[] { File.class });
++            Object[] args = new Object[] {(Object)f};
++            Boolean result = (Boolean)m.invoke(fs, args);
++            return result.booleanValue();
++        } finally {
++            return false;
++        }
++    }
++
+     public String resolve(File f) {
+         if (!booted)
+             return fs.resolve(f);
+-- 
+GitLab
+

--- a/pkgs/development/libraries/libbluray/default.nix
+++ b/pkgs/development/libraries/libbluray/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-wksPQcW3N7u2XFRP5jSVY3p3HBClGd/IAudp8RK0O3U=";
   };
 
-  patches = optional withJava ./BDJ-JARFILE-path.patch;
+  patches = optionals withJava [ ./BDJ-JARFILE-path.patch ./Fix-build-failure-after-Oracle-Java-CPU-for-April-2022.patch ];
 
   nativeBuildInputs = [ pkg-config autoreconfHook ]
                       ++ optionals withJava [ ant ]


### PR DESCRIPTION
###### Description of changes

Fix building of libbluray with Java support. Fixes #133652

Tested that Blu-ray menus work properly in VLC when built from `vlc.override { libbluray = libbluray.override { withJava = true; }; }` with this these changes applied.

Maintainer: @abbradar

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
