### PR TITLE
tt-rss: 2021-06-21 -> 2022-08-01

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -358,6 +358,13 @@
       </listitem>
       <listitem>
         <para>
+          The <literal>tt-rss</literal> service performs two database
+          migrations when you first use its web UI after upgrade.
+          Consider backing up its database before updating.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           The <literal>pass-secret-service</literal> package now
           includes systemd units from upstream, so adding it to the
           NixOS <literal>services.dbus.packages</literal> option will

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -134,6 +134,8 @@ Use `configure.packages` instead.
 
 - Add udev rules for the Teensy family of microcontrollers.
 
+- The `tt-rss` service performs two database migrations when you first use its web UI after upgrade. Consider backing up its database before updating.
+
 - The `pass-secret-service` package now includes systemd units from upstream, so adding it to the NixOS `services.dbus.packages` option will make it start automatically as a systemd user service when an application tries to talk to the libsecret D-Bus API.
 
 - There is a new module for the `thunar` program (the Xfce file manager), which depends on the `xfconf` dbus service, and also has a dbus service and a systemd unit. The option `services.xserver.desktopManager.xfce.thunarPlugins` has been renamed to `programs.thunar.plugins`, and in a future release it may be removed.

--- a/pkgs/servers/tt-rss/default.nix
+++ b/pkgs/servers/tt-rss/default.nix
@@ -1,16 +1,13 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenv, fetchgit }:
 
 stdenv.mkDerivation rec {
   pname = "tt-rss";
-  year = "21";
-  month = "06";
-  day = "21";
-  version = "20${year}-${month}-${day}";
-  rev = "cd26dbe64c9b14418f0b2d826a38a35c6bf8a270";
+  version = "unstable-2022-08-01";
 
-  src = fetchurl {
-    url = "https://git.tt-rss.org/fox/tt-rss/archive/${rev}.tar.gz";
-    sha256 = "1dpmzi7hknv5rk2g1iw13r8zcxcwrhkd5hhf292ml0dw3cwki0gm";
+  src = fetchgit {
+    url = "https://git.tt-rss.org/fox/tt-rss.git";
+    rev = "ed2cbeffcc456a86726b52d37c977a35b895968c";
+    sha256 = "0ab1q316y4f432z2kwn86kc144awk529cild7b4jbffh2ydlj3r4";
   };
 
   installPhase = ''
@@ -21,7 +18,7 @@ stdenv.mkDerivation rec {
 
     # see the code of Config::get_version(). you can check that the version in
     # the footer of the preferences pages is not UNKNOWN
-    echo "${year}.${month}" > $out/version_static.txt
+    echo "22.08" > $out/version_static.txt
 
     runHook postInstall
   '';


### PR DESCRIPTION
###### Description of changes

Pick up a year's worth of changes from upstream.

I've got an instance of this running, apparently without problems. But there was a database migration of two versions involved, and I didn't have any data to migrate, so I have no idea if this aspect is OK. I also had some trouble cloning the repo until I did `nix-prefetch-git` at various points - the upstream repository is `cgit` in a configuration which I think just doesn't serve tarballs? - but eventually `nixpkgs-review` was happy; and for some reason the feed update daemon didn't start (nor were there any obvious errors) until I rebooted my machine, whereupon it came up happily.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
