### PR TITLE
libhwy: 0.15.0 -> 0.17.0

### DIFF
--- a/pkgs/development/libraries/libhwy/default.nix
+++ b/pkgs/development/libraries/libhwy/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, cmake, ninja, gtest, fetchpatch, fetchFromGitHub }:
+{ lib, stdenv, cmake, ninja, gtest, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
   pname = "libhwy";

--- a/pkgs/development/libraries/libhwy/default.nix
+++ b/pkgs/development/libraries/libhwy/default.nix
@@ -2,24 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "libhwy";
-  version = "0.15.0";
+  version = "0.17.0";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "highway";
     rev = version;
-    sha256 = "sha256-v2HyyHtBydr7QiI83DW1yRv2kWjUOGxFT6mmdrN9XPo=";
+    hash = "sha256-CHjLD2qXmmggJXm15tdp+Nc/vyUIlrg4ZOvI4FA9lkc=";
   };
-
-  patches = [
-    # Remove on next release
-    # https://github.com/google/highway/issues/460
-    (fetchpatch {
-      name = "hwy-add-missing-includes.patch";
-      url = "https://github.com/google/highway/commit/8ccab40c2f931aca6004d175eec342cc60f6baec.patch";
-      sha256 = "sha256-wlp5gIvK2+OlKtsZwxq/pXTbESkUtimHXaYDjcBzmQ0=";
-    })
-  ];
 
   nativeBuildInputs = [ cmake ninja ];
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Change log for libhwy versions 0.16.0 and 0.17.0: https://github.com/google/highway/releases/tag/0.16.0 and https://github.com/google/highway/releases/tag/0.17.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
