### PR TITLE
binutils: fix the kernel build for PowerPC

### DIFF
--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -105,6 +105,17 @@ stdenv.mkDerivation {
      (if stdenv.targetPlatform.isMusl
       then substitute { src = ./mips64-default-n64.patch; replacements = [ "--replace" "gnuabi64" "muslabi64" ]; }
       else ./mips64-default-n64.patch)
+  # On PowerPC, when generating assembly code, GCC generates a `.machine`
+  # custom instruction which instructs the assembler to generate code for this
+  # machine. However, some GCC versions generate the wrong one, or make it
+  # too strict, which leads to some confusing "unrecognized opcode: wrtee"
+  # or "unrecognized opcode: eieio" errors.
+  #
+  # To remove when binutils 2.39 is released.
+  #
+  # Upstream commit:
+  # https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=cebc89b9328eab994f6b0314c263f94e7949a553
+  ++ lib.optional stdenv.targetPlatform.isPower ./ppc-make-machine-less-strict.patch
   ;
 
   outputs = [ "out" "info" "man" ];

--- a/pkgs/development/tools/misc/binutils/ppc-make-machine-less-strict.patch
+++ b/pkgs/development/tools/misc/binutils/ppc-make-machine-less-strict.patch
@@ -1,0 +1,51 @@
+From cebc89b9328eab994f6b0314c263f94e7949a553 Mon Sep 17 00:00:00 2001
+From: Alan Modra <amodra@gmail.com>
+Date: Mon, 21 Feb 2022 10:58:57 +1030
+Subject: [PATCH] binutils 2.38 vs. ppc32 linux kernel
+
+Commit b25f942e18d6 made .machine more strict.  Weaken it again.
+
+	* config/tc-ppc.c (ppc_machine): Treat an early .machine specially,
+	keeping sticky options to work around gcc bugs.
+---
+ gas/config/tc-ppc.c | 25 ++++++++++++++++++++++++-
+ 1 file changed, 24 insertions(+), 1 deletion(-)
+
+diff --git a/gas/config/tc-ppc.c b/gas/config/tc-ppc.c
+index 054f9c72161..89bc7d3f9b9 100644
+--- a/gas/config/tc-ppc.c
++++ b/gas/config/tc-ppc.c
+@@ -5965,7 +5965,30 @@ ppc_machine (int ignore ATTRIBUTE_UNUSED)
+ 	     options do not count as a new machine, instead they add
+ 	     to currently selected opcodes.  */
+ 	  ppc_cpu_t machine_sticky = 0;
+-	  new_cpu = ppc_parse_cpu (ppc_cpu, &machine_sticky, cpu_string);
++	  /* Unfortunately, some versions of gcc emit a .machine
++	     directive very near the start of the compiler's assembly
++	     output file.  This is bad because it overrides user -Wa
++	     cpu selection.  Worse, there are versions of gcc that
++	     emit the *wrong* cpu, not even respecting the -mcpu given
++	     to gcc.  See gcc pr101393.  And to compound the problem,
++	     as of 20220222 gcc doesn't pass the correct cpu option to
++	     gas on the command line.  See gcc pr59828.  Hack around
++	     this by keeping sticky options for an early .machine.  */
++	  asection *sec;
++	  for (sec = stdoutput->sections; sec != NULL; sec = sec->next)
++	    {
++	      segment_info_type *info = seg_info (sec);
++	      /* Are the frags for this section perturbed from their
++		 initial state?  Even .align will count here.  */
++	      if (info != NULL
++		  && (info->frchainP->frch_root != info->frchainP->frch_last
++		      || info->frchainP->frch_root->fr_type != rs_fill
++		      || info->frchainP->frch_root->fr_fix != 0))
++		break;
++	    }
++	  new_cpu = ppc_parse_cpu (ppc_cpu,
++				   sec == NULL ? &sticky : &machine_sticky,
++				   cpu_string);
+ 	  if (new_cpu != 0)
+ 	    ppc_cpu = new_cpu;
+ 	  else
+-- 
+2.31.1


### PR DESCRIPTION
###### Description of changes

The kernel fails to build on PowerPC. This is a bug unrelated to NixOS, but it is patched upstream, so I'm proposing to add it here.

Fun fact: Yocto is using an untagged version of binutils from the `binutils-2_38-branch` branch. This fix missed the tag by 14 days :slightly_smiling_face: 

To test the changes:

```nix
let pkgs = import nixpkgs {
    system = "x86_64-linux";
    crossSystem =
      nixpkgs.lib.systems.examples.ppc64 // {
        linux-kernel = {
          # ppc64e_defconfig implies DEFAULT_UIMAGE which needs U-Boot
          target = "uImage";
          # But somehow there is no Make target to install the uImage...
          # I should create a separate issue for this.
          installTarget = "install";
          baseConfig = "ppc64e_defconfig";
          autoModules = false;
          name = "ppc64e";
        };
      };
  };
in pkgs.linux
```

Pinging @ericson2314 and @lovesegfault as maintainers. @r-burns might also be interested.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
