### PR TITLE
gcc: always enable inhibit_libc=true for --without-headers builds

### DIFF
--- a/pkgs/development/compilers/gcc/10/default.nix
+++ b/pkgs/development/compilers/gcc/10/default.nix
@@ -191,7 +191,7 @@ stdenv.mkDerivation ({
 
   preConfigure = import ../common/pre-configure.nix {
     inherit lib;
-    inherit version targetPlatform hostPlatform gnatboot langAda langGo langJit;
+    inherit version targetPlatform hostPlatform gnatboot langAda langGo langJit crossStageStatic;
   };
 
   dontDisableStatic = true;

--- a/pkgs/development/compilers/gcc/11/default.nix
+++ b/pkgs/development/compilers/gcc/11/default.nix
@@ -199,7 +199,7 @@ stdenv.mkDerivation ({
 
   preConfigure = import ../common/pre-configure.nix {
     inherit lib;
-    inherit version targetPlatform hostPlatform gnatboot langAda langGo langJit;
+    inherit version targetPlatform hostPlatform gnatboot langAda langGo langJit crossStageStatic;
   };
 
   dontDisableStatic = true;

--- a/pkgs/development/compilers/gcc/12/default.nix
+++ b/pkgs/development/compilers/gcc/12/default.nix
@@ -194,7 +194,7 @@ stdenv.mkDerivation ({
 
   preConfigure = import ../common/pre-configure.nix {
     inherit lib;
-    inherit version targetPlatform hostPlatform gnatboot langAda langGo langJit;
+    inherit version targetPlatform hostPlatform gnatboot langAda langGo langJit crossStageStatic;
   };
 
   dontDisableStatic = true;

--- a/pkgs/development/compilers/gcc/4.8/default.nix
+++ b/pkgs/development/compilers/gcc/4.8/default.nix
@@ -198,7 +198,7 @@ stdenv.mkDerivation ({
 
   preConfigure = import ../common/pre-configure.nix {
     inherit lib;
-    inherit version targetPlatform hostPlatform langJava langGo;
+    inherit version targetPlatform hostPlatform langJava langGo crossStageStatic;
   };
 
   dontDisableStatic = true;

--- a/pkgs/development/compilers/gcc/4.9/default.nix
+++ b/pkgs/development/compilers/gcc/4.9/default.nix
@@ -218,7 +218,7 @@ stdenv.mkDerivation ({
 
   preConfigure = import ../common/pre-configure.nix {
     inherit lib;
-    inherit version targetPlatform hostPlatform langJava langGo;
+    inherit version targetPlatform hostPlatform langJava langGo crossStageStatic;
   };
 
   dontDisableStatic = true;

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -230,7 +230,7 @@ stdenv.mkDerivation ({
 
   preConfigure = import ../common/pre-configure.nix {
     inherit lib;
-    inherit version targetPlatform hostPlatform gnatboot langJava langAda langGo;
+    inherit version targetPlatform hostPlatform gnatboot langJava langAda langGo crossStageStatic;
   };
 
   dontDisableStatic = true;

--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -197,7 +197,7 @@ stdenv.mkDerivation ({
 
   preConfigure = import ../common/pre-configure.nix {
     inherit lib;
-    inherit version targetPlatform hostPlatform langGo;
+    inherit version targetPlatform hostPlatform langGo crossStageStatic;
   };
 
   dontDisableStatic = true;

--- a/pkgs/development/compilers/gcc/8/default.nix
+++ b/pkgs/development/compilers/gcc/8/default.nix
@@ -180,7 +180,7 @@ stdenv.mkDerivation ({
 
   preConfigure = import ../common/pre-configure.nix {
     inherit lib;
-    inherit version targetPlatform hostPlatform langGo;
+    inherit version targetPlatform hostPlatform langGo crossStageStatic;
   };
 
   dontDisableStatic = true;

--- a/pkgs/development/compilers/gcc/9/default.nix
+++ b/pkgs/development/compilers/gcc/9/default.nix
@@ -193,7 +193,7 @@ stdenv.mkDerivation ({
 
   preConfigure = import ../common/pre-configure.nix {
     inherit lib;
-    inherit version targetPlatform hostPlatform gnatboot langAda langGo langJit;
+    inherit version targetPlatform hostPlatform gnatboot langAda langGo langJit crossStageStatic;
   };
 
   dontDisableStatic = true;

--- a/pkgs/development/compilers/gcc/common/pre-configure.nix
+++ b/pkgs/development/compilers/gcc/common/pre-configure.nix
@@ -3,7 +3,9 @@
 , langAda ? false
 , langJava ? false
 , langJit ? false
-, langGo }:
+, langGo
+, crossStageStatic
+}:
 
 assert langJava -> lib.versionOlder version "7";
 assert langAda -> gnatboot != null; let
@@ -66,4 +68,13 @@ in lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''
 # is in fact building a cross compiler although it doesn't believe it.
 + lib.optionalString (targetPlatform.config == hostPlatform.config && targetPlatform != hostPlatform) ''
   substituteInPlace configure --replace is_cross_compiler=no is_cross_compiler=yes
+''
+
+# Normally (for host != target case) --without-headers automatically
+# enables 'inhibit_libc=true' in gcc's gcc/configure.ac. But case of
+# gcc->clang "cross"-compilation manages to evade it: there
+# hostPlatform != targetPlatform, hostPlatform.config == targetPlatform.config.
+# We explicitly inhibit libc headers use in this case as well.
++ lib.optionalString (targetPlatform != hostPlatform && crossStageStatic) ''
+  export inhibit_libc=true
 ''


### PR DESCRIPTION
It's a follow-up to the breakage caused by 21966e13d2d72b91c
("gcc: pass --with-build-sysroot=/"). It caused `pkgsLLVM`
cross-toolchain bootstrap breakage:

    $ nix build --no-link -f. pkgsLLVM.hello
    ...
    failed: /nix/store/...-x86_64-unknown-linux-gnu-stage-static-gcc-13.0.0.drv:
    ...
    configure flags: ... --enable-languages=c --disable-multilib \
      --disable-shared --enable-plugin ... --disable-libssp --disable-nls \
      --without-headers --disable-threads --disable-libgomp --disable-libquadmath \
      --disable-shared --disable-libatomic --disable-decimal-float --disable-libmpx \
      --disable-bootstrap \
      \
      --build=x86_64-unknown-linux-gnu \
      --host=x86_64-unknown-linux-gnu \
      --target=x86_64-unknown-linux-gnu
    ...
    The directory that should contain system headers does not exist:
      /usr/include
    make[2]: *** [Makefile:3279: stmp-fixinc] Error 1 shuffle=1658621302
    rm gfdl.pod gcc.pod gcov-dump.pod gcov-tool.pod fsf-funding.pod gpl.pod cpp.pod gcov.pod lto-dump.pod
    make[2]: Leaving directory '/build/build/gcc'

Note: it's a no-libc build. It's not expected to use any libc headers.
But in this case fixincludes tries to run and uses default /usr/include
location.

Fixinsludes is not normally expected to run during cross-compilation
on --without-headers. gcc/configure.ac:

    : ${inhibit_libc=false}
    if { { test x$host != x$target && test "x$with_sysroot" = x ; } ||
           test x$with_newlib = xyes ; } &&
         { test "x$with_headers" = xno || test ! -f "$target_header_dir/stdio.h"; } ; then
           inhibit_libc=true
    fi

The change explicitly passes inhibit_libc=true to configure to disable
include fixing on such cases.

Fixed `nix build --no-link -f. pkgsLLVM.hello` toolchain bootstrap.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
