### PR TITLE
nixos: get system type from pkgs instance

### DIFF
--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -10,7 +10,7 @@
 # types.submodule instead of using eval-config.nix
 evalConfigArgs@
 { # !!! system can be set modularly, would be nice to remove
-  system ? builtins.currentSystem
+  system ? pkgs.system or builtins.currentSystem
 , # !!! is this argument needed any more? The pkgs argument can
   # be set modularly anyway.
   pkgs ? null


### PR DESCRIPTION
###### Description of changes

This avoids repetition when a flake `nixosSystem` caller is passing a `pkgs` instance to the function.

For example, when passing `pkgs = nixpkgs.legacyPackages.x86_64-linux` it should not be required to also pass `system = "x86_64-linux"`.

###### Examples

This change makes it possible to have similar nixosSystem and homeManagerConfiguration calls. For example:
```nix
{
  # ...
  outputs = { nixpkgs, home-manager, ... }: {

    nixosConfigurations = {
      "foo" = nixpkgs.lib.nixosSystem {
        pkgs = nixpkgs.legacyPackages.x86_64-linux;
        modules = [ ./nixos/configuration.nix ];
      };
    };

    homeConfigurations = {
      "bob@foo" = home-manager.lib.homeManagerConfiguration {
        pkgs = nixpkgs.legacyPackages.x86_64-linux;
        modules = [ ./home-manager/home.nix ];
      };
    };

  };
}
```

This also helps with more complex setups (passing `pkgs` is specially useful when using overlays):
```nix
{
  # ...
  outputs = { nixpkgs, home-manager, ... }:
  let
    forAllSystems = with nixpkgs.lib; genAttrs systems.flakeExposed;
  in rec {
    overlays.default = import ./overlay;

    legacyPackages = forAllSystems (system:
      import nixpkgs { inherit system; overlays = [ overlays.default ]; }
    );

    nixosConfigurations = {
      "foo" = nixpkgs.lib.nixosSystem {
        pkgs = legacyPackages.aarch64-linux;
        modules = [ ./hosts/foo ];
      };
      "bar" = nixpkgs.lib.nixosSystem {
        pkgs = legacyPackages.x86_64-linux;
        modules = [ ./hosts/bar ];
      };
    };

    homeConfigurations = {
      "bob@foo" = home-manager.lib.homeManagerConfiguration {
        pkgs = legacyPackages.aarch64-linux;
        modules = [ ./homes/bob ];
      };
      "alice@bar" = home-manager.lib.homeManagerConfiguration {
        pkgs = legacyPackages.x86_64-linux;
        modules = [ ./homes/alice ];
      };
    };
  };
}
```

`system` will still default to `builtins.currentSystem` (which, by design, does not work under flakes) when `pkgs` is not specified.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
