### PR TITLE
glances: 3.2.6.4 -> 3.2.7

### DIFF
--- a/pkgs/applications/system/glances/default.nix
+++ b/pkgs/applications/system/glances/default.nix
@@ -9,28 +9,15 @@
 
 buildPythonApplication rec {
   pname = "glances";
-  version = "3.2.6.4";
+  version = "3.2.7";
   disabled = isPyPy;
 
   src = fetchFromGitHub {
     owner = "nicolargo";
     repo = "glances";
     rev = "v${version}";
-    sha256 = "sha256-i88bz6AwfDbqC+7yvr7uDofAqBwQmnfoKbt3iJz4Ft8=";
+    sha256 = "sha256-WZDvC95Y6Xc7dOuPJJlJLI4PCZR76pYPl8NGtmxe91o=";
   };
-
-  # Some tests fail in the sandbox (they e.g. require access to /sys/class/power_supply):
-  patches = lib.optional (doCheck && stdenv.isLinux) ./skip-failing-tests.patch
-    ++ lib.optional (doCheck && stdenv.isDarwin)
-    [
-      # Fix "TypeError: unsupported operand type(s) for +=: 'int' and 'NoneType'" on darwin
-      # https://github.com/nicolargo/glances/pull/2082
-      (fetchpatch {
-        name = "fix-typeerror-when-testing-on-darwin.patch";
-        url = "https://patch-diff.githubusercontent.com/raw/nicolargo/glances/pull/2082.patch";
-        sha256 = "sha256-MIePPywZ2dTTqXjf7EJiHlQ7eltiHzgocqrnLeLJwZ4=";
-      })
-    ];
 
   # On Darwin this package segfaults due to mismatch of pure and impure
   # CoreFoundation. This issues was solved for binaries but for interpreted


### PR DESCRIPTION
###### Description of changes

nicolargo/glances#2082 is part of `3.2.7`.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

