### PR TITLE
stegsolve: init at 1.3

### DIFF
--- a/pkgs/tools/graphics/stegsolve/default.nix
+++ b/pkgs/tools/graphics/stegsolve/default.nix
@@ -1,0 +1,47 @@
+{ lib, stdenv, fetchurl, jre, makeWrapper, copyDesktopItems, makeDesktopItem }:
+
+stdenv.mkDerivation rec {
+  pname = "stegsolve";
+  version = "1.3";
+
+  src = fetchurl {
+    # No versioned binary is published :(
+    url = "http://www.caesum.com/handbook/Stegsolve.jar";
+    sha256 = "0np5zb28sg6yzkp1vic80pm8iiaamvjpbf5dxmi9kwvqcrh4jyq0";
+  };
+
+  dontUnpack = true;
+
+  desktopItems = [
+    (makeDesktopItem {
+      type = "Application";
+      name = pname;
+      desktopName = "Stegsolve";
+      comment = "A steganographic image analyzer, solver and data extractor for challanges";
+      exec = pname;
+      categories = [ "Graphics" ];
+    })
+  ];
+
+  nativeBuildInputs = [ makeWrapper copyDesktopItems ];
+
+  installPhase = ''
+    runHook preInstall
+
+    export JAR=$out/share/java/stegsolve/stegsolve.jar
+    install -D $src $JAR
+    makeWrapper ${jre}/bin/java $out/bin/stegsolve \
+      --add-flags "-jar $JAR"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A steganographic image analyzer, solver and data extractor for challanges";
+    homepage = "http://www.caesum.com/handbook/stego.htm";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
+    license = licenses.unfree;
+    maintainers = with maintainers; [ emilytrau ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21263,6 +21263,8 @@ with pkgs;
 
   stb = callPackage ../development/libraries/stb { };
 
+  stegsolve = callPackage ../tools/graphics/stegsolve { };
+
   StormLib = callPackage ../development/libraries/StormLib { };
 
   stxxl = callPackage ../development/libraries/stxxl { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

A steganographic image analyzer, solver and data extractor for challanges

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
