### PR TITLE
mopidy: fix pygobject issues for dependent packages

### DIFF
--- a/pkgs/applications/audio/mopidy/mopidy.nix
+++ b/pkgs/applications/audio/mopidy/mopidy.nix
@@ -35,6 +35,10 @@ pythonPackages.buildPythonApplication rec {
     ] ++ lib.optional (!stdenv.isDarwin) dbus-python
   );
 
+  propagatedNativeBuildInputs = [
+    gobject-introspection
+  ];
+
   # There are no tests
   doCheck = false;
 


### PR DESCRIPTION
###### Description of changes

This PR fixes issues for dependent packages of `mopidy`, like `mopidy-local`, which started failing due to pygobject issues related to `gobject-introspection` not getting propagated as both a `buildInput` and a `nativeBuildInput` (see hydra build [185467300](https://hydra.nixos.org/build/185467300)). Specifically, this adds `gobject-introspection` to `propagatedNativeBuildInputs` for the `mopidy` package

I'm not entirely certain what changed 2 days ago to cause it to start failing now (probably something in the last staging-next iteration?), but I do know Python packages are built with `strictDeps = true` by default and `gobject-introspection` needs to be a `buildInput` and a `nativeBuildInput` when strict deps are on (see #56943)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### nixpkgs-review

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>19 packages built:</summary>
  <ul>
    <li>mopidy</li>
    <li>mopidy-bandcamp</li>
    <li>mopidy-iris</li>
    <li>mopidy-jellyfin</li>
    <li>mopidy-local</li>
    <li>mopidy-moped</li>
    <li>mopidy-mopify</li>
    <li>mopidy-mpd</li>
    <li>mopidy-mpris</li>
    <li>mopidy-muse</li>
    <li>mopidy-musicbox-webclient</li>
    <li>mopidy-podcast</li>
    <li>mopidy-scrobbler</li>
    <li>mopidy-somafm</li>
    <li>mopidy-soundcloud</li>
    <li>mopidy-subidy</li>
    <li>mopidy-tunein</li>
    <li>mopidy-youtube</li>
    <li>mopidy-ytmusic</li>
  </ul>
</details>