### PR TITLE
deepwave: 0.0.11 -> 0.0.12

### DIFF
--- a/pkgs/development/python-modules/deepwave/default.nix
+++ b/pkgs/development/python-modules/deepwave/default.nix
@@ -10,6 +10,12 @@
 , pytestCheckHook
 }:
 
+let
+  linePatch = ''
+    import os
+    os.environ['PATH'] = os.environ['PATH'] + ':${ninja}/bin'
+  '';
+in
 buildPythonPackage rec {
   pname = "deepwave";
   version = "0.0.12";
@@ -25,14 +31,19 @@ buildPythonPackage rec {
   # unable to find ninja although it is available, most likely because it looks for its pip version
   postPatch = ''
     substituteInPlace setup.cfg --replace "ninja" ""
+
+    # Adding ninja to the path forcibly
+    mv src/deepwave/__init__.py tmp
+    echo "${linePatch}" > src/deepwave/__init__.py
+    cat tmp >> src/deepwave/__init__.py
+    rm tmp
   '';
 
   # The source files are compiled at runtime and cached at the
   # $HOME/.cache folder, so for the check phase it is needed to
   # have a temporary home. This is also the reason ninja is not
   # needed at the nativeBuildInputs, since it will only be used
-  # at runtime. The user will have to add it to its nix-shell
-  # along with deepwave
+  # at runtime.
   preBuild = ''
     export HOME=$(mktemp -d)
   '';
@@ -40,7 +51,6 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ pytorch pybind11 ];
 
   checkInputs = [
-    ninja
     which
     scipy
     pytest-xdist

--- a/pkgs/development/python-modules/deepwave/default.nix
+++ b/pkgs/development/python-modules/deepwave/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "deepwave";
-  version = "0.0.11";
+  version = "0.0.12";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "ar4";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-d4EahmzHACHaeKoNZy63OKwWZdlHbUydrbr4fD43X8s=";
+    sha256 = "sha256-WWu0LyHlOwWMVPUy+LAszKF3VlgcqlcMlDi4oon4Dl8=";
   };
 
   # unable to find ninja although it is available, most likely because it looks for its pip version


### PR DESCRIPTION
###### Description of changes

I didn't update to the latest version 0.0.13 because one test there is failing. I also added ninja to the PATH forcibly by patching the __init__.py file.

Changes made:
Compiling failed with version 10.1 of the nvcc compiler (although was
successful with version 11). This fix removes the problem that caused
the older compiler to fail. This issue was reported in #44.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
