### PR TITLE
opencl-headers: 2021.06.30 -> 2022.05.18

### DIFF
--- a/pkgs/development/libraries/opencl-clhpp/default.nix
+++ b/pkgs/development/libraries/opencl-clhpp/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "opencl-clhpp";
-  version = "2.0.15";
+  version = "2.0.17";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "OpenCL-CLHPP";
-    rev = "v${version}";
-    sha256 = "sha256-A12GdevbMaO2QkGAk3VsXzwcDkF+6dEapse2xfdqzPM=";
+    rev = "v2022.05.18"; # XXX: tag uses different name than current release
+    hash = "sha256-u4hbcBw3KEPo0+RC7lgPlExS5ZyDubxiLXN9ya0Ork8=";
   };
 
   nativeBuildInputs = [ cmake python3 ];
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "OpenCL Host API C++ bindings";
     homepage = "http://github.khronos.org/OpenCL-CLHPP/";
-    license = licenses.mit;
+    license = licenses.asl20;
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/opencl-headers/default.nix
+++ b/pkgs/development/libraries/opencl-headers/default.nix
@@ -1,21 +1,36 @@
-{ lib, stdenv, fetchFromGitHub
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake
 }:
 
 stdenv.mkDerivation rec {
   pname = "opencl-headers";
-  version = "2021.06.30";
+  version = "2022.05.18";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "OpenCL-Headers";
     rev = "v${version}";
-    sha256 = "sha256-MdKC48f1zhVAcHrqzrgT9iaYrHXurV8vDt+GnDroO9s=";
+    hash = "sha256-A2MKU1ppfCKroN4qKGKN9XJvkcGZJy+Kn8FvxceQv7o=";
   };
 
-  installPhase = ''
-    mkdir -p $out/include/CL
-    cp CL/* $out/include/CL
-  '';
+  nativeBuildInputs = [ cmake ];
+
+  patches = [
+    # Fix CMake-based install on Darwin
+    # https://github.com/KhronosGroup/OpenCL-Headers/pull/203
+    (fetchpatch {
+      url = "https://github.com/KhronosGroup/OpenCL-Headers/commit/7bdd9509899ef9558a71a795b5daa6f6811a165d.patch";
+      hash = "sha256-NshYHAJlPWLWnfilgb6KNDerHO3bEiIajTSLkw6Ipl8=";
+    })
+    (fetchpatch {
+      url = "https://github.com/KhronosGroup/OpenCL-Headers/commit/0fbd141e2c18595d5a57590565354c795b9eb8c2.patch";
+      hash = "sha256-dPdnTwC0qvsiuHlZSgqb/oyPd1HvvSi5iRRQ/eETV4I=";
+    })
+  ];
+
+  cmakeFlags = [
+    "-DOPENCL_HEADERS_BUILD_TESTING=OFF"
+    "-DOPENCL_HEADERS_BUILD_CXX_TESTS=OFF"
+  ];
 
   meta = with lib; {
     description = "Khronos OpenCL headers version ${version}";


### PR DESCRIPTION
###### Description of changes

- `opencl-headers`:

  Use the new CMake-based installer, which installs the headers and CMake config files. It needs to be patched on Darwin.

  The installed CMake config files are required to update `opencl-clhpp`.

  Releases:
  - https://github.com/KhronosGroup/OpenCL-Headers/releases/tag/v2022.01.04
  - https://github.com/KhronosGroup/OpenCL-Headers/releases/tag/v2022.05.18

- `opencl-clhpp`:
  
  The tag for the latest release v2.0.17 is now different from the release version.

  Also fix license.
  
  Releases:
  - https://github.com/KhronosGroup/OpenCL-CLHPP/releases/tag/v2.0.16
  - https://github.com/KhronosGroup/OpenCL-CLHPP/releases/tag/v2022.05.18
  
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Closes #159638 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
