### PR TITLE
gnome-commander: init at 1.14.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13282,6 +13282,15 @@
     github = "twitchyliquid64";
     githubId = 6328589;
   };
+  twz123 = {
+    name = "Tom Wieczorek";
+    email = "tom@bibbu.net";
+    github = "twz123";
+    githubId = 1215104;
+    keys = [{
+      fingerprint = "B1FD 4E2A 84B2 2379 F4BF  2EF5 FE33 A228 2371 E831";
+    }];
+  };
   typetetris = {
     email = "ericwolf42@mail.com";
     github = "typetetris";

--- a/pkgs/applications/file-managers/gnome-commander/default.nix
+++ b/pkgs/applications/file-managers/gnome-commander/default.nix
@@ -1,0 +1,68 @@
+{ stdenv
+, lib
+, fetchurl
+, flex
+, itstool
+, pkg-config
+, libxslt
+, wrapGAppsHook
+, exiv2
+, glib
+, gtk2
+, gvfs
+, libgsf
+, libunique
+, poppler
+, taglib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gnome-commander";
+  version = "1.14.3";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "sha256-eNjc5w+5IrKQnPdneDBTsIESE6TWpJs4dVEM86hO/Xs=";
+  };
+
+  nativeBuildInputs = [
+    flex
+    itstool
+    pkg-config
+    libxslt
+    (wrapGAppsHook.override { gtk3 = gtk2; })
+  ];
+
+  buildInputs = [
+    exiv2
+    glib
+    gtk2
+    libgsf
+    libunique
+    poppler
+    taglib
+  ];
+
+  patches = [ ./gsettings.patch ];
+
+  postPatch = ''
+    substituteInPlace data/org.gnome.${pname}.gschema.xml \
+      --replace /usr/local/share/pixmaps/${pname}/mime-icons "$out"/share/pixmaps/${pname}/mime-icons
+  '';
+
+  postInstall = ''
+    substituteInPlace "$out"/share/applications/org.gnome.${pname}.desktop \
+      --replace Exec=${pname} Exec="$out"/bin/${pname}
+
+    mkdir -p -- "$out"/share/icons/hicolor/scalable/apps
+    ln -s -- "$out"/share/pixmaps/${pname}.svg "$out"/share/icons/hicolor/scalable/apps/${pname}.svg
+  '';
+
+  meta = with lib; {
+    homepage = "https://gcmd.github.io/";
+    description = "A powerful file manager for the GNOME desktop environment";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ twz123 ];
+  };
+}

--- a/pkgs/applications/file-managers/gnome-commander/gsettings.patch
+++ b/pkgs/applications/file-managers/gnome-commander/gsettings.patch
@@ -1,0 +1,62 @@
+diff --git a/plugins/fileroller/file-roller-plugin.cc b/plugins/fileroller/file-roller-plugin.cc
+index ff2f14af..77c1b137 100644
+--- a/plugins/fileroller/file-roller-plugin.cc
++++ b/plugins/fileroller/file-roller-plugin.cc
+@@ -93,9 +93,17 @@ static GSettingsSchemaSource* GetGlobalSchemaSource()
+     GSettingsSchemaSource   *global_schema_source;
+     std::string              g_schema_path(PREFIX);
+ 
+-    g_schema_path.append("/share/glib-2.0/schemas");
++    g_schema_path.append("/share/gsettings-schemas/");
++    g_schema_path.append(PACKAGE);
++    g_schema_path.append("-");
++    g_schema_path.append(VERSION);
++    g_schema_path.append("/glib-2.0/schemas");
+ 
+     global_schema_source = g_settings_schema_source_get_default ();
++    if (global_schema_source == nullptr)
++    {
++        g_printerr(_("Could not load default schemas\n"));
++    }
+ 
+     GSettingsSchemaSource *parent = global_schema_source;
+     GError *error = nullptr;
+@@ -111,6 +119,7 @@ static GSettingsSchemaSource* GetGlobalSchemaSource()
+         g_printerr(_("Could not load schemas from %s: %s\n"),
+                    (gchar*) g_schema_path.c_str(), error->message);
+         g_clear_error (&error);
++        return parent;
+     }
+ 
+     return global_schema_source;
+diff --git a/src/gnome-cmd-data.cc b/src/gnome-cmd-data.cc
+index 2d125f5f..7ca3fb79 100644
+--- a/src/gnome-cmd-data.cc
++++ b/src/gnome-cmd-data.cc
+@@ -60,9 +60,17 @@ GSettingsSchemaSource* GnomeCmdData::GetGlobalSchemaSource()
+     GSettingsSchemaSource   *global_schema_source;
+     std::string              g_schema_path(PREFIX);
+ 
+-    g_schema_path.append("/share/glib-2.0/schemas");
++    g_schema_path.append("/share/gsettings-schemas/");
++    g_schema_path.append(PACKAGE);
++    g_schema_path.append("-");
++    g_schema_path.append(VERSION);
++    g_schema_path.append("/glib-2.0/schemas");
+ 
+     global_schema_source = g_settings_schema_source_get_default ();
++    if (global_schema_source == nullptr)
++    {
++        g_printerr(_("Could not load default schemas\n"));
++    }
+ 
+     GSettingsSchemaSource *parent = global_schema_source;
+     GError *error = nullptr;
+@@ -78,6 +86,7 @@ GSettingsSchemaSource* GnomeCmdData::GetGlobalSchemaSource()
+         g_printerr(_("Could not load schemas from %s: %s\n"),
+                    (gchar*) g_schema_path.c_str(), error->message);
+         g_clear_error (&error);
++        return parent;
+     }
+ 
+     return global_schema_source;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6759,6 +6759,8 @@ with pkgs;
 
   gnome-builder = callPackage ../applications/editors/gnome-builder { };
 
+  gnome-commander = callPackage ../applications/file-managers/gnome-commander { };
+
   gnome-desktop = callPackage ../development/libraries/gnome-desktop { };
 
   gnome-feeds = callPackage ../applications/networking/feedreaders/gnome-feeds {};


### PR DESCRIPTION
###### Description of changes

GNOME Commander is yet another two-pane file manager targeting the GNOME desktop. In addition to performing the basic filemanager functions the program is also an FTP-client and it can browse SMB-networks.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).