### PR TITLE
Introducing lib.symbols

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -20,6 +20,7 @@ let
     lists = callLibs ./lists.nix;
     strings = callLibs ./strings.nix;
     stringsWithDeps = callLibs ./strings-with-deps.nix;
+    symbols = import ./symbols.nix;
 
     # packaging
     customisation = callLibs ./customisation.nix;

--- a/lib/symbols.nix
+++ b/lib/symbols.nix
@@ -14,4 +14,16 @@ rec {
     { __toString = _: description; };
 
   # ---- list of global symbols ----
+
+  /* NOCHROOT is an argument that can be passed to various derivation
+     constructors in nixpkgs and tell them to disable the Nix build sandbox
+     instead of using a pre-computed Hash when fetching dependencies.
+
+     For "__noChroot = true" to work on derivations, Nix has to be configured
+     with "sandbox = relaxed".
+
+     NOTE: This argument should never be used by nixpkgs packages themselves
+           and is only meant for third-party usage.
+  */
+  NOCHROOT = mkSymbol "no-chroot";
 }

--- a/lib/symbols.nix
+++ b/lib/symbols.nix
@@ -1,0 +1,17 @@
+rec {
+  /* mkSymbol returns a value that is only comparable to itself. The main
+     use is to create unique identifiers or labels and enables a form of weak
+     encapsulation, or information hiding.
+
+     The reason this works is that function equality works by comparing the
+     memory location. So two mkSymbol calls with the same description will
+     generate two different singletons.
+
+     Usage:
+       mkSymbol "mydescription"
+  */
+  mkSymbol = description:
+    { __toString = _: description; };
+
+  # ---- list of global symbols ----
+}

--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -23,6 +23,8 @@
 #
 # if vendorSha256 is null, then we won't fetch any dependencies and
 # rely on the vendor folder within the source.
+# if vendorSha256 is symbols.NOCHROOT, then we disable the build sandbox while
+# fetching the dependendencies.
 , vendorSha256
 # Whether to delete the vendor folder supplied with the source.
 , deleteVendor ? false
@@ -129,6 +131,9 @@ let
 
     dontFixup = true;
   }; in modArgs // (
+    if vendorSha256 == lib.symbols.NOCHROOT then
+      { __noChroot = true; }
+    else
       {
         outputHashMode = "recursive";
         outputHashAlgo = "sha256";


### PR DESCRIPTION
###### Description of changes

I noticed that in a few places, the meaning of "null" and other types of arguments gets overloaded. Actually, I wanted to do this myself to allow passing yet another type of argument to vendorSha256.

This PR introduces a new `lib.symbols.mkSymbol` that is inspired by the JavaScript Symbol (I'm sure Haskell has a more academic name for this), and can create singleton values that are only comparable to themselves. And then goes on and extends one of those vendorSha256.

This PR is a bit of an experiment and has two parts:
* is the symbol a good idea; one thing that I didn't do yet is to demonstrate existing places where this could be a replacement for stringly-typed or overloaded nulls.
* is it ok to add __noChroot usage to nixpkgs functions (but still disallow their use in nixpkgs itself). There is a strong usability argument (IMO) to introduce that for third-party usage. See https://zimbatm.com/notes/nix-packaging-the-heretic-way


###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
