### PR TITLE
akonadi: Add package argument for PostgreSQL support

### DIFF
--- a/pkgs/applications/kde/akonadi/default.nix
+++ b/pkgs/applications/kde/akonadi/default.nix
@@ -2,9 +2,15 @@
   mkDerivation, lib, kdepimTeam, substituteAll,
   extra-cmake-modules, shared-mime-info, qtbase, accounts-qt,
   boost, kaccounts-integration, kcompletion, kconfigwidgets, kcrash, kdbusaddons,
-  kdesignerplugin, ki18n, kiconthemes, kio, kitemmodels, kwindowsystem, mariadb, qttools,
-  signond, xz,
+  kdesignerplugin, ki18n, kiconthemes, kio, kitemmodels, kwindowsystem, mariadb,
+  postgresql, qttools, signond, xz,
+
+  mysqlSupport ? true,
+  postgresSupport ? false,
+  defaultDriver ? if mysqlSupport then "MYSQL" else "POSTGRES",
 }:
+
+assert mysqlSupport || postgresSupport;
 
 mkDerivation {
   pname = "akonadi";
@@ -26,16 +32,18 @@ mkDerivation {
   propagatedBuildInputs = [ boost kitemmodels ];
   outputs = [ "out" "dev" ];
   CXXFLAGS = [
-    ''-DNIXPKGS_MYSQL_MYSQLD=\"${lib.getBin mariadb}/bin/mysqld\"''
-    ''-DNIXPKGS_MYSQL_MYSQLADMIN=\"${lib.getBin mariadb}/bin/mysqladmin\"''
-    ''-DNIXPKGS_MYSQL_MYSQL_INSTALL_DB=\"${lib.getBin mariadb}/bin/mysql_install_db\"''
-    ''-DNIXPKGS_MYSQL_MYSQLCHECK=\"${lib.getBin mariadb}/bin/mysqlcheck\"''
-    ''-DNIXPKGS_POSTGRES_PG_CTL=\"\"''
-    ''-DNIXPKGS_POSTGRES_PG_UPGRADE=\"\"''
-    ''-DNIXPKGS_POSTGRES_INITDB=\"\"''
+    ''-DNIXPKGS_MYSQL_MYSQLD=\"${lib.optionalString mysqlSupport "${lib.getBin mariadb}/bin/mysqld"}\"''
+    ''-DNIXPKGS_MYSQL_MYSQLADMIN=\"${lib.optionalString mysqlSupport "${lib.getBin mariadb}/bin/mysqladmin"}\"''
+    ''-DNIXPKGS_MYSQL_MYSQL_INSTALL_DB=\"${lib.optionalString mysqlSupport "${lib.getBin mariadb}/bin/mysql_install_db"}\"''
+    ''-DNIXPKGS_MYSQL_MYSQLCHECK=\"${lib.optionalString mysqlSupport "${lib.getBin mariadb}/bin/mysqlcheck"}\"''
+    ''-DNIXPKGS_POSTGRES_PG_CTL=\"${lib.optionalString postgresSupport "${lib.getBin postgresql}/bin/pg_ctl"}\"''
+    ''-DNIXPKGS_POSTGRES_PG_UPGRADE=\"${lib.optionalString postgresSupport "${lib.getBin postgresql}/bin/pg_upgrade"}\"''
+    ''-DNIXPKGS_POSTGRES_INITDB=\"${lib.optionalString postgresSupport "${lib.getBin postgresql}/bin/initdb"}\"''
     ''-DNIX_OUT=\"${placeholder "out"}\"''
     ''-I${lib.getDev kio}/include/KF5''  # Fixes: kio_version.h: No such file or directory
   ];
+
+  cmakeFlags = lib.optional (defaultDriver != "MYSQL") "-DDATABASE_BACKEND=${defaultDriver}";
 
   # compatibility symlinks for kmymoney, can probably be removed in next kde bump
   postInstall = ''


### PR DESCRIPTION
###### Description of changes

Allows enabling PostgreSQL support for the Akonadi package via an override. Since the Nix patches already support postgres, this is pretty much just a matter of setting the C defines and specifying the default database driver in the cmake flags. The default is still MySQL only, so the behavior of the package in nixpkgs without any overlays shouldn't change.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
