### PR TITLE
podman-tui: 0.4.0 -> 0.5.0

### DIFF
--- a/pkgs/applications/virtualization/podman-tui/default.nix
+++ b/pkgs/applications/virtualization/podman-tui/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , pkg-config
 , fetchFromGitHub
+, fetchpatch
 , buildGoModule
 , btrfs-progs
 , gpgme
@@ -12,14 +13,22 @@
 }:
 buildGoModule rec {
   pname = "podman-tui";
-  version = "0.4.0";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "containers";
     repo = "podman-tui";
     rev = "v${version}";
-    sha256 = "sha256-2WugN5JdTkz3OOt3ggzT7HwMXy1jxn85RwF7409D8m8=";
+    sha256 = "sha256-XLC1DqOME9xMF4z+cOPe5H60JnxU9gGaSOQQIofdtj8=";
   };
+
+  patches = [
+    # Fix flaky tests. See https://github.com/containers/podman-tui/pull/129.
+    (fetchpatch {
+      url = "https://github.com/containers/podman-tui/commit/7fff27e95a3891163da79d86bbc796f29b523f80.patch";
+      sha256 = "sha256-mETDXoMLq7vb8Qhpz/CmNG1LmY2DTaogI10Qav/qN9Q=";
+    })
+  ];
 
   vendorSha256 = null;
 
@@ -29,6 +38,10 @@ buildGoModule rec {
     ++ lib.optionals stdenv.isLinux [ btrfs-progs lvm2 ];
 
   ldflags = [ "-s" "-w" ];
+
+  preCheck = ''
+    export HOME=/home/$(whoami)
+  '';
 
   passthru.tests.version = testers.testVersion {
     package = podman-tui;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
