### PR TITLE
nixos/plasma: remove systemdBoot option

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -186,12 +186,6 @@ in
       description = "Enable HiDPI scaling in Qt.";
     };
 
-    runUsingSystemd = mkOption {
-      description = "Use systemd to manage the Plasma session";
-      type = types.bool;
-      default = false;
-    };
-
     excludePackages = mkOption {
       description = "List of default packages to exclude from the configuration";
       type = types.listOf types.package;
@@ -232,6 +226,7 @@ in
   };
 
   imports = [
+    (mkRemovedOptionModule [ "services" "xserver" "desktopManager" "plasma5" "runUsingSystemd" ] "systemd startup is now enabled by default.")
     (mkRemovedOptionModule [ "services" "xserver" "desktopManager" "plasma5" "enableQt4Support" ] "Phonon no longer supports Qt 4.")
     (mkRenamedOptionModule [ "services" "xserver" "desktopManager" "kde5" ] [ "services" "xserver" "desktopManager" "plasma5" ])
   ];
@@ -426,15 +421,6 @@ in
       security.pam.services.lightdm.enableKwallet = true;
       security.pam.services.sddm.enableKwallet = true;
 
-      systemd.user.services = {
-        plasma-early-setup = mkIf cfg.runUsingSystemd {
-          description = "Early Plasma setup";
-          wantedBy = [ "graphical-session-pre.target" ];
-          serviceConfig.Type = "oneshot";
-          script = activationScript;
-        };
-      };
-
       xdg.portal.enable = true;
       xdg.portal.extraPortals = [ plasma5.xdg-desktop-portal-kde ];
 
@@ -494,20 +480,6 @@ in
             print-manager
           ];
       in requiredPackages ++ utils.removePackagesByName optionalPackages cfg.excludePackages;
-
-      systemd.user.services = {
-        plasma-run-with-systemd = {
-          description = "Run KDE Plasma via systemd";
-          wantedBy = [ "basic.target" ];
-          serviceConfig.Type = "oneshot";
-          script = ''
-            ${set_XDG_CONFIG_HOME}
-
-            ${kdeFrameworks.kconfig}/bin/kwriteconfig5 \
-              --file startkderc --group General --key systemdBoot ${lib.boolToString cfg.runUsingSystemd}
-          '';
-        };
-      };
     })
 
     # Plasma Mobile


### PR DESCRIPTION
###### Description of changes

It's enabled by default in 5.25 and up, and the old startup method isn't really supported anymore. If anyone wants to shoot themselves in the foot, they can edit startkderc manually.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
