### PR TITLE
pipewire: do no depend on buildPackages.pipewire

### DIFF
--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -187,17 +187,13 @@ let
 
     postInstall = ''
       mkdir $out/nix-support
-      ${if (stdenv.hostPlatform == stdenv.buildPlatform) then ''
-        pushd $lib/share/pipewire
-        for f in *.conf; do
-          echo "Generating JSON from $f"
+      pushd $lib/share/pipewire
+      for f in *.conf; do
+        echo "Generating JSON from $f"
 
-          $out/bin/spa-json-dump "$f" > "$out/nix-support/$f.json"
-        done
-        popd
-      '' else ''
-        cp ${buildPackages.pipewire}/nix-support/*.json "$out/nix-support"
-      ''}
+        ${stdenv.targetPlatform.emulator buildPackages} $out/bin/spa-json-dump "$f" > "$out/nix-support/$f.json"
+      done
+      popd
 
       ${lib.optionalString enableSystemd ''
         moveToOutput "share/systemd/user/pipewire-pulse.*" "$pulse"


### PR DESCRIPTION
reduces the dependency chain of cross-compiled pipewire and as such
reduces the compilation time

confirmed that the json files did not change

$ nix why-depends "/nix/store/mkzpi8c9k30bazylpnklsk1yzl77d3j5-sway-unwrapped-aarch64-unknown-linux-gnu-1.7.drv" "/nix/store/zz112z16jji08wj13dcbmy79xz7nql8n-mesa-22.1.4.drv" --derivation
/nix/store/mkzpi8c9k30bazylpnklsk1yzl77d3j5-sway-unwrapped-aarch64-unknown-linux-gnu-1.7.drv
└───/nix/store/n2k1plc300625yh5lalv13py7ca1m783-wlroots-aarch64-unknown-linux-gnu-0.15.1.drv
    └───/nix/store/69vinc0xsyinx4wan9g87myzaq4gw8b9-ffmpeg-aarch64-unknown-linux-gnu-4.4.2.drv
        └───/nix/store/14d1gq7qw68lpwmfww8dkqm7lxqn033i-SDL2-aarch64-unknown-linux-gnu-2.0.22.drv
            └───/nix/store/bvaivv3p8c2q4m51qfqb405495kn2461-pipewire-aarch64-unknown-linux-gnu-0.3.56.drv
                └───/nix/store/mpk9nqbarpd9ds07qbargz3fckn31fra-pipewire-0.3.56.drv
                    └───/nix/store/8fyy06ycxzkxm3533ygq2nwl1blsggkq-ffmpeg-4.4.2.drv
                        └───/nix/store/6j5incgzp9jwgq8j5ycgb9fgp5zzh16k-SDL2-2.0.22.drv
                            └───/nix/store/zz112z16jji08wj13dcbmy79xz7nql8n-mesa-22.1.4.drv

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
