### PR TITLE
linuxPackages.apfs: unstable-2022-02-03 -> unstable-2022-07-24

### DIFF
--- a/pkgs/os-specific/linux/apfs/default.nix
+++ b/pkgs/os-specific/linux/apfs/default.nix
@@ -1,29 +1,19 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , kernel
 }:
 
 stdenv.mkDerivation {
   pname = "apfs";
-  version = "unstable-2022-02-03-${kernel.version}";
+  version = "unstable-2022-07-24-${kernel.version}";
 
   src = fetchFromGitHub {
     owner = "linux-apfs";
     repo = "linux-apfs-rw";
-    rev = "a0d6a4dca69b6eab3cabaaee4d4284807828a266";
-    sha256 = "sha256-3T1BNc6g3SDTxb0VrronLUIp/CWbwnzXTsc8Qk5c4jY=";
+    rev = "925d86b7be3ccf21b17734cfececf40e43c4598e";
+    sha256 = "sha256-N5lGJu4c03cVDk3WTcegzZHBDmguPEX8dCedJS2TMSI=";
   };
-
-  patches = [
-    # Fix build for Linux 5.18+.
-    # https://github.com/linux-apfs/linux-apfs-rw/pull/24
-    (fetchpatch {
-      url = "https://github.com/linux-apfs/linux-apfs-rw/commit/93b93767acab614c4e6426c9fd38bdf9af00bc13.patch";
-      sha256 = "1ss7cal851qadcmkn3jcckpa2f003nzb03xsx1g8vkb1cl0n8gi7";
-    })
-  ];
 
   hardeningDisable = [ "pic" ];
   nativeBuildInputs = kernel.moduleBuildDependencies;


### PR DESCRIPTION
###### Description of changes
There have been quite a few fixes and improvements: https://github.com/linux-apfs/linux-apfs-rw/compare/a0d6a4dca69b6eab3cabaaee4d4284807828a266...925d86b7be3ccf21b17734cfececf40e43c4598e.
Most notably, there were incompatibilities with the 5.18 kernel that have now been fixed: https://github.com/linux-apfs/linux-apfs-rw/issues/27.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).