### PR TITLE
hylafaxplus: 7.0.5 -> 7.0.6

### DIFF
--- a/pkgs/servers/hylafaxplus/default.nix
+++ b/pkgs/servers/hylafaxplus/default.nix
@@ -13,6 +13,7 @@
 , gnugrep
 , gnused
 , libtiff
+, openssl
 , psmisc
 , sharutils
 , util-linux
@@ -30,8 +31,8 @@
 let
 
   pname = "hylafaxplus";
-  version = "7.0.5";
-  sha256 = "1blv251r0yhnhxk9wgkjgr35al50q23hiskjkcbs8lmqqrz0cm8f";
+  version = "7.0.6";
+  hash = "sha512-0faeEwF/XQE/85zwUMOnrGzvGanuWRDr53SnrgbX0i/SHjHelzSEd2TK6plVOfV4w8RY7Ox7lSO1gjqEEzfZyw==";
 
   configSite = substituteAll {
     name = "${pname}-config.site";
@@ -65,7 +66,7 @@ stdenv.mkDerivation {
   inherit pname version;
   src = fetchurl {
     url = "mirror://sourceforge/hylafax/hylafax-${version}.tar.gz";
-    inherit sha256;
+    inherit hash;
   };
   patches = [
     # adjust configure check to work with libtiff > 4.1
@@ -78,6 +79,7 @@ stdenv.mkDerivation {
     file  # for `file` command
     ghostscript
     libtiff
+    openssl
     psmisc  # for `fuser` command
     sharutils  # for `uuencode` command
     util-linux  # for `agetty` command

--- a/pkgs/servers/hylafaxplus/libtiff-4.patch
+++ b/pkgs/servers/hylafaxplus/libtiff-4.patch
@@ -5,7 +5,7 @@ https://bugs.gentoo.org/706154
  				echo '#define TIFFSTRIPBYTECOUNTS uint32_t'
  				echo '#define TIFFVERSION TIFF_VERSION'
  				echo '#define TIFFHEADER TIFFHeader';;
--		4.[0123])	tiff_runlen_t="uint32_t"
+-		4.[01234])	tiff_runlen_t="uint32_t"
 +		4.[0-9])	tiff_runlen_t="uint32_t"
  				tiff_offset_t="uint64_t"
  				echo '#define TIFFSTRIPBYTECOUNTS uint64_t'


### PR DESCRIPTION
###### Description of changes

Update `hylafaxplus` to latest version, released yesterday.

The package now needs `openssl` to build.  Maybe another ssl library would also work -- I didn't try.

Release notes: https://hylafax.sourceforge.io/news/7.0.6.php


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

More:

- [x] Tested sending/receiving with a virtual modem (iaxmodem), with corner cases like busy/unresponsive/bad line: all successful
- [x] Tested basic sending/receiving with a real modem and real landline: successful

###### Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>1 package built:</summary>
  <ul>
    <li>hylafaxplus</li>
  </ul>
</details>
