### PR TITLE
pip-tools: fix build

### DIFF
--- a/pkgs/development/python-modules/pip-tools/default.nix
+++ b/pkgs/development/python-modules/pip-tools/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , buildPythonPackage
+, build
 , click
 , fetchPypi
 , pep517
@@ -25,11 +26,14 @@ buildPythonPackage rec {
     hash = "sha256-Oeiu5GVEbgInjYDb69QyXR3YYzJI9DITxzol9Y59ilU=";
   };
 
+  patches = [ ./fix-setup-py-bad-syntax-detection.patch ];
+
   nativeBuildInputs = [
     setuptools-scm
   ];
 
   propagatedBuildInputs = [
+    build
     click
     pep517
     pip
@@ -51,6 +55,7 @@ buildPythonPackage rec {
     # Tests require network access
     "network"
     "test_direct_reference_with_extras"
+    "test_local_duplicate_subdependency_combined"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/pip-tools/fix-setup-py-bad-syntax-detection.patch
+++ b/pkgs/development/python-modules/pip-tools/fix-setup-py-bad-syntax-detection.patch
@@ -1,0 +1,21 @@
+diff --color -ru a/piptools/scripts/compile.py b/piptools/scripts/compile.py
+--- a/piptools/scripts/compile.py	2022-06-30 11:24:26.000000000 +0200
++++ b/piptools/scripts/compile.py	2022-08-01 13:40:58.392515765 +0200
+@@ -6,7 +6,7 @@
+ from typing import IO, Any, BinaryIO, List, Optional, Tuple, Union, cast
+ 
+ import click
+-from build import BuildBackendException
++from build import BuildException
+ from build.util import project_wheel_metadata
+ from click.utils import LazyFile, safecall
+ from pip._internal.commands import create_command
+@@ -421,7 +421,7 @@
+                 metadata = project_wheel_metadata(
+                     os.path.dirname(os.path.abspath(src_file))
+                 )
+-            except BuildBackendException as e:
++            except (BuildException,StopIteration) as e:
+                 log.error(str(e))
+                 log.error(f"Failed to parse {os.path.abspath(src_file)}")
+                 sys.exit(2)


### PR DESCRIPTION
###### Description of changes
Fixes https://github.com/NixOS/nixpkgs/issues/184205
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done
Added the `build` module to deps. The exception thrown by Nix's `build.util.project_wheel_metadata` when the provided directory contains a malformed `setup.py` is `StopIteration` whereas excepted was `BuildBackendException` cf https://github.com/jazzband/pip-tools/blob/86aa4bd044921e43a686e26b569f838c239d8bca/piptools/scripts/compile.py#L427-L432

It could be a version mismatch but it seems like both Nixpkgs and pip-tools' CI use the same version of build (0.8.0) cf 
 - nix: https://github.com/NixOS/nixpkgs/blob/c60d5f08da0ee25b9ad5c9da5b1f978d51847b98/pkgs/development/python-modules/build/default.nix
 - pip-tools' CI: https://github.com/jazzband/pip-tools/runs/7527266246?check_suite_focus=true#step:9:15

As a workaround created `fix-setup-py-bad-syntax-detection.patch` which replaces `BuildBackendException` with `StopIteration`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
