### PR TITLE
python3Packages.monai: init at 0.9.0

### DIFF
--- a/pkgs/development/python-modules/monai/default.nix
+++ b/pkgs/development/python-modules/monai/default.nix
@@ -1,0 +1,64 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, ninja
+, ignite
+, numpy
+, pybind11
+, pytorch
+, which
+}:
+
+buildPythonPackage rec {
+  pname = "monai";
+  version = "0.9.0";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "Project-MONAI";
+    repo = "MONAI";
+    rev = version;
+    sha256 = "sha256-HxW9WYxt2a7fS9/1E9DtiH+SCTTJoxYBfgZqskYdcvI=";
+  };
+
+  # Ninja is not detected by setuptools for some reason even though it's present:
+  postPatch = ''
+    substituteInPlace "setup.cfg" --replace "ninja" ""
+  '';
+
+  preBuild = ''
+    export MAX_JOBS=$NIX_BUILD_CORES;
+  '';
+
+  nativeBuildInputs = [ ninja which ];
+  buildInputs = [ pybind11 ];
+  propagatedBuildInputs = [ numpy pytorch ignite ];
+
+  BUILD_MONAI = 1;
+
+  doCheck = false;  # takes too long; numerous dependencies, some not in Nixpkgs
+
+  pythonImportsCheck = [
+    "monai"
+    "monai.apps"
+    "monai.data"
+    "monai.engines"
+    "monai.handlers"
+    "monai.inferers"
+    "monai.losses"
+    "monai.metrics"
+    "monai.optimizers"
+    "monai.networks"
+    "monai.transforms"
+    "monai.utils"
+    "monai.visualize"
+  ];
+
+  meta = with lib; {
+    description = "Pytorch framework (based on Ignite) for deep learning in medical imaging";
+    homepage = "https://github.com/Project-MONAI/MONAI";
+    license = licenses.asl20;
+    maintainers = [ maintainers.bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5541,6 +5541,8 @@ in {
 
   moku = callPackage ../development/python-modules/moku { };
 
+  monai = callPackage ../development/python-modules/monai { };
+
   monero = callPackage ../development/python-modules/monero { };
 
   mongomock = callPackage ../development/python-modules/mongomock { };


### PR DESCRIPTION
###### Description of changes

Add MONAI, a Pytorch-based library for deep learning in medical imaging.  (Refresh of stale #147538.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [NA] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [NA] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [NA] (Package updates) Added a release notes entry if the change is major or breaking
  - [NA] (Module updates) Added a release notes entry if the change is significant
  - [NA] (Module addition) Added a release notes entry if adding a new NixOS module
  - [NA] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
