### PR TITLE
dbx: 0.5.0 -> 0.6.8 (also fix nixpkgs-review)

### DIFF
--- a/pkgs/applications/misc/dbx/default.nix
+++ b/pkgs/applications/misc/dbx/default.nix
@@ -2,7 +2,7 @@
 , fetchFromGitHub
 , databricks-cli
 , scipy
-, pathpy
+, path
 , pathspec
 , pydantic
 , protobuf
@@ -37,7 +37,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     databricks-cli
     scipy
-    pathpy
+    path
     pathspec
     pydantic
     protobuf

--- a/pkgs/applications/misc/dbx/default.nix
+++ b/pkgs/applications/misc/dbx/default.nix
@@ -18,24 +18,21 @@
 , pytestCheckHook
 , pytest-asyncio
 , pytest-timeout
+, pytest-mock
 , lib
+, git
 }:
 
 buildPythonPackage rec {
   pname = "dbx";
-  version = "0.5.0";
+  version = "0.6.8";
 
   src = fetchFromGitHub {
     owner = "databrickslabs";
     repo = "dbx";
     rev = "v${version}";
-    sha256 = "gd466hhyTfPZwC3B3LlydRrkDtfzjY7SvTKy13HDFG8=";
+    sha256 = "sha256-Ou+VdHFVQzmsxJiyaeDd/+FqHvJZeNGB+OXyoagJwtk=";
   };
-
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "protobuf==4.21.1" "protobuf>=3.19.4"
-  '';
 
   propagatedBuildInputs = [
     databricks-cli
@@ -59,36 +56,15 @@ buildPythonPackage rec {
     pytestCheckHook
     pytest-asyncio
     pytest-timeout
+    pytest-mock
+    git
   ];
 
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
   disabledTests = [
-    # require a HOME for cookiecutter
-    "test_configure"
-    "test_datafactory_deploy"
-    "test_deploy_incorrect_artifact_location"
-    "test_deploy_listed_jobs"
-    "test_deploy_multitask_json"
-    "test_deploy_multitask_yaml"
-    "test_deploy_non_existent_env"
-    "test_deploy_path_adjustment_json"
-    "test_deploy_path_adjustment_yaml"
-    "test_deploy_with_jobs"
-    "test_deploy_with_requirements_and_branch"
-    "test_deployment_with_bad_env_variable"
-    "test_update_job_negative"
-    "test_update_job_positive"
-    "test_with_permissions"
-    "test_write_specs_to_file"
-    "test_awake_cluster"
-    "test_execute"
-    "test_preprocess_cluster_args"
-    "test_launch"
-    "test_launch_run_submit"
-    "test_launch_with_parameters"
-    "test_no_runs"
-    "test_no_runs_run_submit"
-    "test_payload_keys"
-    "test_trace_runs"
     # fails because of dbfs CLI wrong call
     "test_dbfs_unknown_user"
     "test_dbfs_no_root"


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
