### PR TITLE
l3afpad: init at unstable-2022-02-14

### DIFF
--- a/pkgs/applications/editors/l3afpad/default.nix
+++ b/pkgs/applications/editors/l3afpad/default.nix
@@ -1,0 +1,25 @@
+{ lib, stdenv, fetchurl, intltool, pkg-config, gtk3, fetchFromGitHub
+, autoreconfHook, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  version = "unstable-2022-02-14";
+  pname = "l3afpad";
+
+  src = fetchFromGitHub {
+    owner = "stevenhoneyman";
+    repo = pname;
+    rev = "16f22222116b78b7f6a6fd83289937cdaabed624";
+    sha256 = "sha256-ly2w9jmRlprm/PnyC0LYjrxBVK+J0DLiSpzuTUMZpWA=";
+  };
+
+  nativeBuildInputs = [ pkg-config autoreconfHook wrapGAppsHook ];
+  buildInputs = [ intltool gtk3 ];
+
+  meta = with lib; {
+    description = "Simple text editor forked from Leafpad using GTK+ 3.x";
+    homepage = "https://github.com/stevenhoneyman/l3afpad";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ ckie ];
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9077,6 +9077,8 @@ with pkgs;
 
   leafpad = callPackage ../applications/editors/leafpad { };
 
+  l3afpad = callPackage ../applications/editors/l3afpad { };
+
   leatherman = callPackage ../development/libraries/leatherman { };
 
   ledit = callPackage ../tools/misc/ledit {


### PR DESCRIPTION
###### Description of changes
> \<夜坂雅 | Yorusaka Miyabi>
> About GTK2, What do you think about l3afpad ? Maybe I can package this as I believe it's trivial to do.
> l3afpad: https://github.com/stevenhoneyman/l3afpad
> 
> \<hexa>
> https://github.com/stevenhoneyman/l3afpad/commits/master
> woefully undermaintained software
> not a fan
>
> \<夜坂雅 | Yorusaka Miyabi>
> 👀
> 
> \<ckie (they/them)>
> it looks fairly trivial indeed

It was.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
