### PR TITLE
python310Packages.omegaconf: Enable more tests

### DIFF
--- a/pkgs/development/python-modules/omegaconf/default.nix
+++ b/pkgs/development/python-modules/omegaconf/default.nix
@@ -1,5 +1,13 @@
-{ lib, buildPythonPackage, fetchFromGitHub, pytest-mock, pytestCheckHook
-, pyyaml, pythonOlder, jre_minimal, antlr4_9-python3-runtime }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytest-mock
+, pytestCheckHook
+, pyyaml
+, pythonOlder
+, jre_minimal
+, antlr4_9-python3-runtime
+, pydevd }:
 
 buildPythonPackage rec {
   pname = "omegaconf";
@@ -18,11 +26,22 @@ buildPythonPackage rec {
     substituteInPlace setup.py --replace 'setup_requires=["pytest-runner"]' 'setup_requires=[]'
   '';
 
-  checkInputs = [ pytestCheckHook pytest-mock ];
-  nativeBuildInputs = [ jre_minimal ];
-  propagatedBuildInputs = [ antlr4_9-python3-runtime pyyaml ];
+  nativeBuildInputs = [
+    jre_minimal
+  ];
 
-  disabledTestPaths = [ "tests/test_pydev_resolver_plugin.py" ];  # needs pydevd - not in Nixpkgs
+  propagatedBuildInputs = [
+    antlr4_9-python3-runtime
+    pyyaml
+  ];
+
+  checkInputs = [
+    pydevd
+    pytestCheckHook
+    pytest-mock
+  ];
+
+  pythonImportsCheck = [ "omegaconf" ];
 
   meta = with lib; {
     description = "A framework for configuring complex applications";

--- a/pkgs/development/python-modules/pydevd/default.nix
+++ b/pkgs/development/python-modules/pydevd/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, pytestCheckHook
+, untangle
+, psutil
+, trio
+, numpy
+}:
+
+buildPythonPackage rec {
+  pname = "pydevd";
+  version = "2.8.0";
+
+  src = fetchFromGitHub {
+    owner = "fabioz";
+    repo = "PyDev.Debugger";
+    rev = "pydev_debugger_${lib.replaceStrings ["."] ["_"] version}";
+    sha256 = "sha256-+yRngN10654trB09ZZa8QQsTPdM7VxVj7r6jh7OcgAA=";
+  };
+
+  checkInputs = [
+    numpy
+    psutil
+    pytestCheckHook
+    trio
+    untangle
+  ];
+
+  disabledTests = [
+    # Require network connection
+    "test_completion_sockets_and_messages"
+    "test_path_translation"
+    "test_attach_to_pid_no_threads"
+    "test_attach_to_pid_halted"
+    "test_remote_debugger_threads"
+    "test_path_translation_and_source_reference"
+    "test_attach_to_pid"
+    "test_terminate"
+    "test_gui_event_loop_custom"
+    # AssertionError: assert '/usr/bin/' == '/usr/bin'
+    # https://github.com/fabioz/PyDev.Debugger/issues/227
+    "test_to_server_and_to_client"
+    # AssertionError pydevd_tracing.set_trace_to_threads(tracing_func) == 0
+    "test_tracing_other_threads"
+    "test_tracing_basic"
+  ];
+
+  pythonImportsCheck = [ "pydevd" ];
+
+  meta = with lib; {
+    description = "PyDev.Debugger (used in PyDev, PyCharm and VSCode Python)";
+    homepage = "https://github.com/fabioz/PyDev.Debugger";
+    license = licenses.epl10;
+    maintainers = with maintainers; [ onny ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7347,6 +7347,8 @@ in {
 
   pydevccu = callPackage ../development/python-modules/pydevccu { };
 
+  pydevd = callPackage ../development/python-modules/pydevd { };
+
   pydexcom = callPackage ../development/python-modules/pydexcom { };
 
   pydicom = callPackage ../development/python-modules/pydicom { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
