### PR TITLE
ladybird: init at unstable-2022-07-20

### DIFF
--- a/pkgs/applications/networking/browsers/ladybird/default.nix
+++ b/pkgs/applications/networking/browsers/ladybird/default.nix
@@ -1,0 +1,94 @@
+{ lib
+, gcc11Stdenv
+, fetchFromGitHub
+, cmake
+, ninja
+, unzip
+, wrapQtAppsHook
+, makeWrapper
+, qtbase
+, qttools
+}:
+
+let serenity = fetchFromGitHub {
+  owner = "SerenityOS";
+  repo = "serenity";
+  rev = "094ba6525f0217f3b8d5e467cef326caeb659e8a";
+  hash = "sha256-IHXe2Td9iRSL1oQVwL2gZHxEM2ID4SghZwK6ewjFV1Y=";
+};
+
+in gcc11Stdenv.mkDerivation {
+  pname = "ladybird";
+  version = "unstable-2022-07-20";
+
+  # Remember to update `serenity` too!
+  src = fetchFromGitHub {
+    owner = "awesomekling";
+    repo = "ladybird";
+    rev = "9e3a1f47d484cee6f23c4dae6c51750af155a8fc";
+    hash = "sha256-1cPWpPvjM/VcVUEf2k+MvGvTgZ3Fc4LFHZCLh1wU78Y=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    unzip
+    wrapQtAppsHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    qtbase
+  ];
+
+  cmakeFlags = [
+    "-DSERENITY_SOURCE_DIR=${serenity}"
+    # Disable network operations
+    "-DENABLE_TIME_ZONE_DATABASE_DOWNLOAD=false"
+    "-DENABLE_UNICODE_DATABASE_DOWNLOAD=false"
+  ];
+
+  NIX_CFLAGS_COMPILE = [ "-Wno-error" ];
+
+  # Upstream install rules are missing
+  # https://github.com/awesomekling/ladybird/issues/36
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 ladybird $out/bin/ladybird
+    mkdir -p $out/lib/ladybird
+    cp -d _deps/lagom-build/*.so* $out/lib/ladybird/
+    runHook postInstall
+  '';
+
+  # Patch rpaths
+  # https://github.com/awesomekling/ladybird/issues/36
+  preFixup = ''
+    for f in $out/bin/ladybird $out/lib/ladybird/*.so; do
+      old_rpath=$(patchelf --print-rpath "$f")
+      # Remove reference to libraries from build directory
+      rpath_without_build=$(sed -e 's@[^:]*/_deps/lagom-build:@@g' <<< $old_rpath)
+      # Add directory where we install those libraries
+      new_rpath=$out/lib/ladybird:$rpath_without_build
+      patchelf --set-rpath "$new_rpath" "$f"
+    done
+  '';
+
+  # According to the readme, the program needs access to the serenity sources
+  # at runtime
+  postFixup = ''
+    wrapProgram $out/bin/ladybird --set SERENITY_SOURCE_DIR "${serenity}"
+  '';
+
+  # Stripping results in a symbol lookup error
+  dontStrip = true;
+
+  meta = with lib; {
+    description = "A browser using the SerenityOS LibWeb engine with a Qt GUI";
+    homepage = "https://github.com/awesomekling/ladybird";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ fgaz ];
+    # SerenityOS only works on x86, and can only be built on unix systems.
+    # We also use patchelf in preFixup, so we restrict that to linux only.
+    platforms = [ "x86_64-linux" "i686-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28282,6 +28282,8 @@ with pkgs;
 
   ladspa-sdk = callPackage ../applications/audio/ladspa-sdk { };
 
+  ladybird = qt6.callPackage ../applications/networking/browsers/ladybird { };
+
   lazpaint = callPackage ../applications/graphics/lazpaint { };
 
   caps = callPackage ../applications/audio/caps { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
The Ladybird Web Browser is a browser using the SerenityOS LibWeb engine with a Qt GUI.
https://github.com/awesomekling/ladybird

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
