### PR TITLE
Fix coqPackages.serapi version 8.15 for ocamlPackages.janeStreet version 0.15

### DIFF
--- a/pkgs/development/coq-modules/serapi/default.nix
+++ b/pkgs/development/coq-modules/serapi/default.nix
@@ -27,6 +27,8 @@ in
 
   useDune2 = true;
 
+  patches = [ ./janestreet-0.15.patch ];
+
   propagatedBuildInputs =
     with coq.ocamlPackages; [
       cmdliner
@@ -76,5 +78,7 @@ in
     then [
       ./8.12.0+0.12.1.patch
     ]
-    else [];
+    else [
+      ./janestreet-0.15.patch
+    ];
 })

--- a/pkgs/development/coq-modules/serapi/janestreet-0.15.patch
+++ b/pkgs/development/coq-modules/serapi/janestreet-0.15.patch
@@ -1,0 +1,80 @@
+diff --git a/serlib/ser_constr.ml b/serlib/ser_constr.ml
+index 69b2077..47fa06a 100644
+--- a/serlib/ser_constr.ml
++++ b/serlib/ser_constr.ml
+@@ -99,11 +99,13 @@ type 'constr pcase_branch =
+ let map_pcase_branch f (bi, c) = (bi, f c)
+ 
+ type 'types pcase_return =
+-  [%import: 'constr Constr.pcase_return]
++  [%import: 'types Constr.pcase_return]
+   [@@deriving sexp,yojson]
+ 
+ let map_pcase_return f (bi, c) = (bi, f c)
+ 
++type 'a identity = 'a [@@deriving sexp,yojson]
++
+ type _constr =
+   | Rel       of int
+   | Var       of Names.Id.t
+@@ -126,7 +128,7 @@ type _constr =
+   | Float     of Float64.t
+   | Array     of Univ.Instance.t * _constr array * _constr * _types
+ [@@deriving sexp,yojson]
+-and _types = _constr
++and _types = _constr identity
+ [@@deriving sexp,yojson]
+ 
+ let rec _constr_put (c : constr) : _constr =
+diff --git a/serlib/ser_locus.ml b/serlib/ser_locus.ml
+index 1f74ebc..cdcfc99 100644
+--- a/serlib/ser_locus.ml
++++ b/serlib/ser_locus.ml
+@@ -57,7 +57,7 @@ type clause_atom =
+   [%import: Locus.clause_atom]
+   [@@deriving sexp]
+ 
+-type concrete_clause =
++type 'id concrete_clause =
+   [%import: 'id Locus.clause_expr]
+   [@@deriving sexp]
+ 
+@@ -65,7 +65,7 @@ type hyp_location =
+   [%import: Locus.clause_atom]
+   [@@deriving sexp]
+ 
+-type goal_location =
++type 'id goal_location =
+   [%import: 'id Locus.clause_expr]
+   [@@deriving sexp]
+ 
+@@ -73,7 +73,7 @@ type simple_clause =
+   [%import: Locus.clause_atom]
+   [@@deriving sexp]
+ 
+-type 'a or_like_first =
++type 'id or_like_first =
+   [%import: 'id Locus.clause_expr]
+   [@@deriving sexp]
+ 
+diff --git a/serlib/ser_stdlib.ml b/serlib/ser_stdlib.ml
+index fdb1720..3907548 100644
+--- a/serlib/ser_stdlib.ml
++++ b/serlib/ser_stdlib.ml
+@@ -16,6 +16,16 @@
+ open Sexplib.Conv
+ 
+ type nonrec 'a ref = 'a ref
++let ref = ref
++let ( ! ) = ( ! )
++let ( := ) = ( := )
++
++module Option = struct
++  type 'a t = 'a option =
++    | None
++    | Some of 'a
++  [@@deriving sexp]
++end
+ 
+ let ref_of_sexp = ref_of_sexp
+ let sexp_of_ref = sexp_of_ref


### PR DESCRIPTION


###### Description of changes

This is a follow-up to #166033 adding a patch for coqPackages.serapi
so that it builds successfully with the new Jane Street OCaml
packages.  I did not upstream this patch because
upstream (coq-serapi-v8.16) already includes commits mentioning Jane
Street 0.15 compatibility with a similar patch.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
