### PR TITLE
twitch-tui: init at 1.6.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/twitch-tui/default.nix
+++ b/pkgs/applications/networking/instant-messengers/twitch-tui/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchFromGitHub, rustPlatform, pkg-config, openssl }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "twitch-tui";
+  version = "1.6.0";
+
+  src = fetchFromGitHub {
+    owner = "Xithrius";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-144yn/QQPIZJOgqKFUWjB7KCmEKfNpj6XjMGhTpQdEQ=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ];
+
+  cargoHash = "sha256-zUeI01EyXsuoKzHbpVu3jyA3H2aBk6wMY+GW3h3v8vc=";
+
+  meta = with lib; {
+    description = "Twitch chat in the terminal";
+    homepage = "https://github.com/Xithrius/twitch-tui";
+    license = licenses.mit;
+    maintainers = [ maintainers.taha ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5029,6 +5029,8 @@ with pkgs;
 
   keyd = callPackage ../tools/inputmethods/keyd { };
 
+  twitch-tui = callPackage ../applications/networking/instant-messengers/twitch-tui { };
+
   gebaar-libinput = callPackage ../tools/inputmethods/gebaar-libinput { stdenv = gcc10StdenvCompat; };
 
   kime = callPackage ../tools/inputmethods/kime { };


### PR DESCRIPTION
###### Description of changes

https://github.com/Xithrius/twitch-tui

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).