### PR TITLE
gnuradio.pkgs.gsm: 2016-08-25 -> 2021-05-05

### DIFF
--- a/pkgs/development/gnuradio-modules/gsm/default.nix
+++ b/pkgs/development/gnuradio-modules/gsm/default.nix
@@ -10,18 +10,26 @@
 , python
 , libosmocore
 , osmosdr
+, thrift
+, gmp
+, fftwFloat
+, gnuradio
 }:
 
 mkDerivation {
   pname = "gr-gsm";
-  version = "2016-08-25";
+  version = "2021-05-05";
   src = fetchFromGitHub {
     owner = "ptrkrysik";
     repo = "gr-gsm";
-    rev = "3ca05e6914ef29eb536da5dbec323701fbc2050d";
-    sha256 = "13nnq927kpf91iqccr8db9ripy5czjl5jiyivizn6bia0bam2pvx";
+    rev = "2de47e28ce1fb9a518337bfc0add36c8e3cff5eb";
+    sha256 = "sha256-OD3sVBBG+OoJ2f5CJ6KcdpVCgJWNdDjA9kiIuTklyPc=";
   };
-  disabledForGRafter = "3.8";
+  disabledForGRafter = "3.9";
+
+  # grcc complains about grgsm_livemon being an invalid block
+  # so just don't try to compile it
+  cmakeFlags = [ "-DENABLE_GRCC=OFF" ];
 
   nativeBuildInputs = [
     cmake
@@ -36,6 +44,11 @@ mkDerivation {
     boost
     libosmocore
     osmosdr
+    gmp
+    fftwFloat
+  ] ++ lib.optionals (gnuradio.hasFeature "gr-ctrlport") [
+    thrift
+    python.pkgs.thrift
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updated gr-gsm to its most recent upstream commit, which supports GNU Radio 3.8.
Currently, grgsm_livemon isn't being built.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
