### PR TITLE
schemaspy: 6.1.0 -> dev to fix graphviz

### DIFF
--- a/pkgs/development/tools/database/schemaspy/default.nix
+++ b/pkgs/development/tools/database/schemaspy/default.nix
@@ -1,30 +1,83 @@
-{ lib, stdenv, fetchurl, jre, makeWrapper, graphviz }:
+{ lib
+, stdenv
+, callPackage
+, maven
+, jdk
+, jre
+, buildMaven
+, makeWrapper
+, git
+, fetchFromGitHub
+, graphviz
+, ensureNewerSourcesHook
+}:
 
-stdenv.mkDerivation rec {
-  version = "6.1.0";
+let
+  version = "6.1.1-SNAPSHOT";
   pname = "schemaspy";
 
-  src = fetchurl {
-    url = "https://github.com/schemaspy/schemaspy/releases/download/v${version}/${pname}-${version}.jar";
-    sha256 = "0lgz6b17hx9857fb2l03ggz8y3n8a37vrcsylif0gmkwj1v4qgl7";
+  src = fetchFromGitHub {
+    owner = "schemaspy";
+    repo = "schemaspy";
+    rev = "110b1614f9ae4aec0e4dc4e8f0e7c647274d3af6";
+    sha256 = "sha256-X5B34zGhD/NxcK8TQvwdk1NljGJ1HwfBp47ocbE4HiU=";
   };
 
-  dontUnpack = true;
+  deps = stdenv.mkDerivation {
+    name = "${pname}-${version}-deps";
+    inherit src;
+
+    nativeBuildInputs = [ jdk maven git ];
+    buildInputs = [ jre ];
+
+    buildPhase = ''
+      mvn package -Dmaven.test.skip=true -Dmaven.repo.local=$out/.m2 -Dmaven.wagon.rto=5000
+    '';
+
+    # keep only *.{pom,jar,sha1,nbm} and delete all ephemeral files with lastModified timestamps inside
+    installPhase = ''
+      find $out/.m2 -type f -regex '.+\(\.lastUpdated\|resolver-status\.properties\|_remote\.repositories\)' -delete
+      find $out/.m2 -type f -iname '*.pom' -exec sed -i -e 's/\r\+$//' {} \;
+    '';
+
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = "sha256-CUFA9L6qqjo3Jp5Yy1yCqbS9QAEb9PElys4ArPa9VhA=";
+
+    doCheck = false;
+  };
+in
+stdenv.mkDerivation rec {
+  inherit version pname src;
 
   buildInputs = [
-    jre
+    maven
   ];
 
   nativeBuildInputs = [
     makeWrapper
+    # the build system gets angry if it doesn't see git (even though it's not
+    # actually in a git repository)
+    git
+
+    # springframework boot gets angry about 1970 sources
+    # fix from https://github.com/nix-community/mavenix/issues/25
+    (ensureNewerSourcesHook { year = "1980"; })
   ];
 
   wrappedPath = lib.makeBinPath [
     graphviz
   ];
 
+  buildPhase = ''
+    VERSION=${version}
+    SEMVER_STR=${version}
+
+    mvn package --offline -Dmaven.test.skip=true -Dmaven.repo.local=$(cp -dpR ${deps}/.m2 ./ && chmod +w -R .m2 && pwd)/.m2
+  '';
+
   installPhase = ''
-    install -D ${src} "$out/share/java/${pname}-${version}.jar"
+    install -D target/${pname}-${version}.jar $out/share/java/${pname}-${version}.jar
 
     makeWrapper ${jre}/bin/java $out/bin/schemaspy \
       --add-flags "-jar $out/share/java/${pname}-${version}.jar" \
@@ -34,8 +87,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://schemaspy.org";
     description = "Document your database simply and easily";
-    sourceProvenance = with sourceTypes; [ binaryBytecode ];
-    license = licenses.mit;
+    license = licenses.lgpl3Plus;
     maintainers = with maintainers; [ jraygauthier ];
   };
 }


### PR DESCRIPTION
Unfortunately, schemaspy is broken with graphviz 3.0.0, and they haven't
tagged any releases in a very long time. It's fixed on master because they took out the version check.

Let's just build master from source and not worry about it.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
