### PR TITLE
way-displays 1.5.3 -> 1.6.0

### DIFF
--- a/pkgs/tools/wayland/way-displays/default.nix
+++ b/pkgs/tools/wayland/way-displays/default.nix
@@ -9,7 +9,7 @@
 
 stdenv.mkDerivation rec {
   pname = "way-displays";
-  version = "1.5.3";
+  version = "1.6.0";
 
   src = fetchFromGitHub {
     owner = "alex-courtis";
@@ -17,10 +17,6 @@ stdenv.mkDerivation rec {
     rev = "${version}";
     sha256 = "sha256-5A0qZRpWw3Deo9cGqGULpQMoPCVh85cWE/wJ5XSbVJk=";
   };
-
-  postPatch = ''
-    substituteInPlace src/cfg.cpp --replace "\"/etc" "\"$out/etc"
-  '';
 
   strictDeps = true;
 
@@ -35,7 +31,7 @@ stdenv.mkDerivation rec {
     libinput
   ];
 
-  makeFlags = [ "DESTDIR=$(out) PREFIX= PREFIX_ETC="];
+  makeFlags = [ "DESTDIR=$(out) PREFIX= PREFIX_ETC= ROOT_ETC=$(out)/etc"];
 
   meta = with lib; {
     homepage = "https://github.com/alex-courtis/way-displays";

--- a/pkgs/tools/wayland/way-displays/default.nix
+++ b/pkgs/tools/wayland/way-displays/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     owner = "alex-courtis";
     repo = "way-displays";
     rev = "${version}";
-    sha256 = "sha256-5A0qZRpWw3Deo9cGqGULpQMoPCVh85cWE/wJ5XSbVJk=";
+    sha256 = "sha256-wrfRSJaVz0GjYxuIDvJ+16aaz+kRTtv0q5jN2IG4Uco=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
###### Description of changes

Attn @simoneruffini 

Refactor for 1.6.0 changed a source file, breaking postPatch.

Removed postPatch and added `ROOT_ETC` as discussed here: https://github.com/alex-courtis/way-displays/issues/45

I would be most grateful for your review / testing / advice.

I do not know how to encode the sha256. My attempts to encode the git hash for 1.5.3 gave different results...

[CHANGELOG.txt](https://github.com/alex-courtis/way-displays/blob/master/CHANGELOG.txt)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).