### PR TITLE
gnome-frog: init at 1.1.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4356,6 +4356,12 @@
     githubId = 405105;
     name = "Dustin Frisch";
   };
+  foo-dogsquared = {
+    email = "foo.dogsquared@gmail.com";
+    github = "foo-dogsquared";
+    githubId = 34962634;
+    name = "Gabriel Arazas";
+  };
   forkk = {
     email = "forkk@forkk.net";
     github = "Forkk";

--- a/pkgs/applications/misc/gnome-frog/default.nix
+++ b/pkgs/applications/misc/gnome-frog/default.nix
@@ -1,0 +1,89 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, python3Packages
+, wrapGAppsHook4
+, gtk4
+, meson
+, ninja
+, pkg-config
+, appstream-glib
+, desktop-file-utils
+, glib
+, gobject-introspection
+, libnotify
+, libadwaita
+, libportal
+, gettext
+, librsvg
+, tesseract5
+, zbar
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "gnome-frog";
+  version = "1.1.3";
+
+  src = fetchFromGitHub {
+    owner = "TenderOwl";
+    repo = "Frog";
+    rev = version;
+    sha256 = "sha256-yOjfiGJUU25zb/4WprPU59yDAMpttS3jREp1kB5mXUE=";
+  };
+
+  format = "other";
+
+  patches = [ ./update-compatible-with-non-flatpak-env.patch ];
+  postPatch = ''
+    chmod +x ./build-aux/meson/postinstall.py
+    patchShebangs ./build-aux/meson/postinstall.py
+    substituteInPlace ./build-aux/meson/postinstall.py \
+      --replace "gtk-update-icon-cache" "gtk4-update-icon-cache"
+    substituteInPlace ./frog/language_manager.py --subst-var out
+  '';
+
+  nativeBuildInputs = [
+    appstream-glib
+    desktop-file-utils
+    gettext
+    meson
+    ninja
+    pkg-config
+    glib
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    librsvg
+    gobject-introspection
+    libnotify
+    libadwaita
+    libportal
+    zbar
+    tesseract5
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    pygobject3
+    pillow
+    pytesseract
+    pyzbar
+  ];
+
+  # This is to prevent double-wrapping the package. We'll let
+  # Python do it by adding certain arguments inside of the
+  # wrapper instead.
+  dontWrapGApps = true;
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  meta = with lib; {
+    homepage = "https://getfrog.app/";
+    description =
+      "Intuitive text extraction tool (OCR) for GNOME desktop";
+    license = licenses.mit;
+    maintainers = with maintainers; [ foo-dogsquared ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/gnome-frog/update-compatible-with-non-flatpak-env.patch
+++ b/pkgs/applications/misc/gnome-frog/update-compatible-with-non-flatpak-env.patch
@@ -1,0 +1,33 @@
+diff --git a/frog/config.py b/frog/config.py
+index 9837755..b73e4e3 100644
+--- a/frog/config.py
++++ b/frog/config.py
+@@ -30,10 +30,14 @@ import os
+ APP_ID = "com.github.tenderowl.frog"
+ RESOURCE_PREFIX = "/com/github/tenderowl/frog"
+ 
++# This is based from the XDG Base Directory specification.
++if not os.getenv('XDG_DATA_HOME'):
++    os.environ['XDG_DATA_HOME'] = os.path.expanduser("~/.local/share")
++
+ if not os.path.exists(os.path.join(os.environ['XDG_DATA_HOME'], 'tessdata')):
+     os.mkdir(os.path.join(os.environ['XDG_DATA_HOME'], 'tessdata'))
+ 
+ tessdata_url = "https://github.com/tesseract-ocr/tessdata/raw/main/"
+ tessdata_best_url = "https://github.com/tesseract-ocr/tessdata_best/raw/main/"
+ tessdata_dir = os.path.join(os.environ['XDG_DATA_HOME'], 'tessdata')
+-tessdata_config = f'--tessdata-dir {tessdata_dir} –psm 6'
++tessdata_config = f'–-psm 6 --tessdata-dir {tessdata_dir}'
+diff --git a/frog/language_manager.py b/frog/language_manager.py
+index 5752be6..4f6a908 100644
+--- a/frog/language_manager.py
++++ b/frog/language_manager.py
+@@ -156,7 +156,7 @@ class LanguageManager(GObject.GObject):
+             os.mkdir(tessdata_dir)
+ 
+         dest_path = os.path.join(tessdata_dir, 'eng.traineddata')
+-        source_path = pathlib.Path('/app/share/appdata/eng.traineddata')
++        source_path = pathlib.Path('@out@/share/appdata/eng.traineddata')
+         if os.path.exists(dest_path):
+             return
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6694,6 +6694,8 @@ with pkgs;
 
   gnome-feeds = callPackage ../applications/networking/feedreaders/gnome-feeds {};
 
+  gnome-frog = callPackage ../applications/misc/gnome-frog { };
+
   gnome-keysign = callPackage ../tools/security/gnome-keysign { };
 
   gnome-secrets = callPackage ../applications/misc/gnome-secrets { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
