### PR TITLE
micro: 2.0.10 → 2.0.11

### DIFF
--- a/pkgs/applications/editors/micro/default.nix
+++ b/pkgs/applications/editors/micro/default.nix
@@ -2,22 +2,27 @@
 
 buildGoModule rec {
   pname = "micro";
-  version = "2.0.10";
+  version = "2.0.11";
 
   src = fetchFromGitHub {
     owner = "zyedidia";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-hVFmViwGXuYVAKaCkzK/LHjCi8AtLu0tsPpT61glxys=";
+    sha256 = "sha256-3Rppi8UcAc4zdXOd81Y+sb5Psezx2TQsNw73WdPVMgE=";
   };
 
   nativeBuildInputs = [ installShellFiles ];
 
   subPackages = [ "cmd/micro" ];
 
-  vendorSha256 = "sha256-YcAKl4keizkbgQLAZGiCG3CGpNTNad8EvOJEXLX2s0s=";
+  vendorSha256 = "sha256-/bWIn5joZOTOtuAbljOc0NgBfjrFkbFZih+cPNHnS9w=";
 
-  ldflags = [ "-s" "-w" "-X github.com/zyedidia/micro/v2/internal/util.Version=${version}" "-X github.com/zyedidia/micro/v2/internal/util.CommitHash=${src.rev}" ];
+  ldflags = let t = "github.com/zyedidia/micro/v2/internal"; in [
+    "-s"
+    "-w"
+    "-X ${t}/util.Version=${version}"
+    "-X ${t}/util.CommitHash=${src.rev}"
+  ];
 
   postInstall = ''
     installManPage assets/packaging/micro.1


### PR DESCRIPTION
###### Description of changes
[Changelog](https://github.com/zyedidia/micro/releases/tag/v2.0.11)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
