### PR TITLE
volumeicon: use github as source

### DIFF
--- a/pkgs/tools/audio/volumeicon/default.nix
+++ b/pkgs/tools/audio/volumeicon/default.nix
@@ -1,24 +1,36 @@
-{ pkgs, fetchurl, lib, stdenv, gtk3, pkg-config, intltool, alsa-lib }:
+{ fetchFromGitHub, lib, stdenv
+, autoreconfHook, intltool, pkg-config
+, gtk3, alsa-lib
+}:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "volumeicon";
   version = "0.5.1";
 
-  src = fetchurl {
-    url = "http://softwarebakery.com/maato/files/volumeicon/volumeicon-0.5.1.tar.gz";
-    sha256 = "182xl2w8syv6ky2h2bc9imc6ap8pzh0p7rp63hh8nw0xm38c3f14";
+  src = fetchFromGitHub {
+    owner = "Maato";
+    repo = "volumeicon";
+    rev = version;
+    hash = "sha256-zYKC7rOoLf08rV4B43TrGNBcXfSBFxWZCe9bQD9JzaA";
   };
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ gtk3 intltool alsa-lib ];
+  nativeBuildInputs = [
+    autoreconfHook
+    intltool
+    pkg-config
+  ];
+
+  buildInputs = [
+    gtk3
+    alsa-lib
+  ];
 
   meta = with lib; {
     description = "A lightweight volume control that sits in your systray";
-    homepage = "http://softwarebakery.com/maato/volumeicon.html";
-    platforms = pkgs.lib.platforms.linux;
+    homepage = "http://nullwise.com/volumeicon.html";
+    platforms = platforms.linux;
     maintainers = with maintainers; [ bobvanderlinden ];
-    license = pkgs.lib.licenses.gpl3;
+    license = licenses.gpl3;
   };
-
 }
 


### PR DESCRIPTION
###### Description of changes

Currently the src of volumeicon is down: http://softwarebakery.com/. The website of volumeicon is now http://nullwise.com/volumeicon.html, which also hosts new source. Since the source is not hosted under https I thought I'd use GitHub instead.

In order to use GitHub as the source, `autogen.sh` needs to be executed, which introduces a few autoconf build inputs.

While I was at it I formatted the derivation a bit.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
