### PR TITLE
roundcubePlugins:thunderbird_labels: init at 1.4.11

### DIFF
--- a/pkgs/servers/roundcube/plugins/plugins.nix
+++ b/pkgs/servers/roundcube/plugins/plugins.nix
@@ -7,4 +7,5 @@
 
   carddav = callPackage ./carddav { };
   persistent_login = callPackage ./persistent_login { };
+  thunderbird_labels = callPackage ./thunderbird_labels { };
 }

--- a/pkgs/servers/roundcube/plugins/thunderbird_labels/default.nix
+++ b/pkgs/servers/roundcube/plugins/thunderbird_labels/default.nix
@@ -1,0 +1,11 @@
+{ roundcubePlugin, fetchzip }:
+
+roundcubePlugin rec {
+  pname = "thunderbird_labels";
+  version = "1.4.11";
+
+  src = fetchzip {
+    url = "https://github.com/mike-kfed/roundcube-thunderbird_labels/archive/refs/tags/v${version}.tar.gz";
+    sha256 = "1agnj4lsy6bcqvxyrf2vv63fsxhr6sjn5z8qkkb8yp8fjmmn4fbx";
+  };
+}


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adding another roundcube mail plugin: thunderbird_labels.
I added it in the same way the other existing plugins were added, which seem a really stripped down `default.nix` inside the `plugins` folder of the roundcube package.

Original plugin is maintained on github at https://github.com/mike-kfed/roundcube-thunderbird_labels

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Successfully tested it on an nginx virtualhost using:
```
root = pkgs.roundcube.withPlugins (plugins: with plugins; [ thunderbird_labels ]);
```