### PR TITLE
replay-io: 20220516 -> 20220726

### DIFF
--- a/pkgs/development/tools/replay-io/default.nix
+++ b/pkgs/development/tools/replay-io/default.nix
@@ -17,6 +17,11 @@ in rec {
       cp linux-recordreplay.so $out
       runHook postInstall
     '';
+    postFixup = ''
+      patchelf --set-rpath "$(patchelf --print-rpath $out):${
+        lib.makeLibraryPath [ openssl ]
+      }" $out
+    '';
     meta = with lib; {
       description = "RecordReplay internal recording library";
       homepage = "https://www.replay.io/";

--- a/pkgs/development/tools/replay-io/meta.json
+++ b/pkgs/development/tools/replay-io/meta.json
@@ -1,15 +1,15 @@
 {
   "replay": {
-     "url": "https://static.replay.io/downloads/linux-gecko-20220516-372662e7c79d-a9c63f38ea9b.tar.bz2",
-     "sha256": "151k0ykd2mn722zk7n902si6llcsrqnhgjb5bs4wgn9rik9advbi"
+     "url": "https://static.replay.io/downloads/linux-gecko-20220722-71c783507536-b7eae18423ef.tar.bz2",
+     "sha256": "0d3zbiid849nljhpfffi45qy2frghs33s28r86q8xrnli1d0cg83"
   },
   "recordreplay": {
-     "url": "https://static.replay.io/downloads/linux-recordreplay-a9c63f38ea9b.tgz",
-     "sha256": "032x9wiw4jcdkn0wjgr5j3pc4parrdy5n4r8bgmfxsldg5j48hmk",
+     "url": "https://static.replay.io/downloads/linux-recordreplay-b7eae18423ef.tgz",
+     "sha256": "1nvhka6ryiw8hac2fkg6va1narb0d7jiqqhxgs1dzblian3kw5j3",
      "stripRoot": false
   },
   "replay-node": {
-      "url": "https://static.replay.io/downloads/linux-node-20220506-096c12cb47eb-a1d05f422dff",
-      "sha256": "1fbqlx01vp6llbvvz285brmz86jxc989v0cw6s06jk0657g87inq"
+      "url": "https://static.replay.io/downloads/linux-node-20220726-bac6d66b5ca1-5b966f2f136c",
+      "sha256": "1563bypnh60wd3k4s5xkla10cymyvnzcl4cfnkpyyrv5920qqc19"
   }
 }


### PR DESCRIPTION
###### Description of changes

Updated the packages to the newest upstream release.

A direct update resulted in 

> DoLoadDriverHandle: dlopen failed /nix/store/rd4y8y9axdvp8vkwc1q6ns2dib8lqkg6-replay-recordreplay-b7eae18423ef: libcrypto.so.1.1: cannot open shared object file: No such file or directory

when trying to do a recording. So I had to manually add openssl to the rpath, after which recording works again.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
