### PR TITLE
xp-pen-deco-01-v2-driver: init at 3.2.3.220323-1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13454,6 +13454,12 @@
     githubId = 118959;
     name = "VinyMeuh";
   };
+  virchau13 = {
+    email = "virchau13@hexular.net";
+    github = "virchau13";
+    githubId = 16955157;
+    name = "Vir Chaudhury";
+  };
   viraptor = {
     email = "nix@viraptor.info";
     github = "viraptor";

--- a/pkgs/os-specific/linux/xp-pen-drivers/deco-01-v2/default.nix
+++ b/pkgs/os-specific/linux/xp-pen-drivers/deco-01-v2/default.nix
@@ -1,0 +1,81 @@
+{ lib
+, stdenv
+, fetchzip
+, libusb1
+, glibc
+, libGL
+, xorg
+, qtx11extras
+, wrapQtAppsHook
+, autoPatchelfHook
+, libX11
+, libXtst
+, libXi
+, libXrandr
+, libXinerama
+}:
+
+let
+  dataDir = "var/lib/xppend1v2";
+in
+stdenv.mkDerivation rec {
+  pname = "xp-pen-deco-01-v2-driver";
+  version = "3.2.3.220323-1";
+
+  src = fetchzip {
+    url = "https://www.xp-pen.com/download/file/id/1936/pid/440/ext/gz.html#.tar.gz";
+    name = "xp-pen-deco-01-v2-driver-${version}.tar.gz";
+    sha256 = "sha256-n/yutkRsjcIRRhB4q1yqEmaa03/1SO8RigJi/ZkfLbk=";
+  };
+
+  nativeBuildInputs = [
+    wrapQtAppsHook
+    autoPatchelfHook
+  ];
+
+  dontBuild = true;
+
+  dontWrapQtApps = true; # this is done manually
+
+  buildInputs = [
+    libusb1
+    libX11
+    libXtst
+    libXi
+    libXrandr
+    libXinerama
+    glibc
+    libGL
+    stdenv.cc.cc.lib
+    qtx11extras
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{opt,bin}
+    cp -r App/usr/lib/pentablet/{pentablet,resource.rcc,conf} $out/opt
+    chmod +x $out/opt/pentablet
+    cp -r App/lib $out/lib
+    sed -i 's#usr/lib/pentablet#${dataDir}#g' $out/opt/pentablet
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    makeWrapper $out/opt/pentablet $out/bin/xp-pen-deco-01-v2-driver \
+      "''${qtWrapperArgs[@]}" \
+      --run 'if [ "$EUID" -ne 0 ]; then echo "Please run as root."; exit 1; fi' \
+      --run 'if [ ! -d /${dataDir} ]; then mkdir -p /${dataDir}; cp -r '$out'/opt/conf /${dataDir}; chmod u+w -R /${dataDir}; fi'
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.xp-pen.com/product/461.html";
+    description = "Drivers for the XP-PEN Deco 01 v2 drawing tablet";
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    maintainers = with maintainers; [ virchau13 ];
+    license = licenses.unfree;
+  };
+}
+

--- a/pkgs/os-specific/linux/xp-pen-drivers/g430/default.nix
+++ b/pkgs/os-specific/linux/xp-pen-drivers/g430/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, mkDerivation, fetchzip, autoPatchelfHook, libusb1, libX11, libXtst, qtbase, libglvnd }:
 
 mkDerivation rec {
-  pname = "pentablet-driver";
+  pname = "xp-pen-g430-driver";
   version = "1.2.13.1";
 
   src = fetchzip {

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1021,6 +1021,7 @@ mapAliases ({
   pdf2htmlEx = throw "pdf2htmlEx has been removed from nixpkgs, as it was unmaintained"; # Added 2020-11-03
   pdfmod = throw "pdfmod has been removed"; # Added 2022-01-15
   pdfread = throw "pdfread has been remove because it is unmaintained for years and the sources are no longer available"; # Added 2021-07-22
+  pentablet-driver = xp-pen-g430-driver; # Added 2022-06-23
   perlXMLParser = throw "'perlXMLParser' has been renamed to/replaced by 'perlPackages.XMLParser'"; # Converted to throw 2022-02-22
   perlArchiveCpio = throw "'perlArchiveCpio' has been renamed to/replaced by 'perlPackages.ArchiveCpio'"; # Converted to throw 2022-02-22
   pgadmin = pgadmin4;
@@ -1509,7 +1510,7 @@ mapAliases ({
   xmonad_log_applet_gnome3 = throw "'xmonad_log_applet_gnome3' has been renamed to/replaced by 'xmonad_log_applet'"; # Converted to throw 2022-02-22
   xmpp-client = throw "xmpp-client has been dropped due to the lack of maintanence from upstream since 2017"; # Added 2022-06-02
   xmpppy = throw "xmpppy has been removed from nixpkgs as it is unmaintained and python2-only";
-  xp-pen-g430 = pentablet-driver; # Added 2020-05-03
+  xp-pen-g430 = throw "xp-pen-g430 has been renamed to xp-pen-g430-driver"; # Converted to throw 2022-06-23
   xpf = throw "xpf has been removed: abandoned by upstream"; # Added 2022-04-26
   xf86_video_nouveau = throw "'xf86_video_nouveau' has been renamed to/replaced by 'xorg.xf86videonouveau'"; # Converted to throw 2022-02-22
   xf86_input_mtrack = throw ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35930,7 +35930,7 @@ with pkgs;
 
   xp-pen-deco-01-v2-driver = libsForQt5.xp-pen-deco-01-v2-driver;
 
-  pentablet-driver = libsForQt5.callPackage ../misc/drivers/pentablet-driver { };
+  xp-pen-g430-driver = libsForQt5.xp-pen-g430-driver;
 
   new-session-manager = callPackage ../applications/audio/new-session-manager { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35928,6 +35928,8 @@ with pkgs;
 
   bcompare = libsForQt5.callPackage ../applications/version-management/bcompare {};
 
+  xp-pen-deco-01-v2-driver = libsForQt5.xp-pen-deco-01-v2-driver;
+
   pentablet-driver = libsForQt5.callPackage ../misc/drivers/pentablet-driver { };
 
   new-session-manager = callPackage ../applications/audio/new-session-manager { };

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -235,5 +235,7 @@ in (kdeFrameworks // plasmaMobileGear // plasma5 // plasma5.thirdParty // kdeGea
 
   soundkonverter = callPackage ../applications/audio/soundkonverter {};
 
+  xp-pen-deco-01-v2-driver = callPackage ../os-specific/linux/xp-pen-drivers/deco-01-v2 { };
+
   yuview = callPackage ../applications/video/yuview { };
 })))

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -237,5 +237,7 @@ in (kdeFrameworks // plasmaMobileGear // plasma5 // plasma5.thirdParty // kdeGea
 
   xp-pen-deco-01-v2-driver = callPackage ../os-specific/linux/xp-pen-drivers/deco-01-v2 { };
 
+  xp-pen-g430-driver = callPackage ../os-specific/linux/xp-pen-drivers/g430 { };
+
   yuview = callPackage ../applications/video/yuview { };
 })))


### PR DESCRIPTION
###### Description of changes

This adds a (GUI) driver for the [XP-PEN Deco 01 v2 tablet](https://www.xp-pen.com/product/461.html).

This is my first attempt at adding a package to Nixpkgs, so please tell me if I messed something up.

The binary has a hard dependency on a `resource.rcc` file being in the same directory as the binary, so I put the binary and resource file in `$out/opt` and added a wrapper that invoked it. The wrapper automatically copies the default data files of the driver (`$out/opt/conf`) to `/var/lib/xppend1v2` upon load if the directory doesn't already exist. (The condensed name is because the binary had to have the string /usr/lib/pentablet manually replaced with an equivalent path in /var/lib, and I believed that "pentablet" was too generic). The wrapper also rejects if the program isn't being run as root (since the driver breaks if that happens).

(Also this seems to invalidate the naming of the `pentablet-driver` package (#86666), since it no longer applies as being the sole driver of XP-PEN tablets. I'm not sure what to do about that, though.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
