### PR TITLE
gpick: ensure Gsettings schemas are available

### DIFF
--- a/pkgs/tools/misc/gpick/default.nix
+++ b/pkgs/tools/misc/gpick/default.nix
@@ -1,4 +1,15 @@
-{ stdenv, fetchFromGitHub, cmake, glib, boost, pkg-config, gtk3, ragel, lua, lib }:
+{ stdenv
+, fetchFromGitHub
+, cmake
+, glib
+, wrapGAppsHook
+, boost
+, pkg-config
+, gtk3
+, ragel
+, lua
+, lib
+}:
 
 stdenv.mkDerivation rec {
   pname = "gpick";
@@ -11,7 +22,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-Z67EJRtKJZLoTUtdMttVTLkzTV2F5rKZ96vaothLiFo=";
   };
 
-  nativeBuildInputs = [ cmake pkg-config ];
+  nativeBuildInputs = [ cmake pkg-config wrapGAppsHook ];
   NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0";
   buildInputs = [ boost gtk3 ragel lua ];
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Ensure GSettings schemas are available to `gpick`.

Running gpick on a system where GSettings schemas are not provided (e.g. XMonad with no desktop environment), any attempt to save or export color info from gpick will cause gpick to crash:
```
(gpick:388008): GLib-GIO-ERROR **: 19:32:37.823: No GSettings schemas are installed on the system
```

The nixpkgs manual describes [how to fix such errors](https://nixos.org/manual/nixpkgs/stable/#ssec-gnome-common-issues-no-schemas). Following that advice appears to have fixed the issue, as I can now use all gpick functionality (including save and export) without any errors.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
