### PR TITLE
treewide: patchPhase -> postPatch

### DIFF
--- a/pkgs/applications/audio/AMB-plugins/default.nix
+++ b/pkgs/applications/audio/AMB-plugins/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ladspaH ];
 
-  patchPhase = ''
+  postPatch = ''
     sed -i 's@/usr/bin/install@install@g' Makefile
     sed -i 's@/bin/rm@rm@g' Makefile
     sed -i 's@/usr/lib/ladspa@$(out)/lib/ladspa@g' Makefile

--- a/pkgs/applications/audio/FIL-plugins/default.nix
+++ b/pkgs/applications/audio/FIL-plugins/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ladspaH ];
 
-  patchPhase = ''
+  postPatch = ''
     sed -i 's@/usr/bin/install@install@g' Makefile
     sed -i 's@/bin/rm@rm@g' Makefile
     sed -i 's@/usr/lib/ladspa@$(out)/lib/ladspa@g' Makefile

--- a/pkgs/applications/audio/MMA/default.nix
+++ b/pkgs/applications/audio/MMA/default.nix
@@ -12,7 +12,7 @@
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ python3 alsa-utils timidity ];
 
-  patchPhase = ''
+  postPatch = ''
     sed -i 's@/usr/bin/aplaymidi@/${alsa-utils}/bin/aplaymidi@g' mma-splitrec
     sed -i 's@/usr/bin/aplaymidi@/${alsa-utils}/bin/aplaymidi@g' util/mma-splitrec.py
     sed -i 's@/usr/bin/arecord@/${alsa-utils}/bin/arecord@g' mma-splitrec

--- a/pkgs/applications/audio/aeolus/default.nix
+++ b/pkgs/applications/audio/aeolus/default.nix
@@ -16,7 +16,9 @@ stdenv.mkDerivation rec {
     libX11 libXft readline
   ];
 
-  patchPhase = ''sed "s@ldconfig.*@@" -i source/Makefile'';
+  postPatch = ''
+    sed "s@ldconfig.*@@" -i source/Makefile
+  '';
 
   preBuild = "cd source";
 

--- a/pkgs/applications/audio/bristol/default.nix
+++ b/pkgs/applications/audio/bristol/default.nix
@@ -15,7 +15,9 @@ stdenv.mkDerivation  rec {
     xorg.xorgproto
   ];
 
-  patchPhase = "sed -i '41,43d' libbristolaudio/audioEngineJack.c"; # disable alsa/iatomic
+  postPatch = ''
+    sed -i '41,43d' libbristolaudio/audioEngineJack.c # disable alsa/iatomic
+  '';
 
   configurePhase = "./configure --prefix=$out --enable-jack-default-audio --enable-jack-default-midi";
 

--- a/pkgs/applications/audio/ladspa-plugins/default.nix
+++ b/pkgs/applications/audio/ladspa-plugins/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook pkg-config ];
   buildInputs = [ fftw ladspaH libxml2 perlPackages.perl perlPackages.XMLParser ];
 
-  patchPhase = ''
+  postPatch = ''
     patchShebangs .
     patchShebangs ./metadata/
     cp ${automake}/share/automake-*/mkinstalldirs .

--- a/pkgs/applications/audio/ladspa-sdk/default.nix
+++ b/pkgs/applications/audio/ladspa-sdk/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
     sha256 = "1vgx54cgsnc3ncl9qbgjbmq12c444xjafjkgr348h36j16draaa2";
   };
 
-  patchPhase = ''
+  postPatch = ''
     cd src
     sed -i 's@/usr/@$(out)/@g'  Makefile
     sed -i 's@-mkdirhier@mkdir -p@g'  Makefile

--- a/pkgs/applications/audio/magnetophonDSP/VoiceOfFaust/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/VoiceOfFaust/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   runtimeInputs = [ pitchTracker ];
 
-  patchPhase = ''
+  postPatch = ''
     sed -i "s@pd -nodac@${pitchTracker}/bin/pd -nodac@g" launchers/synthWrapper
     sed -i "s@../PureData/OscSendVoc.pd@$out/PureData/OscSendVoc.pd@g" launchers/pitchTracker
   '';

--- a/pkgs/applications/audio/mooSpace/default.nix
+++ b/pkgs/applications/audio/mooSpace/default.nix
@@ -12,7 +12,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ faust2jaqt faust2lv2 ];
 
-  patchPhase = "mv ${pname}_faust.dsp ${pname}.dsp";
+  postPatch = ''
+    mv ${pname}_faust.dsp ${pname}.dsp
+  '';
 
   buildPhase = ''
     faust2jaqt -time -vec -t 0 ${pname}.dsp

--- a/pkgs/applications/audio/ninjas2/default.nix
+++ b/pkgs/applications/audio/ninjas2/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  patchPhase = ''
+  postPatch = ''
     patchShebangs dpf/utils/generate-ttl.sh
   '';
 

--- a/pkgs/applications/audio/nova-filters/default.nix
+++ b/pkgs/applications/audio/nova-filters/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ pkg-config sconsPackages.scons_3_0_1 ];
   buildInputs = [ boost ladspaH ];
 
-  patchPhase = ''
+  postPatch = ''
     # remove TERM:
     sed -i -e '4d' SConstruct
     sed -i "s@mfpmath=sse@mfpmath=sse -I ${boost.dev}/include@g" SConstruct

--- a/pkgs/applications/audio/pd-plugins/helmholtz/default.nix
+++ b/pkgs/applications/audio/pd-plugins/helmholtz/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
     rm -rf __MACOSX
   '';
 
-  patchPhase = ''
+  postPatch = ''
     mkdir -p $out/helmholtz~
     sed -i "s@current: pd_darwin@current: pd_linux@g" Makefile
     sed -i "s@-Wl@@g" Makefile

--- a/pkgs/applications/audio/pd-plugins/mrpeach/default.nix
+++ b/pkgs/applications/audio/pd-plugins/mrpeach/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
 
   hardeningDisable = [ "format" ];
 
-  patchPhase = ''
+  postPatch = ''
     for D in net osc
     do
       sed -i "s@prefix = /usr/local@prefix = $out@g" $D/Makefile

--- a/pkgs/applications/audio/picoloop/default.nix
+++ b/pkgs/applications/audio/picoloop/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace SDL_GUI.cpp \
     --replace "\"font.ttf\"" "\"$out/share/font.ttf\"" \
     --replace "\"font.bmp\"" "\"$out/share/font.bmp\""

--- a/pkgs/applications/audio/swh-lv2/default.nix
+++ b/pkgs/applications/audio/swh-lv2/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-v6aJUWDbBZEmz0v6+cSCi/KhOYNUeK/MJLUSgzi39ng=";
   };
 
-  patchPhase = ''
+  postPatch = ''
     sed -e "s#xsltproc#${libxslt.bin}/bin/xsltproc#" -i Makefile
     sed -e "s#PREFIX = /usr/local#PREFIX = $out#" -i Makefile
   '';

--- a/pkgs/applications/audio/wolf-shaper/default.nix
+++ b/pkgs/applications/audio/wolf-shaper/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     "BUILD_JACK=true"
   ];
 
-  patchPhase = ''
+  postPatch = ''
     patchShebangs ./dpf/utils/generate-ttl.sh
   '';
 

--- a/pkgs/applications/audio/x42-plugins/default.nix
+++ b/pkgs/applications/audio/x42-plugins/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "PREFIX=$(out)" "FONTFILE=${freefont_ttf}/share/fonts/truetype/FreeSansBold.ttf" ];
 
-  patchPhase = ''
+  postPatch = ''
     patchShebangs ./stepseq.lv2/gridgen.sh
     patchShebangs ./matrixmixer.lv2/genttl.sh
     patchShebangs ./matrixmixer.lv2/genhead.sh

--- a/pkgs/applications/editors/manuskript/default.nix
+++ b/pkgs/applications/editors/manuskript/default.nix
@@ -21,7 +21,7 @@ python3Packages.buildPythonApplication rec {
     zlib
   ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace manuskript/ui/welcome.py \
       --replace sample-projects $out/share/${pname}/sample-projects
    '';

--- a/pkgs/applications/editors/qxw/default.nix
+++ b/pkgs/applications/editors/qxw/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "DESTDIR=$(out)" ];
 
-  patchPhase = ''
+  postPatch = ''
     sed -i 's/ `dpkg-buildflags[^`]*`//g;
             /mkdir -p/d;
             s/cp -a/install -D/;

--- a/pkgs/applications/emulators/attract-mode/default.nix
+++ b/pkgs/applications/emulators/attract-mode/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config ];
 
-  patchPhase = ''
+  postPatch = ''
     sed -i "s|prefix=/usr/local|prefix=$out|" Makefile
   '';
 

--- a/pkgs/applications/emulators/termtekst/default.nix
+++ b/pkgs/applications/emulators/termtekst/default.nix
@@ -13,7 +13,7 @@ python3Packages.buildPythonApplication rec {
 
   propagatedBuildInputs = with python3Packages; [ ncurses requests ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace setup.py \
       --replace "assert" "assert 1==1 #"
     substituteInPlace src/tt \

--- a/pkgs/applications/gis/grass/default.nix
+++ b/pkgs/applications/gis/grass/default.nix
@@ -30,8 +30,8 @@ stdenv.mkDerivation rec {
   patches = [ ./no_symbolic_links.patch ];
 
   # Correct mysql_config query
-  patchPhase = ''
-      substituteInPlace configure --replace "--libmysqld-libs" "--libs"
+  postPatch = ''
+    substituteInPlace configure --replace "--libmysqld-libs" "--libs"
   '';
 
   configureFlags = [

--- a/pkgs/applications/graphics/jpegrescan/default.nix
+++ b/pkgs/applications/graphics/jpegrescan/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "0cnl46z28lkqc5x27b8rpghvagahivrqcfvhzcsv9w1qs8qbd6dm";
   };
 
-  patchPhase = ''
+  postPatch = ''
     patchShebangs jpegrescan
   '';
 

--- a/pkgs/applications/graphics/minidjvu/default.nix
+++ b/pkgs/applications/graphics/minidjvu/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0jmpvy4g68k6xgplj9zsl6brg6vi81mx3nx2x9hfbr1f4zh95j79";
   };
 
-  patchPhase = ''
+  postPatch = ''
     sed -i s,/usr/bin/gzip,gzip, Makefile.in
   '';
 

--- a/pkgs/applications/graphics/qview/default.nix
+++ b/pkgs/applications/graphics/qview/default.nix
@@ -26,7 +26,7 @@ mkDerivation rec {
     qtsvg
   ];
 
-  patchPhase = ''
+  postPatch = ''
     sed "s|/usr/|$out/|g" -i qView.pro
   '';
 

--- a/pkgs/applications/graphics/sane/backends/brscan4/udev_rules_type1.nix
+++ b/pkgs/applications/graphics/sane/backends/brscan4/udev_rules_type1.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
      -  <http://ubuntuforums.org/showthread.php?t=1496878>
      -  <http://www.planet-libre.org/index.php?post_id=10937>
   */
-  patchPhase = ''
+  postPatch = ''
     sed -i -e s/SYSFS/ATTR/g opt/brother/scanner/udev-rules/type1/*.rules
   '';
 

--- a/pkgs/applications/graphics/sane/backends/dsseries/default.nix
+++ b/pkgs/applications/graphics/sane/backends/dsseries/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     popd
   '';
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace etc/udev/rules.d/50-Brother_DSScanner.rules \
       --replace 'GROUP="users"' 'GROUP="scanner", ENV{libsane_matched}="yes"'
 

--- a/pkgs/applications/graphics/screencloud/default.nix
+++ b/pkgs/applications/graphics/screencloud/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ qt4 quazip qt-mobility qxt python2Packages.python python2Packages.pycrypto ];
 
-  patchPhase = ''
+  postPatch = ''
     # Required to make the configure script work. Normally, screencloud's
     # CMakeLists file sets the install prefix to /opt by force. This is stupid
     # and breaks nix, so we force it to install where we want. Please don't

--- a/pkgs/applications/graphics/wings/default.nix
+++ b/pkgs/applications/graphics/wings/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   ERL_LIBS = "${cl}/lib/erlang/lib";
 
-  patchPhase = ''
+  postPatch = ''
     sed -i 's,-Werror ,,' e3d/Makefile
     sed -i 's,../../wings/,../,' icons/Makefile
     find plugins_src -mindepth 2 -type f -name "*.[eh]rl" -exec sed -i 's,wings/src/,../../src/,' {} \;

--- a/pkgs/applications/misc/ape/default.nix
+++ b/pkgs/applications/misc/ape/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
      sha256 = "0xyvna2fbr18hi5yvm0zwh77q02dfna1g4g53z9mn2rmlfn2mhjh";
   };
 
-  patchPhase = ''
+  postPatch = ''
     # We move the file first to avoid "same file" error in the default case
     cp ${lexiconPath} new_lexicon.pl
     rm prolog/lexicon/clex_lexicon.pl

--- a/pkgs/applications/misc/cbatticon/default.nix
+++ b/pkgs/applications/misc/cbatticon/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   buildInputs =  [ glib gtk3 libnotify ];
 
-  patchPhase = ''
+  postPatch = ''
     sed -i -e 's/ -Wno-format//g' Makefile
   '';
 

--- a/pkgs/applications/misc/gv/default.nix
+++ b/pkgs/applications/misc/gv/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     libiconv
   ];
 
-  patchPhase = ''
+  postPatch = ''
     sed 's|\<gs\>|${ghostscriptX}/bin/gs|g' -i "src/"*.in
     sed 's|"gs"|"${ghostscriptX}/bin/gs"|g' -i "src/"*.c
   '';

--- a/pkgs/applications/misc/k40-whisperer/default.nix
+++ b/pkgs/applications/misc/k40-whisperer/default.nix
@@ -33,7 +33,7 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace svg_reader.py \
       --replace '"/usr/bin/inkscape"' '"${inkscape}/bin/inkscape"'
   '';

--- a/pkgs/applications/misc/pgmanage/default.nix
+++ b/pkgs/applications/misc/pgmanage/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1a1dbc32b3y0ph8ydf800h6pz7dg6g1gxgid4gffk7k58xj0c5yf";
   };
 
-  patchPhase = ''
+  postPatch = ''
     patchShebangs src/configure
   '';
 

--- a/pkgs/applications/misc/posterazor/default.nix
+++ b/pkgs/applications/misc/posterazor/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   '';
 
   # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=667328
-  patchPhase = ''
+  postPatch = ''
     sed "s/\(#define CASESENSITIVESTRCMP strcasecmp\)/#include <unistd.h>\n\1/" -i FlPosteRazorDialog.cpp
   '';
 

--- a/pkgs/applications/misc/redshift-plasma-applet/default.nix
+++ b/pkgs/applications/misc/redshift-plasma-applet/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
     })
   ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace package/contents/ui/main.qml \
       --replace "redshiftCommand: 'redshift'" \
                 "redshiftCommand: '${redshift}/bin/redshift'" \

--- a/pkgs/applications/misc/sleepyhead/default.nix
+++ b/pkgs/applications/misc/sleepyhead/default.nix
@@ -19,7 +19,7 @@ mkDerivation {
 
   nativeBuildInputs = [ wrapQtAppsHook ];
 
-  patchPhase = ''
+  postPatch = ''
     patchShebangs configure
   '';
 

--- a/pkgs/applications/misc/wordnet/default.nix
+++ b/pkgs/applications/misc/wordnet/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
-  patchPhase = ''
+  postPatch = ''
     sed "13i#define USE_INTERP_RESULT 1" -i src/stubs.c
   '';
 

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -118,7 +118,7 @@ let
 
     PATCH_RPATH = mkrpath [ gcc.cc glib nspr nss ];
 
-    patchPhase = ''
+    postPatch = ''
       patchelf --set-rpath "$PATCH_RPATH" _platform_specific/linux_x64/libwidevinecdm.so
     '';
 

--- a/pkgs/applications/networking/browsers/chromium/ungoogled.nix
+++ b/pkgs/applications/networking/browsers/chromium/ungoogled.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     makeWrapper
   ];
 
-  patchPhase = ''
+  postPatch = ''
     sed -i '/chromium-widevine/d' patches/series
   '';
 

--- a/pkgs/applications/networking/browsers/firefox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/default.nix
@@ -151,7 +151,7 @@ stdenv.mkDerivation {
   dontStrip = true;
   dontPatchELF = true;
 
-  patchPhase = ''
+  postPatch = ''
     # Don't download updates from Mozilla directly
     echo 'pref("app.update.auto", "false");' >> defaults/pref/channel-prefs.js
   '';

--- a/pkgs/applications/networking/cluster/openshift/default.nix
+++ b/pkgs/applications/networking/cluster/openshift/default.nix
@@ -26,7 +26,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  patchPhase = ''
+  postPatch = ''
     patchShebangs ./hack
   '';
 

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
@@ -156,7 +156,7 @@ stdenv.mkDerivation {
   dontStrip = true;
   dontPatchELF = true;
 
-  patchPhase = ''
+  postPatch = ''
     # Don't download updates from Mozilla directly
     echo 'pref("app.update.auto", "false");' >> defaults/pref/channel-prefs.js
   '';

--- a/pkgs/applications/networking/p2p/freenet/default.nix
+++ b/pkgs/applications/networking/p2p/freenet/default.nix
@@ -28,7 +28,7 @@ let
       sha256 = "0wddkfyhsgs7bcq9svicz6l0a35yv82yqzmji3c345hg4hbch3kb";
     };
 
-    patchPhase = ''
+    postPatch = ''
       cp ${freenet_ext} lib/freenet/freenet-ext.jar
       cp ${bcprov} lib/bcprov-${bcprov_version}.jar
 

--- a/pkgs/applications/networking/p2p/gnunet/gtk.nix
+++ b/pkgs/applications/networking/p2p/gnunet/gtk.nix
@@ -38,7 +38,9 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--with-gnunet=${gnunet}" ];
 
-  patchPhase = "patchShebangs pixmaps/icon-theme-installer";
+  postPatch = ''
+    patchShebangs pixmaps/icon-theme-installer
+  '';
 
   meta = gnunet.meta // {
     description = "GNUnet GTK User Interface";

--- a/pkgs/applications/networking/ps2client/default.nix
+++ b/pkgs/applications/networking/ps2client/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
     sha256 = "1rlmns44pxm6dkh6d3cz9sw8v7pvi53r7r5r3kgwdzkhixjj0cdg";
   };
 
-  patchPhase = ''
+  postPatch = ''
    sed -i -e "s|-I/usr/include||g" -e "s|-I/usr/local/include||g" Makefile
   '';
 

--- a/pkgs/applications/networking/qv2ray/default.nix
+++ b/pkgs/applications/networking/qv2ray/default.nix
@@ -29,7 +29,7 @@ mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  patchPhase = lib.optionals stdenv.isDarwin ''
+  postPatch = lib.optionals stdenv.isDarwin ''
     substituteInPlace cmake/platforms/macos.cmake \
       --replace \''${QV2RAY_QtX_DIR}/../../../bin/macdeployqt macdeployqt
   '';

--- a/pkgs/applications/office/paperwork/openpaperwork-core.nix
+++ b/pkgs/applications/office/paperwork/openpaperwork-core.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   # Python 2.x is not supported.
   disabled = !isPy3k && !isPyPy;
 
-  patchPhase = ''
+  postPatch = ''
     echo 'version = "${version}"' > src/openpaperwork_core/_version.py
     chmod a+w -R ..
     patchShebangs ../tools

--- a/pkgs/applications/office/paperwork/openpaperwork-gtk.nix
+++ b/pkgs/applications/office/paperwork/openpaperwork-gtk.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   # Python 2.x is not supported.
   disabled = !isPy3k && !isPyPy;
 
-  patchPhase = ''
+  postPatch = ''
     echo 'version = "${version}"' > src/openpaperwork_gtk/_version.py
     chmod a+w -R ..
     patchShebangs ../tools

--- a/pkgs/applications/office/paperwork/paperwork-backend.nix
+++ b/pkgs/applications/office/paperwork/paperwork-backend.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
   # Python 2.x is not supported.
   disabled = !isPy3k && !isPyPy;
 
-  patchPhase = ''
+  postPatch = ''
     echo 'version = "${version}"' > src/paperwork_backend/_version.py
     chmod a+w -R ..
     patchShebangs ../tools

--- a/pkgs/applications/office/paperwork/paperwork-shell.nix
+++ b/pkgs/applications/office/paperwork/paperwork-shell.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   # Python 2.x is not supported.
   disabled = !isPy3k && !isPyPy;
 
-  patchPhase = ''
+  postPatch = ''
     echo 'version = "${version}"' > src/paperwork_shell/_version.py
     chmod a+w -R ..
     patchShebangs ../tools

--- a/pkgs/applications/office/qnotero/default.nix
+++ b/pkgs/applications/office/qnotero/default.nix
@@ -14,7 +14,7 @@ python3Packages.buildPythonPackage rec {
 
   propagatedBuildInputs = [ python3Packages.pyqt5 wrapQtAppsHook ];
 
-  patchPhase = ''
+  postPatch = ''
       substituteInPlace ./setup.py \
         --replace "/usr/share" "usr/share"
 

--- a/pkgs/applications/office/timeline/default.nix
+++ b/pkgs/applications/office/timeline/default.nix
@@ -43,7 +43,7 @@ python3.pkgs.buildPythonApplication rec {
   dontBuild = true;
   doCheck = false;
 
-  patchPhase = ''
+  postPatch = ''
     sed -i "s|_ROOT =.*|_ROOT = \"$out/usr/share/timeline/\"|" source/timelinelib/config/paths.py
   '';
 

--- a/pkgs/applications/science/astronomy/astrolog/default.nix
+++ b/pkgs/applications/science/astronomy/astrolog/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     stripRoot = false;
   };
 
-  patchPhase = ''
+  postPatch = ''
     sed -i "s:~/astrolog:$out/astrolog:g" astrolog.h
     substituteInPlace Makefile --replace cc "$CC" --replace strip "$STRIP"
   '';

--- a/pkgs/applications/science/biology/kent/default.nix
+++ b/pkgs/applications/science/biology/kent/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libpng libuuid zlib bzip2 xz openssl curl libmysqlclient ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace ./src/checkUmask.sh \
       --replace "/bin/bash" "${bash}/bin/bash"
 

--- a/pkgs/applications/science/biology/seaview/default.nix
+++ b/pkgs/applications/science/biology/seaview/default.nix
@@ -11,7 +11,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ fltk libjpeg ];
 
-  patchPhase = "sed -i 's#PATH=/bin:/usr/bin rm#'${coreutils}/bin/rm'#' seaview.cxx";
+  postPatch = ''
+    sed -i 's#PATH=/bin:/usr/bin rm#'${coreutils}/bin/rm'#' seaview.cxx
+  '';
+
   installPhase = "mkdir -p $out/bin; cp seaview $out/bin";
 
   meta = with lib; {

--- a/pkgs/applications/science/chemistry/jmol/default.nix
+++ b/pkgs/applications/science/chemistry/jmol/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-9bcOwORHLZfn95RFur4JdP3Djpq8K8utnWIsniqKAI4=";
   };
 
-  patchPhase = ''
+  postPatch = ''
     sed -i -e "4s:.*:command=${jre}/bin/java:" -e "10s:.*:jarpath=$out/share/jmol/Jmol.jar:" -e "11,21d" jmol
   '';
 

--- a/pkgs/applications/science/electronics/tkgate/1.x.nix
+++ b/pkgs/applications/science/electronics/tkgate/1.x.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ tcl tk libX11 xorgproto ];
   dontUseImakeConfigure = true;
 
-  patchPhase = ''
+  postPatch = ''
     sed -i config.h \
       -e 's|.*#define.*TKGATE_TCLTK_VERSIONS.*|#define TKGATE_TCLTK_VERSIONS "${tcl.release}"|' \
       -e 's|.*#define.*TKGATE_INCDIRS.*|#define TKGATE_INCDIRS "${tcl}/include ${tk}/include ${libiconvInc} ${libX11.dev}/include"|' \

--- a/pkgs/applications/science/logic/cryptoverif/default.nix
+++ b/pkgs/applications/science/logic/cryptoverif/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   /* Fix up the frontend to load the 'default' cryptoverif library
   ** from under $out/libexec. By default, it expects to find the files
   ** in $CWD which doesn't work. */
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace ./src/syntax.ml \
       --replace \"default\" \"$out/libexec/default\"
   '';

--- a/pkgs/applications/science/logic/mcy/default.nix
+++ b/pkgs/applications/science/logic/mcy/default.nix
@@ -17,7 +17,8 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [ python ];
-  patchPhase = ''
+
+  postPatch = ''
     chmod +x scripts/create_mutated.sh
     patchShebangs .
 

--- a/pkgs/applications/science/logic/metis-prover/default.nix
+++ b/pkgs/applications/science/logic/metis-prover/default.nix
@@ -14,7 +14,9 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ perl ];
   buildInputs = [ mlton ];
 
-  patchPhase = "patchShebangs .";
+  postPatch = ''
+    patchShebangs .
+  '';
 
   buildPhase = "make mlton";
 

--- a/pkgs/applications/science/logic/symbiyosys/default.nix
+++ b/pkgs/applications/science/logic/symbiyosys/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [ ];
-  patchPhase = ''
+  postPatch = ''
     patchShebangs .
 
     # Fix up Yosys imports

--- a/pkgs/applications/science/math/LiE/default.nix
+++ b/pkgs/applications/science/math/LiE/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation {
 
   buildInputs = [ bison readline ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace make_lie \
       --replace \`/bin/pwd\` $out
   '';

--- a/pkgs/applications/science/math/cplex/default.nix
+++ b/pkgs/applications/science/math/cplex/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
   unpackPhase = "cp $src $name";
 
-  patchPhase = ''
+  postPatch = ''
     sed -i -e 's|/usr/bin/tr"|tr"         |' $name
   '';
 

--- a/pkgs/applications/science/math/hmetis/default.nix
+++ b/pkgs/applications/science/math/hmetis/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   binaryFiles = "hmetis khmetis shmetis";
 
-  patchPhase = ''
+  postPatch = ''
     for binaryfile in $binaryFiles; do
       patchelf \
         --set-interpreter ${stdenv.cc.libc}/lib/ld-linux.so.2 \

--- a/pkgs/applications/science/math/palp/default.nix
+++ b/pkgs/applications/science/math/palp/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     "format"
   ];
 
-  patchPhase = lib.optionalString stdenv.isDarwin ''
+  postPatch = lib.optionalString stdenv.isDarwin ''
     substituteInPlace GNUmakefile --replace gcc cc
   '';
 

--- a/pkgs/applications/science/math/singular/default.nix
+++ b/pkgs/applications/science/math/singular/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
     "--enable-gfanlib"
   ];
 
-  prePatch = ''
+  postPatch = ''
     # don't let the tests depend on `hostname`
     substituteInPlace Tst/regress.cmd --replace 'mysystem_catch("hostname")' 'nix_test_runner'
 

--- a/pkgs/applications/terminal-emulators/cool-retro-term/default.nix
+++ b/pkgs/applications/terminal-emulators/cool-retro-term/default.nix
@@ -12,7 +12,7 @@ mkDerivation rec {
     sha256 = "0mird4k88ml6y61hky2jynrjmnxl849fvhsr5jfdlnv0i7r5vwi5";
   };
 
-  patchPhase = ''
+  postPatch = ''
     sed -i -e '/qmltermwidget/d' cool-retro-term.pro
   '';
 

--- a/pkgs/applications/version-management/git-and-tools/darcs-to-git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/darcs-to-git/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
     sha256 = "sha256-UQI3av+0zj1SNwEonwuk5n2RjZN3+tSJFJuFCjrorFM=";
   };
 
-  patchPhase = let
+  postPatch = let
     matchExecution = ''(\<(output_of|system|run)\([^"%]*("|%w\()|^[^"`]*`)'';
   in ''
     sed -r -i \

--- a/pkgs/applications/version-management/sparkleshare/default.nix
+++ b/pkgs/applications/version-management/sparkleshare/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     webkit2-sharp
   ];
 
-  patchPhase = ''
+  postPatch = ''
     # Nix will manage the icon cache.
     echo '#!/bin/sh' >scripts/post-install.sh
   '';

--- a/pkgs/applications/version-management/tkrev/default.nix
+++ b/pkgs/applications/version-management/tkrev/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ tcl tk ];
 
-  patchPhase = ''
+  postPatch = ''
     for file in tkrev/tkrev.tcl tkdiff/tkdiff; do
         substituteInPlace "$file" \
             --replace "exec wish" "exec ${tk}/bin/wish"

--- a/pkgs/applications/video/dvd-slideshow/default.nix
+++ b/pkgs/applications/video/dvd-slideshow/default.nix
@@ -36,7 +36,7 @@ in stdenv.mkDerivation rec {
     sha256 = "17c09aqvippiji2sd0pcxjg3nb1mnh9k5nia4gn5lhcvngjcp1q5";
   };
 
-  patchPhase = ''
+  postPatch = ''
     # fix upstream typos
     substituteInPlace dvd-slideshow \
       --replace "version='0.8.4-1'" "version='0.8.4-2'" \

--- a/pkgs/applications/video/qstopmotion/default.nix
+++ b/pkgs/applications/video/qstopmotion/default.nix
@@ -56,7 +56,7 @@ mkDerivation rec {
     libv4l
   ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace CMakeLists.txt \
       --replace "find_package(Qt5 REQUIRED COMPONENTS Core Widgets Xml" \
                 "find_package(Qt5 REQUIRED COMPONENTS Core Widgets Xml Multimedia"

--- a/pkgs/applications/window-managers/dzen2/default.nix
+++ b/pkgs/applications/window-managers/dzen2/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "d4f7943cd39dc23fd825eb684b49dc3484860fa8443d30b06ee38af72a53b556";
   };
 
-  patchPhase = ''
+  postPatch = ''
     CFLAGS=" -Wall -Os ''${INCS} -DVERSION=\"''${VERSION}\" -DDZEN_XINERAMA -DDZEN_XPM -DDZEN_XFT `pkg-config --cflags xft`"
     LIBS=" -L/usr/lib -lc -lXft -lXpm -lXinerama -lX11"
     echo "CFLAGS=$CFLAGS" >>config.mk

--- a/pkgs/data/fonts/google-fonts/default.nix
+++ b/pkgs/data/fonts/google-fonts/default.nix
@@ -13,7 +13,7 @@ stdenvNoCC.mkDerivation {
     sha256 = "sha256-IFkKwRRyZeOXD8/9n8UDrruUKK6oQK4BD9wYN2dmSAc=";
   };
 
-  patchPhase = ''
+  postPatch = ''
     # These directories need to be removed because they contain
     # older or duplicate versions of fonts also present in other
     # directories. This causes non-determinism in the install since

--- a/pkgs/data/fonts/ricty/default.nix
+++ b/pkgs/data/fonts/ricty/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     install -m 0770 $src ricty_generator.sh
   '';
 
-  patchPhase = ''
+  postPatch = ''
     sed -i 's/fonts_directories=".*"/fonts_directories="$inconsolata $migu"/' ricty_generator.sh
   '';
 

--- a/pkgs/development/compilers/bigloo/default.nix
+++ b/pkgs/development/compilers/bigloo/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     '' export CXXCPP="$CXX -E"
     '';
 
-  patchPhase = ''
+  postPatch = ''
     # Fix absolute paths.
     sed -e 's=/bin/mv=mv=g' -e 's=/bin/rm=rm=g'			\
         -e 's=/tmp=$TMPDIR=g' -i autoconf/*		\

--- a/pkgs/development/compilers/chez/default.nix
+++ b/pkgs/development/compilers/chez/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   ** paths in some helper scripts, otherwise the build will fail on
   ** NixOS or in any chroot build.
   */
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace ./configure \
       --replace "git submodule init && git submodule update || exit 1" "true"
 

--- a/pkgs/development/compilers/gprolog/default.nix
+++ b/pkgs/development/compilers/gprolog/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = lib.optional stdenv.isi686 "pic";
 
-  patchPhase = ''
+  postPatch = ''
     sed -i -e "s|/tmp/make.log|$TMPDIR/make.log|g" src/Pl2Wam/check_boot
   '';
 

--- a/pkgs/development/compilers/mercury/default.nix
+++ b/pkgs/development/compilers/mercury/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ gcc flex bison texinfo jdk erlang readline ];
 
-  patchPhase = ''
+  postPatch = ''
     # Fix calls to programs in /bin
     for p in uname pwd ; do
       for f in $(egrep -lr /bin/$p *) ; do

--- a/pkgs/development/compilers/nextpnr/default.nix
+++ b/pkgs/development/compilers/nextpnr/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
     ++ (lib.optional (enableGui && stdenv.isDarwin)
         "-DOPENGL_INCLUDE_DIR=${OpenGL}/Library/Frameworks");
 
-  patchPhase = with builtins; ''
+  postPatch = with builtins; ''
     # use PyPy for icestorm if enabled
     substituteInPlace ./ice40/CMakeLists.txt \
       --replace ''\'''${PYTHON_EXECUTABLE}' '${icestorm.pythonInterp}'

--- a/pkgs/development/compilers/shaderc/default.nix
+++ b/pkgs/development/compilers/shaderc/default.nix
@@ -36,7 +36,7 @@ in stdenv.mkDerivation rec {
     sha256 = "sha256-RfSMzrGVtdXbr/mjSrHoN447e3vMQfJbesQMvLOARBs=";
   };
 
-  patchPhase = ''
+  postPatch = ''
     cp -r --no-preserve=mode ${glslang} third_party/glslang
     cp -r --no-preserve=mode ${spirv-tools} third_party/spirv-tools
     ln -s ${spirv-headers} third_party/spirv-tools/external/spirv-headers

--- a/pkgs/development/compilers/smlnj/default.nix
+++ b/pkgs/development/compilers/smlnj/default.nix
@@ -47,7 +47,7 @@ in stdenv.mkDerivation {
 
   inherit sources;
 
-  patchPhase = ''
+  postPatch = ''
     sed -i '/PATH=/d' config/_arch-n-opsys base/runtime/config/gen-posix-names.sh
     echo SRCARCHIVEURL="file:/$TMP" > config/srcarchiveurl
     patch --verbose config/_heap2exec ${./heap2exec.diff}

--- a/pkgs/development/embedded/fpga/icestorm/default.nix
+++ b/pkgs/development/embedded/fpga/icestorm/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
   #
   # also, fix up the path to the chosen Python interpreter. for pypy-compatible
   # platforms, it offers significant performance improvements.
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace ./icebox/icebox_vlog.py \
       --replace /usr/local/share "$out/share"
 

--- a/pkgs/development/interpreters/gnu-apl/default.nix
+++ b/pkgs/development/interpreters/gnu-apl/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     "-Wno-error=misleading-indentation"
    ]) ++ optional stdenv.cc.isClang "-Wno-error=null-dereference");
 
-  patchPhase = lib.optionalString stdenv.isDarwin ''
+  postPatch = lib.optionalString stdenv.isDarwin ''
     substituteInPlace src/LApack.cc --replace "malloc.h" "malloc/malloc.h"
   '';
 

--- a/pkgs/development/interpreters/picolisp/default.nix
+++ b/pkgs/development/interpreters/picolisp/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [openssl] ++ optional stdenv.is64bit jdk;
-  patchPhase = ''
+  postPatch = ''
     sed -i "s/which java/command -v java/g" mkAsm
 
     ${optionalString stdenv.isAarch32 ''

--- a/pkgs/development/interpreters/tinyscheme/default.nix
+++ b/pkgs/development/interpreters/tinyscheme/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-F7Cxv/0i89SdWDPiKhILM5A50s/aC0bW/FHdLwG0B60=";
   };
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace scheme.c --replace "init.scm" "$out/lib/init.scm"
   '';
 

--- a/pkgs/development/libraries/SDL_gpu/default.nix
+++ b/pkgs/development/libraries/SDL_gpu/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
     "-DSDL_gpu_BUILD_TESTS=OFF"
   ];
 
-  patchPhase = ''
+  postPatch = ''
     sed -ie '210s#''${OUTPUT_DIR}/lib#''${CMAKE_INSTALL_LIBDIR}#' src/CMakeLists.txt
     sed -ie '213s#''${OUTPUT_DIR}/lib#''${CMAKE_INSTALL_LIBDIR}#' src/CMakeLists.txt
   '';

--- a/pkgs/development/libraries/acl/default.nix
+++ b/pkgs/development/libraries/acl/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   # Upstream use C++-style comments in C code. Remove them.
   # This comment breaks compilation if too strict gcc flags are used.
-  patchPhase = ''
+  postPatch = ''
     echo "Removing C++-style comments from include/acl.h"
     sed -e '/^\/\//d' -i include/acl.h
 

--- a/pkgs/development/libraries/audio/zita-convolver/default.nix
+++ b/pkgs/development/libraries/audio/zita-convolver/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ fftwFloat ];
 
-  patchPhase = ''
+  postPatch = ''
     cd source
     sed -e "s@ldconfig@@" -i Makefile
   '';

--- a/pkgs/development/libraries/bash/bash-preexec/default.nix
+++ b/pkgs/development/libraries/bash/bash-preexec/default.nix
@@ -18,7 +18,7 @@ in stdenvNoCC.mkDerivation {
   doCheck = true;
   dontBuild = true;
 
-  patchPhase = ''
+  postPatch = ''
     # Needed since the tests expect that HISTCONTROL is set.
     sed -i '/setup()/a HISTCONTROL=""' test/bash-preexec.bats
 

--- a/pkgs/development/libraries/ctpp2/default.nix
+++ b/pkgs/development/libraries/ctpp2/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  patchPhase = ''
+  postPatch = ''
     # include <unistd.h> to fix undefined getcwd
     sed -ie 's/<stdlib.h>/<stdlib.h>\n#include <unistd.h>/' src/CTPP2FileSourceLoader.cpp
   '';

--- a/pkgs/development/libraries/dclxvi/default.nix
+++ b/pkgs/development/libraries/dclxvi/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
 
   buildFlags = [ "libdclxvipairing.so" ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace Makefile \
       --replace "gcc" "cc"
   '' + lib.optionalString stdenv.isDarwin ''

--- a/pkgs/development/libraries/freenect/default.nix
+++ b/pkgs/development/libraries/freenect/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkg-config ];
 
   # see https://aur.archlinux.org/cgit/aur.git/commit/PKGBUILD?h=libfreenect&id=0d17db49ba64bcb9e3a4eed61cf55c9a5ceb97f1
-  patchPhase = lib.concatMapStrings (x: ''
+  postPatch = lib.concatMapStrings (x: ''
     substituteInPlace ${x} --replace "{GLUT_LIBRARY}" "{GLUT_LIBRARIES}"
   '') [ "examples/CMakeLists.txt" "wrappers/cpp/CMakeLists.txt" ];
 

--- a/pkgs/development/libraries/geis/default.nix
+++ b/pkgs/development/libraries/geis/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     gtk3 libX11 libXext libXi libXtst pango python3Packages.python xorgserver
   ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace python/geis/geis_v2.py --replace \
       "ctypes.util.find_library(\"geis\")" "'$out/lib/libgeis.so'"
   '';

--- a/pkgs/development/libraries/ggz_base_libs/default.nix
+++ b/pkgs/development/libraries/ggz_base_libs/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ intltool openssl expat libgcrypt ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace configure \
       --replace "/usr/local/ssl/include" "${openssl.dev}/include" \
       --replace "/usr/local/ssl/lib" "${lib.getLib openssl}/lib"

--- a/pkgs/development/libraries/glew/1.10.nix
+++ b/pkgs/development/libraries/glew/1.10.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   buildInputs = if stdenv.isDarwin then [ AGL ] else [ xlibsWrapper libXmu libXi ];
   propagatedBuildInputs = if stdenv.isDarwin then [ OpenGL ] else [ libGLU ]; # GL/glew.h includes GL/glu.h
 
-  patchPhase = ''
+  postPatch = ''
     sed -i 's|lib64|lib|' config/Makefile.linux
     ${optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
     sed -i -e 's/\(INSTALL.*\)-s/\1/' Makefile

--- a/pkgs/development/libraries/gsettings-qt/default.nix
+++ b/pkgs/development/libraries/gsettings-qt/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     qtdeclarative
   ];
 
-  patchPhase = ''
+  postPatch = ''
     # force ordered build of subdirs
     sed -i -e "\$aCONFIG += ordered" gsettings-qt.pro
 

--- a/pkgs/development/libraries/gsm/default.nix
+++ b/pkgs/development/libraries/gsm/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     sha256 = "1xkha9ss5g5qnfaybi8il0mcvp8knwg9plgh8404vh58d0pna0s9";
   };
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace Makefile \
       --replace "= gcc " "?= gcc "
     # Fix include directory

--- a/pkgs/development/libraries/hawknl/default.nix
+++ b/pkgs/development/libraries/hawknl/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   makefile = "makefile.linux";
 
-  patchPhase = ''
+  postPatch = ''
     sed -i s/soname,NL/soname,libNL/ src/makefile.linux
   '';
 

--- a/pkgs/development/libraries/incrtcl/default.nix
+++ b/pkgs/development/libraries/incrtcl/default.nix
@@ -11,7 +11,7 @@ tcl.mkTclDerivation rec {
 
   enableParallelBuilding = true;
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace configure --replace "\''${TCL_SRC_DIR}/generic" "${tcl}/include"
   '';
 

--- a/pkgs/development/libraries/iso-codes/default.nix
+++ b/pkgs/development/libraries/iso-codes/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "02lq602ghws423w04jsyjr92p0nmrfp59n1m5hbbi1c6fhxryghc";
   };
 
-  patchPhase = ''
+  postPatch = ''
     for i in `find . -name \*.py`
     do
         sed -i -e "s|#!/usr/bin/env python|#!${python3}/bin/python|" $i

--- a/pkgs/development/libraries/levmar/default.nix
+++ b/pkgs/development/libraries/levmar/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1mxsjip9x782z6qa6k5781wjwpvj5aczrn782m9yspa7lhgfzx1v";
   };
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace levmar.h --replace "define HAVE_LAPACK" "undef HAVE_LAPACK"
     sed -i 's/LAPACKLIBS=.*/LAPACKLIBS=/' Makefile
     substituteInPlace Makefile --replace "gcc" "${stdenv.cc.targetPrefix}cc"

--- a/pkgs/development/libraries/libcec/default.nix
+++ b/pkgs/development/libraries/libcec/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = [ "-DBUILD_SHARED_LIBS=1" ];
 
   # Fix dlopen path
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace include/cecloader.h --replace "libcec.so" "$out/lib/libcec.so"
   '';
 

--- a/pkgs/development/libraries/libclthreads/default.nix
+++ b/pkgs/development/libraries/libclthreads/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0cbs1w89q8wfjrrhvxf6xk0y02nkjl5hd0yb692c8ma01i6b2nf6";
   };
 
-  patchPhase = ''
+  postPatch = ''
     cd source
     # don't run ldconfig:
     sed -e "/ldconfig/d" -i ./Makefile

--- a/pkgs/development/libraries/libclxclient/default.nix
+++ b/pkgs/development/libraries/libclxclient/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = "-I${xorg.xorgproto}/include -I${libXft.dev}/include";
 
-  patchPhase = ''
+  postPatch = ''
     cd source
     # use pkg-config instead of pkgcon:
     sed -e 's/pkgconf/pkg-config/g' -i ./Makefile

--- a/pkgs/development/libraries/libftdi/default.nix
+++ b/pkgs/development/libraries/libftdi/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   # allow async mode. from ubuntu. see:
   #   https://bazaar.launchpad.net/~ubuntu-branches/ubuntu/trusty/libftdi/trusty/view/head:/debian/patches/04_async_mode.diff
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace ./src/ftdi.c \
       --replace "ifdef USB_CLASS_PTP" "if 0"
   '';

--- a/pkgs/development/libraries/libhdhomerun/default.nix
+++ b/pkgs/development/libraries/libhdhomerun/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-HlT/78LUiTkRUB2jHmYrnQY+bBiv4stcZlMyUnelSpc=";
   };
 
-  patchPhase = lib.optionalString stdenv.isDarwin ''
+  postPatch = lib.optionalString stdenv.isDarwin ''
     substituteInPlace Makefile --replace "gcc" "cc"
     substituteInPlace Makefile --replace "-arch i386" ""
   '';

--- a/pkgs/development/libraries/libndctl/default.nix
+++ b/pkgs/development/libraries/libndctl/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
       "--disable-asciidoctor" # depends on ruby 2.7, use asciidoc instead
     ];
 
-  patchPhase = ''
+  postPatch = ''
     patchShebangs test
 
     substituteInPlace git-version --replace /bin/bash ${stdenv.shell}

--- a/pkgs/development/libraries/libpseudo/default.nix
+++ b/pkgs/development/libraries/libpseudo/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0d3pw0m3frycr3x5kzqcaj4r2qh43iv6b0fpd6l4yk0aa4a9560n";
   };
 
-  patchPhase = ''
+  postPatch = ''
     sed -i -e s@/usr/local@$out@ -e /ldconfig/d Makefile
   '';
 

--- a/pkgs/development/libraries/libqalculate/default.nix
+++ b/pkgs/development/libraries/libqalculate/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     intltoolize -f
   '';
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace libqalculate/Calculator-plot.cc \
       --replace 'commandline = "gnuplot"' 'commandline = "${gnuplot}/bin/gnuplot"' \
       --replace '"gnuplot - ' '"${gnuplot}/bin/gnuplot - '

--- a/pkgs/development/libraries/librseq/default.nix
+++ b/pkgs/development/libraries/librseq/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   separateDebugInfo = true;
   enableParallelBuilding = true;
 
-  patchPhase = ''
+  postPatch = ''
     patchShebangs tests
   '';
 

--- a/pkgs/development/libraries/libseccomp/default.nix
+++ b/pkgs/development/libraries/libseccomp/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ gperf ];
   buildInputs = [ getopt ];
 
-  patchPhase = ''
+  postPatch = ''
     patchShebangs .
   '';
 

--- a/pkgs/development/libraries/libvterm/default.nix
+++ b/pkgs/development/libraries/libvterm/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "10gaqygmmwp0cwk3j8qflri5caf8vl3f7pwfl2svw5whv8wkn0k2";
   };
 
-  patchPhase = ''
+  postPatch = ''
     sed -i -e s@/usr@$out@ -e /ldconfig/d Makefile
   '';
 

--- a/pkgs/development/libraries/libx86emu/default.nix
+++ b/pkgs/development/libraries/libx86emu/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ perl ];
 
   postUnpack = "rm $sourceRoot/git2log";
-  patchPhase = ''
+  postPatch = ''
     # VERSION is usually generated using Git
     echo "${version}" > VERSION
     substituteInPlace Makefile --replace "/usr" "/"

--- a/pkgs/development/libraries/physfs/default.nix
+++ b/pkgs/development/libraries/physfs/default.nix
@@ -16,7 +16,7 @@ let
     buildInputs = [ zlib ]
       ++ lib.optionals stdenv.isDarwin [ Foundation Carbon ];
 
-    patchPhase = ''
+    postPatch = ''
       sed s,-Werror,, -i CMakeLists.txt
     '';
 

--- a/pkgs/development/libraries/pmdk/default.nix
+++ b/pkgs/development/libraries/pmdk/default.nix
@@ -19,7 +19,9 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "lib" "dev" "man" ];
 
-  patchPhase = "patchShebangs utils";
+  postPatch = ''
+    patchShebangs utils
+  '';
 
   NIX_CFLAGS_COMPILE = "-Wno-error";
 

--- a/pkgs/development/libraries/ptex/default.nix
+++ b/pkgs/development/libraries/ptex/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec
 
   # Can be removed in the next release
   # https://github.com/wdas/ptex/pull/42
-  patchPhase = ''
+  postPatch = ''
     echo v${version} >version
   '';
 

--- a/pkgs/development/libraries/qmlbox2d/default.nix
+++ b/pkgs/development/libraries/qmlbox2d/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
 
   buildInputs = [ qtdeclarative ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace box2d.pro \
       --replace '$$[QT_INSTALL_QML]' "/$qtQmlPrefix/"
     qmakeFlags="$qmakeFlags PREFIXSHORTCUT=$out"

--- a/pkgs/development/libraries/qt-mobility/default.nix
+++ b/pkgs/development/libraries/qt-mobility/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   # https://bugreports.qt-project.org/browse/QTMOBILITY-1085
   #  - features/mobility.prf (/tmp/nix-build-9kh12nhf9cyplfwiws96gz414v6wgl67-qt-mobility-1.2.0.drv-0/qt-mobility-opensource-src-1.2.0)
 
-  patchPhase = ''
+  postPatch = ''
     # required to make the configure script work
     substituteInPlace configure --replace "/bin/pwd" "${coreutils}/bin/pwd"
 

--- a/pkgs/development/libraries/rep-gtk/default.nix
+++ b/pkgs/development/libraries/rep-gtk/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     librep
   ];
 
-  patchPhase = ''
+  postPatch = ''
     sed -e 's|installdir=$(repexecdir)|installdir=$(libdir)/rep|g' -i Makefile.in
   '';
 

--- a/pkgs/development/libraries/webrtc-audio-processing/0.3.nix
+++ b/pkgs/development/libraries/webrtc-audio-processing/0.3.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ ApplicationServices ]);
 
-  patchPhase = lib.optionalString stdenv.hostPlatform.isMusl ''
+  postPatch = lib.optionalString stdenv.hostPlatform.isMusl ''
     substituteInPlace webrtc/base/checks.cc --replace 'defined(__UCLIBC__)' 1
   '';
 

--- a/pkgs/development/libraries/webrtc-audio-processing/default.nix
+++ b/pkgs/development/libraries/webrtc-audio-processing/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     abseil-cpp_202111
   ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ ApplicationServices ]);
 
-  patchPhase = ''
+  postPatch = ''
     # this is just incorrect upstream
     # see https://gitlab.freedesktop.org/pulseaudio/webrtc-audio-processing/-/issues/4
     substituteInPlace meson.build \

--- a/pkgs/development/libraries/wlroots/protocols.nix
+++ b/pkgs/development/libraries/wlroots/protocols.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   strictDeps = true;
   checkInputs = [ wayland-scanner ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace wlr-protocols.pc.in \
       --replace '=''${pc_sysrootdir}' "=" \
       --replace '=@prefix@' "=$out"

--- a/pkgs/development/libraries/xavs/default.nix
+++ b/pkgs/development/libraries/xavs/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  patchPhase = ''
+  postPatch = ''
     patchShebangs configure
     patchShebangs config.sub
     patchShebangs version.sh

--- a/pkgs/development/misc/rpiboot/default.nix
+++ b/pkgs/development/misc/rpiboot/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ libusb1 ];
 
-  patchPhase = ''
+  postPatch = ''
     sed -i "s@/usr/@$out/@g" main.c
   '';
 

--- a/pkgs/development/octave-modules/fits/default.nix
+++ b/pkgs/development/octave-modules/fits/default.nix
@@ -16,7 +16,7 @@ buildOctavePackage rec {
   };
 
   # Found here: https://build.opensuse.org/package/view_file/science/octave-forge-fits/octave-forge-fits.spec?expand=1
-  patchPhase = ''
+  postPatch = ''
     sed -i -s -e 's/D_NINT/octave::math::x_nint/g' src/*.cc
   '';
 

--- a/pkgs/development/octave-modules/level-set/default.nix
+++ b/pkgs/development/octave-modules/level-set/default.nix
@@ -23,7 +23,7 @@ buildOctavePackage rec {
   # corrected to have a %s format specifier. However, logic_error() also
   # exists, (a simple regex also matches that), but logic_error() doesn't
   # require a format specifier. So, this regex was born to handle that...
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace build.sh --replace "level-set-0.3.1" "${pname}-${version}" \
                                --replace "\`pwd\`" '/build'
     sed -i -E 's#[^[:graph:]]error \(# error \(\"%s\", #g' src/*.cpp

--- a/pkgs/development/octave-modules/octclip/default.nix
+++ b/pkgs/development/octave-modules/octclip/default.nix
@@ -15,7 +15,7 @@ buildOctavePackage rec {
   # The only compilation problem is that no formatting specifier was provided
   # for the error function. Because errorText is a string, I provide such a
   # formatting specifier.
-  patchPhase = ''
+  postPatch = ''
     sed -i s/"error(errorText)"/"error(\"%s\", errorText)"/g src/*.cc
   '';
 

--- a/pkgs/development/octave-modules/octproj/default.nix
+++ b/pkgs/development/octave-modules/octproj/default.nix
@@ -14,7 +14,7 @@ buildOctavePackage rec {
   };
 
   # The sed changes below allow for the package to be compiled.
-  patchPhase = ''
+  postPatch = ''
     sed -i s/"error(errorText)"/"error(\"%s\", errorText)"/g src/*.cc
     sed -i s/"warning(errorText)"/"warning(\"%s\", errorText)"/g src/*.cc
   '';

--- a/pkgs/development/octave-modules/quaternion/default.nix
+++ b/pkgs/development/octave-modules/quaternion/default.nix
@@ -14,7 +14,7 @@ buildOctavePackage rec {
 
   # Octave replaced many of the is_thing_type check function with isthing.
   # The patch changes the occurrences of the old functions.
-  patchPhase = ''
+  postPatch = ''
     sed -i s/is_numeric_type/isnumeric/g src/*.cc
     sed -i s/is_real_type/isreal/g src/*.cc
     sed -i s/is_bool_type/islogical/g src/*.cc

--- a/pkgs/development/octave-modules/strings/default.nix
+++ b/pkgs/development/octave-modules/strings/default.nix
@@ -23,7 +23,7 @@ buildOctavePackage rec {
   # toascii is a deprecated function. Has been fixed in recent commits, but has
   # not been released yet.
   # https://sourceforge.net/p/octave/strings/ci/2db1dbb75557eef94605cb4ac682783ab78ac8d8/
-  patchPhase = ''
+  postPatch = ''
     sed -i -s -e 's/gripes.h/errwarn.h/' -e 's/gripe_/err_/g' src/*.cc
     sed -i s/toascii/double/g inst/*.m
   '';

--- a/pkgs/development/python-modules/aafigure/default.nix
+++ b/pkgs/development/python-modules/aafigure/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   # Fix impurity. TODO: Do the font lookup using fontconfig instead of this
   # manual method. Until that is fixed, we get this whenever we run aafigure:
   #   WARNING: font not found, using PIL default font
-  patchPhase = ''
+  postPatch = ''
     sed -i "s|/usr/share/fonts|/nonexisting-fonts-path|" aafigure/PILhelper.py
   '';
 

--- a/pkgs/development/python-modules/acme-tiny/default.nix
+++ b/pkgs/development/python-modules/acme-tiny/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     sha256 = "378549808eece574c3b5dcea82b216534949423d5c7ac241d9419212d676bc8d";
   };
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace acme_tiny.py --replace '"openssl"' '"${openssl.bin}/bin/openssl"'
     substituteInPlace tests/test_module.py --replace '"openssl"' '"${openssl.bin}/bin/openssl"'
     substituteInPlace tests/utils.py --replace /etc/ssl/openssl.cnf ${openssl.out}/etc/ssl/openssl.cnf

--- a/pkgs/development/python-modules/clf/default.nix
+++ b/pkgs/development/python-modules/clf/default.nix
@@ -10,7 +10,7 @@ buildPythonPackage rec {
     sha256 = "abc919a1e99667f32fdde15dfb4bc527dbe22cf86a17acb78a449d7f2dfe937e";
   };
 
-  patchPhase = ''
+  postPatch = ''
     sed -i 's/==/>=/' requirements.txt
   '';
 

--- a/pkgs/development/python-modules/clldutils/default.nix
+++ b/pkgs/development/python-modules/clldutils/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     sha256 = "07ljq7v1zvaxyl6xn4a2p4097lgd5j9bz71lf05y5bz8k024mxbr";
   };
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace setup.cfg --replace "--cov" ""
   '';
 

--- a/pkgs/development/python-modules/compiledb/default.nix
+++ b/pkgs/development/python-modules/compiledb/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   };
 
   # fix the tests
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace tests/data/multiple_commands_oneline.txt \
                       --replace /bin/echo ${coreutils}/bin/echo
   '';

--- a/pkgs/development/python-modules/csvw/default.nix
+++ b/pkgs/development/python-modules/csvw/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     pytest-mock
   ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace setup.cfg \
       --replace "--cov" ""
   '';

--- a/pkgs/development/python-modules/discid/default.nix
+++ b/pkgs/development/python-modules/discid/default.nix
@@ -9,7 +9,7 @@ buildPythonPackage rec {
     sha256 = "1fc6kvnqwaz9lrs2qgsp8wh0nabf49010r0r53wnsmpmafy315nd";
   };
 
-  patchPhase =
+  postPatch =
     let extension = stdenv.hostPlatform.extensions.sharedLibrary; in
     ''
       substituteInPlace discid/libdiscid.py \

--- a/pkgs/development/python-modules/discordpy/default.nix
+++ b/pkgs/development/python-modules/discordpy/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
     ffmpeg
   ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace "discord/opus.py" \
       --replace "ctypes.util.find_library('opus')" "'${libopus}/lib/libopus.so.0'"
     substituteInPlace requirements.txt \

--- a/pkgs/development/python-modules/dkimpy/default.nix
+++ b/pkgs/development/python-modules/dkimpy/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   checkInputs = [ pytest ];
   propagatedBuildInputs =  [ openssl dnspython pynacl authres ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace dkim/dknewkey.py --replace \
       /usr/bin/openssl ${openssl}/bin/openssl
   '';

--- a/pkgs/development/python-modules/etcd/default.nix
+++ b/pkgs/development/python-modules/etcd/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
     sha256 = "sha256-h+jYIRSNdrGkW3tBV1ifIDEXU46EQGyeJoz/Mxym4pI=";
   };
 
-  patchPhase = ''
+  postPatch = ''
     sed -i -e '13,14d;37d' setup.py
   '';
 

--- a/pkgs/development/python-modules/evdev/default.nix
+++ b/pkgs/development/python-modules/evdev/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
 
   buildInputs = [ linuxHeaders ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace setup.py --replace /usr/include/linux ${linuxHeaders}/include/linux
   '';
 

--- a/pkgs/development/python-modules/flask-assets/default.nix
+++ b/pkgs/development/python-modules/flask-assets/default.nix
@@ -9,7 +9,7 @@ buildPythonPackage rec {
     sha256 = "1dfdea35e40744d46aada72831f7613d67bf38e8b20ccaaa9e91fdc37aa3b8c2";
   };
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace tests/test_integration.py --replace 'static_path=' 'static_url_path='
     substituteInPlace tests/test_integration.py --replace "static_folder = '/'" "static_folder = '/x'"
     substituteInPlace tests/test_integration.py --replace "'/foo'" "'/x/foo'"

--- a/pkgs/development/python-modules/fusepy/default.nix
+++ b/pkgs/development/python-modules/fusepy/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   # On macOS, users are expected to install macFUSE. This means fusepy should
   # be able to find libfuse in /usr/local/lib.
-  patchPhase = lib.optionalString (!stdenv.isDarwin) ''
+  postPatch = lib.optionalString (!stdenv.isDarwin) ''
     substituteInPlace fuse.py --replace \
       "find_library('fuse')" "'${pkgs.fuse}/lib/libfuse.so'"
   '';

--- a/pkgs/development/python-modules/geoip2/default.nix
+++ b/pkgs/development/python-modules/geoip2/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
     sha256 = "sha256-8OgLzoCwa7OL0Iv0h31ahONU6TIJXmzPtNJ7tZj6T4M=";
   };
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace requirements.txt --replace "requests>=2.24.0,<3.0.0" "requests"
   '';
 

--- a/pkgs/development/python-modules/gnureadline/default.nix
+++ b/pkgs/development/python-modules/gnureadline/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   };
 
   buildInputs = [ pkgs.ncurses ];
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace setup.py --replace "/bin/bash" "${pkgs.bash}/bin/bash"
   '';
 

--- a/pkgs/development/python-modules/grammalecte/default.nix
+++ b/pkgs/development/python-modules/grammalecte/default.nix
@@ -14,10 +14,8 @@ buildPythonPackage rec {
     sha256 = "076jv3ywdgqqzg92bfbagc7ypy08xjq5zn4vgna6j9350fkfqhzn";
   };
 
-  patchPhase = ''
-    runHook prePatch
+  postPatch = ''
     substituteInPlace grammalecte-server.py --replace sys.version_info.major sys.version_info
-    runHook postPatch
   '';
 
   propagatedBuildInputs = [ bottle ];

--- a/pkgs/development/python-modules/jaraco_collections/default.nix
+++ b/pkgs/development/python-modules/jaraco_collections/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ six jaraco_classes jaraco_text ];
 
   # break dependency cycle
-  patchPhase = ''
+  postPatch = ''
     sed -i "/'jaraco.text',/d" setup.py
   '';
 }

--- a/pkgs/development/python-modules/kaggle/default.nix
+++ b/pkgs/development/python-modules/kaggle/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   # The version bounds in the setup.py file are unnecessarily restrictive.
   # They have both python-slugify and slugify, don't know why
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace setup.py \
       --replace 'urllib3 >= 1.21.1, < 1.25' 'urllib3' \
       --replace " 'slugify'," " "

--- a/pkgs/development/python-modules/magic/default.nix
+++ b/pkgs/development/python-modules/magic/default.nix
@@ -8,7 +8,7 @@ buildPythonPackage {
 
   src = pkgs.file.src;
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace python/magic.py --replace "find_library('magic')" "'${pkgs.file}/lib/libmagic${stdenv.hostPlatform.extensions.sharedLibrary}'"
   '';
 

--- a/pkgs/development/python-modules/mailchimp/default.nix
+++ b/pkgs/development/python-modules/mailchimp/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   buildInputs = [ docopt ];
   propagatedBuildInputs = [ requests ];
-  patchPhase = ''
+  postPatch = ''
     sed -i 's/==/>=/' setup.py
   '';
 

--- a/pkgs/development/python-modules/meinheld/default.nix
+++ b/pkgs/development/python-modules/meinheld/default.nix
@@ -9,7 +9,7 @@ buildPythonPackage rec {
     sha256 = "008c76937ac2117cc69e032dc69cea9f85fc605de9bac1417f447c41c16a56d6";
   };
 
-  patchPhase = ''
+  postPatch = ''
     # Allow greenlet-1.0.0.
     # See https://github.com/mopemope/meinheld/pull/123
     substituteInPlace setup.py --replace "greenlet>=0.4.5,<0.5" "greenlet>=0.4.5,<2.0.0"

--- a/pkgs/development/python-modules/monotonic/default.nix
+++ b/pkgs/development/python-modules/monotonic/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   __propagatedImpureHostDeps = lib.optional stdenv.isDarwin "/usr/lib/libc.dylib";
 
-  patchPhase = lib.optionalString stdenv.isLinux ''
+  postPatch = lib.optionalString stdenv.isLinux ''
     substituteInPlace monotonic.py --replace \
       "ctypes.util.find_library('c')" "'${stdenv.cc.libc}/lib/libc.so'"
   '';

--- a/pkgs/development/python-modules/napalm/hp-procurve.nix
+++ b/pkgs/development/python-modules/napalm/hp-procurve.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   };
 
   # dependency installation in setup.py doesn't work
-  patchPhase = ''
+  postPatch = ''
     echo -n > requirements.txt
   '';
 

--- a/pkgs/development/python-modules/ofxclient/default.nix
+++ b/pkgs/development/python-modules/ofxclient/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
     sha256 = "0jdhqsbl34yn3n0x6mwsnl58c25v5lp6vr910c2hk7l74l5y7538";
   };
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace setup.py --replace '"argparse",' ""
   '';
 

--- a/pkgs/development/python-modules/podcats/default.nix
+++ b/pkgs/development/python-modules/podcats/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
     sha256 = "0zjdgry5n209rv19kj9yaxy7c7zq5gxr488izrgs4sc75vdzz8xc";
   };
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace podcats.py \
       --replace 'debug=True' 'debug=True, use_reloader=False'
   '';

--- a/pkgs/development/python-modules/pyads/default.nix
+++ b/pkgs/development/python-modules/pyads/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     adslib
   ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace pyads/pyads_ex.py \
       --replace "ctypes.CDLL(adslib)" "ctypes.CDLL(\"${adslib}/lib/adslib.so\")"
   '';

--- a/pkgs/development/python-modules/pyopengl/default.nix
+++ b/pkgs/development/python-modules/pyopengl/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ pillow ];
 
-  patchPhase = let
+  postPatch = let
     ext = stdenv.hostPlatform.extensions.sharedLibrary; in ''
     # Theses lines are patching the name of dynamic libraries
     # so pyopengl can find them at runtime.

--- a/pkgs/development/python-modules/pytest-ansible/default.nix
+++ b/pkgs/development/python-modules/pytest-ansible/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     sha256 = "0vr015msciwzz20zplxalfmfx5hbg8rkf8vwjdg3z12fba8z8ks4";
   };
 
-  patchPhase = ''
+  postPatch = ''
     sed -i "s/'setuptools-markdown'//g" setup.py
   '';
 

--- a/pkgs/development/python-modules/python-gnupg/default.nix
+++ b/pkgs/development/python-modules/python-gnupg/default.nix
@@ -10,7 +10,7 @@ buildPythonPackage rec {
   };
 
   # Let's make the library default to our gpg binary
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace gnupg.py \
     --replace "gpgbinary='gpg'" "gpgbinary='${gnupg}/bin/gpg'"
     substituteInPlace test_gnupg.py \

--- a/pkgs/development/python-modules/pythondialog/default.nix
+++ b/pkgs/development/python-modules/pythondialog/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
     sha256 = "b2a34a8af0a6625ccbdf45cd343b854fc6c1a85231dadc80b8805db836756323";
   };
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace dialog.py --replace ":/bin:/usr/bin" ":$out/bin"
   '';
 

--- a/pkgs/development/python-modules/pyverilog/default.nix
+++ b/pkgs/development/python-modules/pyverilog/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.7";
 
-  patchPhase = ''
+  postPatch = ''
     # The path to Icarus can still be overridden via an environment variable at runtime.
     substituteInPlace pyverilog/vparser/preprocessor.py \
       --replace "iverilog = 'iverilog'" "iverilog = '${verilog}/bin/iverilog'"

--- a/pkgs/development/python-modules/requests-mock/default.nix
+++ b/pkgs/development/python-modules/requests-mock/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     sha256 = "8d72abe54546c1fc9696fa1516672f1031d72a55a1d66c85184f972a24ba0eba";
   };
 
-  patchPhase = ''
+  postPatch = ''
     sed -i 's@python@${python.interpreter}@' .testr.conf
   '';
 

--- a/pkgs/development/python-modules/requestsexceptions/default.nix
+++ b/pkgs/development/python-modules/requestsexceptions/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ pbr ];
 
   # upstream hacking package is not required for functional testing
-  patchPhase = ''
+  postPatch = ''
     sed -i '/^hacking/d' test-requirements.txt
   '';
 

--- a/pkgs/development/python-modules/segments/default.nix
+++ b/pkgs/development/python-modules/segments/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     sha256 = "04yc8q79zk09xj0wnal0vdg5azi9jlarfmf2iyljqyr80p79gwvv";
   };
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace setup.cfg --replace "--cov" ""
   '';
 

--- a/pkgs/development/python-modules/sigtools/default.nix
+++ b/pkgs/development/python-modules/sigtools/default.nix
@@ -20,7 +20,9 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ funcsigs six ];
 
-  patchPhase = ''sed -i s/test_suite="'"sigtools.tests"'"/test_suite="'"unittest2.collector"'"/ setup.py'';
+  postPatch = ''
+    sed -i s/test_suite="'"sigtools.tests"'"/test_suite="'"unittest2.collector"'"/ setup.py
+  '';
 
   # repeated_test no longer exists in nixpkgs
   # Also see: https://github.com/epsy/sigtools/issues/26

--- a/pkgs/development/python-modules/solo-python/default.nix
+++ b/pkgs/development/python-modules/solo-python/default.nix
@@ -26,7 +26,7 @@
     sha256 = "sha256-OguAHeNpom+zthREzdhejy5HJUIumrtwB0WJAwUNiSA=";
   };
 
-  patchPhase = ''
+  postPatch = ''
     sed -i '/fido2/c\"fido2",' pyproject.toml
   '';
 

--- a/pkgs/development/python-modules/sparqlwrapper/default.nix
+++ b/pkgs/development/python-modules/sparqlwrapper/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   };
 
   # break circular dependency loop
-  patchPhase = ''
+  postPatch = ''
     sed -i '/rdflib/d' setup.cfg
   '';
 

--- a/pkgs/development/python-modules/statsd/default.nix
+++ b/pkgs/development/python-modules/statsd/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   checkInputs = [ nose mock ];
 
-  patchPhase = ''
+  postPatch = ''
     # Failing test: ERROR: statsd.tests.test_ipv6_resolution_udp
     sed -i 's/test_ipv6_resolution_udp/noop/' statsd/tests.py
     # well this is a noop, but so it was before

--- a/pkgs/development/python-modules/telethon/default.nix
+++ b/pkgs/development/python-modules/telethon/default.nix
@@ -10,7 +10,7 @@ buildPythonPackage rec {
     sha256 = "818cb61281ed3f75ba4da9b68cb69486bed9474d2db4e0aa16e482053117452c";
   };
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace telethon/crypto/libssl.py --replace \
       "ctypes.util.find_library('ssl')" "'${lib.getLib openssl}/lib/libssl.so'"
   '';

--- a/pkgs/development/python-modules/txgithub/default.nix
+++ b/pkgs/development/python-modules/txgithub/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ pyopenssl twisted service-identity ];
 
   # fix python3 issues
-  patchPhase = ''
+  postPatch = ''
     sed -i 's/except usage.UsageError, errortext/except usage.UsageError as errortext/' txgithub/scripts/create_token.py
     sed -i 's/except usage.UsageError, errortext/except usage.UsageError as errortext/' txgithub/scripts/gist.py
     sed -i 's/print response\[\x27html_url\x27\]/print(response\[\x27html_url\x27\])/' txgithub/scripts/gist.py

--- a/pkgs/development/python-modules/websockets/default.nix
+++ b/pkgs/development/python-modules/websockets/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   # Tests fail on Darwin with `OSError: AF_UNIX path too long`
   doCheck = !stdenv.isDarwin;
 
-  patchPhase = ''
+  postPatch = ''
     # Disable all tests that need to terminate within a predetermined amount of
     # time. This is nondeterministic.
     sed -i 's/with self.assertCompletesWithin.*:/if True:/' \

--- a/pkgs/development/python-modules/xcffib/default.nix
+++ b/pkgs/development/python-modules/xcffib/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     sha256 = "12949cfe2e68c806efd57596bb9bf3c151f399d4b53e15d1101b2e9baaa66f5a";
   };
 
-  patchPhase = ''
+  postPatch = ''
     # Hardcode cairo library path
     sed -e 's,ffi\.dlopen(,&"${xorg.libxcb.out}/lib/" + ,' -i xcffib/__init__.py
   '';

--- a/pkgs/development/python-modules/ydiff/default.nix
+++ b/pkgs/development/python-modules/ydiff/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
     sha256 = "f5430577ecd30974d766ee9b8333e06dc76a947b4aae36d39612a0787865a121";
   };
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace ydiff.py \
       --replace "['git'" "['${gitMinimal}/bin/git'" \
       --replace "['hg'" "['${mercurial}/bin/hg'" \

--- a/pkgs/development/python2-modules/pysqlite/default.nix
+++ b/pkgs/development/python2-modules/pysqlite/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   # it a propagated input.
   propagatedBuildInputs = [ pkgs.sqlite ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace "setup.cfg"                                     \
             --replace "/usr/local/include" "${pkgs.sqlite.dev}/include"   \
             --replace "/usr/local/lib" "${pkgs.sqlite.out}/lib"

--- a/pkgs/development/tools/abuild/default.nix
+++ b/pkgs/development/tools/abuild/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     file
   ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace ./Makefile \
       --replace 'chmod 4555' '#chmod 4555'
   '';

--- a/pkgs/development/tools/analysis/valkyrie/default.nix
+++ b/pkgs/development/tools/analysis/valkyrie/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0hwvsncf62mdkahwj9c8hpmm94c1wr5jn89370k6rj894kxry2x7";
   };
 
-  patchPhase = ''
+  postPatch = ''
     sed -i '1s;^;#include <unistd.h>\n;' src/objects/tool_object.cpp
     sed -i '1s;^;#include <unistd.h>\n;' src/utils/vk_config.cpp
     sed -i '1s;^;#include <sys/types.h>\n;' src/utils/vk_config.cpp

--- a/pkgs/development/tools/dapper/default.nix
+++ b/pkgs/development/tools/dapper/default.nix
@@ -15,7 +15,7 @@ buildGoModule rec {
   };
   vendorSha256 = null;
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace main.go --replace 0.0.0 ${version}
   '';
 

--- a/pkgs/development/tools/hexio/default.nix
+++ b/pkgs/development/tools/hexio/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ pcsclite pth python2 ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace Makefile \
       --replace '-I/usr/local/include/PCSC/' '-I${lib.getDev pcsclite}/include/PCSC/' \
       --replace '-L/usr/local/lib/pth' '-I${pth}/lib/'

--- a/pkgs/development/tools/literate-programming/nuweb/default.nix
+++ b/pkgs/development/tools/literate-programming/nuweb/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ tex ];
 
-  patchPhase = ''
+  postPatch = ''
     sed -ie 's|nuweb -r|./nuweb -r|' Makefile
   '';
 

--- a/pkgs/development/tools/misc/abi-dumper/default.nix
+++ b/pkgs/development/tools/misc/abi-dumper/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1i00rfnddrrb9lb1l6ib19g3a76pyasl9lb7rqz2p998gav1gjp2";
   };
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace abi-dumper.pl \
       --replace eu-readelf ${elfutils}/bin/eu-readelf \
       --replace vtable-dumper ${vtable-dumper}/bin/vtable-dumper \

--- a/pkgs/development/tools/misc/cflow/default.nix
+++ b/pkgs/development/tools/misc/cflow/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-0BFGyvkAHiZhM0F8KoJYpktfwW/LCCoU9lKCBNDJcIY=";
   };
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace "src/cflow.h"					\
       --replace "/usr/bin/cpp"						\
                 "$(cat ${stdenv.cc}/nix-support/orig-cc)/bin/cpp"

--- a/pkgs/development/tools/misc/premake/5.nix
+++ b/pkgs/development/tools/misc/premake/5.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = optionals stdenv.isDarwin [ Foundation readline ];
 
-  patchPhase = optional stdenv.isDarwin ''
+  postPatch = optional stdenv.isDarwin ''
     substituteInPlace premake5.lua \
       --replace -mmacosx-version-min=10.4 -mmacosx-version-min=10.5
   '';

--- a/pkgs/development/tools/misc/sloccount/default.nix
+++ b/pkgs/development/tools/misc/sloccount/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   # Make sure the Flex-generated files are newer than the `.l' files, so that
   # Flex isn't needed to recompile them.
-  patchPhase = ''
+  postPatch = ''
     for file in *
     do
       if grep -q /usr/bin/perl "$file"

--- a/pkgs/development/tools/misc/tet/default.nix
+++ b/pkgs/development/tools/misc/tet/default.nix
@@ -11,7 +11,9 @@ stdenv.mkDerivation ({
 
   buildInputs = [ ];
 
-  patchPhase = "chmod +x configure";
+  postPatch = ''
+    chmod +x configure
+  '';
 
   configurePhase = "./configure -t lite";
 

--- a/pkgs/development/tools/pgformatter/default.nix
+++ b/pkgs/development/tools/pgformatter/default.nix
@@ -19,7 +19,7 @@ perlPackages.buildPerlPackage rec {
   installTargets = [ "pure_install" ];
 
   # Makefile.PL only accepts DESTDIR and INSTALLDIRS, but we need to set more to make this work for NixOS.
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace pg_format \
       --replace "#!/usr/bin/env perl" "#!/usr/bin/perl"
     substituteInPlace Makefile.PL \

--- a/pkgs/development/tools/sauce-connect/default.nix
+++ b/pkgs/development/tools/sauce-connect/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ unzip ];
 
-  patchPhase = lib.optionalString stdenv.isLinux ''
+  postPatch = lib.optionalString stdenv.isLinux ''
     patchelf \
       --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
       --set-rpath "$out/lib:${makeLibraryPath [zlib]}" \

--- a/pkgs/development/web/kcgi/default.nix
+++ b/pkgs/development/web/kcgi/default.nix
@@ -11,8 +11,8 @@ stdenv.mkDerivation rec {
     rev = "VERSION_${underscoreVersion}";
     sha256 = "0ha6r7bcgf6pcn5gbd2sl7835givhda1jql49c232f1iair1yqyp";
   };
-  patchPhase = ''substituteInPlace configure \
-    --replace /usr/local /
+  postPatch = ''
+    substituteInPlace configure --replace /usr/local /
   '';
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/games/20kly/default.nix
+++ b/pkgs/games/20kly/default.nix
@@ -16,7 +16,7 @@ python3Packages.buildPythonApplication rec {
     sha256 = "1zxsxg49a02k7zidx3kgk2maa0vv0n1f9wrl5vch07sq3ghvpphx";
   };
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace lightyears \
       --replace \
         "LIGHTYEARS_DIR = \".\"" \

--- a/pkgs/games/alienarena/default.nix
+++ b/pkgs/games/alienarena/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libjpeg libX11 curl libogg libvorbis
                   freetype openal libGL libXxf86vm ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace ./configure \
       --replace libopenal.so.1 ${openal}/lib/libopenal.so.1 \
       --replace libGL.so.1 ${libGL}/lib/libGL.so.1

--- a/pkgs/games/among-sus/default.nix
+++ b/pkgs/games/among-sus/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
     sha256 = "0j1158nczhvy5i1ykvzvhlv4ndhibgng0dq1lw2bmi8q6k1q1s0w";
   };
 
-  patchPhase = ''
+  postPatch = ''
     sed -i 's/port = 1234/port = ${port}/g' main.c
   '';
 

--- a/pkgs/games/colobot/data.nix
+++ b/pkgs/games/colobot/data.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = false;
   # Build procedure requires the data folder
-  patchPhase = ''
+  postPatch = ''
     cp -r $src localSrc
     chmod +w localSrc/help/bots/po
     find -type d -exec chmod +w {} \;

--- a/pkgs/games/dhewm3/default.nix
+++ b/pkgs/games/dhewm3/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   # Add libGLU libGL linking
-  patchPhase = ''
+  postPatch = ''
     sed -i 's/\<idlib\()\?\)$/idlib GL\1/' neo/CMakeLists.txt
   '';
 

--- a/pkgs/games/egoboo/default.nix
+++ b/pkgs/games/egoboo/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     I keep it here for future updates.
 
     # Some files have to go to $HOME, but we put them in the 'shared'.
-    patchPhase = ''
+    postPatch = ''
       sed -i -e 's,''${HOME}/.''${PROJ_NAME},''${PREFIX}/share/games/''${PROJ_NAME},g' Makefile
     '';
 

--- a/pkgs/games/galaxis/default.nix
+++ b/pkgs/games/galaxis/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ncurses xmlto ];
 
-  patchPhase = ''
+  postPatch = ''
     sed -i\
      -e 's|^install: galaxis\.6 uninstall|install: galaxis.6|'\
      -e 's|usr/||g' -e 's|ROOT|DESTDIR|g'\

--- a/pkgs/games/newtonwars/default.nix
+++ b/pkgs/games/newtonwars/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ freeglut libGL libGLU ];
 
-  patchPhase = ''
+  postPatch = ''
     sed -i "s;font24.raw;$out/share/font24.raw;g" display.c
   '';
 

--- a/pkgs/games/oilrush/default.nix
+++ b/pkgs/games/oilrush/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
     cd oilrush
     "$shell" "$src" --tar xf
   '';
-  patchPhase = ''
+  postPatch = ''
     cd bin
     for f in launcher_$arch libQtCoreUnigine_$arch.so.4 OilRush_$arch
     do

--- a/pkgs/games/openlierox/default.nix
+++ b/pkgs/games/openlierox/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     cmakeFlags="$cmakeFlags -DSYSTEM_DATA_DIR=$out/share"
   '';
 
-  patchPhase = ''
+  postPatch = ''
     sed -i s,curl/types.h,curl/curl.h, include/HTTP.h src/common/HTTP.cpp
   '';
 

--- a/pkgs/games/pentobi/default.nix
+++ b/pkgs/games/pentobi/default.nix
@@ -16,7 +16,7 @@ mkDerivation rec {
   nativeBuildInputs = [ cmake docbook_xsl qttools ];
   buildInputs = [ appstream qtbase qtsvg qtquickcontrols2 qtwebview itstool librsvg ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace pentobi_thumbnailer/CMakeLists.txt --replace "/manpages" "/share/xml/docbook-xsl/manpages/"
     substituteInPlace pentobi/unix/CMakeLists.txt --replace "/manpages" "/share/xml/docbook-xsl/manpages/"
     substituteInPlace pentobi/docbook/CMakeLists.txt --replace "/html" "/share/xml/docbook-xsl/html"

--- a/pkgs/games/teetertorture/default.nix
+++ b/pkgs/games/teetertorture/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     sed -i s,data/,$out/share/teetertorture/, src/teetertorture.c
   '';
 
-  patchPhase = ''
+  postPatch = ''
     sed -i '/free(home)/d' src/teetertorture.c
   '';
 

--- a/pkgs/games/xconq/default.nix
+++ b/pkgs/games/xconq/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
-  patchPhase = ''
+  postPatch = ''
     # Fix Makefiles
     find . -name 'Makefile.in' -exec sed -re 's@^        ( *)(cd|[&][&])@	\1\2@' -i '{}' ';'
     find . -name 'Makefile.in' -exec sed -e '/chown/d; /chgrp/d' -i '{}' ';'

--- a/pkgs/games/xtris/default.nix
+++ b/pkgs/games/xtris/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "1vqva99lyv7r6f9c7yikk8ahcfh9aq3clvwm4pz964wlbr9mj1v6";
   };
 
-  patchPhase = ''
+  postPatch = ''
     sed -i '
       s:/usr/local/bin:'$out'/bin:
       s:/usr/local/man:'$out'/share/man:

--- a/pkgs/misc/cups/drivers/brgenml1cupswrapper/default.nix
+++ b/pkgs/misc/cups/drivers/brgenml1cupswrapper/default.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
 
   dontBuild = true;
 
-  patchPhase = ''
+  postPatch = ''
     WRAPPER=opt/brother/Printers/BrGenML1/cupswrapper/brother_lpdwrapper_BrGenML1
     PAPER_CFG=opt/brother/Printers/BrGenML1/cupswrapper/paperconfigml1
 

--- a/pkgs/misc/cups/drivers/brgenml1lpr/default.nix
+++ b/pkgs/misc/cups/drivers/brgenml1lpr/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
 
   dontBuild = true;
 
-  patchPhase = ''
+  postPatch = ''
     INFDIR=opt/brother/Printers/BrGenML1/inf
     LPDDIR=opt/brother/Printers/BrGenML1/lpd
 

--- a/pkgs/misc/cups/drivers/estudio/default.nix
+++ b/pkgs/misc/cups/drivers/estudio/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
 
   buildInputs = [ perl ];
 
-  patchPhase = ''
+  postPatch = ''
     patchShebangs lib/
     gunzip                share/cups/model/Toshiba/TOSHIBA_ColorMFP_CUPS.gz
     sed -i "s+/usr+$out+" share/cups/model/Toshiba/TOSHIBA_ColorMFP_CUPS

--- a/pkgs/misc/cups/drivers/mfcj470dwcupswrapper/default.nix
+++ b/pkgs/misc/cups/drivers/mfcj470dwcupswrapper/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ mfcj470dwlpr ];
 
-  patchPhase = ''
+  postPatch = ''
     WRAPPER=cupswrapper/cupswrappermfcj470dw
 
     substituteInPlace $WRAPPER \

--- a/pkgs/misc/drivers/moltengamepad/default.nix
+++ b/pkgs/misc/drivers/moltengamepad/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
     cp moltengamepad $out/bin
   '';
 
-  patchPhase = ''
+  postPatch = ''
     sed -i -e '159d;161d;472d;473d;474d;475d' source/eventlists/key_list.cpp
   '';
 

--- a/pkgs/misc/sailsd/default.nix
+++ b/pkgs/misc/sailsd/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     chmod 755 -R $sourceRoot/libsailing
   '';
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace Makefile \
       --replace gcc cc
   '';

--- a/pkgs/misc/screensavers/i3lock-pixeled/default.nix
+++ b/pkgs/misc/screensavers/i3lock-pixeled/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     "PREFIX=$(out)/bin"
   ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace i3lock-pixeled \
        --replace i3lock    "${i3lock}/bin/i3lock" \
        --replace convert   "${imagemagick}/bin/convert" \

--- a/pkgs/os-specific/linux/915resolution/default.nix
+++ b/pkgs/os-specific/linux/915resolution/default.nix
@@ -9,7 +9,10 @@ stdenv.mkDerivation rec {
     sha256 = "0hmmy4kkz3x6yigz6hk99416ybznd67dpjaxap50nhay9f1snk5n";
   };
 
-  patchPhase = "rm *.o";
+  postPatch = ''
+    rm *.o
+  '';
+
   installPhase = "mkdir -p $out/sbin; cp 915resolution $out/sbin/";
 
   meta = with lib; {

--- a/pkgs/os-specific/linux/alsa-project/alsa-tools/default.nix
+++ b/pkgs/os-specific/linux/alsa-project/alsa-tools/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ alsa-lib gtk2 gtk3 fltk13 ];
 
-  patchPhase = ''
+  postPatch = ''
     export tools="as10k1 hda-verb hdspmixer echomixer hdajackretask hdspconf hwmixvolume mixartloader rmedigicontrol sscape_ctl vxloader envy24control hdajacksensetest hdsploader ld10k1 pcxhrloader sb16_csp us428control"
     # export tools="as10k1 hda-verb hdspmixer qlo10k1 seq usx2yloader echomixer hdajackretask hdspconf hwmixvolume mixartloader rmedigicontrol sscape_ctl vxloader envy24control hdajacksensetest hdsploader ld10k1 pcxhrloader sb16_csp us428control"
   '';

--- a/pkgs/os-specific/linux/anbox/default.nix
+++ b/pkgs/os-specific/linux/anbox/default.nix
@@ -85,7 +85,7 @@ stdenv.mkDerivation rec {
     systemd
   ];
 
-  patchPhase = ''
+  postPatch = ''
     patchShebangs scripts
 
     cat >cmake/FindGMock.cmake <<'EOF'

--- a/pkgs/os-specific/linux/beefi/default.nix
+++ b/pkgs/os-specific/linux/beefi/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     systemd
   ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace beefi \
       --replace objcopy ${binutils-unwrapped}/bin/objcopy \
       --replace /usr/lib/systemd ${systemd}/lib/systemd

--- a/pkgs/os-specific/linux/cpufrequtils/default.nix
+++ b/pkgs/os-specific/linux/cpufrequtils/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     ./remove-pot-creation-date.patch
   ];
 
-  patchPhase = ''
+  postPatch = ''
     sed -e "s@= /usr/bin/@= @g" \
       -e "s@/usr/@$out/@" \
       -i Makefile

--- a/pkgs/os-specific/linux/cpuid/default.nix
+++ b/pkgs/os-specific/linux/cpuid/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   # The Makefile hardcodes $(BUILDROOT)/usr as installation
   # destination. Just nuke all mentions of /usr to get the right
   # installation location.
-  patchPhase = ''
+  postPatch = ''
     sed -i -e 's,/usr/,/,' Makefile
   '';
 

--- a/pkgs/os-specific/linux/intel-ocl/default.nix
+++ b/pkgs/os-specific/linux/intel-ocl/default.nix
@@ -32,9 +32,7 @@ stdenv.mkDerivation rec {
     rpmextract source/intel-opencl-cpu-r${version}.x86_64.rpm
   '';
 
-  patchPhase = ''
-    runHook prePatch
-
+  postPatch = ''
     # Remove libOpenCL.so, since we use ocl-icd's libOpenCL.so instead and this would cause a clash.
     rm opt/intel/opencl/libOpenCL.so*
 
@@ -42,8 +40,6 @@ stdenv.mkDerivation rec {
     for lib in opt/intel/opencl/*.so; do
       patchelf --set-rpath "${libPath}:$out/lib/intel-ocl" $lib || true
     done
-
-    runHook postPatch
   '';
 
   buildPhase = ''

--- a/pkgs/os-specific/linux/lightum/default.nix
+++ b/pkgs/os-specific/linux/lightum/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
     systemd
   ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace Makefile \
       --replace "libsystemd-login" "libsystemd"
   '';

--- a/pkgs/os-specific/linux/otpw/default.nix
+++ b/pkgs/os-specific/linux/otpw/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1k3hc7xbxz6hkc55kvddi3cibafwf93ivn58sy1l888d3l5dwmrk";
   };
 
-  patchPhase = ''
+  postPatch = ''
     sed -i 's/^CFLAGS.*/CFLAGS=-O2 -fPIC/' Makefile
     sed -i -e 's,PATH=.*;,,' conf.h
     sed -i -e '/ENTROPY_ENV/d' otpw-gen.c

--- a/pkgs/os-specific/linux/pam_ccreds/default.nix
+++ b/pkgs/os-specific/linux/pam_ccreds/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     url = "https://www.padl.com/download/pam_ccreds-${version}.tar.gz";
     sha256 = "1h7zyg1b1h69civyvrj95w22dg0y7lgw3hq4gqkdcg35w1y76fhz";
   };
-  patchPhase = ''
+  postPatch = ''
     sed 's/-o root -g root//' -i Makefile.in
   '';
 

--- a/pkgs/os-specific/linux/pcmciautils/default.nix
+++ b/pkgs/os-specific/linux/pcmciautils/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [udev bison sysfsutils kmod flex];
 
-  patchPhase = ''
+  postPatch = ''
     sed -i "
       s,/sbin/modprobe,${kmod}&,;
       s,/lib/udev/,$out/sbin/,;

--- a/pkgs/os-specific/linux/perf-tools/default.nix
+++ b/pkgs/os-specific/linux/perf-tools/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
 
   buildInputs = [ perl ];
 
-  patchPhase =
+  postPatch =
     ''
       for i in execsnoop iolatency iosnoop kernel/funcslower killsnoop opensnoop; do
         substituteInPlace $i \

--- a/pkgs/os-specific/linux/radeontop/default.nix
+++ b/pkgs/os-specific/linux/radeontop/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace getver.sh --replace ver=unknown ver=${version}
     substituteInPlace Makefile --replace pkg-config "$PKG_CONFIG"
   '';

--- a/pkgs/os-specific/linux/tuna/default.nix
+++ b/pkgs/os-specific/linux/tuna/default.nix
@@ -22,7 +22,7 @@ buildPythonApplication rec {
     sha256 = "sha256-lRHlbdCQ0NcjcWgLvCze67kN8NsK0f5RmKfPbkHhk78=";
   };
 
-  patchPhase = ''
+  postPatch = ''
     mv tuna-cmd.py tuna/cmd.py
 
     substituteInPlace setup.py \

--- a/pkgs/os-specific/linux/v86d/default.nix
+++ b/pkgs/os-specific/linux/v86d/default.nix
@@ -18,7 +18,7 @@ in stdenv.mkDerivation rec {
     hash = "sha256-95LRzVbO/DyddmPwQNNQ290tasCGoQk7FDHlst6LkbA=";
   };
 
-  patchPhase = ''
+  postPatch = ''
     patchShebangs configure
   '';
 

--- a/pkgs/servers/dns/nsd/default.nix
+++ b/pkgs/servers/dns/nsd/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
           "--with-configdir=etc/nsd"
         ];
 
-  patchPhase = ''
+  postPatch = ''
     sed 's@$(INSTALL_DATA) nsd.conf.sample $(DESTDIR)$(nsdconfigfile).sample@@g' -i Makefile.in
   '';
 

--- a/pkgs/servers/foundationdb/python.nix
+++ b/pkgs/servers/foundationdb/python.nix
@@ -7,7 +7,7 @@ buildPythonPackage {
   src = foundationdb.pythonsrc;
   unpackCmd = "tar xf $curSrc";
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace ./fdb/impl.py \
       --replace libfdb_c.so "${foundationdb.lib}/lib/libfdb_c.so"
   '';

--- a/pkgs/servers/http/apache-modules/mod_wsgi/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_wsgi/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ apacheHttpd python ncurses ];
 
-  patchPhase = ''
+  postPatch = ''
     sed -r -i -e "s|^LIBEXECDIR=.*$|LIBEXECDIR=$out/modules|" \
       ${if stdenv.isDarwin then "-e 's|/usr/bin/lipo|lipo|'" else ""} \
       configure

--- a/pkgs/servers/icingaweb2/theme-snow/default.nix
+++ b/pkgs/servers/icingaweb2/theme-snow/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "1c974v85mbsis52y2knwzh33996q8sza7pqrcs6ydx033s0rxjrp";
   };
 
-  patchPhase = ''
+  postPatch = ''
     # Module info contains some fancy ascii art which breaks the module list
 
     awk -i inplace 'BEGIN {empty=0;write=1;}{if ($0 == ""){empty++;};if(empty==2){write=0};if (write==1){print $0}}' module.info

--- a/pkgs/servers/klipper/default.nix
+++ b/pkgs/servers/klipper/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   # 2022-06-28: Python 3 is already supported in klipper, alas shebangs remained
   # the same - we replace them in patchPhase.
-  patchPhase = ''
+  postPatch = ''
     for F in klippy.py console.py parsedump.py; do
       substituteInPlace $F \
         --replace '/usr/bin/env python2' '/usr/bin/env python'

--- a/pkgs/servers/misc/taskserver/default.nix
+++ b/pkgs/servers/misc/taskserver/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1d110q9vw8g5syzihxymik7hd27z1592wkpz55kya6lphzk8i13v";
   };
 
-  patchPhase = ''
+  postPatch = ''
     pkipath=$out/share/taskd/pki
     mkdir -p $pkipath
     cp -r pki/* $pkipath

--- a/pkgs/servers/uftp/default.nix
+++ b/pkgs/servers/uftp/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "man" ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace makefile --replace gcc cc
   '';
 

--- a/pkgs/servers/web-apps/shaarli/default.nix
+++ b/pkgs/servers/web-apps/shaarli/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "doc" ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace index.php \
       --replace "new ConfigManager();" "new ConfigManager(getenv('SHAARLI_CONFIG'));"
   '';

--- a/pkgs/tools/X11/ckbcomp/default.nix
+++ b/pkgs/tools/X11/ckbcomp/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ perl ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace Keyboard/ckbcomp --replace "/usr/share/X11/xkb" "${xkeyboard_config}/share/X11/xkb"
     substituteInPlace Keyboard/ckbcomp --replace "rules = 'xorg'" "rules = 'base'"
   '';

--- a/pkgs/tools/X11/nitrogen/default.nix
+++ b/pkgs/tools/X11/nitrogen/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ glib gtkmm2 ];
 
-  patchPhase = ''
+  postPatch = ''
     patchShebangs data/icon-theme-installer
   '';
 

--- a/pkgs/tools/X11/sselp/default.nix
+++ b/pkgs/tools/X11/sselp/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libX11 ];
 
-  patchPhase = ''
+  postPatch = ''
     sed -i "s@/usr/local@$out@g" config.mk
     sed -i "s@/usr/X11R6/include@${libX11}/include@g" config.mk
     sed -i "s@/usr/X11R6/lib@${libX11}/lib@g" config.mk

--- a/pkgs/tools/archivers/zip/default.nix
+++ b/pkgs/tools/archivers/zip/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     ];
     sha256 = "0sb3h3067pzf3a7mlxn1hikpcjrsvycjcnj9hl9b1c3ykcgvps7h";
   };
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace unix/Makefile --replace 'CC = cc' ""
   '';
 

--- a/pkgs/tools/audio/nanotts/default.nix
+++ b/pkgs/tools/audio/nanotts/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ autoconf automake libtool ];
   buildInputs = [ popt alsaLib ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace "src/main.cpp" --replace "/usr/share/pico/lang" "$out/share/lang"
     echo "" > update_build_version.sh
   '';

--- a/pkgs/tools/audio/patray/default.nix
+++ b/pkgs/tools/audio/patray/default.nix
@@ -12,7 +12,7 @@ python3.pkgs.buildPythonApplication rec {
     sha256 = "0vaapn2p4257m1d5nbnwnh252b7lhl00560gr9pqh2b7xqm1bh6g";
   };
 
-  patchPhase = ''
+  postPatch = ''
     sed -i '30i entry_points = { "console_scripts": [ "patray = patray.__main__:main" ] },' setup.py
     sed -i 's/production.txt/production.in/' setup.py
     sed -i '/pyside2/d' requirements/production.in

--- a/pkgs/tools/backup/rsnapshot/default.nix
+++ b/pkgs/tools/backup/rsnapshot/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--sysconfdir=/etc --prefix=/" ];
   makeFlags = [ "DESTDIR=$(out)" ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace "Makefile.in" --replace \
       "/usr/bin/pod2man" "${perl}/bin/pod2man"
   '';

--- a/pkgs/tools/backup/tarsnap/default.nix
+++ b/pkgs/tools/backup/tarsnap/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     configureFlags="--with-bash-completion-dir=$out/share/bash-completion/completions"
   '';
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace Makefile.in \
       --replace "command -p mv" "mv"
     substituteInPlace configure \

--- a/pkgs/tools/bluetooth/openobex/default.nix
+++ b/pkgs/tools/bluetooth/openobex/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--enable-apps" ];
 
-  patchPhase = ''
+  postPatch = ''
     sed -i "s!/lib/udev!$out/lib/udev!" udev/CMakeLists.txt
     sed -i "/if ( PKGCONFIG_UDEV_FOUND )/,/endif ( PKGCONFIG_UDEV_FOUND )/d" udev/CMakeLists.txt
     '';

--- a/pkgs/tools/filesystems/dduper/default.nix
+++ b/pkgs/tools/filesystems/dduper/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     py3
   ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace ./dduper --replace "/usr/sbin/btrfs.static" "${btrfsProgsPatched}/bin/btrfs"
   '';
 

--- a/pkgs/tools/filesystems/extundelete/default.nix
+++ b/pkgs/tools/filesystems/extundelete/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
 
   # inode field i_dir_acl was repurposed as i_size_high in e2fsprogs 1.44,
   # breaking the build
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace src/insertionops.cc \
       --replace "Directory ACL:" "High 32 bits of size:" \
       --replace "inode.i_dir_acl" "inode.i_size_high"

--- a/pkgs/tools/filesystems/fsfs/default.nix
+++ b/pkgs/tools/filesystems/fsfs/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ fuse openssl ];
 
-  patchPhase = ''
+  postPatch = ''
     sed -i -e 's,CONFDIR=\(.*\),CONFDIR='$out/etc, \
       -e 's,USERCONFPREFIX=\(.*\),USERCONFPREFIX='$out/var/lib, Makefile \
       src/Makefile src/utils/Makefile

--- a/pkgs/tools/filesystems/gitfs/default.nix
+++ b/pkgs/tools/filesystems/gitfs/default.nix
@@ -11,7 +11,7 @@ python3Packages.buildPythonApplication rec {
     sha256 = "1jzwdwan8ndvp2lw6j7zbvg5k9rgf2d8dcxjrwc6bwyk59xdxn4p";
   };
 
-  patchPhase = ''
+  postPatch = ''
     # requirement checks are unnecessary at runtime
     echo > requirements.txt
 

--- a/pkgs/tools/filesystems/ubidump/default.nix
+++ b/pkgs/tools/filesystems/ubidump/default.nix
@@ -16,7 +16,7 @@ python3.pkgs.buildPythonApplication rec {
 
   dontBuild = true;
 
-  patchPhase = ''
+  postPatch = ''
     sed -i '1s;^;#!${python3.interpreter}\n;' ubidump.py
     patchShebangs ubidump.py
   '';

--- a/pkgs/tools/graphics/dcraw/default.nix
+++ b/pkgs/tools/graphics/dcraw/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   # Jasper is disabled because the library is abandoned and has many
   # CVEs.
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace install \
       --replace 'prefix=/usr/local' 'prefix=$out' \
       --replace gcc '$CC' \

--- a/pkgs/tools/graphics/exiftags/default.nix
+++ b/pkgs/tools/graphics/exiftags/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "194ifl6hybx2a5x8jhlh9i56k3qfc6p2l72z0ii1b7v0bzg48myr";
   };
 
-  patchPhase = ''
+  postPatch = ''
     sed -i -e s@/usr/local@$out@ Makefile
   '';
 

--- a/pkgs/tools/graphics/icoutils/default.nix
+++ b/pkgs/tools/graphics/icoutils/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   # upgrades to a newer SDK.
   NIX_CFLAGS_COMPILE = lib.optional stdenv.isDarwin "-DTARGET_OS_IPHONE=0";
 
-  patchPhase = ''
+  postPatch = ''
     patchShebangs extresso/extresso
     patchShebangs extresso/extresso.in
     patchShebangs extresso/genresscript

--- a/pkgs/tools/graphics/pgf/default.nix
+++ b/pkgs/tools/graphics/pgf/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoconf automake ];
   buildInputs = [ libtool dos2unix libpgf freeimage doxygen ];
 
-  patchPhase = ''
+  postPatch = ''
       sed 1i'#include <inttypes.h>' -i src/PGF.cpp
       sed s/__int64/int64_t/g -i src/PGF.cpp
       rm include/FreeImage.h include/FreeImagePlus.h

--- a/pkgs/tools/graphics/pngnq/default.nix
+++ b/pkgs/tools/graphics/pngnq/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ libpng zlib ];
 
-  patchPhase = ''
+  postPatch = ''
     sed -i '/png.h/a \#include <zlib.h>' src/rwpng.c
   '';
 

--- a/pkgs/tools/graphics/wkhtmltopdf/default.nix
+++ b/pkgs/tools/graphics/wkhtmltopdf/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     qtwebkit qtsvg qtxmlpatterns
   ];
 
-  prePatch = ''
+  postPatch = ''
     for f in src/image/image.pro src/pdf/pdf.pro ; do
       substituteInPlace $f --replace '$(INSTALL_ROOT)' ""
     done

--- a/pkgs/tools/misc/automirror/default.nix
+++ b/pkgs/tools/misc/automirror/default.nix
@@ -11,11 +11,13 @@ stdenv.mkDerivation rec {
     sha256 = "1syyf7dcm8fbyw31cpgmacg80h7pg036dayaaf0svvdsk0hqlsch";
   };
 
-  patchPhase = "sed -i s#/usr##g Makefile";
-
   buildInputs = [ git ronn ];
 
   installFlags = [ "DESTDIR=$(out)" ];
+
+  postPatch = ''
+    sed -i s#/usr##g Makefile
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/schlomo/automirror";

--- a/pkgs/tools/misc/cpuminer/default.nix
+++ b/pkgs/tools/misc/cpuminer/default.nix
@@ -17,11 +17,13 @@ stdenv.mkDerivation rec {
     sha256 = "0f44i0z8rid20c2hiyp92xq0q0mjj537r05sa6vdbc0nl0a5q40i";
   };
 
-  patchPhase = if stdenv.cc.isClang then "${perl}/bin/perl ./nomacro.pl" else null;
-
   buildInputs = [ curl jansson autoreconfHook ];
 
   configureFlags = [ "CFLAGS=-O3" ];
+
+  postPatch = lib.optionalString stdenv.cc.isClang ''
+    ${perl}/bin/perl ./nomacro.pl
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/pooler/cpuminer";

--- a/pkgs/tools/misc/dumptorrent/default.nix
+++ b/pkgs/tools/misc/dumptorrent/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
       sha256 = "073h03bmpfdy15qh37lvppayld2747i4acpyk0pm5nf2raiak0zm";
     };
 
-    patchPhase = ''
+    postPatch = ''
       substituteInPlace Makefile \
         --replace "gcc" "cc"
     '';

--- a/pkgs/tools/misc/foma/default.nix
+++ b/pkgs/tools/misc/foma/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     "AR:=$(AR)" # libtool is used for darwin
   ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace Makefile \
       --replace '-ltermcap' ' '
   '';

--- a/pkgs/tools/misc/fsmark/default.nix
+++ b/pkgs/tools/misc/fsmark/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "15f8clcz49qsfijdmcz165ysp8v4ybsm57d3dxhhlnq1bp1i9w33";
   };
 
-  patchPhase = ''
+  postPatch = ''
     sed -i Makefile -e 's/-static //'
   '';
 

--- a/pkgs/tools/misc/heatseeker/default.nix
+++ b/pkgs/tools/misc/heatseeker/default.nix
@@ -16,7 +16,7 @@ rustPlatform.buildRustPackage rec {
   # https://github.com/rschmitt/heatseeker/issues/42
   # I've suggested using `/usr/bin/env stty`, but doing that isn't quite as simple
   # as a substitution, and this works since we have the path to coreutils stty.
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace src/screen/unix.rs --replace "/bin/stty" "${coreutils}/bin/stty"
   '';
 

--- a/pkgs/tools/misc/pal/default.nix
+++ b/pkgs/tools/misc/pal/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "072mahxvd7lcvrayl32y589w4v3vh7bmlcnhiksjylknpsvhqiyf";
   };
 
-  patchPhase = ''
+  postPatch = ''
     sed -i -e 's/-o root//' -e 's,ESTDIR}/etc,ESTDIR}'$out/etc, src/Makefile
     sed -i -e 's,/etc/pal\.conf,'$out/etc/pal.conf, src/input.c
   '';

--- a/pkgs/tools/misc/poweralertd/default.nix
+++ b/pkgs/tools/misc/poweralertd/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "19rw9q4pcqw56nmzjfglfikzx5wwjl4n08awwdhg0jy1k0bm3dvp";
   };
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace meson.build --replace "systemd.get_pkgconfig_variable('systemduserunitdir')" "'${placeholder "out"}/lib/systemd/user'"
   '';
 

--- a/pkgs/tools/misc/q-text-as-data/default.nix
+++ b/pkgs/tools/misc/q-text-as-data/default.nix
@@ -18,7 +18,7 @@ python3Packages.buildPythonApplication rec {
 
   doCheck = false;
 
-  patchPhase = ''
+  postPatch = ''
     # remove broken symlink
     rm bin/qtextasdata.py
 

--- a/pkgs/tools/misc/vorbisgain/default.nix
+++ b/pkgs/tools/misc/vorbisgain/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libogg libvorbis ];
 
-  patchPhase = ''
+  postPatch = ''
     chmod -v +x configure
     configureFlags="--mandir=$out/share/man"
   '';

--- a/pkgs/tools/misc/xfstests/default.nix
+++ b/pkgs/tools/misc/xfstests/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
   hardeningDisable = [ "format" ];
   enableParallelBuilding = true;
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace Makefile \
       --replace "cp include/install-sh ." "cp -f include/install-sh ."
 

--- a/pkgs/tools/networking/aircrack-ng/default.nix
+++ b/pkgs/tools/networking/aircrack-ng/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config makeWrapper autoreconfHook ];
   buildInputs = [ libpcap openssl zlib libnl iw ethtool pciutils ];
 
-  patchPhase = ''
+  postPatch = ''
     sed -e 's@/usr/local/bin@'${wirelesstools}@ -i lib/osdep/linux.c
   '';
 

--- a/pkgs/tools/networking/argus/default.nix
+++ b/pkgs/tools/networking/argus/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libpcap cyrus_sasl tcp_wrappers ];
   propagatedBuildInputs = [ procps which wget lsof net-snmp ];
 
-  patchPhase = ''
+  postPatch = ''
      substituteInPlace events/argus-extip.pl \
        --subst-var-by PERLBIN ${perl}/bin/perl
     substituteInPlace events/argus-lsof.pl \

--- a/pkgs/tools/networking/globalprotect-openconnect/default.nix
+++ b/pkgs/tools/networking/globalprotect-openconnect/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ openconnect qtwebsockets qtwebengine ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace GPService/gpservice.h \
       --replace /usr/local/bin/openconnect ${openconnect}/bin/openconnect;
     substituteInPlace GPClient/settingsdialog.ui \

--- a/pkgs/tools/networking/imapsync/default.nix
+++ b/pkgs/tools/networking/imapsync/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1axacjw2wyaphczfw3kfmi5cl83fyr8nb207nks40fxkbs8q5dlr";
   };
 
-  patchPhase = ''
+  postPatch = ''
     sed -i -e s@/usr@$out@ Makefile
   '';
 

--- a/pkgs/tools/networking/iodine/default.nix
+++ b/pkgs/tools/networking/iodine/default.nix
@@ -13,11 +13,13 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ zlib ];
 
-  patchPhase = ''sed -i "s,/sbin/route,${nettools}/bin/route," src/tun.c'';
-
   NIX_CFLAGS_COMPILE = "-DIFCONFIGPATH=\"${nettools}/bin/\"";
 
   installFlags = [ "prefix=\${out}" ];
+
+  postPatch = ''
+    sed -i "s,/sbin/route,${nettools}/bin/route," src/tun.c
+  '';
 
   passthru.tests = {
     inherit (nixosTests) iodine;

--- a/pkgs/tools/networking/ipgrep/default.nix
+++ b/pkgs/tools/networking/ipgrep/default.nix
@@ -13,7 +13,7 @@ python3Packages.buildPythonApplication rec {
     hash = "sha256-NrhcUFQM+L66KaDRRpAoC+z5s54a+1fqEepTRXVZ5Qs=";
   };
 
-  patchPhase = ''
+  postPatch = ''
     mkdir -p ${pname}
     substituteInPlace setup.py \
       --replace "'scripts': []" "'scripts': { '${pname}.py' }"

--- a/pkgs/tools/networking/memtier-benchmark/default.nix
+++ b/pkgs/tools/networking/memtier-benchmark/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "0m2qnnc71qpdj8w421bxn0zxz6ddvzy7b0n19jvyncnzvk1ff0sq";
   };
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace ./configure.ac \
       --replace '1.2.8' '${version}'
   '';

--- a/pkgs/tools/networking/minio-client/default.nix
+++ b/pkgs/tools/networking/minio-client/default.nix
@@ -15,7 +15,7 @@ buildGoModule rec {
 
   subPackages = [ "." ];
 
-  patchPhase = ''
+  postPatch = ''
     sed -i "s/Version.*/Version = \"${version}\"/g" cmd/build-constants.go
     sed -i "s/ReleaseTag.*/ReleaseTag = \"RELEASE.${version}\"/g" cmd/build-constants.go
     sed -i "s/CommitID.*/CommitID = \"${src.rev}\"/g" cmd/build-constants.go

--- a/pkgs/tools/networking/nettee/default.nix
+++ b/pkgs/tools/networking/nettee/default.nix
@@ -23,7 +23,7 @@ in stdenv.mkDerivation {
 
   outputs = [ "bin" "man" "doc" "out" ];
 
-  patchPhase = ''
+  postPatch = ''
     # h_addr field was removed
     sed -e '1 i #define h_addr h_addr_list[0]' \
         -i nettee.c

--- a/pkgs/tools/networking/s4cmd/default.nix
+++ b/pkgs/tools/networking/s4cmd/default.nix
@@ -13,7 +13,7 @@ python3Packages.buildPythonApplication rec {
 
   # The upstream package tries to install some bash shell completion scripts in /etc.
   # Setuptools is bugged and doesn't handle --prefix properly: https://github.com/pypa/setuptools/issues/130
-  patchPhase = ''
+  postPatch = ''
     sed -i '/ data_files=/d' setup.py
     sed -i 's|os.chmod("/etc.*|pass|' setup.py
   '';

--- a/pkgs/tools/networking/snabb/default.nix
+++ b/pkgs/tools/networking/snabb/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = [ "-Wno-error=stringop-truncation" ];
 
-  patchPhase = ''
+  postPatch = ''
     patchShebangs .
 
     # some hardcodeism

--- a/pkgs/tools/networking/tinyfecvpn/default.nix
+++ b/pkgs/tools/networking/tinyfecvpn/default.nix
@@ -15,10 +15,8 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
   nativeBuildInputs = [ pkg-config ];
 
-  patchPhase = ''
-    runHook prePatch
+  postPatch = ''
     find . -type f -name "makefile" -exec sed "s/ -static/ -g/g" -i \{\} \;
-    runHook postPatch
   '';
 
   installPhase = ''

--- a/pkgs/tools/networking/wrk2/default.nix
+++ b/pkgs/tools/networking/wrk2/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ luajit openssl zlib ];
 
-  patchPhase = ''
+  postPatch = ''
     rm -rf deps/luajit && mkdir deps/luajit
 
     substituteInPlace ./Makefile \

--- a/pkgs/tools/package-management/dpkg/default.nix
+++ b/pkgs/tools/package-management/dpkg/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  patchPhase = ''
+  postPatch = ''
     patchShebangs .
 
     # Dpkg commands sometimes calls out to shell commands

--- a/pkgs/tools/security/chrome-token-signing/default.nix
+++ b/pkgs/tools/security/chrome-token-signing/default.nix
@@ -14,7 +14,7 @@ mkDerivation rec {
   buildInputs = [ qmake pcsclite pkg-config ];
   dontUseQmakeConfigure = true;
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace host-linux/ee.ria.esteid.json --replace /usr $out
     # TODO: macos
     substituteInPlace host-shared/PKCS11Path.cpp \

--- a/pkgs/tools/security/crowbar/default.nix
+++ b/pkgs/tools/security/crowbar/default.nix
@@ -20,7 +20,7 @@ python3Packages.buildPythonApplication rec {
 
   propagatedBuildInputs = [ python3Packages.paramiko ];
 
-  patchPhase = ''
+  postPatch = ''
     sed -i 's,/usr/bin/xfreerdp,${freerdp}/bin/xfreerdp,g' lib/main.py
     sed -i 's,/usr/bin/vncviewer,${tigervnc}/bin/vncviewer,g' lib/main.py
     sed -i 's,/usr/sbin/openvpn,${openvpn}/bin/openvpn,g' lib/main.py

--- a/pkgs/tools/security/pass/extensions/otp.nix
+++ b/pkgs/tools/security/pass/extensions/otp.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   dontBuild = true;
 
-  patchPhase = ''
+  postPatch = ''
     sed -i -e 's|OATH=\$(which oathtool)|OATH=${oath-toolkit}/bin/oathtool|' otp.bash
   '';
 

--- a/pkgs/tools/security/passff-host/default.nix
+++ b/pkgs/tools/security/passff-host/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ python3 ];
   makeFlags = [ "VERSION=${version}" ];
 
-  patchPhase = ''
+  postPatch = ''
     sed -i 's#COMMAND = "pass"#COMMAND = "${pass}/bin/pass"#' src/passff.py
   '';
 

--- a/pkgs/tools/security/pius/default.nix
+++ b/pkgs/tools/security/pius/default.nix
@@ -13,7 +13,7 @@ python3Packages.buildPythonApplication {
     sha256 = "0l87dx7n6iwy8alxnhvval8h1kl4da6a59hsilbi65c6bpj4dh3y";
   };
 
-  patchPhase = ''
+  postPatch = ''
     for file in libpius/constants.py pius-keyring-mgr; do
       sed -i "$file" -E -e's|/usr/bin/gpg2?|${gnupg}/bin/gpg|g'
     done

--- a/pkgs/tools/security/radamsa/default.nix
+++ b/pkgs/tools/security/radamsa/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     sha256 = "0mi1mwvfnlpblrbmp0rcyf5p74m771z6nrbsly6cajyn4mlpmbaq";
   };
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace ./tests/bd.sh  \
       --replace "/bin/echo" echo
 

--- a/pkgs/tools/security/rarcrack/default.nix
+++ b/pkgs/tools/security/rarcrack/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
   buildFlags = lib.optional stdenv.cc.isClang "CC=clang";
   installFlags = [ "PREFIX=\${out}" ];
 
-  patchPhase = ''
+  postPatch = ''
    substituteInPlace rarcrack.c --replace "file -i" "${file}/bin/file -i"
   '';
 

--- a/pkgs/tools/security/scrypt/default.nix
+++ b/pkgs/tools/security/scrypt/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ getconf ];
 
-  patchPhase = ''
+  postPatch = ''
     for f in Makefile.in autotools/Makefile.am libcperciva/cpusupport/Build/cpusupport.sh configure ; do
       substituteInPlace $f --replace "command -p " ""
     done

--- a/pkgs/tools/system/dog/default.nix
+++ b/pkgs/tools/system/dog/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "3ef25907ec5d1dfb0df94c9388c020b593fbe162d7aaa9bd08f35d2a125af056";
   };
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace Makefile \
       --replace "gcc" "cc"
   '';

--- a/pkgs/tools/system/gt5/default.nix
+++ b/pkgs/tools/system/gt5/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0gm0gzyp4d9rxqddbaskbz5zvmlhyr4nyb5x9g7x4abyyxqjlnkq";
   };
 
-  patchPhase = ''
+  postPatch = ''
     sed 's/-o root -g root//' -i Makefile
   '';
 

--- a/pkgs/tools/system/ts/default.nix
+++ b/pkgs/tools/system/ts/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
 
   installPhase=''make install "PREFIX=$out"'';
 
-  patchPhase = ''
+  postPatch = ''
     sed -i s,/usr/sbin/sendmail,${sendmailPath}, mail.c ts.1
   '';
 

--- a/pkgs/tools/system/vbetool/default.nix
+++ b/pkgs/tools/system/vbetool/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ pciutils libx86 zlib ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace Makefile.in --replace '$(libdir)/libpci.a' ""
   '';
 

--- a/pkgs/tools/text/grip-search/default.nix
+++ b/pkgs/tools/text/grip-search/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ boost ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace src/general/config.h --replace "CUSTOM-BUILD" "${version}"
   '';
 

--- a/pkgs/tools/text/multitran/data/default.nix
+++ b/pkgs/tools/text/multitran/data/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
       sha256 = "9c2ff5027c2fe72b0cdf056311cd7543f447feb02b455982f20d4a3966b7828c";
   };
 
-  patchPhase = ''
+  postPatch = ''
     sed -i -e 's@\$(DESTDIR)/usr@'$out'@' Makefile
   '';
 

--- a/pkgs/tools/text/multitran/libbtree/default.nix
+++ b/pkgs/tools/text/multitran/libbtree/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     url = "mirror://sourceforge/multitran/libbtree-${version}.tar.bz2";
     sha256 = "34a584e45058950337ff9342693b6739b52c3ce17e66440526c4bd6f9575802c";
   };
-  patchPhase = ''
+  postPatch = ''
     sed -i -e 's@\$(DESTDIR)/usr@'$out'@' src/Makefile;
   '';
 

--- a/pkgs/tools/text/multitran/libfacet/default.nix
+++ b/pkgs/tools/text/multitran/libfacet/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libmtsupport ];
 
-  patchPhase = ''
+  postPatch = ''
     sed -i -e 's@\$(DESTDIR)/usr@'$out'@' \
       -e 's@/usr/include/mt/support@${libmtsupport}/include/mt/support@' \
       src/Makefile;

--- a/pkgs/tools/text/multitran/libmtquery/default.nix
+++ b/pkgs/tools/text/multitran/libmtquery/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   NIX_LDFLAGS = "-lbtree";
 
-  patchPhase = ''
+  postPatch = ''
     sed -i -e 's@\$(DESTDIR)/usr@'$out'@' \
       -e 's@/usr/include/mt/support@${libmtsupport}/include/mt/support@' \
       -e 's@/usr/include/btree@${libbtree}/include/btree@' \

--- a/pkgs/tools/text/multitran/libmtsupport/default.nix
+++ b/pkgs/tools/text/multitran/libmtsupport/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     url = "mirror://sourceforge/multitran/libmtsupport-${version}.tar.bz2";
     sha256 = "481f0f1ec15d7274f1e4eb93e7d060df10a181efd037eeff5e8056d283a9298b";
   };
-  patchPhase = ''
+  postPatch = ''
     sed -i -e 's@\$(DESTDIR)/usr@'$out'@' src/Makefile;
   '';
 

--- a/pkgs/tools/text/multitran/mtutils/default.nix
+++ b/pkgs/tools/text/multitran/mtutils/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libmtsupport libfacet libbtree libmtquery help2man ];
 
-  patchPhase = ''
+  postPatch = ''
     sed -i -e 's@\$(DESTDIR)/usr@'$out'@' \
       -e 's@/usr/include/mt/support@${libmtsupport}/include/mt/support@' \
       -e 's@/usr/include/btree@${libbtree}/include/btree@' \

--- a/pkgs/tools/text/num-utils/default.nix
+++ b/pkgs/tools/text/num-utils/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ perl ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace Makefile --replace "-o 0 -g 0" "" --replace "\$(RPMDIR)" ""
   '';
   makeFlags = [

--- a/pkgs/tools/text/podiff/default.nix
+++ b/pkgs/tools/text/podiff/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
     sha256 = "sha256-7fpix+GkXsfpRgnkHtk1iXF6ILHri7BtUhNPK6sDQFA=";
   };
 
-  patchPhase = ''
+  postPatch = ''
     sed "s#PREFIX=/usr#PREFIX=$out#g" -i Makefile
     mkdir -p $out/bin
     mkdir -p $out/share/man/man1

--- a/pkgs/tools/text/xidel/default.nix
+++ b/pkgs/tools/text/xidel/default.nix
@@ -40,7 +40,7 @@ in stdenv.mkDerivation rec {
 
   NIX_LDFLAGS = [ "-lcrypto" ];
 
-  patchPhase = ''
+  postPatch = ''
     patchShebangs \
       build.sh \
       tests/test.sh \

--- a/pkgs/tools/wayland/wl-color-picker/default.nix
+++ b/pkgs/tools/wayland/wl-color-picker/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ bash ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace Makefile \
       --replace 'which' 'ls' \
       --replace 'grim' "${grim}/bin/grim" \

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -1180,7 +1180,7 @@ let
       sha256 = "7996e1a42c51216003ccf03c4b5250286b4c55684257971851f5ece9161dc7dd";
     };
     propagatedBuildInputs = [ pkgs.openssl IPCRun3 ];
-    patchPhase = ''
+    postPatch = ''
       sed -i 's|my $openssl_bin = "openssl";|my $openssl_bin = "${pkgs.openssl}/bin/openssl";|' lib/Authen/ModAuthPubTkt.pm
       # -dss1 doesn't exist for dgst in openssl 1.1, -sha1 can also handle DSA keys now
       sed -i 's|-dss1|-sha1|' lib/Authen/ModAuthPubTkt.pm
@@ -5641,7 +5641,7 @@ let
       sha256 = "1ylrj6g1sccnyd5k0dq3xl3l40y1jgcbpcb3jnjj5hknv3hv54gl";
     };
     # for some reason, parsing /etc/localtime does not work anymore - make sure that the fallback "/bin/date +%Z" will work
-    patchPhase = ''
+    postPatch = ''
       sed -i "s#/bin/date#${pkgs.coreutils}/bin/date#" lib/Date/Manip/TZ.pm
     '';
     doCheck = !stdenv.isi686; # build freezes during tests on i686
@@ -10533,7 +10533,7 @@ let
       sha256 = "1iyp2fd6j75cn1xvcwl2lxr8qpjxssy2360cyqn6g3kzd1fzdyxw";
     };
 
-    patchPhase = ''
+    postPatch = ''
       sed -i "s#/usr/include/tidyp#${pkgs.tidyp}/include/tidyp#" Makefile.PL
       sed -i "s#/usr/lib#${pkgs.tidyp}/lib#" Makefile.PL
     '';
@@ -16166,7 +16166,9 @@ let
     };
     perlPreHook = lib.optionalString stdenv.isi686 "export LD=$CC"; # fix undefined reference to `__stack_chk_fail_local'
     # Makefile.PL in this package uses which to find pkg-config -- make it use path instead
-    patchPhase = ''sed -ie 's/`which pkg-config`/"pkg-config"/' Makefile.PL'';
+    postPatch = ''
+      sed -ie 's/`which pkg-config`/"pkg-config"/' Makefile.PL
+    '';
     doCheck = false; # The main test performs network access
     nativeBuildInputs = [ pkgs.pkg-config ];
     propagatedBuildInputs = [ pkgs.libdiscid ];
@@ -16846,7 +16848,7 @@ let
       sha256 = "88a9b2df69e769e5855a408b19f61915b82e8fe070ab5cf4d525dd3b8bbe31c1";
     };
     propagatedBuildInputs = [ pkgs.openssl ];
-    patchPhase = ''
+    postPatch = ''
       sed -i 's|$scp = "scp";|$scp = "${pkgs.openssh}/bin/scp";|' SCP.pm
     '';
     meta = {
@@ -16879,7 +16881,7 @@ let
       sha256 = "b7395081314f26f3b93c857d65e9c80a04a63709df698583f22a360ffce7e178";
     };
     propagatedBuildInputs = [ pkgs.openssl ];
-    patchPhase = ''
+    postPatch = ''
       sed -i "s|$ssh_cmd = 'ssh'|$ssh_cmd = '${pkgs.openssh}/bin/ssh'|" lib/Net/SFTP/Foreign/Backend/Unix.pm
     '';
     meta = {
@@ -16988,7 +16990,7 @@ let
       sha256 = "7c71c7c3cbe953234dfe25bcc1ad7edb0e1f5a0578601f5523bc6070262a3817";
     };
     propagatedBuildInputs = [ pkgs.openssl ];
-    patchPhase = ''
+    postPatch = ''
       sed -i 's|$ssh = "ssh";|$ssh = "${pkgs.openssh}/bin/ssh";|' SSH.pm
     '';
     meta = {
@@ -17947,7 +17949,7 @@ let
       url = "mirror://cpan/authors/id/E/ET/ETJ/PDL-2.025.tar.gz";
       sha256 = "1mlab95ij5a4q5pkrmgfas8x46cms2vqwzyjvaajsxr7mmz1cnhv";
     };
-    patchPhase = ''
+    postPatch = ''
       substituteInPlace perldl.conf \
         --replace 'POSIX_THREADS_LIBS => undef' 'POSIX_THREADS_LIBS => "-L${pkgs.glibc.dev}/lib"' \
         --replace 'POSIX_THREADS_INC  => undef' 'POSIX_THREADS_INC  => "-I${pkgs.glibc.dev}/include"' \
@@ -25228,7 +25230,9 @@ let
     };
     buildInputs = [ pkgs.xorg.libXext pkgs.xorg.libXScrnSaver pkgs.xorg.libX11 ];
     propagatedBuildInputs = [ InlineC ];
-    patchPhase = "sed -ie 's,-L/usr/X11R6/lib/,-L${pkgs.xorg.libX11.out}/lib/ -L${pkgs.xorg.libXext.out}/lib/ -L${pkgs.xorg.libXScrnSaver}/lib/,' IdleTime.pm";
+    postPatch = ''
+      sed -ie 's,-L/usr/X11R6/lib/,-L${pkgs.xorg.libX11.out}/lib/ -L${pkgs.xorg.libXext.out}/lib/ -L${pkgs.xorg.libXScrnSaver}/lib/,' IdleTime.pm
+    '';
     meta = {
       description = "Get the idle time of X11";
     };


### PR DESCRIPTION
###### Description of changes

_This is the first of three trewide PRs I've been working on to reduce unnecessary overriding of phases_.

I don't see a good reason for a derivation to override `patchPhase` unless they are applying external patches in a custom way.

Use `postPatch` like most of other derivations applying changes to the sources. All changes were done manually to check the content of the phase before moving it to a hook.

Before this patch:

```
$ rg 'postPatch =' pkgs | wc -l
    3658
$ rg 'patchPhase =' pkgs | wc -l
     357
```

After this patch:

```
$ rg 'postPatch =' pkgs | wc -l
    3974
$ rg 'patchPhase =' pkgs | wc -l
      49
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
