### PR TITLE
aws-sso-cli: drop nix store path from config

### DIFF
--- a/pkgs/tools/admin/aws-sso-cli/default.nix
+++ b/pkgs/tools/admin/aws-sso-cli/default.nix
@@ -18,6 +18,8 @@ buildGoModule rec {
 
   nativeBuildInputs = [ makeWrapper ];
 
+  patches = [ ./dropfullbinpath.patch ];
+
   postInstall = ''
     mv $out/bin/cmd $out/bin/aws-sso
     wrapProgram $out/bin/aws-sso \

--- a/pkgs/tools/admin/aws-sso-cli/dropfullbinpath.patch
+++ b/pkgs/tools/admin/aws-sso-cli/dropfullbinpath.patch
@@ -1,0 +1,13 @@
+diff --git a/cmd/config_profiles_cmd.go b/cmd/config_profiles_cmd.go
+index daca7b0..1f4b3dd 100644
+--- a/cmd/config_profiles_cmd.go
++++ b/cmd/config_profiles_cmd.go
+@@ -30,7 +30,7 @@ const (
+ 	AWS_CONFIG_FILE = "~/.aws/config"
+ 	CONFIG_TEMPLATE = `{{range $sso, $struct := . }}{{ range $arn, $profile := $struct }}
+ [profile {{ $profile.Profile }}]
+-credential_process = {{ $profile.BinaryPath }} -u {{ $profile.Open }} -S "{{ $profile.Sso }}" process --arn {{ $profile.Arn }}
++credential_process = aws-sso -u {{ $profile.Open }} -S "{{ $profile.Sso }}" process --arn {{ $profile.Arn }}
+ {{ range $key, $value := $profile.ConfigVariables }}{{ $key }} = {{ $value }}
+ {{end}}{{end}}{{end}}`
+ )


### PR DESCRIPTION
###### Description of changes


During the initial configuration the tool populates ~/.aws/config.
This leads to hard coded nix store paths in the config.
Workaround: `aws-sso config-profiles` to regenerate ~/.aws/config
after every version bump.
The patch removes nix store path from the config and makes the upgrade
process slightly smoother.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
