### PR TITLE
convert some varlists in option docs to MD

### DIFF
--- a/nixos/modules/config/qt5.nix
+++ b/nixos/modules/config/qt5.nix
@@ -45,41 +45,17 @@ in
           ["lxqt" "lxqt-qtplugin"]
           ["libsForQt5" "plasma-integration"]
         ];
-        description = ''
-          Selects the platform theme to use for Qt5 applications.</para>
-          <para>The options are
-          <variablelist>
-            <varlistentry>
-              <term><literal>gtk</literal></term>
-              <listitem><para>Use GTK theme with
-                <link xlink:href="https://github.com/qt/qtstyleplugins">qtstyleplugins</link>
-              </para></listitem>
-            </varlistentry>
-            <varlistentry>
-              <term><literal>gnome</literal></term>
-              <listitem><para>Use GNOME theme with
-                <link xlink:href="https://github.com/FedoraQt/QGnomePlatform">qgnomeplatform</link>
-              </para></listitem>
-            </varlistentry>
-            <varlistentry>
-              <term><literal>lxqt</literal></term>
-              <listitem><para>Use LXQt style set using the
-                <link xlink:href="https://github.com/lxqt/lxqt-config">lxqt-config-appearance</link>
-                application.
-              </para></listitem>
-            </varlistentry>
-            <varlistentry>
-              <term><literal>qt5ct</literal></term>
-              <listitem><para>Use Qt style set using the
-                <link xlink:href="https://sourceforge.net/projects/qt5ct/">qt5ct</link>
-                application.
-              </para></listitem>
-            </varlistentry>
-            <varlistentry>
-              <term><literal>kde</literal></term>
-              <listitem><para>Use Qt settings from Plasma.</para></listitem>
-            </varlistentry>
-          </variablelist>
+        description = lib.mdDoc ''
+          Selects the platform theme to use for Qt5 applications.
+
+          The options are
+          - `gtk`: Use GTK theme with [qtstyleplugins](https://github.com/qt/qtstyleplugins)
+          - `gnome`: Use GNOME theme with [qgnomeplatform](https://github.com/FedoraQt/QGnomePlatform)
+          - `lxqt`: Use LXQt style set using the [lxqt-config-appearance](https://github.com/lxqt/lxqt-config)
+             application.
+          - `qt5ct`: Use Qt style set using the [qt5ct](https://sourceforge.net/projects/qt5ct/)
+             application.
+          - `kde`: Use Qt settings from Plasma.
         '';
       };
 
@@ -97,27 +73,14 @@ in
           "adwaita-qt"
           ["libsForQt5" "qtstyleplugins"]
         ];
-        description = ''
-          Selects the style to use for Qt5 applications.</para>
-          <para>The options are
-          <variablelist>
-            <varlistentry>
-              <term><literal>adwaita</literal></term>
-              <term><literal>adwaita-dark</literal></term>
-              <listitem><para>Use Adwaita Qt style with
-                <link xlink:href="https://github.com/FedoraQt/adwaita-qt">adwaita</link>
-              </para></listitem>
-            </varlistentry>
-            <varlistentry>
-              <term><literal>cleanlooks</literal></term>
-              <term><literal>gtk2</literal></term>
-              <term><literal>motif</literal></term>
-              <term><literal>plastique</literal></term>
-              <listitem><para>Use styles from
-                <link xlink:href="https://github.com/qt/qtstyleplugins">qtstyleplugins</link>
-              </para></listitem>
-            </varlistentry>
-          </variablelist>
+        description = lib.mdDoc ''
+          Selects the style to use for Qt5 applications.
+
+          The options are
+          - `adwaita`, `adwaita-dark`: Use Adwaita Qt style with
+            [adwaita](https://github.com/FedoraQt/adwaita-qt)
+          - `cleanlooks`, `gtk2`, `motif`, `plastique`: Use styles from
+            [qtstyleplugins](https://github.com/qt/qtstyleplugins)
         '';
       };
     };

--- a/nixos/modules/system/boot/resolved.nix
+++ b/nixos/modules/system/boot/resolved.nix
@@ -15,7 +15,7 @@ in
     services.resolved.enable = mkOption {
       default = false;
       type = types.bool;
-      description = ''
+      description = lib.mdDoc ''
         Whether to enable the systemd DNS resolver daemon.
       '';
     };
@@ -24,7 +24,7 @@ in
       default = [ ];
       example = [ "8.8.8.8" "2001:4860:4860::8844" ];
       type = types.listOf types.str;
-      description = ''
+      description = lib.mdDoc ''
         A list of IPv4 and IPv6 addresses to use as the fallback DNS servers.
         If this option is empty, a compiled-in list of DNS servers is used instead.
       '';
@@ -35,7 +35,7 @@ in
       defaultText = literalExpression "config.networking.search";
       example = [ "example.com" ];
       type = types.listOf types.str;
-      description = ''
+      description = lib.mdDoc ''
         A list of domains. These domains are used as search suffixes
         when resolving single-label host names (domain names which
         contain no dot), in order to qualify them into fully-qualified
@@ -43,7 +43,7 @@ in
 
         For compatibility reasons, if this setting is not specified,
         the search domains listed in
-        <filename>/etc/resolv.conf</filename> are used instead, if
+        {file}`/etc/resolv.conf` are used instead, if
         that file exists and any domains are configured in it.
       '';
     };
@@ -52,32 +52,14 @@ in
       default = "true";
       example = "false";
       type = types.enum [ "true" "resolve" "false" ];
-      description = ''
+      description = lib.mdDoc ''
         Controls Link-Local Multicast Name Resolution support
         (RFC 4795) on the local host.
 
         If set to
-
-        <variablelist>
-        <varlistentry>
-          <term><literal>"true"</literal></term>
-          <listitem><para>
-            Enables full LLMNR responder and resolver support.
-          </para></listitem>
-        </varlistentry>
-        <varlistentry>
-          <term><literal>"false"</literal></term>
-          <listitem><para>
-            Disables both.
-          </para></listitem>
-        </varlistentry>
-        <varlistentry>
-          <term><literal>"resolve"</literal></term>
-          <listitem><para>
-            Only resolution support is enabled, but responding is disabled.
-          </para></listitem>
-        </varlistentry>
-        </variablelist>
+        - `"true"`: Enables full LLMNR responder and resolver support.
+        - `"false"`: Disables both.
+        - `"resolve"`: Only resolution support is enabled, but responding is disabled.
       '';
     };
 
@@ -85,21 +67,14 @@ in
       default = "allow-downgrade";
       example = "true";
       type = types.enum [ "true" "allow-downgrade" "false" ];
-      description = ''
+      description = lib.mdDoc ''
         If set to
-        <variablelist>
-        <varlistentry>
-          <term><literal>"true"</literal></term>
-          <listitem><para>
+        - `"true"`:
             all DNS lookups are DNSSEC-validated locally (excluding
             LLMNR and Multicast DNS). Note that this mode requires a
             DNS server that supports DNSSEC. If the DNS server does
             not properly support DNSSEC all validations will fail.
-          </para></listitem>
-        </varlistentry>
-        <varlistentry>
-          <term><literal>"allow-downgrade"</literal></term>
-          <listitem><para>
+        - `"allow-downgrade"`:
             DNSSEC validation is attempted, but if the server does not
             support DNSSEC properly, DNSSEC mode is automatically
             disabled. Note that this mode makes DNSSEC validation
@@ -107,22 +82,14 @@ in
             be able to trigger a downgrade to non-DNSSEC mode by
             synthesizing a DNS response that suggests DNSSEC was not
             supported.
-          </para></listitem>
-        </varlistentry>
-        <varlistentry>
-          <term><literal>"false"</literal></term>
-          <listitem><para>
-            DNS lookups are not DNSSEC validated.
-          </para></listitem>
-        </varlistentry>
-        </variablelist>
+        - `"false"`: DNS lookups are not DNSSEC validated.
       '';
     };
 
     services.resolved.extraConfig = mkOption {
       default = "";
       type = types.lines;
-      description = ''
+      description = lib.mdDoc ''
         Extra config to append to resolved.conf.
       '';
     };

--- a/nixos/modules/virtualisation/oci-containers.nix
+++ b/nixos/modules/virtualisation/oci-containers.nix
@@ -14,18 +14,18 @@ let
 
         image = mkOption {
           type = with types; str;
-          description = "OCI image to run.";
+          description = lib.mdDoc "OCI image to run.";
           example = "library/hello-world";
         };
 
         imageFile = mkOption {
           type = with types; nullOr package;
           default = null;
-          description = ''
+          description = lib.mdDoc ''
             Path to an image file to load before running the image. This can
             be used to bypass pulling the image from the registry.
 
-            The <literal>image</literal> attribute must match the name and
+            The `image` attribute must match the name and
             tag of the image contained in this file, as they will be used to
             run the container with that image. If they do not match, the
             image will be pulled from the registry as usual.
@@ -38,20 +38,20 @@ let
           username = mkOption {
             type = with types; nullOr str;
             default = null;
-            description = "Username for login.";
+            description = lib.mdDoc "Username for login.";
           };
 
           passwordFile = mkOption {
             type = with types; nullOr str;
             default = null;
-            description = "Path to file containing password.";
+            description = lib.mdDoc "Path to file containing password.";
             example = "/etc/nixos/dockerhub-password.txt";
           };
 
           registry = mkOption {
             type = with types; nullOr str;
             default = null;
-            description = "Registry where to login to.";
+            description = lib.mdDoc "Registry where to login to.";
             example = "https://docker.pkg.github.com";
           };
 
@@ -60,7 +60,7 @@ let
         cmd = mkOption {
           type =  with types; listOf str;
           default = [];
-          description = "Commandline arguments to pass to the image's entrypoint.";
+          description = lib.mdDoc "Commandline arguments to pass to the image's entrypoint.";
           example = literalExpression ''
             ["--port=9000"]
           '';
@@ -68,7 +68,7 @@ let
 
         entrypoint = mkOption {
           type = with types; nullOr str;
-          description = "Override the default entrypoint of the image.";
+          description = lib.mdDoc "Override the default entrypoint of the image.";
           default = null;
           example = "/bin/my-app";
         };
@@ -76,7 +76,7 @@ let
         environment = mkOption {
           type = with types; attrsOf str;
           default = {};
-          description = "Environment variables to set for this container.";
+          description = lib.mdDoc "Environment variables to set for this container.";
           example = literalExpression ''
             {
               DATABASE_HOST = "db.example.com";
@@ -88,7 +88,7 @@ let
         environmentFiles = mkOption {
           type = with types; listOf path;
           default = [];
-          description = "Environment files for this container.";
+          description = lib.mdDoc "Environment files for this container.";
           example = literalExpression ''
             [
               /path/to/.env
@@ -100,15 +100,15 @@ let
         log-driver = mkOption {
           type = types.str;
           default = "journald";
-          description = ''
+          description = lib.mdDoc ''
             Logging driver for the container.  The default of
-            <literal>"journald"</literal> means that the container's logs will be
+            `"journald"` means that the container's logs will be
             handled as part of the systemd unit.
 
             For more details and a full list of logging drivers, refer to respective backends documentation.
 
             For Docker:
-            <link xlink:href="https://docs.docker.com/engine/reference/run/#logging-drivers---log-driver">Docker engine documentation</link>
+            [Docker engine documentation](https://docs.docker.com/engine/reference/run/#logging-drivers---log-driver)
 
             For Podman:
             Refer to the docker-run(1) man page.
@@ -118,49 +118,27 @@ let
         ports = mkOption {
           type = with types; listOf str;
           default = [];
-          description = ''
+          description = lib.mdDoc ''
             Network ports to publish from the container to the outer host.
 
             Valid formats:
+            - `<ip>:<hostPort>:<containerPort>`
+            - `<ip>::<containerPort>`
+            - `<hostPort>:<containerPort>`
+            - `<containerPort>`
 
-            <itemizedlist>
-              <listitem>
-                <para>
-                  <literal>&lt;ip&gt;:&lt;hostPort&gt;:&lt;containerPort&gt;</literal>
-                </para>
-              </listitem>
-              <listitem>
-                <para>
-                  <literal>&lt;ip&gt;::&lt;containerPort&gt;</literal>
-                </para>
-              </listitem>
-              <listitem>
-                <para>
-                  <literal>&lt;hostPort&gt;:&lt;containerPort&gt;</literal>
-                </para>
-              </listitem>
-              <listitem>
-                <para>
-                  <literal>&lt;containerPort&gt;</literal>
-                </para>
-              </listitem>
-            </itemizedlist>
-
-            Both <literal>hostPort</literal> and
-            <literal>containerPort</literal> can be specified as a range of
+            Both `hostPort` and `containerPort` can be specified as a range of
             ports.  When specifying ranges for both, the number of container
             ports in the range must match the number of host ports in the
-            range.  Example: <literal>1234-1236:1234-1236/tcp</literal>
+            range.  Example: `1234-1236:1234-1236/tcp`
 
-            When specifying a range for <literal>hostPort</literal> only, the
-            <literal>containerPort</literal> must <emphasis>not</emphasis> be a
-            range.  In this case, the container port is published somewhere
-            within the specified <literal>hostPort</literal> range.  Example:
-            <literal>1234-1236:1234/tcp</literal>
+            When specifying a range for `hostPort` only, the `containerPort`
+            must *not* be a range.  In this case, the container port is published
+            somewhere within the specified `hostPort` range.
+            Example: `1234-1236:1234/tcp`
 
             Refer to the
-            <link xlink:href="https://docs.docker.com/engine/reference/run/#expose-incoming-ports">
-            Docker engine documentation</link> for full details.
+            [Docker engine documentation](https://docs.docker.com/engine/reference/run/#expose-incoming-ports) for full details.
           '';
           example = literalExpression ''
             [
@@ -172,7 +150,7 @@ let
         user = mkOption {
           type = with types; nullOr str;
           default = null;
-          description = ''
+          description = lib.mdDoc ''
             Override the username or UID (and optionally groupname or GID) used
             in the container.
           '';
@@ -182,16 +160,15 @@ let
         volumes = mkOption {
           type = with types; listOf str;
           default = [];
-          description = ''
+          description = lib.mdDoc ''
             List of volumes to attach to this container.
 
-            Note that this is a list of <literal>"src:dst"</literal> strings to
-            allow for <literal>src</literal> to refer to
-            <literal>/nix/store</literal> paths, which would be difficult with an
-            attribute set.  There are also a variety of mount options available
-            as a third field; please refer to the
-            <link xlink:href="https://docs.docker.com/engine/reference/run/#volume-shared-filesystems">
-            docker engine documentation</link> for details.
+            Note that this is a list of `"src:dst"` strings to
+            allow for `src` to refer to `/nix/store` paths, which
+            would be difficult with an attribute set.  There are
+            also a variety of mount options available as a third
+            field; please refer to the
+            [docker engine documentation](https://docs.docker.com/engine/reference/run/#volume-shared-filesystems) for details.
           '';
           example = literalExpression ''
             [
@@ -204,17 +181,17 @@ let
         workdir = mkOption {
           type = with types; nullOr str;
           default = null;
-          description = "Override the default working directory for the container.";
+          description = lib.mdDoc "Override the default working directory for the container.";
           example = "/var/lib/hello_world";
         };
 
         dependsOn = mkOption {
           type = with types; listOf str;
           default = [];
-          description = ''
+          description = lib.mdDoc ''
             Define which other containers this one depends on. They will be added to both After and Requires for the unit.
 
-            Use the same name as the attribute under <literal>virtualisation.oci-containers.containers</literal>.
+            Use the same name as the attribute under `virtualisation.oci-containers.containers`.
           '';
           example = literalExpression ''
             virtualisation.oci-containers.containers = {
@@ -229,7 +206,7 @@ let
         extraOptions = mkOption {
           type = with types; listOf str;
           default = [];
-          description = "Extra options for <command>${defaultBackend} run</command>.";
+          description = lib.mdDoc "Extra options for {command}`${defaultBackend} run`.";
           example = literalExpression ''
             ["--network=host"]
           '';
@@ -238,7 +215,7 @@ let
         autoStart = mkOption {
           type = types.bool;
           default = true;
-          description = ''
+          description = lib.mdDoc ''
             When enabled, the container is automatically started on boot.
             If this option is set to false, the container has to be started on-demand via its service.
           '';
@@ -339,13 +316,13 @@ in {
     backend = mkOption {
       type = types.enum [ "podman" "docker" ];
       default = if versionAtLeast config.system.stateVersion "22.05" then "podman" else "docker";
-      description = "The underlying Docker implementation to use.";
+      description = lib.mdDoc "The underlying Docker implementation to use.";
     };
 
     containers = mkOption {
       default = {};
       type = types.attrsOf (types.submodule containerOptions);
-      description = "OCI (Docker) containers to run as systemd services.";
+      description = lib.mdDoc "OCI (Docker) containers to run as systemd services.";
     };
 
   };


### PR DESCRIPTION
###### Description of changes

this is an effort towards figuring out how we want to render what are now varlists in MD option docs. converting them to regular lists of the form `- var{, var}: description` seems good enough for our purposes, renders very similar in the manual and manpages, and can be done without introducing more MD extensions.

tried to run this through #179457, but that failed badly. so here's two manual screenshots of before and after instead.

**before**
![image](https://user-images.githubusercontent.com/82953136/179781873-6d5cae43-c2c0-4c49-bb7a-f223ba6c8802.png)
**after**
![image](https://user-images.githubusercontent.com/82953136/179781960-3256f8f9-fb9e-4f42-99d8-cad57e376d1e.png)