### PR TITLE
linux_xanmod, linux_xanmod_latest: update

### DIFF
--- a/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
@@ -8,8 +8,8 @@ let
   };
 
   edgeVariant = {
-    version = "5.18.15";
-    hash = "sha256-1h5S6ox6v44CK1pSm42HHXHqR7Y0GM+JdcgNC/w5TB4=";
+    version = "5.19.0";
+    hash = "sha256-cudv8Bf58VceZ+zet5XBrTwq0GzYBWX3Od6dtsc5GKU=";
   };
 
   ttVariant = {

--- a/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
@@ -1,14 +1,15 @@
 { lib, stdenv, fetchFromGitHub, buildLinux, ... } @ args:
 
 let
+  # These names are how they are designated in https://xanmod.org.
   ltsVariant = {
     version = "5.15.58";
     hash = "sha256-ToTAqBac/hKUKlnEq49MVGqVUQH3iRm/90e/G2MAxpE=";
   };
 
   edgeVariant = {
-    version = "5.18.11";
-    hash = "sha256-UPLwaEWhBu1yriCUJu9L/B8yy+1zxnTQzHaKlT507UY=";
+    version = "5.18.15";
+    hash = "sha256-1h5S6ox6v44CK1pSm42HHXHqR7Y0GM+JdcgNC/w5TB4=";
   };
 
   ttVariant = {

--- a/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
@@ -2,8 +2,8 @@
 
 let
   ltsVariant = {
-    version = "5.15.54";
-    hash = "sha256-0Odo+ZrQok3MMPl/512F8kIQ31mGZH6e9FyVVpXrYf0=";
+    version = "5.15.58";
+    hash = "sha256-ToTAqBac/hKUKlnEq49MVGqVUQH3iRm/90e/G2MAxpE=";
   };
 
   edgeVariant = {

--- a/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
@@ -9,7 +9,8 @@ let
 
   edgeVariant = {
     version = "5.19.0";
-    hash = "sha256-cudv8Bf58VceZ+zet5XBrTwq0GzYBWX3Od6dtsc5GKU=";
+    suffix = "xanmod2";
+    hash = "sha256-PJY80r5jciVJwB1S82zhii+nplb+D+V7btNq/pVS/NI=";
   };
 
   ttVariant = {

--- a/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
@@ -8,9 +8,8 @@ let
   };
 
   edgeVariant = {
-    version = "5.19.0";
-    suffix = "xanmod2";
-    hash = "sha256-PJY80r5jciVJwB1S82zhii+nplb+D+V7btNq/pVS/NI=";
+    version = "5.19.1";
+    hash = "sha256-Fw+XW2YDAGKEzZ4AO88Y8GcypfOb6AjKp3XOlkT8ZTQ=";
   };
 
   ttVariant = {

--- a/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
@@ -3,8 +3,8 @@
 let
   # These names are how they are designated in https://xanmod.org.
   ltsVariant = {
-    version = "5.15.58";
-    hash = "sha256-ToTAqBac/hKUKlnEq49MVGqVUQH3iRm/90e/G2MAxpE=";
+    version = "5.15.60";
+    hash = "sha256-XSOYgrJ/uvPpEG+P3Zy1geFeF/HMZ4LejsKWtTxMUTs=";
   };
 
   edgeVariant = {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
