### PR TITLE
haskellPackages: update stackage and hackage

### DIFF
--- a/pkgs/data/misc/hackage/pin.json
+++ b/pkgs/data/misc/hackage/pin.json
@@ -1,6 +1,6 @@
 {
-  "commit": "c58387b71e19d6dd43bbade8f84d6a44b6418e24",
-  "url": "https://github.com/commercialhaskell/all-cabal-hashes/archive/c58387b71e19d6dd43bbade8f84d6a44b6418e24.tar.gz",
-  "sha256": "0xdvqn4392l65ns4wm47c8nyp1s7al4i506927dmkzz85m3hvyn0",
-  "msg": "Update from Hackage at 2022-07-26T16:57:53Z"
+  "commit": "84a258f1f060f5f31f44b2d966b6e96305932eb2",
+  "url": "https://github.com/commercialhaskell/all-cabal-hashes/archive/84a258f1f060f5f31f44b2d966b6e96305932eb2.tar.gz",
+  "sha256": "0nyiyxxqa5h46p50jmvrx6sphxy0j8ib2vy3jvfijdpc4d6d5gx6",
+  "msg": "Update from Hackage at 2022-07-27T11:03:11Z"
 }


### PR DESCRIPTION
### This Merge

This PR is the regular merge of the `haskell-updates` branch into `master`.

This branch is being continually built and tested by hydra at https://hydra.nixos.org/jobset/nixpkgs/haskell-updates. You may be able to find an up-to-date Hydra build report at [cdepillabout/nix-haskell-updates-status](https://github.com/cdepillabout/nix-haskell-updates-status).

We roughly aim to merge these `haskell-updates` PRs at least once every two weeks. See the @NixOS/haskell [team calendar](https://cloud.maralorn.de/apps/calendar/p/H6migHmKX7xHoTFa) for who is currently in charge of this branch.

### haskellPackages Workflow Summary

Our workflow is currently described in [`pkgs/development/haskell-modules/HACKING.md`](https://github.com/NixOS/nixpkgs/blob/haskell-updates/pkgs/development/haskell-modules/HACKING.md).

The short version is this:
* We regularly update the Stackage and Hackage pins on `haskell-updates` (normally at the beginning of a merge window).
* The community fixes builds of Haskell packages on that branch.
* We aim at at least one merge of `haskell-updates` into `master` every two weeks.
* We only do the merge if the [`mergeable`](https://hydra.nixos.org/job/nixpkgs/haskell-updates/mergeable) job is succeeding on hydra.
* If a [`maintained`](https://hydra.nixos.org/job/nixpkgs/haskell-updates/maintained) package is still broken at the time of merge, we will only merge if the maintainer has been pinged 7 days in advance. (If you care about a Haskell package, become a maintainer!)

---

This is the follow-up to #183007. Come to [#haskell:nixos.org](https://matrix.to/#/#haskell:nixos.org) if you have any questions.

cc @domenkozar