### PR TITLE
mprime: 29.8b7 → 30.8b15

### DIFF
--- a/pkgs/tools/misc/mprime/default.nix
+++ b/pkgs/tools/misc/mprime/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, unzip, curl, hwloc, gmp }:
+{ stdenv, lib, fetchurl, unzip, boost, curl, hwloc, gmp }:
 
 let
   throwSystem = throw "Unsupported system: ${stdenv.hostPlatform.system}";
@@ -18,11 +18,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "mprime";
-  version = "29.8b7";
+  version = "30.8b15";
 
   src = fetchurl {
     url = "https://www.mersenne.org/ftp_root/gimps/p95v${lib.replaceStrings ["."] [""] version}.source.zip";
-    sha256 = "0x5dk2dcppfnq17n79297lmn6p56rd66cbwrh1ds4l8r4hmwsjaj";
+    hash = "sha256-CNYorZStHV0aESGX9LfLZ4oD5PFR2UOFLN1MiLaKw58=";
   };
 
   postPatch = ''
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ unzip ];
 
-  buildInputs = [ curl hwloc gmp ];
+  buildInputs = [ boost curl hwloc gmp ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Description of changes
[Changelog](https://www.mersenne.org/download/whatsnew_308b15.txt)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
