### PR TITLE
freshBootstrapTools: rename from stdenvBootstrapTools

### DIFF
--- a/pkgs/stdenv/darwin/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/darwin/make-bootstrap-tools.nix
@@ -1,7 +1,5 @@
 { pkgspath ? ../../.., test-pkgspath ? pkgspath
-, localSystem ? { system = builtins.currentSystem; }
-, crossSystem ? null
-, bootstrapFiles ? null
+, system ? builtins.currentSystem, crossSystem ? null, bootstrapFiles ? null
 }:
 
 let cross = if crossSystem != null
@@ -13,7 +11,7 @@ let cross = if crossSystem != null
               in (import "${pkgspath}/pkgs/stdenv/darwin" args').stagesDarwin;
            }
       else {};
-in with import pkgspath ({ inherit localSystem; } // cross // custom-bootstrap);
+in with import pkgspath ({ inherit system; } // cross // custom-bootstrap);
 
 let
   llvmPackages = llvmPackages_11;
@@ -366,7 +364,7 @@ in rec {
   test-pkgs = import test-pkgspath {
     # if the bootstrap tools are for another platform, we should be testing
     # that platform.
-    localSystem = if crossSystem != null then crossSystem else localSystem;
+    system = if crossSystem != null then crossSystem else system;
 
     stdenvStages = args: let
         args' = args // { inherit bootstrapLlvmVersion bootstrapFiles; };

--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -1,6 +1,9 @@
-{ pkgs ? import ../../.. {} }:
+{ localSystem ? { system = builtins.currentSystem; }
+, crossSystem ? null
+}:
 
 let
+  pkgs = import ../../.. { inherit localSystem crossSystem; };
   libc = pkgs.stdenv.cc.libc;
 in with pkgs; rec {
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2054,7 +2054,10 @@ with pkgs;
 
   brewtarget = libsForQt514.callPackage ../applications/misc/brewtarget { } ;
 
-  stdenvBootstrapTools = if stdenv.hostPlatform.isDarwin then
+  # Derivation's result is not used by nixpkgs. Useful for validation for
+  # regressions of bootstrapTools on hydra and on ofborg. Example:
+  #     pkgsCross.aarch64-multiplatform.freshBootstrapTools.build
+  freshBootstrapTools = if stdenv.hostPlatform.isDarwin then
     callPackage ../stdenv/darwin/make-bootstrap-tools.nix {
       localSystem = stdenv.buildPlatform;
       crossSystem =
@@ -2062,7 +2065,7 @@ with pkgs;
     }
   else if stdenv.hostPlatform.isLinux then
     callPackage ../stdenv/linux/make-bootstrap-tools.nix {}
-  else throw "stdenvBootstrapTools: unknown hostPlatform ${stdenv.hostPlatform.config}";
+  else throw "freshBootstrapTools: unknown hostPlatform ${stdenv.hostPlatform.config}";
 
   boxes = callPackage ../tools/text/boxes { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2054,18 +2054,13 @@ with pkgs;
 
   brewtarget = libsForQt514.callPackage ../applications/misc/brewtarget { } ;
 
-  # Derivation's result is not used by nixpkgs. Useful for validation for
-  # regressions of bootstrapTools on hydra and on ofborg. Example:
-  #     pkgsCross.aarch64-multiplatform.freshBootstrapTools.build
-  freshBootstrapTools = if stdenv.hostPlatform.isDarwin then
-    callPackage ../stdenv/darwin/make-bootstrap-tools.nix {
-      localSystem = stdenv.buildPlatform;
-      crossSystem =
-        if stdenv.buildPlatform == stdenv.hostPlatform then null else stdenv.hostPlatform;
-    }
-  else if stdenv.hostPlatform.isLinux then
-    callPackage ../stdenv/linux/make-bootstrap-tools.nix {}
-  else throw "freshBootstrapTools: unknown hostPlatform ${stdenv.hostPlatform.config}";
+  freshBootstrapTools =
+    let args = { crossSystem = stdenv.hostPlatform.system; }; in
+    if stdenv.hostPlatform.isDarwin
+    then callPackage ../stdenv/darwin/make-bootstrap-tools.nix args
+    else if stdenv.hostPlatform.isLinux
+    then callPackage ../stdenv/linux/make-bootstrap-tools.nix args
+    else throw "freshBootstrapTools: unknown hostPlatform ${stdenv.hostPlatform.config}";
 
   boxes = callPackage ../tools/text/boxes { };
 

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -31,169 +31,182 @@ let
   ] (arch: builtins.elem "${arch}-darwin" systemsWithAnySupport);
 
   jobs =
-    { tarball = import ./make-tarball.nix { inherit pkgs nixpkgs officialRelease supportedSystems; };
+    let nonPackageJobs =
+      { tarball = import ./make-tarball.nix { inherit pkgs nixpkgs officialRelease supportedSystems; };
 
-      metrics = import ./metrics.nix { inherit pkgs nixpkgs; };
+        metrics = import ./metrics.nix { inherit pkgs nixpkgs; };
 
-      manual = import ../../doc { inherit pkgs nixpkgs; };
-      lib-tests = import ../../lib/tests/release.nix { inherit pkgs; };
-      pkgs-lib-tests = import ../pkgs-lib/tests { inherit pkgs; };
+        manual = import ../../doc { inherit pkgs nixpkgs; };
+        lib-tests = import ../../lib/tests/release.nix { inherit pkgs; };
+        pkgs-lib-tests = import ../pkgs-lib/tests { inherit pkgs; };
 
-      darwin-tested = if supportDarwin.x86_64 then pkgs.releaseTools.aggregate
-        { name = "nixpkgs-darwin-${jobs.tarball.version}";
-          meta.description = "Release-critical builds for the Nixpkgs darwin channel";
-          constituents =
-            [ jobs.tarball
-              jobs.cabal2nix.x86_64-darwin
-              jobs.ghc.x86_64-darwin
-              jobs.git.x86_64-darwin
-              jobs.go.x86_64-darwin
-              jobs.mariadb.x86_64-darwin
-              jobs.nix.x86_64-darwin
-              jobs.nixpkgs-review.x86_64-darwin
-              jobs.nix-info.x86_64-darwin
-              jobs.nix-info-tested.x86_64-darwin
-              jobs.openssh.x86_64-darwin
-              jobs.openssl.x86_64-darwin
-              jobs.pandoc.x86_64-darwin
-              jobs.postgresql.x86_64-darwin
-              jobs.python3.x86_64-darwin
-              jobs.ruby.x86_64-darwin
-              jobs.rustc.x86_64-darwin
-              # blocking ofBorg CI 2020-02-28
-              # jobs.stack.x86_64-darwin
-              jobs.stdenv.x86_64-darwin
-              jobs.vim.x86_64-darwin
-              jobs.cachix.x86_64-darwin
+        darwin-tested = if supportDarwin.x86_64 then pkgs.releaseTools.aggregate
+          { name = "nixpkgs-darwin-${jobs.tarball.version}";
+            meta.description = "Release-critical builds for the Nixpkgs darwin channel";
+            constituents =
+              [ jobs.tarball
+                jobs.cabal2nix.x86_64-darwin
+                jobs.ghc.x86_64-darwin
+                jobs.git.x86_64-darwin
+                jobs.go.x86_64-darwin
+                jobs.mariadb.x86_64-darwin
+                jobs.nix.x86_64-darwin
+                jobs.nixpkgs-review.x86_64-darwin
+                jobs.nix-info.x86_64-darwin
+                jobs.nix-info-tested.x86_64-darwin
+                jobs.openssh.x86_64-darwin
+                jobs.openssl.x86_64-darwin
+                jobs.pandoc.x86_64-darwin
+                jobs.postgresql.x86_64-darwin
+                jobs.python3.x86_64-darwin
+                jobs.ruby.x86_64-darwin
+                jobs.rustc.x86_64-darwin
+                # blocking ofBorg CI 2020-02-28
+                # jobs.stack.x86_64-darwin
+                jobs.stdenv.x86_64-darwin
+                jobs.vim.x86_64-darwin
+                jobs.cachix.x86_64-darwin
 
-              # UI apps
-              # jobs.firefox-unwrapped.x86_64-darwin
-              jobs.qt5.qtmultimedia.x86_64-darwin
-              jobs.inkscape.x86_64-darwin
-              jobs.gimp.x86_64-darwin
-              jobs.emacs.x86_64-darwin
-              jobs.wireshark.x86_64-darwin
-              jobs.transmission-gtk.x86_64-darwin
+                # UI apps
+                # jobs.firefox-unwrapped.x86_64-darwin
+                jobs.qt5.qtmultimedia.x86_64-darwin
+                jobs.inkscape.x86_64-darwin
+                jobs.gimp.x86_64-darwin
+                jobs.emacs.x86_64-darwin
+                jobs.wireshark.x86_64-darwin
+                jobs.transmission-gtk.x86_64-darwin
 
-              # Tests
-              /*
-              jobs.tests.cc-wrapper.x86_64-darwin
-              jobs.tests.cc-wrapper-clang.x86_64-darwin
-              jobs.tests.cc-wrapper-libcxx.x86_64-darwin
-              jobs.tests.stdenv-inputs.x86_64-darwin
-              jobs.tests.macOSSierraShared.x86_64-darwin
-              jobs.tests.patch-shebangs.x86_64-darwin
-              */
-            ];
-        } else null;
+                # Tests
+                /*
+                jobs.tests.cc-wrapper.x86_64-darwin
+                jobs.tests.cc-wrapper-clang.x86_64-darwin
+                jobs.tests.cc-wrapper-libcxx.x86_64-darwin
+                jobs.tests.stdenv-inputs.x86_64-darwin
+                jobs.tests.macOSSierraShared.x86_64-darwin
+                jobs.tests.patch-shebangs.x86_64-darwin
+                */
+              ];
+          } else null;
 
-      unstable = pkgs.releaseTools.aggregate
-        { name = "nixpkgs-${jobs.tarball.version}";
-          meta.description = "Release-critical builds for the Nixpkgs unstable channel";
-          constituents =
-            [ jobs.tarball
-              jobs.metrics
-              jobs.manual
-              jobs.lib-tests
-              jobs.pkgs-lib-tests
-              jobs.stdenv.x86_64-linux
-              jobs.cargo.x86_64-linux
-              jobs.go.x86_64-linux
-              jobs.linux.x86_64-linux
-              jobs.pandoc.x86_64-linux
-              jobs.python3.x86_64-linux
-              # Needed by contributors to test PRs (by inclusion of the PR template)
-              jobs.nixpkgs-review.x86_64-linux
-              # Needed for support
-              jobs.nix-info.x86_64-linux
-              jobs.nix-info-tested.x86_64-linux
-              # Ensure that X11/GTK are in order.
-              jobs.firefox-unwrapped.x86_64-linux
-              jobs.cachix.x86_64-linux
+        unstable = pkgs.releaseTools.aggregate
+          { name = "nixpkgs-${jobs.tarball.version}";
+            meta.description = "Release-critical builds for the Nixpkgs unstable channel";
+            constituents =
+              [ jobs.tarball
+                jobs.metrics
+                jobs.manual
+                jobs.lib-tests
+                jobs.pkgs-lib-tests
+                jobs.stdenv.x86_64-linux
+                jobs.cargo.x86_64-linux
+                jobs.go.x86_64-linux
+                jobs.linux.x86_64-linux
+                jobs.pandoc.x86_64-linux
+                jobs.python3.x86_64-linux
+                # Needed by contributors to test PRs (by inclusion of the PR template)
+                jobs.nixpkgs-review.x86_64-linux
+                # Needed for support
+                jobs.nix-info.x86_64-linux
+                jobs.nix-info-tested.x86_64-linux
+                # Ensure that X11/GTK are in order.
+                jobs.firefox-unwrapped.x86_64-linux
+                jobs.cachix.x86_64-linux
 
-              /*
-              jobs.tests.cc-wrapper.x86_64-linux
-              jobs.tests.cc-wrapper-gcc7.x86_64-linux
-              jobs.tests.cc-wrapper-gcc8.x86_64-linux
+                /*
+                jobs.tests.cc-wrapper.x86_64-linux
+                jobs.tests.cc-wrapper-gcc7.x86_64-linux
+                jobs.tests.cc-wrapper-gcc8.x86_64-linux
 
-              # broken see issue #40038
+                # broken see issue #40038
 
-              jobs.tests.cc-wrapper-clang.x86_64-linux
-              jobs.tests.cc-wrapper-libcxx.x86_64-linux
-              jobs.tests.cc-wrapper-clang-5.x86_64-linux
-              jobs.tests.cc-wrapper-libcxx-5.x86_64-linux
-              jobs.tests.cc-wrapper-clang-6.x86_64-linux
-              jobs.tests.cc-wrapper-libcxx-6.x86_64-linux
-              jobs.tests.cc-multilib-gcc.x86_64-linux
-              jobs.tests.cc-multilib-clang.x86_64-linux
-              jobs.tests.stdenv-inputs.x86_64-linux
-              jobs.tests.patch-shebangs.x86_64-linux
-              */
-            ]
-            ++ lib.collect lib.isDerivation jobs.stdenvBootstrapTools
-            ++ lib.optionals supportDarwin.x86_64 [
-              jobs.stdenv.x86_64-darwin
-              jobs.cargo.x86_64-darwin
-              jobs.cachix.x86_64-darwin
-              jobs.go.x86_64-darwin
-              jobs.python3.x86_64-darwin
-              jobs.nixpkgs-review.x86_64-darwin
-              jobs.nix-info.x86_64-darwin
-              jobs.nix-info-tested.x86_64-darwin
-              jobs.git.x86_64-darwin
-              jobs.mariadb.x86_64-darwin
-              jobs.vim.x86_64-darwin
-              jobs.inkscape.x86_64-darwin
-              jobs.qt5.qtmultimedia.x86_64-darwin
-              /*
-              jobs.tests.cc-wrapper.x86_64-darwin
-              jobs.tests.cc-wrapper-gcc7.x86_64-darwin
-              # jobs.tests.cc-wrapper-gcc8.x86_64-darwin
-              jobs.tests.cc-wrapper-clang.x86_64-darwin
-              jobs.tests.cc-wrapper-libcxx.x86_64-darwin
-              jobs.tests.cc-wrapper-clang-5.x86_64-darwin
-              jobs.tests.cc-wrapper-libcxx-6.x86_64-darwin
-              jobs.tests.cc-wrapper-clang-6.x86_64-darwin
-              jobs.tests.cc-wrapper-libcxx-6.x86_64-darwin
-              jobs.tests.stdenv-inputs.x86_64-darwin
-              jobs.tests.macOSSierraShared.x86_64-darwin
-              jobs.tests.patch-shebangs.x86_64-darwin
-              */
-            ];
-        };
-
-      stdenvBootstrapTools = with lib;
-        genAttrs systemsWithAnySupport
-          (system: {
-            inherit
-              (import ../stdenv/linux/make-bootstrap-tools.nix {
-                localSystem = { inherit system; };
-              })
-              dist test;
-          })
-        # darwin is special in this
-        // optionalAttrs supportDarwin.x86_64 {
-          x86_64-darwin =
-            let
-              bootstrap = import ../stdenv/darwin/make-bootstrap-tools.nix { system = "x86_64-darwin"; };
-            in {
-              # Lightweight distribution and test
-              inherit (bootstrap) dist test;
-              # Test a full stdenv bootstrap from the bootstrap tools definition
-              inherit (bootstrap.test-pkgs) stdenv;
-            };
-        } // optionalAttrs supportDarwin.aarch64 {
-          # Cross compiled bootstrap tools
-          aarch64-darwin =
-            let
-              bootstrap = import ../stdenv/darwin/make-bootstrap-tools.nix { system = "x86_64-darwin"; crossSystem = "aarch64-darwin"; };
-            in {
-              # Distribution only for now
-              inherit (bootstrap) dist;
-            };
+                jobs.tests.cc-wrapper-clang.x86_64-linux
+                jobs.tests.cc-wrapper-libcxx.x86_64-linux
+                jobs.tests.cc-wrapper-clang-5.x86_64-linux
+                jobs.tests.cc-wrapper-libcxx-5.x86_64-linux
+                jobs.tests.cc-wrapper-clang-6.x86_64-linux
+                jobs.tests.cc-wrapper-libcxx-6.x86_64-linux
+                jobs.tests.cc-multilib-gcc.x86_64-linux
+                jobs.tests.cc-multilib-clang.x86_64-linux
+                jobs.tests.stdenv-inputs.x86_64-linux
+                jobs.tests.patch-shebangs.x86_64-linux
+                */
+              ]
+              ++ lib.collect lib.isDerivation jobs.stdenvBootstrapTools
+              ++ lib.optionals supportDarwin.x86_64 [
+                jobs.stdenv.x86_64-darwin
+                jobs.cargo.x86_64-darwin
+                jobs.cachix.x86_64-darwin
+                jobs.go.x86_64-darwin
+                jobs.python3.x86_64-darwin
+                jobs.nixpkgs-review.x86_64-darwin
+                jobs.nix-info.x86_64-darwin
+                jobs.nix-info-tested.x86_64-darwin
+                jobs.git.x86_64-darwin
+                jobs.mariadb.x86_64-darwin
+                jobs.vim.x86_64-darwin
+                jobs.inkscape.x86_64-darwin
+                jobs.qt5.qtmultimedia.x86_64-darwin
+                /*
+                jobs.tests.cc-wrapper.x86_64-darwin
+                jobs.tests.cc-wrapper-gcc7.x86_64-darwin
+                # jobs.tests.cc-wrapper-gcc8.x86_64-darwin
+                jobs.tests.cc-wrapper-clang.x86_64-darwin
+                jobs.tests.cc-wrapper-libcxx.x86_64-darwin
+                jobs.tests.cc-wrapper-clang-5.x86_64-darwin
+                jobs.tests.cc-wrapper-libcxx-6.x86_64-darwin
+                jobs.tests.cc-wrapper-clang-6.x86_64-darwin
+                jobs.tests.cc-wrapper-libcxx-6.x86_64-darwin
+                jobs.tests.stdenv-inputs.x86_64-darwin
+                jobs.tests.macOSSierraShared.x86_64-darwin
+                jobs.tests.patch-shebangs.x86_64-darwin
+                */
+              ];
           };
 
-    } // (mapTestOn ((packagePlatforms pkgs) // {
+        stdenvBootstrapTools = with lib;
+          genAttrs systemsWithAnySupport
+            (system: {
+              inherit
+                (import ../stdenv/linux/make-bootstrap-tools.nix {
+                  localSystem = { inherit system; };
+                })
+                dist test;
+            })
+          # darwin is special in this
+          // optionalAttrs supportDarwin.x86_64 {
+            x86_64-darwin =
+              let
+                bootstrap = import ../stdenv/darwin/make-bootstrap-tools.nix { system = "x86_64-darwin"; };
+              in {
+                # Lightweight distribution and test
+                inherit (bootstrap) dist test;
+                # Test a full stdenv bootstrap from the bootstrap tools definition
+                inherit (bootstrap.test-pkgs) stdenv;
+              };
+          } // optionalAttrs supportDarwin.aarch64 {
+            # Cross compiled bootstrap tools
+            aarch64-darwin =
+              let
+                bootstrap = import ../stdenv/darwin/make-bootstrap-tools.nix { system = "x86_64-darwin"; crossSystem = "aarch64-darwin"; };
+              in {
+                # Distribution only for now
+                inherit (bootstrap) dist;
+              };
+            };
+
+       };
+    # Do not allow attribute collision between jobs inserted in
+    # 'nonPackageAttrs' and jobs pulled in from 'pkgs'.
+    # Conflicts usually cause silent job drops like in
+    #   https://github.com/NixOS/nixpkgs/pull/182058
+    nonPackageAttrs = lib.attrNames nonPackageJobs;
+    packageAttrs = lib.attrNames pkgs;
+    attributeCollisions = lib.intersectLists nonPackageAttrs packageAttrs;
+    in assert lib.assertMsg
+              (attributeCollisions == [])
+              "jobs: Unexpected attribute collision between 'jobs' and 'pkgs': ${lib.concatStringsSep " " attributeCollisions}";
+
+    nonPackageJobs // (mapTestOn ((packagePlatforms pkgs) // {
       haskell.compiler = packagePlatforms pkgs.haskell.compiler;
       haskellPackages = packagePlatforms pkgs.haskellPackages;
       idrisPackages = packagePlatforms pkgs.idrisPackages;


### PR DESCRIPTION
`stdenvBootstrapTools` was defined in both `nixpkgs` and `releases`
jobsets. This makes hydra view a bit confusing:

    $ git grep -F 'stdenvBootstrapTools =' | cat
    pkgs/top-level/all-packages.nix:  stdenvBootstrapTools = if stdenv.hostPlatform.isDarwin then
    pkgs/top-level/release.nix:      stdenvBootstrapTools = with lib;

The change renames jobset to be distinct. At least it improves grep
experience.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
