### PR TITLE
Revert "python3Packages.rx: 3.2.0 -> 4.0.4" 

### DIFF
--- a/pkgs/development/python-modules/rx/default.nix
+++ b/pkgs/development/python-modules/rx/default.nix
@@ -1,16 +1,16 @@
-{ lib, fetchFromGitHub, buildPythonPackage, pythonOlder, nose }:
+{ lib, fetchPypi, buildPythonPackage, pythonOlder, nose }:
 
 buildPythonPackage rec {
   pname = "rx";
   version = "3.2.0";
   disabled = pythonOlder "3.6";
 
-  # There are no tests on the pypi source
-  src = fetchFromGitHub {
-    owner = "ReactiveX";
-    repo = "rxpy";
-    rev = "v${version}";
-    sha256 = "159ln0c721rrdz0mqyl3zvv6qsry7ql7ddlpwpnxs9q15ik15mnj";
+  # Use fetchPypi to avoid the updater script to migrate it to `reactivex` which
+  # is being developed in the same repository
+  src = fetchPypi {
+    inherit version;
+    pname = "Rx";
+    sha256 = "b657ca2b45aa485da2f7dcfd09fac2e554f7ac51ff3c2f8f2ff962ecd963d91c";
   };
 
   checkInputs = [ nose ];
@@ -19,6 +19,8 @@ buildPythonPackage rec {
   # test_timeout_schedule_action_cancel: https://hydra.nixos.org/build/74954646
   # test_new_thread_scheduler_timeout: https://hydra.nixos.org/build/74949851
   doCheck = false;
+
+  pythonImportsCheck = [ "rx" ];
 
   meta = {
     homepage = "https://github.com/ReactiveX/RxPY";

--- a/pkgs/development/python-modules/rx/default.nix
+++ b/pkgs/development/python-modules/rx/default.nix
@@ -1,31 +1,17 @@
-{ lib, fetchFromGitHub, buildPythonPackage
-, pythonOlder
-, poetry-core
-, nose
-, typing-extensions
-}:
+{ lib, fetchFromGitHub, buildPythonPackage, pythonOlder, nose }:
 
 buildPythonPackage rec {
   pname = "rx";
-  version = "4.0.4";
+  version = "3.2.0";
   disabled = pythonOlder "3.6";
-  format = "pyproject";
 
   # There are no tests on the pypi source
   src = fetchFromGitHub {
     owner = "ReactiveX";
     repo = "rxpy";
-    rev = "refs/tags/v${version}";
-    sha256 = "sha256-W1qYNbYV6Roz1GJtP/vpoPD6KigWaaQOWe1R5DZHlUw=";
+    rev = "v${version}";
+    sha256 = "159ln0c721rrdz0mqyl3zvv6qsry7ql7ddlpwpnxs9q15ik15mnj";
   };
-
-  nativeBuildInputs = [
-    poetry-core
-  ];
-
-  propagatedBuildInputs = [
-    typing-extensions
-  ];
 
   checkInputs = [ nose ];
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/ReactiveX/rxpy renamed the module name to `reactivex` effectively breaking dependent packages.

This reverts commit eb885d30f983a78778220b10309f6d10b1295cde.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
