### PR TITLE
openssl: split runtime dependencies of static builds into a separate output

### DIFF
--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -44,9 +44,21 @@ let
       substituteInPlace crypto/async/arch/async_posix.h \
         --replace '!defined(__ANDROID__) && !defined(__OpenBSD__)' \
                   '!defined(__ANDROID__) && !defined(__OpenBSD__) && 0'
+    '' + lib.optionalString static
+    # On static builds, the ENGINESDIR will be empty, but its path will be
+    # compiled into the library. In order to minimize the runtime dependencies
+    # of packages that statically link openssl, we move it into the OPENSSLDIR,
+    # which will be separated into the 'etc' output.
+    ''
+      substituteInPlace Configurations/unix-Makefile.tmpl \
+        --replace 'ENGINESDIR=$(libdir)/engines-{- $sover_dirname -}' \
+                  'ENGINESDIR=$(OPENSSLDIR)/engines-{- $sover_dirname -}'
     '';
 
-    outputs = [ "bin" "dev" "out" "man" ] ++ lib.optional withDocs "doc";
+    outputs = [ "bin" "dev" "out" "man" ]
+      ++ lib.optional withDocs "doc"
+      # Separate output for the runtime dependencies of the static build.
+      ++ lib.optional static "etc";
     setOutputFlags = false;
     separateDebugInfo =
       !stdenv.hostPlatform.isDarwin &&
@@ -102,7 +114,17 @@ let
     configureFlags = [
       "shared" # "shared" builds both shared and static libraries
       "--libdir=lib"
-      "--openssldir=etc/ssl"
+      (if !static then
+         "--openssldir=etc/ssl"
+       else
+         # Separate the OPENSSLDIR into its own output, as its path will be
+         # compiled into 'libcrypto.a'. This makes it a runtime dependency of
+         # any package that statically links openssl, so we want to keep that
+         # output minimal. We need to prepend '/.' to the path in order to make
+         # it appear absolute before variable expansion, the 'prefix' would be
+         # prepended to it otherwise.
+         "--openssldir=/.$(etc)/etc/ssl"
+      )
     ] ++ lib.optionals withCryptodev [
       "-DHAVE_CRYPTODEV"
       "-DUSE_CRYPTODEV_DIGESTS"
@@ -140,6 +162,9 @@ let
       if [ -n "$(echo $out/lib/*.so $out/lib/*.dylib $out/lib/*.dll)" ]; then
           rm "$out/lib/"*.a
       fi
+
+      # 'etc' is a separate output on static builds only.
+      etc=$out
     '') + lib.optionalString (!stdenv.hostPlatform.isWindows)
       # Fix bin/c_rehash's perl interpreter line
       #
@@ -161,14 +186,15 @@ let
       mv $out/include $dev/
 
       # remove dependency on Perl at runtime
-      rm -r $out/etc/ssl/misc
+      rm -r $etc/etc/ssl/misc
 
-      rmdir $out/etc/ssl/{certs,private}
+      rmdir $etc/etc/ssl/{certs,private}
     '';
 
     postFixup = lib.optionalString (!stdenv.hostPlatform.isWindows) ''
-      # Check to make sure the main output doesn't depend on perl
-      if grep -r '${buildPackages.perl}' $out; then
+      # Check to make sure the main output and the static runtime dependencies
+      # don't depend on perl
+      if grep -r '${buildPackages.perl}' $out $etc; then
         echo "Found an erroneous dependency on perl ^^^" >&2
         exit 1
       fi


### PR DESCRIPTION
This is a forward-ported version of #87879. I'll defer to that PR for the details; if someone is able to push the updated commit to that PR instead that'd be great!

The patch is used in [PostgREST](https://github.com/PostgREST/postgrest/blob/main/nix/patches/nixpkgs-openssl-split-runtime-dependencies-of-static-builds.patch)'s static build.
 
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
