### PR TITLE
coqPackages_8_13.smtcoq: build cvc4 with gcc10

### DIFF
--- a/pkgs/development/coq-modules/smtcoq/cvc4.nix
+++ b/pkgs/development/coq-modules/smtcoq/cvc4.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, cln, fetchurl, gmp, swig, pkg-config
-, readline, libantlr3c, boost, jdk8, autoreconfHook
-, python3, antlr3_4
+, libantlr3c, boost, autoreconfHook
+, python3
 }:
 
 stdenv.mkDerivation rec {
@@ -13,13 +13,12 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
-  buildInputs = [ gmp readline swig libantlr3c antlr3_4 boost jdk8 python3 ]
+  buildInputs = [ gmp swig libantlr3c boost python3 ]
     ++ lib.optionals stdenv.isLinux [ cln ];
 
   configureFlags = [
-    "--enable-language-bindings=c,c++,java"
+    "--enable-language-bindings=c"
     "--enable-gpl"
-    "--with-readline"
     "--with-boost=${boost.dev}"
   ] ++ lib.optionals stdenv.isLinux [ "--with-cln" ];
 

--- a/pkgs/development/coq-modules/smtcoq/default.nix
+++ b/pkgs/development/coq-modules/smtcoq/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, pkgs, mkCoqDerivation, coq, trakt, veriT, zchaff, fetchurl, version ? null }:
+{ lib, stdenv, gcc10StdenvCompat, pkgs, mkCoqDerivation, coq, trakt, veriT, zchaff, fetchurl, version ? null }:
 with lib;
 
 let
@@ -10,7 +10,9 @@ let
     };
     meta.broken = false;
   });
-  cvc4 = pkgs.callPackage ./cvc4.nix {};
+  cvc4 = pkgs.callPackage ./cvc4.nix {
+    stdenv = gcc10StdenvCompat;
+  };
 in
 
 mkCoqDerivation {


### PR DESCRIPTION
###### Description of changes

See: https://github.com/NixOS/nixpkgs/pull/176321#issuecomment-1188836325

cc @siraben @proux01.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
