### PR TITLE
linuxKernel.packages.linux_5_18.nvidia_x11_legacy390: fix build

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -68,6 +68,19 @@ rec {
     sha256_64bit = "sha256-UibkhCBEz/2Qlt6tr2iTTBM9p04FuAzNISNlhLOvsfw=";
     settingsSha256 = "sha256-teXQa0pQctQl1dvddVJtI7U/vVuMu6ER1Xd99Jprpvw=";
     persistencedSha256 = "sha256-FxiTXYABplKFcBXr4orhYWiJq4zVePpplMbg2kvEuXk=";
+    patches =
+      let patch390 = o:
+        (lib.optional ((lib.versions.majorMinor kernel.modDirVersion) == o.version) (fetchpatch {
+          inherit (o) sha256;
+          url = "https://gitlab.com/herecura/packages/nvidia-390xx-dkms/-/raw/herecura/kernel-${o.version}.patch";
+        }));
+      in
+        []
+        ++ (patch390 {
+          version = "5.18";
+          sha256 = "sha256-A6itoozgDWmXKQAU0D8bT2vUaZqh5G5Tg3d3E+CLOTs=";
+        })
+      ;
   };
 
   legacy_340 = generic {


### PR DESCRIPTION
linuxKernel.packages.linux_5_18.nvidia_x11_legacy390: fix build

(Which is breaking at #182480)

Thanks to @PedroHLC for providing the solution.

There is a patch for 5.19 but I'm not able to generate the hash for `fetchpatch` without building it. So I'm leaving it out, until 5.19 can be built.