### PR TITLE
lottieconverter: 0.1.1 -> 0.2

### DIFF
--- a/pkgs/tools/misc/lottieconverter/default.nix
+++ b/pkgs/tools/misc/lottieconverter/default.nix
@@ -1,34 +1,42 @@
-{ lib, stdenv, fetchFromGitHub, libpng, rlottie, zlib }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, libpng
+, rlottie
+, giflib
+}:
 
-stdenv.mkDerivation rec {
-  pname = "LottieConverter";
-  version = "0.1.1";
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lottieconverter";
+  version = "0.2";
 
   src = fetchFromGitHub {
     owner = "sot-tech";
-    repo = pname;
-    rev = "r${version}";
-    hash = "sha256-lAGzh6B2js2zDuN+1U8CZnse09RJGZRXbtmsheGKuYU=";
+    repo = finalAttrs.pname;
+    rev = "r${finalAttrs.version}";
+    hash = "sha256-oCFQsOQbWzmzClaTOeuEtGo7uXoKYtaJuSLLgqAQP1M=";
   };
 
-  buildInputs = [ libpng rlottie zlib ];
-  makeFlags = [ "CONF=Release" ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libpng rlottie giflib ];
+
+  cmakeFlags = [
+    "-DSYSTEM_RL=1"
+    "-DSYSTEM_GL=1"
+  ];
 
   installPhase = ''
     runHook preInstall
-
-    mkdir -p $out/bin
-    cp -v dist/Release/GNU-Linux/lottieconverter $out/bin/
-
+    install -Dm755 lottieconverter "$out/bin/lottieconverter"
     runHook postInstall
   '';
 
   meta = with lib; {
     homepage = "https://github.com/sot-tech/LottieConverter/";
     description = "Lottie converter utility";
-    license = licenses.lgpl21Plus;
+    license = licenses.bsd3;
     platforms = platforms.all;
-    maintainers = with maintainers; [ CRTified ];
-    broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/trunk/lottieconverter.x86_64-darwin
+    maintainers = with maintainers; [ CRTified nickcao ];
   };
-}
+})


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
