### PR TITLE
barman: patch out subprocess wrapper

### DIFF
--- a/pkgs/tools/misc/barman/default.nix
+++ b/pkgs/tools/misc/barman/default.nix
@@ -13,6 +13,10 @@ python3Packages.buildPythonApplication rec {
     sha256 = "sha256-WLKtra1kNxvm4iO3NEhMNCSioHL9I8GIgkbtu95IyTQ=";
   };
 
+  patches = [
+    ./unwrap-subprocess.patch
+  ];
+
   checkInputs = with python3Packages; [
     mock
     python-snappy

--- a/pkgs/tools/misc/barman/unwrap-subprocess.patch
+++ b/pkgs/tools/misc/barman/unwrap-subprocess.patch
@@ -1,0 +1,30 @@
+--- a/barman/command_wrappers.py
++++ b/barman/command_wrappers.py
+@@ -1144,5 +1144,5 @@
+         # * pass the current configuration file with -c
+         # * set it quiet with -q
+-        self.command = [sys.executable, command, "-c", config, "-q", subcommand]
++        self.command = [command, "-c", config, "-q", subcommand]
+         self.keep_descriptors = keep_descriptors
+         # Handle args for the sub-command (like the server name)
+
+--- a/tests/test_command_wrappers.py
++++ a/tests/test_command_wrappers.py
+@@ -1595,5 +1595,4 @@
+         )
+         assert subprocess.command == [
+-            sys.executable,
+             sys.argv[0],
+             "-c",
+@@ -1622,5 +1621,4 @@
+         )
+         assert subprocess.command == [
+-            sys.executable,
+             "path/to/barman",
+             "-c",
+@@ -1644,5 +1642,4 @@
+ 
+         command = [
+-            sys.executable,
+             "path/to/barman",
+             "-c",


### PR DESCRIPTION
This patches the command wrapper to prevent it from executing
subprocesses via sys.executable. This is intended to ensure that the
subprocess is using the same Python interpreter as the superprocess.
However, in this case the barman script has been wrapped as a shell
script, which is not executable as Python.

Since our wrapper script already ensures a consistent version of
Python, this internal wrapping is unnecessary, and so we patch it to
execute the command directly.

Fixes #135238

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
