### PR TITLE
nss-mdns: 0.10.0 -> 0.15.1

### DIFF
--- a/pkgs/tools/networking/nss-mdns/default.nix
+++ b/pkgs/tools/networking/nss-mdns/default.nix
@@ -1,14 +1,17 @@
-{ fetchurl, lib, stdenv, fetchpatch }:
+{ fetchurl, lib, autoreconfHook, pkg-config, stdenv, fetchpatch, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
   pname = "nss-mdns";
-  version = "0.10";
+  version = "v0.15.1";
 
-  src = fetchurl {
-    url = "http://0pointer.de/lennart/projects/nss-mdns/nss-mdns-${version}.tar.gz";
-    sha256 = "0vgs6j0qsl0mwzh5a0m0bykr7x6bx79vnbyn0r3q289rghp3qs0y";
+  src = fetchFromGitHub {
+    owner = "lathiat";
+    repo = pname;
+    rev = version;
+    hash = "sha256-iRaf9/gu9VkGi1VbGpxvC5q+0M8ivezCz/oAKEg5V1M=";
   };
 
+  buildInputs = [ autoreconfHook pkg-config ];
   # Note: Although `nss-mdns' works by talking to `avahi-daemon', it
   # doesn't depend on the Avahi libraries.  Instead, it contains
   # hand-written D-Bus code to talk to the Avahi daemon.
@@ -20,15 +23,6 @@ stdenv.mkDerivation rec {
       # Connect to the daemon at `/var/run/avahi-daemon/socket'.
       "--localstatedir=/var"
     ];
-
-  patches = [
-    # Provide compat definition for libc lacking <nss.h> (e.g. musl)
-    (fetchpatch {
-      url = "https://raw.githubusercontent.com/openembedded/openembedded-core/94f780e889f194b67a48587ac68b3200288bee10/meta/recipes-connectivity/libnss-mdns/libnss-mdns/0001-check-for-nss.h.patch";
-      sha256 = "1l1kjbdw8z31br4vib3l5b85jy7kxin760a2f24lww8v6lqdpgds";
-    })
-  ];
-
 
   meta = {
     description = "The mDNS Name Service Switch (NSS) plug-in";


### PR DESCRIPTION
###### Description of changes

To be forward, this PR may not be suitable to merge in its current state, it probably needs review from someone who was involved in the MUSL patch made to 0.10.0 (@r-burns or someone else) to ensure this newer version doesn't break anything for non-glibc systems.

Additionally I'd like to call attention to the fact that, this version is a fork of the original, so the source repo changed. 

For context, this PR fixes the issue I experienced in #180883. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ x ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
