### PR TITLE
nixos/k3s: use default cgroup-driver again

### DIFF
--- a/nixos/modules/services/cluster/k3s/default.nix
+++ b/nixos/modules/services/cluster/k3s/default.nix
@@ -111,7 +111,6 @@ in
           [
             "${cfg.package}/bin/k3s ${cfg.role}"
           ]
-          ++ (optional (config.systemd.enableUnifiedCgroupHierarchy) "--kubelet-arg=cgroup-driver=systemd")
           ++ (optional cfg.disableAgent "--disable-agent")
           ++ (optional (cfg.serverAddr != "") "--server ${cfg.serverAddr}")
           ++ (optional (cfg.token != "") "--token ${cfg.token}")


### PR DESCRIPTION
###### Description of changes

Setting `cgroup-driver=systemd` was originally necessary to match with
docker, else the kubelet would not start (#111835)

However, since then, docker support has been dropped from k3s (#177790).
As such, this option is much less necessary.

More importantly, it now seems to be actively causing issues. Due to an
upstream k3s bug, it's resulting in the kubelet and containerd having
different cgroup drivers, which seems to result in some difficult to
debug failure modes.

See
https://github.com/NixOS/nixpkgs/issues/181790#issuecomment-1188840862
for a description of this problem.

Removing this flag entirely seems reasonable to me, and it results in
k3s working again on my machine.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests)
      `nix-build -A nixosTests.k3s-single-node`
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

