### PR TITLE
material-kwin-decoration: unstable-2021-10-28 -> unstable-2022-01-19,…

### DIFF
--- a/pkgs/data/themes/material-kwin-decoration/default.nix
+++ b/pkgs/data/themes/material-kwin-decoration/default.nix
@@ -12,23 +12,19 @@
 , kwindowsystem
 , kiconthemes
 , kwayland
+, unstableGitUpdater
 }:
 
 mkDerivation rec {
   pname = "material-kwin-decoration";
-  version = "unstable-2021-10-28";
+  version = "unstable-2022-01-19";
 
   src = fetchFromGitHub {
     owner = "Zren";
     repo = "material-decoration";
-    rev = "cc5cc399a546b66907629b28c339693423c894c8";
-    sha256 = "sha256-aYlnPFhf+ISVe5Ycryu5BSXY8Lb5OoueMqnWQZiv6Lc=";
+    rev = "973949761f609f9c676c5b2b7c6d9560661d34c3";
+    sha256 = "sha256-n+yUmBUrkS+06qLnzl2P6CTQZZbDtJLy+2mDPCcQz9M=";
   };
-
-  postPatch = ''
-    substituteInPlace CMakeLists.txt \
-      --replace "-Werror" ""
-  '';
 
   nativeBuildInputs = [ cmake extra-cmake-modules ];
 
@@ -44,10 +40,14 @@ mkDerivation rec {
     kwayland
   ];
 
+  passthru = {
+    updateScript = unstableGitUpdater { };
+  };
+
   meta = with lib; {
     description = "Material-ish window decoration theme for KWin";
     homepage = "https://github.com/Zren/material-decoration";
     license = licenses.gpl2;
-    maintainers = [ maintainers.nickcao ];
+    maintainers = with maintainers; [ nickcao ];
   };
 }


### PR DESCRIPTION
… add update script

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
