### PR TITLE
tango-controls: init at 9.3.5

### DIFF
--- a/pkgs/applications/science/engineering/tango-controls/default.nix
+++ b/pkgs/applications/science/engineering/tango-controls/default.nix
@@ -1,0 +1,55 @@
+{ stdenv, fetchurl, pkg-config, python3, openjdk8, zlib, zeromq, cppzmq, mariadb-connector-c, lib }:
+let
+  omniorb_4_2 = stdenv.mkDerivation rec {
+    pname = "omniorb";
+    version = "4.2.5";
+
+    src = fetchurl {
+      url = "mirror://sourceforge/project/omniorb/omniORB/omniORB-${version}/omniORB-${version}.tar.bz2";
+      sha256 = "1fvkw3pn9i2312n4k3d4s7892m91jynl8g1v2z0j8k1gzfczjp7h";
+    };
+
+    nativeBuildInputs = [ pkg-config ];
+    buildInputs = [ python3 ];
+
+    enableParallelBuilding = true;
+    hardeningDisable = [ "format" ];
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "tango";
+  version = "9.3.5";
+
+  src = fetchurl {
+    url = "https://gitlab.com/api/v4/projects/24125890/packages/generic/TangoSourceDistribution/${version}/${pname}-${version}.tar.gz";
+    sha256 = "1i59023gqm6sk000520y4kamfnfa8xqy9xwsnz5ch22nflgqn9px";
+  };
+
+  enableParallelBuilding = true;
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ zlib omniorb_4_2 zeromq cppzmq ];
+
+  configureFlags = [
+    "--enable-java=yes"
+    "--enable-dbserver=yes"
+    "--with-java=${openjdk8}/bin/java"
+    "--with-mysqlclient-lib=${mariadb-connector-c}/lib/mariadb/"
+    "--with-mysqlclient-include=${mariadb-connector-c.dev}/include/mariadb"
+  ];
+
+  postInstall = ''
+    mkdir -p $out/share/sql
+    for fn in cppserver/database/*sql; do
+      sed -e "s#^source #source $out/share/sql/#" "$fn" > $out/share/sql/$(basename "$fn")
+    done
+  '';
+
+  meta = with lib; {
+    description = "A free open source device-oriented controls toolkit for controlling any kind of hardware or software and building SCADA systems.";
+    homepage = "https://www.tango-controls.org/";
+    mainProgram = "tango";
+    license = with licenses; [ gpl3Only lgpl3Only ];
+    maintainers = [ maintainers.pmiddend ];
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
+  };
+}

--- a/pkgs/applications/science/engineering/tango-controls/default.nix
+++ b/pkgs/applications/science/engineering/tango-controls/default.nix
@@ -50,6 +50,6 @@ stdenv.mkDerivation rec {
     mainProgram = "tango";
     license = with licenses; [ gpl3Only lgpl3Only ];
     maintainers = [ maintainers.pmiddend ];
-    platforms = [ "x86_64-linux" "aarch64-linux" ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5753,6 +5753,8 @@ with pkgs;
 
   schleuder-cli = callPackage ../tools/security/schleuder/cli { };
 
+  tango-controls = callPackage ../applications/science/engineering/tango-controls { };
+
   tealdeer = callPackage ../tools/misc/tealdeer {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Description of changes

At DESY and other facilities, we use the Tango controls software (see the [home page](https://www.tango-controls.org/)) and also dabble a bit with Nix. I wrote this derivation and successfully tested it on its own (by creating a MariaDB for the configuration and then running `result/bin/tango start`), as well as including it in the build for pytango in poetry2nix.

The controls system contains a few components:

1. The main server is written in C++. The main `tango` executable is just a script which starts the `DataBaseds` server.
2. Astor and Jive are Java-based tools to configure and inspect the running instance. I have tested that these indeed work. If you're wondering about the usage of `openjdk8`, that, unfortunately, is deliberate. Due to their usage of CORBA, they are stuck with Java 8 (exactly 8) for now.
3. To initialize the database (which can be MySQL or MariaDB, in theory - in practise, only MariaDB worked for me) there are `.sql` scripts. Those reference each other using the `source foobar.sql` directive, and I decided to use some `sed` calls to make these references absolute. Hope that's idiomatic enough.

To test this for real, you would need to follow these simple steps:

1. Start a MariaDB, create the `tango` database using the scripts in `result/share/sql/create_db.sql`
2. Build tango-controls and execute:
```
MYSQL_USER=youruser MYSQL_PASSWORD=yourpassword result/bin/tango start
```
3. Test the connection by running `result/bin/jive`.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).