### PR TITLE
lensm: init at 0.0.2

### DIFF
--- a/pkgs/development/tools/lensm/default.nix
+++ b/pkgs/development/tools/lensm/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, pkg-config
+, vulkan-headers
+, libX11
+, libGL
+, libxkbcommon
+, libXcursor
+, libXfixes
+, wayland
+, x11Support ? true
+, waylandSupport ? true
+, nix-update-script
+, stdenv
+}:
+
+buildGoModule rec {
+  pname = "lensm";
+  version = "0.0.2";
+
+  src = fetchFromGitHub {
+    owner = "loov";
+    repo = "lensm";
+    rev = "v${version}";
+    sha256 = "sha256-v4C2ZCJUUKRfnaFoL9wu9hzZk84NIPjRo3DAL7kM2Bw=";
+  };
+
+  vendorSha256 = "sha256-TMvIh+iBW22Xt+y6S92Cdvk3cMLEE6TXyBgxwEbEros=";
+
+  tags = lib.optionals (!x11Support) [ "nox11" ] ++ lib.optionals (!waylandSupport) [ "nowayland" ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs =
+    let
+      x11Deps = [ libX11 libXcursor libXfixes ];
+      waylandDeps = [ wayland ];
+    in
+    [ vulkan-headers libGL libxkbcommon ]
+    ++ lib.optionals x11Support x11Deps
+    ++ lib.optionals waylandSupport waylandDeps;
+
+  passthru.updateScript = nix-update-script { attrPath = pname; };
+
+  meta = with lib; {
+    # gioui.org/internal/cocoainit fails with:
+    #  fatal error: could not build module 'CoreFoundation'
+    # even when it's included as dependency.
+    broken = stdenv.isDarwin;
+
+    description = "Go assembly and source viewer";
+    homepage = "https://github.com/loov/lensm";
+    license = licenses.mit;
+    maintainers = with maintainers; [ viraptor ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16161,6 +16161,8 @@ with pkgs;
 
   lenmus = callPackage ../applications/misc/lenmus { };
 
+  lensm = callPackage ../development/tools/lensm { };
+
   libtool = libtool_2;
 
   libtool_1_5 = callPackage ../development/tools/misc/libtool { };


### PR DESCRIPTION
###### Description of changes

Include `lensm` package. See https://github.com/loov/lensm for project details.
Darwin compilation should work, but I don't know how to resolve it, so marked broken for now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
