### PR TITLE
whitesur-icon-theme: 2022-03-18 -> 2022-05-11

### DIFF
--- a/pkgs/data/icons/whitesur-icon-theme/default.nix
+++ b/pkgs/data/icons/whitesur-icon-theme/default.nix
@@ -1,42 +1,54 @@
-{ lib, stdenvNoCC, fetchFromGitHub, gtk3, hicolor-icon-theme }:
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, gtk3
+, hicolor-icon-theme
+, jdupes
+, boldPanelIcons ? false
+, blackPanelIcons ? false
+, themeVariants ? []
+}:
+
+let
+  pname = "Whitesur-icon-theme";
+in
+lib.checkListOfEnum "${pname}: theme variants" [ "default" "purple" "pink" "red" "orange" "yellow" "green" "grey" "nord" "all" ] themeVariants
 
 stdenvNoCC.mkDerivation rec {
-  pname = "Whitesur-icon-theme";
-  version = "2022-03-18";
+  inherit pname;
+  version = "2022-05-11";
 
   src = fetchFromGitHub {
     owner = "vinceliuice";
     repo = pname;
     rev = version;
-    sha256 = "iHLxZqcDLUo62J67MwZ72CSvsHHiI9/Jk31KwkgIPr4=";
+    sha256 = "sha256-7Bbkjbh6nZdYot0tJMWFuW1Jnl9U4KOLN/n+z92UWh4=";
   };
 
-  nativeBuildInputs = [ gtk3 ];
+  nativeBuildInputs = [ gtk3 jdupes ];
 
   buildInputs = [ hicolor-icon-theme ];
 
+  # These fixup steps are slow and unnecessary
+  dontPatchELF = true;
+  dontRewriteSymlinks = true;
+
   dontDropIconThemeCache = true;
+
+  postPatch = ''
+    patchShebangs install.sh
+  '';
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/share/icons/WhiteSur{,-dark}/status
-    echo "$out/share/icons/WhiteSur/status $out/share/icons/WhiteSur-dark/status" | xargs -n 1 cp -r src/status/{16,22,24,32,symbolic}
-    echo "$out/share/icons/WhiteSur $out/share/icons/WhiteSur-dark" | xargs -n 1 cp -r ./{COPYING,AUTHORS} src/index.theme src/{actions,animations,apps,categories,devices,emblems,mimes,places} links/{actions,apps,categories,devices,emblems,mimes,places,status}
+    ./install.sh --dest $out/share/icons \
+      --name WhiteSur \
+      --theme ${builtins.toString themeVariants} \
+      ${lib.optionalString boldPanelIcons "--bold"} \
+      ${lib.optionalString blackPanelIcons "--black"}
 
-    # Change icon color for dark theme
-    sed -i "s/#363636/#dedede/g" $out/share/icons/WhiteSur-dark/{actions,devices,places,status}/{16,22,24}/*
-    sed -i "s/#363636/#dedede/g" $out/share/icons/WhiteSur-dark/actions/32/*
-    sed -i "s/#363636/#dedede/g" $out/share/icons/WhiteSur-dark/{actions,apps,categories,emblems,devices,mimes,places,status}/symbolic/*
-
-    for f in actions animations apps categories devices emblems mimes places status; do
-      ln -sf $out/share/icons/WhiteSur/$f $out/share/icons/WhiteSur/$f@2x
-      ln -sf $out/share/icons/WhiteSur-dark/$f $out/share/icons/WhiteSur-dark/$f@2x
-    done
-
-    for theme in $out/share/icons/*; do
-      gtk-update-icon-cache $theme
-    done
+    jdupes --link-soft --recurse $out/share
 
     runHook postInstall
   '';


### PR DESCRIPTION
###### Description of changes

https://github.com/vinceliuice/WhiteSur-icon-theme/releases/tag/2022-05-11

Includes some refactoring:
* use the upstream installation script
* provide support for different theme variants
* support bold and black panel icons
* deduplicate files with `jdupes`
* remove slow and unnecessary fixup steps

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).