### PR TITLE
nixos/github-runner: add support for ephemeral and PAT registrations

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -325,6 +325,16 @@
       </listitem>
       <listitem>
         <para>
+          <literal>github-runner</literal> gained support for ephemeral
+          runners and registrations using a personal access token (PAT)
+          instead of a registration token. See
+          <literal>services.github-runner.ephemeral</literal> and
+          <literal>services.github-runner.tokenFile</literal> for
+          details.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           A new module was added for the Saleae Logic device family,
           providing the options
           <literal>hardware.saleae-logic.enable</literal> and

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -125,6 +125,8 @@ Use `configure.packages` instead.
 
 - The `xplr` package has been updated from 0.18.0 to 0.19.0, which brings some breaking changes. See the [upstream release notes](https://github.com/sayanarijit/xplr/releases/tag/v0.19.0) for more details.
 
+- `github-runner` gained support for ephemeral runners and registrations using a personal access token (PAT) instead of a registration token. See `services.github-runner.ephemeral` and `services.github-runner.tokenFile` for details.
+
 - A new module was added for the Saleae Logic device family, providing the options `hardware.saleae-logic.enable` and `hardware.saleae-logic.package`.
 
 - The Redis module now disables RDB persistence when `services.redis.servers.<name>.save = []` instead of using the Redis default.

--- a/nixos/modules/services/continuous-integration/github-runner.nix
+++ b/nixos/modules/services/continuous-integration/github-runner.nix
@@ -18,12 +18,11 @@ in
     enable = mkOption {
       default = false;
       example = true;
-      description = ''
+      description = lib.mdDoc ''
         Whether to enable GitHub Actions runner.
 
         Note: GitHub recommends using self-hosted runners with private repositories only. Learn more here:
-        <link xlink:href="https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners"
-        >About self-hosted runners</link>.
+        [About self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners).
       '';
       type = lib.types.bool;
     };

--- a/nixos/modules/services/continuous-integration/github-runner.nix
+++ b/nixos/modules/services/continuous-integration/github-runner.nix
@@ -137,7 +137,7 @@ in
 
       environment = {
         HOME = runtimeDir;
-        RUNNER_ROOT = runtimeDir;
+        RUNNER_ROOT = stateDir;
       };
 
       path = (with pkgs; [
@@ -214,7 +214,7 @@ in
                 echo "Configuring GitHub Actions Runner"
 
                 token=$(< "$STATE_DIRECTORY"/${newConfigTokenFilename})
-                RUNNER_ROOT="$STATE_DIRECTORY" ${cfg.package}/bin/config.sh \
+                ${cfg.package}/bin/config.sh \
                   --unattended \
                   --disableupdate \
                   --work "$RUNTIME_DIRECTORY" \

--- a/nixos/modules/services/continuous-integration/github-runner.nix
+++ b/nixos/modules/services/continuous-integration/github-runner.nix
@@ -174,7 +174,7 @@ in
       ] ++ cfg.extraPackages;
 
       serviceConfig = rec {
-        ExecStart = "${cfg.package}/bin/runsvc.sh";
+        ExecStart = "${cfg.package}/bin/Runner.Listener run --startuptype service";
 
         # Does the following, sequentially:
         # - If the module configuration or the token has changed, purge the state directory,
@@ -315,8 +315,7 @@ in
         # By default, use a dynamically allocated user
         DynamicUser = true;
 
-        KillMode = "process";
-        KillSignal = "SIGTERM";
+        KillSignal = "SIGINT";
 
         # Hardening (may overlap with DynamicUser=)
         # The following options are only for optimizing:


### PR DESCRIPTION
###### Description of changes

Although [neither](https://docs.github.com/en/actions/hosting-your-own-runners/adding-self-hosted-runners) [documented](https://docs.github.com/en/actions/hosting-your-own-runners/autoscaling-with-self-hosted-runners#authentication-requirements) nor suggested anywhere, the `config.sh` script has a `--pat` option which one can use for new runner registrations instead of `--token`. The help of the `config.sh` script does not suggest one could use it for runner registration: 

```
--pat GitHub personal access token used for checking network connectivity when executing `./run.sh --check`
```

Yet, [it works](https://github.com/actions/runner/blob/052ac521b0ee673dbacf79e71d08e2224a1fd3a5/src/Runner.Listener/Configuration/ConfigurationManager.cs#L555). Supersedes #181823.

Moreover, adds support for ephemeral runners which de-register and wipe their state after processing one job. If the `ephemeral` option is set to `true`, sets the unit's `Restart=` option to `on-success`. Using this option makes mostly sense if using a PAT as `tokenFile`.

Also fixes a bug which uses the runtime directory instead of the state directory as a `RUNNER_ROOT` which breaks the path of some files.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
