### PR TITLE
safeeyes: fix double wrap

### DIFF
--- a/nixos/modules/services/misc/safeeyes.nix
+++ b/nixos/modules/services/misc/safeeyes.nix
@@ -34,8 +34,6 @@ in
       wantedBy = [ "graphical-session.target" ];
       partOf   = [ "graphical-session.target" ];
 
-      path = [ pkgs.alsa-utils ];
-
       startLimitIntervalSec = 350;
       startLimitBurst = 10;
       serviceConfig = {

--- a/pkgs/applications/misc/safeeyes/default.nix
+++ b/pkgs/applications/misc/safeeyes/default.nix
@@ -1,74 +1,74 @@
-{ lib, python3Packages, gobject-introspection, libappindicator-gtk3, libnotify, gtk3, gnome, xprintidle-ng, wrapGAppsHook, gdk-pixbuf, shared-mime-info, librsvg
+{ lib
+, buildPythonApplication
+, fetchPypi
+, alsa-utils
+, gobject-introspection
+, libappindicator-gtk3
+, libnotify
+, wlrctl
+, gtk3
+, xprintidle
+, wrapGAppsHook
+, babel
+, psutil
+, xlib
+, pygobject3
+, dbus-python
+, croniter
 }:
 
-let inherit (python3Packages) python buildPythonApplication fetchPypi croniter;
-
-in buildPythonApplication rec {
+buildPythonApplication rec {
   pname = "safeeyes";
   version = "2.1.3";
-  namePrefix = "";
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "1b5w887hivmdrkm1ydbar4nmnks6grpbbpvxgf9j9s46msj03c9x";
   };
 
-  buildInputs = [
-    gtk3
-    gobject-introspection
-    gnome.adwaita-icon-theme
-    gnome.adwaita-icon-theme
-  ];
-
   nativeBuildInputs = [
     wrapGAppsHook
+    gobject-introspection
   ];
 
-  propagatedBuildInputs = with python3Packages; [
+  buildInputs = [
+    gtk3
+    libappindicator-gtk3
+    libnotify
+  ];
+
+  propagatedBuildInputs = [
     babel
     psutil
     xlib
     pygobject3
     dbus-python
     croniter
-
-    libappindicator-gtk3
-    libnotify
-    xprintidle-ng
   ];
 
-  # patch smartpause plugin
-  postPatch = ''
-    sed -i \
-      -e 's!xprintidle!xprintidle-ng!g' \
-      safeeyes/plugins/smartpause/plugin.py
+  # Prevent double wrapping, let the Python wrapper use the args in preFixup.
+  dontWrapGApps = true;
 
-    sed -i \
-      -e 's!xprintidle!xprintidle-ng!g' \
-      safeeyes/plugins/smartpause/config.json
+  postInstall = ''
+    mkdir -p $out/share/applications
+    cp -r safeeyes/platform/icons $out/share/icons/
+    cp safeeyes/platform/safeeyes.desktop $out/share/applications/safeeyes.desktop
   '';
 
   preFixup = ''
-    gappsWrapperArgs+=(
-      --prefix XDG_DATA_DIRS : "${gdk-pixbuf}/share"
-      --prefix XDG_DATA_DIRS : "${shared-mime-info}/share"
-      --prefix XDG_DATA_DIRS : "${librsvg}/share"
-
-      # safeeyes images
-      --prefix XDG_DATA_DIRS : "$out/lib/${python.libPrefix}/site-packages/usr/share"
+    makeWrapperArgs+=(
+      "''${gappsWrapperArgs[@]}"
+      --prefix PATH : ${lib.makeBinPath [ alsa-utils wlrctl xprintidle ]}
     )
-    mkdir -p $out/share/applications
-    cp -r safeeyes/platform/icons $out/share/
-    cp safeeyes/platform/safeeyes.desktop $out/share/applications/
   '';
 
   doCheck = false; # no tests
 
-  meta = {
+  meta = with lib; {
     homepage = "http://slgobinath.github.io/SafeEyes";
     description = "Protect your eyes from eye strain using this simple and beautiful, yet extensible break reminder. A Free and Open Source Linux alternative to EyeLeo";
-    license = lib.licenses.gpl3;
-    maintainers = with lib.maintainers; [ srghma ];
-    platforms = lib.platforms.all;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ srghma ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10501,7 +10501,7 @@ with pkgs;
 
   safe-rm = callPackage ../tools/system/safe-rm { };
 
-  safeeyes = callPackage ../applications/misc/safeeyes { };
+  safeeyes = with python3.pkgs; toPythonApplication safeeyes;
 
   sahel-fonts = callPackage ../data/fonts/sahel-fonts { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9608,6 +9608,8 @@ in {
 
   safe = callPackage ../development/python-modules/safe { };
 
+  safeeyes = callPackage ../applications/misc/safeeyes { };
+
   safeio = callPackage ../development/python-modules/safeio { };
 
   safety = callPackage ../development/python-modules/safety { };


### PR DESCRIPTION
###### Description of changes
 It doesn't work for me. Maybe due to the double wrap. I also remove the xprintidle-ng replacement since it's inactive while xprintidle is still active. I add wlrctl and alsa-utils dor the plugins. Some icons are missing but I don't know why. The origin fix doesn't work so I remove it.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
