### PR TITLE
wdt: unstable-2022-03-24 -> unstable-2022-07-08, add updateScript

### DIFF
--- a/pkgs/applications/networking/sync/wdt/default.nix
+++ b/pkgs/applications/networking/sync/wdt/default.nix
@@ -1,14 +1,26 @@
-{ stdenv, lib, fetchFromGitHub, cmake, folly, boost, gflags, glog, openssl, double-conversion, fmt }:
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, folly
+, boost
+, gflags
+, glog
+, openssl
+, double-conversion
+, fmt
+, unstableGitUpdater
+}:
 
 stdenv.mkDerivation {
   pname = "wdt";
-  version = "unstable-2022-03-24";
+  version = "unstable-2022-07-08";
 
   src = fetchFromGitHub {
     owner = "facebook";
     repo = "wdt";
-    rev = "43319e59d0c77092468367cdadab37d12d7a2383";
-    sha256 = "sha256-MajYK2eTUbWhEql0iTlgW5yLg9xAGZQk+Dx4fNxFFqw=";
+    rev = "8f01b7558a80e5f08b06244d2821c3eb5c1d6e9b";
+    sha256 = "sha256-ozii7EA3j3F/o+lE2mPsUY5lrm3OOtK75gjGkrvoaQ0=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -23,6 +35,10 @@ stdenv.mkDerivation {
   cmakeFlags = [
     "-DWDT_USE_SYSTEM_FOLLY=ON"
   ];
+
+  passthru = {
+    updateScript = unstableGitUpdater { };
+  };
 
   meta = with lib; {
     description = "Warp speed Data Transfer";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
