### PR TITLE
nix-prefetch-git: fix sparse checkout

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -116,7 +116,7 @@ init_remote(){
     clean_git remote add origin "$url"
     if [ -n "$sparseCheckout" ]; then
         git config remote.origin.partialclonefilter "blob:none"
-        echo "$sparseCheckout" | git sparse-checkout set --stdin
+        echo "$sparseCheckout" | git sparse-checkout set --stdin --no-cone
     fi
     ( [ -n "$http_proxy" ] && clean_git config http.proxy "$http_proxy" ) || true
 }


### PR DESCRIPTION
###### Description of changes

Git v2.37.0 enabled *cone mode* by default for sparse checkouts.

Per the `git-sparse-checkout` [manual page](https://www.git-scm.com/docs/git-sparse-checkout/2.37.0):
> By default, the input list is considered a list of directories, matching the output of `git ls-tree -d --name-only`. This includes interpreting pathnames that begin with a double quote (") as C-style quoted strings. Note that all files under the specified directories (at any depth) will be included in the sparse checkout, as well as files that are siblings of either the given directory or any of its ancestors... In the past, this was not the default, and `--cone` needed to be specified or `core.sparseCheckoutCone` needed to be enabled.

> When `--no-cone` is passed, the input list is considered a list of patterns. This mode has a number of drawbacks, including not working with some options like `--sparse-index`. As explained in the "Non-cone Problems" section below, we do not recommend using it.

The [drawbacks](https://www.git-scm.com/docs/git-sparse-checkout/2.37.0#_internalsnon_cone_problems) are all things we don't care about, since we (in most cases) delete `.git`.

Before this change:
```console
$ nix-build -A tests.fetchgit
this derivation will be built:
  /nix/store/is14bfirqsj4416286jw5cjkm81ypkfg-nix-source-salted-cfcrgsb53gfi.drv
building '/nix/store/is14bfirqsj4416286jw5cjkm81ypkfg-nix-source-salted-cfcrgsb53gfi.drv'...
exporting https://github.com/NixOS/nix (rev 9d9dbe6ed05854e03811c361a3380e09183f4f4a) into /nix/store/g0v40l01ry6lmaj8sqd3y9yj61ifg37d-nix-source-salted-cfcrgsb53gfi
Initialized empty Git repository in /nix/store/g0v40l01ry6lmaj8sqd3y9yj61ifg37d-nix-source-salted-cfcrgsb53gfi/.git/
fatal: invalid refspec '+refs/tags/2.3.15^{}'
remote: Enumerating objects: 61, done.
remote: Counting objects: 100% (61/61), done.
remote: Compressing objects: 100% (43/43), done.
remote: Total 61 (delta 0), reused 37 (delta 0), pack-reused 0
Receiving objects: 100% (61/61), 23.94 KiB | 23.94 MiB/s, done.
From https://github.com/NixOS/nix
 * branch            9d9dbe6ed05854e03811c361a3380e09183f4f4a -> FETCH_HEAD
remote: Enumerating objects: 530, done.
remote: Counting objects: 100% (530/530), done.
remote: Compressing objects: 100% (430/430), done.
remote: Total 530 (delta 7), reused 246 (delta 2), pack-reused 0
Receiving objects: 100% (530/530), 617.49 KiB | 9.36 MiB/s, done.
Resolving deltas: 100% (7/7), done.
Switched to a new branch 'fetchgit'
removing `.git'...
error: hash mismatch in fixed-output derivation '/nix/store/is14bfirqsj4416286jw5cjkm81ypkfg-nix-source-salted-cfcrgsb53gfi.drv':
         specified: sha256-FknO6C/PSnMPfhUqObD4vsW4PhkwdmPa9blNzcNvJQ4=
            got:    sha256-g1PHGTWgAcd/+sXHo1o6AjVWCvC6HiocOfMbMh873LQ=
```

After this change:
```console
$ nix-build -A tests.fetchgit
these 2 derivations will be built:
  /nix/store/0xw1p9py52xnlmyzfv5darj1dbysjzj9-nix-source-salted-d2iymn4klqwb.drv
  /nix/store/fk9jl0fg7r1j0kczzkhjd3041ag6f1zz-nix-source-salted-x89bx46nl7v8.drv
building '/nix/store/0xw1p9py52xnlmyzfv5darj1dbysjzj9-nix-source-salted-d2iymn4klqwb.drv'...
building '/nix/store/fk9jl0fg7r1j0kczzkhjd3041ag6f1zz-nix-source-salted-x89bx46nl7v8.drv'...
exporting https://github.com/NixOS/nix (rev 9d9dbe6ed05854e03811c361a3380e09183f4f4a) into /nix/store/qzd9gvdpv3psl8n7fwwj6asby7vs82a5-nix-source-salted-d2iymn4klqwb
exporting https://github.com/NixOS/nix (rev 9d9dbe6ed05854e03811c361a3380e09183f4f4a) into /nix/store/38pacjkrqafbrf1p3184jm9wa7cwf72b-nix-source-salted-x89bx46nl7v8
Initialized empty Git repository in /nix/store/38pacjkrqafbrf1p3184jm9wa7cwf72b-nix-source-salted-x89bx46nl7v8/.git/
Initialized empty Git repository in /nix/store/qzd9gvdpv3psl8n7fwwj6asby7vs82a5-nix-source-salted-d2iymn4klqwb/.git/
fatal: invalid refspec '+refs/tags/2.3.15^{}'
fatal: invalid refspec '+refs/tags/2.3.15^{}'
remote: Enumerating objects: 61, done.
remote: Counting objects: 100% (61/61), done.
remote: Compressing objects: 100% (43/43), done.
remote: Total 61 (delta 0), reused 37 (delta 0), pack-reused 0
Receiving objects: 100% (61/61), 23.94 KiB | 11.97 MiB/s, done.
remote: Enumerating objects: 777, done.
remote: Counting objects: 100% (777/777), done.
From https://github.com/NixOS/nix
 * branch            9d9dbe6ed05854e03811c361a3380e09183f4f4a -> FETCH_HEAD
remote: Compressing objects: 100% (648/648), done.
remote: Total 777 (delta 30), reused 329 (delta 13), pack-reused 0
Receiving objects: 100% (777/777), 1013.31 KiB | 9.38 MiB/s, done.
Resolving deltas: 100% (30/30), done.
From https://github.com/NixOS/nix
 * branch            9d9dbe6ed05854e03811c361a3380e09183f4f4a -> FETCH_HEAD
Switched to a new branch 'fetchgit'
remote: Enumerating objects: 514, done.
remote: Counting objects: 100% (514/514), done.
removing `.git'...
remote: Compressing objects: 100% (416/416), done.
remote: Total 514 (delta 7), reused 240 (delta 2), pack-reused 0
Receiving objects: 100% (514/514), 595.74 KiB | 3.89 MiB/s, done.
Resolving deltas: 100% (7/7), done.
Switched to a new branch 'fetchgit'
removing `.git'...
/nix/store/38pacjkrqafbrf1p3184jm9wa7cwf72b-nix-source-salted-x89bx46nl7v8
/nix/store/qzd9gvdpv3psl8n7fwwj6asby7vs82a5-nix-source-salted-d2iymn4klqwb
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
