### PR TITLE
plymouth: unstable-2021-10-18 → 22.02.122

### DIFF
--- a/nixos/modules/system/boot/plymouth.nix
+++ b/nixos/modules/system/boot/plymouth.nix
@@ -31,11 +31,6 @@ let
     # See: https://gitlab.freedesktop.org/plymouth/plymouth/-/issues/95#note_813768
     mkdir -p $out/share/plymouth/themes/spinner
     ln -s $logo $out/share/plymouth/themes/spinner/watermark.png
-
-    # Logo for spinfinity theme
-    # See: https://gitlab.freedesktop.org/plymouth/plymouth/-/issues/106
-    mkdir -p $out/share/plymouth/themes/spinfinity
-    ln -s $logo $out/share/plymouth/themes/spinfinity/header-image.png
   '';
 
   themesEnv = pkgs.buildEnv {

--- a/pkgs/os-specific/linux/plymouth/default.nix
+++ b/pkgs/os-specific/linux/plymouth/default.nix
@@ -16,7 +16,7 @@
 
 stdenv.mkDerivation rec {
   pname = "plymouth";
-  version = "unstable-2021-10-18";
+  version = "22.02.122";
 
   outputs = [
     "out"
@@ -27,8 +27,8 @@ stdenv.mkDerivation rec {
     domain = "gitlab.freedesktop.org";
     owner = "plymouth";
     repo = "plymouth";
-    rev = "18363cd887dbfe7e82a2f4cc1a49ef9513919142";
-    sha256 = "sha256-+AP4ALOFdYFt/8MDXjMaHptkogCwK1iXKuza1zfMaws=";
+    rev = version;
+    sha256 = "sha256-0/2k1DtAnjnvF5LeHrbO6cHrFDyQ02AWUj1XgmOZ/wA=";
   };
 
   nativeBuildInputs = [
@@ -85,12 +85,6 @@ stdenv.mkDerivation rec {
     "plymouthd_defaultsdir=${placeholder "out"}/share/plymouth"
     "sysconfdir=${placeholder "out"}/etc"
   ];
-
-  postInstall = ''
-    # Makes a symlink to /usr/share/pixmaps/system-logo-white.png
-    # We'll handle it in the nixos module.
-    rm $out/share/plymouth/themes/spinfinity/header-image.png
-  '';
 
   meta = with lib; {
     homepage = "https://www.freedesktop.org/wiki/Software/Plymouth/";


### PR DESCRIPTION
###### Description of changes

https://gitlab.freedesktop.org/plymouth/plymouth/-/compare/18363cd887dbfe7e82a2f4cc1a49ef951391914...22.02.122

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
