### PR TITLE
oranchelo-icon-theme: 0.8.0.1 -> 0.9.0

### DIFF
--- a/pkgs/data/icons/oranchelo-icon-theme/default.nix
+++ b/pkgs/data/icons/oranchelo-icon-theme/default.nix
@@ -2,13 +2,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "oranchelo-icon-theme";
-  version = "0.8.0.1";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "OrancheloTeam";
     repo = pname;
-    rev = "096c8c8d550ac9a85f5f34f3f30243e6f198df2d";
-    sha256 = "sha256-TKi42SA33pGKdrPtGTpvxFbOP+5N93Y4BvO4CRTveLM=";
+    rev = "v${version}";
+    sha256 = "sha256-IDsZj/X9rFSdDpa3bL6IPEPCRe5GustPteDxSbfz+SA=";
   };
 
   nativeBuildInputs = [
@@ -22,9 +22,18 @@ stdenvNoCC.mkDerivation rec {
 
   dontDropIconThemeCache = true;
 
-  installPhase = ''
-    mkdir -p $out/share/icons
-    cp -r $Oranchelo* $out/share/icons/
+  makeFlags = [
+    "DESTDIR=$(out)"
+    "PREFIX="
+  ];
+
+  postInstall = ''
+    # space in icon name causes gtk-update-icon-cache to fail
+    mv "$out/share/icons/Oranchelo/apps/scalable/ grsync.svg" "$out/share/icons/Oranchelo/apps/scalable/grsync.svg"
+
+    for theme in $out/share/icons/*; do
+      gtk-update-icon-cache "$theme"
+    done
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

https://github.com/OrancheloTeam/oranchelo-icon-theme/releases/tag/v0.9.0

We use the upstream `Makefile` instead of copying the files manually in the `installPhase`.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).