### PR TITLE
_1password: 2.5.1 -> 2.6.0

### DIFF
--- a/pkgs/applications/misc/1password/default.nix
+++ b/pkgs/applications/misc/1password/default.nix
@@ -12,12 +12,12 @@ let
     if extension == "zip" then fetchzip args else fetchurl args;
 
   pname = "1password-cli";
-  version = "2.5.1";
+  version = "2.6.0";
   sources = rec {
-    aarch64-linux = fetch "linux_arm64" "sha256-HZ6AVheJrw9ZR9HGWbB6/kCzbrfYcwApa2z18tDBo1k=" "zip";
-    i686-linux = fetch "linux_386" "sha256-aG6oW0epF+P9pSWMlTStSbBynBDkGX1B+0NHUnwLRhs=" "zip";
-    x86_64-linux = fetch "linux_amd64" "sha256-7GkBVcvXM/WZiXEiIbYh9lS0f4BS4Hc4RCVjr8FoW8A=" "zip";
-    aarch64-darwin = fetch "apple_universal" "sha256-XebD33fX15RsFUdbV+DvMRIi1MSyMfIRC3JOwcmi8kk=" "pkg";
+    aarch64-linux = fetch "linux_arm64" "sha256-2V3/F7/HEOvk2T1dv4rnS0xu6Z5EqGSV/9erED7ZS1w=" "zip";
+    i686-linux = fetch "linux_386" "sha256-z4pKZY5DQ2oDHHuet1S/p7GM+rXS8/8xmTrN+rqCUBo=" "zip";
+    x86_64-linux = fetch "linux_amd64" "sha256-1/DgwHMkUenj+2ZyADeBK1HJ3M/b2PoAey36eAqAUSQ=" "zip";
+    aarch64-darwin = fetch "apple_universal" "sha256-YPidRXNzNNuDoM2Gd5dEsCDxwosBJFKSzjoP0SPkQZs=" "pkg";
     x86_64-darwin = aarch64-darwin;
   };
   platforms = builtins.attrNames sources;


### PR DESCRIPTION
Also addresses hash mismatch on Darwin.

###### Description of changes

Updates _1Password. 2.5.1 seems to have had a bad hash for Darwin (perhaps it was changed after the fact?), so this addresses that too.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
