### PR TITLE
maestral-gui: fix build by using compatible maestral library

### DIFF
--- a/pkgs/applications/networking/maestral-qt/default.nix
+++ b/pkgs/applications/networking/maestral-qt/default.nix
@@ -70,7 +70,7 @@ pypkgs.buildPythonApplication rec {
   meta = with lib; {
     description = "GUI front-end for maestral (an open-source Dropbox client) for Linux";
     license = licenses.mit;
-    maintainers = with maintainers; [ peterhoeg ];
+    maintainers = with maintainers; [ peterhoeg sfrijters ];
     platforms = platforms.linux;
     homepage = "https://maestral.app";
   };

--- a/pkgs/applications/networking/maestral-qt/default.nix
+++ b/pkgs/applications/networking/maestral-qt/default.nix
@@ -5,21 +5,41 @@
 , nixosTests
 }:
 
-python3.pkgs.buildPythonApplication rec {
+let
+  inherit (pypkgs) makePythonPath;
+
+  pypkgs = (python3.override {
+    packageOverrides = self: super: {
+      # Use last available version of maestral that still supports PyQt5
+      # Remove this override when PyQt6 is available
+      maestral = super.maestral.overridePythonAttrs (old: rec {
+        version = "1.5.3";
+        src = fetchFromGitHub {
+          owner = "SamSchott";
+          repo = "maestral";
+          rev = "refs/tags/v${version}";
+          hash = "sha256-Uo3vcYez2qSq162SSKjoCkwygwR5awzDceIq8/h3dao=";
+        };
+      });
+    };
+  }).pkgs;
+
+in
+pypkgs.buildPythonApplication rec {
   pname = "maestral-qt";
   version = "1.5.3";
-  disabled = python3.pkgs.pythonOlder "3.6";
+  disabled = pypkgs.pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "SamSchott";
     repo = "maestral-qt";
-    rev = "v${version}";
+    rev = "refs/tags/v${version}";
     sha256 = "sha256-zaG9Zwz9S/SVb7xDa7eXkjLNt1BhA1cQ3I18rVt+8uQ=";
   };
 
   format = "pyproject";
 
-  propagatedBuildInputs = with python3.pkgs; [
+  propagatedBuildInputs = with pypkgs; [
     click
     markdown2
     maestral
@@ -36,8 +56,8 @@ python3.pkgs.buildPythonApplication rec {
     "\${qtWrapperArgs[@]}"
 
     # Add the installed directories to the python path so the daemon can find them
-    "--prefix" "PYTHONPATH" ":" "${lib.concatStringsSep ":" (map (p: p + "/lib/${python3.libPrefix}/site-packages") (python3.pkgs.requiredPythonModules python3.pkgs.maestral.propagatedBuildInputs))}"
-    "--prefix" "PYTHONPATH" ":" "${python3.pkgs.maestral}/lib/${python3.libPrefix}/site-packages"
+    "--prefix PYTHONPATH : ${makePythonPath (pypkgs.requiredPythonModules pypkgs.maestral.propagatedBuildInputs)}"
+    "--prefix PYTHONPATH : ${makePythonPath [ pypkgs.maestral ]}"
   ];
 
   # no tests

--- a/pkgs/development/python-modules/maestral/default.nix
+++ b/pkgs/development/python-modules/maestral/default.nix
@@ -90,7 +90,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Open-source Dropbox client for macOS and Linux";
     license = licenses.mit;
-    maintainers = with maintainers; [ peterhoeg ];
+    maintainers = with maintainers; [ peterhoeg sfrijters ];
     platforms = platforms.unix;
     homepage = "https://maestral.app";
   };


### PR DESCRIPTION
###### Description of changes

Latest (automatic?) Python update (a3f1b8c2ad99ceccb1f1f995ea4f9e72704423fd) broke maestral-qt, which is being held back  at version 1.5.3 by the PyQt6 requirement of its latest versions.
Solution: use the old matching maestral version for now. 
I did this rather inelegantly; if someone could tell me the magic incantation to override version/hash inside a Python package in the Python package set that may be a cleaner option.

Added myself as a maintainer since this is not the first time surprise updates related to these packages broke my system and I've done many updates to these packages in the past.

@peterhoeg @mweinelt 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
