### PR TITLE
kanata: 1.0.5 -> 1.0.6

### DIFF
--- a/nixos/modules/services/hardware/kanata.nix
+++ b/nixos/modules/services/hardware/kanata.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, utils, ... }:
 
 with lib;
 
@@ -7,10 +7,20 @@ let
 
   keyboard = {
     options = {
-      device = mkOption {
-        type = types.str;
-        example = "/dev/input/by-id/usb-0000_0000-event-kbd";
-        description = lib.mdDoc "Path to the keyboard device.";
+      devices = mkOption {
+        type = types.addCheck (types.listOf types.str)
+          (devices: (length devices) > 0);
+        example = [ "/dev/input/by-id/usb-0000_0000-event-kbd" ];
+        # TODO replace note with tip, which has not been implemented yet in
+        # nixos/lib/make-options-doc/mergeJSON.py
+        description = mdDoc ''
+          Paths to keyboard devices.
+
+          ::: {.note}
+          To avoid unnecessary triggers of the service unit, unplug devices in
+          the order of the list.
+          :::
+        '';
       };
       config = mkOption {
         type = types.lines;
@@ -33,18 +43,32 @@ let
             ;; tap within 100ms for capslk, hold more than 100ms for lctl
             cap (tap-hold 100 100 caps lctl))
         '';
-        description = lib.mdDoc ''
-          Configuration other than defcfg.
-          See <https://github.com/jtroo/kanata> for more information.
+        description = mdDoc ''
+          Configuration other than `defcfg`. See [example config
+          files](https://github.com/jtroo/kanata) for more information.
         '';
       };
       extraDefCfg = mkOption {
         type = types.lines;
         default = "";
         example = "danger-enable-cmd yes";
-        description = lib.mdDoc ''
-          Configuration of defcfg other than linux-dev.
-          See <https://github.com/jtroo/kanata> for more information.
+        description = mdDoc ''
+          Configuration of `defcfg` other than `linux-dev`. See [example
+          config files](https://github.com/jtroo/kanata) for more information.
+        '';
+      };
+      extraArgs = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = mdDoc "Extra command line arguments passed to kanata.";
+      };
+      port = mkOption {
+        type = types.nullOr types.port;
+        default = null;
+        example = 6666;
+        description = mdDoc ''
+          Port to run the notification server on. `null` will not run the
+          server.
         '';
       };
     };
@@ -52,16 +76,18 @@ let
 
   mkName = name: "kanata-${name}";
 
+  mkDevices = devices: concatStringsSep ":" devices;
+
   mkConfig = name: keyboard: pkgs.writeText "${mkName name}-config.kdb" ''
     (defcfg
       ${keyboard.extraDefCfg}
-      linux-dev ${keyboard.device})
+      linux-dev ${mkDevices keyboard.devices})
 
     ${keyboard.config}
   '';
 
   mkService = name: keyboard: nameValuePair (mkName name) {
-    description = "kanata for ${keyboard.device}";
+    description = "kanata for ${mkDevices keyboard.devices}";
 
     # Because path units are used to activate service units, which
     # will start the old stopped services during "nixos-rebuild
@@ -72,10 +98,14 @@ let
     serviceConfig = {
       ExecStart = ''
         ${cfg.package}/bin/kanata \
-          --cfg ${mkConfig name keyboard}
+          --cfg ${mkConfig name keyboard} \
+          --symlink-path ''${RUNTIME_DIRECTORY}/${name} \
+          ${optionalString (keyboard.port != null) "--port ${toString keyboard.port}"} \
+          ${utils.escapeSystemdExecArgs keyboard.extraArgs}
       '';
 
       DynamicUser = true;
+      RuntimeDirectory = mkName name;
       SupplementaryGroups = with config.users.groups; [
         input.name
         uinput.name
@@ -83,15 +113,16 @@ let
 
       # hardening
       DeviceAllow = [
-        "/dev/uinput w"
+        "/dev/uinput rw"
         "char-input r"
       ];
-      CapabilityBoundingSet = "";
+      CapabilityBoundingSet = [ "" ];
       DevicePolicy = "closed";
-      IPAddressDeny = "any";
+      IPAddressAllow = optional (keyboard.port != null) "localhost";
+      IPAddressDeny = [ "any" ];
       LockPersonality = true;
       MemoryDenyWriteExecute = true;
-      PrivateNetwork = true;
+      PrivateNetwork = keyboard.port == null;
       PrivateUsers = true;
       ProcSubset = "pid";
       ProtectClock = true;
@@ -102,10 +133,11 @@ let
       ProtectKernelModules = true;
       ProtectKernelTunables = true;
       ProtectProc = "invisible";
-      RestrictAddressFamilies = "none";
+      RestrictAddressFamilies =
+        if (keyboard.port == null) then "none" else [ "AF_INET" ];
       RestrictNamespaces = true;
       RestrictRealtime = true;
-      SystemCallArchitectures = "native";
+      SystemCallArchitectures = [ "native" ];
       SystemCallFilter = [
         "@system-service"
         "~@privileged"
@@ -115,13 +147,32 @@ let
     };
   };
 
-  mkPath = name: keyboard: nameValuePair (mkName name) {
-    description = "kanata trigger for ${keyboard.device}";
-    wantedBy = [ "multi-user.target" ];
-    pathConfig = {
-      PathExists = keyboard.device;
+  mkPathName = i: name: "${mkName name}-${toString i}";
+
+  mkPath = name: n: i: device:
+    nameValuePair (mkPathName i name) {
+      description =
+        "${toString (i+1)}/${toString n} kanata trigger for ${name}, watching ${device}";
+      wantedBy = optional (i == 0) "multi-user.target";
+      pathConfig = {
+        PathExists = device;
+        # (ab)use systemd.path to construct a trigger chain so that the
+        # service unit is only started when all paths exist
+        # however, manual of systemd.path says Unit's suffix is not ".path"
+        Unit =
+          if (i + 1) == n
+          then "${mkName name}.service"
+          else "${mkPathName (i + 1) name}.path";
+      };
+      unitConfig.StopPropagatedFrom = optional (i > 0) "${mkName name}.service";
     };
-  };
+
+  mkPaths = name: keyboard:
+    let
+      n = length keyboard.devices;
+    in
+    imap0 (mkPath name n) keyboard.devices
+  ;
 in
 {
   options.services.kanata = {
@@ -131,15 +182,19 @@ in
       default = pkgs.kanata;
       defaultText = lib.literalExpression "pkgs.kanata";
       example = lib.literalExpression "pkgs.kanata-with-cmd";
-      description = lib.mdDoc ''
-        kanata package to use.
-        If you enable danger-enable-cmd, pkgs.kanata-with-cmd should be used.
+      description = mdDoc ''
+        The kanata package to use.
+
+        ::: {.note}
+        If `danger-enable-cmd` is enabled in any of the keyboards, the
+        `kanata-with-cmd` package should be used.
+        :::
       '';
     };
     keyboards = mkOption {
       type = types.attrsOf (types.submodule keyboard);
       default = { };
-      description = lib.mdDoc "Keyboard configurations.";
+      description = mdDoc "Keyboard configurations.";
     };
   };
 
@@ -147,7 +202,11 @@ in
     hardware.uinput.enable = true;
 
     systemd = {
-      paths = mapAttrs' mkPath cfg.keyboards;
+      paths = trivial.pipe cfg.keyboards [
+        (mapAttrsToList mkPaths)
+        concatLists
+        listToAttrs
+      ];
       services = mapAttrs' mkService cfg.keyboards;
     };
   };

--- a/pkgs/tools/system/kanata/default.nix
+++ b/pkgs/tools/system/kanata/default.nix
@@ -1,4 +1,5 @@
 { fetchFromGitHub
+, fetchpatch
 , lib
 , libevdev
 , pkg-config
@@ -8,16 +9,24 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "kanata";
-  version = "1.0.5";
+  version = "1.0.6";
 
   src = fetchFromGitHub {
     owner = "jtroo";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-sL9hP+222i8y0sK3ZEx66yXBTgZp5ewoPUlZS4XnphY=";
+    sha256 = "sha256-0S27dOwtHxQi5ERno040RWZNo5+ao0ULFwHKJz27wWw=";
   };
 
-  cargoHash = "sha256-uhN1UdwtU0C0/lpxUYoCcMLABFTPNO5wKsIGOBnFpzw=";
+  cargoHash = "sha256-Ge9CiYIl6R8cjfUAY4B9ggjNZv5vpjmQKMPv93wGJwc=";
+
+  cargoPatches = [
+    (fetchpatch {
+      name = "update-cargo.lock-for-1.0.6.patch";
+      url = "https://github.com/jtroo/kanata/commit/29a7669ac230571c30c9113e5c82e8440c8b89af.patch";
+      sha256 = "sha256-s4R7vUFlrL1XTNpgXRyIpIq4rDuM5A85ECzbMUX4MAw=";
+    })
+  ];
 
   buildFeatures = lib.optional withCmd "cmd";
 


### PR DESCRIPTION
###### Description of changes

https://github.com/jtroo/kanata/releases/tag/v1.0.6

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
