### PR TITLE
rephrase nixos installation doc

### DIFF
--- a/nixos/doc/manual/from_md/installation/installing.chapter.xml
+++ b/nixos/doc/manual/from_md/installation/installing.chapter.xml
@@ -426,7 +426,9 @@ OK
             </term>
             <listitem>
               <para>
-                You <emphasis>must</emphasis> set the option
+                You must select a boot-loader, either system-boot or
+                GRUB. The recommended option is systemd-boot: set the
+                option
                 <xref linkend="opt-boot.loader.systemd-boot.enable" />
                 to <literal>true</literal>.
                 <literal>nixos-generate-config</literal> should do this
@@ -439,6 +441,23 @@ OK
                 and
                 <link linkend="opt-boot.loader.systemd-boot.enable"><literal>boot.loader.systemd-boot</literal></link>
                 as well.
+              </para>
+              <para>
+                If you want to use GRUB, set
+                <xref linkend="opt-boot.loader.grub.device" /> to
+                <literal>nodev</literal> and
+                <xref linkend="opt-boot.loader.grub.efiSupport" /> to
+                <literal>true</literal>.
+              </para>
+              <para>
+                With system-boot, you should not need any special
+                configuration to detect other installed systems. With
+                GRUB, set
+                <xref linkend="opt-boot.loader.grub.useOSProber" /> to
+                <literal>true</literal>, but this will only detect
+                windows partitions, not other linux distributions. If
+                you dual boot another linux distribution, use
+                system-boot instead.
               </para>
             </listitem>
           </varlistentry>

--- a/nixos/doc/manual/installation/installing.chapter.md
+++ b/nixos/doc/manual/installation/installing.chapter.md
@@ -303,7 +303,8 @@ Use the following commands:
 
     UEFI systems
 
-    :   You *must* set the option [](#opt-boot.loader.systemd-boot.enable)
+    :   You must select a boot-loader, either system-boot or GRUB. The recommended
+        option is systemd-boot: set the option [](#opt-boot.loader.systemd-boot.enable)
         to `true`. `nixos-generate-config` should do this automatically
         for new configurations when booted in UEFI mode.
 
@@ -311,6 +312,15 @@ Use the following commands:
         [`boot.loader.efi`](#opt-boot.loader.efi.canTouchEfiVariables) and
         [`boot.loader.systemd-boot`](#opt-boot.loader.systemd-boot.enable)
         as well.
+
+    :   If you want to use GRUB, set [](#opt-boot.loader.grub.device) to `nodev` and
+        [](#opt-boot.loader.grub.efiSupport) to `true`.
+
+    :   With system-boot, you should not need any special configuration to detect
+        other installed systems. With GRUB, set [](#opt-boot.loader.grub.useOSProber)
+        to `true`, but this will only detect windows partitions, not other linux
+        distributions. If you dual boot another linux distribution, use system-boot
+        instead.
 
     If you need to configure networking for your machine the
     configuration options are described in [](#sec-networking). In


### PR DESCRIPTION
systemd-boot is not the only option, even though it "just works" better.


![image](https://user-images.githubusercontent.com/12595971/180804723-0c5ecda3-f90d-4e07-8861-4d9fd043bf93.png)


###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
