### PR TITLE
libsForQt5.kirigami-gallery: init at 22.04.3

### DIFF
--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -145,6 +145,7 @@ let
       kio-extras = callPackage ./kio-extras.nix {};
       kio-gdrive = callPackage ./kio-gdrive.nix {};
       kipi-plugins = callPackage ./kipi-plugins.nix {};
+      kirigami-gallery = callPackage ./kirigami-gallery.nix {};
       kitinerary = callPackage ./kitinerary.nix {};
       kldap = callPackage ./kldap.nix {};
       kleopatra = callPackage ./kleopatra.nix {};

--- a/pkgs/applications/kde/kirigami-gallery.nix
+++ b/pkgs/applications/kde/kirigami-gallery.nix
@@ -1,0 +1,31 @@
+{ mkDerivation
+, lib
+, kirigami2
+, extra-cmake-modules
+, kitemmodels
+, qtgraphicaleffects
+, qtquickcontrols2
+, qttools
+, qtbase
+}:
+
+mkDerivation rec {
+  pname = "kirigami-gallery";
+
+  nativeBuildInputs = [ extra-cmake-modules qttools ];
+
+  buildInputs = [
+    qtgraphicaleffects
+    qtquickcontrols2
+    kirigami2
+    kitemmodels
+  ];
+
+  meta = with lib; {
+    homepage = "https://apps.kde.org/kirigami2.gallery/";
+    description = "View examples of Kirigami components";
+    license = licenses.lgpl2;
+    maintainers = with maintainers; [ shadowrz ];
+    broken = lib.versionOlder qtbase.version "5.15";
+  };
+}

--- a/pkgs/applications/kde/kirigami-gallery.nix
+++ b/pkgs/applications/kde/kirigami-gallery.nix
@@ -26,6 +26,6 @@ mkDerivation rec {
     description = "View examples of Kirigami components";
     license = licenses.lgpl2;
     maintainers = with maintainers; [ shadowrz ];
-    broken = lib.versionOlder qtbase.version "5.15";
+    broken = versionOlder qtbase.version "5.15";
   };
 }


### PR DESCRIPTION
###### Description of changes

https://apps.kde.org/kirigami2.gallery/

Kirigami gallery allows you to preview Kirigami components.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
