### PR TITLE
libdigidocpp: 3.14.8 -> 3.14.10

### DIFF
--- a/pkgs/development/libraries/libdigidocpp/default.nix
+++ b/pkgs/development/libraries/libdigidocpp/default.nix
@@ -2,25 +2,13 @@
 , xercesc, xml-security-c, pkg-config, xsd, zlib, xalanc, xxd }:
 
 stdenv.mkDerivation rec {
-  version = "3.14.8";
+  version = "3.14.10";
   pname = "libdigidocpp";
 
   src = fetchurl {
      url = "https://github.com/open-eid/libdigidocpp/releases/download/v${version}/libdigidocpp-${version}.tar.gz";
-     sha256 = "sha256-U5i5IAyJF4359q6M6mQemEuG7+inPYIXqLy8GHv4dkg=";
+     sha256 = "sha256-n/+R4ho1Qcft3YSKE12oxZjbFHAsUDwoLFNuk5GXf5c=";
   };
-
-  patches = [
-    (fetchpatch {
-      # fix runtime crashes when signing with OpenSSL>1.1.1l
-      # https://github.com/open-eid/libdigidocpp/issues/474 asks for a new release
-      url = "https://github.com/open-eid/libdigidocpp/commit/42a8cfd834c10bdd206fe784a13217df222b1c8e.patch";
-      sha256 = "sha256-o3ZT0dXhIu79C5ZR+2HPdLMZ3YwPG1v3vly5bseuxtU=";
-      excludes = [
-        ".github/workflows/build.yml" # failed hunk
-      ];
-    })
-  ];
 
   nativeBuildInputs = [ cmake pkg-config xxd ];
 

--- a/pkgs/development/libraries/libdigidocpp/default.nix
+++ b/pkgs/development/libraries/libdigidocpp/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
      url = "https://github.com/open-eid/libdigidocpp/releases/download/v${version}/libdigidocpp-${version}.tar.gz";
-     sha256 = "sha256-n/+R4ho1Qcft3YSKE12oxZjbFHAsUDwoLFNuk5GXf5c=";
+     hash = "sha256-n/+R4ho1Qcft3YSKE12oxZjbFHAsUDwoLFNuk5GXf5c=";
   };
 
   nativeBuildInputs = [ cmake pkg-config xxd ];


### PR DESCRIPTION
This includes 42a8cfd834c10bdd206fe784a13217df222b1c8e, fixing crashes
with OpenSSL>1.1.1l. We previously fetchpatched the patch manually.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
