### PR TITLE
qt515: fix on darwin

### DIFF
--- a/pkgs/development/libraries/qt-5/5.15/qtbase.patch.d/0001-qtbase-mkspecs-mac.patch
+++ b/pkgs/development/libraries/qt-5/5.15/qtbase.patch.d/0001-qtbase-mkspecs-mac.patch
@@ -30,7 +30,54 @@ diff --git a/mkspecs/features/mac/default_post.prf b/mkspecs/features/mac/defaul
 index 92a9112bca..b80ec1e801 100644
 --- a/mkspecs/features/mac/default_post.prf
 +++ b/mkspecs/features/mac/default_post.prf
-@@ -68,212 +68,6 @@ qt {
+@@ -1,9 +1,5 @@
+ load(default_post)
+ 
+-# Recompute SDK version in case the user set it explicitly
+-sdk_version = $$QMAKE_MAC_SDK_VERSION
+-QMAKE_MAC_SDK_VERSION = $$xcodeSDKInfo(SDKVersion)
+-
+ contains(TEMPLATE, .*app) {
+     !macx-xcode:if(isEmpty(BUILDS)|build_pass) {
+         # Detect changes to the platform SDK
+@@ -16,36 +12,6 @@ contains(TEMPLATE, .*app) {
+         QMAKE_EXTRA_INCLUDES += $$shell_quote($$PWD/sdk.mk)
+     }
+ 
+-    # Detect incompatible SDK versions
+-
+-    isEmpty(QT_MAC_SDK_VERSION_MIN): \
+-        QT_MAC_SDK_VERSION_MIN = $$QT_MAC_SDK_VERSION
+-
+-    !versionAtLeast(QMAKE_MAC_SDK_VERSION, $$QT_MAC_SDK_VERSION_MIN): \
+-        warning("Qt requires at least version $$QT_MAC_SDK_VERSION_MIN of the platform SDK," \
+-              "you're building against version $${QMAKE_MAC_SDK_VERSION}. Please upgrade.")
+-
+-    !isEmpty(QT_MAC_SDK_VERSION_MAX) {
+-        # For Qt developers only
+-        !isEmpty($$list($$(QT_MAC_SDK_NO_VERSION_CHECK))): \
+-            CONFIG += sdk_no_version_check
+-
+-        QMAKE_MAC_SDK_MAJOR_VERSION = $$replace(QMAKE_MAC_SDK_VERSION, "(\\d+)(\\.\\d+)(\\.\\d+)?", \\1)
+-
+-        !sdk_no_version_check:!versionAtMost(QMAKE_MAC_SDK_MAJOR_VERSION, $$QT_MAC_SDK_VERSION_MAX) {
+-            warning("Qt has only been tested with version $$QT_MAC_SDK_VERSION_MAX"\
+-                    "of the platform SDK, you're using $${QMAKE_MAC_SDK_MAJOR_MINOR_VERSION}.")
+-            warning("This is an unsupported configuration. You may experience build issues," \
+-                    "and by using")
+-            warning("the $$QMAKE_MAC_SDK_VERSION SDK you are opting in to new features" \
+-                    "that Qt has not been prepared for.")
+-
+-            warning("Please downgrade the SDK you use to build your app to version" \
+-                    "$$QT_MAC_SDK_VERSION_MAX, or configure")
+-            warning("with CONFIG+=sdk_no_version_check when running qmake" \
+-                    "to silence this warning.")
+-        }
+-    }
+ }
+ 
+ !no_objective_c:CONFIG += objective_c
+@@ -73,212 +39,6 @@ qt {
      }
  }
  
@@ -308,37 +355,6 @@ index e3534561a5..3b01424e67 100644
 -xcode_copy_phase_strip_setting.name = COPY_PHASE_STRIP
 -xcode_copy_phase_strip_setting.value = NO
 -QMAKE_MAC_XCODE_SETTINGS += xcode_copy_phase_strip_setting
-diff --git a/mkspecs/features/mac/sdk.mk b/mkspecs/features/mac/sdk.mk
---- a/mkspecs/features/mac/sdk.mk
-+++ b/mkspecs/features/mac/sdk.mk
-@@ -1,25 +0,0 @@
--
--ifeq ($(QT_MAC_SDK_NO_VERSION_CHECK),)
--    CHECK_SDK_COMMAND = /usr/bin/xcrun --sdk $(EXPORT_QMAKE_MAC_SDK) -show-sdk-version 2>/dev/null
--    CURRENT_MAC_SDK_VERSION := $(shell DEVELOPER_DIR=$(EXPORT_QMAKE_XCODE_DEVELOPER_PATH) $(CHECK_SDK_COMMAND))
--    ifneq ($(CURRENT_MAC_SDK_VERSION),$(EXPORT_QMAKE_MAC_SDK_VERSION))
--        # We don't want to complain about out of date SDK unless the target needs to be remade.
--        # This covers use-cases such as running 'make check' after moving the build to a
--        # computer without Xcode or with a different Xcode version.
--        TARGET_UP_TO_DATE := $(shell QT_MAC_SDK_NO_VERSION_CHECK=1 $(MAKE) --question $(QMAKE_TARGET) && echo 1 || echo 0)
--        ifeq ($(TARGET_UP_TO_DATE),0)
--            ifneq ($(findstring missing DEVELOPER_DIR path,$(CURRENT_MAC_SDK_VERSION)),)
--                $(info The developer dir $(EXPORT_QMAKE_XCODE_DEVELOPER_PATH) is no longer valid.)
--            else ifneq ($(findstring SDK "$(EXPORT_QMAKE_MAC_SDK)" cannot be located,$(CURRENT_MAC_SDK_VERSION)),)
--                $(info The developer dir $(EXPORT_QMAKE_XCODE_DEVELOPER_PATH) no longer contains the $(EXPORT_QMAKE_MAC_SDK_VERSION) platform SDK.)
--            else ifneq ($(CURRENT_MAC_SDK_VERSION),)
--                $(info The $(EXPORT_QMAKE_MAC_SDK) platform SDK has been changed from version $(EXPORT_QMAKE_MAC_SDK_VERSION) to version $(CURRENT_MAC_SDK_VERSION).)
--            else
--                $(info Unknown error resolving current platform SDK version.)
--            endif
--            $(info This requires a fresh build of your project. Please wipe the build directory)
--            ifneq ($(EXPORT__QMAKE_STASH_),)
--                $(info including the qmake cache in $(EXPORT__QMAKE_STASH_))
--            endif
--            $(error ^)
--        endif
--    endif
--endif
 diff --git a/mkspecs/features/mac/sdk.prf b/mkspecs/features/mac/sdk.prf
 deleted file mode 100644
 index 3a9c2778bb..0000000000
@@ -406,6 +422,14 @@ index 3a9c2778bb..0000000000
 -    $$tool = $$sysrooted $$member(value, 1, -1)
 -    cache($$tool_variable, set stash, $$tool)
 -}
--- 
-2.25.4
-
+diff --git a/mkspecs/features/mac/toolchain.prf b/mkspecs/features/mac/toolchain.prf
+deleted file mode 100644
+index df191eb13c..0000000000
+--- a/mkspecs/features/mac/toolchain.prf
++++ /dev/null
+@@ -1,5 +0,0 @@
+-# Ensure that we process sdk.prf first, as it will update QMAKE_CXX,
+-# which the default path determination uses.
+-sdk: load(sdk)
+-
+-load(toolchain)

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -195,7 +195,10 @@ stdenv.mkDerivation {
       # ignore "is only available on macOS 10.12.2 or newer" in obj-c code
       "-Wno-error=unguarded-availability"
     ]
-    ++ lib.optionals withGtk3 [
+    ++ lib.optionals ((compareVersion "5.15.0" >= 0) && stdenv.isDarwin) [
+      # .moc/moc_qprintdialog.cpp:96:31: error: no member named '_q_togglePageSetCombo' in 'QPrintDialogPrivate'
+      "-DQ_OS_MAC"
+    ] ++ lib.optionals withGtk3 [
          ''-DNIXPKGS_QGTK3_XDG_DATA_DIRS="${gtk3}/share/gsettings-schemas/${gtk3.name}"''
          ''-DNIXPKGS_QGTK3_GIO_EXTRA_MODULES="${dconf.lib}/lib/gio/modules"''
        ]


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
