### PR TITLE
restool: 20.12 → 2.4

### DIFF
--- a/pkgs/os-specific/linux/restool/default.nix
+++ b/pkgs/os-specific/linux/restool/default.nix
@@ -1,20 +1,23 @@
-{ stdenv, lib, fetchgit, bash, coreutils, dtc, file, gawk, gnugrep, gnused, which }:
+{ stdenv, lib, fetchgit, bash, coreutils, dtc, file, gawk, gnugrep, gnused, pandoc, which }:
 
 stdenv.mkDerivation rec {
   pname = "restool";
-  version = "20.12";
+  version = "2.4";
 
   src = fetchgit {
     url = "https://source.codeaurora.org/external/qoriq/qoriq-components/restool";
-    rev = "LSDK-${version}";
-    sha256 = "137xvvms3n4wwb5v2sv70vsib52s3s314306qa0mqpgxf9fb19zl";
+    rev = "abd2f5b7181db9d03db9e6ccda0194923b73e9a2";
+    sha256 = "sha256-ryTDyqSy39e8Omf7l8lK4mLWr8jccDhMVPldkVGSQVo=";
   };
 
-  nativeBuildInputs = [ file ];
+  nativeBuildInputs = [ file pandoc ];
   buildInputs = [ bash coreutils dtc gawk gnugrep gnused which ];
 
+  enableParallelBuilding = true;
   makeFlags = [
-    "prefix=$(out)"
+    "prefix="
+    "bindir_completion=/share/bash-completion/completions"
+    "DESTDIR=$(out)"
     "VERSION=${version}"
   ];
 

--- a/pkgs/os-specific/linux/restool/default.nix
+++ b/pkgs/os-specific/linux/restool/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchgit, bash, coreutils, dtc, file, gawk, gnugrep, gnused }:
+{ stdenv, lib, fetchgit, bash, coreutils, dtc, file, gawk, gnugrep, gnused, which }:
 
 stdenv.mkDerivation rec {
   pname = "restool";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ file ];
-  buildInputs = [ bash coreutils dtc gawk gnugrep gnused ];
+  buildInputs = [ bash coreutils dtc gawk gnugrep gnused which ];
 
   makeFlags = [
     "prefix=$(out)"


### PR DESCRIPTION
###### Description of changes

Updates restool to ~LSDK 21.08, which appears to be the latest release if I understand their versioning scheme.~ the latest upstream commit.

There's unfortunately no upstream changelog, just the git history:
https://source.codeaurora.org/external/qoriq/qoriq-components/restool/log/?h=LSDK-21.08
But it appears to be just new commands and options, and some fixes.

~In this PR I also included a backport of an unreleased commit which is needed to use restool with the latest fsl_dpaa2_switch kernel driver. Let me know if you'd prefer not to include that and I can take it out.~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).