### PR TITLE
joshuto: 0.9.3 -> 0.9.4

### DIFF
--- a/pkgs/applications/file-managers/joshuto/default.nix
+++ b/pkgs/applications/file-managers/joshuto/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "joshuto";
-  version = "0.9.3";
+  version = "0.9.4";
 
   src = fetchFromGitHub {
     owner = "kamiyaa";
     repo = pname;
-    rev = version;
-    sha256 = "sha256-RbA7MM/3u2LJG6QD5f15E/XoLwHMkPasx0ht4PqV/jc=";
+    rev = "v${version}";
+    sha256 = "sha256-sSrXBPZe9R8s+MzWA7cRlaRCyf/4z2qb6DrUCgvKQh8=";
   };
 
-  cargoSha256 = "sha256-vhTfAoAwDJ9BjhgUEkV2H+KAetJR1YqwaZ7suF6yMXA=";
+  cargoSha256 = "sha256-e4asmP/wTnX6/xrK6lAgCkRlGRFniveEiL5GRXVzcZg=";
 
   buildInputs = lib.optionals stdenv.isDarwin [ SystemConfiguration Foundation ];
 

--- a/pkgs/applications/file-managers/joshuto/default.nix
+++ b/pkgs/applications/file-managers/joshuto/default.nix
@@ -19,6 +19,6 @@ rustPlatform.buildRustPackage rec {
     description = "Ranger-like terminal file manager written in Rust";
     homepage = "https://github.com/kamiyaa/joshuto";
     license = licenses.lgpl3Only;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = with maintainers; [ figsoda totoroot ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Update joshuto from version 0.9.3 to 0.9.4
Add myself (@totoroot) as a maintainer

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
