### PR TITLE
firefly-iii: init at 5.7.18, nixos/firefly-iii: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1125,6 +1125,7 @@
   ./services/web-apps/dolibarr.nix
   ./services/web-apps/engelsystem.nix
   ./services/web-apps/ethercalc.nix
+  ./services/web-apps/firefly-iii.nix
   ./services/web-apps/fluidd.nix
   ./services/web-apps/freshrss.nix
   ./services/web-apps/galene.nix

--- a/nixos/modules/services/web-apps/firefly-iii.nix
+++ b/nixos/modules/services/web-apps/firefly-iii.nix
@@ -1,0 +1,434 @@
+{ pkgs, config, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.services.firefly-iii;
+  db = cfg.database;
+  mail = cfg.mail;
+
+  user = cfg.user;
+  group = cfg.group;
+
+  firefly-iii = pkgs.firefly-iii;
+
+  defaultUser = "firefly-iii";
+  defaultGroup = defaultUser;
+
+  tlsEnabled = cfg.nginx.addSSL || cfg.nginx.forceSSL || cfg.nginx.onlySSL || cfg.nginx.enableACME;
+
+in {
+
+  options.services.firefly-iii = {
+
+    enable = mkEnableOption "Firefly III";
+
+    dataDir = mkOption {
+      description = mdDoc "Firefly III data directory";
+      default = "/var/lib/firefly-iii";
+      type = types.path;
+    };
+
+    # App configuration
+    appURL = mkOption {
+      description = mdDoc ''
+        The root URL that you want to host Firefly III on. All URLs in Firefly III will be generated using this value.
+      '';
+      default = "http${lib.optionalString tlsEnabled "s"}://${cfg.hostname}";
+      defaultText = ''http''${lib.optionalString tlsEnabled "s"}://''${cfg.hostname}'';
+      example = "https://example.com";
+      type = types.str;
+    };
+
+    appKeyFile = mkOption {
+      description = mdDoc ''
+        A file containing the Laravel APP_KEY - a 32 character long,
+        base64 encoded key used for encryption where needed. Can be
+        generated with `head -c 32 /dev/urandom | base64`.
+      '';
+      example = "/run/keys/firefly-iii-appkey";
+      type = types.path;
+    };
+
+    # PHP
+    poolConfig = mkOption {
+      type = with types; attrsOf (oneOf [ str int bool ]);
+      default = {
+        "pm" = "dynamic";
+        "pm.max_children" = 32;
+        "pm.start_servers" = 2;
+        "pm.min_spare_servers" = 2;
+        "pm.max_spare_servers" = 4;
+        "pm.max_requests" = 500;
+      };
+      description = mdDoc ''
+        Options for the Firefly III PHP pool. See the documentation on <literal>php-fpm.conf</literal>
+        for details on configuration directives.
+      '';
+    };
+
+    # Reverse proxy
+    hostname = lib.mkOption {
+      type = lib.types.str;
+      default = if config.networking.domain != null then
+                  config.networking.fqdn
+                else
+                  config.networking.hostName;
+      defaultText = literalMD "config.networking.fqdn";
+      example = "firefly.example.com";
+      description = mdDoc "The hostname to serve Firefly III on.";
+    };
+
+    nginx = mkOption {
+      type = types.submodule (
+        recursiveUpdate
+          (import ../web-servers/nginx/vhost-options.nix { inherit config lib; }) {}
+      );
+      default = {};
+      example = literalMD ''
+        {
+          serverAliases = [
+            "firefly.''${cfg.hostname}"
+          ];
+
+          # To enable encryption and let Let's Encrypt take care of certificate
+          forceSSL = true;
+          enableACME = true;
+        }
+      '';
+      description = mdDoc "With this option, you can customize the nginx virtualHost settings.";
+    };
+
+    # Config
+    config = mkOption {
+      type = with types;
+        attrsOf
+          (nullOr
+            (either
+              (oneOf [
+                bool
+                int
+                port
+                path
+                str
+              ])
+              (submodule {
+                options = {
+                  _secret = mkOption {
+                    type = nullOr (oneOf [ str path ]);
+                    description = ''
+                      The path to a file containing the value the
+                      option should be set to in the final
+                      configuration file.
+                    '';
+                  };
+                };
+              })));
+      default = {};
+      example = literalMD ''
+        {
+          MAILGUN_SECRET = { _secret = "/run/keys/mailgun_secret" };
+        }
+      '';
+      description = ''
+        Firefly III configuration options to set in the <filename>.env</filename> file.
+
+        Settings containing secret data should be set to an attribute
+        set containing the attribute <literal>_secret</literal> - a
+        string pointing to a file containing the value the option
+        should be set to. See the example to get a better picture of
+        this: in the resulting <filename>.env</filename> file, the
+        <literal>MAILGUN_SECRET</literal> key will be set to the
+        contents of the <filename>/run/keys/mailgun_secret</filename>
+        file.
+      '';
+    };
+
+    database = {
+      type = mkOption {
+        type = types.enum [ "pgsql" "mysql" "sqlite" ];
+        example = "mysql";
+        default = "mysql";
+        description = mdDoc "Database engine to use.";
+      };
+      host = mkOption {
+        type = types.str;
+        default = "localhost";
+        description = mdDoc "Database host address.";
+      };
+      port = mkOption {
+        type = types.port;
+        default = 3306;
+        description = mdDoc "Database host port.";
+      };
+      name = mkOption {
+        type = types.str;
+        default = "firefly";
+        description = mdDoc "Database name.";
+      };
+      user = mkOption {
+        type = types.str;
+        default = user;
+        defaultText = literalMD "user";
+        description = mdDoc "Database username.";
+      };
+      passwordFile = mkOption {
+        type = with types; nullOr path;
+        default = null;
+        example = "/run/keys/firefly-iii-dbpassword";
+        description = ''
+          A file containing the password corresponding to
+          <option>database.user</option>
+        '';
+      };
+      createLocally = mkOption {
+        type = types.bool;
+        default = false;
+        description = mdDoc "Create the database and database user locally.";
+      };
+    };
+
+    mail = {
+      driver = mkOption {
+        type = types.enum [ "smtp" "sendmail" "mandrill" "sparkpost" "log" ];
+        default = "log";
+        description = mdDoc "Mail driver to use.";
+      };
+      host = mkOption {
+        type = with types; nullOr str;
+        default = "null";
+        description = mdDoc "Mail host address.";
+      };
+      port = mkOption {
+        type = types.port;
+        default = 2525;
+        description = mdDoc "Mail host port.";
+      };
+      fromName = mkOption {
+        type = types.str;
+        default = "Firefly III";
+        description = mdDoc "Mail \"from\" name";
+      };
+      user = mkOption {
+        type = with types; nullOr str;
+        default = null;
+        example = "firefly-iii";
+        description = mdDoc "Mail username.";
+      };
+      passwordFile = mkOption {
+        type = with types; nullOr path;
+        default = null;
+        example = "/run/keys/firefly-iii-mailpassword";
+        description = ''
+          A file containing the password corresponding to
+          <option>mail.user</option>.
+        '';
+      };
+      encryption = mkOption {
+        type = with types; nullOr (enum [ "tls" ]);
+        default = null;
+        description = mdDoc "SMTP encryption mechanism to use.";
+      };
+    };
+
+    # User management
+    user = mkOption {
+      default = defaultUser;
+      description = mdDoc "User Firefly III runs as.";
+      type = types.str;
+    };
+
+    group = mkOption {
+      default = defaultGroup;
+      description = mdDoc "Group Firefly III runs as.";
+      type = types.str;
+    };
+
+  };
+
+  #
+  # Config
+  #
+  config = mkIf cfg.enable {
+
+    assertions = [
+      {
+        assertion = db.createLocally -> db.user == user;
+        message = "services.firefly-iii.database.user must be set to ${user} if services.firefly-iii.database.createLocally is set true.";
+      }
+      {
+        assertion = db.createLocally -> db.passwordFile == null;
+        message = "services.firefly-iii.database.passwordFile cannot be specified if services.firefly-iii.database.createLocally is set true.";
+      }
+      {
+        assertion = db.createLocally -> db.type == "mysql";
+        message = "services.firefly-iii.database.type must be set to mysql if services.firefly-iii.database.createLocally is set true.";
+      }
+    ];
+
+    # PHP
+    services.phpfpm.pools.firefly-iii = {
+      inherit user;
+      inherit group;
+      phpOptions = ''
+        log_errors = on
+      '';
+      settings = {
+        "listen.mode" = "0660";
+        "listen.owner" = "nginx";
+        "listen.group" = "nginx";
+      } // cfg.poolConfig;
+    };
+
+    # MySQL
+    services.mysql = mkIf db.createLocally {
+      enable = true;
+      package = mkDefault pkgs.mariadb;
+      ensureDatabases = [ db.name ];
+      ensureUsers = [
+        {
+          name = db.user;
+          ensurePermissions = { "${db.name}.*" = "ALL PRIVILEGES"; };
+        }
+      ];
+    };
+
+    # Reverse proxy
+    services.nginx = {
+      enable = mkDefault true;
+      recommendedTlsSettings = true;
+      recommendedOptimisation = true;
+      recommendedGzipSettings = true;
+      virtualHosts.${cfg.hostname} = mkMerge [ cfg.nginx {
+        root = mkForce "${firefly-iii}/public";
+        locations = {
+          "/" = {
+            index = "index.php";
+            tryFiles = "$uri $uri/ /index.php?$query_string";
+          };
+          "~ \.php$".extraConfig = ''
+            fastcgi_pass unix:${config.services.phpfpm.pools."firefly-iii".socket};
+          '';
+          "~ \.(js|css|gif|png|ico|jpg|jpeg)$" = {
+            extraConfig = "expires 365d;";
+          };
+        };
+      }];
+    };
+
+    # Config
+    services.firefly-iii.config = {
+      APP_URL = cfg.appURL;
+      APP_KEY._secret = cfg.appKeyFile;
+
+      DB_CONNECTION = db.type;
+      DB_HOST = db.host;
+      DB_PORT = db.port;
+      DB_DATABASE = db.name;
+      DB_USERNAME = db.user;
+      DB_PASSWORD._secret = db.passwordFile;
+
+      MAIL_MAILER = mail.driver;
+      MAIL_HOST = mail.host;
+      MAIL_PORT = mail.port;
+      MAIL_FROM = mail.fromName;
+      MAIL_USERNAME = mail.user;
+      MAIL_PASSWORD._secret = mail.passwordFile;
+      MAIL_ENCRYPTION = mail.encryption;
+    };
+
+    # Set-up script
+    systemd.services.firefly-iii-setup = {
+      description = mdDoc "Preparation tasks for Firefly III";
+      before = [ "phpfpm-firefly-iii.service" ];
+      after = optional db.createLocally "mysql.service";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        User = user;
+        WorkingDirectory = "${firefly-iii}";
+      };
+      path = [ pkgs.replace-secret ];
+      script =
+        let
+          isSecret  = v: isAttrs v && v ? _secret && (isString v._secret || builtins.isPath v._secret);
+          fireflyEnvVars = lib.generators.toKeyValue {
+            mkKeyValue = lib.flip lib.generators.mkKeyValueDefault "=" {
+              mkValueString = v: with builtins;
+                if isInt             v then toString v
+                else if isString     v then "\"${v}\""
+                else if true  ==     v then "true"
+                else if false ==     v then "false"
+                else if isSecret     v then
+                  if (isString v._secret) then
+                    hashString "sha256" v._secret
+                  else
+                    hashString "sha256" (builtins.readFile v._secret)
+                else throw "unsupported type ${typeOf v}: ${(lib.generators.toPretty {}) v}";
+            };
+          };
+          secretPaths = lib.mapAttrsToList (_: v: v._secret) (lib.filterAttrs (_: isSecret) cfg.config);
+          mkSecretReplacement = file: ''
+            replace-secret ${escapeShellArgs [
+              (
+                if (isString file) then
+                  builtins.hashString "sha256" file
+                else
+                  builtins.hashString "sha256" (builtins.readFile file)
+              )
+              file
+              "${cfg.dataDir}/.env"
+            ]}
+          '';
+          secretReplacements = lib.concatMapStrings mkSecretReplacement secretPaths;
+          filteredConfig = lib.converge (lib.filterAttrsRecursive (_: v: ! elem v [ {} null ])) cfg.config;
+          fireflyEnv = pkgs.writeText "firefly-iii.env" (fireflyEnvVars filteredConfig);
+      in ''
+        set -euo pipefail
+        umask 077
+
+        # create the .env file
+        install -T -m 0600 -o ${user} ${fireflyEnv} "${cfg.dataDir}/.env"
+        ${secretReplacements}
+        if ! grep 'APP_KEY=base64:' "${cfg.dataDir}/.env" >/dev/null; then
+            sed -i 's/APP_KEY=/APP_KEY=base64:/' "${cfg.dataDir}/.env"
+        fi
+
+        # migrate db
+        ${pkgs.php}/bin/php artisan migrate --force
+      '';
+    };
+
+    # Data dir
+    systemd.tmpfiles.rules = [
+      "d ${cfg.dataDir}                            0710 ${user} ${group} - -"
+      "d ${cfg.dataDir}/storage                    0700 ${user} ${group} - -"
+      "d ${cfg.dataDir}/storage/app                0700 ${user} ${group} - -"
+      "d ${cfg.dataDir}/storage/database           0700 ${user} ${group} - -"
+      "d ${cfg.dataDir}/storage/export             0700 ${user} ${group} - -"
+      "d ${cfg.dataDir}/storage/framework          0700 ${user} ${group} - -"
+      "d ${cfg.dataDir}/storage/framework/cache    0700 ${user} ${group} - -"
+      "d ${cfg.dataDir}/storage/framework/sessions 0700 ${user} ${group} - -"
+      "d ${cfg.dataDir}/storage/framework/views    0700 ${user} ${group} - -"
+      "d ${cfg.dataDir}/storage/logs               0700 ${user} ${group} - -"
+      "d ${cfg.dataDir}/storage/upload             0700 ${user} ${group} - -"
+    ];
+
+    # User management
+    users = {
+      users = mkIf (user == defaultUser) {
+        ${defaultUser} = {
+          inherit group;
+          isSystemUser = true;
+        };
+        "${config.services.nginx.user}".extraGroups = [ group ];
+      };
+      groups = mkIf (group == defaultGroup) {
+        ${defaultGroup} = {};
+      };
+    };
+
+  };
+
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -212,6 +212,7 @@ in {
   fcitx = handleTest ./fcitx {};
   fenics = handleTest ./fenics.nix {};
   ferm = handleTest ./ferm.nix {};
+  firefly-iii = handleTest ./web-apps/firefly-iii.nix {};
   firefox = handleTest ./firefox.nix { firefoxPackage = pkgs.firefox; };
   firefox-esr    = handleTest ./firefox.nix { firefoxPackage = pkgs.firefox-esr; }; # used in `tested` job
   firefox-esr-102 = handleTest ./firefox.nix { firefoxPackage = pkgs.firefox-esr-102; };

--- a/nixos/tests/web-apps/firefly-iii.nix
+++ b/nixos/tests/web-apps/firefly-iii.nix
@@ -1,0 +1,24 @@
+import ../make-test-python.nix ({pkgs, ...}: {
+  name = "firefly-iii";
+
+  nodes.server = { ... }: {
+    environment = {
+      etc = {
+        "firefly-iii/appkey".text = "IHzCAm6JunrQzaCK+Qa3K4F3ISv/vxMqVEmUIQ2Wxdw=";
+      };
+    };
+    services.firefly-iii = {
+      enable = true;
+      appKeyFile = "/etc/firefly-iii/appkey";
+      database.createLocally = true;
+    };
+  };
+
+  testScript = ''
+    server.start()
+    server.wait_for_unit("phpfpm-firefly-iii.service")
+    server.wait_for_open_port(80)
+    server.succeed("curl --fail http://127.0.0.1:80/install 2> /dev/null| grep 'Firefly III'")
+    server.shutdown()
+  '';
+})

--- a/pkgs/servers/web-apps/firefly-iii/composer-env.nix
+++ b/pkgs/servers/web-apps/firefly-iii/composer-env.nix
@@ -1,0 +1,244 @@
+# This file originates from composer2nix
+
+{ stdenv, lib, writeTextFile, fetchurl, php, unzip, phpPackages }:
+
+let
+  inherit (phpPackages) composer;
+
+  filterSrc = src:
+    builtins.filterSource (path: type: type != "directory" || (baseNameOf path != ".git" && baseNameOf path != ".git" && baseNameOf path != ".svn")) src;
+
+  buildZipPackage = { name, src }:
+    stdenv.mkDerivation {
+      inherit name src;
+      nativeBuildInputs = [ unzip ];
+      buildCommand = ''
+        shopt -s dotglob
+        unzip $src
+        baseDir=$(find . -type d -mindepth 1 -maxdepth 1)
+        cd $baseDir
+        mkdir -p $out
+        mv * $out
+      '';
+    };
+
+  buildPackage =
+    { name
+    , src
+    , packages ? {}
+    , devPackages ? {}
+    , buildInputs ? []
+    , symlinkDependencies ? false
+    , executable ? false
+    , removeComposerArtifacts ? false
+    , postInstall ? ""
+    , noDev ? false
+    , composerExtraArgs ? ""
+    , unpackPhase ? "true"
+    , buildPhase ? "true"
+    , ...}@args:
+
+    let
+      reconstructInstalled = writeTextFile {
+        name = "reconstructinstalled.php";
+        executable = true;
+        text = ''
+          #! ${php}/bin/php
+          <?php
+          if(file_exists($argv[1]))
+          {
+              $composerLockStr = file_get_contents($argv[1]);
+
+              if($composerLockStr === false)
+              {
+                  fwrite(STDERR, "Cannot open composer.lock contents\n");
+                  exit(1);
+              }
+              else
+              {
+                  $config = json_decode($composerLockStr, true);
+
+                  if(array_key_exists("packages", $config))
+                      $allPackages = $config["packages"];
+                  else
+                      $allPackages = array();
+
+                  ${lib.optionalString (!noDev) ''
+                    if(array_key_exists("packages-dev", $config))
+                        $allPackages = array_merge($allPackages, $config["packages-dev"]);
+                  ''}
+
+                  $packagesStr = json_encode($allPackages, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+                  print($packagesStr);
+              }
+          }
+          else
+              print("[]");
+          ?>
+        '';
+      };
+
+      constructBin = writeTextFile {
+        name = "constructbin.php";
+        executable = true;
+        text = ''
+          #! ${php}/bin/php
+          <?php
+          $composerJSONStr = file_get_contents($argv[1]);
+
+          if($composerJSONStr === false)
+          {
+              fwrite(STDERR, "Cannot open composer.json contents\n");
+              exit(1);
+          }
+          else
+          {
+              $config = json_decode($composerJSONStr, true);
+
+              if(array_key_exists("bin-dir", $config))
+                  $binDir = $config["bin-dir"];
+              else
+                  $binDir = "bin";
+
+              if(array_key_exists("bin", $config))
+              {
+                  if(!file_exists("vendor/".$binDir))
+                      mkdir("vendor/".$binDir);
+
+                  foreach($config["bin"] as $bin)
+                      symlink("../../".$bin, "vendor/".$binDir."/".basename($bin));
+              }
+          }
+          ?>
+        '';
+      };
+
+      bundleDependencies = dependencies:
+        lib.concatMapStrings (dependencyName:
+          let
+            dependency = dependencies.${dependencyName};
+          in
+          ''
+            ${if dependency.targetDir == "" then ''
+              vendorDir="$(dirname ${dependencyName})"
+              mkdir -p "$vendorDir"
+              ${if symlinkDependencies then
+                ''ln -s "${dependency.src}" "$vendorDir/$(basename "${dependencyName}")"''
+                else
+                ''cp -av "${dependency.src}" "$vendorDir/$(basename "${dependencyName}")"''
+              }
+            '' else ''
+              namespaceDir="${dependencyName}/$(dirname "${dependency.targetDir}")"
+              mkdir -p "$namespaceDir"
+              ${if symlinkDependencies then
+                ''ln -s "${dependency.src}" "$namespaceDir/$(basename "${dependency.targetDir}")"''
+              else
+                ''cp -av "${dependency.src}" "$namespaceDir/$(basename "${dependency.targetDir}")"''
+              }
+            ''}
+          '') (builtins.attrNames dependencies);
+
+      extraArgs = removeAttrs args [ "packages" "devPackages" "buildInputs" ];
+    in
+    stdenv.mkDerivation ({
+      buildInputs = [ php composer ] ++ buildInputs;
+
+      inherit unpackPhase buildPhase;
+
+      installPhase = ''
+        ${if executable then ''
+          mkdir -p $out/share/php
+          cp -av $src $out/share/php/$name
+          chmod -R u+w $out/share/php/$name
+          cd $out/share/php/$name
+        '' else ''
+          cp -av $src $out
+          chmod -R u+w $out
+          cd $out
+        ''}
+
+        # Remove unwanted files
+        rm -f *.nix
+
+        export HOME=$TMPDIR
+
+        # Remove the provided vendor folder if it exists
+        rm -Rf vendor
+
+        # If there is no composer.lock file, compose a dummy file.
+        # Otherwise, composer attempts to download the package.json file from
+        # the registry which we do not want.
+        if [ ! -f composer.lock ]
+        then
+            cat > composer.lock <<EOF
+        {
+            "packages": []
+        }
+        EOF
+        fi
+
+        # Reconstruct the installed.json file from the lock file
+        mkdir -p vendor/composer
+        ${php}/bin/php ${reconstructInstalled} composer.lock > vendor/composer/installed.json
+
+        # Copy or symlink the provided dependencies
+        cd vendor
+        ${bundleDependencies packages}
+        ${lib.optionalString (!noDev) (bundleDependencies devPackages)}
+        cd ..
+
+        # Reconstruct autoload scripts
+        # We use the optimize feature because Nix packages cannot change after they have been built
+        # Using the dynamic loader for a Nix package is useless since there is nothing to dynamically reload.
+        composer dump-autoload --optimize ${lib.optionalString noDev "--no-dev"} ${composerExtraArgs}
+
+        # Run the install step as a validation to confirm that everything works out as expected
+        composer install --optimize-autoloader ${lib.optionalString noDev "--no-dev"} ${composerExtraArgs}
+
+        ${lib.optionalString executable ''
+          # Reconstruct the bin/ folder if we deploy an executable project
+          ${php}/bin/php ${constructBin} composer.json
+          ln -s $(pwd)/vendor/bin $out/bin
+        ''}
+
+        ${lib.optionalString (!symlinkDependencies) ''
+          # Patch the shebangs if possible
+          if [ -d $(pwd)/vendor/bin ]
+          then
+              # Look for all executables in bin/
+              for i in $(pwd)/vendor/bin/*
+              do
+                  # Look for their location
+                  realFile=$(readlink -f "$i")
+
+                  # Restore write permissions
+                  chmod u+wx "$(dirname "$realFile")"
+                  chmod u+w "$realFile"
+
+                  # Patch shebang
+                  sed -e "s|#!/usr/bin/php|#!${php}/bin/php|" \
+                      -e "s|#!/usr/bin/env php|#!${php}/bin/php|" \
+                      "$realFile" > tmp
+                  mv tmp "$realFile"
+                  chmod u+x "$realFile"
+              done
+          fi
+        ''}
+
+        if [ "$removeComposerArtifacts" = "1" ]
+        then
+            # Remove composer stuff
+            rm -f composer.json composer.lock
+        fi
+
+        # Execute post install hook
+        runHook postInstall
+    '';
+  } // extraArgs);
+in
+{
+  inherit filterSrc;
+  composer = lib.makeOverridable composer;
+  buildZipPackage = lib.makeOverridable buildZipPackage;
+  buildPackage = lib.makeOverridable buildPackage;
+}

--- a/pkgs/servers/web-apps/firefly-iii/composition.nix
+++ b/pkgs/servers/web-apps/firefly-iii/composition.nix
@@ -1,0 +1,14 @@
+{pkgs ? import <nixpkgs> {
+    inherit system;
+  }, system ? builtins.currentSystem, noDev ? false, php ? pkgs.php, phpPackages ? pkgs.phpPackages}:
+
+let
+  composerEnv = import ./composer-env.nix {
+    inherit (pkgs) stdenv lib writeTextFile fetchurl unzip;
+    inherit php phpPackages;
+  };
+in
+import ./php-packages.nix {
+  inherit composerEnv noDev;
+  inherit (pkgs) fetchurl fetchgit fetchhg fetchsvn;
+}

--- a/pkgs/servers/web-apps/firefly-iii/default.nix
+++ b/pkgs/servers/web-apps/firefly-iii/default.nix
@@ -1,0 +1,20 @@
+{ pkgs, stdenv, lib, fetchFromGitHub }:
+
+let
+  package = (import ./composition.nix {
+    inherit pkgs;
+    inherit (stdenv.hostPlatform) system;
+    noDev = true;
+  });
+in
+  package.override rec {
+    pname = "firefly-iii";
+    version = "5.7.18";
+
+    src = fetchFromGitHub {
+      owner = "firefly-iii";
+      repo = pname;
+      rev = version;
+      sha256 = "0rrcfhmb7rzi4m5sl99gkl2hijdlncpihirk5lw2v8k9fhb90b8a";
+    };
+  }

--- a/pkgs/servers/web-apps/firefly-iii/default.nix
+++ b/pkgs/servers/web-apps/firefly-iii/default.nix
@@ -1,10 +1,17 @@
-{ pkgs, stdenv, lib, fetchFromGitHub }:
+{ pkgs, stdenv, lib, fetchFromGitHub,
+  dataDir ? "/var/lib/firefly-iii" }:
 
 let
   package = (import ./composition.nix {
     inherit pkgs;
     inherit (stdenv.hostPlatform) system;
     noDev = true;
+  }).overrideAttrs (attrs : {
+    installPhase = attrs.installPhase + ''
+      rm -R $out/storage
+      ln -s ${dataDir}/storage $out/storage
+      ln -s ${dataDir}/.env $out/.env
+    '';
   });
 in
   package.override rec {

--- a/pkgs/servers/web-apps/firefly-iii/php-packages.nix
+++ b/pkgs/servers/web-apps/firefly-iii/php-packages.nix
@@ -1,0 +1,1168 @@
+{composerEnv, fetchurl, fetchgit ? null, fetchhg ? null, fetchsvn ? null, noDev ? false}:
+
+let
+  packages = {
+    "bacon/bacon-qr-code" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "bacon-bacon-qr-code-8674e51bb65af933a5ffaf1c308a660387c35c22";
+        src = fetchurl {
+          url = "https://api.github.com/repos/Bacon/BaconQrCode/zipball/8674e51bb65af933a5ffaf1c308a660387c35c22";
+          sha256 = "0hb0w6m5rwzghw2im3yqn6ly2kvb3jgrv8jwra1lwd0ik6ckrngl";
+        };
+      };
+    };
+    "brick/math" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "brick-math-459f2781e1a08d52ee56b0b1444086e038561e3f";
+        src = fetchurl {
+          url = "https://api.github.com/repos/brick/math/zipball/459f2781e1a08d52ee56b0b1444086e038561e3f";
+          sha256 = "00qgiy3ywrhn0lhzjagizi47np2xj9g4gqm7p2g0iv8cciwkf4bp";
+        };
+      };
+    };
+    "dasprid/enum" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "dasprid-enum-5abf82f213618696dda8e3bf6f64dd042d8542b2";
+        src = fetchurl {
+          url = "https://api.github.com/repos/DASPRiD/Enum/zipball/5abf82f213618696dda8e3bf6f64dd042d8542b2";
+          sha256 = "0rs7i1xiwhssy88s7bwnp5ri5fi2xy3fl7pw6l5k27xf2f1hv7q6";
+        };
+      };
+    };
+    "defuse/php-encryption" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "defuse-php-encryption-77880488b9954b7884c25555c2a0ea9e7053f9d2";
+        src = fetchurl {
+          url = "https://api.github.com/repos/defuse/php-encryption/zipball/77880488b9954b7884c25555c2a0ea9e7053f9d2";
+          sha256 = "1lcvpg56nw72cxyh6sga7fx94qw9l0l1y78z7y7ny3hgdniwhihx";
+        };
+      };
+    };
+    "dflydev/dot-access-data" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "dflydev-dot-access-data-f41715465d65213d644d3141a6a93081be5d3549";
+        src = fetchurl {
+          url = "https://api.github.com/repos/dflydev/dflydev-dot-access-data/zipball/f41715465d65213d644d3141a6a93081be5d3549";
+          sha256 = "1vgbjrq8qh06r26y5nlxfin4989r3h7dib1jifb2l3cjdn1r5bmj";
+        };
+      };
+    };
+    "diglactic/laravel-breadcrumbs" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "diglactic-laravel-breadcrumbs-b2c594e56fd15ef3112436e2067dca13131dd990";
+        src = fetchurl {
+          url = "https://api.github.com/repos/diglactic/laravel-breadcrumbs/zipball/b2c594e56fd15ef3112436e2067dca13131dd990";
+          sha256 = "0byw460jvizj9s4vwld6x71cd705f2knpmdrc4yz1rjb44470pfc";
+        };
+      };
+    };
+    "doctrine/cache" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "doctrine-cache-1ca8f21980e770095a31456042471a57bc4c68fb";
+        src = fetchurl {
+          url = "https://api.github.com/repos/doctrine/cache/zipball/1ca8f21980e770095a31456042471a57bc4c68fb";
+          sha256 = "1p8ia9g3mqz71bv4x8q1ng1fgcidmyksbsli1fjbialpgjk9k1ss";
+        };
+      };
+    };
+    "doctrine/dbal" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "doctrine-dbal-63e513cebbbaf96a6795e5c5ee34d205831bfc85";
+        src = fetchurl {
+          url = "https://api.github.com/repos/doctrine/dbal/zipball/63e513cebbbaf96a6795e5c5ee34d205831bfc85";
+          sha256 = "1c9lhcjlzplnqryax00fpzrnd3gdkwllkckjd62f9j8b36bm05vc";
+        };
+      };
+    };
+    "doctrine/deprecations" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "doctrine-deprecations-0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de";
+        src = fetchurl {
+          url = "https://api.github.com/repos/doctrine/deprecations/zipball/0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de";
+          sha256 = "1sk1f020n0w7p7r4rsi7wnww85vljrim1i5h9wb0qiz2c4l8jj09";
+        };
+      };
+    };
+    "doctrine/event-manager" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "doctrine-event-manager-95aa4cb529f1e96576f3fda9f5705ada4056a520";
+        src = fetchurl {
+          url = "https://api.github.com/repos/doctrine/event-manager/zipball/95aa4cb529f1e96576f3fda9f5705ada4056a520";
+          sha256 = "0xi2s28jmmvrndg1yd0r5s10d9a0q6j2dxdbazvcbws9waf0yrvj";
+        };
+      };
+    };
+    "doctrine/inflector" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "doctrine-inflector-d9d313a36c872fd6ee06d9a6cbcf713eaa40f024";
+        src = fetchurl {
+          url = "https://api.github.com/repos/doctrine/inflector/zipball/d9d313a36c872fd6ee06d9a6cbcf713eaa40f024";
+          sha256 = "1z6y0mxqadarw76whppcl0h0cj7p5n6k7mxihggavq46i2wf7nhj";
+        };
+      };
+    };
+    "doctrine/lexer" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "doctrine-lexer-39ab8fcf5a51ce4b85ca97c7a7d033eb12831124";
+        src = fetchurl {
+          url = "https://api.github.com/repos/doctrine/lexer/zipball/39ab8fcf5a51ce4b85ca97c7a7d033eb12831124";
+          sha256 = "19kak8fh8sf5bpmcn7a90sqikgx30mk2bmjf0jbzcvlbnsjyggah";
+        };
+      };
+    };
+    "dragonmantank/cron-expression" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "dragonmantank-cron-expression-782ca5968ab8b954773518e9e49a6f892a34b2a8";
+        src = fetchurl {
+          url = "https://api.github.com/repos/dragonmantank/cron-expression/zipball/782ca5968ab8b954773518e9e49a6f892a34b2a8";
+          sha256 = "18pxn1v3b2yhwzky22p4wn520h89rcrihl7l6hd0p769vk1b2qg9";
+        };
+      };
+    };
+    "egulias/email-validator" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "egulias-email-validator-5f35e41eba05fdfbabd95d72f83795c835fb7ed2";
+        src = fetchurl {
+          url = "https://api.github.com/repos/egulias/EmailValidator/zipball/5f35e41eba05fdfbabd95d72f83795c835fb7ed2";
+          sha256 = "0fm595bq0wd3vidgd2qh29mvxhyfsizzznrzgymdpwb49c5cfd1j";
+        };
+      };
+    };
+    "facade/ignition-contracts" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "facade-ignition-contracts-3c921a1cdba35b68a7f0ccffc6dffc1995b18267";
+        src = fetchurl {
+          url = "https://api.github.com/repos/facade/ignition-contracts/zipball/3c921a1cdba35b68a7f0ccffc6dffc1995b18267";
+          sha256 = "1nsjwd1k9q8qmfvh7m50rs42yxzxyq4f56r6dq205gwcmqsjb2j0";
+        };
+      };
+    };
+    "filp/whoops" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "filp-whoops-f7948baaa0330277c729714910336383286305da";
+        src = fetchurl {
+          url = "https://api.github.com/repos/filp/whoops/zipball/f7948baaa0330277c729714910336383286305da";
+          sha256 = "1l70lq27h072ria2pgmf9dp3h5awszirqd1khlcknl4w1hww3swv";
+        };
+      };
+    };
+    "firebase/php-jwt" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "firebase-php-jwt-ea7dda77098b96e666c5ef382452f94841e439cd";
+        src = fetchurl {
+          url = "https://api.github.com/repos/firebase/php-jwt/zipball/ea7dda77098b96e666c5ef382452f94841e439cd";
+          sha256 = "0lf4xz4jiqy5k6k91hf609y76py6drf32v175ccncamb6dxixfmr";
+        };
+      };
+    };
+    "fruitcake/php-cors" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "fruitcake-php-cors-58571acbaa5f9f462c9c77e911700ac66f446d4e";
+        src = fetchurl {
+          url = "https://api.github.com/repos/fruitcake/php-cors/zipball/58571acbaa5f9f462c9c77e911700ac66f446d4e";
+          sha256 = "18xm69q4dk9zqfwgp938y2byhlyy9lr5x5qln4k2mg8cq8xr2sm1";
+        };
+      };
+    };
+    "gdbots/query-parser" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "gdbots-query-parser-d35cb9ae613ee8d6a94b5758fb0047668ab1d34c";
+        src = fetchurl {
+          url = "https://api.github.com/repos/gdbots/query-parser-php/zipball/d35cb9ae613ee8d6a94b5758fb0047668ab1d34c";
+          sha256 = "1qn908v7fbx4xg0yp0syn1qh99k4idfb86jkfxws1qjxxfgwnxaw";
+        };
+      };
+    };
+    "graham-campbell/result-type" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "graham-campbell-result-type-a878d45c1914464426dc94da61c9e1d36ae262a8";
+        src = fetchurl {
+          url = "https://api.github.com/repos/GrahamCampbell/Result-Type/zipball/a878d45c1914464426dc94da61c9e1d36ae262a8";
+          sha256 = "1xayas92b467yixpc79l7ydgspy3s76cpfddv7lrvd691y11g1vb";
+        };
+      };
+    };
+    "guzzlehttp/guzzle" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "guzzlehttp-guzzle-b50a2a1251152e43f6a37f0fa053e730a67d25ba";
+        src = fetchurl {
+          url = "https://api.github.com/repos/guzzle/guzzle/zipball/b50a2a1251152e43f6a37f0fa053e730a67d25ba";
+          sha256 = "0cy828r0kafx58jh0k1cy17y77qh248d9kfk9ncn9pyq2q5v9p9p";
+        };
+      };
+    };
+    "guzzlehttp/promises" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "guzzlehttp-promises-b94b2807d85443f9719887892882d0329d1e2598";
+        src = fetchurl {
+          url = "https://api.github.com/repos/guzzle/promises/zipball/b94b2807d85443f9719887892882d0329d1e2598";
+          sha256 = "1vvac7y5ax955qjg7dyjmaw3vab9v2lypjygap0040rv3z4x9vz8";
+        };
+      };
+    };
+    "guzzlehttp/psr7" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "guzzlehttp-psr7-67c26b443f348a51926030c83481b85718457d3d";
+        src = fetchurl {
+          url = "https://api.github.com/repos/guzzle/psr7/zipball/67c26b443f348a51926030c83481b85718457d3d";
+          sha256 = "09avh5xzmzwfpa5xv9zw90ypyfrhpyhszbli395prgh3llnrx9wg";
+        };
+      };
+    };
+    "jc5/google2fa-laravel" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "jc5-google2fa-laravel-0205b0e58b90ee41e6d108d4c26ad9d0f7997baa";
+        src = fetchurl {
+          url = "https://api.github.com/repos/JC5/google2fa-laravel/zipball/0205b0e58b90ee41e6d108d4c26ad9d0f7997baa";
+          sha256 = "01qy0zj9f0rlsfin7ral46ibkpd6xh956084lji14qchxhw7070p";
+        };
+      };
+    };
+    "jc5/recovery" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "jc5-recovery-ad69cb910a92e1aeb75fd7eaa65701cc5b0416f3";
+        src = fetchurl {
+          url = "https://api.github.com/repos/JC5/recovery/zipball/ad69cb910a92e1aeb75fd7eaa65701cc5b0416f3";
+          sha256 = "01pw4kbs5pmp5rvn928yk504ykrj4395jpipqn66ksc6m19nyqdj";
+        };
+      };
+    };
+    "laravel/framework" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "laravel-framework-faeb20d3fc61b69790068161ab42bcf2d5faccbc";
+        src = fetchurl {
+          url = "https://api.github.com/repos/laravel/framework/zipball/faeb20d3fc61b69790068161ab42bcf2d5faccbc";
+          sha256 = "0ly0bd2y1qlg48319yvb2p4c447qimcmv05v8pap1zv4703234g9";
+        };
+      };
+    };
+    "laravel/passport" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "laravel-passport-835febbfe875ba97306c026fdaa94f58f167363e";
+        src = fetchurl {
+          url = "https://api.github.com/repos/laravel/passport/zipball/835febbfe875ba97306c026fdaa94f58f167363e";
+          sha256 = "0wsw8z2prjw87j6bw125pa0ibxyp7kwj0q77n7kz4hl0ah9hsid4";
+        };
+      };
+    };
+    "laravel/sanctum" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "laravel-sanctum-b71e80a3a8e8029e2ec8c1aa814b999609ce16dc";
+        src = fetchurl {
+          url = "https://api.github.com/repos/laravel/sanctum/zipball/b71e80a3a8e8029e2ec8c1aa814b999609ce16dc";
+          sha256 = "1ykfx0qk3p0cfy7giizyb9lpryz0rnqazp9d22v70dl2w4x02p36";
+        };
+      };
+    };
+    "laravel/serializable-closure" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "laravel-serializable-closure-47afb7fae28ed29057fdca37e16a84f90cc62fae";
+        src = fetchurl {
+          url = "https://api.github.com/repos/laravel/serializable-closure/zipball/47afb7fae28ed29057fdca37e16a84f90cc62fae";
+          sha256 = "1mfj1jszq1mssxfh68y3s43sq90bpj25a2kpj0djbmcrccgwd46z";
+        };
+      };
+    };
+    "laravel/ui" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "laravel-ui-ac94e596ffd39c63cfa41f5407b765b07df97483";
+        src = fetchurl {
+          url = "https://api.github.com/repos/laravel/ui/zipball/ac94e596ffd39c63cfa41f5407b765b07df97483";
+          sha256 = "18y1bdl1xf0z9h33igz6lb62xydqq87y4jxazm4i94037d1vazlj";
+        };
+      };
+    };
+    "laravelcollective/html" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "laravelcollective-html-78c3cb516ac9e6d3d76cad9191f81d217302dea6";
+        src = fetchurl {
+          url = "https://api.github.com/repos/LaravelCollective/html/zipball/78c3cb516ac9e6d3d76cad9191f81d217302dea6";
+          sha256 = "14nm7wzlp8hz0ja1xhs10nhci3bq9ss73jpavbs0qazipfpc38sn";
+        };
+      };
+    };
+    "lcobucci/clock" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "lcobucci-clock-fb533e093fd61321bfcbac08b131ce805fe183d3";
+        src = fetchurl {
+          url = "https://api.github.com/repos/lcobucci/clock/zipball/fb533e093fd61321bfcbac08b131ce805fe183d3";
+          sha256 = "05s8mlq54c21j9w3haiw5k0cw9xipig9mmihizrbmd82nzy1n5sl";
+        };
+      };
+    };
+    "lcobucci/jwt" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "lcobucci-jwt-72ac6d807ee51a70ad376ee03a2387e8646e10f3";
+        src = fetchurl {
+          url = "https://api.github.com/repos/lcobucci/jwt/zipball/72ac6d807ee51a70ad376ee03a2387e8646e10f3";
+          sha256 = "1jk9ha8yg6k4l63mbx5l41f66yra91cpwyvz7sivlkkdm3n68srg";
+        };
+      };
+    };
+    "league/commonmark" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "league-commonmark-c493585c130544c4e91d2e0e131e6d35cb0cbc47";
+        src = fetchurl {
+          url = "https://api.github.com/repos/thephpleague/commonmark/zipball/c493585c130544c4e91d2e0e131e6d35cb0cbc47";
+          sha256 = "0z5w4fxd9irxlnbi1vmnjqiikwia1zzwrhax51qn55m4hwkg0aja";
+        };
+      };
+    };
+    "league/config" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "league-config-754b3604fb2984c71f4af4a9cbe7b57f346ec1f3";
+        src = fetchurl {
+          url = "https://api.github.com/repos/thephpleague/config/zipball/754b3604fb2984c71f4af4a9cbe7b57f346ec1f3";
+          sha256 = "0yjb85cd0qa0mra995863dij2hmcwk9x124vs8lrwiylb0l3mn8s";
+        };
+      };
+    };
+    "league/csv" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "league-csv-9d2e0265c5d90f5dd601bc65ff717e05cec19b47";
+        src = fetchurl {
+          url = "https://api.github.com/repos/thephpleague/csv/zipball/9d2e0265c5d90f5dd601bc65ff717e05cec19b47";
+          sha256 = "0mcngirl2r8aw7hgbwaq3hrkkib4xwvhngijdhrkdzg4hj6ii3ap";
+        };
+      };
+    };
+    "league/event" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "league-event-d2cc124cf9a3fab2bb4ff963307f60361ce4d119";
+        src = fetchurl {
+          url = "https://api.github.com/repos/thephpleague/event/zipball/d2cc124cf9a3fab2bb4ff963307f60361ce4d119";
+          sha256 = "1fc8aj0mpbrnh3b93gn8pypix28nf2gfvi403kfl7ibh5iz6ds5l";
+        };
+      };
+    };
+    "league/flysystem" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "league-flysystem-2aef65a47e44f2d6f9938f720f6dd697e7ba7b76";
+        src = fetchurl {
+          url = "https://api.github.com/repos/thephpleague/flysystem/zipball/2aef65a47e44f2d6f9938f720f6dd697e7ba7b76";
+          sha256 = "0q9lv1m3z81fshv5x9yw3dnd5gj4m4m84y5v0gmm5kwrr5vzmjmk";
+        };
+      };
+    };
+    "league/fractal" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "league-fractal-8b9d39b67624db9195c06f9c1ffd0355151eaf62";
+        src = fetchurl {
+          url = "https://api.github.com/repos/thephpleague/fractal/zipball/8b9d39b67624db9195c06f9c1ffd0355151eaf62";
+          sha256 = "02zk3hpwbxrxixw54ar2gflsy762fqkvbdg3wy3d60rvyscpha7l";
+        };
+      };
+    };
+    "league/mime-type-detection" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "league-mime-type-detection-ff6248ea87a9f116e78edd6002e39e5128a0d4dd";
+        src = fetchurl {
+          url = "https://api.github.com/repos/thephpleague/mime-type-detection/zipball/ff6248ea87a9f116e78edd6002e39e5128a0d4dd";
+          sha256 = "1a63nvqd6cz3vck3y8vjswn6c3cfwh13p0cn0ci5pqdf0bgjvvfz";
+        };
+      };
+    };
+    "league/oauth2-server" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "league-oauth2-server-28c5441716c10d0c936bd731860dc385d0f6d1a8";
+        src = fetchurl {
+          url = "https://api.github.com/repos/thephpleague/oauth2-server/zipball/28c5441716c10d0c936bd731860dc385d0f6d1a8";
+          sha256 = "1fifcsfgsflhm3v82744ppccqic5l73wg8a2q2nhva9g60xw7kgr";
+        };
+      };
+    };
+    "league/uri" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "league-uri-d3b50812dd51f3fbf176344cc2981db03d10fe06";
+        src = fetchurl {
+          url = "https://api.github.com/repos/thephpleague/uri/zipball/d3b50812dd51f3fbf176344cc2981db03d10fe06";
+          sha256 = "1ldsc8scs73mix7fbjbk3jsja42fyapn1dnwv37j2b8sk4fvhv4m";
+        };
+      };
+    };
+    "league/uri-interfaces" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "league-uri-interfaces-00e7e2943f76d8cb50c7dfdc2f6dee356e15e383";
+        src = fetchurl {
+          url = "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/00e7e2943f76d8cb50c7dfdc2f6dee356e15e383";
+          sha256 = "01jllf6n9fs4yjcf6sjc4ivqp7k7dkqhbpz354bq9mr14njsjv6x";
+        };
+      };
+    };
+    "monolog/monolog" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "monolog-monolog-720488632c590286b88b80e62aa3d3d551ad4a50";
+        src = fetchurl {
+          url = "https://api.github.com/repos/Seldaek/monolog/zipball/720488632c590286b88b80e62aa3d3d551ad4a50";
+          sha256 = "0wg1y0mghhib6cp9gcavbs6ajfs9rgxc2ssipqb5yfwfkkbwrif6";
+        };
+      };
+    };
+    "nesbot/carbon" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "nesbot-carbon-f2e59963f4c4f4fdfb9fcfd752e8d2e2b79a4e2c";
+        src = fetchurl {
+          url = "https://api.github.com/repos/briannesbitt/Carbon/zipball/f2e59963f4c4f4fdfb9fcfd752e8d2e2b79a4e2c";
+          sha256 = "0qmm18r2mqk8yr28dh37wh95k1544vqpn28qqz95c6xhqy1v26j5";
+        };
+      };
+    };
+    "nette/schema" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "nette-schema-abbdbb70e0245d5f3bf77874cea1dfb0c930d06f";
+        src = fetchurl {
+          url = "https://api.github.com/repos/nette/schema/zipball/abbdbb70e0245d5f3bf77874cea1dfb0c930d06f";
+          sha256 = "16i8gim0jpmmbq0pp4faw8kn2448yvpgsd1zvipbv9xrk37vah5q";
+        };
+      };
+    };
+    "nette/utils" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "nette-utils-02a54c4c872b99e4ec05c4aec54b5a06eb0f6368";
+        src = fetchurl {
+          url = "https://api.github.com/repos/nette/utils/zipball/02a54c4c872b99e4ec05c4aec54b5a06eb0f6368";
+          sha256 = "17kj603xalq0il1ss8zgylckjr9r2zlglk7gylpa7v9iddmfbw5p";
+        };
+      };
+    };
+    "nunomaduro/collision" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "nunomaduro-collision-83699b231e7f277bfa2e823788973bf4082f019a";
+        src = fetchurl {
+          url = "https://api.github.com/repos/nunomaduro/collision/zipball/83699b231e7f277bfa2e823788973bf4082f019a";
+          sha256 = "1krvh4m7y5qvc338z3p4im6dlv6sf1y8qhx2vk2c6597lksx75ip";
+        };
+      };
+    };
+    "nunomaduro/termwind" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "nunomaduro-termwind-594ab862396c16ead000de0c3c38f4a5cbe1938d";
+        src = fetchurl {
+          url = "https://api.github.com/repos/nunomaduro/termwind/zipball/594ab862396c16ead000de0c3c38f4a5cbe1938d";
+          sha256 = "0j3my0cdcvvnicv0izjcidm4gn64km61cszz3vnxh7pnig6s0i0x";
+        };
+      };
+    };
+    "nyholm/psr7" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "nyholm-psr7-f734364e38a876a23be4d906a2a089e1315be18a";
+        src = fetchurl {
+          url = "https://api.github.com/repos/Nyholm/psr7/zipball/f734364e38a876a23be4d906a2a089e1315be18a";
+          sha256 = "0w8i5l1qg8dkc1zsyz1gpwn2awgkhlm295l1b8smmzabqdc65dcx";
+        };
+      };
+    };
+    "paragonie/constant_time_encoding" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "paragonie-constant_time_encoding-58c3f47f650c94ec05a151692652a868995d2938";
+        src = fetchurl {
+          url = "https://api.github.com/repos/paragonie/constant_time_encoding/zipball/58c3f47f650c94ec05a151692652a868995d2938";
+          sha256 = "0i9km0lzvc7df9758fm1p3y0679pzvr5m9x3mrz0d2hxlppsm764";
+        };
+      };
+    };
+    "paragonie/random_compat" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "paragonie-random_compat-996434e5492cb4c3edcb9168db6fbb1359ef965a";
+        src = fetchurl {
+          url = "https://api.github.com/repos/paragonie/random_compat/zipball/996434e5492cb4c3edcb9168db6fbb1359ef965a";
+          sha256 = "0ky7lal59dihf969r1k3pb96ql8zzdc5062jdbg69j6rj0scgkyx";
+        };
+      };
+    };
+    "php-http/message-factory" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "php-http-message-factory-a478cb11f66a6ac48d8954216cfed9aa06a501a1";
+        src = fetchurl {
+          url = "https://api.github.com/repos/php-http/message-factory/zipball/a478cb11f66a6ac48d8954216cfed9aa06a501a1";
+          sha256 = "13drpc83bq332hz0b97whibkm7jpk56msq4yppw9nmrchzwgy7cs";
+        };
+      };
+    };
+    "phpoption/phpoption" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "phpoption-phpoption-dc5ff11e274a90cc1c743f66c9ad700ce50db9ab";
+        src = fetchurl {
+          url = "https://api.github.com/repos/schmittjoh/php-option/zipball/dc5ff11e274a90cc1c743f66c9ad700ce50db9ab";
+          sha256 = "12i9gc2q75iv6c0x87zj3j499pl8k0wzh3yzvgrhg97nhbdhab5c";
+        };
+      };
+    };
+    "phpseclib/phpseclib" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "phpseclib-phpseclib-f28693d38ba21bb0d9f0c411ee5dae2b178201da";
+        src = fetchurl {
+          url = "https://api.github.com/repos/phpseclib/phpseclib/zipball/f28693d38ba21bb0d9f0c411ee5dae2b178201da";
+          sha256 = "11hvq1mwk2zn1fgrwvifh5z4md178vzka5nfykj8l28vk7r0vb98";
+        };
+      };
+    };
+    "pragmarx/google2fa" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "pragmarx-google2fa-80c3d801b31fe165f8fe99ea085e0a37834e1be3";
+        src = fetchurl {
+          url = "https://api.github.com/repos/antonioribeiro/google2fa/zipball/80c3d801b31fe165f8fe99ea085e0a37834e1be3";
+          sha256 = "0qfjgkl02ifc0zicv3d5d6zs8mwpq68bg211jy3psgghnqpxyhlm";
+        };
+      };
+    };
+    "pragmarx/google2fa-qrcode" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "pragmarx-google2fa-qrcode-fd5ff0531a48b193a659309cc5fb882c14dbd03f";
+        src = fetchurl {
+          url = "https://api.github.com/repos/antonioribeiro/google2fa-qrcode/zipball/fd5ff0531a48b193a659309cc5fb882c14dbd03f";
+          sha256 = "1csa15v68bznrz3262xjcdgcgw0lg8fwb6fhrbms2mnylhq4s35g";
+        };
+      };
+    };
+    "pragmarx/random" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "pragmarx-random-daf08a189c5d2d40d1a827db46364d3a741a51b7";
+        src = fetchurl {
+          url = "https://api.github.com/repos/antonioribeiro/random/zipball/daf08a189c5d2d40d1a827db46364d3a741a51b7";
+          sha256 = "05szknpz05jj6jan39mgbmkl0m23clcaaiky649d6z9whbcd18wh";
+        };
+      };
+    };
+    "predis/predis" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "predis-predis-ff59f745815150c65ed388f7d64e7660fe961771";
+        src = fetchurl {
+          url = "https://api.github.com/repos/predis/predis/zipball/ff59f745815150c65ed388f7d64e7660fe961771";
+          sha256 = "06a78idnww57zxqypa2xrz09w2hdim0nbxxa099zzba4v9wdls4q";
+        };
+      };
+    };
+    "psr/cache" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "psr-cache-aa5030cfa5405eccfdcb1083ce040c2cb8d253bf";
+        src = fetchurl {
+          url = "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf";
+          sha256 = "07rnyjwb445sfj30v5ny3gfsgc1m7j7cyvwjgs2cm9slns1k1ml8";
+        };
+      };
+    };
+    "psr/clock" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "psr-clock-e41a24703d4560fd0acb709162f73b8adfc3aa0d";
+        src = fetchurl {
+          url = "https://api.github.com/repos/php-fig/clock/zipball/e41a24703d4560fd0acb709162f73b8adfc3aa0d";
+          sha256 = "0wz5b8hgkxn3jg88cb3901hj71axsj0fil6pwl413igghch6i8kj";
+        };
+      };
+    };
+    "psr/container" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "psr-container-c71ecc56dfe541dbd90c5360474fbc405f8d5963";
+        src = fetchurl {
+          url = "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963";
+          sha256 = "1mvan38yb65hwk68hl0p7jymwzr4zfnaxmwjbw7nj3rsknvga49i";
+        };
+      };
+    };
+    "psr/event-dispatcher" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "psr-event-dispatcher-dbefd12671e8a14ec7f180cab83036ed26714bb0";
+        src = fetchurl {
+          url = "https://api.github.com/repos/php-fig/event-dispatcher/zipball/dbefd12671e8a14ec7f180cab83036ed26714bb0";
+          sha256 = "05nicsd9lwl467bsv4sn44fjnnvqvzj1xqw2mmz9bac9zm66fsjd";
+        };
+      };
+    };
+    "psr/http-client" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "psr-http-client-2dfb5f6c5eff0e91e20e913f8c5452ed95b86621";
+        src = fetchurl {
+          url = "https://api.github.com/repos/php-fig/http-client/zipball/2dfb5f6c5eff0e91e20e913f8c5452ed95b86621";
+          sha256 = "0cmkifa3ji1r8kn3y1rwg81rh8g2crvnhbv2am6d688dzsbw967v";
+        };
+      };
+    };
+    "psr/http-factory" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "psr-http-factory-12ac7fcd07e5b077433f5f2bee95b3a771bf61be";
+        src = fetchurl {
+          url = "https://api.github.com/repos/php-fig/http-factory/zipball/12ac7fcd07e5b077433f5f2bee95b3a771bf61be";
+          sha256 = "0inbnqpc5bfhbbda9dwazsrw9xscfnc8rdx82q1qm3r446mc1vds";
+        };
+      };
+    };
+    "psr/http-message" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "psr-http-message-f6561bf28d520154e4b0ec72be95418abe6d9363";
+        src = fetchurl {
+          url = "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363";
+          sha256 = "195dd67hva9bmr52iadr4kyp2gw2f5l51lplfiay2pv6l9y4cf45";
+        };
+      };
+    };
+    "psr/log" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "psr-log-fe5ea303b0887d5caefd3d431c3e61ad47037001";
+        src = fetchurl {
+          url = "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001";
+          sha256 = "0a0rwg38vdkmal3nwsgx58z06qkfl85w2yvhbgwg45anr0b3bhmv";
+        };
+      };
+    };
+    "psr/simple-cache" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "psr-simple-cache-764e0b3939f5ca87cb904f570ef9be2d78a07865";
+        src = fetchurl {
+          url = "https://api.github.com/repos/php-fig/simple-cache/zipball/764e0b3939f5ca87cb904f570ef9be2d78a07865";
+          sha256 = "0hgcanvd9gqwkaaaq41lh8fsfdraxmp2n611lvqv69jwm1iy76g8";
+        };
+      };
+    };
+    "ralouphie/getallheaders" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "ralouphie-getallheaders-120b605dfeb996808c31b6477290a714d356e822";
+        src = fetchurl {
+          url = "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822";
+          sha256 = "1bv7ndkkankrqlr2b4kw7qp3fl0dxi6bp26bnim6dnlhavd6a0gg";
+        };
+      };
+    };
+    "ramsey/collection" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "ramsey-collection-ad7475d1c9e70b190ecffc58f2d989416af339b4";
+        src = fetchurl {
+          url = "https://api.github.com/repos/ramsey/collection/zipball/ad7475d1c9e70b190ecffc58f2d989416af339b4";
+          sha256 = "1a1wqdwdrbzkf2hias2kw9crr31265pn027vm69pr7alyq2qrzfw";
+        };
+      };
+    };
+    "ramsey/uuid" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "ramsey-uuid-a1acf96007170234a8399586a6e2ab8feba109d1";
+        src = fetchurl {
+          url = "https://api.github.com/repos/ramsey/uuid/zipball/a1acf96007170234a8399586a6e2ab8feba109d1";
+          sha256 = "0mgw1gacs8lm3kamw8w8v75ysfddj2fjkkxx4ka1l4pznf1785x1";
+        };
+      };
+    };
+    "rcrowe/twigbridge" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "rcrowe-twigbridge-f4968efb99537cc1b37c5bf20280614aadc31825";
+        src = fetchurl {
+          url = "https://api.github.com/repos/rcrowe/TwigBridge/zipball/f4968efb99537cc1b37c5bf20280614aadc31825";
+          sha256 = "0kxaw5jmyjq5n5lvhg5a4j5wdvlnp0r3hcs34299mgpx7na9b5cd";
+        };
+      };
+    };
+    "spatie/backtrace" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "spatie-backtrace-4ee7d41aa5268107906ea8a4d9ceccde136dbd5b";
+        src = fetchurl {
+          url = "https://api.github.com/repos/spatie/backtrace/zipball/4ee7d41aa5268107906ea8a4d9ceccde136dbd5b";
+          sha256 = "0gkdqik1lvld5lw74w8wxykix5xam1pa6z2njd3zi4f5hjdsw51b";
+        };
+      };
+    };
+    "spatie/data-transfer-object" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "spatie-data-transfer-object-1df0906c4e9e3aebd6c0506fd82c8b7d5548c1c8";
+        src = fetchurl {
+          url = "https://api.github.com/repos/spatie/data-transfer-object/zipball/1df0906c4e9e3aebd6c0506fd82c8b7d5548c1c8";
+          sha256 = "1b9hyw3q2ld3idxjx9xpyqdbb2lkbghkaw5vz968cjp48xbpsxbj";
+        };
+      };
+    };
+    "spatie/flare-client-php" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "spatie-flare-client-php-609903bd154ba3d71f5e23a91c3b431fa8f71868";
+        src = fetchurl {
+          url = "https://api.github.com/repos/spatie/flare-client-php/zipball/609903bd154ba3d71f5e23a91c3b431fa8f71868";
+          sha256 = "1clrkgdqdi2vbw44sd8qhlij3szwzyyak72nifv8qz7jdyzxjnih";
+        };
+      };
+    };
+    "spatie/ignition" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "spatie-ignition-dd3d456779108d7078baf4e43f8c2b937d9794a1";
+        src = fetchurl {
+          url = "https://api.github.com/repos/spatie/ignition/zipball/dd3d456779108d7078baf4e43f8c2b937d9794a1";
+          sha256 = "1vdblm5yn9910vhgs1pngf5mmfhslgml2m0j1zkcdn47zsh70kgp";
+        };
+      };
+    };
+    "spatie/laravel-ignition" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "spatie-laravel-ignition-2db918babd96f87b73fc26e4195f5a19328dd123";
+        src = fetchurl {
+          url = "https://api.github.com/repos/spatie/laravel-ignition/zipball/2db918babd96f87b73fc26e4195f5a19328dd123";
+          sha256 = "1zvn7xgb92ldlkzzvj6b6fckq2lpgcnng9yqyg5dx9qs8vpsg5qy";
+        };
+      };
+    };
+    "stella-maris/clock" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "stella-maris-clock-fa23ce16019289a18bb3446fdecd45befcdd94f8";
+        src = fetchurl {
+          url = "https://api.github.com/repos/stella-maris-solutions/clock/zipball/fa23ce16019289a18bb3446fdecd45befcdd94f8";
+          sha256 = "12w5zy8h7wmzgk7bk7lxq8pmbv8gmnxwdrkqn4lv5z5k9nj74zyr";
+        };
+      };
+    };
+    "symfony/console" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "symfony-console-2ab307342a7233b9a260edd5ef94087aaca57d18";
+        src = fetchurl {
+          url = "https://api.github.com/repos/symfony/console/zipball/2ab307342a7233b9a260edd5ef94087aaca57d18";
+          sha256 = "1gglw32gwiq50mrgfj238h65xbb0snbrhn6z60rjxz439p2ksx5j";
+        };
+      };
+    };
+    "symfony/css-selector" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "symfony-css-selector-3e526b732295b5d4c16c38d557b74ba8498a92b4";
+        src = fetchurl {
+          url = "https://api.github.com/repos/symfony/css-selector/zipball/3e526b732295b5d4c16c38d557b74ba8498a92b4";
+          sha256 = "1shiqfcxmngr0lhwaibqs6kicy311vr51pzp10g0x19yn1sdcdpx";
+        };
+      };
+    };
+    "symfony/deprecation-contracts" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "symfony-deprecation-contracts-26954b3d62a6c5fd0ea8a2a00c0353a14978d05c";
+        src = fetchurl {
+          url = "https://api.github.com/repos/symfony/deprecation-contracts/zipball/26954b3d62a6c5fd0ea8a2a00c0353a14978d05c";
+          sha256 = "1wlaj9ngbyjmgr92gjyf7lsmjfswyh8vpbzq5rdzaxjb6bcsj3dp";
+        };
+      };
+    };
+    "symfony/error-handler" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "symfony-error-handler-1113c4bcf3bc77a9c79562543317479c90ba7b82";
+        src = fetchurl {
+          url = "https://api.github.com/repos/symfony/error-handler/zipball/1113c4bcf3bc77a9c79562543317479c90ba7b82";
+          sha256 = "08f2cll45dxvfijsnaa1hqmz7m74i1hb7ai7zi24fmikdvw7nc39";
+        };
+      };
+    };
+    "symfony/event-dispatcher" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "symfony-event-dispatcher-42b3985aa07837c9df36013ec5b965e9f2d480bc";
+        src = fetchurl {
+          url = "https://api.github.com/repos/symfony/event-dispatcher/zipball/42b3985aa07837c9df36013ec5b965e9f2d480bc";
+          sha256 = "0rvwbrg0a918f5jcp946aphvxbzpva1nd88ql0ix6lpcrw23j33y";
+        };
+      };
+    };
+    "symfony/event-dispatcher-contracts" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "symfony-event-dispatcher-contracts-7bc61cc2db649b4637d331240c5346dcc7708051";
+        src = fetchurl {
+          url = "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/7bc61cc2db649b4637d331240c5346dcc7708051";
+          sha256 = "1crx2j4g5jn904fwk7919ar9zpyfd5bvgm80lmyg15kinsjm3w4i";
+        };
+      };
+    };
+    "symfony/finder" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "symfony-finder-d467d625fc88f7cebf96f495e588a7196a669db1";
+        src = fetchurl {
+          url = "https://api.github.com/repos/symfony/finder/zipball/d467d625fc88f7cebf96f495e588a7196a669db1";
+          sha256 = "1lm82llcf5lklz08sha1br0kqw8mrb7y56y1hg7ny3mjrk2k2n12";
+        };
+      };
+    };
+    "symfony/http-client" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "symfony-http-client-d104286d135d29a17ead777888087e7f0fd11771";
+        src = fetchurl {
+          url = "https://api.github.com/repos/symfony/http-client/zipball/d104286d135d29a17ead777888087e7f0fd11771";
+          sha256 = "000yps2br00w864wdqvnd6laf07pqjm9xijycl4mkslgijfgcqyx";
+        };
+      };
+    };
+    "symfony/http-client-contracts" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "symfony-http-client-contracts-4184b9b63af1edaf35b6a7974c6f1f9f33294129";
+        src = fetchurl {
+          url = "https://api.github.com/repos/symfony/http-client-contracts/zipball/4184b9b63af1edaf35b6a7974c6f1f9f33294129";
+          sha256 = "0pj951z5x6k9g81kalsdnnjb8q4z0046x38f3wc2hklh0274f11v";
+        };
+      };
+    };
+    "symfony/http-foundation" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "symfony-http-foundation-22fe17e40b0481d39212e7165e004eb26422085d";
+        src = fetchurl {
+          url = "https://api.github.com/repos/symfony/http-foundation/zipball/22fe17e40b0481d39212e7165e004eb26422085d";
+          sha256 = "07gaqgl9abkr4f8xbb2arm5agsqb3d26iddl7gvixfd5gpszdnhf";
+        };
+      };
+    };
+    "symfony/http-kernel" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "symfony-http-kernel-71b52f9e5740b124894b454244fa0db48bb15814";
+        src = fetchurl {
+          url = "https://api.github.com/repos/symfony/http-kernel/zipball/71b52f9e5740b124894b454244fa0db48bb15814";
+          sha256 = "1qbmgkwcwshn326kbbd5nf10d2a0rhfqziy5zb4nkiflvb4rri5p";
+        };
+      };
+    };
+    "symfony/mailer" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "symfony-mailer-0d4562cd13f1e5b78b578120ae5cbd5527ec1534";
+        src = fetchurl {
+          url = "https://api.github.com/repos/symfony/mailer/zipball/0d4562cd13f1e5b78b578120ae5cbd5527ec1534";
+          sha256 = "19ykm2c6i95rnz725a8la62klydfjdckbz80m32lfxrkjz476k99";
+        };
+      };
+    };
+    "symfony/mailgun-mailer" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "symfony-mailgun-mailer-f0d032c26683b26f4bc26864e09b1e08fa55226e";
+        src = fetchurl {
+          url = "https://api.github.com/repos/symfony/mailgun-mailer/zipball/f0d032c26683b26f4bc26864e09b1e08fa55226e";
+          sha256 = "0l8jgjc0j61mpqhcaw6wid270my3q2j0wvm340x55a8n618dkn0d";
+        };
+      };
+    };
+    "symfony/mime" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "symfony-mime-3e6a7ba15997020778312ed576ad01ab60dc2336";
+        src = fetchurl {
+          url = "https://api.github.com/repos/symfony/mime/zipball/3e6a7ba15997020778312ed576ad01ab60dc2336";
+          sha256 = "11xr7npxkk4isg1q35w2r1n0fl7bh14saarc9zywhyp67rq9c8bj";
+        };
+      };
+    };
+    "symfony/polyfill-ctype" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "symfony-polyfill-ctype-5bbc823adecdae860bb64756d639ecfec17b050a";
+        src = fetchurl {
+          url = "https://api.github.com/repos/symfony/polyfill-ctype/zipball/5bbc823adecdae860bb64756d639ecfec17b050a";
+          sha256 = "0vyv70z1yi2is727d1mkb961w5r1pb1v3wy1pvdp30h8ffy15wk6";
+        };
+      };
+    };
+    "symfony/polyfill-intl-grapheme" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "symfony-polyfill-intl-grapheme-511a08c03c1960e08a883f4cffcacd219b758354";
+        src = fetchurl {
+          url = "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/511a08c03c1960e08a883f4cffcacd219b758354";
+          sha256 = "0ifsgsyxf0z0nkynqvr5259dm5dsmbgdpvyi5zfvy8935mi0ki0i";
+        };
+      };
+    };
+    "symfony/polyfill-intl-idn" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "symfony-polyfill-intl-idn-639084e360537a19f9ee352433b84ce831f3d2da";
+        src = fetchurl {
+          url = "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/639084e360537a19f9ee352433b84ce831f3d2da";
+          sha256 = "1i2wcsbfbwdyrx8545yrrvbdaf4l2393pjvg9266q74611j6pzxj";
+        };
+      };
+    };
+    "symfony/polyfill-intl-normalizer" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "symfony-polyfill-intl-normalizer-19bd1e4fcd5b91116f14d8533c57831ed00571b6";
+        src = fetchurl {
+          url = "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/19bd1e4fcd5b91116f14d8533c57831ed00571b6";
+          sha256 = "1d80jph5ykiw6ydv8fwd43s0aglh24qc1yrzds2f3aqanpbk1gr2";
+        };
+      };
+    };
+    "symfony/polyfill-mbstring" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "symfony-polyfill-mbstring-8ad114f6b39e2c98a8b0e3bd907732c207c2b534";
+        src = fetchurl {
+          url = "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/8ad114f6b39e2c98a8b0e3bd907732c207c2b534";
+          sha256 = "1ym84qp609i50lv4vkd4yz99y19kaxd5kmpdnh66mxx1a4a104mi";
+        };
+      };
+    };
+    "symfony/polyfill-php72" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "symfony-polyfill-php72-869329b1e9894268a8a61dabb69153029b7a8c97";
+        src = fetchurl {
+          url = "https://api.github.com/repos/symfony/polyfill-php72/zipball/869329b1e9894268a8a61dabb69153029b7a8c97";
+          sha256 = "1h0lbh8d41sa4fymmw03yzws3v3z0lz4lv1kgcld7r53i2m3wfwp";
+        };
+      };
+    };
+    "symfony/polyfill-php80" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "symfony-polyfill-php80-7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936";
+        src = fetchurl {
+          url = "https://api.github.com/repos/symfony/polyfill-php80/zipball/7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936";
+          sha256 = "16yydk7rsknlasrpn47n4b4js8svvp4rxzw99dkav52wr3cqmcwd";
+        };
+      };
+    };
+    "symfony/polyfill-php81" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "symfony-polyfill-php81-707403074c8ea6e2edaf8794b0157a0bfa52157a";
+        src = fetchurl {
+          url = "https://api.github.com/repos/symfony/polyfill-php81/zipball/707403074c8ea6e2edaf8794b0157a0bfa52157a";
+          sha256 = "05qrjfnnnz402l11wm0ydblrip7hjll12yqxmh2wd02b0s8dj29f";
+        };
+      };
+    };
+    "symfony/polyfill-uuid" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "symfony-polyfill-uuid-f3cf1a645c2734236ed1e2e671e273eeb3586166";
+        src = fetchurl {
+          url = "https://api.github.com/repos/symfony/polyfill-uuid/zipball/f3cf1a645c2734236ed1e2e671e273eeb3586166";
+          sha256 = "1pjh861iwlf71frm9f9i7acw4bbiq40gkh96a5wd09nfd2c3w7mc";
+        };
+      };
+    };
+    "symfony/process" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "symfony-process-44270a08ccb664143dede554ff1c00aaa2247a43";
+        src = fetchurl {
+          url = "https://api.github.com/repos/symfony/process/zipball/44270a08ccb664143dede554ff1c00aaa2247a43";
+          sha256 = "1rbv3navjd6y7prbkg2im8i2b7abkdpvn9pqmbgkavpk0jr4by3s";
+        };
+      };
+    };
+    "symfony/psr-http-message-bridge" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "symfony-psr-http-message-bridge-a125b93ef378c492e274f217874906fb9babdebb";
+        src = fetchurl {
+          url = "https://api.github.com/repos/symfony/psr-http-message-bridge/zipball/a125b93ef378c492e274f217874906fb9babdebb";
+          sha256 = "1c23bv3j2zwbxklizvkvkzrgn2fd1164qb0smgswa15pshwmr0gw";
+        };
+      };
+    };
+    "symfony/routing" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "symfony-routing-61687a0aa80f6807c52e116ee64072f6ec53780c";
+        src = fetchurl {
+          url = "https://api.github.com/repos/symfony/routing/zipball/61687a0aa80f6807c52e116ee64072f6ec53780c";
+          sha256 = "01zk0cbd99h4qjr1y5v2vps3g71vyh9rw9knnai5s8cqc20pz7lc";
+        };
+      };
+    };
+    "symfony/service-contracts" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "symfony-service-contracts-d78d39c1599bd1188b8e26bb341da52c3c6d8a66";
+        src = fetchurl {
+          url = "https://api.github.com/repos/symfony/service-contracts/zipball/d78d39c1599bd1188b8e26bb341da52c3c6d8a66";
+          sha256 = "1cgbn2yx2fyrc3c1d85vdriiwwifr1sdg868f3rhq9bh78f03z99";
+        };
+      };
+    };
+    "symfony/string" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "symfony-string-3f57003dd8a67ed76870cc03092f8501db7788d9";
+        src = fetchurl {
+          url = "https://api.github.com/repos/symfony/string/zipball/3f57003dd8a67ed76870cc03092f8501db7788d9";
+          sha256 = "0gfbac5r0dyv89khn7c759mc3xdzm94m3fry6bxdigzak4px529j";
+        };
+      };
+    };
+    "symfony/translation" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "symfony-translation-6f99eb179aee4652c0a7cd7c11f2a870d904330c";
+        src = fetchurl {
+          url = "https://api.github.com/repos/symfony/translation/zipball/6f99eb179aee4652c0a7cd7c11f2a870d904330c";
+          sha256 = "007rfhxpijbv3h2nz64ay5pawxgj1l4lfyprhx4n5f16fcr9ahml";
+        };
+      };
+    };
+    "symfony/translation-contracts" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "symfony-translation-contracts-acbfbb274e730e5a0236f619b6168d9dedb3e282";
+        src = fetchurl {
+          url = "https://api.github.com/repos/symfony/translation-contracts/zipball/acbfbb274e730e5a0236f619b6168d9dedb3e282";
+          sha256 = "1r496j63a6q3ch0ax76qa1apmc4iqf41zc8rf6yn8vkir3nzkqr0";
+        };
+      };
+    };
+    "symfony/uid" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "symfony-uid-db426b27173f5e2d8b960dd10fa8ce19ea9ca5f3";
+        src = fetchurl {
+          url = "https://api.github.com/repos/symfony/uid/zipball/db426b27173f5e2d8b960dd10fa8ce19ea9ca5f3";
+          sha256 = "0v2xhnqrk0qhbnn78cv6rn1bx20by7bmfqsc0mkind321lw6i5lf";
+        };
+      };
+    };
+    "symfony/var-dumper" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "symfony-var-dumper-7d8e7c3c67c77790425ebe33691419dada154e65";
+        src = fetchurl {
+          url = "https://api.github.com/repos/symfony/var-dumper/zipball/7d8e7c3c67c77790425ebe33691419dada154e65";
+          sha256 = "1lyr6j1zhlngxxpq6cab7apj3jyqkq888hd6bjb57d5b2x3xfwh1";
+        };
+      };
+    };
+    "tijsverkoyen/css-to-inline-styles" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "tijsverkoyen-css-to-inline-styles-4348a3a06651827a27d989ad1d13efec6bb49b19";
+        src = fetchurl {
+          url = "https://api.github.com/repos/tijsverkoyen/CssToInlineStyles/zipball/4348a3a06651827a27d989ad1d13efec6bb49b19";
+          sha256 = "0fs2w9hw0drf1hszidrmplrph7ay8m8pv58pqv26v0228m4l6vlm";
+        };
+      };
+    };
+    "twig/twig" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "twig-twig-3ffcf4b7d890770466da3b2666f82ac054e7ec72";
+        src = fetchurl {
+          url = "https://api.github.com/repos/twigphp/Twig/zipball/3ffcf4b7d890770466da3b2666f82ac054e7ec72";
+          sha256 = "1lm0qggvsb7qszjn9509wgx7b6d7czcgrg5r9hm104990xwbph83";
+        };
+      };
+    };
+    "vlucas/phpdotenv" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "vlucas-phpdotenv-1a7ea2afc49c3ee6d87061f5a233e3a035d0eae7";
+        src = fetchurl {
+          url = "https://api.github.com/repos/vlucas/phpdotenv/zipball/1a7ea2afc49c3ee6d87061f5a233e3a035d0eae7";
+          sha256 = "13h4xyxhdjn1n7xcxbcdhj20rv5fsaigbsbz61x2i224hj76620a";
+        };
+      };
+    };
+    "voku/portable-ascii" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "voku-portable-ascii-b56450eed252f6801410d810c8e1727224ae0743";
+        src = fetchurl {
+          url = "https://api.github.com/repos/voku/portable-ascii/zipball/b56450eed252f6801410d810c8e1727224ae0743";
+          sha256 = "0gwlv1hr6ycrf8ik1pnvlwaac8cpm8sa1nf4d49s8rp4k2y5anyl";
+        };
+      };
+    };
+    "webmozart/assert" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "webmozart-assert-11cb2199493b2f8a3b53e7f19068fc6aac760991";
+        src = fetchurl {
+          url = "https://api.github.com/repos/webmozarts/assert/zipball/11cb2199493b2f8a3b53e7f19068fc6aac760991";
+          sha256 = "18qiza1ynwxpi6731jx1w5qsgw98prld1lgvfk54z92b1nc7psix";
+        };
+      };
+    };
+  };
+  devPackages = {};
+in
+composerEnv.buildPackage {
+  inherit packages devPackages noDev;
+  name = "firefly-iii";
+  src = composerEnv.filterSrc ./.;
+  executable = false;
+  symlinkDependencies = false;
+  meta = {
+    homepage = "https://github.com/firefly-iii/firefly-iii";
+    license = "AGPL-3.0-or-later";
+  };
+}

--- a/pkgs/servers/web-apps/firefly-iii/update.sh
+++ b/pkgs/servers/web-apps/firefly-iii/update.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i nixpkgs=../../../.. -i bash -p nix curl jq
+
+# The update script requires composer2nix.
+if ! command -v composer2nix &> /dev/null
+then
+    echo "composer2nix (https://github.com/svanderburg/composer2nix) is required for the update script."
+    exit 1
+fi
+
+# Determine the latest version.
+GITHUB_OWNER=firefly-iii
+GITHUB_REPO=firefly-iii
+latest_version=$(curl -s --show-error "https://api.github.com/repos/$GITHUB_OWNER/$GITHUB_REPO/releases/latest" | jq -r '.tag_name')
+
+# Determine if we are already at the latest version.
+NIXPKGS_ROOT=../../../..
+current_version=$(nix eval -f $NIXPKGS_ROOT --raw firefly-iii.version)
+
+if [[ "$current_version" == "$latest_version" ]]; then
+    echo "firefly-iii: already at $current_version"
+    exit 0
+fi
+
+echo "firefly-iii: $current_version -> $latest_version";
+
+# Download the latest composer.json & composer.lock
+remote_raw="https://github.com/$GITHUB_OWNER/$GITHUB_REPO/raw/$latest_version"
+curl -LO "$remote_raw/composer.json" && curl -LO "$remote_raw/composer.lock"
+
+# Run composer2nix.
+composer2nix --name "firefly-iii" \
+    --composition=composition.nix \
+    --no-dev
+rm composer.json composer.lock
+
+# Update the version number and hash in default.nix
+setKV () {
+    sed -i "s|$1 = \".*\"|$1 = \"${2:-}\"|" ./default.nix
+}
+
+sha256=$(nix-prefetch-url --unpack --quiet "https://github.com/$GITHUB_OWNER/$GITHUB_REPO/archive/refs/tags/$latest_version.zip")
+
+setKV version $latest_version
+setKV sha256 $sha256
+
+# Check if the update worked by attempting a build.
+nix-build $NIXPKGS_ROOT -A firefly-iii
+exit $?

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24056,6 +24056,8 @@ with pkgs;
 
   inherit (callPackages ../servers/firebird { }) firebird_4 firebird_3 firebird_2_5 firebird;
 
+  firefly-iii = callPackage ../servers/web-apps/firefly-iii { };
+
   freeradius = callPackage ../servers/freeradius {
     openssl = openssl_1_1;
   };


### PR DESCRIPTION
###### Description of changes

Official website: https://www.firefly-iii.org/

According to the official introduction:

> "Firefly III" is a (self-hosted) manager for your personal finances. It can help you keep track of your expenses and income, so you can spend less and save more.
Personal financial management is pretty difficult, and everybody has their own approach to it. Some people make budgets, other people limit their cashflow by throwing away their credit cards, others try to increase their current cashflow. There are tons of ways to save and earn money. Firefly III works on the principle that if you know where your money is going, you can stop it from going there.
By keeping track of your expenses and your income you can budget accordingly and save money. Stop living from paycheck to paycheck but give yourself the financial wiggle room you need.

This PR introduces both the PHP package for `firefly-iii` (via `composer2nix`), as well as the accompanying module. The module has configuration support for database, mail, nginx reverse proxy. There's also a very simple sanity check.

The work done here was heavily inspired by the work of @ymarkus and @talyz , from the `bookstack` package, which uses the same framework (Laravel). Thanks!

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
