### PR TITLE
smartdeblur: unstable-2013-01-09 -> unstable-2018-10-29

### DIFF
--- a/pkgs/applications/graphics/smartdeblur/default.nix
+++ b/pkgs/applications/graphics/smartdeblur/default.nix
@@ -1,24 +1,29 @@
-{ lib, stdenv, fetchFromGitHub, cmake, qt4, fftw }:
+{ stdenv, lib, fetchFromGitHub, cmake, fftw
+, qtbase, qmake, wrapQtAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "smartdeblur";
-  version = "unstable-2013-01-09";
+  version = "unstable-2018-10-29";
 
   src = fetchFromGitHub {
     owner = "Y-Vladimir";
     repo = "SmartDeblur";
-    rev = "9895036d26cbb823a9ade28cdcb26fd0ac37258e";
-    sha256 = "sha256-+EbqEpOG1fj2OKmlz8NRF/CGfT2OYGwY5/lwJHCHaMw=";
+    rev = "5af573c7048ac49ef68e638f3405d3a571b96a8b";
+    sha256 = "151vdd5ld0clw0vgp0fvp2gp2ybwpx9g43dad9fvbvwkg60izs87";
   };
 
-  preConfigure = ''
-    cd src
+  sourceRoot = "${src.name}/src";
+
+  nativeBuildInputs = [ qmake wrapQtAppsHook ];
+  buildInputs = [ qtbase fftw ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 ./SmartDeblur -t $out/bin
+
+    runHook postInstall
   '';
-
-  nativeBuildInputs = [ cmake ];
-  buildInputs = [ qt4 fftw ];
-
-  cmakeFlags = [ "-DUSE_SYSTEM_FFTW=ON" ];
 
   meta = with lib; {
     homepage = "https://github.com/Y-Vladimir/SmartDeblur";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30281,7 +30281,7 @@ with pkgs;
     jre = openjdk11;
   };
 
-  smartdeblur = callPackage ../applications/graphics/smartdeblur { };
+  smartdeblur = libsForQt5.callPackage ../applications/graphics/smartdeblur { };
 
   snapper = callPackage ../tools/misc/snapper { };
   snapper-gui = callPackage ../applications/misc/snapper-gui { };


### PR DESCRIPTION
###### Description of changes
qt4 -> qt5

Splitting out parts of https://github.com/NixOS/nixpkgs/pull/174634, to make it more reviewable

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).