### PR TITLE
split uboot initrds into own builds

### DIFF
--- a/nixos/modules/installer/netboot/netboot.nix
+++ b/nixos/modules/installer/netboot/netboot.nix
@@ -81,15 +81,20 @@ with lib;
 
 
     # Create the initrd
-    system.build.netbootRamdisk = pkgs.makeInitrdNG {
+    system.build.netbootRawRamdisk = pkgs.makeInitrdNG {
       inherit (config.boot.initrd) compressor;
-      prepend = [ "${config.system.build.initialRamdisk}/initrd" ];
+      prepend = [ "${config.system.build.rawInitialRamdisk}/initrd" ];
 
       contents =
         [ { object = config.system.build.squashfsStore;
             symlink = "/nix-store.squashfs";
           }
         ];
+    };
+
+    system.build.netbootRamdisk = pkgs.wrapInitrd {
+      rawInitialRamdisk = config.system.build.netbootRawRamdisk;
+      inherit (config.boot.initrd) compressor;
     };
 
     system.build.netbootIpxeScript = pkgs.writeTextDir "netboot.ipxe" ''

--- a/pkgs/build-support/kernel/make-initrd.sh
+++ b/pkgs/build-support/kernel/make-initrd.sh
@@ -42,10 +42,4 @@ done
 (cd root && find * .[^.*] -exec touch -h -d '@1' '{}' +)
 (cd root && find * .[^.*] -print0 | sort -z | bsdtar --uid 0 --gid 0 -cnf - -T - | bsdtar --null -cf - --format=newc @- | eval -- $compress >> "$out/initrd")
 
-if [ -n "$makeUInitrd" ]; then
-    mkimage -A "$uInitrdArch" -O linux -T ramdisk -C "$uInitrdCompression" -d "$out/initrd" $out/initrd.img
-    # Compatibility symlink
-    ln -sf "initrd.img" "$out/initrd"
-else
-    ln -s "initrd" "$out/initrd$extension"
-fi
+ln -s "initrd" "$out/initrd$extension"

--- a/pkgs/build-support/kernel/wrap-initrd.nix
+++ b/pkgs/build-support/kernel/wrap-initrd.nix
@@ -1,0 +1,60 @@
+# This derivation wraps 'rawInitialRamdisk' in a U-Boot image, if it has
+# detected that it is desirable, by checking if the kernel image is an 'uImage'
+
+let
+  # Some metadata on various compression programs, relevant to naming
+  # the initramfs file and, if applicable, generating a u-boot image
+  # from it.
+  compressors = import ./initrd-compressor-meta.nix;
+
+  # Get the basename of the actual compression program from the whole
+  # compression command, for the purpose of guessing the u-boot
+  # compression type and filename extension.
+  compressorName = fullCommand: builtins.elemAt (builtins.match "([^ ]*/)?([^ ]+).*" fullCommand) 1;
+in
+{ stdenvNoCC
+, lib
+, pkgsBuildHost
+, runCommand
+, ubootTools
+, rawInitialRamdisk
+
+  # Program used to compress the cpio archive; use "cat" for no compression.
+  # This can also be a function which takes a package set and returns the path to the compressor,
+  # such as `pkgs: "${pkgs.lzop}/bin/lzop"`.
+, compressor ? "gzip"
+, _compressorFunction ? if lib.isFunction compressor then compressor
+  else if ! builtins.hasContext compressor && builtins.hasAttr compressor compressors then compressors.${compressor}.executable
+  else _: compressor
+, _compressorExecutable ? _compressorFunction pkgsBuildHost
+, _compressorName ? compressorName _compressorExecutable
+, _compressorMeta ? compressors.${_compressorName} or { }
+
+  # If generating a u-boot image, the architecture to use. The default
+  # guess may not align with u-boot's nomenclature correctly, so it can
+  # be overridden.
+  # See https://gitlab.denx.de/u-boot/u-boot/-/blob/9bfb567e5f1bfe7de8eb41f8c6d00f49d2b9a426/common/image.c#L81-106 for a list.
+, uInitrdArch ? stdenvNoCC.hostPlatform.linuxArch
+
+  # The name of the compression, as recognised by u-boot.
+  # See https://gitlab.denx.de/u-boot/u-boot/-/blob/9bfb567e5f1bfe7de8eb41f8c6d00f49d2b9a426/common/image.c#L195-204 for a list.
+  # If this isn't guessed, you may want to complete the metadata above and send a PR :)
+, uInitrdCompression ? _compressorMeta.ubootName or
+    (throw "Unrecognised compressor ${_compressorName}, please specify uInitrdCompression")
+}:
+
+if stdenvNoCC.hostPlatform.linux-kernel.target == "uImage"
+then
+  runCommand "uboot-${rawInitialRamdisk.name}"
+  {
+    nativeBuildInputs = [ ubootTools ];
+    inherit uInitrdArch uInitrdCompression;
+  } ''
+    mkdir -p $out
+    mkimage -A "$uInitrdArch" -O linux -T ramdisk -C "$uInitrdCompression" -d "${rawInitialRamdisk}/initrd" $out/initrd.img
+    # Compatibility symlink
+    ln -sf "initrd.img" "$out/initrd"
+  ''
+else
+  # No-op
+  rawInitialRamdisk

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -847,6 +847,8 @@ with pkgs;
   makeInitrdNG = callPackage ../build-support/kernel/make-initrd-ng.nix;
   makeInitrdNGTool = callPackage ../build-support/kernel/make-initrd-ng-tool.nix {};
 
+  wrapInitrd = callPackage ../build-support/kernel/wrap-initrd.nix;
+
   makeWrapper = makeShellWrapper;
 
   makeShellWrapper = makeSetupHook


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This is done so that the netboot initrd is not wrapped twice by uboot.

This PR is WIP because I think it needs some more testing, and some documentation.

@r-burns might be interested.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
