### PR TITLE
psipred: init at 4.0

### DIFF
--- a/pkgs/applications/science/biology/psipred/default.nix
+++ b/pkgs/applications/science/biology/psipred/default.nix
@@ -1,0 +1,44 @@
+{ lib, stdenv, fetchFromGitHub, blast, tcsh, }:
+
+stdenv.mkDerivation rec {
+  pname = "psipred";
+  version = "4.0";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1frxpnrxkhj968k0w6r4npsn5g0jjd0bx6wmb68yqbqkns1qfrgf";
+  };
+
+  buildInputs = [ blast tcsh ];
+
+  postPatch = ''
+    substituteInPlace ./BLAST+/runpsipredplus \
+      --replace "uniref90filt" "\$SEQUENCE_DATA_BANK" \
+      --replace "/usr/local/bin" "${blast}/bin" \
+      --replace "../bin" "$out/bin" \
+      --replace "../data" "$out/share/psipred/data"
+  '';
+
+  preBuild = ''
+    cd ./src
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm 755 psipred psipass2 chkparse seq2mtx ../BLAST+/runpsipredplus -t $out/bin
+    install -Dm 755 ../data/* -t $out/share/psipred/data
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Protein Secondary Structure Predictor";
+    homepage = "http://bioinf.cs.ucl.ac.uk/psipred";
+    license = licenses.free;
+    maintainers = with maintainers; [ natsukium ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33530,6 +33530,8 @@ with pkgs;
 
   prodigal = callPackage ../applications/science/biology/prodigal { };
 
+  psipred = callPackage ../applications/science/biology/psipred { };
+
   quast = callPackage ../applications/science/biology/quast { };
 
   raxml = callPackage ../applications/science/biology/raxml { };


### PR DESCRIPTION
###### Description of changes

PSIPRED Protein Secondary Structure Predictor
http://bioinf.cs.ucl.ac.uk/psipred/
repo: https://github.com/psipred/psipred

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
