### PR TITLE
acme-client: add LibreSSL 3.5 compatibility patch

### DIFF
--- a/pkgs/tools/networking/acme-client/default.nix
+++ b/pkgs/tools/networking/acme-client/default.nix
@@ -15,6 +15,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-rIeWZSOT+nPzLf2mDtOkN/wmCGffG4H6PCQb2Vxbxxk=";
   };
 
+  patches = [
+    ./libressl-3.5-compat.patch
+  ];
+
   nativeBuildInputs = [
     pkg-config
   ];

--- a/pkgs/tools/networking/acme-client/libressl-3.5-compat.patch
+++ b/pkgs/tools/networking/acme-client/libressl-3.5-compat.patch
@@ -1,0 +1,59 @@
+From bdeaad4625a4821c18615b0e34530d3fdb2dff4d Mon Sep 17 00:00:00 2001
+From: Ruud van Asseldonk <dev@veniogames.com>
+Date: Sat, 23 Jul 2022 11:58:41 +0200
+Subject: [PATCH] Fix compatibility with LibreSSL 3.5
+
+LibreSSL 3.5 supports the same interface as OpenSSL. This breaks
+compatibility with LibreSSL 3.4, which does not support this interface,
+but if you are using a recent acme-client, you should probably also be
+using a recent LibreSSL.
+---
+ usr.sbin/acme-client/acctproc.c | 16 ++++------------
+ 1 file changed, 4 insertions(+), 12 deletions(-)
+
+diff --git a/usr.sbin/acme-client/acctproc.c b/usr.sbin/acme-client/acctproc.c
+index d1384fb..8b4c057 100644
+--- a/usr.sbin/acme-client/acctproc.c
++++ b/usr.sbin/acme-client/acctproc.c
+@@ -28,14 +28,6 @@
+ #include <openssl/rand.h>
+ #include <openssl/err.h>
+ 
+-#ifdef LIBRESSL_VERSION_NUMBER
+-# define COMPAT_OPENSSL_get0_n(r) (r->n)
+-# define COMPAT_OPENSSL_get0_e(r) (r->e)
+-#else
+-# define COMPAT_OPENSSL_get0_n(r) (RSA_get0_n(r))
+-# define COMPAT_OPENSSL_get0_e(r) (RSA_get0_e(r))
+-#endif
+-
+ #if OPENSSL_VERSION_MAJOR >= 3
+ # include <openssl/core_names.h>
+ #endif
+@@ -102,9 +94,9 @@ op_thumb_rsa(EVP_PKEY *pkey)
+ 
+ 	if ((r = EVP_PKEY_get0_RSA(pkey)) == NULL)
+ 		warnx("EVP_PKEY_get0_RSA");
+-	else if ((n = COMPAT_OPENSSL_get0_n(r)) == NULL)
++	else if ((n = RSA_get0_n(r)) == NULL)
+ 		warnx("bn2string");
+-	else if ((e = COMPAT_OPENSSL_get0_e(r)) == NULL)
++	else if ((e = RSA_get0_e(r)) == NULL)
+ 		warnx("bn2string");
+ #endif
+ 	else if ((mod = bn2string(n)) == NULL)
+@@ -259,9 +251,9 @@ op_sign_rsa(char **prot, EVP_PKEY *pkey, const char *nonce, const char *url)
+ #else
+ 	if ((r = EVP_PKEY_get0_RSA(pkey)) == NULL)
+ 		warnx("EVP_PKEY_get0_RSA");
+-	else if ((n = COMPAT_OPENSSL_get0_n(r)) == NULL)
++	else if ((n = RSA_get0_n(r)) == NULL)
+ 		warnx("bn2string");
+-	else if ((e = COMPAT_OPENSSL_get0_e(r)) == NULL)
++	else if ((e = RSA_get0_e(r)) == NULL)
+ 		warnx("bn2string");
+ #endif
+ 	else if ((mod = bn2string(n)) == NULL)
+-- 
+2.37.1
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1079,7 +1079,6 @@ with pkgs;
 
   acme-client = callPackage ../tools/networking/acme-client {
     stdenv = gccStdenv;
-    libressl = libressl_3_4;
   };
 
   adrgen = callPackage ../tools/misc/adrgen { };


### PR DESCRIPTION
###### Description of changes

LibreSSL and OpenSSL used to have a slight incompatibility up to LibreSSL 3.4. To be compatible with both, acme-client used to have a macro that expanded differently for LibreSSL and OpenSSL. But in LibreSSL 3.5, LibreSSL adopted OpenSSL's interface. The compatibility macro now actually breaks the build when building against LibreSSL 3.5.

For now it's not a problem that acme-client is incompatible with LibreSSL 3.5, but 3.4 will stop being supported in October (1 year after the OpenBSD 7.0 release on 2021-10-14), so make sure that we can use the latest LibreSSL versions.

[I also submitted this patch upstream](https://lists.sr.ht/~graywolf/public-inbox/%3C78e2881e-05ea-ebe2-6d40-5504041c5c4d%40veniogames.com%3E).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
