### PR TITLE
cmctl: 1.8.2 -> 1.9.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6339,6 +6339,12 @@
     github = "JoshuaFern";
     githubId = 4300747;
   };
+  joshvanl = {
+    email = " me@joshvanl.dev ";
+    github = "joshvanl";
+    githubId = 15893072;
+    name = "Josh van Leeuwen";
+  };
   jpas = {
     name = "Jarrod Pas";
     email = "jarrod@jarrodpas.com";

--- a/pkgs/applications/networking/cluster/cmctl/default.nix
+++ b/pkgs/applications/networking/cluster/cmctl/default.nix
@@ -2,20 +2,24 @@
 
 buildGoModule rec {
   pname = "cmctl";
-  version = "1.8.2";
+  version = "1.9.1";
 
   src = fetchFromGitHub {
     owner = "cert-manager";
     repo = "cert-manager";
     rev = "v${version}";
-    sha256 = "sha256-sfC1acnCrcQ4A1tXXcjh47Af6xeJqjdGXy0gK21ZSFg=";
+    hash = "sha256-Z1aJ18X4mfJPlCPBC7QgfdX5Tk4+PK8mYoJZhGwz9ec=";
   };
 
-  vendorSha256 = "sha256-UYw9WdQ6VwzuuiOsa1yovkLZG7NmLYSW51p8UhmQMeI=";
+  vendorSha256 = "sha256-45+tZZAEHaLdTN1NQCueJVTx5x2IanwDl+Y9MELqdBE=";
 
   subPackages = [ "cmd/ctl" ];
 
-  ldflags = [ "-s" "-w" ];
+  ldflags = [
+    "-s" "-w"
+    "-X github.com/cert-manager/cert-manager/cmd/ctl/pkg/build.name=cmctl"
+    "-X github.com/cert-manager/cert-manager/cmd/ctl/pkg/build/commands.registerCompletion=true"
+  ];
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -28,11 +32,21 @@ buildGoModule rec {
   '';
 
   meta = with lib; {
-    description = "A CLI tool for managing Cert-Manager service on Kubernetes clusters";
+    description = "A CLI tool for managing cert-manager service on Kubernetes clusters";
+    longDescription = ''
+      cert-manager adds certificates and certificate issuers as resource types
+      in Kubernetes clusters, and simplifies the process of obtaining, renewing
+      and using those certificates.
+
+      It can issue certificates from a variety of supported sources, including
+      Let's Encrypt, HashiCorp Vault, and Venafi as well as private PKI, and it
+      ensures certificates remain valid and up to date, attempting to renew
+      certificates at an appropriate time before expiry.
+    '';
     downloadPage = "https://github.com/cert-manager/cert-manager";
     license = licenses.asl20;
     homepage = "https://cert-manager.io/";
-    maintainers = with maintainers; [ superherointj ];
+    maintainers = with maintainers; [ joshvanl superherointj ];
   };
 }
 


### PR DESCRIPTION
###### Description of changes

https://cert-manager.io

Updates cmctl to version `v1.9.1`.


Adds `joshvanl` as a maintainer, and adds `joshvanl` as a maintainer for `cmctl`.

To inspect upstream changes

- [Release on GitHub](https://github.com/cert-manager/cert-manager/releases/tag/v1.9.1)
-  [Compare changes on GitHub](https://github.com/cert-manager/cert-manager/compare/v1.8.0...v1.9.1)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
~- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))~
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
