### PR TITLE
qogir-icon-theme: 2022-01-12 -> 2022-07-20

### DIFF
--- a/pkgs/data/icons/qogir-icon-theme/default.nix
+++ b/pkgs/data/icons/qogir-icon-theme/default.nix
@@ -28,9 +28,12 @@ stdenvNoCC.mkDerivation rec {
   dontPatchELF = true;
   dontRewriteSymlinks = true;
 
+  postPatch = ''
+    patchShebangs install.sh
+  '';
+
   installPhase = ''
     runHook preInstall
-    patchShebangs install.sh
     mkdir -p $out/share/icons
     name= ./install.sh -d $out/share/icons
     jdupes -L -r $out/share/icons

--- a/pkgs/data/icons/qogir-icon-theme/default.nix
+++ b/pkgs/data/icons/qogir-icon-theme/default.nix
@@ -36,7 +36,9 @@ stdenvNoCC.mkDerivation rec {
     runHook preInstall
     mkdir -p $out/share/icons
     name= ./install.sh -d $out/share/icons
-    jdupes -L -r $out/share/icons
+
+    jdupes --quiet --link-soft --recurse $out/share
+
     runHook postInstall
   '';
 

--- a/pkgs/data/icons/qogir-icon-theme/default.nix
+++ b/pkgs/data/icons/qogir-icon-theme/default.nix
@@ -5,10 +5,19 @@
 , gtk3
 , hicolor-icon-theme
 , jdupes
+, colorVariants ? [] # default is all
+, themeVariants ? [] # default is all
 }:
 
-stdenvNoCC.mkDerivation rec {
+let
   pname = "qogir-icon-theme";
+
+in
+lib.checkListOfEnum "${pname}: color variants" [ "default" "dark" "all" ] colorVariants
+lib.checkListOfEnum "${pname}: theme variants" [ "default" "manjaro" "ubuntu" "all" ] themeVariants
+
+stdenvNoCC.mkDerivation rec {
+  inherit pname;
   version = "2022-07-20";
 
   src = fetchFromGitHub {
@@ -34,8 +43,13 @@ stdenvNoCC.mkDerivation rec {
 
   installPhase = ''
     runHook preInstall
+
     mkdir -p $out/share/icons
-    name= ./install.sh -d $out/share/icons
+
+    name= ./install.sh \
+      ${lib.optionalString (themeVariants != []) ("--theme " + builtins.toString themeVariants)} \
+      ${lib.optionalString (colorVariants != []) ("--color " + builtins.toString colorVariants)} \
+      --dest $out/share/icons
 
     jdupes --quiet --link-soft --recurse $out/share
 

--- a/pkgs/data/icons/qogir-icon-theme/default.nix
+++ b/pkgs/data/icons/qogir-icon-theme/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenvNoCC
 , fetchFromGitHub
+, gitUpdater
 , gtk3
 , hicolor-icon-theme
 , jdupes
@@ -35,6 +36,8 @@ stdenvNoCC.mkDerivation rec {
     jdupes -L -r $out/share/icons
     runHook postInstall
   '';
+
+  passthru.updateScript = gitUpdater { inherit pname version; };
 
   meta = with lib; {
     description = "Flat colorful design icon theme";

--- a/pkgs/data/icons/qogir-icon-theme/default.nix
+++ b/pkgs/data/icons/qogir-icon-theme/default.nix
@@ -9,13 +9,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "qogir-icon-theme";
-  version = "2022-01-12";
+  version = "2022-07-20";
 
   src = fetchFromGitHub {
     owner = "vinceliuice";
     repo = pname;
     rev = version;
-    sha256 = "1daayxsqh7di3bvfnl39h1arsj1fypd3ba30mas6dl1d0qy17z1p";
+    sha256 = "sha256-I+eojCTR3fXcp7v5Bdie9vstmJja9HB71aQSF5jLDD4=";
   };
 
   nativeBuildInputs = [ gtk3 jdupes ];


### PR DESCRIPTION
###### Description of changes

- add update script
- move `patchShebangs` to post patch phase
- use soft links instead of hard links
- update to version [2022-07-20](https://github.com/vinceliuice/Qogir-icon-theme/releases/tag/2022-07-20)
- add optional arguments

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
