### PR TITLE
nushell: 0.65.0 -> 0.67.0

### DIFF
--- a/pkgs/shells/nushell/default.nix
+++ b/pkgs/shells/nushell/default.nix
@@ -13,7 +13,6 @@
 , Security
 , nghttp2
 , libgit2
-, cargo-edit
 , withExtraFeatures ? true
 , testers
 , nushell
@@ -30,23 +29,10 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-PaPj2hbObY4wXubN3Mvr0TlpI13Zgkey90qAgpB0qOo=";
   };
 
-  cargoSha256 = "sha256-4gYafGaQu+UWMQoQ9bf8Cm5rKZhO5ZbKDOitC4HXNdI=";
-  # Since 0.34, nu has an indirect dependency on `zstd-sys` (via `polars` and
-  # `parquet`, for dataframe support), which by default has an impure build
-  # (git submodule for the `zstd` C library). The `pkg-config` feature flag
-  # fixes this, but it's hard to invoke this in the right place, because of
-  # the indirect dependencies. So add a direct dependency on `zstd-sys` here
-  # at the top level, along with this feature flag, to ensure that when
-  # `zstd-sys` is transitively invoked, it triggers a pure build using the
-  # system `zstd` library provided above.
-  depsExtraArgs = { nativeBuildInputs = [ cargo-edit ]; };
-  # cargo add has been merged in to cargo so the above can be removed once 1.62.0 is available in nixpkgs
-  # https://github.com/rust-lang/cargo/pull/10472
-  cargoUpdateHook = ''
-    cargo add zstd-sys --features pkg-config --offline
-    # write the change to the lockfile
-    cargo update --package zstd-sys --offline
-  '';
+  cargoSha256 = "sha256-KRkPVemgK7RDWJi4TqHNqZLwpwUkx+K15u52Do+pqik=";
+
+  # enable pkg-config feature of zstd
+  cargoPatches = [ ./zstd-pkg-config.patch ];
 
   nativeBuildInputs = [ pkg-config ]
     ++ lib.optionals (withExtraFeatures && stdenv.isLinux) [ python3 ]

--- a/pkgs/shells/nushell/default.nix
+++ b/pkgs/shells/nushell/default.nix
@@ -24,16 +24,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "nushell";
-  version = "0.66.2";
+  version = "0.67.0";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "sha256-PaPj2hbObY4wXubN3Mvr0TlpI13Zgkey90qAgpB0qOo=";
+    sha256 = "sha256-O5uM27DvcpwlZStFFLYRDRtFXzAzUdG7v0phK9LJsSo=";
   };
 
-  cargoSha256 = "sha256-KRkPVemgK7RDWJi4TqHNqZLwpwUkx+K15u52Do+pqik=";
+  cargoSha256 = "sha256-eGUI+/Vmqv+BCIQCGoF4Egf3oNyonM3tpt1R3EjIocQ=";
 
   # enable pkg-config feature of zstd
   cargoPatches = [ ./zstd-pkg-config.patch ];

--- a/pkgs/shells/nushell/default.nix
+++ b/pkgs/shells/nushell/default.nix
@@ -21,16 +21,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "nushell";
-  version = "0.65.0";
+  version = "0.66.2";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "sha256-KgXhmAOJaAvmNuDqSaW+h6GF5rWYgj8/wn+vz9V9S7M=";
+    sha256 = "sha256-PaPj2hbObY4wXubN3Mvr0TlpI13Zgkey90qAgpB0qOo=";
   };
 
-  cargoSha256 = "sha256-YqtM/1p6oP0+E0rYSFPeCbof06E81eC2PZIwkU7J0I4=";
+  cargoSha256 = "sha256-4gYafGaQu+UWMQoQ9bf8Cm5rKZhO5ZbKDOitC4HXNdI=";
   # Since 0.34, nu has an indirect dependency on `zstd-sys` (via `polars` and
   # `parquet`, for dataframe support), which by default has an impure build
   # (git submodule for the `zstd` C library). The `pkg-config` feature flag
@@ -49,7 +49,8 @@ rustPlatform.buildRustPackage rec {
   '';
 
   nativeBuildInputs = [ pkg-config ]
-    ++ lib.optionals (withExtraFeatures && stdenv.isLinux) [ python3 ];
+    ++ lib.optionals (withExtraFeatures && stdenv.isLinux) [ python3 ]
+    ++ lib.optionals stdenv.isDarwin [ rustPlatform.bindgenHook ];
 
   buildInputs = [ openssl zstd ]
     ++ lib.optionals stdenv.isDarwin [ zlib libiconv Security ]

--- a/pkgs/shells/nushell/default.nix
+++ b/pkgs/shells/nushell/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitHub
+, runCommand
 , rustPlatform
 , openssl
 , zlib
@@ -10,7 +11,10 @@
 , xorg
 , libiconv
 , AppKit
+, Foundation
 , Security
+# darwin.apple_sdk.sdk
+, sdk
 , nghttp2
 , libgit2
 , withExtraFeatures ? true
@@ -40,7 +44,21 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [ openssl zstd ]
     ++ lib.optionals stdenv.isDarwin [ zlib libiconv Security ]
-    ++ lib.optionals (withExtraFeatures && stdenv.isLinux) [ xorg.libX11 ]
+    ++ lib.optionals (stdenv.isDarwin && stdenv.isx86_64) [
+    Foundation
+    (
+      # Pull a header that contains a definition of proc_pid_rusage().
+      # (We pick just that one because using the other headers from `sdk` is not
+      # compatible with our C++ standard library. This header is already in
+      # the standard library on aarch64)
+      # See also:
+      # https://github.com/shanesveller/nixpkgs/tree/90ed23b1b23c8ee67928937bdec7ddcd1a0050f5/pkgs/development/libraries/webkitgtk/default.nix
+      # https://github.com/shanesveller/nixpkgs/blob/90ed23b1b23c8ee67928937bdec7ddcd1a0050f5/pkgs/tools/system/btop/default.nix#L32-L38
+      runCommand "${pname}_headers" { } ''
+        install -Dm444 "${lib.getDev sdk}"/include/libproc.h "$out"/include/libproc.h
+      ''
+    )
+  ] ++ lib.optionals (withExtraFeatures && stdenv.isLinux) [ xorg.libX11 ]
     ++ lib.optionals (withExtraFeatures && stdenv.isDarwin) [ AppKit nghttp2 libgit2 ];
 
   buildFeatures = lib.optional withExtraFeatures "extra";

--- a/pkgs/shells/nushell/zstd-pkg-config.patch
+++ b/pkgs/shells/nushell/zstd-pkg-config.patch
@@ -1,0 +1,31 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index d4c2ebe3a..bc78478c3 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -2641,6 +2641,7 @@ dependencies = [
+  "wax",
+  "which",
+  "windows",
++ "zstd",
+ ]
+ 
+ [[package]]
+@@ -5604,4 +5605,5 @@ checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
+ dependencies = [
+  "cc",
+  "libc",
++ "pkg-config",
+ ]
+diff --git a/crates/nu-command/Cargo.toml b/crates/nu-command/Cargo.toml
+index 8a9d29562..374ffa153 100644
+--- a/crates/nu-command/Cargo.toml
++++ b/crates/nu-command/Cargo.toml
+@@ -89,6 +89,8 @@ wax = { version =  "0.5.0", features = ["diagnostics"] }
+ rusqlite = { version = "0.28.0", features = ["bundled"], optional = true }
+ sqlparser = { version = "0.16.0", features = ["serde"], optional = true }
+ 
++zstd = { version = "*", features = [ "pkg-config" ] }
++
+ [target.'cfg(unix)'.dependencies]
+ umask = "2.0.0"
+ users = "0.11.0"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24470,7 +24470,8 @@ with pkgs;
   nsh = callPackage ../shells/nsh { };
 
   nushell = callPackage ../shells/nushell {
-    inherit (darwin.apple_sdk.frameworks) AppKit Security;
+    inherit (darwin.apple_sdk.frameworks) AppKit Foundation Security;
+    inherit (darwin.apple_sdk) sdk;
   };
 
   nettools = if stdenv.isLinux


### PR DESCRIPTION
###### Description of changes

https://www.nushell.sh/blog/2022-07-26-nushell-0_66.html
https://github.com/nushell/nushell/releases/tag/0.66.1
https://github.com/nushell/nushell/releases/tag/0.66.2
https://github.com/nushell/nushell/compare/0.66.0...0.66.2

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
