### PR TITLE
inkcut: fixes for use with newer inkscape and python

### DIFF
--- a/pkgs/applications/misc/inkcut/default.nix
+++ b/pkgs/applications/misc/inkcut/default.nix
@@ -1,4 +1,5 @@
 { lib
+, fetchpatch
 , python3Packages
 , fetchFromGitHub
 , wrapQtAppsHook
@@ -17,6 +18,28 @@ buildPythonApplication rec {
     rev = "refs/tags/v${version}";
     sha256 = "sha256-S5IrNWVoUp1w+P7DrKlOUOyY3Q16CHSct9ndZOB3UpU=";
   };
+
+  patches = [
+    # fix opening the extension on inkscape 1.2
+    # https://github.com/inkcut/inkcut/pull/340
+    (fetchpatch {
+      url = "https://github.com/inkcut/inkcut/commit/d5d5d0ab3c588c576b668f4c7b07a10609ba2fd0.patch";
+      hash = "sha256-szfiOujuV7OOwYK/OU51m9FK6dzkbWds+h0cr5dGIg4=";
+    })
+    # fix loading a document from stdin (as used from the extension)
+    # https://github.com/inkcut/inkcut/issues/341
+    (fetchpatch {
+      url = "https://github.com/inkcut/inkcut/commit/748ab4157f87afec37dadd715094e87d02c9c739.patch";
+      hash = "sha256-ZGiwZru2bUYu749YSz5vxmGwLTAoYIAsafcX6PmdbYo=";
+      revert = true;
+    })
+    # fix distutils deprecation error
+    # https://github.com/inkcut/inkcut/pull/343
+    (fetchpatch {
+      url = "https://github.com/inkcut/inkcut/commit/9fb95204981bcc51401a1bc10caa02d1fae0d6cb.patch";
+      hash = "sha256-nriys7IWPGykZjVz+DIDsE9Tm40DewkHQlIUaxFwtzM=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace inkcut/device/transports/printer/plugin.py \


### PR DESCRIPTION
###### Description of changes

* avoid inkex.py error with Inkscape 1.2
* avoid distutils deprecation error with recent python
* workaround for problem loading documents from stdin

Fixes #183619

###### Things done

Tested both standalone and as an inkscape plugin

```
{ pkgs ? import <nixpkgs> {} }:

pkgs.mkShell {
  buildInputs = [
    (pkgs.inkscape-with-extensions.override {
      inkscapeExtensions = [
        pkgs.inkscape-extensions.inkcut
      ];
    })
  ];
}
```

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->