### PR TITLE
Revert "openldap: load client config from /etc, not the nix store"

### DIFF
--- a/nixos/tests/openldap.nix
+++ b/nixos/tests/openldap.nix
@@ -13,17 +13,10 @@ let
     objectClass: organizationalUnit
     ou: users
   '';
-  ldapClientConfig = {
-    enable = true;
-    loginPam = false;
-    nsswitch = false;
-    server = "ldap://";
-    base = "dc=example";
-  };
   testScript = ''
     machine.wait_for_unit("openldap.service")
     machine.succeed(
-        'ldapsearch -LLL -D "cn=root,dc=example" -w notapassword',
+        'ldapsearch -LLL -D "cn=root,dc=example" -w notapassword -b "dc=example"',
     )
   '';
 in {
@@ -64,7 +57,6 @@ in {
         };
         declarativeContents."dc=example" = dbContents;
       };
-      users.ldap = ldapClientConfig;
     };
   }) { inherit pkgs system; };
 
@@ -84,7 +76,6 @@ in {
         rootpw = "notapassword";
         declarativeContents."dc=example" = dbContents;
       };
-      users.ldap = ldapClientConfig;
     };
   }) { inherit system pkgs; };
 
@@ -97,7 +88,6 @@ in {
         enable = true;
         configDir = "/var/db/slapd.d";
       };
-      users.ldap = ldapClientConfig;
     };
 
     testScript = let

--- a/pkgs/development/libraries/openldap/default.nix
+++ b/pkgs/development/libraries/openldap/default.nix
@@ -97,7 +97,7 @@ stdenv.mkDerivation rec {
     "CC=${stdenv.cc.targetPrefix}cc"
     "STRIP="  # Disable install stripping as it breaks cross-compiling. We strip binaries anyway in fixupPhase.
     "prefix=${placeholder "out"}"
-    "sysconfdir=/etc"
+    "sysconfdir=${placeholder "out"}/etc"
     "systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
     # contrib modules require these
     "moduledir=${placeholder "out"}/lib/modules"
@@ -134,7 +134,6 @@ stdenv.mkDerivation rec {
 
   installFlags = [
     "prefix=${placeholder "out"}"
-    "sysconfdir=${placeholder "out"}/etc"
     "moduledir=${placeholder "out"}/lib/modules"
     "INSTALL=install"
   ];


### PR DESCRIPTION
Reverts NixOS/nixpkgs#182080

Missed the target branch, this should've gone into staging, not master.