### PR TITLE
image-roll: 1.4.1 -> 2.1.0

### DIFF
--- a/pkgs/applications/graphics/image-roll/default.nix
+++ b/pkgs/applications/graphics/image-roll/default.nix
@@ -4,25 +4,30 @@
 , glib
 , pkg-config
 , wrapGAppsHook
-, gtk3
+, gtk4
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "image-roll";
-  version = "1.4.1";
+  version = "2.1.0";
 
   src = fetchFromGitHub {
     owner = "weclaw1";
     repo = pname;
     rev = version;
-    sha256 = "sha256-SyG/syIDnyQaXUgGkXZkY98dmFs7O+OFnGL50250nJI=";
+    sha256 = "sha256-CC40TU38bJFnbJl2EHqeB9RBvbVUrBmRdZVS2GxqGu4=";
   };
 
-  cargoSha256 = "sha256-pyeJ7WmtkbQjbek/rRh2UKFQ5o006Rf7phZ1yl2s4wA=";
+  cargoSha256 = "sha256-cUE2IZOunR/NIo/qytORRfNqCsf87LfpKA8o/v4Nkhk=";
 
   nativeBuildInputs = [ glib pkg-config wrapGAppsHook ];
 
-  buildInputs = [ gtk3 ];
+  buildInputs = [ gtk4 ];
+
+  checkFlags = [
+    # fails in the sandbox
+    "--skip=file_list::tests"
+  ];
 
   postInstall = ''
     install -Dm444 src/resources/com.github.weclaw1.ImageRoll.desktop -t $out/share/applications/


### PR DESCRIPTION
###### Description of changes

https://github.com/weclaw1/image-roll/compare/1.4.1...2.1.0

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
