### PR TITLE
WIP: Python: override style derivations

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -293,4 +293,67 @@ rec {
       };
     in self;
 
+  /* Convert a builder to take not only `args` but also `self: args`. */
+  makeDerivationExtensible = makeDerivation: let
+
+    # Based off lib.makeExtensible, with modifications:
+    makeDerivationExtensible_ = rattrs:
+      let
+        # NOTE: The following is a hint that will be printed by the Nix cli when
+        # encountering an infinite recursion. It must not be formatted into
+        # separate lines, because Nix would only show the last line of the comment.
+
+        # An infinite recursion here can be caused by having the attribute names of expression `e` in `.overrideAttrs(finalAttrs: previousAttrs: e)` depend on `finalAttrs`. Only the attribute values of `e` can depend on `finalAttrs`.
+        args = rattrs (args // { inherit finalPackage; });
+        #              ^^^^
+
+        finalPackage =
+          mkDerivationSimple
+            (f0:
+              let
+                f = self: super:
+                  # Convert f0 to an overlay. Legacy is:
+                  #   overrideAttrs (super: {})
+                  # We want to introduce self. We follow the convention of overlays:
+                  #   overrideAttrs (self: super: {})
+                  # Which means the first parameter can be either self or super.
+                  # This is surprising, but far better than the confusion that would
+                  # arise from flipping an overlay's parameters in some cases.
+                  let x = f0 super;
+                  in
+                    if builtins.isFunction x
+                    then
+                      # Can't reuse `x`, because `self` comes first.
+                      # Looks inefficient, but `f0 super` was a cheap thunk.
+                      f0 self super
+                    else x;
+              in
+                makeDerivationExtensible_
+                  (self: let super = rattrs self; in super // f self super))
+            args;
+      in finalPackage;
+
+    # makeDerivationExtensibleConst == makeDerivationExtensible_ (_: attrs),
+    # but pre-evaluated for a slight improvement in performance.
+    makeDerivationExtensibleConst = attrs:
+      mkDerivationSimple
+        (f0:
+          let
+            f = self: super:
+              let x = f0 super;
+              in
+                if builtins.isFunction x
+                then
+                  f0 self super
+                else x;
+          in
+            makeDerivationExtensible_ (self: attrs // f self attrs))
+        attrs;
+
+    mkDerivationSimple = makeDerivation;
+
+  in fnOrAttrs:
+    if builtins.isFunction fnOrAttrs
+    then makeDerivationExtensible_ fnOrAttrs
+    else makeDerivationExtensibleConst fnOrAttrs;
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -38,15 +38,21 @@ let
       }
       else ff;
 
-  buildPythonPackage = makeOverridablePythonPackage (lib.makeOverridable (callPackage ../development/interpreters/python/mk-python-derivation.nix {
+  funcs = [
+    makeOverridablePythonPackage
+    lib.makeOverridable
+    lib.customisation.makeDerivationExtensible
+  ];
+
+  buildPythonPackage = lib.pipe (callPackage ../development/interpreters/python/mk-python-derivation.nix {
     inherit namePrefix;     # We want Python libraries to be named like e.g. "python3.6-${name}"
     inherit toPythonModule; # Libraries provide modules
-  }));
+  }) funcs;
 
-  buildPythonApplication = makeOverridablePythonPackage (lib.makeOverridable (callPackage ../development/interpreters/python/mk-python-derivation.nix {
+  buildPythonApplication = lib.pipe (callPackage ../development/interpreters/python/mk-python-derivation.nix {
     namePrefix = "";        # Python applications should not have any prefix
     toPythonModule = x: x;  # Application does not provide modules.
-  }));
+  }) funcs;
 
   # See build-setupcfg/default.nix for documentation.
   buildSetupcfg = import ../build-support/build-setupcfg self;


### PR DESCRIPTION
###### Description of changes

Attempt at providing override-style for Python packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
