### PR TITLE
fractal-next: init at unstable-2022-07-10

### DIFF
--- a/pkgs/applications/networking/instant-messengers/fractal-next/default.nix
+++ b/pkgs/applications/networking/instant-messengers/fractal-next/default.nix
@@ -1,0 +1,76 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, meson
+, ninja
+, rustPlatform
+, pkg-config
+, glib
+, gtk4
+, gtksourceview5
+, libadwaita
+, gstreamer
+, gst-plugins-base
+, gst-plugins-bad
+, libsecret
+, desktop-file-utils
+, appstream-glib
+, openssl
+, pipewire
+, libshumate
+, wrapGAppsHook4
+}:
+
+stdenv.mkDerivation rec {
+  pname = "fractal-next";
+  version = "unstable-2022-07-10";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "GNOME";
+    repo = "fractal";
+    rev = "837b56978474fe512469805844b8ee234587499a";
+    hash = "sha256-6op/+eiDra5EFRludpkQOucBXdPl5a/oQWPwwhJEx+M=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    hash = "sha256-2mE26ES+fYSWdfMr8uTsX2VVGTNMDQ9MXEk5E/L95UI=";
+  };
+
+  nativeBuildInputs = [
+    glib
+    gtk4
+    meson
+    ninja
+    pkg-config
+    rustPlatform.bindgenHook
+    rustPlatform.cargoSetupHook
+    rustPlatform.rust.cargo
+    rustPlatform.rust.rustc
+    desktop-file-utils
+    appstream-glib
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    glib
+    gstreamer
+    gst-plugins-base
+    gst-plugins-bad
+    gtk4
+    gtksourceview5
+    libadwaita
+    libsecret
+    openssl
+    pipewire
+    libshumate
+  ];
+
+  meta = with lib; {
+    description = "Matrix group messaging app (development version)";
+    homepage = "https://gitlab.gnome.org/GNOME/fractal";
+    license = licenses.gpl3Plus;
+    maintainers = teams.gnome.members ++ (with maintainers; [ anselmschueler ]);
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27045,6 +27045,10 @@ with pkgs;
 
   fractal = callPackage ../applications/networking/instant-messengers/fractal { };
 
+  fractal-next = callPackage ../applications/networking/instant-messengers/fractal-next {
+    inherit (gst_all_1) gstreamer gst-plugins-base gst-plugins-bad;
+  };
+
   fragments = callPackage ../applications/networking/p2p/fragments { };
 
   freecad = libsForQt5.callPackage ../applications/graphics/freecad {


### PR DESCRIPTION
###### Description of changes

Added Fractal Next  
Fractal Next is the developement version and relaunch of Fractal, a GNOME Matrix client.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
