### PR TITLE
pythonPackages.oscpy: fix flaky tests

### DIFF
--- a/pkgs/development/python-modules/oscpy/default.nix
+++ b/pkgs/development/python-modules/oscpy/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchFromGitHub, pytestCheckHook }:
+{ lib, buildPythonPackage, fetchFromGitHub, fetchpatch, pytestCheckHook }:
 
 buildPythonPackage rec {
   pname = "oscpy";
@@ -10,6 +10,15 @@ buildPythonPackage rec {
     rev = "v${version}";
     hash = "sha256-Luj36JLgU9xbBMydeobyf98U5zs5VwWQOPGV7TPXQwA=";
   };
+
+  patches = [
+    # Fix flaky tests with kivy/oscpy#67 - https://github.com/kivy/oscpy/pull/67
+    (fetchpatch {
+      name = "improve-reliability-of-test_intercept_errors.patch";
+      url = "https://github.com/kivy/oscpy/commit/2bc114a97692aef28f8b84d52d0d5a41554a7d93.patch";
+      hash = "sha256-iT7cB3ChWD1o0Zx7//Czkk8TaU1oTU1pRQWvPeIpeWY=";
+    })
+  ];
 
   checkInputs = [ pytestCheckHook ];
 


### PR DESCRIPTION
###### Description of changes

The Hydra build has been failing every few times due to the flaky oscpy tests (see builds [182318295](https://hydra.nixos.org/build/182318295) and [184814775](https://hydra.nixos.org/build/184814775/nixlog/3/tail)). This PR pulls the 3 commits from kivy/oscpy#67 to fix them

cc: @yurkobb

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### nixpkgs-review

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages built:</summary>
  <ul>
    <li>python310Packages.oscpy</li>
    <li>python39Packages.oscpy</li>
  </ul>
</details>