### PR TITLE
python3Packages.commitizen: 2.21.2 -> 2.29.2

### DIFF
--- a/pkgs/applications/version-management/commitizen/default.nix
+++ b/pkgs/applications/version-management/commitizen/default.nix
@@ -16,6 +16,7 @@
 , termcolor
 , tomlkit
 , typing-extensions
+, chardet
 
 , argcomplete, fetchPypi
 }:
@@ -34,13 +35,13 @@ in
 
 buildPythonApplication rec {
   pname = "commitizen";
-  version = "2.21.2";
+  version = "2.29.2";
 
   src = fetchFromGitHub {
     owner = "commitizen-tools";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-7S676bpSrlAqpbgDj9nAo0WjeitbbHoYc693MJm35Js=";
+    hash = "sha256-4mK+GA1rfctJkMv4ZMfXE/qih/9fF0kwT6bIcLVB/Bk=";
     deepClone = true;
   };
 
@@ -49,6 +50,7 @@ buildPythonApplication rec {
   nativeBuildInputs = [ poetry ];
 
   propagatedBuildInputs = [
+    chardet
     termcolor
     questionary
     colorama
@@ -85,6 +87,8 @@ buildPythonApplication rec {
     "test_bump_on_git_with_hooks_no_verify_disabled"
     "test_bump_on_git_with_hooks_no_verify_enabled"
     "test_bump_patch_increment"
+    "test_bump_pre_commit_changelog"
+    "test_bump_pre_commit_changelog_fails_always"
     "test_bump_tag_exists_raises_exception"
     "test_bump_when_bumpping_is_not_support"
     "test_bump_when_version_inconsistent_in_version_files"

--- a/pkgs/development/python-modules/questionary/default.nix
+++ b/pkgs/development/python-modules/questionary/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "questionary";
-  version = "1.10.0";
+  version = "unstable-2022-07-27";
   format = "pyproject";
 
   disabled = pythonOlder "3.6";
@@ -18,8 +18,8 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "tmbo";
     repo = pname;
-    rev = version;
-    sha256 = "14k24fq2nmk90iv0k7pnmmdhmk8z261397wg52sfcsccyhpdw3i7";
+    rev = "848b040c5b7086ffe75bd92c656e15e94d905146";
+    hash = "sha256-W0d1Uoy5JdN3BFfeyk1GG0HBzmgKoBApaGad0UykZaY=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
- python3Packages.questionary: 1.10.0 -> unstable-2022-07-27
- python3Packages.commitizen: 2.21.2 -> 2.29.2

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
