### PR TITLE
python3Packages.mistune_0_8: mark `knownVulnerabilities` for CVE-2022-34749

### DIFF
--- a/pkgs/development/python-modules/mistune/common.nix
+++ b/pkgs/development/python-modules/mistune/common.nix
@@ -1,4 +1,12 @@
-{ lib, buildPythonPackage, fetchPypi, nose, version, sha256, format ? "setuptools" }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, nose
+, version
+, sha256
+, format ? "setuptools"
+, extraMeta ? {}
+}:
 
 buildPythonPackage rec {
   inherit version format;
@@ -15,5 +23,5 @@ buildPythonPackage rec {
     description = "The fastest markdown parser in pure Python";
     homepage = "https://github.com/lepture/mistune";
     license = licenses.bsd3;
-  };
+  } // extraMeta;
 }

--- a/pkgs/development/python-modules/mistune/default.nix
+++ b/pkgs/development/python-modules/mistune/default.nix
@@ -2,6 +2,9 @@ self: rec {
   mistune_0_8 = self.callPackage ./common.nix {
     version = "0.8.4";
     sha256 = "59a3429db53c50b5c6bcc8a07f8848cb00d7dc8bdb431a4ab41920d201d4756e";
+    extraMeta = {
+      knownVulnerabilities = [ "CVE-2022-34749" ];
+    };
   };
   mistune_2_0 = self.callPackage ./common.nix {
     version = "2.0.4";


### PR DESCRIPTION
###### Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2022-34749

If someone wants to backport the fix instead, be my guest. Ultimately we probably want to remove `mistune_0_8`, but we'll still need to apply this `knownVulnerabilities` to 22.05.

`mistune_2_0` addressed in  #184019 & #184050

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
