### PR TITLE
genext2fs: 1.4.1 > 1.5.0

### DIFF
--- a/pkgs/tools/filesystems/genext2fs/default.nix
+++ b/pkgs/tools/filesystems/genext2fs/default.nix
@@ -1,22 +1,32 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, libarchive }:
 
 stdenv.mkDerivation rec {
   pname = "genext2fs";
-  version = "1.4.1";
+  version = "1.5.0";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/genext2fs/genext2fs-${version}.tar.gz";
-    sha256 = "1z7czvsf3ircvz2cw1cf53yifsq29ljxmj15hbgc79l6gbxbnka0";
+  src = fetchFromGitHub {
+    owner = "bestouff";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-9LAU5XuCwwEhU985MzZ2X+YYibvyECULQSn9X2jdj5I=";
   };
 
-  # https://sourceforge.net/p/genext2fs/bugs/2/
-  # Will be fixed in the next release, whenever this happens
-  postPatch = ''
-    sed -e 's@4 [*] (EXT2_TIND_BLOCK+1)@-1+&@' -i genext2fs.c
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [
+    libarchive
+  ];
+
+  configureFlags = [
+    "--enable-libarchive"
+  ];
+
+  doCheck = true;
+  checkPhase = ''
+    ./test.sh
   '';
 
   meta = with lib; {
-    homepage = "http://genext2fs.sourceforge.net/";
+    homepage = "https://github.com/bestouff/genext2fs";
     description = "A tool to generate ext2 filesystem images without requiring root privileges";
     license = licenses.gpl2;
     platforms = platforms.all;


### PR DESCRIPTION
###### Description of changes

A new version was released a while ago.

This also enables libarchive support and runs the tests.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).