### PR TITLE
plan9port: update darwin inputs

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14009,6 +14009,12 @@
     githubId = 5978566;
     name = "Yves-Stan Le Cornec";
   };
+  ylh = {
+    email = "nixpkgs@ylh.io";
+    github = "ylh";
+    githubId = 9125590;
+    name = "Yestin L. Harrison";
+  };
   ylwghst = {
     email = "ylwghst@onionmail.info";
     github = "ylwghst";

--- a/pkgs/tools/system/plan9port/default.nix
+++ b/pkgs/tools/system/plan9port/default.nix
@@ -1,24 +1,17 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, darwin ? null
-, fontconfig ? null
-, freetype ? null
-, libX11
-, libXext ? null
-, libXt ? null
-, perl ? null  # For building web manuals
+{ lib, stdenv, fetchFromGitHub
+, fontconfig, freetype, libX11, libXext, libXt, xorgproto
+, Carbon, Cocoa, IOKit, Metal, QuartzCore, DarwinTools
+, perl # For building web manuals
 , which
-, xorgproto ? null
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "plan9port";
   version = "2021-10-19";
 
-  src =  fetchFromGitHub {
+  src = fetchFromGitHub {
     owner = "9fans";
-    repo = "plan9port";
+    repo = pname;
     rev = "d0d440860f2000a1560abb3f593cdc325fcead4c";
     hash = "sha256-2aYXqPGwrReyFPrLDtEjgQd/RJjpOfI3ge/tDocYpRQ=";
   };
@@ -44,22 +37,20 @@ stdenv.mkDerivation {
       --replace "case Kcmd+'v':" "case 0x16: case Kcmd+'v':"
   '';
 
-  buildInputs = [
-    perl
-  ] ++ lib.optionals (!stdenv.isDarwin) [
+  buildInputs = [ perl ] ++ (if !stdenv.isDarwin then [
     fontconfig
-    freetype # fontsrv wants ft2build.h provides system fonts for acme and sam
+    freetype # fontsrv wants ft2build.h
     libX11
     libXext
     libXt
     xorgproto
-  ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+  ] else [
     Carbon
     Cocoa
     IOKit
     Metal
     QuartzCore
-    darwin.DarwinTools
+    DarwinTools
   ]);
 
   builder = ./builder.sh;

--- a/pkgs/tools/system/plan9port/default.nix
+++ b/pkgs/tools/system/plan9port/default.nix
@@ -91,6 +91,7 @@ stdenv.mkDerivation rec {
       ehmry
       ftrvxmtrx
       kovirobi
+      ylh
     ];
     mainProgram = "9";
     platforms = platforms.unix;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9646,7 +9646,10 @@ with pkgs;
 
   plantuml-server = callPackage ../tools/misc/plantuml-server { };
 
-  plan9port = callPackage ../tools/system/plan9port { };
+  plan9port = callPackage ../tools/system/plan9port {
+    inherit (darwin.apple_sdk.frameworks) Carbon Cocoa IOKit Metal QuartzCore;
+    inherit (darwin) DarwinTools;
+  };
 
   platformioPackages = dontRecurseIntoAttrs (callPackage ../development/embedded/platformio { });
   platformio = platformioPackages.platformio-chrootenv;


### PR DESCRIPTION
###### Description of changes

Refactor to the modern style of calling darwin deps, as promised in https://github.com/NixOS/nixpkgs/pull/148087#issuecomment-984201791. Does not appear to cause rebuilds on any platform.

Also adding myself as a maintainer. A few more changes (which *will* cause rebuilds) are forthcoming.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

