### PR TITLE
fwupd: 1.8.1 → 1.8.3

### DIFF
--- a/pkgs/os-specific/linux/firmware/fwupd/add-option-for-installation-sysconfdir.patch
+++ b/pkgs/os-specific/linux/firmware/fwupd/add-option-for-installation-sysconfdir.patch
@@ -1,33 +1,33 @@
 diff --git a/data/meson.build b/data/meson.build
-index 9176aa34..1a0298a9 100644
+index d8494020d..7c896fa0d 100644
 --- a/data/meson.build
 +++ b/data/meson.build
 @@ -26,7 +26,7 @@ endif
  
  if build_standalone
    install_data(['daemon.conf'],
--    install_dir : join_paths(sysconfdir, 'fwupd')
-+    install_dir : join_paths(sysconfdir_install, 'fwupd')
+-    install_dir: join_paths(sysconfdir, 'fwupd')
++    install_dir: join_paths(sysconfdir_install, 'fwupd')
    )
-   install_data(['power.quirk', 'cfi.quirk'],
-     install_dir: join_paths(datadir, 'fwupd', 'quirks.d'))
+   plugin_quirks += join_paths(meson.current_source_dir(), 'power.quirk')
+   plugin_quirks += join_paths(meson.current_source_dir(), 'cfi.quirk')
 diff --git a/data/pki/meson.build b/data/pki/meson.build
-index 499b7201..1be13607 100644
+index 3649fecea..c3462744b 100644
 --- a/data/pki/meson.build
 +++ b/data/pki/meson.build
 @@ -12,13 +12,13 @@ install_data([
      'GPG-KEY-Linux-Foundation-Firmware',
      'GPG-KEY-Linux-Vendor-Firmware-Service',
    ],
--  install_dir : join_paths(sysconfdir, 'pki', 'fwupd')
-+  install_dir : join_paths(sysconfdir_install, 'pki', 'fwupd')
+-  install_dir: join_paths(sysconfdir, 'pki', 'fwupd')
++  install_dir: join_paths(sysconfdir_install, 'pki', 'fwupd')
  )
  install_data([
      'GPG-KEY-Linux-Foundation-Metadata',
      'GPG-KEY-Linux-Vendor-Firmware-Service',
    ],
--  install_dir : join_paths(sysconfdir, 'pki', 'fwupd-metadata')
-+  install_dir : join_paths(sysconfdir_install, 'pki', 'fwupd-metadata')
+-  install_dir: join_paths(sysconfdir, 'pki', 'fwupd-metadata')
++  install_dir: join_paths(sysconfdir_install, 'pki', 'fwupd-metadata')
  )
  endif
  
@@ -35,32 +35,32 @@ index 499b7201..1be13607 100644
  install_data([
      'LVFS-CA.pem',
    ],
--  install_dir : join_paths(sysconfdir, 'pki', 'fwupd')
-+  install_dir : join_paths(sysconfdir_install, 'pki', 'fwupd')
+-  install_dir: join_paths(sysconfdir, 'pki', 'fwupd')
++  install_dir: join_paths(sysconfdir_install, 'pki', 'fwupd')
  )
  install_data([
      'LVFS-CA.pem',
    ],
--  install_dir : join_paths(sysconfdir, 'pki', 'fwupd-metadata')
-+  install_dir : join_paths(sysconfdir_install, 'pki', 'fwupd-metadata')
+-  install_dir: join_paths(sysconfdir, 'pki', 'fwupd-metadata')
++  install_dir: join_paths(sysconfdir_install, 'pki', 'fwupd-metadata')
  )
  endif
 diff --git a/data/remotes.d/meson.build b/data/remotes.d/meson.build
-index 87e794b1..ebeeeca7 100644
+index 1d1698a7e..5469d00a6 100644
 --- a/data/remotes.d/meson.build
 +++ b/data/remotes.d/meson.build
 @@ -2,7 +2,7 @@ if build_standalone and get_option('lvfs') != 'false'
    install_data([
        'lvfs-testing.conf',
      ],
--    install_dir : join_paths(sysconfdir, 'fwupd', 'remotes.d')
-+    install_dir : join_paths(sysconfdir_install, 'fwupd', 'remotes.d')
+-    install_dir: join_paths(sysconfdir, 'fwupd', 'remotes.d')
++    install_dir: join_paths(sysconfdir_install, 'fwupd', 'remotes.d')
    )
    con3 = configuration_data()
    if get_option('lvfs') == 'disabled'
 @@ -15,7 +15,7 @@ if build_standalone and get_option('lvfs') != 'false'
-     output : 'lvfs.conf',
-     configuration : con3,
+     output: 'lvfs.conf',
+     configuration: con3,
      install: true,
 -    install_dir: join_paths(sysconfdir, 'fwupd', 'remotes.d'),
 +    install_dir: join_paths(sysconfdir_install, 'fwupd', 'remotes.d'),
@@ -68,22 +68,22 @@ index 87e794b1..ebeeeca7 100644
    i18n.merge_file(
      input: 'lvfs.metainfo.xml',
 @@ -49,12 +49,12 @@ configure_file(
-   output : 'vendor.conf',
-   configuration : con2,
+   output: 'vendor.conf',
+   configuration: con2,
    install: true,
 -  install_dir: join_paths(sysconfdir, 'fwupd', 'remotes.d'),
 +  install_dir: join_paths(sysconfdir_install, 'fwupd', 'remotes.d'),
  )
  configure_file(
-   input : 'vendor-directory.conf',
-   output : 'vendor-directory.conf',
-   configuration : con2,
+   input: 'vendor-directory.conf',
+   output: 'vendor-directory.conf',
+   configuration: con2,
    install: true,
 -  install_dir: join_paths(sysconfdir, 'fwupd', 'remotes.d'),
 +  install_dir: join_paths(sysconfdir_install, 'fwupd', 'remotes.d'),
  )
 diff --git a/meson.build b/meson.build
-index b91dd037..a8de7810 100644
+index e6b717078..f8a7a7455 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -195,6 +195,12 @@ endif
@@ -97,10 +97,10 @@ index b91dd037..a8de7810 100644
 +endif
 +
  diffcmd = find_program('diff')
- gio = dependency('gio-2.0', version : '>= 2.45.8')
- giounix = dependency('gio-unix-2.0', version : '>= 2.45.8', required: false)
+ gio = dependency('gio-2.0', version: '>= 2.45.8')
+ giounix = dependency('gio-unix-2.0', version: '>= 2.45.8', required: false)
 diff --git a/meson_options.txt b/meson_options.txt
-index d00038db..c84652ca 100644
+index 06d242371..d9e517fc0 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
 @@ -1,3 +1,4 @@
@@ -109,75 +109,75 @@ index d00038db..c84652ca 100644
  option('consolekit', type : 'feature', description : 'ConsoleKit support', deprecated: {'true': 'enabled', 'false': 'disabled'})
  option('static_analysis', type : 'boolean', value : false, description : 'enable GCC static analysis support')
 diff --git a/plugins/dell-esrt/meson.build b/plugins/dell-esrt/meson.build
-index 00b7ecda..789f34ca 100644
+index 67bd3b9d9..ad04a91b6 100644
 --- a/plugins/dell-esrt/meson.build
 +++ b/plugins/dell-esrt/meson.build
 @@ -38,6 +38,6 @@ configure_file(
-   output : 'dell-esrt.conf',
-   configuration : con2,
+   output: 'dell-esrt.conf',
+   configuration: con2,
    install: true,
 -  install_dir: join_paths(sysconfdir, 'fwupd', 'remotes.d'),
 +  install_dir: join_paths(sysconfdir_install, 'fwupd', 'remotes.d'),
  )
  endif
 diff --git a/plugins/msr/meson.build b/plugins/msr/meson.build
-index 1a278375..f57ae530 100644
+index 13f03ccd4..9235ebe33 100644
 --- a/plugins/msr/meson.build
 +++ b/plugins/msr/meson.build
-@@ -12,7 +12,7 @@ install_data(['fwupd-msr.conf'],
+@@ -10,7 +10,7 @@ install_data(['fwupd-msr.conf'],
  endif
  
  install_data(['msr.conf'],
--  install_dir:  join_paths(sysconfdir, 'fwupd')
-+  install_dir:  join_paths(sysconfdir_install, 'fwupd')
+-  install_dir: join_paths(sysconfdir, 'fwupd')
++  install_dir: join_paths(sysconfdir_install, 'fwupd')
  )
  shared_module('fu_plugin_msr',
    fu_hash,
 diff --git a/plugins/redfish/meson.build b/plugins/redfish/meson.build
-index 8717d50f..9a703723 100644
+index 95606e478..e5355e520 100644
 --- a/plugins/redfish/meson.build
 +++ b/plugins/redfish/meson.build
-@@ -51,7 +51,7 @@ shared_module('fu_plugin_redfish',
+@@ -43,7 +43,7 @@ shared_module('fu_plugin_redfish',
  )
  
  install_data(['redfish.conf'],
--  install_dir:  join_paths(sysconfdir, 'fwupd'),
-+  install_dir:  join_paths(sysconfdir_install, 'fwupd'),
+-  install_dir: join_paths(sysconfdir, 'fwupd'),
++  install_dir: join_paths(sysconfdir_install, 'fwupd'),
  )
  
  if get_option('tests')
 diff --git a/plugins/thunderbolt/meson.build b/plugins/thunderbolt/meson.build
-index aa6c8ce1..61734c4d 100644
+index 5f8ffbf90..9ba323e75 100644
 --- a/plugins/thunderbolt/meson.build
 +++ b/plugins/thunderbolt/meson.build
-@@ -35,7 +35,7 @@ fu_plugin_thunderbolt = shared_module('fu_plugin_thunderbolt',
+@@ -32,7 +32,7 @@ fu_plugin_thunderbolt = shared_module('fu_plugin_thunderbolt',
  )
  
  install_data(['thunderbolt.conf'],
--  install_dir:  join_paths(sysconfdir, 'fwupd')
-+  install_dir:  join_paths(sysconfdir_install, 'fwupd')
+-  install_dir: join_paths(sysconfdir, 'fwupd')
++  install_dir: join_paths(sysconfdir_install, 'fwupd')
  )
  # we use functions from 2.52 in the tests
  if get_option('tests') and run_sanitize_unsafe_tests and umockdev.found() and gio.version().version_compare('>= 2.52')
 diff --git a/plugins/uefi-capsule/meson.build b/plugins/uefi-capsule/meson.build
-index 2d9ba819..0feb5f6b 100644
+index ef38dc03e..78ff65e1d 100644
 --- a/plugins/uefi-capsule/meson.build
 +++ b/plugins/uefi-capsule/meson.build
-@@ -21,7 +21,7 @@ if host_machine.system() == 'linux'
-     output : '35_fwupd',
-     configuration : con2,
+@@ -20,7 +20,7 @@ if host_machine.system() == 'linux'
+     output: '35_fwupd',
+     configuration: con2,
      install: true,
 -    install_dir: join_paths(sysconfdir, 'grub.d')
 +    install_dir: join_paths(sysconfdir_install, 'grub.d')
    )
  elif host_machine.system() == 'freebsd'
    backend_srcs += 'fu-uefi-backend-freebsd.c'
-@@ -112,7 +112,7 @@ if get_option('compat_cli') and get_option('man')
+@@ -110,7 +110,7 @@ if get_option('compat_cli') and get_option('man')
  endif
  
  install_data(['uefi_capsule.conf'],
--  install_dir:  join_paths(sysconfdir, 'fwupd')
-+  install_dir:  join_paths(sysconfdir_install, 'fwupd')
+-  install_dir: join_paths(sysconfdir, 'fwupd')
++  install_dir: join_paths(sysconfdir_install, 'fwupd')
  )
  
  # add all the .po files as inputs to watch

--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -4,7 +4,7 @@
 , lib
 , fetchurl
 , fetchFromGitHub
-, gtk-doc
+, gi-docgen
 , pkg-config
 , gobject-introspection
 , gettext
@@ -17,7 +17,6 @@
 , libarchive
 , curl
 , libjcat
-, libxslt
 , elfutils
 , libsmbios
 , efivar
@@ -25,8 +24,6 @@
 , meson
 , libuuid
 , colord
-, docbook_xml_dtd_43
-, docbook-xsl-nons
 , ninja
 , gcab
 , gnutls
@@ -117,7 +114,7 @@ let
 
   self = stdenv.mkDerivation rec {
     pname = "fwupd";
-    version = "1.8.1";
+    version = "1.8.3";
 
     # libfwupd goes to lib
     # daemon, plug-ins and libfwupdplugin go to out
@@ -126,7 +123,7 @@ let
 
     src = fetchurl {
       url = "https://people.freedesktop.org/~hughsient/releases/fwupd-${version}.tar.xz";
-      sha256 = "sha256-V1ZGZELrkTT7QM3IpG+eAQAyR8jqyC+l2LFvZCA3W3k=";
+      sha256 = "sha256-ciIpd86KhmJRH/o8CIFWb2xFjsjWHSUNlGYRfWEiOOw=";
     };
 
     patches = [
@@ -152,7 +149,7 @@ let
     nativeBuildInputs = [
       meson
       ninja
-      gtk-doc
+      gi-docgen
       pkg-config
       gobject-introspection
       gettext
@@ -160,9 +157,6 @@ let
       valgrind
       gcab
       gnutls
-      docbook_xml_dtd_43
-      docbook-xsl-nons
-      libxslt
       protobufc # for protoc
       python
       wrapGAppsHook
@@ -201,7 +195,7 @@ let
     ];
 
     mesonFlags = [
-      "-Ddocs=gtkdoc"
+      "-Ddocs=enabled"
       "-Dplugin_dummy=true"
       # We are building the official releases.
       "-Dsupported_build=enabled"
@@ -216,6 +210,8 @@ let
       "-Dsysconfdir_install=${placeholder "out"}/etc"
       "-Defi_os_dir=nixos"
       "-Dplugin_modem_manager=enabled"
+      # Requires Meson 0.63
+      "-Dgresource_quirks=disabled"
 
       # We do not want to place the daemon into lib (cyclic reference)
       "--libexecdir=${placeholder "out"}/libexec"
@@ -261,8 +257,18 @@ let
         meson_post_install.sh \
         po/test-deps
 
+      # This checks a version of a dependency of gi-docgen but gi-docgen is self-contained in Nixpkgs.
+      echo "Clearing docs/test-deps.py"
+      test -f docs/test-deps.py
+      echo > docs/test-deps.py
+
       substituteInPlace data/installed-tests/fwupdmgr-p2p.sh \
         --replace "gdbus" ${glib.bin}/bin/gdbus
+    '';
+
+    preBuild = ''
+      # jcat-tool at buildtime requires a home directory
+      export HOME="$(mktemp -d)"
     '';
 
     preCheck = ''
@@ -298,8 +304,8 @@ let
       )
     '';
 
-    # Since we had to disable wrapGAppsHook, we need to wrap the executables manually.
     postFixup = ''
+      # Since we had to disable wrapGAppsHook, we need to wrap the executables manually.
       find -L "$out/bin" "$out/libexec" -type f -executable -print0 \
         | while IFS= read -r -d ''' file; do
         if [[ "$file" != *.efi ]]; then
@@ -307,6 +313,9 @@ let
           wrapGApp "$file"
         fi
       done
+
+      # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
+      moveToOutput "share/doc" "$devdoc"
     '';
 
     separateDebugInfo = true;

--- a/pkgs/os-specific/linux/firmware/fwupd/install-fwupdplugin-to-out.patch
+++ b/pkgs/os-specific/linux/firmware/fwupd/install-fwupdplugin-to-out.patch
@@ -4,11 +4,11 @@ index 1afa28e1..3da81d30 100644
 +++ b/libfwupdplugin/meson.build
 @@ -220,7 +220,8 @@ fwupdplugin = library(
    ],
-   link_args : cc.get_supported_link_arguments([vflag]),
-   link_depends : fwupdplugin_mapfile,
--  install : true
-+  install : true,
-+  install_dir : bindir / '..' / 'lib',
+   link_args: cc.get_supported_link_arguments([vflag]),
+   link_depends: fwupdplugin_mapfile,
+-  install: true
++  install: true,
++  install_dir: bindir / '..' / 'lib',
  )
  
  fwupdplugin_pkgg = import('pkgconfig')
@@ -16,9 +16,9 @@ index 1afa28e1..3da81d30 100644
        girtargets,
        fwupd_gir[0],
      ],
--    install : true
-+    install : true,
-+    install_dir_typelib : bindir / '..' / 'lib' / 'girepository-1.0',
+-    install: true
++    install: true,
++    install_dir_typelib: bindir / '..' / 'lib' / 'girepository-1.0',
    )
  
    # Verify the map file is correct -- note we can't actually use the generated


### PR DESCRIPTION
###### Description of changes

https://github.com/fwupd/fwupd/releases/tag/1.8.2
https://github.com/fwupd/fwupd/releases/tag/1.8.3

https://blogs.gnome.org/hughsie/2022/07/29/emulated-host-profiles-in-fwupd/

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
