### PR TITLE
windows.mingw_w64: enable stripping

### DIFF
--- a/pkgs/os-specific/windows/mingw-w64/default.nix
+++ b/pkgs/os-specific/windows/mingw-w64/default.nix
@@ -21,7 +21,6 @@ in stdenv.mkDerivation {
   enableParallelBuilding = true;
 
   buildInputs = [ windows.mingw_w64_headers ];
-  dontStrip = true;
   hardeningDisable = [ "stackprotector" "fortify" ];
 
   meta = {


### PR DESCRIPTION
With 0507725 "setup-hooks/strip.sh: run RANLIB on static
archives after stripping" it should now be safe to run strip
on wider range of .a files.

mingw-w64 is a good example where a reference was preserved
to gcc from intermediate stage. Enabling stripping by default
decreases `pkgsCross.mingw32` closure for 20%:

Before:

    $ nix path-info -rsSh $(nix-build -A pkgsCross.mingw32.stdenv)
    ...
    /nix/store/qzhkidff0wxhqf2gi97ng6qismzvpnbp-stdenv-linux 43.6K    1.0G

After:

    $ nix path-info -rsSh $(nix-build -A pkgsCross.mingw32.stdenv)
    ...
    /nix/store/fj4dv1n3sa3jgcb1j3nwn6njsf943n48-stdenv-linux 43.6K  792.4M

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
