### PR TITLE
lightdm-slick-greeter: init at 1.5.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13856,6 +13856,12 @@
     github = "wamserma";
     githubId = 60148;
   };
+  water-sucks = {
+    email = "varun@cvte.org";
+    name = "Varun Narravula";
+    github = "water-sucks";
+    githubId = 68445574;
+  };
   waynr = {
     name = "Wayne Warren";
     email = "wayne.warren.s@gmail.com";

--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -97,7 +97,9 @@
       </listitem>
       <listitem>
         <para>
-          Cinnamon has been updated to 5.4.
+          Cinnamon has been updated to 5.4. While at it, the cinnamon
+          module now defaults to blueman as bluetooth manager and
+          slick-greeter as lightdm greeter to match upstream.
         </para>
       </listitem>
       <listitem>

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -46,7 +46,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - PHP now defaults to PHP 8.1, updated from 8.0.
 
-- Cinnamon has been updated to 5.4.
+- Cinnamon has been updated to 5.4. While at it, the cinnamon module now defaults to
+  blueman as bluetooth manager and slick-greeter as lightdm greeter to match upstream.
 
 - `hardware.nvidia` has a new option `open` that can be used to opt in the opensource version of NVIDIA kernel driver. Note that the driver's support for GeForce and Workstation GPUs is still alpha quality, see [NVIDIA Releases Open-Source GPU Kernel Modules](https://developer.nvidia.com/blog/nvidia-releases-open-source-gpu-kernel-modules/) for the official announcement.
 

--- a/nixos/modules/services/x11/desktop-managers/cinnamon.nix
+++ b/nixos/modules/services/x11/desktop-managers/cinnamon.nix
@@ -58,13 +58,18 @@ in
   };
 
   config = mkMerge [
-    (mkIf (cfg.enable && config.services.xserver.displayManager.lightdm.enable && config.services.xserver.displayManager.lightdm.greeters.gtk.enable) {
-      services.xserver.displayManager.lightdm.greeters.gtk.extraConfig = mkDefault (builtins.readFile "${pkgs.cinnamon.mint-artwork}/etc/lightdm/lightdm-gtk-greeter.conf.d/99_linuxmint.conf");
-      })
-
     (mkIf cfg.enable {
       services.xserver.displayManager.sessionPackages = [ pkgs.cinnamon.cinnamon-common ];
 
+      services.xserver.displayManager.lightdm.greeters.slick = {
+        enable = mkDefault true;
+
+        # Taken from mint-artwork.gschema.override
+        theme.name = mkDefault "Mint-X";
+        theme.package = mkDefault pkgs.cinnamon.mint-themes;
+        iconTheme.name = mkDefault "Mint-X-Dark";
+        iconTheme.package = mkDefault pkgs.cinnamon.mint-x-icons;
+      };
       services.xserver.displayManager.sessionCommands = ''
         if test "$XDG_CURRENT_DESKTOP" = "Cinnamon"; then
             true

--- a/nixos/modules/services/x11/display-managers/lightdm-greeters/slick.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm-greeters/slick.nix
@@ -1,0 +1,124 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  ldmcfg = config.services.xserver.displayManager.lightdm;
+  cfg = ldmcfg.greeters.slick;
+
+  inherit (pkgs) writeText;
+
+  theme = cfg.theme.package;
+  icons = cfg.iconTheme.package;
+  font = cfg.font.package;
+
+  slickGreeterConf = writeText "slick-greeter.conf" ''
+    [Greeter]
+    background=${ldmcfg.background}
+    theme-name=${cfg.theme.name}
+    icon-theme-name=${cfg.iconTheme.name}
+    font-name=${cfg.font.name}
+    draw-user-backgrounds=${boolToString cfg.draw-user-backgrounds}
+    ${cfg.extraConfig}
+  '';
+in
+{
+  options = {
+    services.xserver.displayManager.lightdm.greeters.slick = {
+      enable = mkOption {
+        type = types.bool;
+        default = true;
+        description = lib.mdDoc ''
+          Whether to enable lightdm-slick-greeter as the lightdm greeter.
+        '';
+      };
+
+      theme = {
+        package = mkOption {
+          type = types.package;
+          default = pkgs.gnome.gnome-themes-extra;
+          defaultText = literalExpression "pkgs.gnome.gnome-themes-extra";
+          description = lib.mdDoc ''
+            The package path that contains the theme given in the name option.
+          '';
+        };
+
+        name = mkOption {
+          type = types.str;
+          default = "Adwaita";
+          description = lib.mdDoc ''
+            Name of the theme to use for the lightdm-slick-greeter.
+          '';
+        };
+      };
+
+      iconTheme = {
+        package = mkOption {
+          type = types.package;
+          default = pkgs.gnome.adwaita-icon-theme;
+          defaultText = literalExpression "pkgs.gnome.adwaita-icon-theme";
+          description = lib.mdDoc ''
+            The package path that contains the icon theme given in the name option.
+          '';
+        };
+
+        name = mkOption {
+          type = types.str;
+          default = "Adwaita";
+          description = lib.mdDoc ''
+            Name of the icon theme to use for the lightdm-slick-greeter.
+          '';
+        };
+      };
+
+      font = {
+        package = mkOption {
+          type = types.package;
+          default = pkgs.ubuntu_font_family;
+          defaultText = literalExpression "pkgs.ubuntu_font_family";
+          description = lib.mdDoc ''
+            The package path that contains the font given in the name option.
+          '';
+        };
+
+        name = mkOption {
+          type = types.str;
+          default = "Ubuntu 11";
+          description = lib.mdDoc ''
+            Name of the font to use.
+          '';
+        };
+      };
+
+      draw-user-backgrounds = mkEnableOption "draw user backgrounds";
+
+      extraConfig = mkOption {
+        type = types.lines;
+        default = "";
+        description = lib.mdDoc ''
+          Extra configuration that should be put in the lightdm-slick-greeter.conf
+          configuration file.
+        '';
+      };
+    };
+  };
+
+  config = mkIf (ldmcfg.enable && cfg.enable) {
+    services.xserver.displayManager.lightdm = {
+      greeters.gtk.enable = false;
+      greeter = mkDefault {
+        package = pkgs.lightdm-slick-greeter.xgreeters;
+        name = "lightdm-slick-greeter";
+      };
+    };
+
+    environment.systemPackages = [
+      icons
+      theme
+    ];
+
+    fonts.fonts = [ font ];
+
+    environment.etc."lightdm/slick-greeter.conf".source = slickGreeterConf;
+  };
+}

--- a/nixos/modules/services/x11/display-managers/lightdm.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm.nix
@@ -82,6 +82,7 @@ in
     ./lightdm-greeters/enso-os.nix
     ./lightdm-greeters/pantheon.nix
     ./lightdm-greeters/tiny.nix
+    ./lightdm-greeters/slick.nix
     (mkRenamedOptionModule [ "services" "xserver" "displayManager" "lightdm" "autoLogin" "enable" ] [
       "services"
       "xserver"

--- a/pkgs/applications/display-managers/lightdm-slick-greeter/default.nix
+++ b/pkgs/applications/display-managers/lightdm-slick-greeter/default.nix
@@ -1,0 +1,110 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, python3
+, vala
+, intltool
+, autoreconfHook
+, wrapGAppsHook
+, lightdm
+, gtk3
+, pixman
+, libcanberra
+, libX11
+, libXext
+, linkFarm
+, lightdm-slick-greeter
+, numlockx
+}:
+
+stdenv.mkDerivation rec {
+  pname = "lightdm-slick-greeter";
+  version = "1.5.9";
+
+  src = fetchFromGitHub {
+    owner = "linuxmint";
+    repo = "slick-greeter";
+    rev = version;
+    sha256 = "sha256-UEzidH4ZWggcOWHHuAclHbbgATDBdogL99Ze0PlwRoc=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    vala
+    intltool
+    autoreconfHook
+    wrapGAppsHook
+    python3
+    python3.pkgs.wrapPython
+  ];
+
+  buildInputs = [
+    lightdm
+    gtk3
+    pixman
+    libcanberra
+    libX11
+    libXext
+  ];
+
+  pythonPath = [
+    python3.pkgs.pygobject3 # for slick-greeter-check-hidpi
+  ];
+
+  postPatch = ''
+    substituteInPlace src/slick-greeter.vala \
+      --replace "/usr/bin/numlockx" "${numlockx}/bin/numlockx" \
+      --replace "/usr/share/xsessions/" "/run/current-system/sw/share/xsessions/" \
+      --replace "/usr/bin/slick-greeter" "${placeholder "out"}/bin/slick-greeter"
+
+    substituteInPlace src/session-list.vala \
+      --replace "/usr/share" "${placeholder "out"}/share"
+
+    patchShebangs files/usr/bin/*
+  '';
+
+  preAutoreconf = ''
+    # intltoolize fails during autoreconfPhase unless this
+    # directory is created manually.
+    mkdir m4
+  '';
+
+  configureFlags = [
+    "--localstatedir=/var"
+    "--sysconfdir=/etc"
+    "--sbindir=${placeholder "out"}/bin"
+  ];
+
+  installFlags = [
+    "localstatedir=\${TMPDIR}"
+    "sysconfdir=${placeholder "out"}/etc"
+  ];
+
+  postInstall = ''
+    substituteInPlace "$out/share/xgreeters/slick-greeter.desktop" \
+      --replace "Exec=slick-greeter" "Exec=$out/bin/slick-greeter"
+
+    cp -r files/usr/* $out
+  '';
+
+  preFixup = ''
+    buildPythonPath "$out $pythonPath"
+    gappsWrapperArgs+=(
+      --prefix PYTHONPATH : "$program_PYTHONPATH"
+    )
+  '';
+
+  passthru.xgreeters = linkFarm "lightdm-slick-greeter-xgreeters" [{
+    path = "${lightdm-slick-greeter}/share/xgreeters/slick-greeter.desktop";
+    name = "lightdm-slick-greeter.desktop";
+  }];
+
+  meta = with lib; {
+    description = "A slick-looking LightDM greeter";
+    homepage = "https://github.com/linuxmint/slick-greeter";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ water-sucks ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/desktops/cinnamon/mint-artwork/default.nix
+++ b/pkgs/desktops/cinnamon/mint-artwork/default.nix
@@ -28,7 +28,6 @@ stdenv.mkDerivation rec {
       -e s,DMZ-White,Vanilla-DMZ,g \
       -e s,DMZ-Black,Vanilla-DMZ-AA,g \
       -e s,linuxmint-logo-5,cinnamon-symbolic,g \
-      -e s,^theme-name=Mint-X$,theme-name=Mint-X-Dark,g \
       {} +
 
     # fixup broken symlink

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30551,6 +30551,8 @@ with pkgs;
     inherit (xfce) xfce4-dev-tools;
   };
 
+  lightdm-slick-greeter = callPackage ../applications/display-managers/lightdm-slick-greeter { };
+
   lightdm-mini-greeter = callPackage ../applications/display-managers/lightdm-mini-greeter { };
 
   lightdm-tiny-greeter = callPackage ../applications/display-managers/lightdm-tiny-greeter {


### PR DESCRIPTION
###### Description of changes

Didn't see this packaged and I wanted to use it for my LightDM greeter. I think a lot of people are accustomed to using this because it is the default on Linux Mint and whatnot.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
