### PR TITLE
mautrix-telegram: 0.11.3 -> 0.12.0 and rework packaging

### DIFF
--- a/pkgs/development/python-modules/cryptg/default.nix
+++ b/pkgs/development/python-modules/cryptg/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, rustPlatform
+, setuptools-rust
+}:
+
+buildPythonPackage rec {
+  pname = "cryptg";
+  version = "0.3.1";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "cher-nov";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-IhzwQrWu8k308ZZhWz4Z3FHAkSLTXiCydyiy0MPN8NI=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    hash = "sha256-M2ySVqfgpgHktLh4t5Sh1UTBCzajlQiDku4O9azHJwk=";
+  };
+
+  nativeBuildInputs = with rustPlatform;[
+    setuptools-rust
+    cargoSetupHook
+    rust.rustc
+    rust.cargo
+  ];
+
+  # has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "cryptg" ];
+
+  meta = with lib; {
+    description = "Official Telethon extension to provide much faster cryptography for Telegram API requests";
+    homepage = "https://github.com/cher-nov/cryptg";
+    license = licenses.cc0;
+    maintainers = with maintainers; [ nickcao ];
+  };
+}

--- a/pkgs/development/python-modules/mautrix/default.nix
+++ b/pkgs/development/python-modules/mautrix/default.nix
@@ -4,11 +4,11 @@
 
 buildPythonPackage rec {
   pname = "mautrix";
-  version = "0.17.3";
+  version = "0.17.8";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-j49NrZJMDw8m5ZGP4DXxk7uzF+0BxDjs4coEkMDUP+0=";
+    sha256 = "sha256-DFajAD5mnXLQmJGRv4j2mWhtIj77nZNSQhbesX4qMys=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/servers/mautrix-telegram/default.nix
+++ b/pkgs/servers/mautrix-telegram/default.nix
@@ -1,5 +1,8 @@
-{ lib, python3, mautrix-telegram, fetchFromGitHub
+{ lib
+, python3
+, fetchFromGitHub
 , withE2BE ? true
+, withHQthumbnails ? false
 }:
 
 let
@@ -21,75 +24,65 @@ let
         };
       });
       tulir-telethon = self.telethon.overridePythonAttrs (oldAttrs: rec {
-        version = "1.25.0a7";
+        version = "1.25.0a20";
         pname = "tulir-telethon";
         src = oldAttrs.src.override {
           inherit pname version;
-          sha256 = "sha256-+wHRrBluM0ejdHjIvSk28wOIfCfIyibBcmwG/ksbiac=";
+          sha256 = "sha256-X9oo+YCNMqQrJvQa/PIi9dFgaeQxbrlnwUJnwjRb6Jc=";
         };
       });
     };
   };
-
-  # officially supported database drivers
-  dbDrivers = with python.pkgs; [
-    psycopg2
-    aiosqlite
-    # sqlite driver is already shipped with python by default
-  ];
-
 in python.pkgs.buildPythonPackage rec {
   pname = "mautrix-telegram";
-  version = "0.11.3";
+  version = "0.12.0";
   disabled = python.pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "mautrix";
     repo = "telegram";
     rev = "v${version}";
-    sha256 = "sha256-PfER/wqJ607w0xVrFZadzmxYyj72O10c2lIvCW7LT8Y=";
+    sha256 = "sha256-SUwiRrTY8NgOGQ643prsm3ZklOlwX/59m/u1aewFuik=";
   };
 
   patches = [ ./0001-Re-add-entrypoint.patch ];
 
   propagatedBuildInputs = with python.pkgs; ([
-    Mako
-    aiohttp
-    mautrix
-    sqlalchemy
-    CommonMark
     ruamel-yaml
     python-magic
+    CommonMark
+    aiohttp
+    yarl
+    mautrix
     tulir-telethon
-    telethon-session-sqlalchemy
-    pillow
-    lxml
-    setuptools
-    prometheus-client
-  ] ++ lib.optionals withE2BE [
     asyncpg
+    Mako
+    # optional
+    cryptg
+    cchardet
+    aiodns
+    brotli
+    pillow
+    qrcode
+    phonenumbers
+    prometheus-client
+    aiosqlite
+  ] ++ lib.optionals withHQthumbnails [
+    moviepy
+  ] ++ lib.optionals withE2BE [
     python-olm
     pycryptodome
     unpaddedbase64
-  ]) ++ dbDrivers;
+  ]);
 
-  # Tests are broken and throw the following for every test:
-  #   TypeError: 'Mock' object is not subscriptable
-  #
-  # The tests were touched the last time in 2019 and upstream CI doesn't even build
-  # those, so it's safe to assume that this part of the software is abandoned.
+  # has no tests
   doCheck = false;
-  checkInputs = with python.pkgs; [
-    pytest
-    pytest-mock
-    pytest-asyncio
-  ];
 
   meta = with lib; {
     homepage = "https://github.com/mautrix/telegram";
     description = "A Matrix-Telegram hybrid puppeting/relaybot bridge";
     license = licenses.agpl3Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ nyanloutre ma27 ];
+    maintainers = with maintainers; [ nyanloutre ma27 nickcao ];
   };
 }

--- a/pkgs/servers/mautrix-telegram/default.nix
+++ b/pkgs/servers/mautrix-telegram/default.nix
@@ -8,21 +8,6 @@
 let
   python = python3.override {
     packageOverrides = self: super: {
-      asyncpg = super.asyncpg.overridePythonAttrs (oldAttrs: rec {
-        version = "0.25.0";
-        src = oldAttrs.src.override {
-          inherit version;
-          hash = "sha256-Y/jmppczsoVJfChVRko03mV/LMzSWurutQcYcuk4JUA=";
-        };
-      });
-      mautrix = super.mautrix.overridePythonAttrs (oldAttrs: rec {
-        version = "0.16.3";
-        src = oldAttrs.src.override {
-          inherit (oldAttrs) pname;
-          inherit version;
-          sha256 = "sha256-OpHLh5pCzGooQ5yxAa0+85m/szAafV+l+OfipQcfLtU=";
-        };
-      });
       tulir-telethon = self.telethon.overridePythonAttrs (oldAttrs: rec {
         version = "1.25.0a20";
         pname = "tulir-telethon";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2115,6 +2115,8 @@ in {
 
   cryptacular = callPackage ../development/python-modules/cryptacular { };
 
+  cryptg = callPackage ../development/python-modules/cryptg { };
+
   cryptography = callPackage ../development/python-modules/cryptography {
     inherit (pkgs.darwin) libiconv;
     inherit (pkgs.darwin.apple_sdk.frameworks) Security;


### PR DESCRIPTION
###### Description of changes
Removed some unused dependencies, added some optional ones. `moviepy` is left out by default as it greatly bloats the closure size by 600M.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
