### PR TITLE
python310Packages.dparse, python310Packages.dparse2: Enable more tests

### DIFF
--- a/pkgs/development/python-modules/dparse/default.nix
+++ b/pkgs/development/python-modules/dparse/default.nix
@@ -6,6 +6,7 @@
 , pyyaml
 , packaging
 , pytestCheckHook
+, pipenv
 }:
 
 buildPythonPackage rec {
@@ -25,13 +26,11 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
+    pipenv
     pytestCheckHook
   ];
 
-  disabledTests = [
-    # requires unpackaged dependency pipenv
-    "test_update_pipfile"
-  ];
+  pythonImportsCheck = [ "dparse" ];
 
   meta = with lib; {
     description = "A parser for Python dependency files";

--- a/pkgs/development/python-modules/dparse2/default.nix
+++ b/pkgs/development/python-modules/dparse2/default.nix
@@ -32,11 +32,6 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  disabledTestPaths = [
-    # Requries pipenv
-    "tests/test_parse.py"
-  ];
-
   pythonImportsCheck = [
     "dparse2"
   ];

--- a/pkgs/development/python-modules/pipenv/default.nix
+++ b/pkgs/development/python-modules/pipenv/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, virtualenv-clone
+, certifi
+, pytestCheckHook
+, requests
+, pytest-pypi
+}:
+
+buildPythonPackage rec {
+  pname = "pipenv";
+  version = "2022.7.24";
+
+  src = fetchFromGitHub {
+    owner = "pypa";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-vxJ6AcBGM2+s97h8fbYHuQ4EesdZdDcrKgGljIuUG2A=";
+  };
+
+  propagatedBuildInputs = [
+    certifi
+    virtualenv-clone
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-pypi
+    requests
+  ];
+
+  pythonImportsCheck = [ "pipenv" ];
+
+  meta = with lib; {
+    description = "Python Development Workflow for Humans";
+    homepage = "https://github.com/pypa/pipenv";
+    license = licenses.mit;
+    maintainers = with maintainers; [ onny ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-pypi/default.nix
+++ b/pkgs/development/python-modules/pytest-pypi/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, six
+, flask
+, pytest
+, importlib-metadata
+, distlib
+, pytestCheckHook
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-pypi";
+  version = "2022.7.24";
+
+  src = fetchFromGitHub {
+    owner = "pypa";
+    repo = "pipenv";
+    rev = "v${version}";
+    sha256 = "sha256-vxJ6AcBGM2+s97h8fbYHuQ4EesdZdDcrKgGljIuUG2A=";
+  };
+
+  sourceRoot = "source/tests/pytest-pypi";
+
+  propagatedBuildInputs = [
+    flask
+    pytest
+    importlib-metadata
+    six
+  ];
+
+  checkInputs = [
+    distlib
+    requests
+  ];
+
+  # Doesn't include any tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "pytest_pypi" ];
+
+  meta = with lib; {
+    description = "Easily test your HTTP library against a local copy of pypi";
+    homepage = "https://github.com/pypa/pipenv/tests/pytest-pypi";
+    license = licenses.mit;
+    maintainers = with maintainers; [ onny ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8431,6 +8431,8 @@ in {
 
   pytest-pylint = callPackage ../development/python-modules/pytest-pylint { };
 
+  pytest-pypi = callPackage ../development/python-modules/pytest-pypi { };
+
   pytest-qt = callPackage ../development/python-modules/pytest-qt { };
 
   pytest-quickcheck = callPackage ../development/python-modules/pytest-quickcheck { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6588,6 +6588,8 @@ in {
 
   pipdeptree = callPackage ../development/python-modules/pipdeptree { };
 
+  pipenv = callPackage ../development/python-modules/pipenv { };
+
   pipenv-poetry-migrate = callPackage ../development/python-modules/pipenv-poetry-migrate { };
 
   pip-api = callPackage ../development/python-modules/pip-api { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
