### PR TITLE
qogir-kde: init at unstable-2022-07-08

### DIFF
--- a/pkgs/data/themes/qogir-kde/default.nix
+++ b/pkgs/data/themes/qogir-kde/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, gitUpdater
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "qogir-kde";
+  version = "unstable-2022-07-08";
+
+  src = fetchFromGitHub {
+    owner = "vinceliuice";
+    repo = pname;
+    rev = "f240eae10978c7fee518f7a8be1c41a21a9d5c2e";
+    hash = "sha256-AV60IQWwgvLwDO3ylILwx1DkKadwo4isn3JX3WpKoxQ=";
+  };
+
+  postPatch = ''
+    patchShebangs install.sh
+
+    substituteInPlace install.sh \
+      --replace '$HOME/.local' $out \
+      --replace '$HOME/.config' $out/share
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/plasma/plasmoids
+
+    name= HOME="$TMPDIR" ./install.sh --dest $out/share/themes
+
+    mkdir -p $out/share/sddm/themes
+    cp -a sddm/Qogir $out/share/sddm/themes/
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = gitUpdater { inherit pname version; };
+
+  meta = with lib; {
+    description = "A flat Design theme for KDE Plasma desktop";
+    homepage = "https://github.com/vinceliuice/Qogir-kde";
+    license = licenses.gpl3Only;
+    platforms = platforms.all;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25268,6 +25268,8 @@ with pkgs;
 
   qogir-icon-theme = callPackage ../data/icons/qogir-icon-theme { };
 
+  qogir-kde = callPackage ../data/themes/qogir-kde { };
+
   qogir-theme = callPackage ../data/themes/qogir { };
 
   quintom-cursor-theme = callPackage ../data/icons/quintom-cursor-theme { };


### PR DESCRIPTION
###### Description of changes

Add [qogir-kde](https://github.com/vinceliuice/Qogir-kde), a flat Design theme for KDE Plasma desktop.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
