### PR TITLE
vscode-extensions: properly split marketplace ref attributes

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/vscode-utils.nix
+++ b/pkgs/applications/editors/vscode/extensions/vscode-utils.nix
@@ -43,7 +43,7 @@ let
   });
 
   fetchVsixFromVscodeMarketplace = mktplcExtRef:
-    fetchurl((import ./mktplcExtRefToFetchArgs.nix mktplcExtRef));
+    fetchurl (import ./mktplcExtRefToFetchArgs.nix mktplcExtRef);
 
   buildVscodeMarketplaceExtension = a@{
     name ? "",
@@ -65,11 +65,12 @@ let
     "publisher"
     "version"
     "sha256"
+    "arch"
   ];
 
   mktplcExtRefToExtDrv = ext:
-    buildVscodeMarketplaceExtension ((removeAttrs ext mktplcRefAttrList) // {
-      mktplcRef = ext;
+    buildVscodeMarketplaceExtension (removeAttrs ext mktplcRefAttrList // {
+      mktplcRef = builtins.intersectAttrs (lib.genAttrs mktplcRefAttrList (_: null)) ext;
     });
 
   extensionFromVscodeMarketplace = mktplcExtRefToExtDrv;


### PR DESCRIPTION
So that e.g. `postPatch` isn't passed to `mktplcExtRefToFetchArgs.nix`, for example in

```nix
        {
          name = "agda-mode";
          publisher = "banacorn";
          version = "0.3.9";
          sha256 = "0iqp9mldlxbxh4zn3jid07m5cyyhvk0xd5iapqx020yw82s40fmb";
          postPatch = ''
            sed -i '/agda-mode-body {/,/font-size/{/font-size/d}' dist/style.css
          '';
        }
```