### PR TITLE
alire: init at 1.3-dev

### DIFF
--- a/pkgs/development/tools/alire/default.nix
+++ b/pkgs/development/tools/alire/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, lib, fetchFromGitHub, gnat, gprbuild }:
+
+stdenv.mkDerivation {
+  pname = "alire";
+  version = "1.3-dev-2022-06-24";
+  src = fetchFromGitHub {
+    owner = "alire-project";
+    repo = "alire";
+    rev = "8f44a810";
+    hash = "sha256-kYntEMeVPo1+gRI+Q/6qfSyICXNf8yLT+LcbuyeRu/E=";
+    fetchSubmodules = true;
+  };
+
+  OS = if stdenv.isDarwin then "macOS" else null;
+
+  nativeBuildInputs = [ gnat gprbuild ];
+
+  buildPhase = ''
+    runHook preBuild
+    gprbuild -j0 -P alr_env
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    gprinstall --mode=usage -P alr_env -p -r --prefix=$out
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/alire-project/alire";
+    description = "Ada LIbrary REpository";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ ethindp ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -222,6 +222,8 @@ with pkgs;
 
   align = callPackage ../tools/text/align { };
 
+  alire = callPackage ../development/tools/alire { };
+
   althttpd = callPackage ../servers/althttpd { };
 
   anders = callPackage ../applications/science/logic/anders { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Alire is the ada library manager for the Ada programming language. (I'm recreating this since I'd like this to be backported to NixOS 22.05 and 21.11 and PR #182418 seemed to be stalled, though that might've been my fault.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
