### PR TITLE
tree-wide: skip manpage/completion installs depending on host binaries

### DIFF
--- a/pkgs/applications/audio/radioboat/default.nix
+++ b/pkgs/applications/audio/radioboat/default.nix
@@ -7,6 +7,7 @@
 , nix-update-script
 , testers
 , radioboat
+, stdenv
 }:
 
 buildGoModule rec {
@@ -34,7 +35,7 @@ buildGoModule rec {
     wrapProgram $out/bin/radioboat --prefix PATH ":" "${lib.makeBinPath [ mpv ]}";
   '';
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
     installShellCompletion --cmd radioboat \
       --bash <($out/bin/radioboat completion bash) \
       --fish <($out/bin/radioboat completion fish) \

--- a/pkgs/applications/audio/spotify-tui/default.nix
+++ b/pkgs/applications/audio/spotify-tui/default.nix
@@ -51,7 +51,7 @@ rustPlatform.buildRustPackage rec {
     ++ lib.optionals stdenv.isLinux [ openssl libxcb ]
     ++ lib.optionals stdenv.isDarwin [ AppKit Security ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
     for shell in bash fish zsh; do
       $out/bin/spt --completions $shell > spt.$shell
       installShellCompletion spt.$shell

--- a/pkgs/applications/logging/humioctl/default.nix
+++ b/pkgs/applications/logging/humioctl/default.nix
@@ -1,4 +1,4 @@
-{ buildGoModule, fetchFromGitHub, installShellFiles, lib }:
+{ buildGoModule, fetchFromGitHub, installShellFiles, lib, stdenv }:
 
 let
   humioCtlVersion = "0.28.11";
@@ -24,7 +24,7 @@ in buildGoModule {
 
     nativeBuildInputs = [ installShellFiles ];
 
-    postInstall = ''
+    postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
       $out/bin/humioctl completion bash > humioctl.bash
       $out/bin/humioctl completion zsh > humioctl.zsh
       installShellCompletion humioctl.{bash,zsh}

--- a/pkgs/applications/misc/1password/default.nix
+++ b/pkgs/applications/misc/1password/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
     HOME=$TMPDIR
     installShellCompletion --cmd ${mainProgram} \
       --bash <($out/bin/${mainProgram} completion bash) \

--- a/pkgs/applications/misc/expenses/default.nix
+++ b/pkgs/applications/misc/expenses/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , sqlite
 , installShellFiles
+, stdenv
 }:
 
 buildGoModule rec {
@@ -29,7 +30,7 @@ buildGoModule rec {
     "-s" "-w" "-X github.com/manojkarthick/expenses/cmd.Version=${version}"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
     installShellCompletion --cmd expenses \
       --bash <($out/bin/expenses completion bash) \
       --zsh <($out/bin/expenses completion zsh) \

--- a/pkgs/applications/misc/flavours/default.nix
+++ b/pkgs/applications/misc/flavours/default.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
     installShellCompletion --cmd flavours \
       --zsh <($out/bin/flavours --completions zsh) \
       --fish <($out/bin/flavours --completions fish) \

--- a/pkgs/applications/misc/hugo/default.nix
+++ b/pkgs/applications/misc/hugo/default.nix
@@ -23,7 +23,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
     $out/bin/hugo gen man
     installManPage man/*
     installShellCompletion --cmd hugo \

--- a/pkgs/applications/misc/pueue/default.nix
+++ b/pkgs/applications/misc/pueue/default.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage rec {
 
   checkFlags = [ "--skip=test_single_huge_payload" "--skip=test_create_unix_socket" ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
     for shell in bash fish zsh; do
       $out/bin/pueue completions $shell .
     done

--- a/pkgs/tools/virtualization/kubevirt/default.nix
+++ b/pkgs/tools/virtualization/kubevirt/default.nix
@@ -4,6 +4,7 @@
 , lib
 , testers
 , kubevirt
+, stdenv
 }:
 
 buildGoModule rec {
@@ -31,7 +32,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
     installShellCompletion --cmd virtctl \
       --bash <($out/bin/virtctl completion bash) \
       --fish <($out/bin/virtctl completion fish) \

--- a/pkgs/tools/virtualization/linode-cli/default.nix
+++ b/pkgs/tools/virtualization/linode-cli/default.nix
@@ -8,6 +8,7 @@
 , requests
 , setuptools
 , terminaltables
+, stdenv
 }:
 
 let
@@ -62,7 +63,7 @@ buildPythonApplication rec {
   '';
 
   nativeBuildInputs = [ installShellFiles ];
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
     installShellCompletion --cmd linode-cli --bash <($out/bin/linode-cli --skip-config completion bash)
   '';
 


### PR DESCRIPTION
When doing cross compiling we cannot execute the target binary.  To not
break the build we skip it for that reason.  The alternative would be to
pull in the native package from `buildPackages`, however this require
building the package twice.

There are more packages affected by this pattern. This is just the first batch.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
