### PR TITLE
ocamlPackages.omd: 1.3.1 → 1.3.2

### DIFF
--- a/pkgs/development/ocaml-modules/omd/default.nix
+++ b/pkgs/development/ocaml-modules/omd/default.nix
@@ -1,25 +1,15 @@
-{ stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild }:
+{ lib, buildDunePackage, fetchurl }:
 
-stdenv.mkDerivation rec {
-  pname = "ocaml${ocaml.version}-omd";
-  version = "1.3.1";
+buildDunePackage rec {
+  pname = "omd";
+  version = "1.3.2";
+
+  minimalOCamlVersion = "4.03";
 
   src = fetchurl {
-    url = "https://github.com/Chris00/omd/releases/download/${version}/omd-${version}.tar.gz";
-    sha256 = "1sgdgzpx96br7npj8mh91cli5mqmzsjpngwm7x4212n3k1d0ivwa";
+    url = "https://github.com/ocaml/omd/releases/download/${version}/omd-${version}.tbz";
+    sha256 = "sha256-YCPhZCYx8I9njrVyWCCHnte7Wj/+53fN7evCjB+F+ts=";
   };
-
-  nativeBuildInputs = [ ocaml findlib ocamlbuild ];
-
-  strictDeps = true;
-
-  createFindlibDestdir = true;
-
-  configurePhase = ''
-    runHook preConfigure
-    ocaml setup.ml -configure --prefix $out
-    runHook postConfigure
-  '';
 
   meta = {
     description = "Extensible Markdown library and tool in OCaml";
@@ -27,6 +17,5 @@ stdenv.mkDerivation rec {
     license = lib.licenses.isc;
     maintainers = [ lib.maintainers.vbgl ];
     mainProgram = "omd";
-    inherit (ocaml.meta) platforms;
   };
 }


### PR DESCRIPTION
###### Description of changes

Compatibility with future OCaml: https://github.com/ocaml/omd/releases/tag/1.3.2

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
