### PR TITLE
qc71_laptop: init at unstable-2022-06-01

### DIFF
--- a/pkgs/os-specific/linux/qc71_laptop/default.nix
+++ b/pkgs/os-specific/linux/qc71_laptop/default.nix
@@ -1,0 +1,34 @@
+{ lib, stdenv, fetchFromGitHub, kernel }:
+
+stdenv.mkDerivation rec {
+  pname = "qc71_laptop";
+  version = "unstable-2022-06-01";
+
+  src = fetchFromGitHub {
+    owner = "pobrn";
+    repo = "qc71_laptop";
+    rev = "28106e0602807d78d1f5fa220ab6148dd6477c1c";
+    hash = "sha256-3bhw2HbEVuxPfGMt/eE2nCuMLHzYHRY3nRWPzZxKHro=";
+  };
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  makeFlags = kernel.makeFlags ++ [
+    "VERSION=${version}"
+    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -D qc71_laptop.ko -t $out/lib/modules/${kernel.modDirVersion}/extra
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Linux driver for QC71 laptop";
+    homepage = "https://github.com/pobrn/qc71_laptop/";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ aacebedo ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -497,6 +497,8 @@ in {
 
     can-isotp = callPackage ../os-specific/linux/can-isotp { };
 
+    qc71_laptop = callPackage ../os-specific/linux/qc71_laptop { };
+
   } // lib.optionalAttrs config.allowAliases {
     ati_drivers_x11 = throw "ati drivers are no longer supported by any kernel >=4.1"; # added 2021-05-18;
   });


### PR DESCRIPTION
###### Description of changes

Add a module to control hardware elements of a QC71 laptop (fans, lightbar, etc.)

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).