### PR TITLE
gostatic: init at 2.35

### DIFF
--- a/pkgs/applications/misc/gostatic/default.nix
+++ b/pkgs/applications/misc/gostatic/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, fetchFromGitHub
+, buildGoModule
+, nix-update-script
+, testers
+, gostatic
+}:
+
+buildGoModule rec {
+  pname = "gostatic";
+  version = "2.35";
+
+  src = fetchFromGitHub {
+    owner = "piranha";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-pxk9tauB7u0oe6g4maHh+dREZXKwMz44v3KB43yYW6c=";
+  };
+
+  vendorSha256 = "sha256-9YCt9crLuYjd+TUXJyx/EAYIMWM5TD+ZyzLeu0RMxVc=";
+
+  ldflags = [ "-s" "-w" ];
+
+  passthru = {
+    updateScript = nix-update-script { attrPath = pname; };
+    tests.version = testers.testVersion {
+      package = gostatic;
+      command = "gostatic -V";
+    };
+  };
+
+  meta = with lib; {
+    description = "Fast static site generator";
+    homepage = "https://github.com/piranha/gostatic";
+    changelog = "https://github.com/piranha/gostatic/releases/tag/${src.rev}";
+    license = licenses.isc;
+    maintainers = with maintainers; [ zendo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6829,6 +6829,8 @@ with pkgs;
 
   gost = callPackage ../tools/networking/gost { };
 
+  gostatic = callPackage ../applications/misc/gostatic { };
+
   gource = callPackage ../applications/version-management/gource { };
 
   govc = callPackage ../tools/virtualization/govc { };


### PR DESCRIPTION
###### Description of changes

#182477 

Gostatic is a static site generator written in Go.
https://github.com/piranha/gostatic

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
