### PR TITLE
kube-hunter: trim unnecessary dependency

### DIFF
--- a/pkgs/tools/security/kube-hunter/default.nix
+++ b/pkgs/tools/security/kube-hunter/default.nix
@@ -21,7 +21,6 @@ python3.pkgs.buildPythonApplication rec {
   propagatedBuildInputs = with python3.pkgs; [
     netaddr
     netifaces
-    scapy
     requests
     prettytable
     urllib3


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

kube-hunter itself no longer requires scapy since https://github.com/aquasecurity/kube-hunter/pull/500

```
# With scapy
λ nix path-info $(nix-build -A kube-hunter) -Sh
/nix/store/zgcqa3iv9a6qmb7snzdryfyqbgh8lyb1-kube-hunter-0.6.8	 636.5M
λ nix path-info $(nix-build -A kube-hunter.inputDerivation) -Sh
/nix/store/m37bfq2yajjd5n7w695k4ljbc1a4r5z1-kube-hunter-0.6.8	 884.0M
# Without scapy
λ nix path-info $(nix-build -A kube-hunter) -Sh
/nix/store/blyf2c8vdyckspylmpz6i7hglqa4ax2c-kube-hunter-0.6.8	 196.3M
λ nix path-info $(nix-build -A kube-hunter.inputDerivation) -Sh
/nix/store/r8wfyzkx4ic1pr35pl8n44wxs0d777v3-kube-hunter-0.6.8	 453.5M
```

We might want to package the plugins now: kube-hunter-arp-spoof kube-hunter-dns-spoof

https://github.com/aquasecurity/kube-hunter-plugins

If we do it'd be best to use `scapy` with an override to disable `withVoipSupport` and `withPlottingSupport` since they're what makes it so large

cc: @fab

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
