### PR TITLE
[staging-next] More python fixes

### DIFF
--- a/pkgs/development/python-modules/jupyterlab_server/default.nix
+++ b/pkgs/development/python-modules/jupyterlab_server/default.nix
@@ -2,6 +2,7 @@
 , lib
 , buildPythonPackage
 , fetchPypi
+, hatchling
 , jsonschema
 , pythonOlder
 , requests
@@ -10,6 +11,7 @@
 , babel
 , jupyter_server
 , openapi-core
+, pytest-timeout
 , pytest-tornasync
 , ruamel-yaml
 , strict-rfc3339
@@ -18,6 +20,7 @@
 buildPythonPackage rec {
   pname = "jupyterlab_server";
   version = "2.15.0";
+  format = "pyproject";
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
@@ -33,11 +36,16 @@ buildPythonPackage rec {
     rm -r tests/translations/
   '';
 
+  nativeBuildInputs = [
+    hatchling
+  ];
+
   propagatedBuildInputs = [ requests jsonschema pyjson5 babel jupyter_server ];
 
   checkInputs = [
     openapi-core
     pytestCheckHook
+    pytest-timeout
     pytest-tornasync
     ruamel-yaml
   ];
@@ -45,6 +53,11 @@ buildPythonPackage rec {
   preCheck = ''
     export HOME=$(mktemp -d)
   '';
+
+  pytestFlagsArray = [
+    # DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
+    "-W ignore::DeprecationWarning"
+  ];
 
   __darwinAllowLocalNetworking = true;
 

--- a/pkgs/development/python-modules/pypdf2/default.nix
+++ b/pkgs/development/python-modules/pypdf2/default.nix
@@ -1,29 +1,35 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, pythonOlder
 , glibcLocales
+, typing-extensions
 , python
 , isPy3k
 }:
 
 buildPythonPackage rec {
   pname = "PyPDF2";
-  version = "2.5.0";
+  version = "2.8.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-WAKx9A+nm+G1q57claTn9+czmVidtPDmbKgx9Ennos0=";
+    sha256 = "sha256-ad39ck3f4HAQ7zpWyVvxIYVT7Anig2Nuzw8HLsEZWZo=";
   };
 
   LC_ALL = "en_US.UTF-8";
   buildInputs = [ glibcLocales ];
 
+  propagatedBuildInputs = lib.optionals (pythonOlder "3.10") [
+    typing-extensions
+  ];
+
   checkPhase = ''
-    ${python.interpreter} -m unittest discover -s Tests
+    ${python.interpreter} -m unittest discover
   '';
 
   # Tests broken on Python 3.x
-  doCheck = !(isPy3k);
+  #doCheck = !(isPy3k);
 
   meta = with lib; {
     description = "A Pure-Python library built as a PDF toolkit";

--- a/pkgs/development/python-modules/pyprosegur/default.nix
+++ b/pkgs/development/python-modules/pyprosegur/default.nix
@@ -1,4 +1,5 @@
 { lib
+, aiofiles
 , aiohttp
 , backoff
 , buildPythonPackage
@@ -20,6 +21,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
+    aiofiles
     aiohttp
     backoff
     click

--- a/pkgs/development/python-modules/uvicorn/default.nix
+++ b/pkgs/development/python-modules/uvicorn/default.nix
@@ -9,9 +9,8 @@
 , pyyaml
 , typing-extensions
 , uvloop
-, watchgod
+, watchfiles
 , websockets
-, wsproto
 , pythonOlder
 }:
 
@@ -35,15 +34,17 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     click
     h11
+  ] ++ lib.optionals (pythonOlder "3.8") [
+    typing-extensions
+  ];
+
+  passthru.optional-dependencies.standard = [
     httptools
     python-dotenv
     pyyaml
     uvloop
-    watchgod
+    watchfiles
     websockets
-    wsproto
-  ] ++ lib.optionals (pythonOlder "3.8") [
-    typing-extensions
   ];
 
   postInstall = ''

--- a/pkgs/development/python-modules/uvicorn/tests.nix
+++ b/pkgs/development/python-modules/uvicorn/tests.nix
@@ -1,5 +1,6 @@
 { stdenv
 , buildPythonPackage
+, asgiref
 , uvicorn
 , httpx
 , pytest-asyncio
@@ -7,6 +8,8 @@
 , pytest-mock
 , requests
 , trustme
+, watchgod
+, wsproto
 }:
 
 buildPythonPackage rec {
@@ -19,6 +22,7 @@ buildPythonPackage rec {
   dontInstall = true;
 
   checkInputs = [
+    asgiref
     uvicorn
     httpx
     pytestCheckHook
@@ -26,7 +30,12 @@ buildPythonPackage rec {
     pytest-mock
     requests
     trustme
-  ];
+
+    # strictly optional dependencies
+    watchgod
+    wsproto
+  ]
+  ++ uvicorn.optional-dependencies.standard;
 
   doCheck = !stdenv.isDarwin;
 

--- a/pkgs/servers/monitoring/prometheus/dmarc-metrics-exporter/default.nix
+++ b/pkgs/servers/monitoring/prometheus/dmarc-metrics-exporter/default.nix
@@ -4,7 +4,7 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "dmarc-metrics-exporter";
-  version = "0.6.0";
+  version = "0.6.1";
 
   disabled = python3.pythonOlder "3.7";
 
@@ -12,11 +12,12 @@ python3.pkgs.buildPythonApplication rec {
 
   src = python3.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "70f39b373ead42acb8caf56040f7ebf13ab67aea505511025c09ecf4560f8b1b";
+    hash = "sha256-VYmSHDde3zLq7NcsX7xp1JYe6x6RKFEravpakIzW390=";
   };
 
   postPatch = ''
     substituteInPlace pyproject.toml \
+      --replace 'uvicorn = {extras = ["standard"], version = "^0.15.0"}' 'uvicorn = {version = "^0.15.0"}' \
       --replace '"^' '">='
   '';
 
@@ -31,7 +32,8 @@ python3.pkgs.buildPythonApplication rec {
     typing-extensions
     uvicorn
     xsdata
-  ];
+  ]
+  ++ uvicorn.optional-dependencies.standard;
 
   checkInputs = with python3.pkgs; [
     aiohttp


### PR DESCRIPTION
Noticed uvicorn was kinda broken, opening this PR to check up on whether reverse dependencies can handle the dependency split.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
