### PR TITLE
plan9port: remove spurious patches

### DIFF
--- a/pkgs/tools/system/plan9port/default.nix
+++ b/pkgs/tools/system/plan9port/default.nix
@@ -17,24 +17,8 @@ stdenv.mkDerivation rec {
   };
 
   postPatch = ''
-    #hardcoded path
-    substituteInPlace src/cmd/acme/acme.c \
-      --replace /lib/font/bit $out/plan9/font
-
-    #deprecated flags
-    find . -type f \
-      -exec sed -i -e 's/_SVID_SOURCE/_DEFAULT_SOURCE/g' {} \; \
-      -exec sed -i -e 's/_BSD_SOURCE/_DEFAULT_SOURCE/g' {} \;
-
     substituteInPlace bin/9c \
       --replace 'which uniq' '${which}/bin/which uniq'
-  '' + lib.optionalString (!stdenv.isDarwin) ''
-    #add missing ctrl+c\z\x\v keybind for non-Darwin
-    substituteInPlace src/cmd/acme/text.c \
-      --replace "case Kcmd+'c':" "case 0x03: case Kcmd+'c':" \
-      --replace "case Kcmd+'z':" "case 0x1a: case Kcmd+'z':" \
-      --replace "case Kcmd+'x':" "case 0x18: case Kcmd+'x':" \
-      --replace "case Kcmd+'v':" "case 0x16: case Kcmd+'v':"
   '';
 
   buildInputs = [ perl ] ++ (if !stdenv.isDarwin then [


### PR DESCRIPTION
## Description of changes

Three patches are undone:

### “hardcoded” font paths in acme

These are not hardcoded paths. A quick glance reveals that they are unlikely to exist on any contemporary system. In fact, they are *magic* paths, understood by [`openfont(3)`] (which is what receives these paths if you follow the function calls) to mean exactly what this patch replaces them with. 

### `_DEFAULT_SOURCE` substitution

This was introduced in 2015 with e852a8e. 9fans/plan9port@657f699 in 2016 added definitions of `_DEFAULT_SOURCE` where appropriate to make glibc happy. Additionally, the heavy-handed way this is currently done makes `patchPhase` sluggish, and inadvertently makes [one of the `fortune` entries] slightly less funny.

### “missing” clipboard shorcuts

Philosophically, these are not “missing” in any meaningful sense. Upstream adds them on Darwin and only Darwin for the same reason as Alt/Cmd-click – mouse chording on a one-button Apple trackpad is bothersome.

Practically, this breaks crucial workflow – when running nixpkgs p9p on X11, overriding `^C` means *it is no longer possible to issue interrupts to programs in `win` sessions within acme*. This was one of the reasons given when this short-lived behaviour was reverted upstream with 9fans/plan9port@113ea95.

[`openfont(3)`]: https://github.com/9fans/plan9port/blob/88a87fadae6629932d9c160f53ad5d79775f8f94/src/libdraw/openfont.c#L47-L48
[one of the `fortune` entries]: https://github.com/9fans/plan9port/blob/dc60de7b64948e89832f03181e6db799060036b8/lib/fortunes#L3683

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
