### PR TITLE
protoc-gen-rust-grpc: init at 0.8.3

### DIFF
--- a/pkgs/development/tools/protoc-gen-rust-grpc/default.nix
+++ b/pkgs/development/tools/protoc-gen-rust-grpc/default.nix
@@ -1,0 +1,21 @@
+{ fetchCrate, lib, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "protoc-gen-rust-grpc";
+  version = "0.8.3";
+
+  src = fetchCrate {
+    pname = "grpc-compiler";
+    inherit version;
+    sha256 = "sha256-gt+Qa68N5EkqhCAvU2ISvVPT9vYPXMySad4DCyTVHkQ=";
+  };
+
+  cargoSha256 = "sha256-08xEPc1GaRIYLbIlSRpfBvSQcs16vduJ7v/NDg7Awfs=";
+
+  meta = with lib; {
+    description = "Protobuf plugin for generating Rust code for gRPC";
+    homepage = "https://github.com/stepancheg/grpc-rust";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lucperkins ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -484,6 +484,8 @@ with pkgs;
 
   protoc-gen-rust = callPackage ../development/tools/protoc-gen-rust { };
 
+  protoc-gen-rust-grpc = callPackage ../development/tools/protoc-gen-rust-grpc { };
+
   protoc-gen-twirp = callPackage ../development/tools/protoc-gen-twirp { };
 
   protoc-gen-twirp_php = callPackage ../development/tools/protoc-gen-twirp_php { };


### PR DESCRIPTION
###### Description of changes

This PR adds a Protobuf generator for Rust + gRPC code from the [`grpc-rust`](https://github.com/stepancheg/grpc-rust) project.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
