### PR TITLE
Upgrade Erlang R24 to 24.3.4.2

### DIFF
--- a/pkgs/development/interpreters/erlang/R24.nix
+++ b/pkgs/development/interpreters/erlang/R24.nix
@@ -3,6 +3,6 @@
 # How to obtain `sha256`:
 # nix-prefetch-url --unpack https://github.com/erlang/otp/archive/OTP-${version}.tar.gz
 mkDerivation {
-  version = "24.2";
-  sha256 = "10s57v2i2qqyg3gddm85n3crzrkikl4zfwgzqmxjzdynsyb4xg68";
+  version = "24.3.4.2";
+  sha256 = "10gym0bdmrk0dph8gyy3nf38lgapxnwmpjdkpaak31d74caf230a";
 }


### PR DESCRIPTION
###### Description of changes

This PR upgrades R24.nix to Erlang 24.3.4.2 (current edge of 24.x).
We are currently experimenting on adoption of nixpkgs for our development environment building. And Erlang 24 was one of our core dependencies.
As we observing the state of Erlang releases in nixpkgs-unstable channel, R25 was updated recently but R24 (which is the current default for Erlang in nixpkgs) was stale for a while.
Of course, we do not intend to pressure on mainteners, rather, we have found that we can create necessary PRs by ourselves and test-built them, so here it is!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### Comments

I'm opening this PR as draft since I'm planning to run build on another environment (especially on aarch64-darwin).

I have already run `nixpkgs-review wip` before commiting and got the following result:

```sh
$ nix-env --option system x86_64-linux -f /home/ymtszw/.cache/nixpkgs-review/rev-4b90397139936f93c0347848cb7db8a5e3f3d4d4-dirty/nixpkgs -qaP --xml --out-path --show-trace --meta
28 packages updated:
cl ejabberd elixir elixir elixir elixir elixir elixir-ls elvis-erlang erlang (24.2 → 24.3.4.2) erlang_nox (24.2 → 24.3.4.2) erlang-ls erlang_javac (24.2 → 24.3.4.2) erlang_odbc_javac (24.2 → 24.3.4.2) erlang_odbc (24.2 → 24.3.4.2) erlfmt mercury mix2nix notmuch-bower plausible pleroma pleroma rabbitmq-server rebar rebar3 sonic-pi tsung wings

$ nix --experimental-features nix-command build --no-link --keep-going --option build-use-sandbox relaxed -f /home/ymtszw/.cache/nixpkgs-review/rev-4b90397139936f93c0347848cb7db8a5e3f3d4d4-dirty/build.nix
1 package marked as broken and skipped:
pleroma-otp

27 packages built:
cl ejabberd elixir elixir_1_10 elixir_1_11 elixir_1_12 elixir_1_9 elixir_ls elvis-erlang erlang erlang-ls erlang_javac erlang_nox erlang_odbc erlang_odbc_javac erlfmt mercury mix2nix notmuch-bower plausible pleroma rabbitmq-server rebar rebar3 sonic-pi tsung wings
```

Also, will check basic functionality of binary files as described above.
