### PR TITLE
Upgrade ocamlPackages.odoc-parser and ocamlformat

### DIFF
--- a/pkgs/development/ocaml-modules/odoc-parser/default.nix
+++ b/pkgs/development/ocaml-modules/odoc-parser/default.nix
@@ -1,11 +1,21 @@
-{ lib, fetchurl, buildDunePackage, astring, result , version ? "1.0.0" }:
+{ lib, fetchurl, buildDunePackage, astring, result, camlp-streams, version ? "1.0.0" }:
 
 let param = {
+  "2.0.0" = {
+    sha256 = "sha256-QHkZ+7DrlXYdb8bsZ3dijZSqGQc0O9ymeLGIC6+zOSI=";
+    extraBuildInputs = [ camlp-streams ];
+  };
+  "1.0.1" = {
+    sha256 = "sha256-orvo5CAbYOmAurAeluQfK6CwW6P1C0T3WDfoovuQfSw=";
+    extraBuildInputs = [ camlp-streams ];
+  };
   "1.0.0" = {
     sha256 = "sha256-tqoI6nGp662bK+vE2h7aDXE882dObVfRBFnZNChueqE=";
+    extraBuildInputs = [];
   };
   "0.9.0" = {
     sha256 = "sha256-3w2tG605v03mvmZsS2O5c71y66O3W+n3JjFxIbXwvXk=";
+    extraBuildInputs = [];
   };
 }."${version}"; in
 
@@ -23,7 +33,7 @@ buildDunePackage rec {
 
   useDune2 = true;
 
-  propagatedBuildInputs = [ astring result ];
+  propagatedBuildInputs = [ astring result ] ++ param.extraBuildInputs;
 
   meta = {
     description = "Parser for Ocaml documentation comments";

--- a/pkgs/development/ocaml-modules/odoc-parser/default.nix
+++ b/pkgs/development/ocaml-modules/odoc-parser/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, buildDunePackage, astring, result, camlp-streams, version ? "1.0.0" }:
+{ lib, fetchurl, buildDunePackage, astring, result, camlp-streams, version ? "2.0.0" }:
 
 let param = {
   "2.0.0" = {

--- a/pkgs/development/tools/ocaml/ocamlformat/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlformat/default.nix
@@ -1,39 +1,17 @@
 { lib, fetchurl, fetchzip, callPackage }:
 
-let mkOCamlformat = callPackage ./generic.nix; in
-
 # Older versions should be removed when their usage decrease
 # This script scraps Github looking for OCamlformat's options and versions usage:
 #  https://gist.github.com/Julow/110dc94308d6078225e0665e3eccd433
 
 rec {
-  ocamlformat_0_19_0 = mkOCamlformat {
-    version = "0.19.0";
-  };
+  ocamlformat_0_19_0 = ocamlformat.override { version = "0.19.0"; };
+  ocamlformat_0_20_0 = ocamlformat.override { version = "0.20.0"; };
+  ocamlformat_0_20_1 = ocamlformat.override { version = "0.20.1"; };
+  ocamlformat_0_21_0 = ocamlformat.override { version = "0.21.0"; };
+  ocamlformat_0_22_4 = ocamlformat.override { version = "0.22.4"; };
+  ocamlformat_0_23_0 = ocamlformat.override { version = "0.23.0"; };
+  ocamlformat_0_24_0 = ocamlformat.override { version = "0.24.0"; };
 
-  ocamlformat_0_20_0 = mkOCamlformat {
-    version = "0.20.0";
-  };
-
-  ocamlformat_0_20_1 = mkOCamlformat {
-    version = "0.20.1";
-  };
-
-  ocamlformat_0_21_0 = mkOCamlformat {
-    version = "0.21.0";
-  };
-
-  ocamlformat_0_22_4 = mkOCamlformat {
-    version = "0.22.4";
-  };
-
-  ocamlformat_0_23_0 = mkOCamlformat {
-    version = "0.23.0";
-  };
-
-  ocamlformat_0_24_0 = mkOCamlformat {
-    version = "0.24.0";
-  };
-
-  ocamlformat = ocamlformat_0_24_0;
+  ocamlformat = callPackage ./generic.nix {};
 }

--- a/pkgs/development/tools/ocaml/ocamlformat/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlformat/default.nix
@@ -31,5 +31,9 @@ rec {
     version = "0.23.0";
   };
 
-  ocamlformat = ocamlformat_0_23_0;
+  ocamlformat_0_24_0 = mkOCamlformat {
+    version = "0.24.0";
+  };
+
+  ocamlformat = ocamlformat_0_24_0;
 }

--- a/pkgs/development/tools/ocaml/ocamlformat/generic.nix
+++ b/pkgs/development/tools/ocaml/ocamlformat/generic.nix
@@ -13,6 +13,7 @@ let src =
       "0.21.0" = "sha256-KhgX9rxYH/DM6fCqloe4l7AnJuKrdXSe6Y1XY3BXMy0=";
       "0.22.4" = "sha256-61TeK4GsfMLmjYGn3ICzkagbc3/Po++Wnqkb2tbJwGA=";
       "0.23.0" = "sha256-m9Pjz7DaGy917M1GjyfqG5Lm5ne7YSlJF2SVcDHe3+0=";
+      "0.24.0" = "sha256-Zil0wceeXmq2xy0OVLxa/Ujl4Dtsmc4COyv6Jo7rVaM=";
     }."${version}";
   };
   ocamlPackages = ocaml-ng.ocamlPackages;
@@ -48,8 +49,10 @@ buildDunePackage {
     uutf
   ]
   ++ lib.optionals (lib.versionAtLeast version "0.20.0") [ ocaml-version either ]
-  ++ (if lib.versionAtLeast version "0.20.1"
-      then [ odoc-parser ]
+  ++ (if lib.versionAtLeast version "0.24.0"
+      then [ (odoc-parser.override { version = "2.0.0"; }) ]
+      else if lib.versionAtLeast version "0.20.1"
+      then [ (odoc-parser.override { version = "1.0.1"; }) ]
       else [ (odoc-parser.override { version = "0.9.0"; }) ])
   ++ (if lib.versionAtLeast version "0.21.0"
       then [ cmdliner_1_1 ]

--- a/pkgs/development/tools/ocaml/ocamlformat/generic.nix
+++ b/pkgs/development/tools/ocaml/ocamlformat/generic.nix
@@ -1,5 +1,5 @@
 { lib, fetchurl, fetchzip, ocaml-ng
-, version
+, version ? "0.24.0"
 , tarballName ? "ocamlformat-${version}.tbz",
 }:
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13995,7 +13995,7 @@ with pkgs;
   inherit (callPackage ../development/tools/ocaml/ocamlformat { })
     ocamlformat # latest version
     ocamlformat_0_19_0 ocamlformat_0_20_0 ocamlformat_0_20_1 ocamlformat_0_21_0
-    ocamlformat_0_22_4 ocamlformat_0_23_0;
+    ocamlformat_0_22_4 ocamlformat_0_23_0 ocamlformat_0_24_0;
 
   orc = callPackage ../development/compilers/orc { };
 


### PR DESCRIPTION
###### Description of changes

- The first commit adds versions `1.0.1` and `2.0.0` versions of `odoc-parser`. All the versions are required by the different versions of ocamlformat. Selecting a different version is easy with the `version` argument that was already here.
- The second commit changes the default version of `odoc-parser`. It's a separate commit because it might cause breakage and can be reverted.
- Init `ocamlformat_0_24_0`
- The last commit change the ocamlformat definition to use the `.override { version ...; }` pattern. This might be a good pattern to use in the future for other ocaml packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
