### PR TITLE
python3Packages.geomdl: init at 5.3.1

### DIFF
--- a/pkgs/development/python-modules/geomdl/default.nix
+++ b/pkgs/development/python-modules/geomdl/default.nix
@@ -1,0 +1,44 @@
+{
+  lib
+  , buildPythonPackage
+  , pythonOlder
+  , fetchFromGitHub
+  , pytestCheckHook
+  , pyparsing
+  , numpy
+  , matplotlib
+  , plotly
+}:
+
+buildPythonPackage rec {
+  version = "5.3.1";
+  pname = "geomdl";
+
+  disabled = pythonOlder "3.4";
+
+  src = fetchFromGitHub {
+    owner = "orbingol";
+    repo = "NURBS-Python";
+    rev = "v${version}";
+    sha256 = "sha256-FboZ6wIvIvwo09+5ZL6skOYRwtDKta3Ywyisq24evfc=";
+  };
+
+  checkInputs = [ pytestCheckHook ];
+
+  pytestFlagsArray = [
+    "-W ignore::DeprecationWarning"
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+    matplotlib
+    plotly
+  ];
+
+  meta = with lib; {
+    description = "A pure Python, self-contained, object-oriented B-Spline and NURBS spline library";
+    homepage = "https://onurraufbingol.com/NURBS-Python/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ marcus7070 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3506,6 +3506,8 @@ in {
 
   geojson-client = callPackage ../development/python-modules/geojson-client { };
 
+  geomdl = callPackage ../development/python-modules/geomdl { };
+
   geomet = callPackage ../development/python-modules/geomet { };
 
   geometric = callPackage ../development/python-modules/geometric { };


### PR DESCRIPTION
###### Description of changes

Adds `geomdl`, an object-oriented B-Spline and NURBS spline library.

nixpkgs currently has an outdated version of `python3Packages.ezdxf`. Recent versions of ezdxf have introduced geomdl as a dependency (just for tests). I'll update ezdxf after this is merged.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Results of nixpkgs-review
Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages built:</summary>
  <ul>
    <li>python310Packages.geomdl</li>
    <li>python39Packages.geomdl</li>
  </ul>
</details>
