### PR TITLE
[22.05] wolfssl: add patches for CVE-2022-34293 & encrypted memory improvements

### DIFF
--- a/pkgs/development/libraries/wolfssl/default.nix
+++ b/pkgs/development/libraries/wolfssl/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , autoreconfHook
 , openssl
 }:
@@ -15,6 +16,19 @@ stdenv.mkDerivation rec {
     rev = "v${version}-stable";
     sha256 = "sha256-KteArWAgDohlqEYaNfzLPuBn6uy5ABA8vV/LRCVIPGA=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2022-34293.patch";
+      url = "https://github.com/wolfSSL/wolfssl/commit/17d7098bf63b2716ef36a72754c7c93baacc9cee.patch";
+      sha256 = "sha256-BgBMtOdyPV94aptlpt9IvcW9eJ0hlvlgp+H8LxQ2shs=";
+    })
+    (fetchpatch {
+      name = "ecc-dh-improve-encrypted-memory-implementations.patch";
+      url = "https://github.com/wolfSSL/wolfssl/commit/3c634e1f593586ff011623dd746f5a37d5659faf.patch";
+      sha256 = "sha256-AUATjk/GIWuh+qUw21Ruzj9yzYU11wNiLvOzagkILcw=";
+    })
+  ];
 
   postPatch = ''
     patchShebangs ./scripts


### PR DESCRIPTION
###### Description of changes
These are the actionable security issues announced with 5.4.0 (merged in #181566)

https://www.wolfssl.com/docs/security-vulnerabilities/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
    - [x] `pkgsMusl` variant
    - [x] `pkgsCross.aarch64-multiplatform` variant
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. (*skipped long build of rpcs3*)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
