### PR TITLE
haskellPackages: Use proper absolute path in haskell builds

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -196,6 +196,7 @@ let
     "--prefix=$out"
     "--libdir=\\$prefix/lib/\\$compiler"
     "--libsubdir=\\$abi/\\$libname"
+    "--with-compiler=${ghcCommand}"
     (optionalString enableSeparateDataOutput "--datadir=$data/share/${ghcNameWithPrefix}")
     (optionalString enableSeparateDocOutput "--docdir=${docdir "$doc"}")
   ] ++ optionals stdenv.hasCC [
@@ -273,11 +274,11 @@ let
   setupCommand = "./Setup";
 
   ghcCommand' = if isGhcjs then "ghcjs" else "ghc";
-  ghcCommand = "${ghc.targetPrefix}${ghcCommand'}";
+  ghcCommand = "${ghc}/bin/${ghc.targetPrefix}${ghcCommand'}";
 
   ghcNameWithPrefix = "${ghc.targetPrefix}${ghc.haskellCompilerName}";
 
-  nativeGhcCommand = "${nativeGhc.targetPrefix}ghc";
+  nativeGhcCommand = "${nativeGhc}/bin/${nativeGhc.targetPrefix}ghc";
 
   buildPkgDb = ghcName: packageConfDir: ''
     # If this dependency has a package database, then copy the contents of it,


### PR DESCRIPTION
###### Description of changes

This fixes small issues with the Haskell generic-build scripts.
The old build scripts did not really take into account that we sometimes want to build the Cabal/Setup.hs layer with GHC9 and compile the actual project with GHC8. Some Haskell libraries however need this.

By using the absolute paths to the compilers, we make it possible to override them separately.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux