### PR TITLE
python310Packages.doit: 0.35.0 -> 0.36.0

### DIFF
--- a/pkgs/development/python-modules/configclass/default.nix
+++ b/pkgs/development/python-modules/configclass/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, mergedict
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "configclass";
+  version = "0.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-aoDKBuDxJCeXbVwCXhse6FCbDDM30/Xa8p9qRvDkWBk=";
+  };
+
+  propagatedBuildInputs = [ mergedict ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "configclass" ];
+
+  meta = with lib; {
+    description = "A Python to class to hold configuration values";
+    homepage = "https://github.com/schettino72/configclass/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ onny ];
+  };
+}

--- a/pkgs/development/python-modules/doit-py/default.nix
+++ b/pkgs/development/python-modules/doit-py/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, doit
+, configclass
+, mergedict
+, pytestCheckHook
+, hunspell
+, hunspellDicts
+}:
+
+buildPythonPackage rec {
+  pname = "doit-py";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "pydoit";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-DBl6/no04ZGRHHmN9gkEtBmAMgmyZWcfPCcFz0uxAv4=";
+  };
+
+  propagatedBuildInputs = [
+    configclass
+    doit
+    mergedict
+  ];
+
+  checkInputs = [
+    hunspell
+    hunspellDicts.en_US
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # Disable linting checks
+    "tests/test_pyflakes.py"
+  ];
+
+  pythonImportsCheck = [ "doitpy" ];
+
+  meta = with lib; {
+    description = "doit tasks for python stuff";
+    homepage = "http://pythonhosted.org/doit-py";
+    license = licenses.mit;
+    maintainers = with maintainers; [ onny ];
+  };
+}

--- a/pkgs/development/python-modules/mergedict/default.nix
+++ b/pkgs/development/python-modules/mergedict/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "mergedict";
+  version = "1.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-4ZkrNqVCKQFPvLx6nIwo0fSuEx6h2NNFyTlz+fDcb9w=";
+  };
+
+  checkInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "mergedict" ];
+
+  meta = with lib; {
+    description = "A Python dict with a merge() method";
+    homepage = "https://github.com/schettino72/mergedict";
+    license = licenses.mit;
+    maintainers = with maintainers; [ onny ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1914,6 +1914,8 @@ in {
 
   configargparse = callPackage ../development/python-modules/configargparse { };
 
+  configclass = callPackage ../development/python-modules/configclass { };
+
   configobj = callPackage ../development/python-modules/configobj { };
 
   configparser = callPackage ../development/python-modules/configparser { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5424,6 +5424,8 @@ in {
 
   mergedeep = callPackage ../development/python-modules/mergedeep { };
 
+  mergedict = callPackage ../development/python-modules/mergedict { };
+
   merkletools = callPackage ../development/python-modules/merkletools { };
 
   meross-iot = callPackage ../development/python-modules/meross-iot { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2615,6 +2615,8 @@ in {
 
   doit = callPackage ../development/python-modules/doit { };
 
+  doit-py = callPackage ../development/python-modules/doit-py { };
+
   dominate = callPackage ../development/python-modules/dominate { };
 
   doorbirdpy = callPackage ../development/python-modules/doorbirdpy { };


### PR DESCRIPTION
###### Description of changes

Enabled more tests by adding missing check dependencies. To avoid infinite recursion between doit and doit-py I had to put tests to external file.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
