### PR TITLE
nixos/vrising-server: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -432,6 +432,7 @@
   ./services/games/quake3-server.nix
   ./services/games/teeworlds.nix
   ./services/games/terraria.nix
+  ./services/games/vrising-server.nix
   ./services/hardware/acpid.nix
   ./services/hardware/actkbd.nix
   ./services/hardware/argonone.nix

--- a/nixos/modules/services/games/vrising-server.nix
+++ b/nixos/modules/services/games/vrising-server.nix
@@ -1,0 +1,176 @@
+{ config, lib, pkgs, ... }:
+with lib;
+
+let
+  cfg = config.services.vrising-server;
+  varLibStateDir = "/var/lib/${cfg.stateDir}";
+  format = pkgs.formats.json { };
+in {
+  options = {
+    services.vrising-server = {
+      enable = mkEnableOption "V Rising dedicated server";
+
+      stateDir = mkOption {
+        type = types.str;
+        default = "vrising-server";
+        description = ''
+          Directory to store all stateful configuration, logs and save files.
+          Will be created as subdirectory of <literal>/var/lib/</literal>.
+        '';
+      };
+
+      passwordFile = mkOption {
+        type = types.path;
+        description = ''
+          File that contains the password for the server.
+        '';
+      };
+
+      openFirewall = mkEnableOption ''
+        Whether to open the ports for the server defined in hostSettings in the firewall.
+      '';
+
+      hostSettings = mkOption {
+        type = types.submodule {
+          freeformType = format.type;
+
+          options = {
+            port = mkOption {
+              type = types.port;
+              default = 9876;
+              description = ''
+                Port for the server, will be added to allowedUDPPorts.
+              '';
+            };
+
+            queryPort = mkOption {
+              type = types.port;
+              default = 9877;
+              description = ''
+                Query port for the server, will be added to allowedUDPPorts.
+              '';
+            };
+          };
+        };
+        default = { };
+        example = literalExpression ''
+          {
+            Name = "V Rising Server";
+            Description = "";
+            MaxConnectedUsers = 5;
+            MaxConnectedAdmins = 5;
+            ServerFps = 30;
+            SaveName = "world1";
+            Secure = true;
+            ListOnMasterServer = false;
+            AutoSaveCount = 20;
+            AutoSaveInterval = 300;
+            GameSettingsPreset = "StandardPvE";
+            AdminOnlyDebugEvents = true;
+            DisableDebugEvents = false;
+          }'';
+        description = ''
+          Host settings as defined in <link xlink:href="https://github.com/StunlockStudios/vrising-dedicated-server-instructions">this repository</link>.
+          Look at the reference to see what you can configure in this attribute set.
+
+          Do not set <literal>Password</literal> here but use the dedicated <literal>passwordFile</literal> option instead.
+        '';
+      };
+
+      gameSettings = mkOption {
+        type = format.type;
+        default = { };
+        example = literalExpression ''
+          {
+            GameModeType = "PvE";
+            DeathContainerPermission = "ClanMembers";
+            RelicSpawnType = "Plentiful";
+            CastleHeartDamageMode = "CanBeDestroyedOnlyWhenDecaying";
+            CastleDamageMode = "Never";
+            BloodBoundEquipment = true;
+            CanLootEnemyContainers = false;
+            Death_DurabilityFactorLoss = 0.0;
+            Death_DurabilityLossFactorAsResources = 0.0;
+            AnnounceSiegeWeaponSpawn = false;
+          }'';
+        description = ''
+          Game settings as defined in <link xlink:href="https://cdn.stunlock.com/blog/2022/05/25083113/Game-Server-Settings.pdf">this file</link>.
+          Look at the reference to see what you can configure in this attribute set.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    warnings = optional (cfg.hostSettings ? Password) ''
+      You have defined a host password using the hostSettings option, which
+      will be ignored. Use the dedicated passwordFile option instead.
+    '';
+
+    networking.firewall.allowedUDPPorts = mkIf cfg.openFirewall [
+      cfg.hostSettings.port
+      cfg.hostSettings.queryPort
+    ];
+
+    systemd.services.vrising-server = {
+      description = "V Rising dedicated server";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+
+      environment = {
+        # steamcmd uses $HOME/.local for temporary files
+        HOME = varLibStateDir;
+        saveDir = "./save-data";
+      };
+
+      serviceConfig = {
+        ExecStartPre = ''
+          ${pkgs.steamcmd}/bin/steamcmd \
+            +force_install_dir ${varLibStateDir} \
+            +login anonymous \
+            +app_update 1829350 \
+            +quit
+        '';
+        # sometimes winedevice processes are left running https://github.com/lutris/lutris/issues/4046
+        ExecStop = "${pkgs.wine64}/bin/wineserver -k";
+        WorkingDirectory = varLibStateDir;
+        Restart = "no";
+        StateDirectory = cfg.stateDir;
+        DynamicUser = true;
+        # in case execstop does not kill all winedevice processes
+        TimeoutStopSec = 10;
+        LoadCredential = "password:${cfg.passwordFile}";
+
+        # Hardening
+        SystemCallFilter = "@system-service @mount @debug";
+        SystemCallErrorNumber = "EPERM";
+        CapabilityBoundingSet = "";
+        RestrictNamespaces = "cgroup mnt user uts";
+        RestrictAddressFamilies = "AF_UNIX AF_INET AF_INET6 AF_NETLINK";
+      };
+
+      # script is needed here since loadcredential is not accessible in
+      # ExecPreStart. Wine sometimes fails with dll import errors, removing
+      # .wine resolves this, same issue as reported in the first comment of this
+      # PR https://github.com/NixOS/nixpkgs/pull/157921
+      script = ''
+        rm -rf .wine
+        mkdir -p $saveDir/Settings
+        ${pkgs.jq}/bin/jq --slurpfile pw <(${pkgs.jq}/bin/jq -R . < $CREDENTIALS_DIRECTORY/password ) \
+          '.Password = $pw[0]' ${
+            format.generate "hostSettings.json" cfg.hostSettings
+          } > $saveDir/Settings/ServerHostSettings.json
+        ln -sf ${
+          format.generate "gameSettings.json" cfg.gameSettings
+        } $saveDir/Settings/ServerGameSettings.json
+        exec ${pkgs.xvfb-run}/bin/xvfb-run \
+          --auto-servernum \
+          --server-args='-screen 0 320x180x8' \
+          ${pkgs.wine64}/bin/wine64 VRisingServer.exe \
+          -persistentDataPath $saveDir \
+          -logFile server.log
+      '';
+    };
+  };
+}


### PR DESCRIPTION
NixOS module for the dedicated server of V Rising.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
