### PR TITLE
i2p: 1.6.1 -> 1.9.0

### DIFF
--- a/pkgs/tools/networking/i2p/default.nix
+++ b/pkgs/tools/networking/i2p/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "i2p";
-  version = "1.8.0";
+  version = "1.9.0";
 
   src = fetchurl {
     url = "https://files.i2p-projekt.de/${version}/i2psource_${version}.tar.bz2";
-    sha256 = "sha256-Ul8q0yZ/EwuBKWs90kEC/c8q3wmNVCctpOG+Sr2H3wQ=";
+    sha256 = "sha256-V/YYFQmMNVk9ft4wX5i5AVxMYTxyIxrQhOaAaj4qo3E=";
   };
 
   buildInputs = [ jdk ant gettext which ];

--- a/pkgs/tools/networking/i2p/default.nix
+++ b/pkgs/tools/networking/i2p/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "i2p";
-  version = "1.6.1";
+  version = "1.8.0";
 
   src = fetchurl {
-    url = "https://download.i2p2.de/releases/${version}/i2psource_${version}.tar.bz2";
-    sha256 = "sha256-cZYGxMtRDeT+dPJLv6U5EacFMYIfwe55op49luqhZzM=";
+    url = "https://files.i2p-projekt.de/${version}/i2psource_${version}.tar.bz2";
+    sha256 = "sha256-Ul8q0yZ/EwuBKWs90kEC/c8q3wmNVCctpOG+Sr2H3wQ=";
   };
 
   buildInputs = [ jdk ant gettext which ];


### PR DESCRIPTION
###### Description of changes

- [1.9.0](https://geti2p.net/en/blog/post/2022/8/22/1.9.0-Release) - SSU2: Enable for Android, ARM, and a small portion of others at random
- [1.8.0](https://geti2p.net/en/blog/post/2022/5/23/1.8.0-Release) - bug fixes and preliminary implementation of SSU2
- [1.7.0](https://geti2p.net/en/blog/post/2022/2/21/1.7.0-Release) - improvements and fixes

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).