### PR TITLE
Remove myself as a maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6387,13 +6387,6 @@
     githubId = 3267697;
     name = "Joshua Potter";
   };
-  jschievink = {
-    email = "jonasschievink@gmail.com";
-    matrix = "@jschievink:matrix.org";
-    github = "jonas-schievink";
-    githubId = 1786438;
-    name = "Jonas Schievink";
-  };
   jshcmpbll = {
     email = "me@joshuadcampbell.com";
     github = "jshcmpbll";

--- a/pkgs/development/libraries/pc-ble-driver/default.nix
+++ b/pkgs/development/libraries/pc-ble-driver/default.nix
@@ -35,6 +35,5 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/NordicSemiconductor/pc-ble-driver";
     license = licenses.unfreeRedistributable;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ jschievink ];
   };
 }


### PR DESCRIPTION
I no longer use NixOS, and don't have the time or energy to maintain anything here at the moment.

The only package I was the maintainer of is `pc-ble-driver`, which is a dependency of `nrfutil` (and only `nrfutil`). @gebner, since you're the maintainer of `nrfutil`, would you like to take over maintenance of `pc-ble-driver`?