### PR TITLE
python310Packages.apptools: Enable more tests

### DIFF
--- a/pkgs/development/python-modules/apptools/default.nix
+++ b/pkgs/development/python-modules/apptools/default.nix
@@ -26,11 +26,20 @@ buildPythonPackage rec {
   };
 
   patches = [
+    # python310: Fix tests
+    # https://github.com/enthought/apptools/issues/303
+    (fetchpatch {
+      url = "https://github.com/enthought/apptools/commit/10fb73916124f7ae7edf6c6688a05ad95678488f.patch";
+      sha256 = "sha256-izAcP5RWobLvnk2PQx31SX/TUGkw+prbYbjamYVmtjY=";
+      name = "fix_python310_tests.patch";
+    })
+
     # python39: importlib_resources -> importlib.resources. This patch will be included
     # in the next release after 5.1.0.
     (fetchpatch {
       url = "https://github.com/enthought/apptools/commit/0ae4f52f19a8c0ca9d7926e17c7de949097f24b4.patch";
       sha256 = "165aiwjisr5c3lasg7xblcha7y1y5bq23vi3g9gc80c24bzwcbsw";
+      name = "fix_importlib-resources_naming.patch";
     })
   ];
 
@@ -51,14 +60,6 @@ buildPythonPackage rec {
   preCheck = ''
     export HOME=$TMP
   '';
-
-  disabledTestPaths = lib.optionals (pythonAtLeast "3.10") [
-    # https://github.com/enthought/apptools/issues/303
-    "apptools/io/h5/tests/test_dict_node.py"
-    "apptools/io/h5/tests/test_file.py"
-    "apptools/io/h5/tests/test_table_node.py"
-  ];
-
 
   pythonImportsCheck = [
     "apptools"


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
