### PR TITLE
gnu-cobol: refactor

### DIFF
--- a/pkgs/development/compilers/gnu-cobol/default.nix
+++ b/pkgs/development/compilers/gnu-cobol/default.nix
@@ -1,5 +1,22 @@
-{ lib, stdenv, fetchurl, gcc, makeWrapper
-, db, gmp, ncurses }:
+{ lib
+, stdenv
+, fetchurl
+, autoconf269
+, automake
+, libtool
+# libs
+, cjson
+, db
+, gmp
+, libxml2
+, ncurses
+# docs
+, help2man
+, texinfo
+, texlive
+# test
+, writeText
+}:
 
 stdenv.mkDerivation rec {
   pname = "gnu-cobol";
@@ -10,27 +27,76 @@ stdenv.mkDerivation rec {
     sha256 = "0x15ybfm63g7c9340fc6712h9v59spnbyaz4rf85pmnp3zbhaw2r";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    autoconf269
+    automake
+    libtool
+    help2man
+    texinfo
+    texlive.combined.scheme-basic
+  ];
 
-  buildInputs = [ db gmp ncurses ];
+  buildInputs = [
+    cjson
+    db
+    gmp
+    libxml2
+    ncurses
+  ];
 
-  cflags  = lib.concatMapStringsSep " " (p: "-L" + (lib.getLib p) + "/lib ") buildInputs;
-  ldflags = lib.concatMapStringsSep " " (p: "-I" + (lib.getDev p) + "/include ") buildInputs;
+  outputs = [ "bin" "dev" "lib" "out" ];
+  # XXX: Without this, we get a cycle between bin and dev
+  propagatedBuildOutputs = [];
 
-  cobolCCFlags = "-I$out/include ${ldflags} -L$out/lib ${cflags}";
+  # Skips a broken test
+  postPatch = ''
+    sed -i '/^AT_CHECK.*crud\.cob/i AT_SKIP_IF([true])' tests/testsuite.src/listings.at
+  '';
 
-  postInstall = with lib; ''
-    wrapProgram "$out/bin/cobc" \
-      --set COB_CC "${gcc}/bin/gcc" \
-      --prefix COB_LDFLAGS " " "${cobolCCFlags}" \
-      --prefix COB_CFLAGS " " "${cobolCCFlags}"
+  preConfigure = ''
+    autoconf
+    aclocal
+    automake
+  '';
+
+  enableParallelBuilding = true;
+
+  installFlags = [ "install-pdf" "install-html" "localedir=$out/share/locale" ];
+
+  # Tests must run after install.
+  doCheck = false;
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    # Run tests
+    make -j$NIX_BUILD_CORES check
+
+    # Sanity check
+    message="Hello, COBOL!"
+    # XXX: Don't for a second think you can just get rid of these spaces, they
+    # are load bearing.
+    tee hello.cbl <<EOF
+           IDENTIFICATION DIVISION.
+           PROGRAM-ID. HELLO.
+
+           PROCEDURE DIVISION.
+           DISPLAY "$message".
+           STOP RUN.
+    EOF
+    $bin/bin/cobc -x -o hello-cobol "hello.cbl"
+    hello="$(./hello-cobol | tee >(cat >&2))"
+    [[ "$hello" == "$message" ]] || exit 1
+
+    runHook postInstallCheck
   '';
 
   meta = with lib; {
     description = "An open-source COBOL compiler";
     homepage = "https://sourceforge.net/projects/gnucobol/";
     license = with licenses; [ gpl3Only lgpl3Only ];
-    maintainers = with maintainers; [ ericsagnes ];
+    maintainers = with maintainers; [ ericsagnes lovesegfault ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Description of changes

This is a major refactoring of the gnu-cobol package, which gives us:

1. Split outputs, allowing for small container images for COBOL
   applications.
2. Tests running (for Linux)
3. Parallel building
4. Documentation building
5. XML and JSON support

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
