### PR TITLE
linuxKernel.packages.linux_5_18.mwprocapture: mark broken

### DIFF
--- a/pkgs/os-specific/linux/mwprocapture/default.nix
+++ b/pkgs/os-specific/linux/mwprocapture/default.nix
@@ -55,6 +55,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
+    broken = kernel.kernelAtLeast "5.16";
     homepage = "http://www.magewell.com/";
     description = "Linux driver for the Magewell Pro Capture family";
     license = licenses.unfreeRedistributable;


### PR DESCRIPTION
linuxKernel.packages.linux_5_18.mwprocapture: mark broken

Tested as:
* `linuxKernel.packages.linux_5_15.mwprocapture` builds.
* `linuxKernel.packages.linux_5_18.mwprocapture` fails.

Notify maintainer: @MP2E 