### PR TITLE
pomodoro: init at 0.1.0

### DIFF
--- a/pkgs/applications/misc/pomodoro/default.nix
+++ b/pkgs/applications/misc/pomodoro/default.nix
@@ -12,7 +12,6 @@ rustPlatform.buildRustPackage rec {
   };
 
   cargoSha256 = "sha256-6ZhWStZebXSwrej36DXifrsrmR1SWW3PwGUX0hqPwE4=";
-  
   buildInputs = lib.optionals stdenv.isDarwin [ Foundation ];
 
   meta = with lib; {

--- a/pkgs/applications/misc/pomodoro/default.nix
+++ b/pkgs/applications/misc/pomodoro/default.nix
@@ -19,5 +19,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/SanderJSA/Pomodoro";
     license = licenses.mit;
     maintainers = with maintainers; [ annaaurora ];
+    # error: redefinition of module 'ObjectiveC'
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/applications/misc/pomodoro/default.nix
+++ b/pkgs/applications/misc/pomodoro/default.nix
@@ -1,0 +1,22 @@
+{ lib, fetchFromGitHub, rustPlatform, Foundation }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "pomodoro";
+  version = "unstable-2021-06-18";
+
+  src = fetchFromGitHub {
+    owner = "SanderJSA";
+    repo = "Pomodoro";
+    rev = "c833b9551ed0b09e311cdb369cc8226c5b9cac6a";
+    sha256 = "sha256-ZA1q1YVJcdSUF9NTikyT3vrRnqbsu5plzRI2gMu+qnQ=";
+  };
+
+  cargoSha256 = "sha256-6ZhWStZebXSwrej36DXifrsrmR1SWW3PwGUX0hqPwE4=";
+
+  meta = with lib; {
+    description = "A simple CLI pomodoro timer using desktop notifications written in Rust";
+    homepage = "https://github.com/SanderJSA/Pomodoro";
+    license = licenses.mit;
+    maintainers = with maintainers; [ annaaurora ];
+  };
+}

--- a/pkgs/applications/misc/pomodoro/default.nix
+++ b/pkgs/applications/misc/pomodoro/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, rustPlatform, Foundation }:
+{ lib, stdenv, fetchFromGitHub, rustPlatform, Foundation }:
 
 rustPlatform.buildRustPackage rec {
   pname = "pomodoro";
@@ -12,6 +12,8 @@ rustPlatform.buildRustPackage rec {
   };
 
   cargoSha256 = "sha256-6ZhWStZebXSwrej36DXifrsrmR1SWW3PwGUX0hqPwE4=";
+  
+  buildInputs = lib.optionals stdenv.isDarwin [ Foundation ];
 
   meta = with lib; {
     description = "A simple CLI pomodoro timer using desktop notifications written in Rust";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29663,6 +29663,10 @@ with pkgs;
 
   polymake = callPackage ../applications/science/math/polymake { };
 
+  pomodoro = callPackage ../applications/misc/pomodoro {
+    inherit (darwin.apple_sdk.frameworks) Foundation;
+  };
+
   pomotroid = callPackage ../applications/misc/pomotroid {
     electron = electron_9;
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
