### PR TITLE
dssp: init at 4.0.5

### DIFF
--- a/pkgs/applications/science/biology/dssp/default.nix
+++ b/pkgs/applications/science/biology/dssp/default.nix
@@ -1,0 +1,25 @@
+{ lib, stdenv, fetchFromGitHub, boost, cmake, libcifpp, zlib, }:
+
+stdenv.mkDerivation rec {
+  pname = "dssp";
+  version = "4.0.5";
+
+  src = fetchFromGitHub {
+    owner = "PDB-REDO";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1x35rdcm4fch66pjbmy73lv0gdb6g9y3v023a66512a6nzsqjsir";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ boost libcifpp zlib ];
+
+  meta = with lib; {
+    description = "Calculate the most likely secondary structure assignment given the 3D structure of a protein";
+    homepage = "https://github.com/PDB-REDO/dssp";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ natsukium ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/libcifpp/default.nix
+++ b/pkgs/development/libraries/libcifpp/default.nix
@@ -1,0 +1,25 @@
+{ lib, stdenv, fetchFromGitHub, boost, cmake, }:
+
+stdenv.mkDerivation rec {
+  pname = "libcifpp";
+  version = "4.2.0";
+
+  src = fetchFromGitHub {
+    owner = "PDB-REDO";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1hzi6fgbsmy8h8nfwkyfds9jz13nqw72h0x81jqw5516kkvar5iw";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ boost ];
+
+  meta = with lib; {
+    description = "Manipulate mmCIF and PDB files";
+    homepage = "https://github.com/PDB-REDO/libcifpp";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ natsukium ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18714,6 +18714,8 @@ with pkgs;
 
   libchop = callPackage ../development/libraries/libchop { };
 
+  libcifpp = callPackage ../development/libraries/libcifpp { };
+
   libcint = callPackage ../development/libraries/libcint { };
 
   libclc = callPackage ../development/libraries/libclc { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33378,6 +33378,8 @@ with pkgs;
 
   diamond = callPackage ../applications/science/biology/diamond { };
 
+  dssp = callPackage ../applications/science/biology/dssp { };
+
   ecopcr = callPackage ../applications/science/biology/ecopcr { };
 
   eggnog-mapper = callPackage ../applications/science/biology/eggnog-mapper { };


### PR DESCRIPTION
###### Description of changes

The DSSP program was designed by Wolfgang Kabsch and Chris Sander to standardize secondary structure assignment. DSSP is a database of secondary structure assignments (and much more) for all protein entries in the Protein Data Bank (PDB). DSSP is also the program that calculates DSSP entries from PDB entries. 
https://swift.cmbi.umcn.nl/gv/dssp/index.html

repo:
https://github.com/PDB-REDO/dssp

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
