### PR TITLE
fetchurl: disallow specifying both `sha256` and `hash`

### DIFF
--- a/pkgs/applications/networking/powerdns-admin/default.nix
+++ b/pkgs/applications/networking/powerdns-admin/default.nix
@@ -19,6 +19,7 @@ let
         src = oldAttrs.src.override {
           inherit version;
           hash = "sha256-yKhbKNN3zHc35G4tnytPRO48Dh3qxr9G3e/HGH0weXo=";
+          sha256 = "";
         };
 
         SETUPTOOLS_SCM_PRETEND_VERSION = version;

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -117,6 +117,9 @@ let
     else throw "fetchurl requires either `url` or `urls` to be set";
 
   hash_ =
+    # Many other combinations don't make sense, but this is the most common one:
+    if hash != "" && sha256 != "" then throw "multiple hashes passed to fetchurl" else
+
     if hash != "" then { outputHashAlgo = null; outputHash = hash; }
     else if md5 != "" then throw "fetchurl does not support md5 anymore, please use sha256 or sha512"
     else if (outputHash != "" && outputHashAlgo != "") then { inherit outputHashAlgo outputHash; }

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -48,8 +48,9 @@ let
     (self: super: {
       pytest-aiohttp = super.pytest-aiohttp.overridePythonAttrs (oldAttrs: rec {
         version = "0.3.0";
-        src = oldAttrs.src.override {
+        src = self.fetchPypi {
           inherit version;
+          pname = "pytest-aiohttp";
           hash = "sha256-ySmFQzljeXc3WDhwO2L+9jUoWYvAqdRRY566lfSqpE8=";
         };
         propagatedBuildInputs = with python3.pkgs; [ aiohttp pytest ];
@@ -86,7 +87,16 @@ let
     })
 
     # Pinned due to API changes in 0.1.0
-    (mkOverride "poolsense" "0.0.8" "sha256-17MHrYRmqkH+1QLtgq2d6zaRtqvb9ju9dvPt9gB2xCc=")
+    (self: super: {
+      poolsense = super.poolsense.overridePythonAttrs (oldAttrs: rec {
+        version = "0.0.8";
+        src = super.fetchPypi {
+          pname = "poolsense";
+          inherit version;
+          hash = "sha256-17MHrYRmqkH+1QLtgq2d6zaRtqvb9ju9dvPt9gB2xCc=";
+        };
+      });
+    })
 
     # Pinned due to API changes >0.3.5.3
     (self: super: {
@@ -143,16 +153,6 @@ let
       home-assistant-frontend = self.callPackage ./frontend.nix { };
     })
   ];
-
-  mkOverride = attrName: version: hash:
-    self: super: {
-      ${attrName} = super.${attrName}.overridePythonAttrs (oldAttrs: {
-        inherit version;
-        src = oldAttrs.src.override {
-          inherit version hash;
-        };
-      });
-    };
 
   python = python3.override {
     # Put packageOverrides at the start so they are applied after defaultOverrides

--- a/pkgs/tools/admin/oci-cli/default.nix
+++ b/pkgs/tools/admin/oci-cli/default.nix
@@ -13,6 +13,7 @@ let
         src = oldAttrs.src.override {
           inherit version;
           hash = "sha256-0rUlXHxjSbwb0eWeCM0SrLvWPOZJ8liHVXg6qU37axo=";
+          sha256 = "";
         };
       });
 
@@ -21,6 +22,7 @@ let
         src = oldAttrs.src.override {
           inherit version;
           sha256 = "b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9";
+          hash = "";
         };
       });
 

--- a/pkgs/tools/audio/tts/default.nix
+++ b/pkgs/tools/audio/tts/default.nix
@@ -21,7 +21,8 @@ let
       # TypeError: mel() takes 0 positional arguments but 2 positional arguments (and 3 keyword-only arguments) were given
       librosa = super.librosa.overridePythonAttrs (oldAttrs: rec {
         version = "0.8.1";
-        src = oldAttrs.src.override {
+        src = super.fetchPypi {
+          pname = "librosa";
           inherit version;
           sha256 = "c53d05e768ae4a3e553ae21c2e5015293e5efbfd5c12d497f1104cb519cca6b3";
         };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15235,6 +15235,7 @@ with pkgs;
     src = oldAttrs.src.override {
       inherit version;
       hash = "sha256-XzZuhRFZ2Pcs5o0yuMDt2lbuU3wB6faOyjgr0VEK9l0=";
+      sha256 = "";
     };
     meta.changelog = "https://github.com/ansible/ansible/blob/v${version}/changelogs/CHANGELOG-v${lib.versions.majorMinor version}.rst";
   }));


### PR DESCRIPTION
A full check would be more complicated to write -
and more importantly - probably also more expensive.

Motivation: eval-time catch for errors like in commit 8198636be07e4.