### PR TITLE
o: init at 2.55.1

### DIFF
--- a/pkgs/applications/editors/o/default.nix
+++ b/pkgs/applications/editors/o/default.nix
@@ -1,0 +1,43 @@
+{ lib, stdenv, buildGoModule, fetchFromGitHub, installShellFiles, makeWrapper, pkg-config
+, tcsh
+, withGui ? stdenv.isLinux, vte # vte is broken on darwin
+}:
+
+buildGoModule rec {
+  pname = "o";
+  version = "2.55.1";
+
+  src = fetchFromGitHub {
+    owner = "xyproto";
+    repo = "o";
+    rev = "v${version}";
+    hash = "sha256-owueLd6kR/bDFxKI9QOUgriH63XRsEEpIFfp5aRTSbI=";
+  };
+
+  postPatch = ''
+    substituteInPlace ko/main.cpp --replace '/bin/csh' '${tcsh}/bin/tcsh'
+  '';
+
+  vendorSha256 = null;
+
+  nativeBuildInputs = [ installShellFiles makeWrapper pkg-config ];
+
+  buildInputs = lib.optional withGui vte;
+
+  preBuild = "cd v2";
+
+  postInstall = ''
+    cd ..
+    installManPage o.1
+  '' + lib.optionalString withGui ''
+    make install-gui PREFIX=$out
+    wrapProgram $out/bin/ko --prefix PATH : $out/bin
+  '';
+
+  meta = with lib; {
+    description = "Config-free text editor and IDE limited to VT100";
+    homepage = "https://github.com/xyproto/o";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ sikmir ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26648,6 +26648,8 @@ with pkgs;
 
   edbrowse = callPackage ../applications/editors/edbrowse { };
 
+  o = callPackage ../applications/editors/o { };
+
   oed = callPackage ../applications/editors/oed { };
 
   ekho = callPackage ../applications/audio/ekho { };


### PR DESCRIPTION
###### Description of changes
**[o](https://github.com/xyproto/o)** is a text editor and a minimalistic IDE.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
