### PR TITLE
linuxKernel.packages.linux_5_18.can-isotp: mark broken

### DIFF
--- a/pkgs/os-specific/linux/can-isotp/default.nix
+++ b/pkgs/os-specific/linux/can-isotp/default.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
   meta = with lib; {
+    broken = kernel.kernelAtLeast "5.16";
     description = "Kernel module for ISO-TP (ISO 15765-2)";
     homepage = "https://github.com/hartkopp/can-isotp";
     license = licenses.gpl2;


### PR DESCRIPTION
linuxKernel.packages.linux_5_18.can-isotp: mark broken

Tested as:
* `linuxKernel.packages.linux_5_15.can-isotp` builds.
* `linuxKernel.packages.linux_5_18.can-isotp` fails. [Logs](https://termbin.com/to50)

Notify maintainer: @evck