### PR TITLE
siglo: init at 0.9.9

### DIFF
--- a/pkgs/applications/misc/siglo/default.nix
+++ b/pkgs/applications/misc/siglo/default.nix
@@ -1,0 +1,70 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, glib
+, meson
+, ninja
+, wrapGAppsHook
+, desktop-file-utils
+, gobject-introspection
+, gtk3
+, python3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "siglo";
+  version = "0.9.9";
+
+  src = fetchFromGitHub {
+    owner = "theironrobin";
+    repo = "siglo";
+    rev = "v${version}";
+    hash = "sha256-4jKsRpzuyHH31LXndC3Ua4TYcI0G0v9qqe0cbvLuCDA=";
+  };
+
+  patches = [
+    ./siglo-no-user-install.patch
+  ];
+
+  postPatch = ''
+    chmod +x build-aux/meson/postinstall.py # patchShebangs requires an executable file
+    patchShebangs build-aux/meson/postinstall.py
+  '';
+
+  nativeBuildInputs = [
+    glib
+    meson
+    ninja
+    wrapGAppsHook
+    python3.pkgs.wrapPython
+    python3
+    desktop-file-utils
+    gtk3
+  ];
+
+  buildInputs = [
+    gtk3
+    python3.pkgs.gatt
+    gobject-introspection
+  ];
+
+  pythonPath = with python3.pkgs; [
+    gatt
+    pybluez
+    requests
+  ];
+
+  preFixup = ''
+    buildPythonPath "$out $pythonPath"
+    gappsWrapperArgs+=(--prefix PYTHONPATH : "$program_PYTHONPATH")
+  '';
+
+  meta = with lib; {
+    description = "GTK app to sync InfiniTime watch with PinePhone";
+    homepage = "https://github.com/theironrobin/siglo";
+    changelog = "https://github.com/theironrobin/siglo/tags/v${version}";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ tomfitzhenry ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/siglo/siglo-no-user-install.patch
+++ b/pkgs/applications/misc/siglo/siglo-no-user-install.patch
@@ -1,0 +1,13 @@
+diff --git a/data/meson.build b/data/meson.build
+index 62a00fe..5319974 100644
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -18,8 +18,6 @@ install_data(join_paths('icons', 'com.github.alexr4535.siglo.svg'),
+   install_dir: join_paths(get_option('datadir'), 'icons')
+ )
+ 
+-install_data('siglo.service', install_dir: '/etc/systemd/user/')
+-
+ appstream_file = i18n.merge_file(
+   input: 'com.github.alexr4535.siglo.appdata.xml.in',
+   output: 'com.github.alexr4535.siglo.appdata.xml',

--- a/pkgs/development/python-modules/gatt/default.nix
+++ b/pkgs/development/python-modules/gatt/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, dbus-python
+, pygobject3
+}:
+
+buildPythonPackage rec {
+  pname = "gatt";
+  version = "0.2.6";
+
+  src = fetchFromGitHub {
+    owner = "getsenic";
+    repo = "gatt-python";
+    rev = "${version}";
+    hash = "sha256-GMLqQ9ojQ649hbbJB+KiQoOhiTWweOgv6zaCDzhIB5A=";
+  };
+
+  propagatedBuildInputs = [
+    dbus-python
+    pygobject3
+  ];
+
+  pythonImportsCheck = [ "gatt" ];
+
+  meta = with lib; {
+    description = "Bluetooth (Generic Attribute Profile) GATT SDK for Python";
+    homepage = "https://github.com/getsenic/gatt-python/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ tomfitzhenry ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4429,6 +4429,8 @@ with pkgs;
 
   shisho = callPackage ../tools/security/shisho { };
 
+  siglo = callPackage ../applications/misc/siglo { };
+
   simg2img = callPackage ../tools/filesystems/simg2img { };
 
   snazy = callPackage ../development/tools/snazy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3414,6 +3414,8 @@ in {
 
   garages-amsterdam = callPackage ../development/python-modules/garages-amsterdam { };
 
+  gatt = callPackage ../development/python-modules/gatt { };
+
   gattlib = callPackage ../development/python-modules/gattlib {
     inherit (pkgs) bluez glib pkg-config;
   };


### PR DESCRIPTION
###### Description of changes

Introduce https://github.com/theironrobin/siglo , a "GTK app to sync InfiniTime watch with PinePhone ".

Tested by starting the Siglo app, connecting to my Pinetime watch, and remotely flashing firmware.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).