### PR TITLE
deno: 1.23.4 -> 1.25.1

### DIFF
--- a/pkgs/development/compilers/tinycc/default.nix
+++ b/pkgs/development/compilers/tinycc/default.nix
@@ -8,6 +8,10 @@
 , which
 }:
 
+let
+  # avoid "malformed 32-bit x.y.z" error on mac when using clang
+  isCleanVer = version: builtins.match "^[0-9]\\.+[0-9]+\\.[0-9]+" version != null;
+in
 stdenv.mkDerivation rec {
   pname = "tcc";
   version = "unstable-2022-07-15";
@@ -62,7 +66,11 @@ stdenv.mkDerivation rec {
   ];
 
   preConfigure = ''
-    echo ${version} > VERSION
+    ${
+      if stdenv.isDarwin && ! isCleanVer version
+      then "echo 'not overwriting VERSION since it would upset ld'"
+      else "echo ${version} > VERSION"
+    }
     configureFlagsArray+=("--elfinterp=$(< $NIX_CC/nix-support/dynamic-linker)")
   '';
 

--- a/pkgs/development/web/deno/default.nix
+++ b/pkgs/development/web/deno/default.nix
@@ -4,7 +4,6 @@
 , fetchFromGitHub
 , rustPlatform
 , installShellFiles
-, fetchpatch
 , tinycc
 , libiconv
 , libobjc
@@ -30,24 +29,15 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "deno";
-  version = "1.23.4";
+  version = "1.25.1";
 
   src = fetchFromGitHub {
     owner = "denoland";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-nLQqfLRuh9mhZfjeiPaGpQbi5bXEg7HiGwrwDmaIRWM=";
+    sha256 = "sha256-nKMQDfCU1HsOfdzVwmgCIWa/rUmvufHlsS9jcDwcZzw=";
   };
-  cargoSha256 = "sha256-l5Ce/ypYXZKEi859OFskwC/Unpo842ZPxIHvp6lCjQc=";
-
-  patches = [
-    # remove after https://github.com/denoland/deno/pull/15193 is in a release
-    (fetchpatch {
-      name = "byo-tcc.patch";
-      url = "https://github.com/denoland/deno/pull/15193/commits/c43698b2b58af1ef69b1558d55c8ebea0268dfea.patch";
-      sha256 = "sha256-YE5mGHyEm20FjFhr8yveBRlrOVL3+qQYxz2xp/IfmJs=";
-    })
-  ];
+  cargoSha256 = "sha256-jFoVQK74gnhC6Ume/PHe8NG7rNeTkwPMBBWn/hT7nCs=";
 
   postPatch = ''
     # upstream uses lld on aarch64-darwin for faster builds
@@ -68,7 +58,7 @@ rustPlatform.buildRustPackage rec {
   # The deno_ffi package currently needs libtcc.a on linux and macos and will try to compile it at build time
   # To avoid this we point it to our copy (dir)
   # In the future tinycc will be replaced with asm
-  DENO_FFI_LIBTCC = "${libtcc}/lib";
+  TCC_PATH = "${libtcc}/lib";
 
   # Tests have some inconsistencies between runs with output integration tests
   # Skipping until resolved
@@ -111,5 +101,6 @@ rustPlatform.buildRustPackage rec {
     license = licenses.mit;
     maintainers = with maintainers; [ jk ];
     platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+    broken = stdenv.isDarwin; # currently fail to build tinycc on darwin in nixpkgs
   };
 }

--- a/pkgs/development/web/deno/librusty_v8.nix
+++ b/pkgs/development/web/deno/librusty_v8.nix
@@ -11,11 +11,11 @@ let
   };
 in
 fetch_librusty_v8 {
-  version = "0.45.0";
+  version = "0.49.0";
   shas = {
-    x86_64-linux = "sha256-yZw6zwEhJyRntqOmyk03N+sHxzIrbY/e67AQ21ePlAU=";
-    aarch64-linux = "sha256-2p21Smm5wZycv9u+yDbyerKTjSTB7yau5WC2aJ+Vr8w=";
-    x86_64-darwin = "sha256-HO287V+iBwdqKZUWhZJnuGJO9RE4wGG4cQMN8CkB7WQ=";
-    aarch64-darwin = "sha256-ekoMhWMQpBUdM7R7i82NWrNtQMNqCujNYy1ijOxT64U=";
+    x86_64-linux = "sha256-l6+NdMzYI9r2aHU7/OUhbgmc/LmAZjEFL8y8GrJ+EX8=";
+    aarch64-linux = "sha256-uo+/Wsrlkm+xotoIr8xlQWoiWzMz02TKFW+olfXtpz8=";
+    x86_64-darwin = "sha256-gWxljTgt6aXUzwex2zu46B9YzTvhN0Pi9C1Ll1eiohg=";
+    aarch64-darwin = "sha256-/UnBIQ/wA/0biIG9vIDKylhqFJ8QCoqjKH7xiePZ/eg=";
   };
 }

--- a/pkgs/development/web/deno/update/librusty_v8.ts
+++ b/pkgs/development/web/deno/update/librusty_v8.ts
@@ -27,7 +27,7 @@ const getLibrustyV8Version = async (
 ) =>
   fetch(`https://github.com/${owner}/${repo}/raw/${version}/core/Cargo.toml`)
     .then((res) => res.text())
-    .then((txt) => mod.parse(txt).dependencies.v8.version);
+    .then((txt) => toml.parse(txt).dependencies.v8.version);
 
 const fetchArchShaTasks = (version: string, arches: Architecture[]) =>
   arches.map(


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Bump deno to `1.25.1`

~In draft until tinycc issues are resolved~
tinycc darwin issues were a pain, there's no point holding up this update since it's already broken

resolves #181982

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
