### PR TITLE
qgit: update source sha256 for tag moved upstream

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/qgit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/qgit/default.nix
@@ -8,7 +8,7 @@ mkDerivation rec {
     owner = "tibirna";
     repo = "qgit";
     rev = "${pname}-${version}";
-    sha256 = "1cwq43ywvii9zh4m31mgkgisfc9qhiixlz0zlv99skk9vb5v6r38";
+    sha256 = "sha256-xM0nroWs4WByc2O469zVeAlzKn6LLr+8WDlEdSjtRYI=";
   };
 
   buildInputs = [ qtbase ];


### PR DESCRIPTION
###### Description of changes
At a point after qgit was updated in Nixpkgs to 2.10, upstream [moved the Git tag](https://github.com/tibirna/qgit/pull/123#issuecomment-1010171222). This updates `sha256` to the current tag.

The only change in the source is updating the displayed version inside qgit to "2.10".

<details>
<summary>Diffoscope diff of sources</summary>

# Comparing `/nix/store/aysf7flia4q41kzd28kplp37vkn3das0-source` & `/nix/store/3j5j4s3vf0l4fvc80z8w7qpbh4g685v5-source`

## Comparing `/nix/store/aysf7flia4q41kzd28kplp37vkn3das0-source/qgit_inno_setup.iss` & `/nix/store/3j5j4s3vf0l4fvc80z8w7qpbh4g685v5-source/qgit_inno_setup.iss`

```diff
@@ -3,15 +3,15 @@
 ; QGit should be compiled with MSVC 2008, statically linked
 ; to Qt4.3 or better Trolltech libraries and directory of
 ; Visual C++ redistributable dll files copied under 'bin\'
 ; directory
 
 [Setup]
 AppName=QGit
-AppVerName=QGit version 2.9.1
+AppVerName=QGit version 2.10
 DefaultDirName={pf}\QGit
 DefaultGroupName=QGit
 UninstallDisplayIcon={app}\qgit.exe
 Compression=lzma
 SolidCompression=yes
 LicenseFile=COPYING.rtf
 SetupIconFile=src\resources\qgit.ico
```

### stat {}

```diff
@@ -1,7 +1,7 @@
 
-  Size: 3586      	Blocks: 8          IO Block: 4096   regular file
+  Size: 3585      	Blocks: 8          IO Block: 4096   regular file
 Device: 0,31	Access: (0444/-r--r--r--)  Uid: (    0/    root)   Gid: (    0/    root)
 
 Modify: 1970-01-01 00:00:01.000000000 +0000
```

## Comparing `/nix/store/aysf7flia4q41kzd28kplp37vkn3das0-source/src` & `/nix/store/3j5j4s3vf0l4fvc80z8w7qpbh4g685v5-source/src`

### Comparing `/nix/store/aysf7flia4q41kzd28kplp37vkn3das0-source/src/config.h` & `/nix/store/3j5j4s3vf0l4fvc80z8w7qpbh4g685v5-source/src/config.h`

```diff
@@ -13,11 +13,11 @@
 /* Define to the full name and version of this package. */
 #define PACKAGE_STRING "qgit"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "qgit"
 
 /* Define to the version of this package. */
+#define PACKAGE_VERSION "2.10"
-#define PACKAGE_VERSION "2.9.1"
 
 /* Version number of package */
+#define VERSION "2.10"
-#define VERSION "2.9.1"
```

#### stat {}

```diff
@@ -1,7 +1,7 @@
 
+  Size: 651       	Blocks: 8          IO Block: 4096   regular file
-  Size: 653       	Blocks: 8          IO Block: 4096   regular file
 Device: 0,31	Access: (0444/-r--r--r--)  Uid: (    0/    root)   Gid: (    0/    root)
 
 Modify: 1970-01-01 00:00:01.000000000 +0000
```
</details>

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

