### PR TITLE
androidStudioPackages: add update script

### DIFF
--- a/pkgs/applications/editors/android-studio/common.nix
+++ b/pkgs/applications/editors/android-studio/common.nix
@@ -49,11 +49,11 @@
 , unzip
 , usbutils
 , which
-, runCommand
 , xkeyboard_config
 , zlib
 , makeDesktopItem
 , tiling_wm # if we are using a tiling wm, need to set _JAVA_AWT_WM_NONREPARENTING in wrapper
+, runCommandLocal
 }:
 
 let
@@ -184,14 +184,14 @@ let
       ncurses5
 
       # Flutter can only search for certs Fedora-way.
-      (runCommand "fedoracert" {}
+      (runCommandLocal "fedoracert" {}
         ''
         mkdir -p $out/etc/pki/tls/
         ln -s ${cacert}/etc/ssl/certs $out/etc/pki/tls/certs
         '')
     ];
   };
-in runCommand
+in runCommandLocal
   drvName
   {
     startScript = ''
@@ -201,7 +201,14 @@ in runCommand
     preferLocalBuild = true;
     allowSubstitutes = false;
     passthru = {
+      inherit version;
       unwrapped = androidStudio;
+      updateScript = runCommandLocal "update-android-studio-${channel}" {
+        src = ./update.sh;
+        nativeBuildInputs = [ makeWrapper ];
+      } ''
+        makeWrapper $src $out --add-flags "${channel}"
+      '';
     };
     meta = with lib; {
       description = "The Official IDE for Android (${channel} channel)";

--- a/pkgs/applications/editors/android-studio/update.sh
+++ b/pkgs/applications/editors/android-studio/update.sh
@@ -1,0 +1,70 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -I nixpkgs=./. -i bash -p python3Packages.yq nix-prefetch-scripts
+
+set -euo pipefail
+
+DEFAULT_NIX="$(realpath "./pkgs/applications/editors/android-studio/default.nix")"
+RELEASES_XML="$(curl -v --silent https://raw.githubusercontent.com/JetBrains/intellij-sdk-docs/main/topics/_generated/android_studio_releases.xml 2>/dev/null)"
+
+# Available channels: Release/Patch (stable), Beta, Canary
+getLatest() {
+    local attribute="$1"
+    local channel="$2"
+    [[ "$channel" = "stable" ]] && channel="release" # Our naming convention is different
+    local result="$(echo "$RELEASES_XML" \
+        | xq -r ".[].item[] | select(.channel == \"${channel^}\") | .${attribute}" \
+        | sort --version-sort \
+        | tail -n 1)"
+
+    if [[ -n "$result" ]]; then
+        echo "$result"
+    else
+        echo "could not find the latest $attribute for $channel"
+        exit 1
+    fi
+}
+
+updateChannel() {
+    local channel="$1"
+    local latestVersion="$(getLatest "version" "$channel")"
+    if [[ "$channel" = "stable" ]]; then
+        # Sometimes the latest stable version is published under the `patch` channel instead of `release`,
+        # so we need to check if the latest version of the release channel isnt older than the patch channel
+        local latestPatchVersion="$(getLatest "version" "patch")"
+        if [[ "$(nix eval --expr "with import ./default.nix {}; lib.versionOlder \"${latestVersion}\" \"${latestPatchVersion}\"" --impure)" = "true" ]]; then
+            latestVersion="$latestPatchVersion"
+        fi
+    fi
+
+    local localVersion="$(nix eval --raw --file . androidStudioPackages."${channel}".version)"
+    if [[ "${latestVersion}" == "${localVersion}" ]]; then
+        echo "$channel is already up to date!"
+        return 0
+    fi
+    echo "updating $channel from $localVersion to $latestVersion"
+
+    local latestHash="$(nix-prefetch-url --quiet "https://dl.google.com/dl/android/studio/ide-zips/${latestVersion}/android-studio-${latestVersion}-linux.tar.gz")"
+    local localHash="$(nix eval --raw --file . androidStudioPackages."${channel}".unwrapped.src.drvAttrs.outputHash)"
+    sed -i "s/${localHash}/${latestHash}/g" "${DEFAULT_NIX}"
+
+    # Match the formatting of default.nix: `version = "2021.3.1.14"; # "Android Studio Dolphin (2021.3.1) Beta 5"`
+    local versionString="${latestVersion}\"; # \"$(getLatest "name" "${channel}")\""
+    sed -i "s/${localVersion}.*/${versionString}/g" "${DEFAULT_NIX}"
+    echo "updated ${channel} to ${latestVersion}"
+}
+
+if (( $# == 0 )); then
+    for channel in "beta" "canary" "stable"; do
+        updateChannel "$channel"
+    done
+else
+    while (( "$#" )); do
+        case "$1" in
+            beta|canary|stable)
+                updateChannel "$1" ;;
+            *)
+                echo "unknown channel: $1" && exit 1 ;;
+        esac
+        shift 1
+    done
+fi


### PR DESCRIPTION
###### Description of changes
This adds an update script for all branches of Android Studio, with the latest information being fetched from jetbrains [intellij-sdk-docs](https://github.com/JetBrains/intellij-sdk-docs) repo. Thanks to @PixelyIon for finding the entrypoint.

 When running the script from the root of your nixpkgs checkout it will update all branches, and when running it from passthru with `nix build -Lf . android-studio.updateScript && ./result` it will only update the branch of the parent derivation. I've also made sure that running it from the maintainer script with ` nix-shell ./maintainers/scripts/update.nix --argstr package android-studio` works, so that r-ryantm can update this as well.

cc @alapshin

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and “core” functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
