### PR TITLE
DRAFT: buildGo{Module,Package}: add defaultLdflags `-s -w`

### DIFF
--- a/doc/languages-frameworks/go.section.md
+++ b/doc/languages-frameworks/go.section.md
@@ -115,10 +115,17 @@ Arguments to pass to the Go linker tool via the `-ldflags` argument of `go build
 
 ```nix
   ldflags = [
-    "-s" "-w"
     "-X main.Version=${version}"
     "-X main.Commit=${version}"
   ];
+```
+
+### `defaultLdflags` {#var-go-defaultLdflags}
+
+`-s` and `-w` are set by default for `ldflags`, they can be disabled via `defaultLdflags`. For example:
+
+```nix
+  defaultLdflags = false;
 ```
 
 ### `tags` {#var-go-tags}

--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -9,6 +9,8 @@
 
 # Go linker flags, passed to go via -ldflags
 , ldflags ? []
+# set `-s` `-w` ldflags
+, defaultLdflags ? true
 
 # Go tags, passed to go via -tag
 , tags ? []
@@ -144,6 +146,9 @@ let
     GO111MODULE = "on";
     GOFLAGS = lib.optionals (!proxyVendor) [ "-mod=vendor" ] ++ lib.optionals (!allowGoReference) [ "-trimpath" ];
     inherit CGO_ENABLED;
+
+    # need to use both -s and -w for consistency across all platforms
+    ldflags = (args.ldflags or []) ++ lib.optionals defaultLdflags [ "-s" "-w" ];
 
     configurePhase = args.configurePhase or ''
       runHook preConfigure

--- a/pkgs/development/go-packages/generic/default.nix
+++ b/pkgs/development/go-packages/generic/default.nix
@@ -9,6 +9,8 @@
 
 # Go linker flags, passed to go via -ldflags
 , ldflags ? []
+# set `-s` `-w` ldflags
+, defaultLdflags ? true
 
 # Go tags, passed to go via -tag
 , tags ? []
@@ -96,6 +98,9 @@ let
 
     GO111MODULE = "off";
     GOFLAGS = lib.optionals (!allowGoReference) [ "-trimpath" ];
+
+    # need to use both -s and -w for consistency across all platforms
+    ldflags = (args.ldflags or []) ++ lib.optionals defaultLdflags [ "-s" "-w" ];
 
     GOARM = toString (lib.intersectLists [(stdenv.hostPlatform.parsed.cpu.version or "")] ["5" "6" "7"]);
 


### PR DESCRIPTION
> https://pkg.go.dev/cmd/link
>-s
> Omit the symbol table and debug information.
>-w
> Omit the DWARF symbol table.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

