### PR TITLE
samtools: Fix cross-compilation

### DIFF
--- a/pkgs/applications/science/biology/samtools/default.nix
+++ b/pkgs/applications/science/biology/samtools/default.nix
@@ -18,6 +18,9 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  # tests require `bgzip` from the htslib package
+  checkInputs = [ htslib ];
+
   nativeBuildInputs = [ perl ];
 
   buildInputs = [ zlib ncurses htslib ];


### PR DESCRIPTION
Tests require bgzip which comes from the htslib package (and is not
available when cross-compiling).

This did not cause problems prior to
41485e7337baca768dc542c553a9d66030df7b33 as tests were not run in
cross-compilation.

`nix build -f . pkgsCross.musl64.pkgsStatic.samtools` fails on `master` and works with this PR

The standard package is unchanged (same hash)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

