### PR TITLE
python3Packages.python-lsp-server: fix test issues from 1.5.0 upgrade

### DIFF
--- a/pkgs/development/python-modules/whatthepatch/default.nix
+++ b/pkgs/development/python-modules/whatthepatch/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "whatthepatch";
+  version = "1.0.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-xUDqWRc+CikeGcdC3YtAbFbivgOaYA7bfG/Drku9+p8=";
+  };
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/cscorley/whatthepatch";
+    description = "A Python patch parsing library";
+    maintainers = with maintainers; [ lilyinstarlight ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11357,6 +11357,8 @@ in {
 
   wget = callPackage ../development/python-modules/wget { };
 
+  whatthepatch = callPackage ../development/python-modules/whatthepatch { };
+
   wheel = callPackage ../development/python-modules/wheel { };
 
   wheel-filename = callPackage ../development/python-modules/wheel-filename { };


### PR DESCRIPTION
###### Description of changes

Fixes issues building `python-lsp-server` since it was bumped to 1.5.0 in #181620 (see hydra build [185438708](https://hydra.nixos.org/build/185438708))

Changes:
* The `test_numpy_completion` test is currently broken - see https://github.com/davidhalter/jedi/issues/1864
* The test flags were moved from setup.cfg to pyproject.toml - see https://github.com/python-lsp/python-lsp-server/pull/207
* A dependency on `whatthepatch` was added for yapf - see https://github.com/python-lsp/python-lsp-server/pull/136

The package `python3Packages.spyder` (which depends on this package) is still failing due to the `python3Packages.qdarkstyle` update, but that's unrelated to this PR (I might open another PR to fix that one, but I don't personally use it, unlike this one)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### nixpkgs-review

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages failed to build:</summary>
  <ul>
    <li>spyder (python310Packages.spyder)</li>
    <li>python39Packages.spyder</li>
  </ul>
</details>
<details>
  <summary>14 packages built:</summary>
  <ul>
    <li>python310Packages.pyls-flake8</li>
    <li>python310Packages.pyls-isort</li>
    <li>python310Packages.pyls-spyder</li>
    <li>python310Packages.pylsp-mypy</li>
    <li>python310Packages.python-lsp-black</li>
    <li>python310Packages.python-lsp-server</li>
    <li>python310Packages.whatthepatch</li>
    <li>python39Packages.pyls-flake8</li>
    <li>python39Packages.pyls-isort</li>
    <li>python39Packages.pyls-spyder</li>
    <li>python39Packages.pylsp-mypy</li>
    <li>python39Packages.python-lsp-black</li>
    <li>python39Packages.python-lsp-server</li>
    <li>python39Packages.whatthepatch</li>
  </ul>
</details>