### PR TITLE
invoiceplane: Mark as broken, missing php 8 support

### DIFF
--- a/pkgs/servers/web-apps/invoiceplane/default.nix
+++ b/pkgs/servers/web-apps/invoiceplane/default.nix
@@ -16,27 +16,30 @@ stdenv.mkDerivation rec {
     # https://github.com/NixOS/nixpkgs/issues/166655
     # https://github.com/InvoicePlane/InvoicePlane/pull/754
     (fetchpatch {
-      url = "https://patch-diff.githubusercontent.com/raw/InvoicePlane/InvoicePlane/pull/754.patch";
+      url = "https://github.com/InvoicePlane/InvoicePlane/commit/5db67d65ccaaec661885bd029b1e516bf3ca6c2a.patch";
       sha256 = "sha256-EHXw7Zqli/nA3tPIrhxpt8ueXvDtshz0XRzZT78sdQk=";
+      name = "cve-2021-29024-fix.patch";
     })
 
     # Fix CVE-2021-29023, password reset rate-limiting
-    # Should be included in a later release > 1.5.11
-    # https://github.com/NixOS/nixpkgs/issues/166655
-    # https://github.com/InvoicePlane/InvoicePlane/pull/739
-    (fetchpatch {
-      url = "https://patch-diff.githubusercontent.com/raw/InvoicePlane/InvoicePlane/pull/739.patch";
-      sha256 = "sha256-6ksJjW6awr3lZsDRxa22pCcRGBVBYyV8+TbhOp6HBq0=";
-    })
-
-    # Fix CVE-2021-29022, full path disclosure
     # Should be included in a later release > 1.5.11
     # https://github.com/NixOS/nixpkgs/issues/166655
     # https://github.com/InvoicePlane/InvoicePlane/pull/767
     #(fetchpatch {
     #  url = "https://patch-diff.githubusercontent.com/raw/InvoicePlane/InvoicePlane/pull/767.patch";
     #  sha256 = "sha256-rSWDH8KeHSRWLyQEa7RSwv+8+ja9etTz+6Q9XThuwUo=";
+    #  name = "cve-2021-29023-fix.patch";
     #})
+
+    # Fix CVE-2021-29022, full path disclosure
+    # Should be included in a later release > 1.5.11
+    # https://github.com/NixOS/nixpkgs/issues/166655
+    # https://github.com/InvoicePlane/InvoicePlane/pull/739
+    (fetchpatch {
+      url = "https://github.com/InvoicePlane/InvoicePlane/commit/694ba97d6e207bd4357ce4d2992601f0320f69fe.patch";
+      sha256 = "sha256-6ksJjW6awr3lZsDRxa22pCcRGBVBYyV8+TbhOp6HBq0=";
+      name = "cve-2021-29022-fix.patch"
+    })
 
   ];
 
@@ -54,10 +57,16 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    description = "Self-hosted open source application for managing your invoices, clients and payments";
+    description = ''
+      Self-hosted open source application for managing your invoices, clients
+      and payments
+    '';
     license = licenses.mit;
     homepage = "https://www.invoiceplane.com";
     platforms = platforms.all;
     maintainers = with maintainers; [ onny ];
+    # Not yet working with php >= 8
+    # https://github.com/InvoicePlane/InvoicePlane/issues/798
+    broken = true;
   };
 }


### PR DESCRIPTION
###### Description of changes

Temporary mark [invoiceplane](https://github.com/InvoicePlane/InvoicePlane) as broken because current stable version is missing PHP8 support.

It's possible that they'll release a new version soon so I don't want to drop the package yet https://github.com/InvoicePlane/InvoicePlane/issues/798

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
