### PR TITLE
lxqt.pcmanfm-qt: add libexif dependence

### DIFF
--- a/pkgs/desktops/lxqt/pcmanfm-qt/default.nix
+++ b/pkgs/desktops/lxqt/pcmanfm-qt/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , cmake
 , pkg-config
+, libexif
 , lxqt
 , qtbase
 , qttools
@@ -32,6 +33,7 @@ mkDerivation rec {
   ];
 
   buildInputs = [
+    libexif
     qtbase
     qttools
     qtx11extras


### PR DESCRIPTION
###### Description of changes

`pcmanfm-qt` is failing with the error:

```console
$ pcmanfm-qt
/run/current-system/sw/bin/pcmanfm-qt: error while loading shared libraries: libexif.so.12: cannot open shared object file: No such file or directory

$ readlink -f $(which pcmanfm-qt)
/nix/store/qhsx7s847h6bsgnhkpis83ngk64r448h-pcmanfm-qt-1.1.0/bin/pcmanfm-qt

$ ldd /nix/store/qhsx7s847h6bsgnhkpis83ngk64r448h-pcmanfm-qt-1.1.0/bin/.pcmanfm-qt-wrapped | grep libexif
	libexif.so.12 => not found
	libexif.so.12 => /nix/store/fp8cbnjbc3ny9dnwk3fjkqqz74790dcn-libexif-0.6.24/lib/libexif.so.12 (0x00007fced0db0000)
```

This PR adds an explicit dependence on `libexif`. Probably it was being propagated from some other dependence, and something changed.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
