### PR TITLE
mni_autoreg: unstable-2017-09-22 -> unstable-2022-05-20

### DIFF
--- a/pkgs/applications/science/biology/mni_autoreg/default.nix
+++ b/pkgs/applications/science/biology/mni_autoreg/default.nix
@@ -1,25 +1,15 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, makeWrapper, perlPackages, libminc }:
+{ lib, stdenv, fetchFromGitHub, cmake, makeWrapper, perlPackages, libminc }:
 
 stdenv.mkDerivation rec {
   pname = "mni_autoreg";
-  version = "unstable-2017-09-22";
+  version = "unstable-2022-05-20";
 
   src = fetchFromGitHub {
     owner = "BIC-MNI";
     repo = pname;
-    rev = "ab99e29987dc029737785baebf24896ec37a2d76";
-    sha256 = "0axl069nv57vmb2wvqq7s9v3bfxwspzmk37bxm4973ai1irgppjq";
+    rev = "be7bd25bf7776974e0f2c1d90b6e7f8ccc0c8874";
+    sha256 = "sGMZbCrdV6yAOgGiqvBFOUr6pGlTCqwy8yNrPxMoKco=";
   };
-
-  patches = [
-    # Pull upstream workaround for -fno-common toolchains:
-    #  https://github.com/BIC-MNI/mni_autoreg/pull/28
-    (fetchpatch {
-      name = "fno-common.patch";
-      url = "https://github.com/BIC-MNI/mni_autoreg/commit/06adfacbd84369ea3bcc4376596ac1c0f2e49af9.patch";
-      sha256 = "004sdrbx9kcj1qqwjly6p03svakl0x2sbv83salyg63fv67jynx8";
-    })
-  ];
 
   nativeBuildInputs = [ cmake makeWrapper ];
   buildInputs = [ libminc ];

--- a/pkgs/development/libraries/libminc/default.nix
+++ b/pkgs/development/libraries/libminc/default.nix
@@ -2,15 +2,15 @@
 
 stdenv.mkDerivation rec {
   pname   = "libminc";
-  version = "unstable-2020-07-17";
+  version = "2.4.05";
 
   owner = "BIC-MNI";
 
   src = fetchFromGitHub {
     inherit owner;
     repo   = pname;
-    rev    = "ffb5fb234a852ea7e8da8bb2b3b49f67acbe56ca";
-    sha256 = "0yr4ksghpvxh9zg0a4p7hvln3qirsi08plvjp5kxx2qiyj96zsdm";
+    rev    = "aa08255f0856e70fb001c5f9ee1f4e5a8c12d47d";  # new release, but no git tag
+    sha256 = "XMTO6/HkyrrQ0s5DzJLCmmWheye2DGMnpDbcGdP6J+A=";
   };
 
   postPatch = ''
@@ -24,14 +24,14 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DLIBMINC_MINC1_SUPPORT=ON"
     "-DLIBMINC_BUILD_SHARED_LIBS=ON"
+    "-DLIBMINC_USE_NIFTI=ON"
     "-DLIBMINC_USE_SYSTEM_NIFTI=ON"
   ];
 
   doCheck = !stdenv.isDarwin;
-  checkPhase = ''
-    ctest -j1 -E 'ezminc_rw_test' --output-on-failure
     # -j1: see https://github.com/BIC-MNI/libminc/issues/110
-    # ezminc_rw_test: can't find libminc_io.so.5.2.0
+  checkPhase = ''
+    ctest -j1 --output-on-failure
   '';
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19440,9 +19440,7 @@ with pkgs;
 
   libmilter = callPackage ../development/libraries/libmilter { };
 
-  libminc = callPackage ../development/libraries/libminc {
-    hdf5 = hdf5_1_10;
-  };
+  libminc = callPackage ../development/libraries/libminc { };
 
   libmkv = callPackage ../development/libraries/libmkv { };
 


### PR DESCRIPTION
libminc: unstable-2020-07-17 -> 2.4.05

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [NA] (Package updates) Added a release notes entry if the change is major or breaking
  - [NA] (Module updates) Added a release notes entry if the change is significant
  - [NA] (Module addition) Added a release notes entry if adding a new NixOS module
  - [NA] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
