### PR TITLE
musikcube: fix rpath for musikcube

### DIFF
--- a/pkgs/applications/audio/musikcube/default.nix
+++ b/pkgs/applications/audio/musikcube/default.nix
@@ -76,10 +76,10 @@ stdenv.mkDerivation rec {
     "-DDISABLE_STRIP=true"
   ];
 
-  postFixup = if stdenv.hostPlatform.isDarwin then ''
-    install_name_tool -add_rpath $out/share/${pname} $out/share//${pname}/${pname}
-    install_name_tool -add_rpath $out/share/${pname} $out/share//${pname}/${pname}d
-  '' else "";
+  postFixup = lib.optionals stdenv.isDarwin ''
+    install_name_tool -add_rpath $out/share/${pname} $out/share/${pname}/${pname}
+    install_name_tool -add_rpath $out/share/${pname} $out/share/${pname}/${pname}d
+  '';
 
   meta = with lib; {
     description = "A fully functional terminal-based music player, library, and streaming audio server";

--- a/pkgs/applications/audio/musikcube/default.nix
+++ b/pkgs/applications/audio/musikcube/default.nix
@@ -76,6 +76,11 @@ stdenv.mkDerivation rec {
     "-DDISABLE_STRIP=true"
   ];
 
+  postFixup = if stdenv.hostPlatform.isDarwin then ''
+    install_name_tool -add_rpath $out/share/${pname} $out/share//${pname}/${pname}
+    install_name_tool -add_rpath $out/share/${pname} $out/share//${pname}/${pname}d
+  '' else "";
+
   meta = with lib; {
     description = "A fully functional terminal-based music player, library, and streaming audio server";
     homepage = "https://musikcube.com/";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I've filed [clangen/musikcube#538](https://github.com/clangen/musikcube/issues/538), since the latest version of musikcube aborts on Darwin when installed with nixpkgs due to an incorrect/unresolved `rpath`.
At the time of writing I'm uncertain whether this is an upstream issue with musikcube that was introduced with 0.98.0 or something in nix/nixpkgs has changed.

Putting up this draft PR for review to get a conversation going how and where this issue would be resolved best.

Any suggestions for improvement in this PR are welcome.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
