### PR TITLE
jedit, matio, proj: remove myself from meta.maintainers

### DIFF
--- a/pkgs/applications/editors/jedit/default.nix
+++ b/pkgs/applications/editors/jedit/default.nix
@@ -58,6 +58,6 @@ stdenv.mkDerivation {
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl2;
     platforms = platforms.unix;
-    maintainers = [ maintainers.vbgl ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/libraries/matio/default.nix
+++ b/pkgs/development/libraries/matio/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     description = "A C library for reading and writing Matlab MAT files";
     homepage = "http://matio.sourceforge.net/";
     license = licenses.bsd2;
-    maintainers = [ maintainers.vbgl ];
+    maintainers = [ ];
     mainProgram = "matdump";
     platforms = platforms.all;
   };

--- a/pkgs/development/libraries/proj/7.nix
+++ b/pkgs/development/libraries/proj/7.nix
@@ -54,6 +54,6 @@ stdenv.mkDerivation rec {
     homepage = "https://proj4.org";
     license = licenses.mit;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ vbgl dotlambda ];
+    maintainers = with maintainers; [ dotlambda ];
   };
 }

--- a/pkgs/development/libraries/proj/default.nix
+++ b/pkgs/development/libraries/proj/default.nix
@@ -54,6 +54,6 @@ stdenv.mkDerivation rec {
     homepage = "https://proj.org/";
     license = licenses.mit;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ vbgl dotlambda ];
+    maintainers = with maintainers; [ dotlambda ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Make things closer to reality.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
