### PR TITLE
nixos: add programs.smartctl.enable option

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -208,6 +208,7 @@
   ./programs/seahorse.nix
   ./programs/slock.nix
   ./programs/shadow.nix
+  ./programs/smartctl.nix
   ./programs/spacefm.nix
   ./programs/singularity.nix
   ./programs/ssh.nix

--- a/nixos/modules/programs/smartctl.nix
+++ b/nixos/modules/programs/smartctl.nix
@@ -1,0 +1,27 @@
+{ config, lib, pkgs, ... }:
+
+let
+  smartctlGroup = "smartctl";
+in
+{
+  meta.maintainers = with lib.maintainers; [ bjornfor ];
+
+  options = {
+    programs.smartctl = {
+      enable = lib.mkEnableOption "smartctl setuid wrapper, available to users in the ${smartctlGroup} group";
+    };
+  };
+
+  config = lib.mkIf config.programs.smartctl.enable {
+    security.wrappers.smartctl = {
+      source = "${pkgs.smartmontools}/bin/smartctl";
+      owner = "root";
+      group = smartctlGroup;
+      setuid = true;
+      setgid = false;
+      permissions = "u+rx,g+rx,o-rwx";
+    };
+
+    users.groups."${smartctlGroup}" = {};
+  };
+}


### PR DESCRIPTION
###### Description of changes
This option adds a smartctl setuid wrapper, available to users in the
smartctl group.

I've had this in my nixos-config.git repo for 2+ years. Should we add it to NixOS?

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
