### PR TITLE
python310Packages.pystemd: 0.8.0 -> 0.10.0

### DIFF
--- a/pkgs/development/python-modules/pystemd/default.nix
+++ b/pkgs/development/python-modules/pystemd/default.nix
@@ -1,23 +1,36 @@
-{ stdenv, lib, python, systemd }:
+{ stdenv
+, buildPythonPackage
+, lib
+, python
+, systemd
+, pytest
+, mock
+, pkg-config }:
 
-python.pkgs.buildPythonPackage rec {
+buildPythonPackage rec {
   pname = "pystemd";
-  version = "0.8.0";
+  version = "0.10.0";
   src = python.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "0wlrid2xd73dmzl4m0jgg6cqmkx3qs9v9nikvwxd8a5b8chf9hna";
+    sha256 = "sha256-10qBS/2gEIXbGorZC+PLJ9ryOlGrawPn4p7IEfoq6Fk=";
   };
 
   disabled = python.pythonOlder "3.4";
 
   buildInputs = [ systemd ];
 
-  checkInputs = with python.pkgs; [ pytest mock ];
+  nativeBuildInputs = [ pkg-config ];
+
+  checkInputs = [ pytest mock ];
+
   checkPhase = "pytest tests";
 
   meta = with lib; {
     broken = (stdenv.isLinux && stdenv.isAarch64);
-    description = "A thin Cython-based wrapper on top of libsystemd, focused on exposing the dbus API via sd-bus in an automated and easy to consume way.";
+    description = ''
+      Thin Cython-based wrapper on top of libsystemd, focused on exposing the
+      dbus API via sd-bus in an automated and easy to consume way
+    '';
     homepage = "https://github.com/facebookincubator/pystemd/";
     license = licenses.lgpl21Plus;
     maintainers = with maintainers; [ flokli ];


### PR DESCRIPTION
###### Description of changes

update package and fix build ( https://hydra.nixos.org/build/183056907/nixlog/1 )

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
