### PR TITLE
sea-orm-cli: init at 0.9.1

### DIFF
--- a/pkgs/development/tools/rust/sea-orm-cli/default.nix
+++ b/pkgs/development/tools/rust/sea-orm-cli/default.nix
@@ -1,0 +1,31 @@
+{ lib, stdenv, fetchCrate, openssl, pkg-config, rustPlatform
+, SystemConfiguration }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "sea-orm-cli";
+  version = "0.9.1";
+
+  src = fetchCrate {
+    inherit pname version;
+    sha256 = "sha256-OEsUNicNRfXUctpuVAb/3Raa+x6qeg9Mtx9FtHzBcjw=";
+  };
+
+  cargoSha256 = "sha256-aiUk+3Ppn+AgezNnK7s3AlmFTduH8stg3oxHbbczBE0=";
+
+  cargoBuildFlags = [ "--bin" pname ];
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ]
+    ++ lib.optionals stdenv.isDarwin [ SystemConfiguration ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://www.sea-ql.org/SeaORM";
+    description =
+      "SeaORM is a relational ORM to help you build web services in Rust with the familiarity of dynamic languages";
+    license = with licenses; [ asl20 mit ];
+    maintainers = with maintainers; [ lucperkins ];
+    mainProgram = "sea-orm-cli";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14367,6 +14367,10 @@ with pkgs;
     gputils = null;
   };
 
+  sea-orm-cli = callPackage ../development/tools/rust/sea-orm-cli {
+    inherit (darwin.apple_sdk.frameworks) SystemConfiguration;
+  };
+
   seren = callPackage ../applications/networking/instant-messengers/seren { };
 
   serialdv = callPackage ../development/libraries/serialdv {  };


### PR DESCRIPTION
###### Description of changes

This PR adds a package for the CLI tool for [Sea ORM](https://www.sea-ql.org/SeaORM) a popular object-relational mapper for Rust.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
