### PR TITLE
openjdk17: Remove default java.library.path

### DIFF
--- a/pkgs/development/compilers/openjdk/17.nix
+++ b/pkgs/development/compilers/openjdk/17.nix
@@ -41,6 +41,7 @@ let
       ./currency-date-range-jdk10.patch
       ./increase-javadoc-heap-jdk13.patch
       ./ignore-LegalNoticeFilePlugin.patch
+      ./fix-library-path-jdk17.patch
 
       # -Wformat etc. are stricter in newer gccs, per
       # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=79677

--- a/pkgs/development/compilers/openjdk/fix-library-path-jdk17.patch
+++ b/pkgs/development/compilers/openjdk/fix-library-path-jdk17.patch
@@ -1,0 +1,60 @@
+--- a/src/hotspot/os/linux/os_linux.cpp
++++ b/src/hotspot/os/linux/os_linux.cpp
+@@ -412,18 +412,8 @@ void os::init_system_properties_values() {
+   //        1: ...
+   //        ...
+   //        7: The default directories, normally /lib and /usr/lib.
+-#ifndef OVERRIDE_LIBPATH
+-  #if defined(_LP64)
+-    #define DEFAULT_LIBPATH "/usr/lib64:/lib64:/lib:/usr/lib"
+-  #else
+-    #define DEFAULT_LIBPATH "/lib:/usr/lib"
+-  #endif
+-#else
+-  #define DEFAULT_LIBPATH OVERRIDE_LIBPATH
+-#endif
+ 
+ // Base path of extensions installed on the system.
+-#define SYS_EXT_DIR     "/usr/java/packages"
+ #define EXTENSIONS_DIR  "/lib/ext"
+ 
+   // Buffer that fits several sprintfs.
+@@ -431,7 +421,7 @@ void os::init_system_properties_values() {
+   // by the nulls included by the sizeof operator.
+   const size_t bufsize =
+     MAX2((size_t)MAXPATHLEN,  // For dll_dir & friends.
+-         (size_t)MAXPATHLEN + sizeof(EXTENSIONS_DIR) + sizeof(SYS_EXT_DIR) + sizeof(EXTENSIONS_DIR)); // extensions dir
++         (size_t)MAXPATHLEN + sizeof(EXTENSIONS_DIR) + sizeof(EXTENSIONS_DIR)); // extensions dir
+   char *buf = NEW_C_HEAP_ARRAY(char, bufsize, mtInternal);
+ 
+   // sysclasspath, java_home, dll_dir
+@@ -478,26 +468,22 @@ void os::init_system_properties_values() {
+     // should always exist (until the legacy problem cited above is
+     // addressed).
+     const char *v = ::getenv("LD_LIBRARY_PATH");
+-    const char *v_colon = ":";
+-    if (v == NULL) { v = ""; v_colon = ""; }
++    if (v == NULL) { v = ""; }
+     // That's +1 for the colon and +1 for the trailing '\0'.
+     char *ld_library_path = NEW_C_HEAP_ARRAY(char,
+-                                             strlen(v) + 1 +
+-                                             sizeof(SYS_EXT_DIR) + sizeof("/lib/") + sizeof(DEFAULT_LIBPATH) + 1,
++                                             strlen(v) + 1,
+                                              mtInternal);
+-    sprintf(ld_library_path, "%s%s" SYS_EXT_DIR "/lib:" DEFAULT_LIBPATH, v, v_colon);
++    sprintf(ld_library_path, "%s", v);
+     Arguments::set_library_path(ld_library_path);
+     FREE_C_HEAP_ARRAY(char, ld_library_path);
+   }
+ 
+   // Extensions directories.
+-  sprintf(buf, "%s" EXTENSIONS_DIR ":" SYS_EXT_DIR EXTENSIONS_DIR, Arguments::get_java_home());
++  sprintf(buf, "%s" EXTENSIONS_DIR, Arguments::get_java_home());
+   Arguments::set_ext_dirs(buf);
+ 
+   FREE_C_HEAP_ARRAY(char, buf);
+ 
+-#undef DEFAULT_LIBPATH
+-#undef SYS_EXT_DIR
+ #undef EXTENSIONS_DIR
+ }


### PR DESCRIPTION
see #103493, #127106 and #123708

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
