### PR TITLE
breath-theme: init at unstable-2022-12-22

### DIFF
--- a/pkgs/data/themes/breath-theme/default.nix
+++ b/pkgs/data/themes/breath-theme/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, cmake
+, extra-cmake-modules
+, kdecoration
+, plasma-workspace
+, qtbase
+}:
+
+stdenv.mkDerivation {
+  pname = "breath-theme";
+  version = "unstable-2022-12-22";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.manjaro.org";
+    owner = "themes";
+    group = "artwork";
+    repo = "breath";
+    rev = "98822e7d903f16116bfb02ff9921824c139d7bbc";
+    sha256 = "sha256-gvzhHOuOhxV3TC3UZeVpxeSDLpCJV+SaapcJ5mbHskY=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+
+    kdecoration
+    plasma-workspace
+    qtbase
+  ];
+
+  dontWrapQtApps = true;
+
+  cmakeFlags = [ "-DBUILD_PLASMA_THEMES=ON" "-DBUILD_SDDM_THEME=ON" ];
+
+  meta = with lib; {
+    description = "Manjaro KDE default theme";
+    homepage = "https://gitlab.manjaro.org/artwork/themes/breath";
+    license = licenses.cc-by-sa-40;
+    maintainers = with maintainers; [ huantian ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26895,6 +26895,8 @@ with pkgs;
 
   blackout = callPackage ../data/fonts/blackout { };
 
+  breath-theme = libsForQt5.callPackage ../data/themes/breath-theme { };
+
   brise = callPackage ../data/misc/brise { };
 
   cacert = callPackage ../data/misc/cacert { };


### PR DESCRIPTION
###### Description of changes
[Breath](https://gitlab.manjaro.org/artwork/themes/breath) is the default KDE theme for Manjaro.

Tested working on KDE Plasma 5.25.3 (Shows up in themes and correctly changes window theming when selected)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
