### PR TITLE
steam-rom-manager: init at 2.3.40

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11709,6 +11709,12 @@
     githubId = 36899624;
     name = "squalus";
   };
+  squarepear = {
+    email = "contact@jeffreyharmon.dev";
+    github = "SquarePear";
+    githubId = 16364318;
+    name = "Jeffrey Harmon";
+  };
   srapenne = {
     email = "solene@perso.pw";
     github = "rapenne-s";

--- a/pkgs/tools/games/steam-rom-manager/default.nix
+++ b/pkgs/tools/games/steam-rom-manager/default.nix
@@ -1,0 +1,28 @@
+{ lib, appimageTools, fetchurl }:
+
+appimageTools.wrapType2 rec {
+  name = "steam-rom-manager";
+  version = "2.3.40";
+
+  src = fetchurl {
+    url = "https://github.com/SteamGridDB/steam-rom-manager/releases/download/v${version}/Steam-ROM-Manager-${version}.AppImage";
+    sha256 = "sha256-qm7F1/+3iVtsxSAptbhiI5sEHR0B9vo7AdEPy1/PANU=";
+  };
+
+  extraInstallCommands = let
+    appimageContents = appimageTools.extract { inherit name src; };
+    in ''
+      install -m 444 -D ${appimageContents}/${name}.desktop -t $out/share/applications
+      substituteInPlace $out/share/applications/${name}.desktop \
+        --replace 'Exec=AppRun' 'Exec=${name}'
+      cp -r ${appimageContents}/usr/share/icons $out/share
+    '';
+
+  meta = with lib; {
+    description = "An app for managing ROMs in Steam";
+    homepage = "https://github.com/SteamGridDB/steam-rom-manager";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ squarepear ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31787,6 +31787,8 @@ with pkgs;
 
   protonup = with python3Packages; toPythonApplication protonup;
 
+  steam-rom-manager = callPackage ../tools/games/steam-rom-manager {};
+
   sdlpop = callPackage ../games/sdlpop { };
 
   stepmania = callPackage ../games/stepmania { };


### PR DESCRIPTION
###### Description of changes

[steam-rom-manager](https://github.com/SteamGridDB/steam-rom-manager): An app for managing ROMs in Steam

Tested in NixOS and everything seems to work great!

Not 100% sure if I put the file in the correct place, so let me know if I should move it.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
