### PR TITLE
build-fhs-userenv-bubblewrap: Preserve symlinks in /etc

### DIFF
--- a/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
@@ -98,7 +98,7 @@ let
   '';
 
   bwrapCmd = { initArgs ? "" }: ''
-    blacklist=(/nix /dev /proc /etc)
+    ignored=(/nix /dev /proc /etc)
     ro_mounts=()
     symlinks=()
     etc_ignored=()
@@ -108,10 +108,10 @@ let
         :
       elif [[ -L $i ]]; then
         symlinks+=(--symlink "$(${coreutils}/bin/readlink "$i")" "$path")
-        blacklist+=("$path")
+        ignored+=("$path")
       else
         ro_mounts+=(--ro-bind "$i" "$path")
-        blacklist+=("$path")
+        ignored+=("$path")
       fi
     done
 
@@ -142,8 +142,8 @@ let
     declare -a auto_mounts
     # loop through all directories in the root
     for dir in /*; do
-      # if it is a directory and it is not in the blacklist
-      if [[ -d "$dir" ]] && [[ ! "''${blacklist[@]}" =~ "$dir" ]]; then
+      # if it is a directory and it is not ignored
+      if [[ -d "$dir" ]] && [[ ! "''${ignored[@]}" =~ "$dir" ]]; then
         # add it to the mount list
         auto_mounts+=(--bind "$dir" "$dir")
       fi


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

If the original file in `/etc` is a symlink, make it a symlink inside the sandbox as well. This PR is a more complete solution to https://github.com/NixOS/nixpkgs/issues/126234#issuecomment-1192203498, replacing #145258.

If you bind-mount an individual file and the file is deleted then recreated, the mountpoint will still refer to the original file and cannot be further bind-mounted:

```bash
touch mp1 mp2
echo "original content" >file
sudo mount -o bind file mp1
cat mp1 # "original content"

# delete and recreate the file
rm file
echo "new content" >file
cat mp1 # "original content"

# the steam soldier runtime uses bwrap internally, causing another bind-mount
sudo mount -o bind mp1 mp2 # "mount(2) system call failed: No such file or directory."
```

Since both `/etc/static` and `/run` are bind-mounted already, we should just keep the symlinks inside the sandbox.

Tested in the same manner as in https://github.com/NixOS/nixpkgs/issues/126234#issuecomment-1192203498. I can launch games after disconnecting and reconnecting to Wi-Fi with `steam -steamdeck`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
