### PR TITLE
python3Packages.python-lsp-server: fix build

### DIFF
--- a/pkgs/development/python-modules/python-lsp-server/default.nix
+++ b/pkgs/development/python-modules/python-lsp-server/default.nix
@@ -23,6 +23,7 @@
 , setuptools-scm
 , stdenv
 , ujson
+, whatthepatch
 , yapf
 , withAutopep8 ? true
 , withFlake8 ? true
@@ -50,7 +51,7 @@ buildPythonPackage rec {
   };
 
   postPatch = ''
-    substituteInPlace setup.cfg \
+    substituteInPlace pyproject.toml \
       --replace "--cov-report html --cov-report term --junitxml=pytest.xml" "" \
       --replace "--cov pylsp --cov test" "" \
       --replace "mccabe>=0.6.0,<0.7.0" "mccabe"
@@ -75,7 +76,7 @@ buildPythonPackage rec {
   ++ lib.optional withPyflakes pyflakes
   ++ lib.optional withPylint pylint
   ++ lib.optional withRope rope
-  ++ lib.optional withYapf yapf;
+  ++ lib.optionals withYapf [ whatthepatch yapf ];
 
   checkInputs = [
     flaky
@@ -87,7 +88,9 @@ buildPythonPackage rec {
   # pyqt5 is broken on aarch64-darwin
   ++ lib.optionals (!stdenv.isDarwin || !stdenv.isAarch64) [ pyqt5 ];
 
-  disabledTests = lib.optional (!withPycodestyle) "test_workspace_loads_pycodestyle_config"
+  disabledTests = [
+    "test_numpy_completions" # https://github.com/python-lsp/python-lsp-server/issues/243
+  ] ++ lib.optional (!withPycodestyle) "test_workspace_loads_pycodestyle_config"
   # pyqt5 is broken on aarch64-darwin
   ++ lib.optional (stdenv.isDarwin && stdenv.isAarch64) "test_pyqt_completion";
 

--- a/pkgs/development/python-modules/whatthepatch/default.nix
+++ b/pkgs/development/python-modules/whatthepatch/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "whatthepatch";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "cscorley";
+    repo = pname;
+    rev = version;
+    hash = "sha256-0l/Ebq7Js9sKFJ/RzkQ1aWEDCxt+COVd2qVnLSWwFx0=";
+  };
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "whatthepatch" ];
+
+  meta = with lib; {
+    description = "Python library for both parsing and applying patch files";
+    homepage = "https://github.com/cscorley/whatthepatch";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jyooru ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11353,6 +11353,8 @@ in {
 
   wget = callPackage ../development/python-modules/wget { };
 
+  whatthepatch = callPackage ../development/python-modules/whatthepatch { };
+
   wheel = callPackage ../development/python-modules/wheel { };
 
   wheel-filename = callPackage ../development/python-modules/wheel-filename { };


### PR DESCRIPTION
###### Description of changes

- yapf tests were failing due to missing whatthepatch
- disabled a test that was failing due to an incompatibility with numpy 1.23 (https://github.com/python-lsp/python-lsp-server/issues/243)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
