### PR TITLE
tere: init at 1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10341,6 +10341,12 @@
       }
     ];
   };
+  ProducerMatt = {
+    name = "Matthew Pherigo";
+    email = "ProducerMatt42@gmail.com";
+    github = "ProducerMatt";
+    githubId = 58014742;
+  };
   Profpatsch = {
     email = "mail@profpatsch.de";
     github = "Profpatsch";

--- a/pkgs/tools/misc/tere/brokentest.patch
+++ b/pkgs/tools/misc/tere/brokentest.patch
@@ -1,0 +1,19 @@
+diff --git a/src/app_state.rs b/src/app_state.rs
+index e44acb6..713642a 100644
+--- a/src/app_state.rs
++++ b/src/app_state.rs
+@@ -1272,7 +1272,7 @@ mod tests {
+         assert_eq!(s.cursor_pos, 1);
+         assert_eq!(s.scroll_pos, 2);
+     }
+-
++    /*
+     #[test]
+     fn test_advance_search_with_filter_search_and_scrolling2() {
+         let mut s = create_test_state_with_buf(
+@@ -1302,4 +1302,5 @@ mod tests {
+         assert_eq!(s.cursor_pos, 1);
+         assert_eq!(s.scroll_pos, 0);
+     }
++    */
+ }

--- a/pkgs/tools/misc/tere/default.nix
+++ b/pkgs/tools/misc/tere/default.nix
@@ -1,0 +1,26 @@
+{ lib, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "tere";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "mgunyho";
+    repo = "tere";
+    rev = "v${version}";
+    sha256 = "BD7onBkFyo/JAw/neqL9N9nBYSxoMrmaG6egeznV9Xs=";
+  };
+
+  cargoSha256 = "gAq9ULQ2YFPmn4IsHaYrC0L7NqbPUWqXSb45ZjlMXEs=";
+
+  # This test confirmed not working.
+  # https://github.com/mgunyho/tere/issues/44
+  cargoPatches = [ ./brokentest.patch ];
+
+  meta = with lib; {
+    description = "A faster alternative to cd + ls";
+    homepage = "https://github.com/mgunyho/tere";
+    license = licenses.eupl12;
+    maintainers = with maintainers; [ ProducerMatt ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1275,6 +1275,8 @@ with pkgs;
 
   tauon = callPackage ../applications/audio/tauon { };
 
+  tere = callPackage ../tools/misc/tere { };
+
   termusic = callPackage ../applications/audio/termusic { };
 
   tfk8s = callPackage ../tools/misc/tfk8s { };


### PR DESCRIPTION
###### Description of changes

A failing test was keeping it from building. I [confirmed with the
dev](https://github.com/mgunyho/tere/issues/44) it's known and ignored
so I commented it out with a patch.

This app isn't that useful until some [shell hooks have been
added.](https://github.com/mgunyho/tere#setup) So I hope to add a config
option to home-manager such as:

```nix
programs.tere = {
  enabled = true;
  useBashIntegration = true;
  useFishIntegration = true;
};
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
