### PR TITLE
qdigidoc: 4.2.11 -> 4.2.12

### DIFF
--- a/pkgs/tools/security/qdigidoc/default.nix
+++ b/pkgs/tools/security/qdigidoc/default.nix
@@ -1,6 +1,18 @@
-{ lib, mkDerivation, fetchurl, cmake, gettext
-, pkg-config, libdigidocpp, opensc, openldap, openssl, pcsclite, qtbase
-, qttranslations, qtsvg }:
+{ lib
+, mkDerivation
+, fetchurl
+, cmake
+, gettext
+, pkg-config
+, libdigidocpp
+, opensc
+, openldap
+, openssl
+, pcsclite
+, qtbase
+, qttranslations
+, qtsvg
+}:
 
 mkDerivation rec {
   pname = "qdigidoc";

--- a/pkgs/tools/security/qdigidoc/default.nix
+++ b/pkgs/tools/security/qdigidoc/default.nix
@@ -20,8 +20,8 @@ mkDerivation rec {
 
   src = fetchurl {
     url =
-      "https://github.com/open-eid/DigiDoc4-Client/releases/download/v${version}/qdigidoc4_${version}.118-1804.tar.xz";
-    hash = "sha256-tdirhSEpBa1hnpau+bWP9Ioy44DLJHulSBx7xWl0hG4=";
+      "https://github.com/open-eid/DigiDoc4-Client/releases/download/v${version}/qdigidoc4-${version}.tar.gz";
+    hash = "sha256-6bso1qvhVhbBfrcTq4S+aHtHli7X2A926N4r45ztq4E=";
   };
 
   tsl = fetchurl {

--- a/pkgs/tools/security/qdigidoc/default.nix
+++ b/pkgs/tools/security/qdigidoc/default.nix
@@ -4,12 +4,12 @@
 
 mkDerivation rec {
   pname = "qdigidoc";
-  version = "4.2.11";
+  version = "4.2.12";
 
   src = fetchurl {
     url =
-      "https://github.com/open-eid/DigiDoc4-Client/releases/download/v${version}/qdigidoc4_${version}.110-1804.tar.xz";
-    sha256 = "sha256-Sg6lFZeIJn3T/suDc5Z/kNqBf/sIV9c6EJJ0Nr0dwTM=";
+      "https://github.com/open-eid/DigiDoc4-Client/releases/download/v${version}/qdigidoc4_${version}.118-1804.tar.xz";
+    hash = "sha256-tdirhSEpBa1hnpau+bWP9Ioy44DLJHulSBx7xWl0hG4=";
   };
 
   tsl = fetchurl {


### PR DESCRIPTION
From https://github.com/open-eid/DigiDoc4-Client/releases/tag/v4.2.12:

> Code, Text and translation improvements and updates


cc @klemensn 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
