### PR TITLE
mask: 0.11.1 -> 0.11.2

### DIFF
--- a/pkgs/development/tools/mask/default.nix
+++ b/pkgs/development/tools/mask/default.nix
@@ -2,23 +2,23 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "mask";
-  version = "0.11.1";
+  version = "0.11.2";
 
   src = fetchFromGitHub {
-    owner = "jakedeichert";
+    owner = "jacobdeichert";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-qRN9M/DxkxcF1/dmYqmf3qB8yHzuaN3LRENy1ehgg0c=";
+    sha256 = "sha256-mlARZ05xppPvr6Z5uoveYt3Y3LtdMkbFqxW1EkX+ud0=";
   };
 
-  cargoSha256 = "sha256-7ts63n9aGtaK8INBh11TShOQCVpV+82VADmNbKURv+g=";
+  cargoSha256 = "sha256-EulRz/IjLLvNT9YxyNjJynFEGyQ/Q2Out984xS9Wp5o=";
 
   # tests require mask to be installed
   doCheck = false;
 
   meta = with lib; {
     description = "A CLI task runner defined by a simple markdown file";
-    homepage = "https://github.com/jakedeichert/mask";
+    homepage = "https://github.com/jacobdeichert/mask";
     license = licenses.mit;
     maintainers = with maintainers; [ figsoda ];
   };


### PR DESCRIPTION
###### Description of changes

https://github.com/jacobdeichert/mask/compare/v0.11.1...v0.11.2
[changelog](https://github.com/jacobdeichert/mask/blob/v0.11.2/CHANGELOG.md)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
