### PR TITLE
uade & bencodetools: renames, tests & bumps

### DIFF
--- a/pkgs/applications/audio/uade/default.nix
+++ b/pkgs/applications/audio/uade/default.nix
@@ -11,17 +11,19 @@
 , lame
 , flac
 , vorbis-tools
+# https://gitlab.com/uade-music-player/uade/-/issues/38
+, withWriteAudio ? !stdenv.hostPlatform.isDarwin
 }:
 
 stdenv.mkDerivation rec {
-  pname = "uade123";
-  version = "3.01";
+  pname = "uade";
+  version = "3.02";
 
   src = fetchFromGitLab {
     owner = "uade-music-player";
     repo = "uade";
     rev = "uade-${version}";
-    sha256 = "0fam3g8mlzrirrac3iwcwsz9jmsqwdy7lkwwdr2q4pkq9cpmh8m5";
+    sha256 = "sha256-skPEXBQwyr326zCmZ2jwGxcBoTt3Y/h2hagDeeqbMpw=";
   };
 
   postPatch = ''
@@ -31,12 +33,18 @@ stdenv.mkDerivation rec {
     substituteInPlace src/frontends/mod2ogg/mod2ogg2.sh.in \
       --replace '-e stat' '-n stat' \
       --replace '/usr/local' "$out"
+    substituteInPlace python/uade/generate_oscilloscope_view.py \
+      --replace "default='uade123'" "default='$out/bin/uade123'"
+    # https://gitlab.com/uade-music-player/uade/-/issues/37
+    substituteInPlace write_audio/Makefile.in \
+      --replace 'g++' '${stdenv.cc.targetPrefix}c++'
   '';
 
   nativeBuildInputs = [
     pkg-config
     which
     makeWrapper
+  ] ++ lib.optionals withWriteAudio [
     python3
   ];
 
@@ -47,14 +55,19 @@ stdenv.mkDerivation rec {
     lame
     flac
     vorbis-tools
+  ] ++ lib.optionals withWriteAudio [
     (python3.withPackages (p: with p; [
       pillow
       tqdm
+      more-itertools
     ]))
   ];
 
   configureFlags = [
     "--bencode-tools-prefix=${bencodetools}"
+    "--with-text-scope"
+  ] ++ lib.optionals (!withWriteAudio) [
+    "--without-write-audio"
   ];
 
   enableParallelBuilding = true;
@@ -66,6 +79,7 @@ stdenv.mkDerivation rec {
       --prefix PATH : $out/bin:${lib.makeBinPath [ sox lame flac vorbis-tools ]}
     # This is an old script, don't break expectations by renaming it
     ln -s $out/bin/mod2ogg2{.sh,}
+  '' + lib.optionalString withWriteAudio ''
     wrapProgram $out/bin/generate_amiga_oscilloscope_view \
       --prefix PYTHONPATH : "$PYTHONPATH:$out/${python3.sitePackages}"
   '';
@@ -79,6 +93,7 @@ stdenv.mkDerivation rec {
     # Let's make it easy and flag the whole package as unfree.
     license = licenses.unfree;
     maintainers = with maintainers; [ OPNA2608 ];
+    mainProgram = "uade123";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/audio/uade123/default.nix
+++ b/pkgs/applications/audio/uade123/default.nix
@@ -6,7 +6,7 @@
 , which
 , makeWrapper
 , libao
-, libbencodetools
+, bencodetools
 , sox
 , lame
 , flac
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     libao
-    libbencodetools
+    bencodetools
     sox
     lame
     flac
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
   ];
 
   configureFlags = [
-    "--bencode-tools-prefix=${libbencodetools}"
+    "--bencode-tools-prefix=${bencodetools}"
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/bencodetools/default.nix
+++ b/pkgs/development/libraries/bencodetools/default.nix
@@ -5,7 +5,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "libbencodetools";
+  pname = "bencodetools";
   version = "unstable-2022-05-11";
 
   src = fetchFromGitLab {
@@ -26,6 +26,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     python3
   ];
+
+  # installCheck instead of check due to -install_name'd library on Darwin
+  doInstallCheck = stdenv.buildPlatform == stdenv.hostPlatform;
+  installCheckTarget = "check";
 
   meta = with lib; {
     description = "Collection of tools for manipulating bencoded data";

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1434,6 +1434,7 @@ mapAliases ({
 
   ### U ###
 
+  uade123 = uade; # Added 2022-07-30
   uberwriter = apostrophe; # Added 2020-04-23
   ubootBeagleboneBlack = ubootAmx335xEVM; # Added 2020-01-21
   uchiwa = throw "uchiwa is deprecated and archived by upstream"; # Added 2022-05-02

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -697,6 +697,7 @@ mapAliases ({
   letsencrypt = throw "'letsencrypt' has been renamed to/replaced by 'certbot'"; # Converted to throw 2022-02-22
   libGL_driver = throw "'libGL_driver' has been renamed to/replaced by 'mesa.drivers'"; # Converted to throw 2022-02-22
   libaudit = throw "'libaudit' has been renamed to/replaced by 'audit'"; # Converted to throw 2022-02-22
+  libbencodetools = bencodetools; # Added 2022-07-30
   libbluedevil = throw "'libbluedevil' (Qt4) is unmaintained and unused since 'kde4.bluedevil's removal in 2017"; # Added 2022-06-14
   libcanberra_gtk2 = throw "'libcanberra_gtk2' has been renamed to/replaced by 'libcanberra-gtk2'"; # Converted to throw 2022-02-22
   libcanberra_gtk3 = throw "'libcanberra_gtk3' has been renamed to/replaced by 'libcanberra-gtk3'"; # Converted to throw 2022-02-22

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17181,6 +17181,8 @@ with pkgs;
 
   belr = callPackage ../development/libraries/belr { };
 
+  bencodetools = callPackage ../development/libraries/bencodetools { };
+
   beignet = callPackage ../development/libraries/beignet {
     inherit (llvmPackages_6) libllvm libclang;
   };
@@ -18775,8 +18777,6 @@ with pkgs;
   libbass_fx = (callPackage ../development/libraries/audio/libbass { }).bass_fx;
 
   libbde = callPackage ../development/libraries/libbde { };
-
-  libbencodetools = callPackage ../development/libraries/libbencodetools { };
 
   libbdplus = callPackage ../development/libraries/libbdplus { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30252,7 +30252,7 @@ with pkgs;
     inherit (gnome) zenity;
   };
 
-  uade123 = callPackage ../applications/audio/uade123 {};
+  uade = callPackage ../applications/audio/uade {};
 
   udevil = callPackage ../applications/misc/udevil {};
 


### PR DESCRIPTION
###### Description of changes

bencodetools:
- rename from libbencodetools (libbencodetools is only one part of the project that was added later on)
- enable tests

uade:
- rename from uade123 (main binary is called uade123, the project itself UADE, the project it's based on UAE)
- 3.01 -> 3.02

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
