### PR TITLE
wails: 2.0.0-beta.38 -> 2.0.0-beta.42

### DIFF
--- a/pkgs/development/tools/wails/default.nix
+++ b/pkgs/development/tools/wails/default.nix
@@ -15,16 +15,16 @@
 
 buildGoModule rec {
   pname = "wails";
-  version = "2.0.0-beta.38";
+  version = "2.0.0-beta.42";
 
   src = fetchFromGitHub {
     owner = "wailsapp";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-yZgqdJMc48IKd3fimCWPLNkCdUEeIiQs4Xi4D9f5sHA=";
+    sha256 = "sha256-ZfzaDUUM3W2ZvmLJufeVZ3eK/grvSxbKbsReV7BmcGA=";
   } + "/v2";
 
-  vendorSha256 = "sha256-tUNOMNQ2NoYvNt2AdKzkMa+oiPNszBjuhs9EgbDVcTU=";
+  vendorSha256 = "sha256-qmj7pZV9VaxWcC7EgbKZOjlDj6/66Qf5d222aj4TViw=";
 
   proxyVendor = true;
 

--- a/pkgs/development/tools/wails/default.nix
+++ b/pkgs/development/tools/wails/default.nix
@@ -66,8 +66,6 @@ buildGoModule rec {
       --set CGO_LDFLAGS "-L${lib.makeLibraryPath [ zlib ]}"
   '';
 
-  doCheck = true;
-
   meta = with lib; {
     description = "Build applications using Go + HTML + CSS + JS";
     homepage = "https://wails.io";


### PR DESCRIPTION
###### Description of changes

Update Wails app builder to latest version.

Changelogs:

https://github.com/wailsapp/wails/releases/tag/v2.0.0-beta.42
https://github.com/wailsapp/wails/releases/tag/v2.0.0-beta.39.2
https://github.com/wailsapp/wails/releases/tag/v2.0.0-beta.39

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
