### PR TITLE
fira-go: init at 1.001

### DIFF
--- a/pkgs/data/fonts/fira-go/default.nix
+++ b/pkgs/data/fonts/fira-go/default.nix
@@ -1,0 +1,34 @@
+{ lib, fetchzip }:
+
+let
+  pname = "fira-go";
+  version = "1.001";
+  user = "bBoxType";
+  repo = "FiraGo";
+  rev = "9882ba0851f88ab904dc237f250db1d45641f45d";
+in
+fetchzip {
+  name = "${pname}-${version}";
+
+  url = "https://github.com/${user}/${repo}/archive/${rev}.zip";
+
+  postFetch = ''
+    mkdir -p $out/share/fonts/opentype
+    mv $out/Fonts/FiraGO_OTF_1001/{Roman,Italic}/*.otf \
+      $out/share/fonts/opentype
+    rm -r $out/{Fonts,'Technical Report PDF',OFL.txt,README.md,*.pdf}
+  '';
+
+  sha256 = "sha256-MDGRba1eao/yVzSuncJ/nvCG8cpdrI4roVPI1G9qCbU=";
+
+  meta = with lib; {
+    homepage = "https://bboxtype.com/typefaces/FiraGO";
+    description = ''
+      Font with the same glyph set as Fira Sans 4.3 and additionally
+      supports Arabic, Devenagari, Georgian, Hebrew and Thai
+    '';
+    license = licenses.ofl;
+    maintainers = [ maintainers.loicreynier ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24894,6 +24894,8 @@ with pkgs;
   fira-code = callPackage ../data/fonts/fira-code { };
   fira-code-symbols = callPackage ../data/fonts/fira-code/symbols.nix { };
 
+  fira-go = callPackage ../data/fonts/fira-go { };
+
   fira-mono = callPackage ../data/fonts/fira-mono { };
 
   flat-remix-icon-theme = callPackage ../data/icons/flat-remix-icon-theme {


### PR DESCRIPTION
###### Description of changes

Add [FiraGo](https://bboxtype.com/typefaces/FiraGO/), an extension to the Fira Sans font.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
