### PR TITLE
ocamlPackages.mariadb: 1.1.4 → 1.1.6

### DIFF
--- a/pkgs/development/ocaml-modules/mariadb/default.nix
+++ b/pkgs/development/ocaml-modules/mariadb/default.nix
@@ -1,26 +1,32 @@
-{ lib, fetchFromGitHub, buildOasisPackage
+{ lib, fetchurl, stdenv
+, ocaml, findlib, ocamlbuild
 , ctypes, mariadb, libmysqlclient }:
 
-buildOasisPackage rec {
-  pname = "mariadb";
-  version = "1.1.4";
+lib.throwIfNot (lib.versionAtLeast ocaml.version "4.07")
+  "mariadb is not available for OCaml ${ocaml.version}"
 
-  minimumOCamlVersion = "4.07.0";
+stdenv.mkDerivation rec {
+  pname = "ocaml${ocaml.version}-mariadb";
+  version = "1.1.6";
 
-  src = fetchFromGitHub {
-    owner = "andrenth";
-    repo = "ocaml-mariadb";
-    rev = version;
-    sha256 = "1rxqvxr6sv4x2hsi05qm9jz0asaq969m71db4ckl672rcql1kwbr";
+  src = fetchurl {
+    url = "https://github.com/andrenth/ocaml-mariadb/releases/download/${version}/ocaml-mariadb-${version}.tar.gz";
+    sha256 = "sha256-3/C1Gz6luUzS7oaudLlDHMT6JB2v5OdbLVzJhtayHGM=";
   };
 
+  nativeBuildInputs = [ ocaml findlib ocamlbuild ];
   buildInputs = [ mariadb libmysqlclient ];
   propagatedBuildInputs = [ ctypes ];
+
+  strictDeps = true;
+
+  preInstall = "mkdir -p $OCAMLFIND_DESTDIR/stublibs";
 
   meta = {
     description = "OCaml bindings for MariaDB";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ bcc32 ];
     homepage = "https://github.com/andrenth/ocaml-mariadb";
+    inherit (ocaml.meta) platforms;
   };
 }


### PR DESCRIPTION
###### Description of changes

Compatibility with latest OCaml.

cc maintainer @bcc32.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
