### PR TITLE
xfce.catfish: 4.16.3 -> 4.16.4

### DIFF
--- a/pkgs/desktops/xfce/applications/catfish/default.nix
+++ b/pkgs/desktops/xfce/applications/catfish/default.nix
@@ -1,6 +1,16 @@
-{ lib, fetchurl, file, which, intltool, gobject-introspection,
-  findutils, xdg-utils, dconf, gtk3, python3Packages, xfconf,
-  wrapGAppsHook
+{ lib
+, fetchurl
+, file
+, which
+, intltool
+, gobject-introspection
+, findutils
+, xdg-utils
+, dconf
+, gtk3
+, python3Packages
+, xfconf
+, wrapGAppsHook
 }:
 
 python3Packages.buildPythonApplication rec {

--- a/pkgs/desktops/xfce/applications/catfish/default.nix
+++ b/pkgs/desktops/xfce/applications/catfish/default.nix
@@ -16,14 +16,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "catfish";
-  version = "4.16.3";
+  version = "4.16.4";
 
   src = fetchFromGitLab {
     domain = "gitlab.xfce.org";
     owner = "apps";
     repo = pname;
     rev = "${pname}-${version}";
-    sha256 = "sha256-jAAMZbhviKvSvhaDCva7t0oEDutY+K2vaCPz0B5OoUs=";
+    sha256 = "sha256-hdrEFdBa/4i/PF7VyEI7ObiJXLIRW+RFSe8yGnUpqRc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/xfce/applications/catfish/default.nix
+++ b/pkgs/desktops/xfce/applications/catfish/default.nix
@@ -1,5 +1,5 @@
 { lib
-, fetchurl
+, fetchFromGitLab
 , file
 , which
 , intltool
@@ -17,9 +17,12 @@ python3Packages.buildPythonApplication rec {
   pname = "catfish";
   version = "4.16.3";
 
-  src = fetchurl {
-    url = "https://archive.xfce.org/src/apps/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-6amaYtEJgTkVCN1D88v6LVCmm9a30e7vfTC6TGc9z9o=";
+  src = fetchFromGitLab {
+    domain = "gitlab.xfce.org";
+    owner = "apps";
+    repo = pname;
+    rev = "${pname}-${version}";
+    sha256 = "sha256-jAAMZbhviKvSvhaDCva7t0oEDutY+K2vaCPz0B5OoUs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/xfce/applications/catfish/default.nix
+++ b/pkgs/desktops/xfce/applications/catfish/default.nix
@@ -1,5 +1,6 @@
 { lib
 , fetchFromGitLab
+, gitUpdater
 , file
 , which
 , intltool
@@ -63,6 +64,11 @@ python3Packages.buildPythonApplication rec {
 
   # Disable check because there is no test in the source distribution
   doCheck = false;
+
+  passthru.updateScript = gitUpdater {
+    inherit pname version;
+    rev-prefix = "${pname}-";
+  };
 
   meta = with lib; {
     homepage = "https://docs.xfce.org/apps/catfish/start";


### PR DESCRIPTION
###### Description of changes

- reformat the nix expression
- fetch from gitlab
- add update script
- update to version [4.16.4](https://gitlab.xfce.org/apps/catfish/-/tags/catfish-4.16.4)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
