### PR TITLE
treewide: fix fallout from 'cmake/setup-hook.sh: Don't skip build-RPATH'

### DIFF
--- a/pkgs/applications/audio/in-formant/default.nix
+++ b/pkgs/applications/audio/in-formant/default.nix
@@ -35,6 +35,9 @@ stdenv.mkDerivation rec {
     cp in-formant $out/bin
   '';
 
+  # RPATH of binary /nix/store/.../bin/... contains a forbidden reference to /build/
+  cmakeFlags = [ "-DCMAKE_SKIP_BUILD_RPATH=ON" ];
+
   meta = with lib; {
     description = "A real-time pitch and formant tracking software";
     homepage = "https://github.com/in-formant/in-formant";

--- a/pkgs/applications/science/misc/simgrid/default.nix
+++ b/pkgs/applications/science/misc/simgrid/default.nix
@@ -76,6 +76,11 @@ stdenv.mkDerivation rec {
     patchShebangs ..
   '';
 
+  # needed by tests (so libsimgrid.so is found)
+  preConfigure = ''
+    export LD_LIBRARY_PATH="$PWD/build/lib"
+  '';
+
   doCheck = true;
   preCheck = ''
     # prevent the execution of tests known to fail

--- a/pkgs/applications/video/ccextractor/default.nix
+++ b/pkgs/applications/video/ccextractor/default.nix
@@ -36,7 +36,10 @@ stdenv.mkDerivation rec {
     ++ lib.optional (!stdenv.isLinux) libiconv
     ++ lib.optionals enableOcr [ leptonica tesseract4 ffmpeg ];
 
-  cmakeFlags = lib.optionals enableOcr [ "-DWITH_OCR=on" "-DWITH_HARDSUBX=on" ];
+  cmakeFlags = [
+    # file RPATH_CHANGE could not write new RPATH:
+    "-DCMAKE_SKIP_BUILD_RPATH=ON"
+  ] ++ lib.optionals enableOcr [ "-DWITH_OCR=on" "-DWITH_HARDSUBX=on" ];
 
   postInstall = lib.optionalString enableOcr ''
     wrapProgram "$out/bin/ccextractor" \

--- a/pkgs/development/libraries/galario/default.nix
+++ b/pkgs/development/libraries/galario/default.nix
@@ -49,8 +49,14 @@ stdenv.mkDerivation rec {
   '';
 
   preCheck = ''
+    ${if stdenv.isDarwin then "export DYLD_LIBRARY_PATH=$(pwd)/src/" else "export LD_LIBRARY_PATH=$(pwd)/src/"}
     ${if enablePython then "sed -i -e 's|^#!.*|#!${stdenv.shell}|' python/py.test.sh" else ""}
   '';
+
+  cmakeFlags = lib.optionals enablePython [
+    # RPATH of binary /nix/store/.../lib/python3.10/site-packages/galario/double/libcommon.so contains a forbidden reference to /build/
+    "-DCMAKE_SKIP_BUILD_RPATH=ON"
+  ];
 
   doCheck = true;
 

--- a/pkgs/development/tools/qtcreator/default.nix
+++ b/pkgs/development/tools/qtcreator/default.nix
@@ -9,6 +9,8 @@ let
   # Fetch clang from qt vendor, this contains submodules like this:
   # clang<-clang-tools-extra<-clazy.
   clang_qt_vendor = llvmPackages_8.clang-unwrapped.overrideAttrs (oldAttrs: {
+    # file RPATH_CHANGE could not write new RPATH
+    cmakeFlags = [ "-DCMAKE_SKIP_BUILD_RPATH=ON" ];
     src = fetchgit {
       url = "https://code.qt.io/clang/clang.git";
       rev = "c12b012bb7465299490cf93c2ae90499a5c417d5";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
