### PR TITLE
somebar: init at 1.0.0

### DIFF
--- a/pkgs/applications/misc/somebar/default.nix
+++ b/pkgs/applications/misc/somebar/default.nix
@@ -26,8 +26,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-snCW7dC8JI/pg1+HLjX0JXsTzwa3akA6rLcSNgKLF0c=";
   };
 
-  buildInputs = [ pango wayland wayland-protocols ];
   nativeBuildInputs = [ meson ninja pkg-config ];
+  buildInputs = [ pango wayland wayland-protocols ];
 
   prePatch = ''
     cp ${configFile} src/config.hpp

--- a/pkgs/applications/misc/somebar/default.nix
+++ b/pkgs/applications/misc/somebar/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, stdenv
+, fetchFromSourcehut
+, meson
+, ninja
+, pkg-config
+, wayland
+, pango
+, wayland-protocols
+, conf ? null
+}:
+
+let
+  # There is a configuration in src/config.def.hpp, which we use by default
+  configFile = if lib.isDerivation conf || builtins.isPath conf then conf else "src/config.def.hpp";
+in
+
+stdenv.mkDerivation rec {
+  pname = "somebar";
+  version = "1.0.0";
+
+  src = fetchFromSourcehut {
+    owner = "~raphi";
+    repo = "somebar";
+    rev = "${version}";
+    sha256 = "sha256-snCW7dC8JI/pg1+HLjX0JXsTzwa3akA6rLcSNgKLF0c=";
+  };
+
+  buildInputs = [ pango wayland wayland-protocols ];
+  nativeBuildInputs = [ meson ninja pkg-config ];
+
+  prePatch = ''
+    cp ${configFile} src/config.hpp
+  '';
+
+  meta = with lib; {
+    homepage = "https://git.sr.ht/~raphi/somebar";
+    description = "dwm-like bar for dwl";
+    license = licenses.mit;
+    maintainers = with maintainers; [ magnouvean ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10852,6 +10852,8 @@ with pkgs;
 
   sourceHighlight = callPackage ../tools/text/source-highlight { };
 
+  somebar = callPackage ../applications/misc/somebar { };
+
   spacebar = callPackage ../os-specific/darwin/spacebar {
     inherit (darwin.apple_sdk.frameworks)
       Carbon Cocoa ScriptingBridge SkyLight;


### PR DESCRIPTION
###### Description of changes
Somebar is a status bar, basically equivalent to dwmbar, but for dwl instead (dwmbar for wayland in other words). Dwl is already packaged so I thought it would be nice to have this packaged as well. As of now 1.0.0 is the only release avaliable.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
