### PR TITLE
synology-drive-client: multiple changes

### DIFF
--- a/pkgs/applications/networking/synology-drive-client/default.nix
+++ b/pkgs/applications/networking/synology-drive-client/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, lib, qt5, fetchurl, autoPatchelfHook, dpkg, glibc, cpio, xar, undmg, gtk3, pango }:
+{ stdenv, lib, writeScript, qt5, fetchurl, autoPatchelfHook, dpkg, glibc, cpio, xar, undmg, gtk3, pango, libxcb }:
 let
   pname = "synology-drive-client";
   baseUrl = "https://global.download.synology.com/download/Utility/SynologyDriveClient";
-  buildNumber = "12920";
-  version = "3.1.0";
+  version = "3.1.0-12923";
+  buildNumber = with lib; last (splitString "-" version);
   meta = with lib; {
     description = "Desktop application to synchronize files and folders between the computer and the Synology Drive server.";
     homepage = "https://www.synology.com/en-global/dsm/feature/drive";
@@ -11,18 +11,29 @@ let
     maintainers = with maintainers; [ jcouyang MoritzBoehme ];
     platforms = [ "x86_64-linux" "x86_64-darwin" ];
   };
+  passthru.updateScript = writeScript "update-synology-drive-client" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p curl common-updater-scripts
+
+    set -eu -o pipefail
+
+    version="$(curl -s https://www.synology.com/en-uk/releaseNote/SynologyDriveClient \
+             | grep -oP '(?<=data-version=")(\d.){2}\d-\d{5}' \
+             | head -1)"
+    update-source-version synology-drive-client "$version"
+  '';
 
   linux = qt5.mkDerivation {
-    inherit pname version meta;
+    inherit pname version meta passthru;
 
     src = fetchurl {
-      url = "${baseUrl}/${version}-${buildNumber}/Ubuntu/Installer/x86_64/synology-drive-client-${buildNumber}.x86_64.deb";
-      sha256 = "sha256-UAO/LwqPchIMhjdQP4METjVorMJsbvIDRkp4JxtZgOs=";
+      url = "${baseUrl}/${version}/Ubuntu/Installer/x86_64/synology-drive-client-${buildNumber}.x86_64.deb";
+      sha256 = "sha256-gL08uJbA2S+SuP1afMBmcJMIcu7QRzdiXgIMxSZQl/I=";
     };
 
     nativeBuildInputs = [ autoPatchelfHook dpkg ];
 
-    buildInputs = [ glibc gtk3 pango ];
+    buildInputs = [ glibc gtk3 pango libxcb ];
 
     unpackPhase = ''
       mkdir -p $out
@@ -43,11 +54,11 @@ let
   };
 
   darwin = stdenv.mkDerivation {
-    inherit pname version meta;
+    inherit pname version meta passthru;
 
     src = fetchurl {
-      url = "${baseUrl}/${version}-${buildNumber}/Mac/Installer/synology-drive-client-${buildNumber}.dmg";
-      sha256 = "15wici8ycil1mfh5cf89rfan4kb93wfkdsd4kmpvzjj4bnddwlxa";
+      url = "${baseUrl}/${version}/Mac/Installer/synology-drive-client-${buildNumber}.dmg";
+      sha256 = "0pwm2xi1b9p9zmhy4dhix3aas49i183wxslyidfwvlaphic9qkxm";
     };
 
     nativeBuildInputs = [ cpio xar undmg ];


### PR DESCRIPTION
###### Description of changes

Fix issue where `libxcb.so.1` is not found.
Bump version.
Add an update script.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
