### PR TITLE
LimeSurvey: 3.27.22+220125 -> 5.3.27+220725

### DIFF
--- a/nixos/modules/services/web-apps/limesurvey.nix
+++ b/nixos/modules/services/web-apps/limesurvey.nix
@@ -12,7 +12,7 @@ let
   group = config.services.httpd.group;
   stateDir = "/var/lib/limesurvey";
 
-  pkg = config.services.limesurvey.package;
+  pkg = pkgs.limesurvey;
 
   configType = with types; oneOf [ (attrsOf configType) str int bool ] // {
     description = "limesurvey config type (str, int, bool or attribute set thereof)";
@@ -34,23 +34,16 @@ in
   options.services.limesurvey = {
     enable = mkEnableOption "Limesurvey web application.";
 
-    package = mkOption{
-      type = types.package;
-      default = pkgs.limesurvey;
-      defaultText = literalExpression "pkgs.limesurvey";
-      description = "The Limesurvey Package to Use";
-    };
-
     encryptionKey = mkOption{
       type = types.str;
       default = "E17687FC77CEE247F0E22BB3ECF27FDE8BEC310A892347EC13013ABA11AA7EB5";
-      description = "CHANGE THIS! 32 Byte long key as used to encrypt Values in the database";
+      description = "CHANGE THIS! 32 Byte long key used to encrypt Values in the database";
     };
 
     encryptionNonce = mkOption{
       type = types.str;
       default = "1ACC8555619929DB91310BE848025A427B0F364A884FFA77";
-      description = "CHANGE THIS! 24 Byte long nonce as used to encrypt Values in the database";
+      description = "CHANGE THIS! 24 Byte long nonce used to encrypt Values in the database";
     };
 
     database = {

--- a/pkgs/servers/limesurvey/default.nix
+++ b/pkgs/servers/limesurvey/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "limesurvey";
-  version = "3.27.33+220125";
+  version = "5.3.27+220725";
 
   src = fetchFromGitHub {
     owner = "LimeSurvey";
     repo = "LimeSurvey";
     rev = version;
-    sha256 = "sha256-iwTsn+glh8fwt1IaH9iDKDhEAnx1s1zvv1dmsdzUk8g=";
+    sha256 = "sha256-Wotvo3QDqPq0LSTgLcFvVkGokWQ9yNj26KjN7gR/eio=";
   };
 
   phpConfig = writeText "config.php" ''


### PR DESCRIPTION
###### Description of changes
Since the support for the currently used Limesurvey CE version isn't guaranteed anymore ([see](https://manual.limesurvey.org/LimeSurvey_roadmap#Limesurvey_3.x_-_Status:_Released_.28Feb_2018.29)) I changed the package Version to the latest release and modified the service module to work with 5.3 Limesurvey Versions.

Also prevent the overide of a whole set X in services.limesurvey.config if the user defines a Option Y in the Set X 
(e.g.  User specifying services.limesurvey.config.config.publicurl="http://example.com/limesurvey" would remove config.tempdir, config.uploaddir etc. from the final config)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
