### PR TITLE
qemu: 7.0.0 -> 7.1.0

### DIFF
--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -41,11 +41,11 @@ stdenv.mkDerivation rec {
     + lib.optionalString xenSupport "-xen"
     + lib.optionalString hostCpuOnly "-host-cpu-only"
     + lib.optionalString nixosTestRunner "-for-vm-tests";
-  version = "7.0.0";
+  version = "7.1.0";
 
   src = fetchurl {
-    url= "https://download.qemu.org/qemu-${version}.tar.xz";
-    sha256 = "sha256-9rN1x5UfcoQCeYsLqrsthkeMpT1Eztvvq74cRr9G+Dk=";
+    url = "https://download.qemu.org/qemu-${version}.tar.xz";
+    sha256 = "1rmvrgqjhrvcmchnz170dxvrrf14n6nm39y8ivrprmfydd9lwqx0";
   };
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
@@ -108,44 +108,6 @@ stdenv.mkDerivation rec {
       url = "https://gitlab.com/qemu-project/qemu/-/commit/3e4546d5bd38a1e98d4bd2de48631abf0398a3a2.diff";
       sha256 = "sha256-oC+bRjEHixv1QEFO9XAm4HHOwoiT+NkhknKGPydnZ5E=";
       revert = true;
-    })
-    # make nixos tests that boot from USB more stable
-    # https://lists.nongnu.org/archive/html/qemu-devel/2022-05/msg01484.html
-    (fetchpatch {
-      url = "https://gitlab.com/raboof/qemu/-/commit/3fb5e8fe4434130b1167a995b2a01c077cca2cd5.patch";
-      sha256 = "sha256-evzrN3i4ntc/AFG0C0rezQpQbWcnx74nXO+5DLErX8o=";
-    })
-    # fix 9p on macOS host, landed in master
-    (fetchpatch {
-      name = "fix-9p-on-macos.patch";
-      url = "https://gitlab.com/qemu/qemu/-/commit/f5643914a9e8f79c606a76e6a9d7ea82a3fc3e65.patch";
-      sha256 = "sha256-8i13wU135h+YxoXFtkXweBN3hMslpWoNoeQ7Ydmn3V4=";
-    })
-    (fetchpatch {
-      name = "CVE-2022-35414.patch";
-      url = "https://gitlab.com/qemu-project/qemu/-/commit/418ade7849ce7641c0f7333718caf5091a02fd4c.patch";
-      sha256 = "sha256-zQHDXedIXZBnabv4+3TA4z5mY1+KZiPmqUbhaSkGLgA=";
-    })
-    # needed for CVE-2022-0216's test to pass
-    (fetchpatch {
-      name = "fuzz-tests-x86-only.patch";
-      url = "https://gitlab.com/qemu-project/qemu/-/commit/b911c30c566dee48a27bc1bfa1ee6df3a729cbbb.patch";
-      sha256 = "sha256-RXKRmZo25yZ1VuBtBA+BsY8as9kIcACqE6aEYmIm9KQ=";
-    })
-    (fetchpatch {
-      name = "CVE-2022-0216.part-1.patch";
-      url = "https://gitlab.com/qemu-project/qemu/-/commit/6c8fa961da5e60f574bb52fd3ad44b1e9e8ad4b8.patch";
-      sha256 = "sha256-0z0zVPBVXFSU8qEV0Ea2+rDxyikMyitlDM0jZOLLC6s=";
-    })
-    (fetchpatch {
-      name = "CVE-2022-0216.part-2.patch";
-      url = "https://gitlab.com/qemu-project/qemu/-/commit/4367a20cc442c56b05611b4224de9a61908f9eac.patch";
-      sha256 = "sha256-hpNu4Zjw1dIbT6Vt57cayHE1Elaltp0a/bsKlDY0Qr8=";
-    })
-    (fetchpatch {
-      name = "CVE-2020-14394.patch";
-      url = "https://gitlab.com/qemu-project/qemu/-/commit/effaf5a240e03020f4ae953e10b764622c3e87cc.patch";
-      sha256 = "sha256-NobsIxRC+xlyj8d/oD4mqgXAGX37pfww/PQQuKhrTzc=";
     })
   ]
   ++ lib.optional nixosTestRunner ./force-uid0-on-9p.patch;

--- a/pkgs/applications/virtualization/qemu/fix-qemu-ga.patch
+++ b/pkgs/applications/virtualization/qemu/fix-qemu-ga.patch
@@ -1,16 +1,17 @@
-diff -Naur a/qga/commands-posix.c b/qga/commands-posix.c
---- a/qga/commands-posix.c
-+++ b/qga/commands-posix.c
-@@ -109,6 +109,8 @@
-         reopen_fd_to_null(1);
-         reopen_fd_to_null(2);
- 
-+        execle("/run/current-system/sw/bin/shutdown", "shutdown", "-h", shutdown_flag, "+0",
-+               "hypervisor initiated shutdown", (char*)NULL, environ);
-         execle("/sbin/shutdown", "shutdown", "-h", shutdown_flag, "+0",
-                "hypervisor initiated shutdown", (char*)NULL, environ);
-         _exit(EXIT_FAILURE);
-@@ -157,11 +159,13 @@
+diff --git i/qga/commands-posix.c w/qga/commands-posix.c
+index 954efed01b..39c4b916ce 100644
+--- i/qga/commands-posix.c
++++ w/qga/commands-posix.c
+@@ -123,6 +123,8 @@ void qmp_guest_shutdown(bool has_mode, const char *mode, Error **errp)
+         execl("/sbin/shutdown", "shutdown", shutdown_flag, "-g0", "-y",
+               "hypervisor initiated shutdown", (char *)NULL);
+ #else
++        execl("/run/current-system/sw/bin/shutdown", "shutdown", "-h", shutdown_flag, "+0",
++               "hypervisor initiated shutdown", (char *)NULL);
+         execl("/sbin/shutdown", "shutdown", "-h", shutdown_flag, "+0",
+                "hypervisor initiated shutdown", (char *)NULL);
+ #endif
+@@ -158,11 +160,13 @@ void qmp_guest_set_time(bool has_time, int64_t time_ns, Error **errp)
      pid_t pid;
      Error *local_err = NULL;
      struct timeval tv;
@@ -25,12 +26,11 @@ diff -Naur a/qga/commands-posix.c b/qga/commands-posix.c
      }
  
      if (!hwclock_available) {
-@@ -207,6 +211,8 @@
+@@ -208,6 +212,7 @@ void qmp_guest_set_time(bool has_time, int64_t time_ns, Error **errp)
  
          /* Use '/sbin/hwclock -w' to set RTC from the system time,
           * or '/sbin/hwclock -s' to set the system time from RTC. */
-+        execle(hwclock_path_nix, "hwclock", has_time ? "-w" : "-s",
-+               NULL, environ);
-         execle(hwclock_path, "hwclock", has_time ? "-w" : "-s",
-                NULL, environ);
++        execl(hwclock_path_nix, "hwclock", has_time ? "-w" : "-s", NULL);
+         execl(hwclock_path, "hwclock", has_time ? "-w" : "-s", NULL);
          _exit(EXIT_FAILURE);
+     } else if (pid < 0) {

--- a/pkgs/applications/virtualization/qemu/revert-ui-cocoa-add-clipboard-support.patch
+++ b/pkgs/applications/virtualization/qemu/revert-ui-cocoa-add-clipboard-support.patch
@@ -1,4 +1,4 @@
-From 19b0952b36b6b5c4bd2665cc0bd4e55a85f81b55 Mon Sep 17 00:00:00 2001
+From 756021d1e433925cf9a732d7ea67b01b0beb061c Mon Sep 17 00:00:00 2001
 From: Will Cohen <willcohen@users.noreply.github.com>
 Date: Tue, 29 Mar 2022 14:00:56 -0400
 Subject: [PATCH] Revert "ui/cocoa: Add clipboard support"
@@ -7,8 +7,8 @@ This reverts commit 7e3e20d89129614f4a7b2451fe321cc6ccca3b76.
 ---
  include/ui/clipboard.h |   2 +-
  ui/clipboard.c         |   2 +-
- ui/cocoa.m             | 121 -----------------------------------------
- 3 files changed, 2 insertions(+), 123 deletions(-)
+ ui/cocoa.m             | 123 -----------------------------------------
+ 3 files changed, 2 insertions(+), 125 deletions(-)
 
 diff --git a/include/ui/clipboard.h b/include/ui/clipboard.h
 index ce76aa451f..c4e1dc4ff4 100644
@@ -37,18 +37,18 @@ index 9079ef829b..6b9ed59e1b 100644
  {
      if (!info ||
 diff --git a/ui/cocoa.m b/ui/cocoa.m
-index c4e5468f9e..cd3bdf0cec 100644
+index 5a8bd5dd84..79ed6d043f 100644
 --- a/ui/cocoa.m
 +++ b/ui/cocoa.m
-@@ -28,7 +28,6 @@
- #include <crt_externs.h>
+@@ -29,7 +29,6 @@
  
- #include "qemu-common.h"
+ #include "qemu/help-texts.h"
+ #include "qemu-main.h"
 -#include "ui/clipboard.h"
  #include "ui/console.h"
  #include "ui/input.h"
  #include "ui/kbd-state.h"
-@@ -107,10 +106,6 @@ static void cocoa_switch(DisplayChangeListener *dcl,
+@@ -109,10 +108,6 @@ static void cocoa_switch(DisplayChangeListener *dcl,
  static QemuSemaphore app_started_sem;
  static bool allow_events;
  
@@ -59,7 +59,7 @@ index c4e5468f9e..cd3bdf0cec 100644
  // Utility functions to run specified code block with iothread lock held
  typedef void (^CodeBlock)(void);
  typedef bool (^BoolCodeBlock)(void);
-@@ -1805,105 +1800,6 @@ static void addRemovableDevicesMenuItems(void)
+@@ -1815,107 +1810,6 @@ static void addRemovableDevicesMenuItems(void)
      qapi_free_BlockInfoList(pointerToFree);
  }
  
@@ -146,16 +146,18 @@ index c4e5468f9e..cd3bdf0cec 100644
 -static void cocoa_clipboard_request(QemuClipboardInfo *info,
 -                                    QemuClipboardType type)
 -{
+-    NSAutoreleasePool *pool;
 -    NSData *text;
 -
 -    switch (type) {
 -    case QEMU_CLIPBOARD_TYPE_TEXT:
+-        pool = [[NSAutoreleasePool alloc] init];
 -        text = [[NSPasteboard generalPasteboard] dataForType:NSPasteboardTypeString];
 -        if (text) {
 -            qemu_clipboard_set_data(&cbpeer, info, type,
 -                                    [text length], [text bytes], true);
--            [text release];
 -        }
+-        [pool release];
 -        break;
 -    default:
 -        break;
@@ -165,7 +167,7 @@ index c4e5468f9e..cd3bdf0cec 100644
  /*
   * The startup process for the OSX/Cocoa UI is complicated, because
   * OSX insists that the UI runs on the initial main thread, and so we
-@@ -1938,7 +1834,6 @@ static void cocoa_clipboard_request(QemuClipboardInfo *info,
+@@ -1950,7 +1844,6 @@ static void cocoa_clipboard_request(QemuClipboardInfo *info,
      COCOA_DEBUG("Second thread: calling qemu_main()\n");
      status = qemu_main(gArgc, gArgv, *_NSGetEnviron());
      COCOA_DEBUG("Second thread: qemu_main() returned, exiting\n");
@@ -173,7 +175,7 @@ index c4e5468f9e..cd3bdf0cec 100644
      exit(status);
  }
  
-@@ -2054,18 +1949,6 @@ static void cocoa_refresh(DisplayChangeListener *dcl)
+@@ -2066,18 +1959,6 @@ static void cocoa_refresh(DisplayChangeListener *dcl)
              [cocoaView setAbsoluteEnabled:YES];
          });
      }
@@ -192,7 +194,7 @@ index c4e5468f9e..cd3bdf0cec 100644
      [pool release];
  }
  
-@@ -2105,10 +1988,6 @@ static void cocoa_display_init(DisplayState *ds, DisplayOptions *opts)
+@@ -2117,10 +1998,6 @@ static void cocoa_display_init(DisplayState *ds, DisplayOptions *opts)
  
      // register vga output callbacks
      register_displaychangelistener(&dcl);


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
**Projected release date: 2022-08-23**

[ChangeLog](https://wiki.qemu.org/ChangeLog/7.1) | [Planning](https://wiki.qemu.org/Planning/7.1)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
