### PR TITLE
kmymoney: 5.1.1 → 5.1.3

### DIFF
--- a/pkgs/applications/office/kmymoney/default.nix
+++ b/pkgs/applications/office/kmymoney/default.nix
@@ -12,7 +12,6 @@
 , qtbase, xvfb-run
 
 , python3
-, python3Packages
 }:
 
 stdenv.mkDerivation rec {
@@ -29,7 +28,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     doxygen extra-cmake-modules graphviz kdoctools
-    python3Packages.wrapPython wrapQtAppsHook autoPatchelfHook
+    python3.pkgs.wrapPython wrapQtAppsHook autoPatchelfHook
   ];
 
   buildInputs = [
@@ -40,10 +39,10 @@ stdenv.mkDerivation rec {
 
     # Put it into buildInputs so that CMake can find it, even though we patch
     # it into the interface later.
-    python3Packages.woob
+    python3.pkgs.woob
   ];
 
-  woobPythonPath = [ python3Packages.woob ];
+  woobPythonPath = [ python3.pkgs.woob ];
 
   postPatch = ''
     buildPythonPath "$woobPythonPath"

--- a/pkgs/applications/office/kmymoney/default.nix
+++ b/pkgs/applications/office/kmymoney/default.nix
@@ -11,6 +11,7 @@
 # Needed for running tests:
 , qtbase, xvfb-run
 
+, python3
 , python3Packages
 }:
 
@@ -66,7 +67,7 @@ stdenv.mkDerivation rec {
   # libpython is required by the python interpreter embedded in kmymoney, so we
   # need to explicitly tell autoPatchelf about it.
   postFixup = ''
-    patchelf --debug --add-needed libpython3.10.so \
+    patchelf --debug --add-needed libpython${python3.pythonVersion}.so \
       "$out/bin/.kmymoney-wrapped"
   '';
 

--- a/pkgs/applications/office/kmymoney/default.nix
+++ b/pkgs/applications/office/kmymoney/default.nix
@@ -11,7 +11,7 @@
 # Needed for running tests:
 , qtbase, xvfb-run
 
-, python2, python3Packages
+, python3Packages
 }:
 
 stdenv.mkDerivation rec {
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = "-I${kitemmodels.dev}/include/KF5";
 
   nativeBuildInputs = [
-    doxygen extra-cmake-modules graphviz kdoctools python2
+    doxygen extra-cmake-modules graphviz kdoctools
     python3Packages.wrapPython wrapQtAppsHook autoPatchelfHook
   ];
 

--- a/pkgs/applications/office/kmymoney/default.nix
+++ b/pkgs/applications/office/kmymoney/default.nix
@@ -15,11 +15,11 @@
 
 stdenv.mkDerivation rec {
   pname = "kmymoney";
-  version = "5.1.1";
+  version = "5.1.3";
 
   src = fetchurl {
     url = "mirror://kde/stable/kmymoney/${version}/src/${pname}-${version}.tar.xz";
-    sha256 = "sha256-33ufeOhZb5nSgpXKc4cI8GVe4Fd4nf2SHHsbq5ZXgpg=";
+    sha256 = "sha256-OTi4B4tzkboy4Su0I5di+uE0aDoMLsGnUQXDAso+Xj8=";
   };
 
   # Hidden dependency that wasn't included in CMakeLists.txt:
@@ -38,20 +38,20 @@ stdenv.mkDerivation rec {
 
     # Put it into buildInputs so that CMake can find it, even though we patch
     # it into the interface later.
-    python3Packages.weboob
+    python3Packages.woob
   ];
 
-  weboobPythonPath = [ python3Packages.weboob ];
+  woobPythonPath = [ python3Packages.woob ];
 
-  postInstall = ''
-    buildPythonPath "$weboobPythonPath"
-    patchPythonScript "$out/share/kmymoney/weboob/kmymoneyweboob.py"
+  postPatch = ''
+    buildPythonPath "$woobPythonPath"
+    patchPythonScript "kmymoney/plugins/woob/interface/kmymoneywoob.py"
 
     # Within the embedded Python interpreter, sys.argv is unavailable, so let's
     # assign it to a dummy value so that the assignment of sys.argv[0] injected
     # by patchPythonScript doesn't fail:
     sed -i -e '1i import sys; sys.argv = [""]' \
-      "$out/share/kmymoney/weboob/kmymoneyweboob.py"
+      "kmymoney/plugins/woob/interface/kmymoneywoob.py"
   '';
 
   doInstallCheck = stdenv.hostPlatform == stdenv.buildPlatform;

--- a/pkgs/applications/office/kmymoney/default.nix
+++ b/pkgs/applications/office/kmymoney/default.nix
@@ -73,5 +73,6 @@ stdenv.mkDerivation rec {
     homepage = "https://kmymoney.org/";
     platforms = lib.platforms.linux;
     license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ aidalgol das-g ];
   };
 }

--- a/pkgs/applications/office/kmymoney/default.nix
+++ b/pkgs/applications/office/kmymoney/default.nix
@@ -1,5 +1,6 @@
 { stdenv, lib, fetchurl, doxygen, extra-cmake-modules, graphviz, kdoctools
 , wrapQtAppsHook
+, autoPatchelfHook
 
 , akonadi, alkimia, aqbanking, gmp, gwenhywfar, kactivities, karchive
 , kcmutils, kcontacts, kdewebkit, kdiagram, kholidays, kidentitymanagement
@@ -27,7 +28,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     doxygen extra-cmake-modules graphviz kdoctools python2
-    python3Packages.wrapPython wrapQtAppsHook
+    python3Packages.wrapPython wrapQtAppsHook autoPatchelfHook
   ];
 
   buildInputs = [
@@ -61,6 +62,13 @@ stdenv.mkDerivation rec {
       xvfb-run -s '-screen 0 1024x768x24' make test \
         ARGS="-E '(reports-chart-test)'" # Test fails, so exclude it for now.
     '';
+
+  # libpython is required by the python interpreter embedded in kmymoney, so we
+  # need to explicitly tell autoPatchelf about it.
+  postFixup = ''
+    patchelf --debug --add-needed libpython3.10.so \
+      "$out/bin/.kmymoney-wrapped"
+  '';
 
   meta = {
     description = "Personal finance manager for KDE";

--- a/pkgs/applications/office/kmymoney/default.nix
+++ b/pkgs/applications/office/kmymoney/default.nix
@@ -42,10 +42,8 @@ stdenv.mkDerivation rec {
     python3.pkgs.woob
   ];
 
-  woobPythonPath = [ python3.pkgs.woob ];
-
   postPatch = ''
-    buildPythonPath "$woobPythonPath"
+    buildPythonPath "${python3.pkgs.woob}"
     patchPythonScript "kmymoney/plugins/woob/interface/kmymoneywoob.py"
 
     # Within the embedded Python interpreter, sys.argv is unavailable, so let's


### PR DESCRIPTION
fixes #182499

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- bump version to 5.1.3 ([announcement of 5.1.2](https://kmymoney.org/2021/06/23/kmymoney-5-1-2-released.html), [announcement of 5.1.3](https://kmymoney.org/2022/07/30/kmymoney-5-1-3-released.html))
  - this includes [a fix](https://invent.kde.org/office/kmymoney/-/commit/265d4dc3d1dc8592ec1122aa04bfb7d431a43d5d) for #182499 (upstream [Bug 443208](https://bugs.kde.org/show_bug.cgi?id=443208))
- replace `weboob` with `woob` everywhere in `pkgs/applications/office/kmymoney/default.nix`
- patch the WOOB Python script already in the source tree before building (in `postPatch`) rather than after building (`in postInstall`) in the build result `$out`, as it's now embedded into a binary rather than visible in the build result as a separate file.
- remove Python 2 from dependencies, as it isn't needed anymore
- make `libpython` available to `.kmymoney-wrapped`, so that the Python interpreter now embedded in that binary can work

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
  - [x] `meta.description` according to [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)
  - [x] `meta.license` fits upstream license (confirmed by upstream [in their Telegram group](https://t.me/KMyMoney/10763))
  - [x] `meta.maintainers` set

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
