### PR TITLE
ghz: init at 0.109.0

### DIFF
--- a/pkgs/tools/networking/ghz/default.nix
+++ b/pkgs/tools/networking/ghz/default.nix
@@ -10,18 +10,18 @@ buildGoModule rec {
     rev = "v${version}";
     sha256 = "sha256-5l2PeN+VxTaORAkmAfI9TCGd4W6y8BFs/eY4T9nYJuc=";
   };
-  
+
   proxyVendor = true;
   vendorSha256 = "sha256-R1OB4jTmyyS2O91vqSNjmSA19KutHzPLcLQ7R7tCsIA=";
 
   subPackages = ["cmd/ghz" "cmd/ghz-web"];
 
-ldflags = [ "-s" "-w" ];
+  ldflags = [ "-s" "-w" ];
 
-  meta = {
+  meta = with lib; {
     description = "Simple gRPC benchmarking and load testing tool";
     homepage = "https://ghz.sh";
-    license = lib.licenses.asl20;
-    maintainers = [ lib.maintainers.zombiezen ];
+    license = licenses.asl20;
+    maintainers = [ maintainers.zombiezen ];
   };
 }

--- a/pkgs/tools/networking/ghz/default.nix
+++ b/pkgs/tools/networking/ghz/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "ghz";
+  version = "0.109.0";
+
+  src = fetchFromGitHub {
+    owner = "bojand";
+    repo = "ghz";
+    rev = "v${version}";
+    sha256 = "sha256-5l2PeN+VxTaORAkmAfI9TCGd4W6y8BFs/eY4T9nYJuc=";
+  };
+  proxyVendor = true;
+  vendorSha256 = "sha256-R1OB4jTmyyS2O91vqSNjmSA19KutHzPLcLQ7R7tCsIA=";
+
+  subPackages = ["cmd/ghz" "cmd/ghz-web"];
+
+  meta = {
+    description = "Simple gRPC benchmarking and load testing tool";
+    homepage = "https://ghz.sh";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.zombiezen ];
+  };
+}

--- a/pkgs/tools/networking/ghz/default.nix
+++ b/pkgs/tools/networking/ghz/default.nix
@@ -10,10 +10,13 @@ buildGoModule rec {
     rev = "v${version}";
     sha256 = "sha256-5l2PeN+VxTaORAkmAfI9TCGd4W6y8BFs/eY4T9nYJuc=";
   };
+  
   proxyVendor = true;
   vendorSha256 = "sha256-R1OB4jTmyyS2O91vqSNjmSA19KutHzPLcLQ7R7tCsIA=";
 
   subPackages = ["cmd/ghz" "cmd/ghz-web"];
+
+ldflags = [ "-s" "-w" ];
 
   meta = {
     description = "Simple gRPC benchmarking and load testing tool";

--- a/pkgs/tools/networking/ghz/default.nix
+++ b/pkgs/tools/networking/ghz/default.nix
@@ -14,7 +14,7 @@ buildGoModule rec {
   proxyVendor = true;
   vendorSha256 = "sha256-R1OB4jTmyyS2O91vqSNjmSA19KutHzPLcLQ7R7tCsIA=";
 
-  subPackages = ["cmd/ghz" "cmd/ghz-web"];
+  subPackages = [ "cmd/ghz" "cmd/ghz-web" ];
 
   ldflags = [ "-s" "-w" ];
 

--- a/pkgs/tools/networking/ghz/default.nix
+++ b/pkgs/tools/networking/ghz/default.nix
@@ -11,8 +11,7 @@ buildGoModule rec {
     sha256 = "sha256-5l2PeN+VxTaORAkmAfI9TCGd4W6y8BFs/eY4T9nYJuc=";
   };
 
-  proxyVendor = true;
-  vendorSha256 = "sha256-R1OB4jTmyyS2O91vqSNjmSA19KutHzPLcLQ7R7tCsIA=";
+  vendorSha256 = "sha256-qZD+qxjjFgyQDtjOQcilS4w2sS9I+7iCK2/ThaAJTy4=";
 
   subPackages = [ "cmd/ghz" "cmd/ghz-web" ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6505,6 +6505,8 @@ with pkgs;
 
   ghrepo-stats = with python3Packages; toPythonApplication ghrepo-stats;
 
+  ghz = callPackage ../tools/networking/ghz { };
+
   gibberish-detector = with python3Packages; toPythonApplication gibberish-detector;
 
   gibo = callPackage ../tools/misc/gibo { };


### PR DESCRIPTION
###### Description of changes

ghz is a gRPC benchmarking and load-testing tool: https://ghz.sh/

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
