### PR TITLE
minetest: 5.5.0 → 5.5.1

### DIFF
--- a/pkgs/development/libraries/irrlichtmt/default.nix
+++ b/pkgs/development/libraries/irrlichtmt/default.nix
@@ -16,13 +16,13 @@
 }:
 stdenv.mkDerivation rec {
   pname = "irrlichtmt";
-  version = "1.9.0mt4";
+  version = "1.9.0mt5";
 
   src = fetchFromGitHub {
     owner = "minetest";
     repo = "irrlicht";
     rev = version;
-    sha256 = "sha256-YlXn9LrfGkjdb8+zQGDgrInolUYj9nVSF2AXWFpEEkw=";
+    sha256 = "sha256-ocsO4nKab2YxHY1qqZbF4OErpBKmG4V+psgC40APs8s=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/games/minetest/default.nix
+++ b/pkgs/games/minetest/default.nix
@@ -91,9 +91,9 @@ let
   };
 
   v5 = {
-    version = "5.5.0";
-    sha256 = "sha256-V+ggqvZibSQrJbrtNCEkmRYHhgSKTQsdBh3c8+t6WeA=";
-    dataSha256 = "sha256-6ZS3EET3nm09eL0czCGadwzon35/EBfAg2KjPX3ZP/0=";
+    version = "5.5.1";
+    sha256 = "sha256-ssaDy6tYxhXGZ1+05J5DwoKYnfhKIKtZj66DOV84WxA=";
+    dataSha256 = "sha256-SI6I1wXbB0CgTmIemm3VY9DNnWMoI5bt/hqRwHlUl4k=";
   };
 
 in {

--- a/pkgs/games/minetest/default.nix
+++ b/pkgs/games/minetest/default.nix
@@ -1,8 +1,44 @@
-{ lib, stdenv, fetchFromGitHub, cmake, irrlichtmt, libpng, bzip2, curl, libogg, jsoncpp
-, libjpeg, libXxf86vm, libGLU, libGL, openal, libvorbis, sqlite, luajit
-, freetype, gettext, doxygen, ncurses, graphviz, xorg, gmp, libspatialindex
-, leveldb, postgresql, hiredis, libiconv, zlib, libXrandr, libX11, ninja, prometheus-cpp
-, OpenGL, OpenAL ? openal, Carbon, Cocoa, withTouchSupport ? false
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, irrlichtmt
+, coreutils
+, libpng
+, bzip2
+, curl
+, libogg
+, jsoncpp
+, libjpeg
+, libXxf86vm
+, libGLU
+, libGL
+, openal
+, libvorbis
+, sqlite
+, luajit
+, freetype
+, gettext
+, doxygen
+, ncurses
+, graphviz
+, xorg
+, gmp
+, libspatialindex
+, leveldb
+, postgresql
+, hiredis
+, libiconv
+, zlib
+, libXrandr
+, libX11
+, ninja
+, prometheus-cpp
+, OpenGL
+, OpenAL ? openal
+, Carbon
+, Cocoa
+, withTouchSupport ? false
 }:
 
 with lib;
@@ -72,9 +108,14 @@ let
       leveldb postgresql hiredis prometheus-cpp
     ];
 
+    postPatch = ''
+      substituteInPlace src/filesys.cpp --replace "/bin/rm" "${coreutils}/bin/rm"
+    '';
+
     postInstall = ''
       mkdir -pv $out/share/minetest/games/minetest_game/
       cp -rv ${sources.data}/* $out/share/minetest/games/minetest_game/
+      patchShebangs $out
     '';
 
     meta = with lib; {


### PR DESCRIPTION
###### Description of changes
* Update package `minetest` to latest release, and update `irrlichtmt` to `1.9.0mt5`.
* Patch shebangs and absolute path `/bin/rm`.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).