### PR TITLE
wapm-cli: init at 0.5.5

### DIFF
--- a/pkgs/tools/package-management/wapm/cli/default.nix
+++ b/pkgs/tools/package-management/wapm/cli/default.nix
@@ -1,12 +1,12 @@
-{ darwin
+{ lib
 , fetchFromGitHub
-, lib
 , libiconv
 , openssl
 , rustPlatform
 , Security
 , stdenv
-, SystemConfiguration }:
+, SystemConfiguration
+}:
 
 rustPlatform.buildRustPackage rec {
   pname = "wapm-cli";

--- a/pkgs/tools/package-management/wapm/cli/default.nix
+++ b/pkgs/tools/package-management/wapm/cli/default.nix
@@ -1,0 +1,35 @@
+{ darwin
+, fetchFromGitHub
+, lib
+, libiconv
+, openssl
+, rustPlatform
+, Security
+, stdenv
+, SystemConfiguration }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "wapm-cli";
+  version = "0.5.5";
+
+  src = fetchFromGitHub {
+    owner = "wasmerio";
+    repo = "wapm-cli";
+    rev = "v${version}";
+    sha256 = "sha256-BKBd1tJwV4VOjRnAx/spQy3LIXzujrO2SS5eA1uybNA=";
+  };
+
+  cargoSha256 = "sha256-dv04AXOnzizjq/qx3qy524ylQHgE4gIBgeYI+2IRTug=";
+
+  buildInputs = [ libiconv openssl ]
+    ++ lib.optionals stdenv.isDarwin [ Security SystemConfiguration ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A package manager for WebAssembly modules";
+    homepage = "https://docs.wasmer.io/ecosystem/wapm";
+    license = with licenses; [ mit ];
+    maintainers = [ maintainers.lucperkins ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15086,6 +15086,10 @@ with pkgs;
 
   trealla = callPackage ../development/interpreters/trealla { };
 
+  wapm-cli = callPackage ../tools/package-management/wapm/cli {
+    inherit (darwin.apple_sdk.frameworks) Security SystemConfiguration;
+  };
+
   wasm = ocamlPackages.wasm;
 
   wasm3 = callPackage ../development/interpreters/wasm3 { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
