### PR TITLE
python310Packages.etils: init at 0.6.0

### DIFF
--- a/pkgs/development/python-modules/etils/default.nix
+++ b/pkgs/development/python-modules/etils/default.nix
@@ -1,0 +1,89 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, flit-core
+
+  # tests
+, chex
+, jaxlib
+, pytest-subtests
+, pytest-xdist
+, pytestCheckHook
+, yapf
+
+  # optional
+, jupyter
+, mediapy
+, numpy
+, importlib-resources
+, typing-extensions
+, zipp
+, absl-py
+, tqdm
+, dm-tree
+, jax
+, tensorflow
+}:
+
+buildPythonPackage rec {
+  pname = "etils";
+  version = "0.6.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-ZnckEFGDXQ2xHElHvK2Tj1e1HqECKQYk+JLx5OUbcOU=";
+  };
+
+  nativeBuildInputs = [
+    flit-core
+  ];
+
+  passthru.optional-dependencies = rec {
+    array-types = enp;
+    ecolab = [ jupyter numpy mediapy ] ++ enp ++ epy;
+    edc = epy;
+    enp = [ numpy ] ++ epy;
+    epath = [ importlib-resources typing-extensions zipp ] ++ epy;
+    epy = [ typing-extensions ];
+    etqdm = [ absl-py tqdm ] ++ epy;
+    etree = array-types ++ epy ++ enp ++ etqdm;
+    etree-dm = [ dm-tree ] ++ etree;
+    etree-jax = [ jax ] ++ etree;
+    etree-tf = [ tensorflow etree ] ++ etree;
+    all = array-types ++ ecolab ++ edc ++ enp ++ epath ++ epy ++ etqdm
+      ++ etree ++ etree-dm ++ etree-jax ++ etree-tf;
+  };
+
+  doCheck = false; # disable tests until https://github.com/NixOS/nixpkgs/issues/185273 is resolved
+
+  pythonImportsCheck = [
+    "etils"
+  ];
+
+  checkInputs = [
+    chex
+    jaxlib
+    pytest-subtests
+    pytest-xdist
+    pytestCheckHook
+    yapf
+  ]
+  ++ passthru.optional-dependencies.all;
+
+  disabledTests = [
+    "test_repr" # known to fail on Python 3.10, see https://github.com/google/etils/issues/143
+    "test_public_access" # requires network access
+    "test_resource_path" # known to fail on Python 3.10, see https://github.com/google/etils/issues/143
+  ];
+
+  meta = with lib; {
+    description = "Collection of eclectic utils for python";
+    homepage = "https://github.com/google/etils";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ mcwitt ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2900,6 +2900,8 @@ in {
 
   eth-utils = callPackage ../development/python-modules/eth-utils { };
 
+  etils = callPackage ../development/python-modules/etils { };
+
   etuples = callPackage ../development/python-modules/etuples { };
 
   et_xmlfile = callPackage ../development/python-modules/et_xmlfile { };


### PR DESCRIPTION
###### Description of changes

Adds https://github.com/google/etils.

Initial motivation is that this is a dependency of [jax>=0.3.14](https://github.com/google/jax/commit/e0ff842c2a56c1e446b1d8bcd491f278e899f414). This is a dependency of https://github.com/NixOS/nixpkgs/pull/183051.

Note: the derivation was contributed by @mweinelt ([commit](https://github.com/mweinelt/nixpkgs/commit/c32c71ddd049532df2ca946dd5cb63b1cd54c235))

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
