### PR TITLE
jetbrains.jdk: openjdk11 (11.0.13-b1751.25) → openjdk17 (17.0.3-b469.37)

### DIFF
--- a/pkgs/development/compilers/jetbrains-jdk/default.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/default.nix
@@ -1,16 +1,24 @@
-{ lib, openjdk11, fetchFromGitHub, jetbrains }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, jetbrains
+, openjdk17
+}:
 
-openjdk11.overrideAttrs (oldAttrs: rec {
+openjdk17.overrideAttrs (oldAttrs: rec {
   pname = "jetbrains-jdk";
-  version = "11_0_13-b1751.25";
+  version = "17.0.3-b469.37";
 
   src = fetchFromGitHub {
     owner = "JetBrains";
     repo = "JetBrainsRuntime";
     rev = "jb${version}";
-    sha256 = "sha256-TPNYZUkAoiZfp7Ci3fslKnRNGY1lnyIhXYUt6J31lwI=";
+    hash =
+     # Upstream issue: https://github.com/JetBrains/JetBrainsRuntime/issues/163
+     if stdenv.isDarwin then "sha256-ExRvjs53rIuhUx4oCgAqu1Av3CNAgmE1ZlN0srEh3XM="
+     else "sha256-O+OIDRJcIsb/vhO2+SYuYdUYWYTGkBcQ9cHTExLIFDE=";
   };
-  patches = [];
+
   meta = with lib; {
     description = "An OpenJDK fork to better support Jetbrains's products.";
     longDescription = ''
@@ -25,9 +33,10 @@ openjdk11.overrideAttrs (oldAttrs: rec {
      your own risk.
     '';
     homepage = "https://confluence.jetbrains.com/display/JBR/JetBrains+Runtime";
-    inherit (openjdk11.meta) license platforms mainProgram;
+    inherit (openjdk17.meta) license platforms mainProgram;
     maintainers = with maintainers; [ edwtjo ];
   };
+
   passthru = oldAttrs.passthru // {
     home = "${jetbrains.jdk}/lib/openjdk";
   };

--- a/pkgs/development/compilers/jetbrains-jdk/default.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/default.nix
@@ -35,6 +35,8 @@ openjdk17.overrideAttrs (oldAttrs: rec {
     homepage = "https://confluence.jetbrains.com/display/JBR/JetBrains+Runtime";
     inherit (openjdk17.meta) license platforms mainProgram;
     maintainers = with maintainers; [ edwtjo ];
+
+    broken = stdenv.isDarwin;
   };
 
   passthru = oldAttrs.passthru // {

--- a/pkgs/top-level/java-packages.nix
+++ b/pkgs/top-level/java-packages.nix
@@ -127,7 +127,7 @@ in {
         inherit openjdk15-bootstrap;
       });
 
-    openjdk17-bootstrap = mkBootstrap adoptopenjdk-16
+    openjdk17-bootstrap = mkBootstrap adoptopenjdk-17
       ../development/compilers/openjdk/16.nix
       (bootstrapArgs // {
         inherit openjdk16-bootstrap;


### PR DESCRIPTION
###### Description of changes

Two bundled updates, one of runtime (JBR) and IntelliJ IDEA Community Edition

I had been using the JBR 17 update for a while in previous versions of Idea Comumnity (only nuance were some warnings), with upstream moving the default forward this might be a good time to move nixpkgs default runtime forward too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
