### PR TITLE
tere: init to 1.1.0 (how do I fix this?)

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14736,4 +14736,10 @@
     github = "nikstur";
     githubId = 61635709;
   };
+  ProducerMatt = {
+    name = "Matthew Pherigo";
+    email = "ProducerMatt42@gmail.com";
+    github = "ProducerMatt";
+    githubId = 58014742;
+  };
 }

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -32,9 +32,9 @@
     }
   },
   "dev": {
-    "version": "105.0.5176.3",
-    "sha256": "11zdihvy1n7d3vfl88477ppbfjd3mmkdsj4pfmfqm4mpw7zgi7fy",
-    "sha256bin64": "08rhg2am01dbb15djh7200wsg0wb48na09i706035wnnf0d8z313",
+    "version": "105.0.5191.2",
+    "sha256": "1vfgazay1h125qjiy9fnymmdskw06l8lhvllkbbpvz08zf9jfmaj",
+    "sha256bin64": "06l9ypr945dic3kj5m12dr9x098lfh208blp8gax6rxvdj8br4wh",
     "deps": {
       "gn": {
         "version": "2022-07-11",

--- a/pkgs/tools/misc/tere/brokentest.patch
+++ b/pkgs/tools/misc/tere/brokentest.patch
@@ -1,0 +1,67 @@
+diff --git a/src/app_state.rs b/src/app_state.rs
+index e44acb6..43da4d9 100644
+--- a/src/app_state.rs
++++ b/src/app_state.rs
+@@ -1273,33 +1273,33 @@ mod tests {
+         assert_eq!(s.scroll_pos, 2);
+     }
+ 
+-    #[test]
+-    fn test_advance_search_with_filter_search_and_scrolling2() {
+-        let mut s = create_test_state_with_buf(
+-            3,
+-            strings_to_ls_buf(vec!["..", "foo", "frob", "bar", "baz"]),
+-        );
+-        s.settings.filter_search = true;
+-        s.move_cursor_to(4);
+-
+-        // current state:
+-        //   ..
+-        //   foo
+-        //   frob |
+-        //   bar  |
+-        // > baz  |
+-
+-        assert_eq!(s.cursor_pos, 2);
+-        assert_eq!(s.scroll_pos, 2);
+-
+-        s.advance_search("b");
+-
+-        // state should now be:
+-        //   bar  |
+-        // > baz  |
+-        //        |
+-
+-        assert_eq!(s.cursor_pos, 1);
+-        assert_eq!(s.scroll_pos, 0);
+-    }
++    //#[test]
++    //fn test_advance_search_with_filter_search_and_scrolling2() {
++    //    let mut s = create_test_state_with_buf(
++    //        3,
++    //        strings_to_ls_buf(vec!["..", "foo", "frob", "bar", "baz"]),
++    //    );
++    //    s.settings.filter_search = true;
++    //    s.move_cursor_to(4);
++
++    //    // current state:
++    //    //   ..
++    //    //   foo
++    //    //   frob |
++    //    //   bar  |
++    //    // > baz  |
++
++    //    assert_eq!(s.cursor_pos, 2);
++    //    assert_eq!(s.scroll_pos, 2);
++
++    //    s.advance_search("b");
++
++    //    // state should now be:
++    //    //   bar  |
++    //    // > baz  |
++    //    //        |
++
++    //    assert_eq!(s.cursor_pos, 1);
++    //    assert_eq!(s.scroll_pos, 0);
++    //}
+ }

--- a/pkgs/tools/misc/tere/default.nix
+++ b/pkgs/tools/misc/tere/default.nix
@@ -1,0 +1,33 @@
+{ lib, fetchFromGitHub, rustPlatform }:
+
+let
+  commonMeta = {
+    name = "tere";
+    version = "1.1.0";
+  };
+  tereSrc = fetchFromGitHub {
+    owner = "mgunyho";
+    repo = commonMeta.name;
+    rev = "v${commonMeta.version}";
+    sha256 = "BD7onBkFyo/JAw/neqL9N9nBYSxoMrmaG6egeznV9Xs=";
+  };
+in
+rustPlatform.buildRustPackage rec
+  {
+    pname = commonMeta.name;
+    version = commonMeta.version;
+
+    src = tereSrc;
+    cargoSha256 = "gAq9ULQ2YFPmn4IsHaYrC0L7NqbPUWqXSb45ZjlMXEs=";
+
+    # This test confirmed not working.
+    # https://github.com/mgunyho/tere/issues/44
+    cargoPatches = [ ./brokentest.patch ];
+
+    meta = with lib; {
+      description = "A faster alternative to cd + ls";
+      homepage = "https://github.com/mgunyho/tere";
+      licence = licenses.eupl12;
+      maintainers = [ maintainers.ProducerMatt ];
+    };
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36132,4 +36132,6 @@ with pkgs;
   swift-corelibs-libdispatch = callPackage ../development/libraries/swift-corelibs-libdispatch { };
 
   swaysettings = callPackage ../applications/misc/swaysettings { };
+
+  tere = callPackage ../tools/misc/tere { };
 }


### PR DESCRIPTION
I'd like to submit my new package for review, however I appear to have accidentally modified authorship of a totally unrelated commit #5c2b817. If someone can help me fix that I'd really appreciate it.

Here's the original notes:

A failing test was keeping Tere from building with buildRustPackage. I [confirmed with the
dev](https://github.com/mgunyho/tere/issues/44) it's known and ignored
so I commented it out with a patch.

This app isn't that useful until some [shell hooks have been
added.](https://github.com/mgunyho/tere#setup) So I hope to later add a config
option to home-manager such as:

```nix
programs.tere = {
  enabled = true;
  useBashIntegration = true;
  useFishIntegration = true;
};
```