### PR TITLE
Add ELFvx ABIs for PowerPC64

### DIFF
--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -94,7 +94,9 @@ in {
                   ++ filterDoubles (matchAttrs { kernel = parse.kernels.linux; abi = parse.abis.gnueabi; })
                   ++ filterDoubles (matchAttrs { kernel = parse.kernels.linux; abi = parse.abis.gnueabihf; })
                   ++ filterDoubles (matchAttrs { kernel = parse.kernels.linux; abi = parse.abis.gnuabin32; })
-                  ++ filterDoubles (matchAttrs { kernel = parse.kernels.linux; abi = parse.abis.gnuabi64; });
+                  ++ filterDoubles (matchAttrs { kernel = parse.kernels.linux; abi = parse.abis.gnuabi64; })
+                  ++ filterDoubles (matchAttrs { kernel = parse.kernels.linux; abi = parse.abis.gnuabielfv1; })
+                  ++ filterDoubles (matchAttrs { kernel = parse.kernels.linux; abi = parse.abis.gnuabielfv2; });
   illumos       = filterDoubles predicates.isSunOS;
   linux         = filterDoubles predicates.isLinux;
   netbsd        = filterDoubles predicates.isNetBSD;

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -22,12 +22,11 @@ rec {
   };
 
   ppc64 = {
-    config = "powerpc64-unknown-linux-gnu";
-    gcc = { abi = "elfv2"; }; # for gcc configuration
+    config = "powerpc64-unknown-linux-gnuabielfv2";
   };
   ppc64-musl = {
     config = "powerpc64-unknown-linux-musl";
-    gcc = { abi = "elfv2"; }; # for gcc configuration
+    gcc = { abi = "elfv2"; };
   };
 
   sheevaplug = {

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -64,7 +64,7 @@ rec {
     isNone         = { kernel = kernels.none; };
 
     isAndroid      = [ { abi = abis.android; } { abi = abis.androideabi; } ];
-    isGnu          = with abis; map (a: { abi = a; }) [ gnuabi64 gnu gnueabi gnueabihf ];
+    isGnu          = with abis; map (a: { abi = a; }) [ gnuabi64 gnu gnueabi gnueabihf gnuabielfv1 gnuabielfv2 ];
     isMusl         = with abis; map (a: { abi = a; }) [ musl musleabi musleabihf muslabin32 muslabi64 ];
     isUClibc       = with abis; map (a: { abi = a; }) [ uclibc uclibceabi uclibceabihf ];
 

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -13,6 +13,13 @@ rec {
     isx86_64       = { cpu = { family = "x86"; bits = 64; }; };
     isPower        = { cpu = { family = "power"; }; };
     isPower64      = { cpu = { family = "power"; bits = 64; }; };
+    # This ABI is the default in NixOS PowerPC64 BE, but not on mainline GCC,
+    # so it sometimes causes issues in certain packages that makes the wrong
+    # assumption on the used ABI.
+    isAbiElfv2 = [
+      { abi = { abi = "elfv2"; }; }
+      { abi = { name = "musl"; }; cpu = { family = "power"; bits = 64; }; }
+    ];
     isx86          = { cpu = { family = "x86"; }; };
     isAarch32      = { cpu = { family = "arm"; bits = 32; }; };
     isAarch64      = { cpu = { family = "arm"; bits = 64; }; };

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -350,6 +350,11 @@ rec {
             The "gnu" ABI is ambiguous on 32-bit ARM. Use "gnueabi" or "gnueabihf" instead.
           '';
         }
+        { assertion = platform: with platform; !(isPower64 && isBigEndian);
+          message = ''
+            The "gnu" ABI is ambiguous on big-endian 64-bit PowerPC. Use "gnuabielfv2" or "gnuabielfv1" instead.
+          '';
+        }
       ];
     };
     gnuabi64     = { abi = "64"; };
@@ -360,6 +365,9 @@ rec {
     # https://www.linux-mips.org/pub/linux/mips/doc/ABI/MIPS-N32-ABI-Handbook.pdf
     gnuabin32    = { abi = "n32"; };
     muslabin32   = { abi = "n32"; };
+
+    gnuabielfv2  = { abi = "elfv2"; };
+    gnuabielfv1  = { abi = "elfv1"; };
 
     musleabi     = { float = "soft"; };
     musleabihf   = { float = "hard"; };

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -472,6 +472,8 @@ rec {
             if lib.versionAtLeast (parsed.cpu.version or "0") "6"
             then abis.gnueabihf
             else abis.gnueabi
+          # Default ppc64 BE to ELFv2
+          else if isPower64 parsed && isBigEndian parsed then abis.gnuabielfv2
           else abis.gnu
         else                     abis.unknown;
     };

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -78,6 +78,8 @@ let
           gnueabihf = lib.systems.parse.abis.musleabihf;
           gnuabin32 = lib.systems.parse.abis.muslabin32;
           gnuabi64 = lib.systems.parse.abis.muslabi64;
+          gnuabielfv2 = lib.systems.parse.abis.musl;
+          gnuabielfv1 = lib.systems.parse.abis.musl;
           # The following two entries ensure that this function is idempotent.
           musleabi = lib.systems.parse.abis.musleabi;
           musleabihf = lib.systems.parse.abis.musleabihf;
@@ -257,8 +259,6 @@ let
       crossSystem = {
         isStatic = true;
         parsed = makeMuslParsedPlatform stdenv.hostPlatform.parsed;
-      } // lib.optionalAttrs (stdenv.hostPlatform.system == "powerpc64-linux") {
-        gcc.abi = "elfv2";
       };
     });
   };


### PR DESCRIPTION
###### Description of changes

Little context:

Today the PowerPC ISA has access to several ABIs, notably ELFv1 and ELFv2. If I got the history right, the ELFv1 architecture and PowerPC big-endian came first. Then, ELFv2 was created for PowerPC little-endian, but intentionally in a way that is compatible with PowerPC big-endian.<sup>[1]</sup>

In this situation, GCC made the sensible choice of defaulting to ELFv1 for big-endian, and ELFv2 for little-endian in order not to break ABI compatibility with existing compiled code.

Today ELFv1 is less and less used, and some distributions (Gentoo, Void Linux, FreeBSD) are using PowerPC64 big-endian with the ELFv2 ABI by default. I've understood that in NixOS we would want ELFv2 as a default.

However, some packages wrongfully make the assumption that PowerPC64 big-endian implies ELFv1. On the other hand, some packages just don't work with ELFv1, for example the whole musl libc.

[1]: https://llvm.org/devmtg/2014-04/PDFs/Talks/Euro-LLVM-2014-Weigand.pdf
---

The `-elfv1` and `-elfv2` system suffixes were added in #111345, but removed in #116495. This PR adds them back, as `gnuabielfv1`, `gnuabielfv2`, and `muslabielfv2`.

This PR also makes gnuabielfv2 the default for PowerPC64 big endian, which users may find less confusing, if they try `crossSystem.system = "powerpc64-linux";` instead of `crossSystem = lib.systems.examples.ppc64;`.

The GNU ELFv1 ABI is available again, although unless someone is `dlopen`ing something outside of Nix, I don't think there are may usecases.

It also adds a convenience `isPower64BeElfv2` function, since a few downstream packages needs patches for this specific case.

Note that LLVM is still an issue.

Pinging @r-burns as the author of both aforementioned PRs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  -  The `gcc` attribute of [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)'s cross tests
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Also managed to compile a NixOS image with some other patches that I'll be upstreaming.
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
