### PR TITLE
[DRAFT] python310Packages.faraday-plugins: Enable more tests

### DIFF
--- a/pkgs/development/python-modules/faraday-plugins/default.nix
+++ b/pkgs/development/python-modules/faraday-plugins/default.nix
@@ -12,6 +12,7 @@
 , requests
 , simplejson
 , tabulate
+, faraday
 }:
 
 buildPythonPackage rec {
@@ -40,18 +41,8 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
+    faraday
     pytestCheckHook
-  ];
-
-  disabledTestPaths = [
-    # faraday itself is currently not available
-    "tests/test_report_collection.py"
-  ];
-
-  disabledTests = [
-    # Fail because of missing faraday
-    "test_detect_report"
-    "test_process_report_summary"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/faraday/default.nix
+++ b/pkgs/development/python-modules/faraday/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, pbr
+, pyserial
+, pytest-flake8
+, click
+, markupsafe
+, flask-cors
+, pytestCheckHook
+, requests
+, enum34
+, aprslib
+, appdirs
+, configparser
+}:
+
+buildPythonPackage rec {
+  pname = "faraday";
+  version = "0.0.1018.dev1438";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-hQu44nPIEzQNA96fU0r8lCeLF6FddLeL68C4eAvXqsk=";
+  };
+
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "enum34>=1.1.6" ""
+  '';
+
+  propagatedBuildInputs = [
+    pbr
+    pyserial
+  ];
+
+  checkInputs = [
+    appdirs
+    aprslib
+    click
+    configparser
+    enum34
+    flask-cors
+    markupsafe
+    pytestCheckHook
+    pytest-flake8
+    requests
+  ];
+
+  pythonImportsCheck = [ "faraday" ];
+
+  meta = with lib; {
+    description = "FaradayRF amateur radio open source software";
+    homepage = "https://github.com/FaradayRF/Faraday-Software";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ onny ];
+  };
+}

--- a/pkgs/development/python-modules/wordfreq/default.nix
+++ b/pkgs/development/python-modules/wordfreq/default.nix
@@ -37,6 +37,7 @@ buildPythonPackage rec {
   '';
 
   checkInputs = [ pytestCheckHook ];
+
   disabledTests = [
     # These languages require additional dictionaries that aren't packaged
     "test_languages"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2992,6 +2992,8 @@ in {
 
   falcon = callPackage ../development/python-modules/falcon { };
 
+  faraday = callPackage ../development/python-modules/faraday { };
+
   faraday-agent-parameters-types = callPackage ../development/python-modules/faraday-agent-parameters-types { };
 
   faraday-plugins = callPackage ../development/python-modules/faraday-plugins { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
