### PR TITLE
playwright: init at 1.22.0

### DIFF
--- a/pkgs/development/python-modules/playwright/default.nix
+++ b/pkgs/development/python-modules/playwright/default.nix
@@ -1,0 +1,252 @@
+{ lib
+, stdenv
+, autoPatchelfHook
+, callPackage
+, fetchFromGitHub
+, fetchurl
+, makeWrapper
+, runCommand
+, unzip
+, git
+, nodejs
+, jq
+
+# Python dependencies
+, python
+, buildPythonPackage
+, pythonOlder
+, autobahn
+, greenlet
+, objgraph
+, pillow
+, pixelmatch
+, pyee
+, pyopenssl
+, requests
+, service-identity
+, setuptools-scm
+, setuptools-scm-git-archive
+, websockets
+
+# For building the browser bundle
+, cacert
+, chromium
+, ffmpeg
+, firefox
+, makeFontsConf
+}:
+
+let
+  inherit (stdenv.hostPlatform) system;
+  throwSystem = throw "Unsupported system: ${stdenv.hostPlatform.system}";
+
+  driverVersion = "1.25.0";
+
+  driver = let
+    suffix = {
+      x86_64-linux = "linux";
+      aarch64-linux = "linux-arm64";
+      x86_64-darwin = "mac";
+      aarch64-darwin = "mac-arm64";
+    }.${system} or throwSystem;
+    filename = "playwright-${driverVersion}-${suffix}.zip";
+  in stdenv.mkDerivation {
+    pname = "playwright-driver";
+    version = driverVersion;
+
+    src = fetchurl {
+      url = "https://playwright.azureedge.net/builds/driver/${filename}";
+      sha256 = {
+        x86_64-linux = "1nah45q9mihzkz2hqx6dwn7ac88vc22m5zspr23hc7dd1q4ll4ys";
+        aarch64-linux = "0wg4z2gb2fhvv4c2gjm6ncvbg9bkaavzq76x1bmm4lsnhjz312hp";
+        x86_64-darwin = "1nd6ll6dj0aqic3hh65y0br051ckbcap8spqbvzm19g8dn7vgv7m";
+        aarch64-darwin = "08qrzahmdhdv8flfjb58m27dqihq8jc4gwix6knc71209a9x8b83";
+      }.${system} or throwSystem;
+    };
+    sourceRoot = ".";
+
+    nativeBuildInputs = [ unzip ];
+    buildInputs = [ nodejs ];
+
+    postPatch = ''
+      # Use Nix's NodeJS instead of the bundled one.
+      substituteInPlace playwright.sh --replace '"$SCRIPT_PATH/node"' '"${nodejs}/bin/node"'
+      rm node
+
+      # Hard-code the script path to be our $out directory. The alternative would be to add
+      # coreutils to the closure and use realpath like the upstream script does.
+      substituteInPlace playwright.sh \
+        --replace 'SCRIPT_PATH="$(cd "$(dirname "$0")" ; pwd -P)"' "SCRIPT_PATH=$out"
+
+      patchShebangs playwright.sh package/bin/*.sh
+    '';
+
+    dontBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/bin $out/share/playwright-driver
+      mv playwright.sh package $out/share/playwright-driver/
+      ln -s $out/share/playwright-driver/playwright.sh $out/bin/playwright
+
+      runHook postInstall
+    '';
+
+    passthru = {
+      inherit filename;
+    };
+  };
+
+  browsers-mac = stdenv.mkDerivation {
+    pname = "playwright-browsers";
+    version = driverVersion;
+
+    src = runCommand "playwright-browsers-base" {
+      outputHashMode = "recursive";
+      outputHashAlgo = "sha256";
+      outputHash = {
+        x86_64-darwin = "1nd6ll6dj0aqic3hh65y0br051ckbcap8spqbvzm19g8dn7vgv7m";
+      }.${system} or throwSystem;
+    } ''
+      export PLAYWRIGHT_BROWSERS_PATH=$out
+      ${driver}/bin/playwright install
+      rm -r $out/.links
+    '';
+
+    dontConfigure = true;
+    dontBuild = true;
+
+    installPhase = ''
+      mkdir $out
+      cp -r * $out/
+    '';
+
+    doCheck = false;
+  };
+
+  browsers-linux = let
+    fontconfig = makeFontsConf {
+      fontDirectories = [];
+    };
+  in runCommand "playwright-browsers" {
+    nativeBuildInputs = [
+      makeWrapper
+      jq
+    ];
+  } ''
+    BROWSERS_JSON=${driver}/share/playwright-driver/package/browsers.json
+    CHROMIUM_REVISION=$(jq -r '.browsers[] | select(.name == "chromium").revision' $BROWSERS_JSON)
+    FFMPEG_REVISION=$(jq -r '.browsers[] | select(.name == "ffmpeg").revision' $BROWSERS_JSON)
+    FIREFOX_REVISION=$(jq -r '.browsers[] | select(.name == "firefox").revision' $BROWSERS_JSON)
+
+    mkdir -p \
+      $out/chromium-$CHROMIUM_REVISION/chrome-linux \
+      $out/ffmpeg-$FFMPEG_REVISION \
+      $out/firefox-$FIREFOX_REVISION
+
+    # See here for the Chrome options:
+    # https://github.com/NixOS/nixpkgs/issues/136207#issuecomment-908637738
+    makeWrapper ${chromium}/bin/chromium $out/chromium-$CHROMIUM_REVISION/chrome-linux/chrome \
+      --set SSL_CERT_FILE /etc/ssl/certs/ca-bundle.crt \
+      --set FONTCONFIG_FILE ${fontconfig}
+
+    ln -s ${ffmpeg}/bin/ffmpeg $out/ffmpeg-$FFMPEG_REVISION/ffmpeg-linux
+
+    ln -s ${firefox}/bin/firefox $out/firefox-$FIREFOX_REVISION/firefox
+  '';
+in
+buildPythonPackage rec {
+  pname = "playwright";
+  version = "1.25.1";
+  format = "pyproject";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "playwright-python";
+    rev = "v${version}";
+    sha256 = "sha256-K9hVTGGqTx3tTjGrwcLQisp3gq/lLJ/Y0GLDZcikSzw=";
+    leaveDotGit = true;
+  };
+
+  patches = [
+    # This patches two things:
+    # - The driver location, which is now a static package in the Nix store.
+    # - The setup script, which would try to download the driver package from
+    #   a CDN and patch wheels so that they include it. We don't want this
+    #   we have our own driver build.
+    ./driver-location.patch
+  ];
+
+  nativeBuildInputs = [ git setuptools-scm ];
+  propagatedBuildInputs = [
+    autobahn
+    greenlet
+    objgraph
+    pillow
+    pixelmatch
+    pyee
+    pyopenssl
+    requests
+    service-identity
+    websockets
+  ];
+
+  postPatch = ''
+    # The package seems to work with pyee 9 as well, which is what nixpkgs has packaged.
+    substituteInPlace meta.yaml \
+      --replace "pyee ==8.1.0" "pyee"
+    substituteInPlace setup.py \
+      --replace "pyee==8.1.0" "pyee" \
+      --replace "websockets==10.1" "websockets"
+
+    # Skip trying to download and extract the driver. We do this manually in
+    # postInstall instead. See here:
+    # https://github.com/microsoft/playwright-python/blob/v1.25.0/setup.py#L123
+    substituteInPlace setup.py \
+      --replace "self._download_and_extract_local_driver(base_wheel_bundles)" ""
+
+    # Set the correct driver path (this requires the patch file from above).
+    substituteInPlace playwright/_impl/_driver.py \
+      --replace "@driver@" "${driver}/bin/playwright"
+  '';
+
+  preInstall = ''
+    # pip names the wheel "dist", but when installing it will expect a properly formatted filename
+    # in dist.
+    mv dist dist.orig
+    mkdir -p dist
+    mv dist.orig dist/playwright-${version}-py3-none-any.whl
+  '';
+
+  postInstall = ''
+    pushd $out/${python.sitePackages}/playwright
+    ln -s ${driver} driver
+    popd
+  '';
+
+  # Skip tests because they require network access.
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "playwright"
+  ];
+
+  passthru = {
+    inherit driver;
+    browsers = {
+      x86_64-linux = browsers-linux;
+      aarch64-linux = browsers-linux;
+      x86_64-darwin = browsers-mac;
+      aarch64-darwin = browsers-mac;
+    }.${system} or throwSystem;
+  };
+
+  meta = with lib; {
+    description = "Python version of the Playwright testing and automation library";
+    homepage = "https://github.com/microsoft/playwright-python";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ techknowlogick yrd ];
+  };
+}

--- a/pkgs/development/python-modules/playwright/driver-location.patch
+++ b/pkgs/development/python-modules/playwright/driver-location.patch
@@ -1,0 +1,47 @@
+diff --git a/playwright/_impl/_driver.py b/playwright/_impl/_driver.py
+index f3b911f..d00e509 100644
+--- a/playwright/_impl/_driver.py
++++ b/playwright/_impl/_driver.py
+@@ -23,11 +23,7 @@ from playwright._repo_version import version
+ 
+ 
+ def compute_driver_executable() -> Path:
+-    package_path = Path(inspect.getfile(playwright)).parent
+-    platform = sys.platform
+-    if platform == "win32":
+-        return package_path / "driver" / "playwright.cmd"
+-    return package_path / "driver" / "playwright.sh"
++   return Path("@driver@")
+ 
+ 
+ if sys.version_info.major == 3 and sys.version_info.minor == 7:
+diff --git a/setup.py b/setup.py
+index 3487a6a..05112c2 100644
+--- a/setup.py
++++ b/setup.py
+@@ -141,25 +141,8 @@ class PlaywrightBDistWheelCommand(BDistWheelCommand):
+         base_wheel_location: str = glob.glob(os.path.join(self.dist_dir, "*.whl"))[0]
+         without_platform = base_wheel_location[:-7]
+         for wheel_bundle in wheels:
+-            download_driver(wheel_bundle["zip_name"])
+-            zip_file = (
+-                f"driver/playwright-{driver_version}-{wheel_bundle['zip_name']}.zip"
+-            )
+-            with zipfile.ZipFile(zip_file, "r") as zip:
+-                extractall(zip, f"driver/{wheel_bundle['zip_name']}")
+             wheel_location = without_platform + wheel_bundle["wheel"]
+             shutil.copy(base_wheel_location, wheel_location)
+-            with zipfile.ZipFile(wheel_location, "a") as zip:
+-                driver_root = os.path.abspath(f"driver/{wheel_bundle['zip_name']}")
+-                for dir_path, _, files in os.walk(driver_root):
+-                    for file in files:
+-                        from_path = os.path.join(dir_path, file)
+-                        to_path = os.path.relpath(from_path, driver_root)
+-                        zip.write(from_path, f"playwright/driver/{to_path}")
+-                zip.writestr(
+-                    "playwright/driver/README.md",
+-                    f"{wheel_bundle['wheel']} driver package",
+-                )
+         os.remove(base_wheel_location)
+         if InWheel:
+             for whlfile in glob.glob(os.path.join(self.dist_dir, "*.whl")):

--- a/pkgs/development/python-modules/playwright/update.sh
+++ b/pkgs/development/python-modules/playwright/update.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnused gawk nix-prefetch common-updater-scripts
+
+set -euo pipefail
+
+# This is the target version of playwright-python we want to update to. Find out
+# what's the current one here:
+# https://pypi.org/project/playwright/
+TARGET_VERSION="1.25.1"
+
+# The driver version required for the specific Playwright version we have is
+# hard-coded here:
+# https://github.com/microsoft/playwright-python/blob/v1.25.1/setup.py#L33
+# Most of the time, this should be the latest stable release of the Node-based
+# Playwright version, but that isn't a guarantee, so this needs to be specified
+# as well:
+DRIVER_VERSION="1.25.0"
+
+
+ROOT="$(dirname "$(readlink -f "$0")")"
+NIX_FILE="$ROOT/default.nix"
+
+fetch_driver_arch() {
+  VERSION="$1"
+  ARCH="$2"
+  nix-prefetch-url "https://playwright.azureedge.net/builds/driver/playwright-${VERSION}-${ARCH}.zip"
+}
+
+replace_sha() {
+  sed -i "s#$1 = \"sha256-.\{44\}\"#$1 = \"$2\"#" "$NIX_FILE"
+}
+
+# Replace SHAs for the driver downloads.
+replace_sha "x86_64-linux" "$(fetch_driver_arch "$DRIVER_VERSION" "linux")"
+replace_sha "x86_64-darwin" "$(fetch_driver_arch "$DRIVER_VERSION" "mac")"
+replace_sha "aarch64-linux" "$(fetch_driver_arch "$DRIVER_VERSION" "linux-arm64")"
+replace_sha "aarch64-darwin" "$(fetch_driver_arch "$DRIVER_VERSION" "mac-arm64")"
+
+# Update the version stamps.
+sed -i "s/driverVersion = \"[^\$]*\"/driverVersion = \"$DRIVER_VERSION\"/" "$NIX_FILE"
+update-source-version playwright "$TARGET_VERSION" --rev="v$TARGET_VERSION"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9362,6 +9362,8 @@ with pkgs;
 
   playbar2 = libsForQt5.callPackage ../applications/audio/playbar2 { };
 
+  playwright = with python3Packages; toPythonApplication playwright;
+
   plujain-ramp = callPackage ../applications/audio/plujain-ramp { };
 
   inherit (callPackage ../servers/plik { })

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6342,6 +6342,10 @@ in {
 
   pkuseg = callPackage ../development/python-modules/pkuseg { };
 
+  playwright = callPackage ../development/python-modules/playwright {
+    inherit (pkgs) jq;
+  };
+
   pmsensor = callPackage ../development/python-modules/pmsensor { };
 
   ppdeep = callPackage ../development/python-modules/ppdeep { };


### PR DESCRIPTION
###### Description of changes

This is a follow-up on @techknowlogick's work from #171577.

The module seems to work now, although a bit more documentation is probably needed. In summary, setting this environment variable should work (choose one):

```plain
PLAYWRIGHT_BROWSERS_PATH=${python.pkgs.playwright.browsers-linux}
PLAYWRIGHT_BROWSERS_PATH=${python.pkgs.playwright.browsers-mac}
```

Note that `browsers-linux` is just a bundle containing FFMpeg and Chromium from Nixpkgs, symlinked to match the directory structure from upstream, instead of the ones provided by Playwright. Playwright's documentation more or less [advises against doing this](https://playwright.dev/python/docs/browsers), but in my (admittedly very limited) testing it seemed to work.

`browsers-mac` still contains a few experiments on using patchelf to patch the upstream browser builds, but I gave up on finding all the required libraries and decided to split the bundle by platform. That stuff can be removed before merging.

Some things (like sha256sums for all platforms) are still missing, but any thoughts are appreciated.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
