### PR TITLE
[22.05] rustdesk: 1.1.8 -> 1.1.9, fix

### DIFF
--- a/pkgs/applications/networking/remote/rustdesk/cargo.patch
+++ b/pkgs/applications/networking/remote/rustdesk/cargo.patch
@@ -1,26 +1,24 @@
 diff --git a/Cargo.lock b/Cargo.lock
-index c3e139e..b77d8bd 100644
+index fb17c7e..ef157e5 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -1761,11 +1761,11 @@ dependencies = [
- 
+@@ -2332,10 +2332,10 @@ dependencies = [
  [[package]]
  name = "magnum-opus"
--version = "0.3.4-2"
--source = "git+https://github.com/open-trade/magnum-opus#ad0836164abf4a4df69009b1ee08eabe3a13b33f"
-+version = "0.4.0"
+ version = "0.4.0"
+-source = "git+https://github.com/open-trade/magnum-opus#3c3d0b86ae95c84930bebffe4bcb03b3bd83342b"
 +source = "git+https://github.com/TheRadioGuy/magnum-opus#171e1d021004626f7444d1e39b98f50bc3cb2604"
  dependencies = [
-- "bindgen 0.59.1",
+- "bindgen",
 - "target_build_utils",
 + "libc",
 + "opusic-sys",
  ]
  
  [[package]]
-@@ -2188,6 +2188,16 @@ version = "0.1.4"
+@@ -2796,6 +2796,16 @@ version = "0.1.5"
  source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
+ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
  
 +[[package]]
 +name = "opusic-sys"
@@ -33,18 +31,18 @@ index c3e139e..b77d8bd 100644
 +]
 +
  [[package]]
- name = "parity-tokio-ipc"
- version = "0.7.2"
+ name = "os_str_bytes"
+ version = "6.0.0"
 diff --git a/Cargo.toml b/Cargo.toml
-index 75504a0..43e1624 100644
+index 1b715bd..960e8da 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -32,7 +32,7 @@ libc = "0.2"
+@@ -35,7 +35,7 @@ libc = "0.2"
  parity-tokio-ipc = { git = "https://github.com/open-trade/parity-tokio-ipc" }
- flexi_logger = "0.17"
+ flexi_logger = { version = "0.22", features = ["async", "use_chrono_for_offset"] }
  runas = "0.2"
 -magnum-opus = { git = "https://github.com/open-trade/magnum-opus" }
 +magnum-opus = { git = "https://github.com/TheRadioGuy/magnum-opus" }
  dasp = { version = "0.11", features = ["signal", "interpolate-linear", "interpolate"], optional = true }
- rubato = { version = "0.8", optional = true }
+ rubato = { version = "0.12", optional = true }
  samplerate = { version = "0.2", optional = true }

--- a/pkgs/applications/networking/remote/rustdesk/default.nix
+++ b/pkgs/applications/networking/remote/rustdesk/default.nix
@@ -24,20 +24,21 @@
 , libsciter
 , llvmPackages
 , wrapGAppsHook
+, writeText
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "rustdesk";
-  version = "1.1.8";
+  version = "1.1.9";
 
   src = fetchFromGitHub {
     owner = "rustdesk";
     repo = "rustdesk";
-    rev = "0325500ebf331b66220cec6e9078afb83b0e98a7";
-    sha256 = "sha256-xglyyoiAjJx3y8+A2OYHZffjqjDkcTjIluPA/J42VVg=";
+    rev = version;
+    sha256 = "sha256-IlrfqwNyaSHE9Ct0mn7MUxEg7p1Ku34eOMYelEAYFW8=";
   };
 
-  cargoSha256 = "sha256-4MQKa54f3X7IHGd29H6RY7v2toeHvTHInIpgXjdotjw=";
+  cargoSha256 = "sha256-1OMWEk+DerltF7kwdo4d04rbgIFLHBRq3vZaL7jtrdE=";
 
   LIBCLANG_PATH="${llvmPackages.libclang.lib}/lib";
 
@@ -51,10 +52,29 @@ rustPlatform.buildRustPackage rec {
   # properly.
   postUnpack = let
     vcpkg_target = "x64-linux";
+
+    updates_vcpkg_file = writeText "update_vcpkg_rustdesk"
+    ''
+    Package : libyuv
+    Architecture : ${vcpkg_target}
+    Version : 1.0
+    Status : is installed
+
+    Package : libvpx
+    Architecture : ${vcpkg_target}
+    Version : 1.0
+    Status : is installed
+    '';
   in ''
     export VCPKG_ROOT="$TMP/vcpkg";
 
+    mkdir -p $VCPKG_ROOT/.vcpkg-root
     mkdir -p $VCPKG_ROOT/installed/${vcpkg_target}/lib
+    mkdir -p $VCPKG_ROOT/installed/vcpkg/updates
+    ln -s ${updates_vcpkg_file} $VCPKG_ROOT/installed/vcpkg/status
+    mkdir -p $VCPKG_ROOT/installed/vcpkg/info
+    touch $VCPKG_ROOT/installed/vcpkg/info/libyuv_1.0_${vcpkg_target}.list
+    touch $VCPKG_ROOT/installed/vcpkg/info/libvpx_1.0_${vcpkg_target}.list
 
     ln -s ${libvpx.out}/lib/* $VCPKG_ROOT/installed/${vcpkg_target}/lib/
     ln -s ${libyuv.out}/lib/* $VCPKG_ROOT/installed/${vcpkg_target}/lib/


### PR DESCRIPTION
Backports: #174966

###### Criteria for Backporting changes

- closes: #182278

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
