### PR TITLE
Assorted fixes

### DIFF
--- a/pkgs/development/libraries/zeroc-ice/default.nix
+++ b/pkgs/development/libraries/zeroc-ice/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub
+{ stdenv, lib, fetchFromGitHub, fetchpatch
 , bzip2, expat, libedit, lmdb, openssl
 , python3 # for tests only
 , cpp11 ? false
@@ -54,6 +54,9 @@ in stdenv.mkDerivation rec {
     # these tests require network access so we need to skip them.
     brokenTests = map escapeRegex [
       "Ice/udp" "Glacier2" "IceGrid/simple" "IceStorm" "IceDiscovery/simple"
+
+      # FIXME: certificate expired, remove for next release?
+      "IceSSL/configuration"
     ];
     # matches CONFIGS flag in makeFlagsArray
     configFlag = optionalString cpp11 "--config=cpp11-shared";

--- a/pkgs/development/python-modules/pysaml2/default.nix
+++ b/pkgs/development/python-modules/pysaml2/default.nix
@@ -3,6 +3,7 @@
 , cryptography
 , defusedxml
 , fetchFromGitHub
+, fetchPypi
 , importlib-resources
 , mock
 , pyasn1
@@ -21,7 +22,16 @@
 , xmlsec
 }:
 
-buildPythonPackage rec {
+let
+  pymongo3 = pymongo.overridePythonAttrs(old: rec {
+    version = "3.12.3";
+    src = fetchPypi {
+      pname = "pymongo";
+      inherit version;
+      sha256 = "sha256-ConK3ABipeU2ZN3gQ/bAlxcrjBxfAJRJAJUoL/mZWl8=";
+    };
+  });
+in buildPythonPackage rec {
   pname = "pysaml2";
   version = "7.1.2";
   format = "setuptools";
@@ -52,7 +62,7 @@ buildPythonPackage rec {
   checkInputs = [
     mock
     pyasn1
-    pymongo
+    pymongo3
     pytestCheckHook
     responses
   ];

--- a/pkgs/tools/security/fprintd/default.nix
+++ b/pkgs/tools/security/fprintd/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv
 , fetchFromGitLab
+, fetchpatch
 , pkg-config
 , gobject-introspection
 , meson
@@ -35,6 +36,14 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "sha256-ePhcIZyXoGr8XlBuzKjpibU9D/44iCXYBlpVR9gcswQ=";
   };
+
+  patches = [
+    # backport upstream patch fixing tests
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/libfprint/fprintd/-/commit/ae04fa989720279e5558c3b8ff9ebe1959b1cf36.patch";
+      sha256 = "sha256-jW5vlzrbZQ1gUDLBf7G50GnZfZxhlnL2Eu+9Bghdwdw=";
+    })
+  ];
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
- fprintd: backport patch to fix tests
- python3Packages.pysaml2: run tests with older pymongo to fix build
- zeroc-ice: skip failing test

All builds on x86_64-linux now.
