### PR TITLE
clipqr: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8022,6 +8022,15 @@
     githubId = 427866;
     name = "Matthias Beyer";
   };
+  MatthieuBarthel = {
+    email = "matthieu@imatt.ch";
+    name = "Matthieu Barthel";
+    github = "MatthieuBarthel";
+    githubId = 435534;
+    keys = [{
+      fingerprint = "80EB 0F2B 484A BB80 7BEF  4145 BA23 F10E AADC 2E26";
+    }];
+  };
   matthuszagh = {
     email = "huszaghmatt@gmail.com";
     github = "matthuszagh";

--- a/pkgs/applications/misc/clipqr/default.nix
+++ b/pkgs/applications/misc/clipqr/default.nix
@@ -1,0 +1,70 @@
+{ buildGoModule
+, copyDesktopItems
+, fetchFromGitLab
+, lib
+, libGL
+, libX11
+, libXcursor
+, libXext
+, libXi
+, libXinerama
+, libXrandr
+, makeDesktopItem
+, mesa
+, pkg-config
+}:
+
+buildGoModule rec {
+  pname = "clipqr";
+  version = "1.0.0";
+
+  src = fetchFromGitLab {
+    owner = "imatt-foss";
+    repo = "clipqr";
+    rev = "v${version}";
+    sha256 = "sha256-E90nTJtx4GOacu8M7oQBznnSQVDIZatibgKMZEpTUaQ=";
+  };
+
+  vendorSha256 = "5kAOSyVbvot4TX/XfRNe1/zZk6fa7pS1Dvn9nz11u3U=";
+
+  ldflags = [ "-s" "-w" ];
+
+  buildInputs = [
+    libGL
+    libX11
+    libXcursor
+    libXext
+    libXi
+    libXinerama
+    libXrandr
+    mesa
+  ];
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    pkg-config
+  ];
+
+  postInstall = ''
+    install -Dm644 icon.svg $out/share/icons/hicolor/scalable/apps/clipqr.svg
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "ClipQR";
+      desktopName = "ClipQR";
+      exec = "clipqr";
+      categories = [ "Utility" ];
+      icon = "clipqr";
+      comment = "Scan QR codes on screen and from camera";
+      genericName = "ClipQR";
+    })
+  ];
+
+  meta = with lib; {
+    description = "Scan QR codes on screen and from camera, the result is in your clipboard";
+    license = licenses.mit;
+    maintainers = with maintainers; [ MatthieuBarthel ];
+    homepage = "https://gitlab.com/imatt-foss/clipqr";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26187,6 +26187,8 @@ with pkgs;
 
   clipit = callPackage ../applications/misc/clipit { };
 
+  clipqr = callPackage ../applications/misc/clipqr { };
+
   cloud-hypervisor = callPackage ../applications/virtualization/cloud-hypervisor { };
 
   clp = callPackage ../applications/science/math/clp { };


### PR DESCRIPTION
###### Description of changes

This is a new package proposal: a simple GUI app to scan QR codes on screen and from camera: https://gitlab.com/imatt-foss/clipqr

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
