### PR TITLE
pkcrack: init at 1.2.2

### DIFF
--- a/pkgs/by-name/pk/pkcrack/package.nix
+++ b/pkgs/by-name/pk/pkcrack/package.nix
@@ -1,0 +1,53 @@
+{ lib
+, stdenv
+, fetchurl
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pkcrack";
+  version = "1.2.2";
+
+  src = fetchurl {
+    url = "https://www.unix-ag.uni-kl.de/~conrad/krypto/pkcrack/pkcrack-${finalAttrs.version}.tar.gz";
+    hash = "sha256-TS3Bk/+kNCrC7TpjEf33cK5qB3Eiaz70U9yo0D5DiVo=";
+  };
+  sourceRoot = "pkcrack-${finalAttrs.version}/src";
+
+  postPatch = ''
+    # malloc.h is not needed because stdlib.h is already included.
+    # On macOS, malloc.h does not even exist, resulting in an error.
+    substituteInPlace exfunc.c extract.c main.c readhead.c zipdecrypt.c \
+      --replace '#include <malloc.h>' ""
+  '';
+
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D extract $out/bin/extract
+    install -D findkey $out/bin/findkey
+    install -D makekey $out/bin/makekey
+    install -D pkcrack $out/bin/pkcrack
+    install -D zipdecrypt $out/bin/zipdecrypt
+
+    mkdir -p $out/share/doc
+    cp -R ../doc/ $out/share/doc/pkcrack
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Breaking PkZip-encryption";
+    homepage = "https://www.unix-ag.uni-kl.de/~conrad/krypto/pkcrack.html";
+    license = {
+      fullName = "PkCrack Non Commercial License";
+      url = "https://www.unix-ag.uni-kl.de/~conrad/krypto/pkcrack/pkcrack-readme.html";
+      free = false;
+    };
+    maintainers = with maintainers; [ emilytrau ];
+    platforms = platforms.all;
+    mainProgram = "pkcrack";
+  };
+})


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

PkCrack is an algorithm for breaking the PkZip cipher that was devised by Eli Biham and Paul Kocher.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
