### PR TITLE
[22.05] vault, vault-bin: 1.10.3 -> 1.10.5

### DIFF
--- a/pkgs/tools/security/vault/default.nix
+++ b/pkgs/tools/security/vault/default.nix
@@ -6,16 +6,16 @@
 
 buildGoModule rec {
   pname = "vault";
-  version = "1.10.3";
+  version = "1.10.5";
 
   src = fetchFromGitHub {
     owner = "hashicorp";
     repo = "vault";
     rev = "v${version}";
-    sha256 = "sha256-12LOYp2ffTC/IOyNyT2PMnkP4FOKT8HROZNRWyTHxhA=";
+    sha256 = "sha256-c9E+5WviguvZFPryWuXjcocgZdZsithZPmZ1iIC3Gck=";
   };
 
-  vendorSha256 = "sha256-w5nUkCNo9xfalbc/U7uYaHZsUdyMV3tKDypQM9MnwE4=";
+  vendorSha256 = "sha256-AKh7MICGhzZsyeJ8uj/F2lx/G1nh8e3Q6ZXzHtZ+P38=";
 
   subPackages = [ "." ];
 

--- a/pkgs/tools/security/vault/vault-bin.nix
+++ b/pkgs/tools/security/vault/vault-bin.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "vault-bin";
-  version = "1.10.3";
+  version = "1.10.5";
 
   src =
     let
@@ -16,11 +16,11 @@ stdenv.mkDerivation rec {
         aarch64-darwin = "darwin_arm64";
       };
       sha256 = selectSystem {
-        x86_64-linux = "sha256-hz7u6sW415h/AsGlyghImo3K54gbAS92N6L0dI8vV8Q=";
-        aarch64-linux = "sha256-DIrVgHeVvDNx0vRwXt2gzf3HDYzDeYQ2JVy+7KlrLUo=";
-        i686-linux = "sha256-B0xamHI6GnHrKLjhIBvs89keShJ45fRgyM7M214S9jY=";
-        x86_64-darwin = "sha256-ubPcl/e0nwYYw5SrN2jfrGSwLHbi99jklYMDZuVdf6s=";
-        aarch64-darwin = "sha256-4CKrelIzaXu2GccWo2ZTzGSqCMTM1qmJ0drGD8F3c0k=";
+        x86_64-linux = "sha256-/tOaKSXx+rnpp0HWjCqgdZtaZZJruyNmWohPdijl2wI=";
+        aarch64-linux = "sha256-nGjVhzhxIfrEkxCf0SQ6pojgM/ZR9ySmSNXsj+3ZA/o=";
+        i686-linux = "sha256-ec8w2Y4nNYD8ELJauZFd8k3gdTU3wxoxALaL6kjnhKY=";
+        x86_64-darwin = "sha256-ubEFX1MX767CTfjnAhU/0SV3n6Rz+YJSoVmXph6Iw0Q=";
+        aarch64-darwin = "sha256-dxK7nGWi+2TCc9EcY8HJ2bcEFHmYGzAXCJ0rAvSCMeo=";
       };
     in
     fetchzip {


### PR DESCRIPTION
###### Description of changes
https://nvd.nist.gov/vuln/detail/CVE-2022-36129
https://discuss.hashicorp.com/t/hcsec-2022-15-vault-enterprise-does-not-verify-existing-voter-status-when-joining-an-integrated-storage-ha-node/42420

Unstable addressed by  #184212 &  #182375

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
