### PR TITLE
ps3iso-utils: init at 277db7de

### DIFF
--- a/pkgs/tools/games/ps3iso-utils/default.nix
+++ b/pkgs/tools/games/ps3iso-utils/default.nix
@@ -16,30 +16,18 @@ stdenv.mkDerivation rec {
   };
 
   buildPhase = ''
-    pushd makeps3iso
-    make
-    ls
-    popd
-
-    pushd extractps3iso
-    make
-    popd
-
-    pushd patchps3iso
-    make
-    popd
-
-    pushd splitps3iso
-    make
-    popd
+    make -C extractps3iso
+    make -C makeps3iso
+    make -C patchps3iso
+    make -C splitps3iso
   '';
 
   installPhase = ''
     mkdir -p $out/bin
-    install -m 0755 makeps3iso/makeps3iso $out/bin
-    install -m 0755 splitps3iso/splitps3iso $out/bin
     install -m 0755 extractps3iso/extractps3iso $out/bin
+    install -m 0755 makeps3iso/makeps3iso $out/bin
     install -m 0755 patchps3iso/patchps3iso $out/bin
+    install -m 0755 splitps3iso/splitps3iso $out/bin
   '';
 
 

--- a/pkgs/tools/games/ps3iso-utils/default.nix
+++ b/pkgs/tools/games/ps3iso-utils/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, stdenv
+, makeWrapper
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation rec {
+  name = "ps3iso-utils";
+  version = "277db7de";
+
+  src = fetchFromGitHub {
+    owner = "bucanero";
+    repo = "ps3iso-utils";
+    rev = version;
+    sha256 = "sha256-CVzJxbYJ2zbBGreqkRFNf3Nw2nj2vpK63DolCYzDFes=";
+  };
+
+  buildPhase = ''
+    pushd makeps3iso
+    make
+    ls
+    popd
+
+    pushd extractps3iso
+    make
+    popd
+
+    pushd patchps3iso
+    make
+    popd
+
+    pushd splitps3iso
+    make
+    popd
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -m 0755 makeps3iso/makeps3iso $out/bin
+    install -m 0755 splitps3iso/splitps3iso $out/bin
+    install -m 0755 extractps3iso/extractps3iso $out/bin
+    install -m 0755 patchps3iso/patchps3iso $out/bin
+  '';
+
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  meta = {
+    homepage = "https://github.com/bucanero/ps3iso-utils";
+    description = "Windows, Linux, and macOS builds of Estwald's PS3ISO utilities";
+    license = lib.licenses.gpl3;
+    maintainers = [ "evanjs" ];
+  };
+}

--- a/pkgs/tools/games/ps3iso-utils/default.nix
+++ b/pkgs/tools/games/ps3iso-utils/default.nix
@@ -24,10 +24,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/bin
-    install -m 0755 extractps3iso/extractps3iso $out/bin
-    install -m 0755 makeps3iso/makeps3iso $out/bin
-    install -m 0755 patchps3iso/patchps3iso $out/bin
-    install -m 0755 splitps3iso/splitps3iso $out/bin
+    find -name "*ps3iso" -type f -exec install -Dm 755 \{} $out/bin \;
   '';
 
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9885,6 +9885,8 @@ with pkgs;
 
   progress = callPackage ../tools/misc/progress { };
 
+  ps3iso-utils = callPackage ../tools/games/ps3iso-utils { };
+
   ps3netsrv = callPackage ../servers/ps3netsrv { };
 
   pscircle = callPackage ../os-specific/linux/pscircle { };


### PR DESCRIPTION
###### Description of changes
Initialize [ps3iso-utils](https://github.com/bucanero/ps3iso-utils) at [277db7de](https://github.com/bucanero/ps3iso-utils/releases/tag/277db7de)

Related: #182972 (init [ps3-disc-dumper](https://github.com/13xforever/ps3-disc-dumper))

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done
___
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
