### PR TITLE
python3Packages.plantuml-markdown: init at 3.6.2

### DIFF
--- a/pkgs/development/python-modules/plantuml-markdown/default.nix
+++ b/pkgs/development/python-modules/plantuml-markdown/default.nix
@@ -1,12 +1,10 @@
 { buildPythonPackage
 , fetchFromGitHub
 , lib
-  # Runtime dependencies
-, pkgs # for pkgs.plantuml
+, plantuml
 , markdown
 , requests
 , six
-  # Test dependencies
 , runCommand
 , writeText
 , plantuml-markdown
@@ -26,14 +24,13 @@ buildPythonPackage {
   };
 
   propagatedBuildInputs = [
-    pkgs.plantuml
+    plantuml
     markdown
     requests
     six
   ];
 
   # The package uses a custom script that downloads a certain version of plantuml for testing.
-  # It also uses the unittest module so failing tests cannot be easily disabled.
   doCheck = false;
 
   pythonImportsCheck = [ "plantuml_markdown" ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6775,7 +6775,7 @@ in {
 
   plantuml = callPackage ../development/python-modules/plantuml { };
 
-  plantuml-markdown = callPackage ../development/python-modules/plantuml-markdown { 
+  plantuml-markdown = callPackage ../development/python-modules/plantuml-markdown {
     inherit (pkgs) plantuml;
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6775,7 +6775,9 @@ in {
 
   plantuml = callPackage ../development/python-modules/plantuml { };
 
-  plantuml-markdown = callPackage ../development/python-modules/plantuml-markdown { };
+  plantuml-markdown = callPackage ../development/python-modules/plantuml-markdown { 
+    inherit (pkgs) plantuml;
+  };
 
   plaster = callPackage ../development/python-modules/plaster { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6775,6 +6775,8 @@ in {
 
   plantuml = callPackage ../development/python-modules/plantuml { };
 
+  plantuml-markdown = callPackage ../development/python-modules/plantuml-markdown { };
+
   plaster = callPackage ../development/python-modules/plaster { };
 
   plaster-pastedeploy = callPackage ../development/python-modules/plaster-pastedeploy { };


### PR DESCRIPTION
###### Description of changes

New package: python3Packages.plantuml-markdown
Homepage: https://github.com/mikitex70/plantuml-markdown

The package allows to render plantuml diagrams inside markdown. It's a plugin for python3Packages.markdown

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
