### PR TITLE
bpf-linker: init at 0.9.4

### DIFF
--- a/pkgs/development/tools/bpf-linker/default.nix
+++ b/pkgs/development/tools/bpf-linker/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, stdenv
+, rustPlatform
+, fetchFromGitHub
+, llvmPackages_14
+, zlib
+, ncurses
+, libxml2
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "bpf-linker";
+  version = "0.9.4";
+
+  src = fetchFromGitHub {
+    owner = "aya-rs";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-jYuBk78aGQLUeNF6d6kjGPuMxEF22XJquHcs23WVGm0=";
+  };
+
+  cargoHash = "sha256-X8EVpOxDHwE/wj/gly/wdZ6tsrMrz3kkDe9gEPbk6iw=";
+
+  buildNoDefaultFeatures = true;
+  buildFeatures = [ "system-llvm" ];
+
+  nativeBuildInputs = [ llvmPackages_14.llvm ];
+  buildInputs = [ zlib ncurses libxml2 ];
+
+  # fails with: couldn't find crate `core` with expected target triple bpfel-unknown-none
+  # rust-src and `-Z build-std=core` are required to properly run the tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Simple BPF static linker";
+    homepage = "https://github.com/aya-rs/bpf-linker";
+    license = with licenses; [ asl20 mit ];
+    maintainers = with maintainers; [ nickcao ];
+    # llvm-sys crate locates llvm by calling llvm-config
+    # which is not available when cross compiling
+    broken = stdenv.buildPlatform != stdenv.hostPlatform;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23379,6 +23379,8 @@ with pkgs;
 
   bolt = callPackage ../os-specific/linux/bolt { };
 
+  bpf-linker = callPackage ../development/tools/bpf-linker { };
+
   bpfmon = callPackage ../os-specific/linux/bpfmon { };
 
   bridge-utils = callPackage ../os-specific/linux/bridge-utils { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
