### PR TITLE
WIP: gcc-arm-embedded: add version 11.2

### DIFF
--- a/pkgs/development/compilers/gcc-arm-embedded/11/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/11/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, stdenv
+, fetchurl
+, ncurses5
+, python27
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gcc-arm-embedded";
+  version = "11.2";
+  release = "11.2-2022.02";
+
+  suffix = {
+    aarch64-linux = "aarch64";
+    x86_64-linux  = "x86_64";
+  }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  src = fetchurl {
+    url = "https://developer.arm.com/-/media/Files/downloads/gnu/${release}/binrel/gcc-arm-${release}-${suffix}-arm-none-eabi.tar.xz";
+    sha256 = {
+      aarch64-linux = "0pzmmdy49xgnnp17jbw76bxfwpdrnn2m976lgv5hhfafi7jq47gg";
+      x86_64-linux  = "09h3qqr7abjszvnrdcff1chrydipq90njmdh8l111h37wmdcsnlc";
+    }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontPatchELF = true;
+  dontStrip = true;
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r * $out
+    ln -s $out/share/doc/gcc-arm-none-eabi/man $out/man
+  '';
+
+  preFixup = ''
+    find $out -type f | while read f; do
+      patchelf "$f" > /dev/null 2>&1 || continue
+      patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) "$f" || true
+      patchelf --set-rpath ${lib.makeLibraryPath [ "$out" stdenv.cc.cc ncurses5 python27 ]} "$f" || true
+    done
+  '';
+
+  meta = with lib; {
+    license = with licenses; [ bsd2 gpl2 gpl3 lgpl21 lgpl3 mit ];
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
+  };
+}


### PR DESCRIPTION
Newer GCC version for arm embedded development

###### Description of changes

Added a nix expression to build GCC 11 for arm embedded development. I'm not sure, I think an entry in all-packages.nix might still be missing for it to take effect?
Tested: Binaries work as expected.
Still open to do: Meta information, maintainers.

###### Things done


- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
- [ ] Tested, as applicable:
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md). (*hopefully*)

