### PR TITLE
lemmy: improve module and add test

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -36,3 +36,6 @@ d08ede042b74b8199dc748323768227b88efcf7c
 
 # fix indentation in mk-python-derivation.nix
 d1c1a0c656ccd8bd3b25d3c4287f2d075faf3cf3
+
+# fix style in nixos/modules/services/web-apps/lemmy.nix
+c0f0b4ef0bc01e446c94bfe705425eeb138d6b0d

--- a/nixos/modules/services/web-apps/lemmy.md
+++ b/nixos/modules/services/web-apps/lemmy.md
@@ -13,22 +13,14 @@ services.lemmy = {
     hostname = "lemmy.union.rocks";
     database.createLocally = true;
   };
-  jwtSecretPath = "/run/secrets/lemmyJwt";
-  caddy.enable = true;
 }
 ```
 
-(note that you can use something like agenix to get your secret jwt to the specified path)
-
-this will start the backend on port 8536 and the frontend on port 1234.
-It will expose your instance with a caddy reverse proxy to the hostname you've provided.
-Postgres will be initialized on that same instance automatically.
+This will start the backend on port 8536 and the frontend on port 1234. Postgres will be initialized on that same instance automatically.
 
 ## Usage {#module-services-lemmy-usage}
 
 On first connection you will be asked to define an admin user.
 
 ## Missing {#module-services-lemmy-missing}
-
-- Exposing with nginx is not implemented yet.
 - This has been tested using a local database with a unix socket connection. Using different database settings will likely require modifications

--- a/nixos/modules/services/web-apps/lemmy.nix
+++ b/nixos/modules/services/web-apps/lemmy.nix
@@ -10,16 +10,27 @@ in
   # `pandoc lemmy.md -t docbook --top-level-division=chapter --extract-media=media -f markdown+smart > lemmy.xml`
   meta.doc = ./lemmy.xml;
 
-  options.services.lemmy = {
+  imports = [
+    (mkRemovedOptionModule [ "services" "lemmy" "jwtSecretPath" ] "This option is no longer required because the secret gets generated automatically.")
+    (mkRemovedOptionModule [ "services" "lemmy" "caddy" ] "This option has been removed due to it being a burden on maintenance, please set up the reverse proxy independently of this service.")
+  ];
 
+  options.services.lemmy = {
     enable = mkEnableOption "lemmy a federated alternative to reddit in rust";
 
-    jwtSecretPath = mkOption {
-      type = types.path;
-      description = lib.mdDoc "Path to read the jwt secret from.";
-    };
-
     ui = {
+      package = mkOption {
+        type = types.package;
+        default = pkgs.lemmy-ui;
+        defaultText = literalExpression "pkgs.lemmy-ui";
+        description = lib.mdDoc "lemmy-ui package to use.";
+      };
+      listenAddress = mkOption {
+        type = types.str;
+        default = "127.0.0.1";
+        example = "0.0.0.0";
+        description = lib.mdDoc "The address for lemmy-ui to listen on.";
+      };
       port = mkOption {
         type = types.port;
         default = 1234;
@@ -27,7 +38,12 @@ in
       };
     };
 
-    caddy.enable = mkEnableOption "exposing lemmy with the caddy reverse proxy";
+    package = mkOption {
+      type = types.package;
+      default = pkgs.lemmy-server;
+      defaultText = literalExpression "pkgs.lemmy-server";
+      description = lib.mdDoc "lemmy-server package to use.";
+    };
 
     settings = mkOption {
       default = { };
@@ -48,6 +64,13 @@ in
           description = lib.mdDoc "Port where lemmy should listen for incoming requests.";
         };
 
+        options.listenAddress = mkOption {
+          type = types.str;
+          default = "127.0.0.1";
+          example = "0.0.0.0";
+          description = lib.mdDoc "The address for lemmy to listen on.";
+        };
+
         options.federation = {
           enabled = mkEnableOption "activitypub federation";
         };
@@ -66,171 +89,107 @@ in
         };
 
         options.database.createLocally = mkEnableOption "creation of database on the instance";
-
       };
     };
-
   };
 
-  config =
-    let
-      localPostgres = (cfg.settings.database.host == "localhost" || cfg.settings.database.host == "/run/postgresql");
-    in
-    lib.mkIf cfg.enable {
-      services.lemmy.settings = (mapAttrs (name: mkDefault)
-        {
-          bind = "127.0.0.1";
-          tls_enabled = true;
-          pictrs_url = with config.services.pict-rs; "http://${address}:${toString port}";
-          actor_name_max_length = 20;
+  config = mkIf cfg.enable {
+    services.lemmy.settings = (mapAttrs (name: mkDefault)
+      {
+        bind = cfg.settings.listenAddress;
+        tls_enabled = true;
+        pictrs_url = with config.services.pict-rs; "http://${address}:${toString port}";
+        actor_name_max_length = 20;
 
-          rate_limit.message = 180;
-          rate_limit.message_per_second = 60;
-          rate_limit.post = 6;
-          rate_limit.post_per_second = 600;
-          rate_limit.register = 3;
-          rate_limit.register_per_second = 3600;
-          rate_limit.image = 6;
-          rate_limit.image_per_second = 3600;
-        } // {
-        database = mapAttrs (name: mkDefault) {
-          user = "lemmy";
-          host = "/run/postgresql";
-          port = 5432;
-          database = "lemmy";
-          pool_size = 5;
-        };
-      });
+        rate_limit.message = 180;
+        rate_limit.message_per_second = 60;
+        rate_limit.post = 6;
+        rate_limit.post_per_second = 600;
+        rate_limit.register = 3;
+        rate_limit.register_per_second = 3600;
+        rate_limit.image = 6;
+        rate_limit.image_per_second = 3600;
+      } // {
+      database = mapAttrs (name: mkDefault) {
+        user = "lemmy";
+        host = "/run/postgresql";
+        port = 5432;
+        database = "lemmy";
+        pool_size = 5;
+      };
+    });
 
-      services.postgresql = mkIf localPostgres {
-        enable = mkDefault true;
+    services.pict-rs.enable = true;
+
+    systemd.services.lemmy = {
+      description = "Lemmy server";
+
+      environment = {
+        LEMMY_CONFIG_LOCATION = "/run/lemmy/config.hjson";
+
+        # Verify how this is used, and don't put the password in the nix store
+        LEMMY_DATABASE_URL = with cfg.settings.database;"postgres:///${database}?host=${host}";
       };
 
-      services.pict-rs.enable = true;
+      documentation = [
+        "https://join-lemmy.org/docs/en/administration/from_scratch.html"
+        "https://join-lemmy.org/docs"
+      ];
 
-      services.caddy = mkIf cfg.caddy.enable {
-        enable = mkDefault true;
-        virtualHosts."${cfg.settings.hostname}" = {
-          extraConfig = ''
-            handle_path /static/* {
-              root * ${pkgs.lemmy-ui}/dist
-              file_server
-            }
-            @for_backend {
-              path /api/* /pictrs/* feeds/* nodeinfo/*
-            }
-            handle @for_backend {
-              reverse_proxy 127.0.0.1:${toString cfg.settings.port}
-            }
-            @post {
-              method POST
-            }
-            handle @post {
-              reverse_proxy 127.0.0.1:${toString cfg.settings.port}
-            }
-            @jsonld {
-              header Accept "application/activity+json"
-              header Accept "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\""
-            }
-            handle @jsonld {
-              reverse_proxy 127.0.0.1:${toString cfg.settings.port}
-            }
-            handle {
-              reverse_proxy 127.0.0.1:${toString cfg.ui.port}
-            }
-          '';
-        };
-      };
+      wantedBy = [ "multi-user.target" ];
 
-      assertions = [{
-        assertion = cfg.settings.database.createLocally -> localPostgres;
-        message = "if you want to create the database locally, you need to use a local database";
-      }];
+      after = [ "pict-rs.service" ] ++ lib.optionals cfg.settings.database.createLocally [ "postgresql.service" ];
 
-      systemd.services.lemmy = {
-        description = "Lemmy server";
+      requires = lib.optionals cfg.settings.database.createLocally [ "postgresql.service" ];
 
-        environment = {
-          LEMMY_CONFIG_LOCATION = "/run/lemmy/config.hjson";
-
-          # Verify how this is used, and don't put the password in the nix store
-          LEMMY_DATABASE_URL = with cfg.settings.database;"postgres:///${database}?host=${host}";
-        };
-
-        documentation = [
-          "https://join-lemmy.org/docs/en/administration/from_scratch.html"
-          "https://join-lemmy.org/docs"
-        ];
-
-        wantedBy = [ "multi-user.target" ];
-
-        after = [ "pict-rs.service" ] ++ lib.optionals cfg.settings.database.createLocally [ "lemmy-postgresql.service" ];
-
-        requires = lib.optionals cfg.settings.database.createLocally [ "lemmy-postgresql.service" ];
-
-        # script is needed here since loadcredential is not accessible on ExecPreStart
-        script = ''
-          ${pkgs.coreutils}/bin/install -m 600 ${settingsFormat.generate "config.hjson" cfg.settings} /run/lemmy/config.hjson
-          jwtSecret="$(< $CREDENTIALS_DIRECTORY/jwt_secret )"
-          ${pkgs.jq}/bin/jq ".jwt_secret = \"$jwtSecret\"" /run/lemmy/config.hjson | ${pkgs.moreutils}/bin/sponge /run/lemmy/config.hjson
-          ${pkgs.lemmy-server}/bin/lemmy_server
-        '';
-
-        serviceConfig = {
-          DynamicUser = true;
-          RuntimeDirectory = "lemmy";
-          LoadCredential = "jwt_secret:${cfg.jwtSecretPath}";
-        };
-      };
-
-      systemd.services.lemmy-ui = {
-        description = "Lemmy ui";
-
-        environment = {
-          LEMMY_UI_HOST = "127.0.0.1:${toString cfg.ui.port}";
-          LEMMY_INTERNAL_HOST = "127.0.0.1:${toString cfg.settings.port}";
-          LEMMY_EXTERNAL_HOST = cfg.settings.hostname;
-          LEMMY_HTTPS = "false";
-        };
-
-        documentation = [
-          "https://join-lemmy.org/docs/en/administration/from_scratch.html"
-          "https://join-lemmy.org/docs"
-        ];
-
-        wantedBy = [ "multi-user.target" ];
-
-        after = [ "lemmy.service" ];
-
-        requires = [ "lemmy.service" ];
-
-        serviceConfig = {
-          DynamicUser = true;
-          WorkingDirectory = "${pkgs.lemmy-ui}";
-          ExecStart = "${pkgs.nodejs}/bin/node ${pkgs.lemmy-ui}/dist/js/server.js";
-        };
-      };
-
-      systemd.services.lemmy-postgresql = mkIf cfg.settings.database.createLocally {
-        description = "Lemmy postgresql db";
-        after = [ "postgresql.service" ];
-        partOf = [ "lemmy.service" ];
-        script = with cfg.settings.database; ''
-          PSQL() {
-            ${config.services.postgresql.package}/bin/psql --port=${toString cfg.settings.database.port} "$@"
-          }
-          # check if the database already exists
-          if ! PSQL -lqt | ${pkgs.coreutils}/bin/cut -d \| -f 1 | ${pkgs.gnugrep}/bin/grep -qw ${database} ; then
-            PSQL -tAc "CREATE ROLE ${user} WITH LOGIN;"
-            PSQL -tAc "CREATE DATABASE ${database} WITH OWNER ${user};"
-          fi
-        '';
-        serviceConfig = {
-          User = config.services.postgresql.superUser;
-          Type = "oneshot";
-          RemainAfterExit = true;
-        };
+      serviceConfig = {
+        DynamicUser = true;
+        RuntimeDirectory = "lemmy";
+        ExecStartPre = "install -m 600 ${settingsFormat.generate "config.hjson" cfg.settings} /run/lemmy/config.hjson";
+        ExecStart = "${cfg.package}/bin/lemmy-server";
       };
     };
 
+    systemd.services.lemmy-ui = {
+      description = "Lemmy ui";
+
+      environment = {
+        LEMMY_UI_HOST = "${cfg.ui.listenAddress}:${toString cfg.ui.port}";
+        LEMMY_INTERNAL_HOST = "${cfg.settings.listenAddress}:${toString cfg.settings.port}";
+        LEMMY_EXTERNAL_HOST = cfg.settings.hostname;
+        LEMMY_HTTPS = "false";
+      };
+
+      documentation = [
+        "https://join-lemmy.org/docs/en/administration/from_scratch.html"
+        "https://join-lemmy.org/docs"
+      ];
+
+      wantedBy = [ "multi-user.target" ];
+
+      after = [ "lemmy.service" ];
+
+      requires = [ "lemmy.service" ];
+
+      serviceConfig = {
+        DynamicUser = true;
+        WorkingDirectory = "${cfg.ui.package}";
+        ExecStart = "${pkgs.nodejs}/bin/node ${cfg.ui.package}/dist/js/server.js";
+      };
+    };
+
+    services.postgresql = mkIf cfg.settings.database.createLocally {
+      enable = true;
+      ensureDatabases = [ cfg.settings.database.database ];
+      ensureUsers = [{
+        name = cfg.settings.database.user;
+        ensurePermissions."DATABASE ${cfg.settings.database.database}" = "ALL PRIVILEGES";
+      }];
+    };
+
+    assertions = [{
+      assertion = cfg.settings.database.createLocally -> (cfg.settings.database.host == "localhost" || cfg.settings.database.host == "/run/postgresql");
+      message = "In order to use database.createLocally, you need to use a local database";
+    }];
+  };
 }

--- a/nixos/modules/services/web-apps/lemmy.nix
+++ b/nixos/modules/services/web-apps/lemmy.nix
@@ -16,7 +16,7 @@ in
   ];
 
   options.services.lemmy = {
-    enable = mkEnableOption "lemmy a federated alternative to reddit in rust";
+    enable = mkEnableOption "Lemmy, a federated alternative to reddit in rust";
 
     ui = {
       package = mkOption {
@@ -72,7 +72,7 @@ in
         };
 
         options.federation = {
-          enabled = mkEnableOption "activitypub federation";
+          enabled = mkEnableOption "ActivityPub federation";
         };
 
         options.captcha = {
@@ -86,110 +86,110 @@ in
             default = "medium";
             description = lib.mdDoc "The difficultly of the captcha to solve.";
           };
+
+          options.database.createLocally = mkEnableOption "creation of database on the instance";
+        };
+      };
+    };
+
+    config = mkIf cfg.enable {
+      services.lemmy.settings = (mapAttrs (name: mkDefault)
+        {
+          bind = cfg.settings.listenAddress;
+          tls_enabled = true;
+          pictrs_url = with config.services.pict-rs; "http://${address}:${toString port}";
+          actor_name_max_length = 20;
+
+          rate_limit.message = 180;
+          rate_limit.message_per_second = 60;
+          rate_limit.post = 6;
+          rate_limit.post_per_second = 600;
+          rate_limit.register = 3;
+          rate_limit.register_per_second = 3600;
+          rate_limit.image = 6;
+          rate_limit.image_per_second = 3600;
+        } // {
+        database = mapAttrs (name: mkDefault) {
+          user = "lemmy";
+          host = "/run/postgresql";
+          port = 5432;
+          database = "lemmy";
+          pool_size = 5;
+        };
+      });
+
+      services.pict-rs.enable = true;
+
+      systemd.services.lemmy = {
+        description = "Lemmy server";
+
+        environment = {
+          LEMMY_CONFIG_LOCATION = "/run/lemmy/config.hjson";
+
+          # Verify how this is used, and don't put the password in the nix store
+          LEMMY_DATABASE_URL = with cfg.settings.database;"postgres:///${database}?host=${host}";
         };
 
-        options.database.createLocally = mkEnableOption "creation of database on the instance";
-      };
-    };
-  };
+        documentation = [
+          "https://join-lemmy.org/docs/en/administration/from_scratch.html"
+          "https://join-lemmy.org/docs"
+        ];
 
-  config = mkIf cfg.enable {
-    services.lemmy.settings = (mapAttrs (name: mkDefault)
-      {
-        bind = cfg.settings.listenAddress;
-        tls_enabled = true;
-        pictrs_url = with config.services.pict-rs; "http://${address}:${toString port}";
-        actor_name_max_length = 20;
+        wantedBy = [ "multi-user.target" ];
 
-        rate_limit.message = 180;
-        rate_limit.message_per_second = 60;
-        rate_limit.post = 6;
-        rate_limit.post_per_second = 600;
-        rate_limit.register = 3;
-        rate_limit.register_per_second = 3600;
-        rate_limit.image = 6;
-        rate_limit.image_per_second = 3600;
-      } // {
-      database = mapAttrs (name: mkDefault) {
-        user = "lemmy";
-        host = "/run/postgresql";
-        port = 5432;
-        database = "lemmy";
-        pool_size = 5;
-      };
-    });
+        after = [ "pict-rs.service" ] ++ lib.optionals cfg.settings.database.createLocally [ "postgresql.service" ];
 
-    services.pict-rs.enable = true;
+        requires = lib.optionals cfg.settings.database.createLocally [ "postgresql.service" ];
 
-    systemd.services.lemmy = {
-      description = "Lemmy server";
-
-      environment = {
-        LEMMY_CONFIG_LOCATION = "/run/lemmy/config.hjson";
-
-        # Verify how this is used, and don't put the password in the nix store
-        LEMMY_DATABASE_URL = with cfg.settings.database;"postgres:///${database}?host=${host}";
+        serviceConfig = {
+          DynamicUser = true;
+          RuntimeDirectory = "lemmy";
+          ExecStartPre = "install -m 600 ${settingsFormat.generate "config.hjson" cfg.settings} /run/lemmy/config.hjson";
+          ExecStart = "${cfg.package}/bin/lemmy-server";
+        };
       };
 
-      documentation = [
-        "https://join-lemmy.org/docs/en/administration/from_scratch.html"
-        "https://join-lemmy.org/docs"
-      ];
+      systemd.services.lemmy-ui = {
+        description = "Lemmy ui";
 
-      wantedBy = [ "multi-user.target" ];
+        environment = {
+          LEMMY_UI_HOST = "${cfg.ui.listenAddress}:${toString cfg.ui.port}";
+          LEMMY_INTERNAL_HOST = "${cfg.settings.listenAddress}:${toString cfg.settings.port}";
+          LEMMY_EXTERNAL_HOST = cfg.settings.hostname;
+          LEMMY_HTTPS = "false";
+        };
 
-      after = [ "pict-rs.service" ] ++ lib.optionals cfg.settings.database.createLocally [ "postgresql.service" ];
+        documentation = [
+          "https://join-lemmy.org/docs/en/administration/from_scratch.html"
+          "https://join-lemmy.org/docs"
+        ];
 
-      requires = lib.optionals cfg.settings.database.createLocally [ "postgresql.service" ];
+        wantedBy = [ "multi-user.target" ];
 
-      serviceConfig = {
-        DynamicUser = true;
-        RuntimeDirectory = "lemmy";
-        ExecStartPre = "install -m 600 ${settingsFormat.generate "config.hjson" cfg.settings} /run/lemmy/config.hjson";
-        ExecStart = "${cfg.package}/bin/lemmy-server";
+        after = [ "lemmy.service" ];
+
+        requires = [ "lemmy.service" ];
+
+        serviceConfig = {
+          DynamicUser = true;
+          WorkingDirectory = "${cfg.ui.package}";
+          ExecStart = "${pkgs.nodejs}/bin/node ${cfg.ui.package}/dist/js/server.js";
+        };
       };
-    };
 
-    systemd.services.lemmy-ui = {
-      description = "Lemmy ui";
-
-      environment = {
-        LEMMY_UI_HOST = "${cfg.ui.listenAddress}:${toString cfg.ui.port}";
-        LEMMY_INTERNAL_HOST = "${cfg.settings.listenAddress}:${toString cfg.settings.port}";
-        LEMMY_EXTERNAL_HOST = cfg.settings.hostname;
-        LEMMY_HTTPS = "false";
+      services.postgresql = mkIf cfg.settings.database.createLocally {
+        enable = true;
+        ensureDatabases = [ cfg.settings.database.database ];
+        ensureUsers = [{
+          name = cfg.settings.database.user;
+          ensurePermissions."DATABASE ${cfg.settings.database.database}" = "ALL PRIVILEGES";
+        }];
       };
 
-      documentation = [
-        "https://join-lemmy.org/docs/en/administration/from_scratch.html"
-        "https://join-lemmy.org/docs"
-      ];
-
-      wantedBy = [ "multi-user.target" ];
-
-      after = [ "lemmy.service" ];
-
-      requires = [ "lemmy.service" ];
-
-      serviceConfig = {
-        DynamicUser = true;
-        WorkingDirectory = "${cfg.ui.package}";
-        ExecStart = "${pkgs.nodejs}/bin/node ${cfg.ui.package}/dist/js/server.js";
-      };
-    };
-
-    services.postgresql = mkIf cfg.settings.database.createLocally {
-      enable = true;
-      ensureDatabases = [ cfg.settings.database.database ];
-      ensureUsers = [{
-        name = cfg.settings.database.user;
-        ensurePermissions."DATABASE ${cfg.settings.database.database}" = "ALL PRIVILEGES";
+      assertions = [{
+        assertion = cfg.settings.database.createLocally -> (cfg.settings.database.host == "localhost" || cfg.settings.database.host == "/run/postgresql");
+        message = "In order to use database.createLocally, you need to use a local database";
       }];
     };
-
-    assertions = [{
-      assertion = cfg.settings.database.createLocally -> (cfg.settings.database.host == "localhost" || cfg.settings.database.host == "/run/postgresql");
-      message = "In order to use database.createLocally, you need to use a local database";
-    }];
   };
 }

--- a/nixos/modules/services/web-apps/lemmy.nix
+++ b/nixos/modules/services/web-apps/lemmy.nix
@@ -91,105 +91,105 @@ in
         };
       };
     };
+  };
 
-    config = mkIf cfg.enable {
-      services.lemmy.settings = (mapAttrs (name: mkDefault)
-        {
-          bind = cfg.settings.listenAddress;
-          tls_enabled = true;
-          pictrs_url = with config.services.pict-rs; "http://${address}:${toString port}";
-          actor_name_max_length = 20;
+  config = mkIf cfg.enable {
+    services.lemmy.settings = (mapAttrs (name: mkDefault)
+      {
+        bind = cfg.settings.listenAddress;
+        tls_enabled = true;
+        pictrs_url = with config.services.pict-rs; "http://${address}:${toString port}";
+        actor_name_max_length = 20;
 
-          rate_limit.message = 180;
-          rate_limit.message_per_second = 60;
-          rate_limit.post = 6;
-          rate_limit.post_per_second = 600;
-          rate_limit.register = 3;
-          rate_limit.register_per_second = 3600;
-          rate_limit.image = 6;
-          rate_limit.image_per_second = 3600;
-        } // {
-        database = mapAttrs (name: mkDefault) {
-          user = "lemmy";
-          host = "/run/postgresql";
-          port = 5432;
-          database = "lemmy";
-          pool_size = 5;
-        };
-      });
+        rate_limit.message = 180;
+        rate_limit.message_per_second = 60;
+        rate_limit.post = 6;
+        rate_limit.post_per_second = 600;
+        rate_limit.register = 3;
+        rate_limit.register_per_second = 3600;
+        rate_limit.image = 6;
+        rate_limit.image_per_second = 3600;
+      } // {
+      database = mapAttrs (name: mkDefault) {
+        user = "lemmy";
+        host = "/run/postgresql";
+        port = 5432;
+        database = "lemmy";
+        pool_size = 5;
+      };
+    });
 
-      services.pict-rs.enable = true;
+    services.pict-rs.enable = true;
 
-      systemd.services.lemmy = {
-        description = "Lemmy server";
+    systemd.services.lemmy = {
+      description = "Lemmy server";
 
-        environment = {
-          LEMMY_CONFIG_LOCATION = "/run/lemmy/config.hjson";
+      environment = {
+        LEMMY_CONFIG_LOCATION = "/run/lemmy/config.hjson";
 
-          # Verify how this is used, and don't put the password in the nix store
-          LEMMY_DATABASE_URL = with cfg.settings.database;"postgres:///${database}?host=${host}";
-        };
-
-        documentation = [
-          "https://join-lemmy.org/docs/en/administration/from_scratch.html"
-          "https://join-lemmy.org/docs"
-        ];
-
-        wantedBy = [ "multi-user.target" ];
-
-        after = [ "pict-rs.service" ] ++ lib.optionals cfg.settings.database.createLocally [ "postgresql.service" ];
-
-        requires = lib.optionals cfg.settings.database.createLocally [ "postgresql.service" ];
-
-        serviceConfig = {
-          DynamicUser = true;
-          RuntimeDirectory = "lemmy";
-          ExecStartPre = "install -m 600 ${settingsFormat.generate "config.hjson" cfg.settings} /run/lemmy/config.hjson";
-          ExecStart = "${cfg.package}/bin/lemmy-server";
-        };
+        # Verify how this is used, and don't put the password in the nix store
+        LEMMY_DATABASE_URL = with cfg.settings.database;"postgres:///${database}?host=${host}";
       };
 
-      systemd.services.lemmy-ui = {
-        description = "Lemmy ui";
+      documentation = [
+        "https://join-lemmy.org/docs/en/administration/from_scratch.html"
+        "https://join-lemmy.org/docs"
+      ];
 
-        environment = {
-          LEMMY_UI_HOST = "${cfg.ui.listenAddress}:${toString cfg.ui.port}";
-          LEMMY_INTERNAL_HOST = "${cfg.settings.listenAddress}:${toString cfg.settings.port}";
-          LEMMY_EXTERNAL_HOST = cfg.settings.hostname;
-          LEMMY_HTTPS = "false";
-        };
+      wantedBy = [ "multi-user.target" ];
 
-        documentation = [
-          "https://join-lemmy.org/docs/en/administration/from_scratch.html"
-          "https://join-lemmy.org/docs"
-        ];
+      after = [ "pict-rs.service" ] ++ lib.optionals cfg.settings.database.createLocally [ "postgresql.service" ];
 
-        wantedBy = [ "multi-user.target" ];
+      requires = lib.optionals cfg.settings.database.createLocally [ "postgresql.service" ];
 
-        after = [ "lemmy.service" ];
+      serviceConfig = {
+        DynamicUser = true;
+        RuntimeDirectory = "lemmy";
+        ExecStartPre = "install -m 600 ${settingsFormat.generate "config.hjson" cfg.settings} /run/lemmy/config.hjson";
+        ExecStart = "${cfg.package}/bin/lemmy-server";
+      };
+    };
 
-        requires = [ "lemmy.service" ];
+    systemd.services.lemmy-ui = {
+      description = "Lemmy ui";
 
-        serviceConfig = {
-          DynamicUser = true;
-          WorkingDirectory = "${cfg.ui.package}";
-          ExecStart = "${pkgs.nodejs}/bin/node ${cfg.ui.package}/dist/js/server.js";
-        };
+      environment = {
+        LEMMY_UI_HOST = "${cfg.ui.listenAddress}:${toString cfg.ui.port}";
+        LEMMY_INTERNAL_HOST = "${cfg.settings.listenAddress}:${toString cfg.settings.port}";
+        LEMMY_EXTERNAL_HOST = cfg.settings.hostname;
+        LEMMY_HTTPS = "false";
       };
 
-      services.postgresql = mkIf cfg.settings.database.createLocally {
-        enable = true;
-        ensureDatabases = [ cfg.settings.database.database ];
-        ensureUsers = [{
-          name = cfg.settings.database.user;
-          ensurePermissions."DATABASE ${cfg.settings.database.database}" = "ALL PRIVILEGES";
-        }];
-      };
+      documentation = [
+        "https://join-lemmy.org/docs/en/administration/from_scratch.html"
+        "https://join-lemmy.org/docs"
+      ];
 
-      assertions = [{
-        assertion = cfg.settings.database.createLocally -> (cfg.settings.database.host == "localhost" || cfg.settings.database.host == "/run/postgresql");
-        message = "In order to use database.createLocally, you need to use a local database";
+      wantedBy = [ "multi-user.target" ];
+
+      after = [ "lemmy.service" ];
+
+      requires = [ "lemmy.service" ];
+
+      serviceConfig = {
+        DynamicUser = true;
+        WorkingDirectory = "${cfg.ui.package}";
+        ExecStart = "${pkgs.nodejs}/bin/node ${cfg.ui.package}/dist/js/server.js";
+      };
+    };
+
+    services.postgresql = mkIf cfg.settings.database.createLocally {
+      enable = true;
+      ensureDatabases = [ cfg.settings.database.database ];
+      ensureUsers = [{
+        name = cfg.settings.database.user;
+        ensurePermissions."DATABASE ${cfg.settings.database.database}" = "ALL PRIVILEGES";
       }];
     };
+
+    assertions = [{
+      assertion = cfg.settings.database.createLocally -> (cfg.settings.database.host == "localhost" || cfg.settings.database.host == "/run/postgresql");
+      message = "In order to use database.createLocally, you need to use a local database";
+    }];
   };
 }

--- a/nixos/modules/services/web-apps/lemmy.xml
+++ b/nixos/modules/services/web-apps/lemmy.xml
@@ -8,26 +8,19 @@
     <para>
       the minimum to start lemmy is
     </para>
-    <programlisting language="bash">
+    <programlisting language="nix">
 services.lemmy = {
   enable = true;
   settings = {
     hostname = &quot;lemmy.union.rocks&quot;;
     database.createLocally = true;
   };
-  jwtSecretPath = &quot;/run/secrets/lemmyJwt&quot;;
-  caddy.enable = true;
 }
 </programlisting>
     <para>
-      (note that you can use something like agenix to get your secret
-      jwt to the specified path)
-    </para>
-    <para>
-      this will start the backend on port 8536 and the frontend on port
-      1234. It will expose your instance with a caddy reverse proxy to
-      the hostname you’ve provided. Postgres will be initialized on that
-      same instance automatically.
+      This will start the backend on port 8536 and the frontend on port
+      1234. Postgres will be initialized on that same instance
+      automatically.
     </para>
   </section>
   <section xml:id="module-services-lemmy-usage">
@@ -39,11 +32,6 @@ services.lemmy = {
   <section xml:id="module-services-lemmy-missing">
     <title>Missing</title>
     <itemizedlist spacing="compact">
-      <listitem>
-        <para>
-          Exposing with nginx is not implemented yet.
-        </para>
-      </listitem>
       <listitem>
         <para>
           This has been tested using a local database with a unix socket

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -274,6 +274,7 @@ in {
   kubernetes = handleTestOn ["x86_64-linux"] ./kubernetes {};
   latestKernel.login = handleTest ./login.nix { latestKernel = true; };
   leaps = handleTest ./leaps.nix {};
+  lemmy = handleTest ./lemmy.nix {};
   libinput = handleTest ./libinput.nix {};
   libreddit = handleTest ./libreddit.nix {};
   libresprite = handleTest ./libresprite.nix {};

--- a/nixos/tests/lemmy.nix
+++ b/nixos/tests/lemmy.nix
@@ -1,0 +1,35 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }:
+  rec {
+    name = "lemmy";
+    meta = with lib.maintainers; { maintainers = [ ]; };
+
+    nodes.default = {
+      services.lemmy = {
+        enable = true;
+        ui = {
+          port = 1234;
+          listenAddress = "127.0.0.0";
+        };
+        settings = {
+          hostname = "example.com";
+          port = 8536;
+          listenAddress = "127.0.0.0";
+        };
+      };
+
+      # pict-rs seems to need more than 1025114112 bytes
+      virtualisation.memorySize = 2000;
+    };
+
+    testScript = ''
+      # Wait for backend service to start
+      machine.wait_for_unit("lemmy.service")
+      machine.wait_for_open_port(${toString nodes.default.services.lemmy.settings.port})
+      # Wait for webui services to start
+      machine.wait_for_unit("lemmy-ui.service")
+      machine.wait_for_open_port(${toString nodes.default.services.lemmy.ui.port})
+      # curl the backend's API and the webui
+      machine.succeed("curl --fail ${nodes.default.services.lemmy.settings.listenAddress}:${toString nodes.default.services.lemmy.settings.port}/api/v3/site")
+      machine.succeed("curl --fail ${nodes.default.services.lemmy.ui.listenAddress}:${toString nodes.default.services.lemmy.ui.port}")
+    '';
+  })


### PR DESCRIPTION
With a recent lemmy release the `jwt` Token can be generated
automatically by the database, making the need for this configuration
option obsolete.

LemmyNet/lemmy#1790

Move the creation of the database from a script to creation through the
psql module.

Add a nixos test module for lemmy.

Co-authored-by: Ctem <c@ctem.me>
Co-authored-by: Ilan Joselevich <personal@ilanjoselevich.com>
Co-authored-by: Matthias Meschede <MMesch@users.noreply.github.com>
Co-authored-by: a-kenji <aks.kenji@protonmail.com>###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
