### PR TITLE
build-support/rust: discard context of lock file contents

### DIFF
--- a/pkgs/build-support/rust/import-cargo-lock.nix
+++ b/pkgs/build-support/rust/import-cargo-lock.nix
@@ -33,7 +33,13 @@ let
     then builtins.readFile lockFile
     else args.lockFileContents;
 
-  packages = (builtins.fromTOML lockFileContents).package;
+  # we need to drop context from the file contents because dependencies of the
+  # surrounding repo are propagated through readFile, and fromTOML does not
+  # allow strings with references as input. we do not lose anything by doing so
+  # since a lock file cannot legally refer to store paths that are not referenced
+  # elsewhere already. setting lockFileContents directly is similar; we cannot add
+  # references to the contents that don't already exist in eg a patch file.
+  packages = (builtins.fromTOML (builtins.unsafeDiscardStringContext lockFileContents)).package;
 
   # There is no source attribute for the source package itself. But
   # since we do not want to vendor the source package anyway, we can


### PR DESCRIPTION
###### Description of changes

context on lock file contents breaks the build when lock files are read
from store paths that depend on other store paths (as can happen in eg
the os-prober tests if the worktree contains a shell script that
references bash by its full store path).

tested by running the `os-prober` test, which fails without this patch and succeeds with it. since any other instances of this problem would have caused a build failure to begin with this is probably low risk.

cc @symphorien 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
