### PR TITLE
pycom-fwtool: init at 1.16.5

### DIFF
--- a/pkgs/tools/admin/pycom-fwtool/default.nix
+++ b/pkgs/tools/admin/pycom-fwtool/default.nix
@@ -1,0 +1,58 @@
+{ stdenvNoCC, lib, zlib, libxcb, fetchurl, autoPatchelfHook, buildFHSUserEnv }:
+
+let
+  version = "1.16.5";
+
+  # Unwrapped package, for putting into the FHS env
+  pycom-fwtool-unwrapped = stdenvNoCC.mkDerivation {
+    pname = "pycom-fwtool-unwrapped";
+    inherit version;
+
+    src = fetchurl {
+      url = "https://software.pycom.io/downloads/pycom_firmware_update_${version}-amd64.tar.gz";
+      sha256 = "sha256-AsGblyB+9YU37NiA1Dd83Hhp/9nKZNw5VKy3Jv3RPU4=";
+    };
+
+    sourceRoot = "pyupgrade";
+
+    buildInputs = [ zlib ];
+
+    nativeBuildInputs = [ autoPatchelfHook ];
+
+    installPhase = ''
+      mkdir -p $out/bin
+      install -m755 -D pycom-fwtool $out/bin
+      install -m755 -D pycom-fwtool-cli $out/bin
+    '';
+  };
+
+  # FHS env, since the binary looks for libxcb with dlopen(), and sources can't
+  # be patched
+  env = buildFHSUserEnv {
+    name = "pycom-fwtool-env-${version}";
+    targetPkgs = _: [ pycom-fwtool-unwrapped libxcb ];
+    runScript = "pycom-fwtool";
+  };
+
+in stdenvNoCC.mkDerivation {
+  pname = "pycom-fwtool";
+  inherit version;
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    ln -s ${env}/bin/* $out/bin/pycom-fwtool
+    ln -s ${pycom-fwtool-unwrapped}/bin/pycom-fwtool-cli $out/bin/pycom-fwtool-cli
+  '';
+
+  meta = with lib; {
+    homepage = "https://software.pycom.io/";
+    platforms = [ "x86_64-linux" ];
+    description = "A tool for updating your Pycom device with the specified firmware image file";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ matthewcroughan ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9940,6 +9940,8 @@ with pkgs;
 
   pycflow2dot = with python3.pkgs; toPythonApplication pycflow2dot;
 
+  pycom-fwtool = callPackage ../tools/admin/pycom-fwtool { };
+
   pydf = callPackage ../applications/misc/pydf { };
 
   pyinfra = with python3Packages; toPythonApplication pyinfra;


### PR DESCRIPTION
###### Description of changes

This adds `pycom-fwtool` which is a gui, and `pycom-fwtool-cli` (as part of the same closure since they are distributed together). `pycom-fwtool` is a qt4 gui which uses dlopen() which means we have to use a FHSUserEnv to circumvent its hardcoded paths, since the source code is not available. This is used to flash Pycom hardware boards, and is of particular interest to engineers and developers that need to do that work.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
