### PR TITLE
firefox{,-bin}: 103.0 -> 103.0.1; firefox-{devedition,beta}-bin: 103.0b9 -> 104.0b4

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
@@ -1,985 +1,985 @@
 {
-  version = "103.0b9";
+  version = "104.0b4";
   sources = [
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/ach/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/ach/firefox-104.0b4.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "26b092bb16d3916e09ddf3771a112bc828df296e6c73053e4ca8e0c9bcb8d70c";
+      sha256 = "9aab97403c15845c0a15b4e80c0c566da586d7f612fcda4f21767bc2805c1195";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/af/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/af/firefox-104.0b4.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "59362a68e173ffe8093460a1a83765d213ac944c683bc21510daf6520271312a";
+      sha256 = "4a88e074f74395d81125d40ddba2aac2eef3b232d5facdd570855032c8c5f876";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/an/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/an/firefox-104.0b4.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "54d30a6355f22e6798fe853c5c223cb8dc1812e5a767b88bce2321483c624dd7";
+      sha256 = "bc46d97d0233a2c0cb5af05d24f99a6dc68c096546f791a0ebb2fd46aaa55158";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/ar/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/ar/firefox-104.0b4.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "9c00920fb2ace6cf0dd3a2e95ac02ac96ae4ae5764965ab53bf70e3a8ee47a68";
+      sha256 = "c0a224c85219eb7bcb8682df43d75ee747bd94082dfa5b80558d1f7841d90fee";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/ast/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/ast/firefox-104.0b4.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "2b7cb632597a6f4276c8b8ed23f43e222920964350af89a95179c1bb3c55134a";
+      sha256 = "c7228c9e3443997623ef850b211d54ec0ad1afac2b8bb9a65d27f7a598ce95dc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/az/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/az/firefox-104.0b4.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "e9a498dfae5df6adbd4ef8ede650e83901ae7a800c3d31ca9365296e71f4e932";
+      sha256 = "849c73d1f06004cd7934c1f9c6ceff059ba5aed3ca794e8d87e80dee307f2cde";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/be/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/be/firefox-104.0b4.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "e2c1bf9fc47db32b6400d5e9d69e1dc0005b41cf0ea2235708c3c483c0839753";
+      sha256 = "ced85dcbb3b98154e78fc3f9e2a74b6b159a6cdc9474d68a135caead222e85c0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/bg/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/bg/firefox-104.0b4.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "2a78a0468657a40583f070b1cbaa24ac0bc864fd12b5fe00d92f212a0c139807";
+      sha256 = "f52099d1e563411678a668d65390630de733bd3e977319b1d01828254235bb6c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/bn/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/bn/firefox-104.0b4.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "ef4593db06d7c17496679927c2d45422b65e1812611384ce1aa6b4c5e195ab5f";
+      sha256 = "f3cfb2f333429f178a7a7f22d88100d81813ef31b0ba60691106f21aba5ff190";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/br/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/br/firefox-104.0b4.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "1d81697a96ef8e468f1777c626a67c55c8648f6c395d2055546c5b7ef54d707a";
+      sha256 = "20bdf60533a5801770d239ee7616e7ed47ee4160a240066a6c71f643028e3945";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/bs/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/bs/firefox-104.0b4.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "368a99d2221348de62dfaa46b84209c3c42947d7e61f39e9e8aa04a81e10a127";
+      sha256 = "5d0abd11bba5ccce1fd0cd4c04da1430053d653df3b4263505f28801e48a5656";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/ca-valencia/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/ca-valencia/firefox-104.0b4.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "c14bd92692d04aab7d785415d76f9fa3536ce54b45a88f51513bd6fc0719b1dc";
+      sha256 = "51ce4bb5a373edeaa48f1c40839445f084c9bc1fde37b41fdc6f94937a3887b3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/ca/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/ca/firefox-104.0b4.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "177628db40e9477ee554744feb34619aa3a9d6937b78d48db999f08b0c55ac08";
+      sha256 = "c129546c4d876d7eef6c27cda86ed36adafd8d9454c21343beb2193c61d11e35";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/cak/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/cak/firefox-104.0b4.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "8ba3a0c8ca7b9de2d16a47aaaf37d891925d5d03ca4646e425412fcb1b61f24d";
+      sha256 = "40e6984998f478dd91859898ccc47e0574fc7633d29bde0d2b96d38e89d99e52";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/cs/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/cs/firefox-104.0b4.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "97edb0fedeed6ab9f3dd83d06189ce903e4e4387156d648377e986bb6e2b2931";
+      sha256 = "c113431a01f2c73760d6235626691b2126cbf378e9fcde0f398b265a49be53e0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/cy/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/cy/firefox-104.0b4.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "c9dd4344bac55fae531036ffd8c9b686af552578899d8f90595c74e6b414c066";
+      sha256 = "7c3828beb82d6d12b763dc20928bc8686b24e33058971a993f68edf1ed87996b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/da/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/da/firefox-104.0b4.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "369cf8a9e06e7ae958756a00dccdc58e0e677b774d04843889307c238c2a8179";
+      sha256 = "357a05bb854389652f6dad5d12fc9c61398c557298c4715e99a887870369dd67";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/de/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/de/firefox-104.0b4.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "75e7d632c6c6cb44bb4c61802e7afbc7a44caa32036bcfab9b529c83fd64b8d0";
+      sha256 = "5204775beae1ebff56013f312df7a5573803e52a738dfc87f4df174a1f5be1d3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/dsb/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/dsb/firefox-104.0b4.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "7e77ccf95f276c47deaed9f66cf8d5486d62c807be1e1a723b1ad7012f80584f";
+      sha256 = "3e1bad57eec534a9a69471212a35f68ed17be2294c26d6df38bf7a9ac71cdba8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/el/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/el/firefox-104.0b4.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "e1f3143697dc04c3f92a1d60e0f11732eec244d165e79c67373fc95ad2db54a0";
+      sha256 = "573f680467aacf7e2d5ed179aa739cedafc85d34a36e40e807d2bfd0afb9edf3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/en-CA/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/en-CA/firefox-104.0b4.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "3c765262b9c7d953bee8564109a7432eaadee43d0f498e099d68afa703454786";
+      sha256 = "8f4e8944b05acb357d23d51dfb877b459f9285224018950accb1ce5357261f7f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/en-GB/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/en-GB/firefox-104.0b4.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "732f0feadf101266e2e2485e4ec977c876868ce6aa9f16cf1b0ac92b60dfb748";
+      sha256 = "e6e024e95d2cc01106fa31fc4d73a13ac445afe1b56c0d302e1d9403cc38bb5b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/en-US/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/en-US/firefox-104.0b4.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "9fd0e767a2a7ef9ff76ab6df70819aa878666ecd14375fb090fe8adb7cafbfaf";
+      sha256 = "9ca36590d247d09a5e18c153a0f2ce6e5d99e859bd53968ed187a87c4b20ff3d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/eo/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/eo/firefox-104.0b4.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "8306755f3ef132d485a326e246935d299fa133544189801041102de87b8d47d7";
+      sha256 = "f87c01afb9d853ac48b27bd75aad1cf1cf5b7132fc2ed8eaa2ba4816b0480e44";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/es-AR/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/es-AR/firefox-104.0b4.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "0b3f5f23ccc45cc5e92294630a0bf99f677aebeb49d2c5a38a27a86bb02f42c4";
+      sha256 = "6a53038d9098c322ede5ed6f1e5c988a8b0c891b77d1e9755a8b8dc9534caf3c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/es-CL/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/es-CL/firefox-104.0b4.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "c3bf5acc1d1050293199b1f0e8ed8aa8916747babe390448caa750629a06d624";
+      sha256 = "d7e69956dc992c2ce8195866cd3e033daa43f1069433584d52cbf1f6769336b3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/es-ES/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/es-ES/firefox-104.0b4.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "a1851537b156a70e2e03e27fa54d03887b7007329ce4063b76c902bb37deb406";
+      sha256 = "15645f2a49205441f3860a3a5603fc073ca47c99fbe6891c2ac949b7a80e9cf4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/es-MX/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/es-MX/firefox-104.0b4.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "1c19afe939f98a97e3a3690c32b878fd8daab9d9b13203d24dd015bd57ab53d9";
+      sha256 = "638d109b6e555f41df2f9bf5fed9e3df766330530b641b40413d59671f4b4732";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/et/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/et/firefox-104.0b4.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "ece0279ce34b70cfbac7277747560952e16e49820a8507ecdb2f8feccc4a2484";
+      sha256 = "373fcd941538ea589b2297162176ddfefcbfa367e7e00d4a66de0d0b81883513";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/eu/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/eu/firefox-104.0b4.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "067d1ea61ddf28b625c281628a59dc77c8859eaeb6d776efd18f88c0a45b0bc4";
+      sha256 = "cf125688f58195b67c9de21f8733da107857fc0c552c551c88ae74f3b5842ed1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/fa/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/fa/firefox-104.0b4.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "b36c7ff55d2adc9d45efbaf9cc272a28f6fe21c55c302f5696c907fd034eaec7";
+      sha256 = "47e5e176bdc615b9da2fbdf35c20ded6a4f546547508afed74daaa8f1eeb58b7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/ff/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/ff/firefox-104.0b4.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "410c73b8672b25cbc528d6c70b42562dda14ff2ef34a9b4b08c882064008451c";
+      sha256 = "0067809f285d01e02336f0ef0cca3872110bf61781ec8b60821e28c642d6cdfc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/fi/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/fi/firefox-104.0b4.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "cd663bf8205de81d1f2e8932eedfed3b8a770f9297916b93468f0d98dad7892a";
+      sha256 = "09f4ab7fdc8906830a05019aefc085a7c29d038341e4546a4fd9444022478bbd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/fr/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/fr/firefox-104.0b4.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "440dd9e19169ae103a60482def975827146013599bc7cfb216ead4611cbf049f";
+      sha256 = "39b8a8d007123b70f450de475473ec5633a15830465dc57ad4a9e76a8b32defd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/fy-NL/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/fy-NL/firefox-104.0b4.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "19229222e0313f7143892e9917a518e15a3cc8bc6f9cb641abe371a4f5b936bf";
+      sha256 = "bf86bdf9819736996737479da460918985ace99240ece8380aeaaab40ce795f2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/ga-IE/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/ga-IE/firefox-104.0b4.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "89ba45a869a79b4adab5e0e3e3ef278018309b646b4f308e37fb4dc77f2b5d5e";
+      sha256 = "f324c686bcdca47deb6209e4609b1058ea2dc241bc237a667c0cf0377bce151b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/gd/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/gd/firefox-104.0b4.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "73ce290c834e4cbd6c4fda29ba0986d9e1463e0e574a5ba7c2c2c458ae35f20d";
+      sha256 = "22153b5d67a46b57394e2ee43bed403cfbe9e3cc2e111443d6aaacd2cd2c0221";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/gl/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/gl/firefox-104.0b4.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "a984c5035bc8cd0528886f363f5f97c7f71288d53cd99fc95af26b8b7c126591";
+      sha256 = "e63e129c8a6fd2c891f6e78083273a7df343f2b7e45aa91038d4a3e60e7971e8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/gn/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/gn/firefox-104.0b4.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "56d58521df6719e31f26233ede5c6c75d916d33c5753cc49e40c9d148610b937";
+      sha256 = "8e5f246d682590019c69343abdfd55e286ad30578a67f945479d53f130de630d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/gu-IN/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/gu-IN/firefox-104.0b4.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "380af70ceb09de1910417961e98c2f476cb206108f87e36f59371f39dc6bc46d";
+      sha256 = "1b1442ab2f408840b296e41dceba28de9402fb02858448ea71e423b380fd7060";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/he/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/he/firefox-104.0b4.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "05c47b52b1888185c865902b95c6b50ea270e8b9c45605c9e421a322d605752d";
+      sha256 = "af5cab55c801a96cb7393f4fd42562cf698802b671f4f9cda4a921c2c19616c7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/hi-IN/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/hi-IN/firefox-104.0b4.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "706932931171b806ef575daab1bb1552eae13178442e7bac5299dfb1c4bf4bea";
+      sha256 = "0d03b46a77a5221dfcb3f0610976435b9326e39109cef27fbe2362f34e8299ff";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/hr/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/hr/firefox-104.0b4.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "9817d9395312553e319f23ff36789627b299ce7c7f7c03b75507dbaa9c014a1a";
+      sha256 = "4f63255ab89ea614bb2d83498b402a99545f433671d2bd2ed34bb8a57f9a873d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/hsb/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/hsb/firefox-104.0b4.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "f81cf22747d9ac643d7e07849facafe096b4612e38dcf651c3211a344dfd27eb";
+      sha256 = "cd8c45063fccba3326b600ebb749ac5639764393114ff6b31d6c678db04e177d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/hu/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/hu/firefox-104.0b4.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "8fd5c45f48465b8bbeb2cc2d7533723eadad59a35b66af64ca8d22787003f9c8";
+      sha256 = "29b156f0e8c7fb022ea8cda3a7dbffe234336e04284439d59d147d3a8b1315e5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/hy-AM/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/hy-AM/firefox-104.0b4.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "5c1229cd177581dfd4d8e130fdcc3d88b971df1a36283feb5a4be79ac9cfbec2";
+      sha256 = "907398ac18826db5d72bbaafca76c950985614d2696020e8d146721cd7dfaaa7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/ia/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/ia/firefox-104.0b4.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "cb0f468e9c9952ad56908c3b2e317d61f26c63a3ad64a4ee4cac7976fec79860";
+      sha256 = "82ac551a3569e61a76127f208d08aa62ccd187c8c9f05d6981bd7611c6b050db";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/id/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/id/firefox-104.0b4.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "7b7b73bc94ee8375f91bf3cd8bbd8867264929ea0883d4ccf4770bed45c6ec94";
+      sha256 = "79175dbba4e95979416b1b7e86da20fbde5d02db121273d2c6c71cc167490e73";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/is/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/is/firefox-104.0b4.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "8fe0eb5bafce0716a60492efbdc6b60bc8efe51258ae00dc03a3c915a721b1b6";
+      sha256 = "47f6c921571b7495272690cc0d62e24845562c8748f9289e1bfbde29a877e01e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/it/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/it/firefox-104.0b4.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "705bc56fbcda1f6facd1b14c2a436843cd490d300c9ce16a85a807c266e7fa02";
+      sha256 = "14cf10a6bb3d254ed5e98398e6f9cda3e546d95fb5220c6410acd9383df7944e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/ja/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/ja/firefox-104.0b4.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "8b840c5662215279cc9129c457dda64daa57d935b5e90355239a3f0bd435d045";
+      sha256 = "e16a20dc0494235b59dd7d55e96404ab9063d65357d3372a90cad5cda942678e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/ka/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/ka/firefox-104.0b4.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "03d1676a019a528e7319fefa563da569d9afef066ccb296c5b03c5a199945288";
+      sha256 = "05d93ed19027df54945205825a78e95a0e679d47522df2e50770e74b904db0f1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/kab/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/kab/firefox-104.0b4.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "cb0982d9bf8a85e845b6e8dc5d62dac9b36755c1134aeacc87a518d7b012deea";
+      sha256 = "f578e9109b34c3a502f86d08952fad6c1c00efe6c5a8377c70cfcce416822a5c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/kk/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/kk/firefox-104.0b4.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "31e98f49cd16315cdd88a6977c9777870a6fd533ee52d38111be397e5005ebe8";
+      sha256 = "ed930e0d46c48b63e600490ae7b80d5cccd4dd25cc633820d733ac447e417701";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/km/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/km/firefox-104.0b4.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "c0b072d8a147eed692d0eabb4e27c1c72ca7779dbfe19fd143e8aff90fbb8712";
+      sha256 = "94411146267f6d887d55dd0cdd7e98f74bfb66b33880cc35c174c826fe543528";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/kn/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/kn/firefox-104.0b4.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "b1651e056aad563e4316866632865d571ca8df193752c9bd342a29256c2eadd1";
+      sha256 = "533bd977d7db52be57f0bdacf7c7716fb1664d8eea18393f0d129bc5adae3e30";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/ko/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/ko/firefox-104.0b4.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "cdc9209ed637495fb015e1360cc6fac9771fc5645024516e3898be77fc935cc9";
+      sha256 = "d8e0aea1c654e9d8a1bf3e45cf3ee990d5182394fec8a75fff264d3f750af870";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/lij/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/lij/firefox-104.0b4.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "8d4e3590a22e6837853e18eb449429a6c010a8cea6bcc1ee7f0d3c31b706189c";
+      sha256 = "a25bfa50f5ab6697a3c38b7d9c01a88562f7b3de68b1cbdf01a1e38424766f15";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/lt/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/lt/firefox-104.0b4.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "28d35dc640547a525ad29b9ed89154b2939f2fdc8c8ddc1538d60d3baa91c4dc";
+      sha256 = "ae4e5588a3a32b36b960170903f88400c7907fdd9a1f497e2cf05e6718269da6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/lv/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/lv/firefox-104.0b4.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "6dba2a6e44e7740b51ffddd1e334395fb7314e8f26ba2f12f195af8e04e5a2ab";
+      sha256 = "c3eb24c88d0603ea569b521f2799378d566b47ad95f76642805e775e1ace95e5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/mk/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/mk/firefox-104.0b4.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "2fc8eb82425826a1f53a85fa45c09a70972ad55118b3a5b649377c5c4ddb21bc";
+      sha256 = "32e433474f887a44bc5d507d0e00b3e3a09900528c88128193ad3ac19f46fd87";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/mr/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/mr/firefox-104.0b4.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "8c8fc083acac5763503a5fe87903e9c082c98c65a000e4879138370b49f50126";
+      sha256 = "6b3064957cecf8a7c276c5becf6f75649c198ec71a106e85aa98668a6feece7c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/ms/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/ms/firefox-104.0b4.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "0ab5e0472522a944cad1afe360be5b41ff857923f9aaf47bd3eb612a24d2fe3e";
+      sha256 = "78fd908ee2fa8df601b239db3cb6e95adf0b136f6fad667023adfbf984efe278";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/my/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/my/firefox-104.0b4.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "6c710a14178c28d2dd856a731d2a129f68c08336a1f2b104e939404f9ca4894d";
+      sha256 = "90b07ced994c32e2540d5b6509e48237edb4e705ad356b77b677fb3b231f6b8a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/nb-NO/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/nb-NO/firefox-104.0b4.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "5962002e9950357fa40baca920a6c0933c561f383030e9a7ebbca0e66814d48d";
+      sha256 = "71029afb27d778dc0b59bd60ffb933b2e2d6f6a83b343c160d20fa83f68f587e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/ne-NP/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/ne-NP/firefox-104.0b4.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "162005ab68e838a3a5c13127f965784b24a2f38a777434c5fe39dce98c914173";
+      sha256 = "585ac065ade8a7757f6d5b89a0cd35331e0c7b86a0a1fee013146c41c48d22d8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/nl/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/nl/firefox-104.0b4.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "4758b0c6e4fad9a3b8b8e4e1ba8c12acef98dda0e512230439ab7fbe4e51d1fe";
+      sha256 = "f5903750c5fa504367480d97f784c6731694daf3c5d221db5eaa85bfde2b63a3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/nn-NO/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/nn-NO/firefox-104.0b4.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "027b0f7ab1d6279b66659412d47cb7ce5faa84ed7ee5da9b3332272a4b4fdaaf";
+      sha256 = "e6362a32ec0c828ac8737cc20aa5438a8338950950efdc017f4138066f53da2e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/oc/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/oc/firefox-104.0b4.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "2b4f9b9615da0a5e05939a3c1bfbc9fe08615cb1cde515683f5d57c46bd0144a";
+      sha256 = "05c0b3a1cd5889aa06adc765e560ccd9f6e5bab12114d991503fbd980eb4107a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/pa-IN/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/pa-IN/firefox-104.0b4.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "f3942b9ee4dddcb956780dc8ba066709b3986bb0eb979e8a55a346fb9c3cdaa5";
+      sha256 = "a1b00c34e4757d759ac4f75969745938dd1d795fa1ad67664dffa16022fbf742";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/pl/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/pl/firefox-104.0b4.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "3395460bf40ceda10aa6ee8b1dc725fd1e23cc2befe6754dfa6f4f9c01cc3f26";
+      sha256 = "7ae3990f66c67841e9762f5a5e9851d8af145a451d75b5d830ad4507f5656676";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/pt-BR/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/pt-BR/firefox-104.0b4.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "07716929ec3cf89d0459e14a115a4d086f5c9239305ec115cc73c85872e0c958";
+      sha256 = "4a8c1c62db1f460f0e00ce780d1b34b855b5a3e4794197bc034c78f164280504";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/pt-PT/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/pt-PT/firefox-104.0b4.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "c4efad517bef23d444308ce52d4e8cddc799f5b9e815f77515785b3dec2c8bcb";
+      sha256 = "d582123ba012aa3a698956f8b4231c68019428110bd4091631b5013dcd9de585";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/rm/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/rm/firefox-104.0b4.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "cca48b51e64e6faf03b23cb260a0be5303c98da7f1e5b9bbe141ecb1e3f7dd87";
+      sha256 = "5e882803a9fad758cebdd7107e887af7104d5ac41547ebfcaaab2257104e3693";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/ro/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/ro/firefox-104.0b4.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "d62459fea5cf8b8ef3508803300f7e46a4d2919d6ea50d0fab01e3f9615d44dd";
+      sha256 = "55ecb2e0add169130161d9467b0fdff1e3533b98f52ee863d349d25a4e35fbf3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/ru/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/ru/firefox-104.0b4.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "056b293be286972fa2c920f57dd419835e3f32c5f02ad704ae6e53e9750512e1";
+      sha256 = "92e33625e6b182c294df91c25d457c5bd8022056b5632342f0ce97cf399730af";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/sco/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/sco/firefox-104.0b4.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "45f982411422ec6f8550fc95317924b29eb390fb144af45de8eaab86b3379963";
+      sha256 = "35275dce3a1dec1ee4d9bbbb28da69e9a4a77976f810d429ebd68141d1b51f67";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/si/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/si/firefox-104.0b4.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "80e5016979982b42b0d7dabcf377fe8c737f314a0bf774efc79ecd5cf9950f24";
+      sha256 = "7095d7b90531e81e3fa707d6479d6e96748f8a843d3ca1c58bdc7d7ca5179f01";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/sk/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/sk/firefox-104.0b4.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "bd11078ec91c7b5016d5c5bc516f17bd068cd567749c70a1336f89c492a5e4f4";
+      sha256 = "6dc069bba78e5e5b3745158731194bcccc230267d59145bfad574bf1b55d7806";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/sl/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/sl/firefox-104.0b4.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "529cc0bfa0b59c037e0dac284f5573649deff1fef0cf1f195c49128b3ecc5ede";
+      sha256 = "1c495bb7036a88e004df0db4ccb4d4dbe5ae7d2e05a7125588fc1424e9b1827f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/son/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/son/firefox-104.0b4.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "1bead22418e24c35cbc3ba92ffd36731ee562fae0a903742b65ab27fe0edd2d1";
+      sha256 = "21e5d0db6d7af47f10a8acbd9c98baf5ed496ccc248310d605ad8815a3695150";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/sq/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/sq/firefox-104.0b4.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "d0160fdf22cb4445ab94073a708d76adbad2326dca95df8bd7cbaf94d41867f1";
+      sha256 = "ee3719250ad18ed22f6c5169559fe7e3ae83fc0796a930bc65bce57c17e077aa";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/sr/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/sr/firefox-104.0b4.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "d28d23cb4b9798d0ccf56687f532945c1d388f2148c16fc2ab80710af97d09d5";
+      sha256 = "95430d54f716e916e8e744df3be8bc9131241e30324b616d68cbd1507e9dfd1a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/sv-SE/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/sv-SE/firefox-104.0b4.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "08ef9d52de8c57c62f924c9fb3f88f7ec8961733c95c29a75816577488d4d523";
+      sha256 = "977998e5a77294ad611bea83cc0a1f655d54f138bc19bdffe1b9bb20c3fe7026";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/szl/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/szl/firefox-104.0b4.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "88779e9730fa9f66dc559863f984d9db384c68fcf6ba169b7ad7dc4bb7a12ff3";
+      sha256 = "f8049f987b24d187de4a444946063ebdd26f4d09ba2773194628ae5f223a2abf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/ta/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/ta/firefox-104.0b4.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "c198895e36fa70f9df8b3cc69e0201581f9573af60e4e547a8a6b74fe9c945ab";
+      sha256 = "960ba9bc8901b596430c5258193c7bd3e3cc5fe43a875e3e7523c268fa04e44b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/te/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/te/firefox-104.0b4.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "fd363845ea2a111c59893a390efbf32066047e9266d440b64d9320214946409b";
+      sha256 = "96d2f52e56c0fd95001ddbd72c9266bad176142c910c4e101b5dc29f8c698951";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/th/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/th/firefox-104.0b4.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "56633fb10ba52a1a6310d7223f99212b187bb073bdd289453553f16af0e819d7";
+      sha256 = "644e66102f1b7b2a762028a1c2e7523d8053c3bc03c10612c64d80dbf0eff14d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/tl/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/tl/firefox-104.0b4.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "ca991a3bfc6bae7255b5e70b3699ea1963fda73732dcd13adbc1f992bfd2a4d3";
+      sha256 = "4970014ced5513ed0f20418ed7c1155552b113f2407f0652f297611f58bc8e25";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/tr/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/tr/firefox-104.0b4.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "c78381662dc98ebfee9bc83ab2f4e8f24bf57b4d982d9f481d5f1525f6380528";
+      sha256 = "cd8b439d5dd63f9b61f191423a909557b991c73c8bc11a6b248b33b556fb9c66";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/trs/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/trs/firefox-104.0b4.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "2938ef28c44eadc8d3978b5067068f682c91567080302af968ec61b242fbc1f9";
+      sha256 = "6dcced8e30683a195640151b896d164260988239cf95929ba3004ac3414475db";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/uk/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/uk/firefox-104.0b4.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "11ba4006b1241c5f77f3b445ff970055854ab39d86e3826c6d032e9e1d5c965f";
+      sha256 = "8fd2e695a93925be29fde7c9c3701ab73100351ac755377b716f9c2c21608bb2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/ur/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/ur/firefox-104.0b4.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "d983acd3cf8ccd88453b407544948175bdbedba10618ad6504df93d01e956221";
+      sha256 = "a2abd79fc8c400e18747ca7a1877a1a8f80425e5ed9fa4708c1707ec36b2c8ac";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/uz/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/uz/firefox-104.0b4.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "aaa8875f9d1ba3b72ad189d31de2e812d690fd54d290b059ab523a17c132dd17";
+      sha256 = "5a1ec309d4576a23a990900d6e7c5ec18f62d62124458d98f95c9b80ffd363a3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/vi/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/vi/firefox-104.0b4.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "2870311fe1e4d7515be9dc40cc5d2ffdd2acd37772dfdde267ed0a46ba569bd6";
+      sha256 = "78aec2addf626105b52743ba1089acee3d160741251e3da120c56d96f5ba1f8f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/xh/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/xh/firefox-104.0b4.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "461105332ebd4005cd1d4a373a9274e9c42a18fdb1b43f372468a606401b235b";
+      sha256 = "973bf97f2a1c502d091a680493ab30ed1a71524f44afa50ae8e2e17b98c6a80f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/zh-CN/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/zh-CN/firefox-104.0b4.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "ff73b696e774b180ed3198058b9eec7940e465185c464ec800d86ada86a7931e";
+      sha256 = "5ac7c0f677f0916d40080aa2481226e0611d3448d53890e9e8c3f16bef93d2e8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-x86_64/zh-TW/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-x86_64/zh-TW/firefox-104.0b4.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "61cbf848169b3ab23565bd4ad8cc05aafb56536c51e30e7aa49001f7e5255137";
+      sha256 = "0cc9bd9a97e2a6e70574b0e74c738efd3a7787460e27493473dd401b5d82a5f4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/ach/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/ach/firefox-104.0b4.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "8b6d2753b45c3ade7a3aa56040826b1832b89d3ec279b63d7a83fd0663d6477d";
+      sha256 = "115e7340cc3f117f953a18328726a53993e5e14b417ed437c62ff92d55932996";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/af/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/af/firefox-104.0b4.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "11aeef4c60af76e8ea3ec20cbcf70de60430a5292ff2edd00f9f4283ce405064";
+      sha256 = "bae4d8ba0a1a0291239800648fc4724dd040e9028ddc98235c97a44acefc322d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/an/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/an/firefox-104.0b4.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "b1f811430dbaf7498d3a37c00756a3517a3e0e7409346810925a3bc95bf24328";
+      sha256 = "72af9eb1f1813cf610a515f03888e8450c7011414cf23485e6841a5d780a0af1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/ar/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/ar/firefox-104.0b4.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "21277d4637e549961f765811bf8dbb784f17f082a4ca9e550f28bba569d06012";
+      sha256 = "89b0051f2bba95111ae993da897db651c26a226674b8aef385396754b3c0bcfd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/ast/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/ast/firefox-104.0b4.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "6410e676b26ce20fa4727f64e7bf4e51b9a30b68e8b4a09ff68e881d6d75b8ec";
+      sha256 = "1d991caf5343cb21b0b680d27cdb6a2e5a9fd95e399b4677c9051e8ff82fcd88";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/az/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/az/firefox-104.0b4.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "0a7c4dd95b0d7cbbb121df61fa3376b7f4ae912c6207eef61443e6eef3999493";
+      sha256 = "df6c071df6fecd3825ef9d88cee75a53aabed778b9ee7ed84c306a0e4e3b46d1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/be/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/be/firefox-104.0b4.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "0695103f30f54a5bf689c1de2c5307d70160f094599ce6fb91044907adb7f7cd";
+      sha256 = "8e310b585fa44612c71c30413c7f2697c728549c9de2a0d549e0094dccde72c3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/bg/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/bg/firefox-104.0b4.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "06b0d65f2dbc996af9fe0938d3daf911d13c5640fc42d1a67dd17551850bd226";
+      sha256 = "8ab0f94d40a32c976b19aed1eedfea796ebc7abea6c9d53cf09e9afb7d9aacf5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/bn/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/bn/firefox-104.0b4.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "00d2c69fa1da67953f13517d169f764201b06e2d092385cecf0f1705c0b89c95";
+      sha256 = "e3ac959ed71670a9ea0137e08be08a10946b0c6893e42c5697a985011b7114a6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/br/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/br/firefox-104.0b4.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "a17d0499e414a8b9792840e289c7162f796c7ea01375515c0ef676b884bfb1a0";
+      sha256 = "3943e869614a9c8e018de293d37ad66ca956880c12372faeb9eec6df9bc8afef";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/bs/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/bs/firefox-104.0b4.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "1f54fd672acb9e941fce6c901aceb245ab756b611c1bd6365be1e44b5e0ac160";
+      sha256 = "66be85bbccad1716a786149216e95fa5c30260733386e6899ffc58030ef09235";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/ca-valencia/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/ca-valencia/firefox-104.0b4.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "fcfb1aa6bc1615e319c7dc69d1e47c737106c6a57478be1d5cd7c602d0244669";
+      sha256 = "ee31d8bcea14f15502c7c72f62c8239ef53dceb489be2a2c2305a2f7c4eb320f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/ca/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/ca/firefox-104.0b4.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "92532b1dac815ef20637da25c4d2abf706cce4807766d82127da558e7fb88acd";
+      sha256 = "71ce2b4088d7db1a2e083a55c05f1c34cc794f5138deb3bd694c384d50336f59";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/cak/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/cak/firefox-104.0b4.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "dc04b678f35fe3653c15e3d0b010990f8be52e14e4abb8de96af5b452dc14ba6";
+      sha256 = "232d277ba101756cd2a6feccf37f3fdba0c317c61894d8c167d28bcb31650adb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/cs/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/cs/firefox-104.0b4.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "cd379c76280a77ca023d67606df93f88a93fbae5883ede17228292c8ad52a270";
+      sha256 = "3d89e4f883fb8c53d4d2fea58400cae52ee4b8e97d22a0f241d8c2b962742fb2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/cy/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/cy/firefox-104.0b4.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "f60ae100939959f0ef2ef1067b21f5c8b551084a437caeb99bf28c82998374fb";
+      sha256 = "c4398262f9477396163c9171855d5c08cd6d91088341e011e83c0812eb84a6aa";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/da/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/da/firefox-104.0b4.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "1c477f23b2cddf061989916d295095f0320fd17539fa64a495e5b264e70dd6b9";
+      sha256 = "b18a6a787a2b490f390bda39f53d1fa56d2fd99e75d6a54f63b7b03c50d1c4df";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/de/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/de/firefox-104.0b4.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "acfaf7c55eea158fe9e9a2496e6ec2b379f76b627da04bdbf127434d1dbca03a";
+      sha256 = "397343a929595db6cae72979100120ae92bc6381e8d23c08bb698dd742267d46";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/dsb/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/dsb/firefox-104.0b4.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "5b8043fbbfc85fcee295e8a736286259b928d21a288c5a5bdc58c00337271d73";
+      sha256 = "f9502210529bd09b95a5a4d9f6d5d062037278629355c4ea127274802a5130e7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/el/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/el/firefox-104.0b4.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "236d256104332d6791aadf11d51fd0c642f52d776b04cf6166d31d588160e783";
+      sha256 = "1e9885b8bca40351a95697fb22eadcf90324acc6a1508e6c5f36d774712cd97e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/en-CA/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/en-CA/firefox-104.0b4.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "65cc433e5d4352aa0efe9122a99c8d714dae25704a394d0026df56a8d85c9f8d";
+      sha256 = "b4330a47b5c574f9947411bcafb4abccfbb5457467cb4d8151099fada9433904";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/en-GB/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/en-GB/firefox-104.0b4.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "7b7ee569a9bb08f9ee79d20f8e6a614e773025b7cb863f74a18191c0ddc00570";
+      sha256 = "3f8e145dc4f2375f22d0dbb4b4ae20756e3e02098db644009da356202b19e9fe";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/en-US/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/en-US/firefox-104.0b4.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "7960b708458518d38cad878174306958ca44064e2d5351f7609ec50befc9a10b";
+      sha256 = "a77789a0f00f9ce09d303c4be4b9dffe8005b2ee9d1030596adc05dd8c33d246";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/eo/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/eo/firefox-104.0b4.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "a8c984a5deb37b7cd51c9c79a5d646933e4d9514648a4fa3d6e19389a581d9a8";
+      sha256 = "c230995083f4f95dc78a3629afaad2c1e94ca54f22a6e41ef1dd70675ad68d3f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/es-AR/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/es-AR/firefox-104.0b4.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "6bb099d51f972ead69a6159953cd6ee383fe98cdd0f2e755140f7aed87c18ef7";
+      sha256 = "6c684e9ff9fa8d639defbafcfbc4d179de2662fde55d0751618f88768eff784d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/es-CL/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/es-CL/firefox-104.0b4.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "443a1d6d3499f4349160c7b288f45f8b80907391db30b3d03f307791c047c284";
+      sha256 = "f47b6356405fcdd76291a05230b156cccc6a849dfdc4d97f90f76ebaf1d7f9cf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/es-ES/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/es-ES/firefox-104.0b4.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "c6937531c39b597a41e247566e282ada78af6e6ad522262bf310a852a710ab1a";
+      sha256 = "591dfb7849d97ebf387d9fa04cb2b80974f8659f4a913be2df53ff92a20d901a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/es-MX/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/es-MX/firefox-104.0b4.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "1a3332429056f96d6f7fc8aa28d9e25a13f33dc821ef48ecd69b2c0c3d2be322";
+      sha256 = "ca034e7aea5700289c42aff8a3c5fd44df0dea208d0ba2cb05c2f3654c12acd6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/et/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/et/firefox-104.0b4.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "e6a8a12fb2f36f6a7476b17f9d141f266460d5e92226cec5db2b4c8e8fec803c";
+      sha256 = "b5dd9c6650769bc679a2d37da823421f4d7ae307eb5a3e3e7fec16c0c24c012e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/eu/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/eu/firefox-104.0b4.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "85529de98fa359122a4846272755dbd930156cf57459c9f274bd673ae84f95df";
+      sha256 = "dc545792b4055aa5ba36677de77265c637638d11ecaf38a96facea1afeebefe9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/fa/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/fa/firefox-104.0b4.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "360dfe416d6f1895ca1b516606fd388958dedb9b382e5654238f3bac8b765a5e";
+      sha256 = "199990239c8f5d31224e4acab9c5238f402d157cb6482d52614e2e47208a2619";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/ff/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/ff/firefox-104.0b4.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "52e272ceb7d3c894ecffcc0decf219b5377972e559480b763a1c770ed62691d3";
+      sha256 = "33af0cc68a1b57f52c21c0a792f4e14fa465ce5c024b400d36a1be51cac2409d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/fi/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/fi/firefox-104.0b4.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "55a7de7ffcce5040864c141714f62039f45518dadd44b27954706ae2d3376c6d";
+      sha256 = "bae631ca152308cb9abcf5672a75fb5558ab0ea61b77f9f82e1a1abe0884631e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/fr/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/fr/firefox-104.0b4.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "1594e02f9da5adbb04b7b36d279b204f644aededf733704ebd54e836a2c95cee";
+      sha256 = "2216296bf9885fb9a24d784bd88dc8422b0772baf1b4183d1be5aea4c8d68598";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/fy-NL/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/fy-NL/firefox-104.0b4.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "69aeb0ad2ec2dcecf07da8162dec9411a1bf2cf6a1f2c4c38b8dc2b644f82d34";
+      sha256 = "0a865e90a56f37860fb647bb3a01f8e640fed66845df993450608feafae436f0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/ga-IE/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/ga-IE/firefox-104.0b4.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "d342b3a2d99d8bee7a82ceff9d9c78b9e2684d1110771b3bff12d83de0999a70";
+      sha256 = "dbd7b1813dad025b46b8f50e2b62c40e54cd74df6cf063f5a47de94b84cd4703";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/gd/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/gd/firefox-104.0b4.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "2688fba5fb101da1cacd2c6e01ec5f919d41213af9edfbaa7a740fff3506dde9";
+      sha256 = "f47b4fcd37444b457c4a78cbe8ffd9c362eef5a409fb8d81c951cfa20378450a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/gl/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/gl/firefox-104.0b4.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "631ef66e762ec15080618eab9a34e68de363eac38e41d4710f9e629d1809bb0a";
+      sha256 = "7e2cde9d545a80fb3d7ab6b400235123aa4ac8c6c20756d478ab11c61d025d32";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/gn/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/gn/firefox-104.0b4.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "a428682f67cb2995928597e5ea04e88cbffa44a5a915af9465371efd7722949f";
+      sha256 = "0058e21c55e7cd8e93ecba3af4231058d50e42dc0851244dc85ee5ebb7e9406e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/gu-IN/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/gu-IN/firefox-104.0b4.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "d412f6cafbe830bc805a3fc0017c035d4d46438d74378a9652906e440edf4f04";
+      sha256 = "159822e43e49084722b135a50943dc8504215a1ab2c498cedf8d5a376e29b3c2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/he/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/he/firefox-104.0b4.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "edf1b560c66659e8e9ba65a483be3b440298049842fbf3fedba92d0bfec1b987";
+      sha256 = "51e2632840848fc23335bd4affa03d07fdab3049a512fdd797ca74c62d2fb386";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/hi-IN/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/hi-IN/firefox-104.0b4.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "c1b87b7521ac265a68c33c2b1e6c332d61d9d3b232cd11c82081282dc00fc0b0";
+      sha256 = "263196c8428f31644765910210c431f2d94d8ef8bdfe36eed0289e9731f052ab";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/hr/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/hr/firefox-104.0b4.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "871d91daa7b86d0df3164c1d32579246b0ca7a7ec8ddad3a905fa3f2fa4b927a";
+      sha256 = "90b2178c61db5cdd6072a3f67079f20faa2e66a5d155ffe63c32bfe61d149c1d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/hsb/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/hsb/firefox-104.0b4.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "fcef16512eb11930ab5e387894c88f4145359b7fc1a28b689d61720ac6f66537";
+      sha256 = "4ed8c373066fdf48761650845ba3533848dacc86d1ea84ba2013326e750dfa32";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/hu/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/hu/firefox-104.0b4.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "38658d0332eea9c3feec08968f54cb363aca6648468ee056593e2aefa9632ec6";
+      sha256 = "fa3f9bb7a7f8570ee68d95526f007cca3de68f606b8730b4e2b239a65c061575";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/hy-AM/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/hy-AM/firefox-104.0b4.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "2a4d9fce5b718aa5a3fe64737aa980c872ff24ff813ab80854d68bc01bb6ae20";
+      sha256 = "332b0020e8009b089c9c3afbf5e20f0f8c86db4c6059b2c49ee9becbb8ab9b3f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/ia/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/ia/firefox-104.0b4.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "fb1c03d7d8f9029d5c9df26a1a93801e5a00d7181eb33ca690e0334d6432dcd4";
+      sha256 = "b980604063ce69876087fb52d705d056b56de9caa0dccf0eee742b8d2348256f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/id/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/id/firefox-104.0b4.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "acf0ec1b5f043c7bae844c5645cb319ac1979fc56652afe7bc745d5a37efcc6b";
+      sha256 = "326f133122f581638d04cd772e9a7d8f1c48608c0f28a745856b5de8aad6d389";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/is/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/is/firefox-104.0b4.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "96f365bd7dc85f914e248ab922df8aef98168e295f9ca3d30f9a6088971ba0e4";
+      sha256 = "4737af7ba15c03e06749cb4297f2d05f3536822926e9e074b4ab8fa7716d8098";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/it/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/it/firefox-104.0b4.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "3eb4898ade9575429924a0293767fbf4d94ed3443a895cb68c7f4d480cdb0e21";
+      sha256 = "8d057d0f60ba4ba522d3d4ad06ac4b26808aa42f4ca4abcb2481db92bdc88591";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/ja/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/ja/firefox-104.0b4.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "402ef5666432af0d6cf720ae098834b621278936de97a749fc08a550d4e8952e";
+      sha256 = "074b76c62cd0fa27bd7093ebfc34ddd4c0677e1a4d2aaf52da392cee29293c8f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/ka/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/ka/firefox-104.0b4.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "6313891d2fd8aa58fdd6d83403ab04d6448fe5487dfb1c5e820a552ba72f61cc";
+      sha256 = "688eee17b56fe8e36af02d0edb21927f9715709ddd37170d9466a5c31bb59c10";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/kab/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/kab/firefox-104.0b4.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "1deadfb40e0bcea879eaac33b37d40e77bf175eae1a16261c96594821bcb504b";
+      sha256 = "d613ea711a9a39ed6cf1d2d979686b75afcb065ea12a2545312453519a8b3bfc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/kk/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/kk/firefox-104.0b4.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "c24dc9acc705ceffed6220a03065b2723493b6153478eeafbe357559a4b6a68e";
+      sha256 = "802ba255e599098ba25ad232523cc128549c80fb5acad2f6b549e146c38ce92f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/km/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/km/firefox-104.0b4.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "2354522c1e85c2d194031907daf9f2a913c18867d4f67718721a618053963735";
+      sha256 = "1ccf35f4abc42a00de61adffc36f1da4e2202ee76e64a6b7b582ab5c7730a5b0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/kn/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/kn/firefox-104.0b4.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "9f43475414ebabfcb57fd3f47f63f819c71db0cc9f1dfd643f5b7ac5a36a3568";
+      sha256 = "2bea3b3fbcc642d29c10e76ac61eed0ae03bfdf5dc7e39592e543c56d32249f9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/ko/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/ko/firefox-104.0b4.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "5f6e85d5d6e95102bdb5d2e6950b09949921e7596aa516e3c4765bd14a8c8f47";
+      sha256 = "dd61a7a3f1e56cd88efb6452c3658226df18c510ea6000ed57095a8a146fa03c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/lij/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/lij/firefox-104.0b4.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "10538dca7e7696499166679feca81d33b01d37d2f3434914097706e10fc9c809";
+      sha256 = "3b807030b19c0114db587cbd54861fafbdb8c96680d60c98c27e7b2364aef479";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/lt/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/lt/firefox-104.0b4.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "161428bee88041c135d5e6010c11af7983ef6939ffa6b825bd56b6652e460ad9";
+      sha256 = "bdab63d7bbccef91658f518c64b4a9f0e536c5a4d04526b9ec1c02db04894b6e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/lv/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/lv/firefox-104.0b4.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "fb2276d7e4cca03ad4b015979f0f0ebb5464e9a5adf1d0ca4306d19d22fad46e";
+      sha256 = "e9229cd4947e64f7b9fc998265343e16ef619e9397ea0a1bfed8c89d432832e8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/mk/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/mk/firefox-104.0b4.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "4f539e41ecc53966ca8a66c594f0c3515349b4aafcf44259844b282371f391ce";
+      sha256 = "0cb2810c674b5301b7a7120a2872ec1b8da25fb1fa6393fe727efb984a65f24f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/mr/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/mr/firefox-104.0b4.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "5bd8cb13f1dda2ca099b41208a76b50d09fd91152dca3571fa52d6a9290896bb";
+      sha256 = "c783abee63b10e31a186f5c8957929c5cc476925142b2c2747f48d304db80157";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/ms/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/ms/firefox-104.0b4.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "206b5d00bdc9eb5531911df1edca297894672e93a4d5ae791c5948f69f144150";
+      sha256 = "7ac0d5a34c8ee97d0ca5a596964af50e3d053097b941bfaa9246b50d359757f7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/my/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/my/firefox-104.0b4.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "4cfa6d0b697575488215c11503a4e45da6323368e0681e0fae73b2c39ece1ec2";
+      sha256 = "7865d44bb390babeb4ba073cb588aea14c8ee61235f283b94e856b9ca7d15b82";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/nb-NO/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/nb-NO/firefox-104.0b4.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "1f6cc0897850ec1f6d7a4cc0cb5f137722144fc3d8886b7314dd773612e78790";
+      sha256 = "4fe7547204ba3e189aa4c4926e7a1f8dc96ebdb4ad779785710eafbae896f2c8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/ne-NP/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/ne-NP/firefox-104.0b4.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "21fb10cd642d269da89b0e1ae999fc83ba64b1ede5ae88d6610192dc71831a64";
+      sha256 = "20fd4e6f6ee40d2301916c1d38b69cea6ee4182b4d2510bfe4893ffe7e452d6c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/nl/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/nl/firefox-104.0b4.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "c9106533d8c3efbec6b53a35e16a34875e785f77217e03054cca81211698aeaf";
+      sha256 = "79272e3b5ad5f3007729655e5905063043fb4cc732e21f1e0635954e3ff6cd66";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/nn-NO/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/nn-NO/firefox-104.0b4.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "422f86e3a83a781153c1655d3779025f1f12f5842511bd1bec3374d3012e52d5";
+      sha256 = "06fe27c09061e45551b4649d80862613b8a382070b82ca72087574105ac800dd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/oc/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/oc/firefox-104.0b4.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "cca7772da2228856a146a6f056e4d461ff001b488eebe01ab13fa158524cbe11";
+      sha256 = "15a6e761a45775fb60f9e11ab1fd804b8e867472f7d7655c877d63a46ad17807";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/pa-IN/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/pa-IN/firefox-104.0b4.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "043818225ca2155ab319c014cd801113743a746988fa50106c25125b5389a7d1";
+      sha256 = "127f7ec50ccbf24d0cc0e1678e8c2e6b576d8147e7a202a41463c292d0491bc9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/pl/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/pl/firefox-104.0b4.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "c4a236c787645db470a2dc5edabd8919680736930f0df7bf1d9935be4bb6d609";
+      sha256 = "e7a2ca16e451a8af1a2b57951b3c3883b83577f58c1cd64090590d4a37409d0b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/pt-BR/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/pt-BR/firefox-104.0b4.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "1a30bb617260f239147adcf64453000043fc7dca78a463a75b0cdbdfd79c39ae";
+      sha256 = "7b3ddd753343b2279bc123d5d45adea9b85726ce4b8c687e7f63b8c5c375cb37";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/pt-PT/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/pt-PT/firefox-104.0b4.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "295c761cb32914adfaed3e04feeb3e7bf82db1cd3790cb171810643e0f8a9e19";
+      sha256 = "27df6ea79dcccfac45e014d295074f9f98e81ae87094ecab7faf1481e580a9d7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/rm/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/rm/firefox-104.0b4.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "225d85baeb516616b801e1be90fc305166521cbbde8bd4a6f8756755ccb19dc0";
+      sha256 = "cfb7c31ba3cd85f583b232d4e9f61439e02c7f76d01da5b6a801b50bd7f4cf1f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/ro/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/ro/firefox-104.0b4.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "164f6136fd043c97364ff2be8c114f73e7c518ee0da9a5c90d9f09e4855781b4";
+      sha256 = "5add3220c8381cfa5fe26d48cbc7155aa70345646923ecd022a7996f2bbf45b0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/ru/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/ru/firefox-104.0b4.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "f8776d46ffbd14ab924858df47b5f9455f66ddbe53a43c8582799783de6b2644";
+      sha256 = "468c8560e15335632da0f07ec2cf23c95483e45a4863384dd78f68822ab55e99";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/sco/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/sco/firefox-104.0b4.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "019a61c2dba8bafb5427b9b63fd61276b39e62fa119233f805e4d4ddb511ce2b";
+      sha256 = "3986cea68b6edf66ea32e983e988e7120c045ae8861a57fe6fe78e510dfd488a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/si/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/si/firefox-104.0b4.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "3018a726b98f4f8f4e4e35d6afb22afff01cd073f327e3838a227f38389050b5";
+      sha256 = "0bdfa4be5dc7605298c134556d2f522e533e76d953df732862966645f856f4f6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/sk/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/sk/firefox-104.0b4.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "aebfa01c62250afc38e3a14bf1a2e06694580873d691d1063d5a8b7adf62cdc5";
+      sha256 = "d2faf232b4bafa6e6b57e6ea8c9a84f0bbd2bbce54876e99cf2a9af46f7cb875";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/sl/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/sl/firefox-104.0b4.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "0d8ef535e7cfee020243f8f994d9d5fb6ecf3fe4b6108a20640bfa13dfdebd95";
+      sha256 = "5e5ccaf297549cf75db473a7033db4ab93135544709716a6fb4833ae331a2fa2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/son/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/son/firefox-104.0b4.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "01c45f4a14be104c47c49280193d9ea401a75c09813f1368a09a37d0fc4ff3c4";
+      sha256 = "ac0a6ac731b23348398cdbdcdabc57dd1382efbe3bf991634dc2deff136dae90";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/sq/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/sq/firefox-104.0b4.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "34ff725f2f02699e4335e2e7e0803f94bbb9e817c6a065b08c5190b614255ca2";
+      sha256 = "5a5c19c54cfd2cf2a72b7d8b05311ed02dcbd9abbda67c689a6d7cc5716432ab";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/sr/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/sr/firefox-104.0b4.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "25bdf32262dcd32cc928c9d525249ec543fef92eabfeaee087071420bc4baccb";
+      sha256 = "bd399f4deeee560dfdc9145b8f4b92bc7dc5bfb735b9765ed3b4d094ff034af7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/sv-SE/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/sv-SE/firefox-104.0b4.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "5371e18bb5d14f04961088d008aabf96a4f8ced5babca52799b7a75eefc39cb7";
+      sha256 = "70e2d38d92e62c46d9406cf8bf20c4a0d7c3df6145f4070cab2d5ff4f400a8b1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/szl/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/szl/firefox-104.0b4.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "3484e13639004d0d83934c5d992b7fe9c716667c0aef0da20852f2177426117c";
+      sha256 = "1a1b977c56e546c6d9b9d35dc3ce03ee9dd14f6240441165a60a82b2514d5e9f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/ta/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/ta/firefox-104.0b4.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "e5a678eba8107510ff46be29a84f3da5bcfce028c389feb26cd6eb43461edfc8";
+      sha256 = "cd642db72217804534178035fe0b6303786316dc5ff736a427be8861548e140c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/te/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/te/firefox-104.0b4.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "a7fb65cb97938ebb742913b7168bf04930af9f9fc65f9b4671bb16878e2eb664";
+      sha256 = "7202fdb15c33deedade99120aa500b5cbbca88d6c8ea1b58ba0e92ac26358230";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/th/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/th/firefox-104.0b4.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "82ec9e534000841e87a1eac179d7ac5ec1dae7ba476b687043a13902b528ef0e";
+      sha256 = "13b009396a68105f0e161b4bbcce1d2a47be6c4ed83454a55d33d466b58e3175";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/tl/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/tl/firefox-104.0b4.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "0302052da07ddeb1020fad3f8e7f3a0a565e7cc3e343de4d4e432d21698cc138";
+      sha256 = "308b0045fea4517621db384ffaa6f54602d9a53a16f6a4fddc13e83bd77ccca3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/tr/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/tr/firefox-104.0b4.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "d8e7d9de5335f4f1316723aa8c6fc00c6c26cdefb2356781fc716ef001d26d31";
+      sha256 = "c2bf30591602ea7c05437cfe47d45f16d5ca43be78662dd2d4238c413c588af4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/trs/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/trs/firefox-104.0b4.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "930f14a671d40595448b7670946753e6d30b03253785f72ba66a97d00baa3c14";
+      sha256 = "dccf6b1de9a7532419efc0a26980607e25379ca903ab1c0d59d2e6e75ce396da";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/uk/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/uk/firefox-104.0b4.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "bfb0c6550f1151d24a164795fa7eaa1e179baf21d5c730feae8e0f11ff04b3f8";
+      sha256 = "1b59f22482c291eb19cea1d6041def19c37d01bb718b043b62bfbcdbf043b5a4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/ur/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/ur/firefox-104.0b4.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "b21aa8ea5aa86bd9f3cf84cff6fb20e035b0ebae97f474f2cee37dd43c991147";
+      sha256 = "15efe5df3adbd02ea97e37c0c931b546ec73bfd9e24ff4519473fbde3c1ad397";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/uz/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/uz/firefox-104.0b4.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "ab3d0a0b0eeb8c6a5f9e688f371db4a1b24c5680d778dfff6dc016e0c06b2561";
+      sha256 = "6442ce7bbc2a8e09469754bdfa9ff3a20333700424f352cff1a777a86ec71228";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/vi/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/vi/firefox-104.0b4.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "ab472dceac1456aff1867de8b7c52fef396005c28e1025fdf74c26e5c96d7984";
+      sha256 = "c6b324b0ed07a6ebe49c69cfd674ad09d86097c50892b87b5378815650d184a4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/xh/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/xh/firefox-104.0b4.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "5fb4b5790e12acc0b0cd5a63c3110714f8fdb8d8c219e182ad20fa1817e9f8c1";
+      sha256 = "055142b462dc9d003815bf072c11120a93af4ebfce821d810a9eb5fc5f26e8a1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/zh-CN/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/zh-CN/firefox-104.0b4.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "ba7fe0630759c38d8538821bfd8b9f99b16291cac92128bcc6620186dad363a5";
+      sha256 = "3506b73be481e402e3199c8af7a3aeb8706e6e790518bde4f22f15d84c1843fa";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0b9/linux-i686/zh-TW/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0b4/linux-i686/zh-TW/firefox-104.0b4.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "75d0eedb61f656b62c3b3c9fa357fedc3b4500a872bb81c5bb8d5e9752aaf937";
+      sha256 = "21c300cdd30c03ebf4b6f62766e6154b8d539d589308017075a2d23363731324";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
@@ -1,985 +1,985 @@
 {
-  version = "103.0b9";
+  version = "104.0b4";
   sources = [
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/ach/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/ach/firefox-104.0b4.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "64325bf0b4d521e20886f8176be09c1ee96b116914a6ac6bcc8440753a9bd5be";
+      sha256 = "9cdbaaebe2d64f05106883d173c25ff883df8dac2c87d98cc113ae5083c61d94";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/af/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/af/firefox-104.0b4.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "13e7fc191bceb0b9d5934daa9eed9ecd6e8c54d2d312689dd9a301d83cc6f9dc";
+      sha256 = "27334e3a11aa89ece00d8384d5e4b8f65cc95f5e6e7dcd419e351326485f1e39";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/an/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/an/firefox-104.0b4.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "40acf9a0666cf321747bdb1ef284b8422d6e9635e049d634f8a2a77df5d89677";
+      sha256 = "6207f96859c9c00696ee7f482b41deab54418f0989219e5fa579e39ffb410e10";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/ar/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/ar/firefox-104.0b4.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "fd2c418dbdce5a9d1ac84dc6733c29088e9526a19cd00c3b65ead4b73cf2ad2f";
+      sha256 = "d0f5ad0b506e7bc8e3b2448862e8c1ab1d9a15d9cd40b63f2891974a23f2e9b3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/ast/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/ast/firefox-104.0b4.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "9a4d958db5cd4840d902a181942470d4d05d10ab35ce1b992c355c14fa2ed88f";
+      sha256 = "e52b28bdc4908f9927273e5a27767a9b13fdda15a231b9d417fcbda6612c2067";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/az/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/az/firefox-104.0b4.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "d7504fd0b23a0369e4eb723334a6a566f79dbbb6b1288a3e7d9f14b040b9e657";
+      sha256 = "868f4c02cf840e28f36a234938865d5f28890cb5c38a24fade933edcfe3e572c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/be/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/be/firefox-104.0b4.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "5e0e9e26784c722a25e4d0f1f00ea68e058ac3a6d17ab8518b1543f0e2e1d901";
+      sha256 = "e74097b48e62d069494b6cb982afc4ab40f70e8d5f0e71de4db7bbef1f2dcc2d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/bg/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/bg/firefox-104.0b4.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "33619c1907fb603e06949d1139bffad811a48e7af3ff30e29893ed509228eedd";
+      sha256 = "35942fc5b32058c0dab715424043e337ab17c8e55366554679cc1e6aa4ce9bdd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/bn/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/bn/firefox-104.0b4.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "a19519a8bf3a8570366db12651f04cd1a746b2e2dc66d6c48630f4cdf1ca2533";
+      sha256 = "7c8475204b024ee1c089fdad16e8218783144c9c154417f1cb72ccd4cef985a0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/br/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/br/firefox-104.0b4.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "d2a67edb6b0dbc0ace9b81738c3a6836940481e338fcbb0d08545ad7f71a21c5";
+      sha256 = "2bdab0d8eb41af2281618db970f2ecc4f83fd9510db2a0b72f6b68e39050e9fe";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/bs/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/bs/firefox-104.0b4.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "d9a5f24544d8b641cd98ca911ad57b47e2ef959ca3942cc970e7a1b492adfc25";
+      sha256 = "a4fe6569c0787b9192bda4afaf294cfde8bccdf62d48e69a4153862233870678";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/ca-valencia/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/ca-valencia/firefox-104.0b4.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "43c41b9fbd5d460a45b5b80771e8d2b1851ac42454747be1df0ecc484d26384c";
+      sha256 = "8af18e7124b65583a776a6078dcf70a254578b3b82bd2acf4ce80935770302d3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/ca/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/ca/firefox-104.0b4.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "55df48b9771fecf4e5d1a41d1feedc1ebc8a797d364f727714c709a2c80c8332";
+      sha256 = "5aa204b109267c747d4a39a0dee927834077bc427aac77d9334007bd1a9ae9f2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/cak/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/cak/firefox-104.0b4.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "1c67a1b1856993a07ae6fefc94c0bed3da0034d71d4f83ca615734aa2f79f703";
+      sha256 = "0ac58b56acd15bcc5a2f425808fe276e06ce9950c026a879202375ca7133d8c3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/cs/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/cs/firefox-104.0b4.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "36f8dbff81459de076aedd0aaf77b911e6f52598039e79ce7a1d8dbce1216e33";
+      sha256 = "fce41851ab935f2e028a1ec1d3b61f3f48751dc2e9c9918182c0d18f89c9d337";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/cy/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/cy/firefox-104.0b4.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "8fbd5129732e6e9833447500c55b8491816d5ebfc674fa68f1bad5747087adad";
+      sha256 = "b91ca257c915fa4e5cad46709525aef7714a6e8b1e34e42b41dc58d9f36f0f25";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/da/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/da/firefox-104.0b4.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "0dea43ac4261ca934d406be29ea0f9a9a8f820bbac11f7ecdcd0b04e99162bb8";
+      sha256 = "cf28b22ee077fc1ad2bd2e2e14b7f67aefb1b0eae100d9d9ee677ca8b3493ac5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/de/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/de/firefox-104.0b4.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "3fb577c6e31a60ab1e5bedf9a67321dd2ec921fa51328c171c8d552fe86bd651";
+      sha256 = "3361cc509d2b9321403510cf53a1e0b191a7f22fff0ce4d3f3e6edcf3888111f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/dsb/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/dsb/firefox-104.0b4.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "71ff7660696b32c9493c3f19efc3209e12d7a78b668d18c5e982587473b284f7";
+      sha256 = "1a1916feea6ff9eb25f58e052b619c4627ecf26cb4e256e40c70cb90ca49c75b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/el/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/el/firefox-104.0b4.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "759f4f1cc92d88d9cb164561512c11b5c998ebd96be6e20065b843f74745049c";
+      sha256 = "229cff788f98bdfb4d5c308d7eeb67b8c4a2232de3e7521d64f6e9a51d407be9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/en-CA/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/en-CA/firefox-104.0b4.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "ac8b1812894d86a80bba9fb83111c28f0e711d932e76e8a8d4ace4bc18dae48a";
+      sha256 = "f9c3046d2e22ca751600aab6139871fadbbb1a0dfb75dc66cb7eac90e6358c5b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/en-GB/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/en-GB/firefox-104.0b4.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "f08bd7ab8ac070dd509afc8f6ef5b5ef93068f62e62e382eeda368b55b34148e";
+      sha256 = "0329fe18d75e44ade610d6e08991387276b56aaa23f53dc44beb84d02ef24657";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/en-US/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/en-US/firefox-104.0b4.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "fabc2830d68ddc54ed13deff0efdaaba5ee9ca55e41130d48bd03539220dd21f";
+      sha256 = "f82c651f50ca9be8edef681cac26908b9edffa4b5a5d9deb86c88a03876b594d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/eo/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/eo/firefox-104.0b4.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "6373e57e2b58768fdd47b9173afab87be2405e4d9646bbca61156a4187e863e4";
+      sha256 = "30551e69414f0e3f8a8e07fcbee3c1b42d3571d012df7f87345bcbc0f6a08cb8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/es-AR/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/es-AR/firefox-104.0b4.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "30fc34e3c7dacae52b4d39dc5588e60216c72fa926938138566cdfe475eda89e";
+      sha256 = "43164387874bc15a55d11504ab54a600c893a0ba9fe47e967d2d3b8f859bf534";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/es-CL/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/es-CL/firefox-104.0b4.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "a0b17d6c169d299565ca80a21e71a4132835f2a0274aacbfe78a744548cccd15";
+      sha256 = "bd58e16f6b93b71461b696725d257bc451ff932743383f1719f2a0b9db203d5d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/es-ES/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/es-ES/firefox-104.0b4.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "2d30fa4ecc6580b30d4a28315a16192bb53d930df168e5c5ab9274460b2d8eac";
+      sha256 = "77ce2be9429f302ec6f2e1d4e73c56ae65610ebbd2e082e309dca8e6bf11d0db";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/es-MX/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/es-MX/firefox-104.0b4.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "e708e661d172746debd0fed59c7276b0d1a52ffa0e28a7f568cc91e88c1ac140";
+      sha256 = "3c872863aef427424a86534853023b4f7df07aa9b9f2a4d919e80aa76025f0f9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/et/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/et/firefox-104.0b4.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "2bc9c9d6e85d13880e74a80427f831f47dcb4e8f8b92bbdee06283ceecdcf42a";
+      sha256 = "f4d0f2553ce8d2238b375d680bd62be31b863df445fc0bc21d70fe808c95f84d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/eu/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/eu/firefox-104.0b4.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "bced386ae4cf4d8bbdf58cdefde116c43b1e1356f53df23e80ee270588ffea9f";
+      sha256 = "9fb9694e14ddda80db6f22ab65954fa00fda78263a87ace8f30b31a38c83ad34";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/fa/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/fa/firefox-104.0b4.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "4a68b37000908907dbb27922cc5812bdf40846687dad2f98e400e7946fd5461e";
+      sha256 = "442db6c7001d81f42550656197bf334bb8218a6f406fc3577db4dc0a79a1d349";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/ff/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/ff/firefox-104.0b4.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "ef22841d2378bb7a9610ffc516e6ec92388725774aec417a564a800c06c9bf85";
+      sha256 = "86c5860c7fb6a756fc5ccfb3eadecaefcf3d7f0acfd2ae301621a73822e3d0f7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/fi/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/fi/firefox-104.0b4.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "d12946181257ac67102f1c26ba52141c767600358b3947ce4032d93bb3386792";
+      sha256 = "c7638a459d26b518183813306d4f87724c20764e0c1187a9db6d0f67f918f6c0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/fr/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/fr/firefox-104.0b4.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "435b1162e8edbf73a60f3e31a6e84aa4de5d1a8fc050ddac3506f32bec57db12";
+      sha256 = "bfec7745e38a34fa439a4e3cd64a46913c63f600446c4ca3fdb398c9e0f5037a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/fy-NL/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/fy-NL/firefox-104.0b4.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "97764ac4df44a0592204750842762e91875ffc6ad0bf7002be9de04eea455a23";
+      sha256 = "92d1901100a5e94e218452828f9d4b8b6c4b8570c05660bd27d3ab5caa63c702";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/ga-IE/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/ga-IE/firefox-104.0b4.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "070c4d3f49aa6d3339f6876661b7dbe7f2f2db1480b10d9e4a0a7e9b12dfb0f3";
+      sha256 = "44eb74306d1665a2f85fc27c0cb17ddba67c5b296365bdbadd41a58d30fcda44";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/gd/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/gd/firefox-104.0b4.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "a16d0d75dd13603a9e74d2a48dee0424e5d5ebe333551bb43d75d4b686030a36";
+      sha256 = "2b1ddcc403f2f432fb8fe37d14fa2ddcdc82b7545a80f0331850eb36c7da17af";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/gl/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/gl/firefox-104.0b4.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "d0fb194b31f44feaaaebc85d6e5a6410ba5afb59c431d1c8e4ac3debd7022ed0";
+      sha256 = "f97d72b1afe2a62315879e2ff35ec4ca3a92671c4bffe36d5cdf7e3d8194cb08";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/gn/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/gn/firefox-104.0b4.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "0e651eedd5bda7bdde25fba72e09ed521b79cd88f468a89b7963f248ad09f3b7";
+      sha256 = "c5885750133329552b7e5980829a30c43c0e97fab7455a365c4e1e6ded97cba7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/gu-IN/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/gu-IN/firefox-104.0b4.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "c225a95c52721124fb49217007c9565984d189b2fd102a7c7d1c26743c83936a";
+      sha256 = "c4fbc0631c79d6f4dbd8fd3e4987fff5d4efeeccc35e29bf1d5c768e16f7194b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/he/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/he/firefox-104.0b4.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "c28bd62d7448261e696571b11a0428978b6c9d3ab5fb52b41ec33668c43d7c53";
+      sha256 = "fa27fa885c777a61e0dd594f8e825e8cc06bb09287624c6d9f8edcf14f7aebce";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/hi-IN/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/hi-IN/firefox-104.0b4.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "a1ca277da4cc971dc5d1bbc79e2593fbf850a51c2367c686cfefdad52e063b77";
+      sha256 = "4829411b786df50766374469bb2080cf3894726686baa870c536fe03cb5ddc6d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/hr/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/hr/firefox-104.0b4.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "581b55231fa207c6c5a65ee24308691d1e5ff4ad729a7f63e62e6fb97d1d7670";
+      sha256 = "dc4fd78df84729446fb7278f3ae7e50729f39ade081364780872a5e546cb3abb";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/hsb/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/hsb/firefox-104.0b4.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "d80dde1c6a645693fd2142abd45a8e3372174d0e726c2dd47109b5f1d6586a31";
+      sha256 = "9f1906377c5b19ab36bb13fb570420218f02e31d6c91e66b0af34ed4f27f9fb5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/hu/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/hu/firefox-104.0b4.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "75c67c1969d8d9dba23aaf6a886cd0cf74332f9e50770a05a186e87c0135cb67";
+      sha256 = "4331f8997ff25de4f3ef2ef72e6b4eabbaa7ab37e5586c6bc12b430e4600df92";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/hy-AM/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/hy-AM/firefox-104.0b4.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "5d03e705b999a75cd4c1f9ce85d50dd06f23f89785096fc819943d90518532a4";
+      sha256 = "ef079ce2e9527a6efe82e73d2ef647934bb8316f03686746ebcc1ad38069bc65";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/ia/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/ia/firefox-104.0b4.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "e5570a75d2c92d50113660b1583cd36d7ae61bdbd4bb7592198447f70cb38039";
+      sha256 = "4f704d27ce21d11bd797145be35bba296e20cac44b6822b6331c74f6f5dcc4d4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/id/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/id/firefox-104.0b4.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "c196692777ebf685dbfb057d174cd10f9874d4fb631ef0815a69ff34a1543d26";
+      sha256 = "ba2c4ce5146e1c8c8cd79bd82a85425230a755cf5abc57659f4e06feef4b74d0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/is/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/is/firefox-104.0b4.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "4277389b5001fdaa11fbee8dc42b320e2783de65b3cd4c129aff3d6d932d403f";
+      sha256 = "7fa4d4c74eaf221a0219ea669b1a700f0a913e7b64df8c95febf8e2acb06b05f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/it/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/it/firefox-104.0b4.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "bdfa178575583f745d5b132c0faa464e7d9a199c183398361e828cf51e3edbfa";
+      sha256 = "e8618e1d694bec96ca6fab6fd93d17e42e4204a3890ac41fd170b0b6c164690c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/ja/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/ja/firefox-104.0b4.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "26ca84e038ae7690c17fb18ca3f989069192906ddc2de639a6a26c7b1e125062";
+      sha256 = "9b3b122d3e8f783bd1debb4214903348fec2d51a032f6265ac53d283014de8c8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/ka/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/ka/firefox-104.0b4.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "a71b58a44ae58735061d82d41e4eda7c29c64d020bb9bdb3f93f731ac75d90f1";
+      sha256 = "485dcc238b59e8823165167fe95b00372c9857befdb645f0b85fe0ebce2a435e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/kab/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/kab/firefox-104.0b4.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "2ded218eb883cde617acc18c55ce0e50851d613db2d04331cc9c9b5ca459d135";
+      sha256 = "b56be4388ec116117ce5cc0867109bcd377ac38773fa9eb842292c8187be180c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/kk/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/kk/firefox-104.0b4.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "f587a6b0ad27c59d1e68dae714daf6abcb26eb3ceb125246647c2756e89fee6c";
+      sha256 = "a38e2b5af418ab97acc6371787494109c42572cf93a8edc197db9d9c74a56868";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/km/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/km/firefox-104.0b4.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "4412ecc392dd6e886b944d2445bea1215df613e4432d95799de8e90d4d825c65";
+      sha256 = "5fbf4e8ed7c6583156055e9485d7ffc5825a768317addb6ccf99c53edd7db489";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/kn/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/kn/firefox-104.0b4.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "94381746795268605597deb7ad81cbb8dcfb9cafdf8b487e7e6d10c56e67036a";
+      sha256 = "35baf5a4c9126ff5544c862529e923e26b96bab0f66e6a40e5f44f5dcadbaf4c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/ko/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/ko/firefox-104.0b4.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "f5e4880cea6774b91957127c601facbc8a580b2092aef1f92396da76a8f6db1d";
+      sha256 = "7fec1ba611951ae4858ded036eac6655073166a531c43e38a9d6a3d995ba615a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/lij/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/lij/firefox-104.0b4.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "51ed0256c8f0738ef3dd01af32de23b3a4fd7d16ecd2fbe5dae6055228f541ae";
+      sha256 = "49b1417d9f9e6be16b84d9c1cb4065c1281a4dc044bcca8a9ce17938336ad4fd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/lt/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/lt/firefox-104.0b4.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "1ce645aecd9d0d7143f7c66d23bebd5109cd38e44f2652d095b99dfcd0de5b88";
+      sha256 = "a90050030b5ed7e5300b5a25ec8614275ec23827a0483efdb660924a735775f7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/lv/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/lv/firefox-104.0b4.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "77a5d0e557edb6d5b97d896d8ab424ef76a6e87b21d0934981749eea8ad5d541";
+      sha256 = "dd02a84a111aa12c93aec35c5b0fbca11b18358e5a4daa835d5b0925b2ac5775";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/mk/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/mk/firefox-104.0b4.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "05c97bfc06f98a45672e5bdd5da998c42b0097ee81decfa00543f3721547df53";
+      sha256 = "baa256c8229ae2d6ee1ea11da1b2fae5d4a9df1c43bfaeb310646b3ca04d34ab";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/mr/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/mr/firefox-104.0b4.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "a8af0a9a10b523ddd93950e2567d7315d1749e253d2fa2ac71ba2cc95cfeb9fe";
+      sha256 = "7657081a696686bd6aeeeb8ac16545e91d1640a1f0727813284ac983ae10398e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/ms/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/ms/firefox-104.0b4.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "f632ea8141dab170566085f9648f405b67d9197623953b773b76f4b917c4211b";
+      sha256 = "2b9e7790ba9a055a2b7b16f665e89277ea7394a87d98403564859ffed840e02a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/my/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/my/firefox-104.0b4.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "75d926803b1a730848398b47de1c8ea657763188dacde1a097191babe944fdf1";
+      sha256 = "2a75ebae6d60510bfeec736ee207ec805b17499845b85257de722d67234d25b8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/nb-NO/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/nb-NO/firefox-104.0b4.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "7ba87b47682ae6482ef2e2b6662fae6c431664fcc759a2057760233005bcb707";
+      sha256 = "6d8f1602938761b221449a8168bae7041ec20f97a57b9c0eb3c115bb0597749e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/ne-NP/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/ne-NP/firefox-104.0b4.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "0fc7cc512afff4a150c2e45d237e170dd2e34c0d6d1bb7caf93c724d31dadd74";
+      sha256 = "385f74a8547efc86271023d4f1c96f57310baa0920ba6258a88be8ba53deeb33";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/nl/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/nl/firefox-104.0b4.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "9fff672db6e89bf3f282a6d8a9d87720c399e9c2102f0dd399e0602521355293";
+      sha256 = "0583d4b7c58f11fec8978e86facb4473363c66a2bdac4bbf03aaab8ed46623c2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/nn-NO/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/nn-NO/firefox-104.0b4.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "aa8d48fda8d09ce420ce5b8e9cc3dbb38d588b8af7f9a6d24edc470af1def904";
+      sha256 = "004f49a0209c02c06071de1f383609a0753287e979e512384ff452b91823e68f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/oc/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/oc/firefox-104.0b4.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "938569a834d6e95fc85bbe85b77ebce88bc7e23222282d85f7132d0325405765";
+      sha256 = "2ee7380c5f5d0b2c819bf915b52b9c64a9548c02e3f407a6533cfcd49e369e4f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/pa-IN/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/pa-IN/firefox-104.0b4.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "a23ae096c4f25fe565d320e2cd6f44b553da455ac7be36e5ec3250978a9ac058";
+      sha256 = "da004945ef89e5b524765b9f38eb644fbc48c9ff489523ab5efa6634598ace0d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/pl/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/pl/firefox-104.0b4.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "36ed02aee3570113ff3c246f012613287c018754335c52463101396197a11dcf";
+      sha256 = "d6b296a7ff8ee29c71a2b7e81d00f8433ae8d8e86cb3cd6891b3d4b393a9acbd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/pt-BR/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/pt-BR/firefox-104.0b4.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "33c4b4f271d37c25540bb25808899093223ec8396db02e17325e7ffec2baf682";
+      sha256 = "286da0ca9eca0aac98ec1a6cacafadae48a7a42e07a743fbd9d99f042aace3b0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/pt-PT/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/pt-PT/firefox-104.0b4.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "bb5d772fd1694fdb00a4de3408a7764f12375e8bdb0d32b743b50b9547f8de7c";
+      sha256 = "10b374798c781ece88db6400ae1934e670f55fb53c1c2fb2101741525d7d5e95";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/rm/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/rm/firefox-104.0b4.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "d4e9740c7a5ee79fb551c5aabe6f3fa3f3cb6d085e91297c4fc87b07c46670e6";
+      sha256 = "644932fd82f4a21191fb19b25dfef39e018ea601a2e162d6725d6aaafee20598";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/ro/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/ro/firefox-104.0b4.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "28fbcdcbf4b98eb805877e6192996a2f2551e4de5f4501f2f23a96c8a6519adc";
+      sha256 = "f175e948233c1baa20962ddd68b3813aa8e93dd6816fe6209aeb74cc80cef14d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/ru/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/ru/firefox-104.0b4.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "3417bb9d152c220f4a70f535f52e117951c86c9811b59c35d4f51007a9a22dcd";
+      sha256 = "a2142631b59278734cb2d6dcb3d0969f441cffc2820ad6478ae594de9f9516bb";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/sco/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/sco/firefox-104.0b4.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "276fd5538306f3bed6bf0a76085b92057438d11c48e87be799a3802c04c1345a";
+      sha256 = "e18bf88e61480c5b0f05d6fb0a5ec424a5db835a8b38db3b0a5505febe9396df";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/si/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/si/firefox-104.0b4.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "c9a7095bc936f4e3e5d6fef4ecdcdff49ae1c624fb70cea7fc5c4f17a71f7757";
+      sha256 = "7f1377abdba68ab935299fc1689f887e68aad7b57997205513d0b174ad2afbaf";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/sk/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/sk/firefox-104.0b4.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "322970da0a28e2218064b1f19341d9ed00ac175442ce2ec2cc3479618845be02";
+      sha256 = "fa6b1ddd1d640f8a3dba55eda30fe9dc97cb5beb25a44573a697cb68de16e64d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/sl/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/sl/firefox-104.0b4.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "a08af24871139589efcde921dddaaed8f263dea7586e837ff3e51b80f639f702";
+      sha256 = "588db7371aaaff0df64ebf4a01909d9fdad5f80ee78a8e2e5fb7b372ebff1453";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/son/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/son/firefox-104.0b4.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "6267f6e46f6a3472cb339dc1b5386d3e65ab87524dd1d77ead0273916beb5cce";
+      sha256 = "7b7ff4520686425a63ce419aea3536f794715531b0b74afafd1a7d8f9449a99d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/sq/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/sq/firefox-104.0b4.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "10785b4c7cb0c50610274efdd4cc42b7e826cfaed5a9d38ed133f6f659f7a814";
+      sha256 = "57fe7edb6257838dda19787f081a1010211c7392c77dbb656fbf61f3cff18e2d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/sr/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/sr/firefox-104.0b4.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "942fd222e6437ef0d7f6240c7dac190dc49b3e057ba468d26a84643c339f3abb";
+      sha256 = "c93115a1dad91eefbeb59349cb7b8e2b02eaa4efb564fb3e06b8f5328f5ce93f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/sv-SE/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/sv-SE/firefox-104.0b4.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "f1f450dbc9e61ceccbd538cf8b6ae72eab03537e28951f5e5a9586b679efd2f3";
+      sha256 = "461bd45bcf3a23eb6a229282898669ae27f7d5e909b0725196ee63e84f16718e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/szl/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/szl/firefox-104.0b4.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "d930a0a8c25d3db30953761c194ef55a8fc434b403e1479860a66c6ccb9e385e";
+      sha256 = "bf7e11b7539bb9a8c1e3397422f00a43db61f41474781aa922212e86f2288ef4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/ta/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/ta/firefox-104.0b4.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "d981e7d393b74110b8ee59eeab12cf2f57a8e94c68bc541f3dff9bd04aec549f";
+      sha256 = "58aaede5463a935887e97dc17e99490290472f093d64cbbbb331bf5392400f8a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/te/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/te/firefox-104.0b4.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "3c5b7d76428e6848e9df543cfeeb82d2535c8652a4dfb9621c544e85693fb21c";
+      sha256 = "3d6c908c2255c51b6bc95e1ef2b249731c6871d940a97cb486881070e7d6ac40";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/th/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/th/firefox-104.0b4.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "d718f9169f9f292c728b53e7377972acf1b5edba0d274e79ac4e8f59dce6b398";
+      sha256 = "9b7b76cc27fed960a50fad9ebad3c95641da6027ef6a8baeba0e4a52bcda3170";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/tl/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/tl/firefox-104.0b4.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "d9577f878fbfb2fcf35364f760a52dfeeb35f188da9dd7a7115432d0a3a6e20c";
+      sha256 = "4f0ee4cfc8d80f5ca6ff628c623a7a2ca41b1c086e13ea7b72dd7314af3eaae1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/tr/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/tr/firefox-104.0b4.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "e7c16782a4516cd903da237a38393ad251d7e2edc365512f28d5e77c98836c66";
+      sha256 = "5f29758dafe0d8a9000724bfb8c5231cdaf9776b4d7bd371f027c25f4c0427ce";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/trs/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/trs/firefox-104.0b4.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "e595a4a350653a19b4283e83c5bab73130cb18dfb4e4f7d88fe7f27a62af906e";
+      sha256 = "131783d4a276dc7bba9a7fa1b2d8fca0a826efcf4c93215fa6ab45aa4cd7a0b0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/uk/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/uk/firefox-104.0b4.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "0bbcb63be2d1008764df9711afe75aceb64f8a6e42c24f763f14a0b146bdb64f";
+      sha256 = "a25b2fdc8ffe6449641a0fa63ca81e30aa465d63b465c4cf0b14de18ac058e0e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/ur/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/ur/firefox-104.0b4.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "259e46049168e24063472f3481506d09cbfea3620a8319417734e4ac6c0c2998";
+      sha256 = "2b80930c79e4ca2b48276fdd351a49583b93e5f41905d6da3c304d7af0a36fa4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/uz/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/uz/firefox-104.0b4.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "4cd81018f1a09d6fd5996a31c9219c9aa4d9a7db98f24393bafd055e8833a828";
+      sha256 = "f7d1aa7a1cf4763831df27187e874cbb537022d757e33fe80c3f7c2d8be6007d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/vi/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/vi/firefox-104.0b4.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "e70c3b704ee4dd0d509440777b6348c61fef6d47e9e445abdf6aaff4909d64a2";
+      sha256 = "d644b2b5496c28602a83c438899cffea4fb5d3508815132691ca155ee127736b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/xh/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/xh/firefox-104.0b4.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "b85eb1e9c47b0ac13726543dac80b08596200837b5025367460866871f168986";
+      sha256 = "23a384512be7728aa4fac7dc991d37982eed8c5172a1dcdb909d9663fd756527";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/zh-CN/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/zh-CN/firefox-104.0b4.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "72b3e97a75ebbd9faf90d98687b713bb513ff8c8b89f67da31115b00b42ac592";
+      sha256 = "51f458cb3bfa6366ff4f1fa031f7435b429b698d008fea984ae144043cada7d9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-x86_64/zh-TW/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-x86_64/zh-TW/firefox-104.0b4.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "587bd6ac19003a0e514185672ae64017f083039e3eb29172a2a392d56cc5e910";
+      sha256 = "38cdab52dac1470561d72a676705b2d9d57304010d60383a6a9d6ae79347a2fa";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/ach/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/ach/firefox-104.0b4.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "8b068f85807838ce8d956081ab1e074413bcc09ab7ca16a88d1ebf1688f32ae0";
+      sha256 = "05ddbaa483122aa26e9585a1f8761a8a94c29662dbce40fe5f95215972e8a22d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/af/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/af/firefox-104.0b4.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "c5437835714cab1517aa88ae5fa8aa3200552e74b086c415019937f62b303bbd";
+      sha256 = "a36be8df47b4f0b02ea22866fcc1942c071ba3676274d37a02b5c25c5c5edcac";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/an/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/an/firefox-104.0b4.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "08a8cdea3e26f79697a926f5bb361ef8bbcccc3b52ee1b0f501d611f2284c286";
+      sha256 = "a08fbb3a82cb02b544009bb2eb8fa33e7b9814c7a72a7d30da85114ff976c75d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/ar/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/ar/firefox-104.0b4.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "67da0d4f6c43670d0ac2cfce724b8038896a0ea34af9af56829a8204019ec2df";
+      sha256 = "992986d3914e35cf4eb58a7ca01804d46542a0f763c4dfa18bda3acdef92a95c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/ast/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/ast/firefox-104.0b4.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "9c7bd59ab34de11e413d72bac6fb628a6858a4392b68516665e78746408338ff";
+      sha256 = "7a79ff422a829bd3fbb9f7ccdac012f0589f954358697fd2f6c4b779b626351c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/az/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/az/firefox-104.0b4.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "eebf383815870cc722e1634bf73fb2ab9877ed1d133ddf79922d79c2afe774fb";
+      sha256 = "e4d5fdc180cc587932eaa4e17c2a80a4da2ef8ab080ef51d0c56125a2a772b0e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/be/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/be/firefox-104.0b4.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "ef48d3196847f7758f8f6c0de9d18eb2782243a2600f9f8923855b0d8529edce";
+      sha256 = "359afc0bbcedc593274cf74d8b32a4175bc405350a589fdb29a39e6f377290b0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/bg/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/bg/firefox-104.0b4.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "2c29a20c39c443b49992fb56eb49ba7d77563eb1f37898ba85e3a4a4cbbfcf0c";
+      sha256 = "e1a1ba618bf88c6b20acf408a9f9296032bf2a690de81244c1c2d069db89842b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/bn/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/bn/firefox-104.0b4.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "bdd8558153b66abdb5296b298843046ce75483b3a7ab2bae8306e0bcfa2840db";
+      sha256 = "79e069b368cf48df09cec9220fad5e317969c973012add12108f4fd54304dcff";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/br/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/br/firefox-104.0b4.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "331c413fb1264b483cbbce736671867f5c8903a57cb0e0e058cec2e18ed752e1";
+      sha256 = "242ff42943ae90cdcf5d15a1b197f1b7354b8a143f1f1e082bce158c88003ef0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/bs/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/bs/firefox-104.0b4.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "2aed3cbd69547350ec84df4024547a60f77e618e7ff1478de3e48762c49c63a4";
+      sha256 = "e6a5335b8785df9b18d2cf83a71b6324fa350876704e1cab18db9c6b7b2e984b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/ca-valencia/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/ca-valencia/firefox-104.0b4.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "ae02fd89f2c22d2252ae86f503c7b9ac858fb006be1849c1b25e30558878a3b4";
+      sha256 = "56a31e1563198d52575c3c665556affec58d24b18b333bcbca27a1c02be2920b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/ca/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/ca/firefox-104.0b4.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "faa76481217d1a69e66daafa85c402ac152f769d55d443f767332b02260571f1";
+      sha256 = "b8064cfc260a38eb1f18d0411ad079cca8d55f3127f141367e9c3c6eaf43686f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/cak/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/cak/firefox-104.0b4.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "c3c4101c1d1c8002913a6ffe6c5d3f1057f10e5f8b4c903f4c38f6a628aba3e1";
+      sha256 = "b02caee5c11b3f379997f78e05df6acc9d487906c85d455f5f5c6a0fbac95f9c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/cs/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/cs/firefox-104.0b4.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "623db91bb4b4a11d69881cc392ed5700f7933900d5187abd3ef9ec5f56bd0d10";
+      sha256 = "20bd8e371ba2c572912c88f89b7bb0ebb2e451cbb8e90a3684c8761b26abae0a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/cy/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/cy/firefox-104.0b4.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "74c22350a24559735baf14f3ef0f09c402f17312250dc3a90a9ff361717a2f5a";
+      sha256 = "eb544b2b02fc170545312b94b6529a31698b93f875df35a25384b8fc563acf86";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/da/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/da/firefox-104.0b4.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "066179e54e2803e8267035f92d2b1a2ad1888764b51a8634a52d3d5f4f82adfb";
+      sha256 = "eff8f807defaa889132762e6bc302ddbedfaeedbf3599a97a677458445f36dc4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/de/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/de/firefox-104.0b4.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "55f2dfb34c5e238c02a31db41b6b7d259d62d399a75f4efed7261e8cc6dcae59";
+      sha256 = "bee7babcd04983bbb50b5f9b00f0eade254363a3ae119afc03d5be156fb6b285";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/dsb/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/dsb/firefox-104.0b4.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "9c8632eae03f70e141f322a1d256499e6a20ea5282305e0e86377d06ff073049";
+      sha256 = "fa41c4fb07aa292b6211337f02c9a68d77e33f08e683bb4450313a1d74f5df4d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/el/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/el/firefox-104.0b4.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "2cbed66f6130c9dec063c2d21795f3385420aa51976386d9334c8acb7821e301";
+      sha256 = "4c452b44efeb82942d8396ac1d0d0ffa2a8604a69a106973cf70f0edb80a61b2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/en-CA/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/en-CA/firefox-104.0b4.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "337719cac11da15ab4a7f6726566352a27f709ba58950c07b76405502be9b59e";
+      sha256 = "71ab1ba1371c68d305084302a6a065a62f4fd3b5527811a79061de316c79a8b3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/en-GB/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/en-GB/firefox-104.0b4.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "b43ed83bf41772fec2c78de88a56e71f28c77726ffee63a1e0c543c071d61939";
+      sha256 = "06a7a5fb53de331ac4827691c7f625908173582932ad48fb0350e3d7b98f49f6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/en-US/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/en-US/firefox-104.0b4.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "5bea6822802dfa6bb53957ef3f3e71f0e0b5721ece801266d76fd64fc6cc41fc";
+      sha256 = "4c476683db18c3513c6f257abc71cf987ca253265bfb6b0b86b8e8cd80820e94";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/eo/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/eo/firefox-104.0b4.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "cfd01f199bdcfdc2d24535b54f220a80c3d3391f99349e8de0f56f3a09d527b5";
+      sha256 = "82ec493718e70130ce087a3bb9f8c5a96540d798f816828fcb88f7b7a995e37e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/es-AR/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/es-AR/firefox-104.0b4.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "4eb70366750998d81e9c487702c1fcf9e805de6bcece82ee9efe25ba750ca514";
+      sha256 = "8bf569b4102ca0f62d831ebf55789f46a6a329bff58529140b1d5be053f429de";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/es-CL/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/es-CL/firefox-104.0b4.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "0496742d5125398cd58bcea8e6f74453bbccfb912218311ecdfdf826f4c06f24";
+      sha256 = "96c364b8ed8a96941c26acb9890e634522867f3243a120154dcc71de9e4906ef";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/es-ES/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/es-ES/firefox-104.0b4.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "36f611a4fd11cee4410a32c7861779633d27a2848a23cc23abe4fa6de54e4859";
+      sha256 = "76fb1d591a00db8b9d1e117478308df38295b786805482867f95581771b652af";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/es-MX/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/es-MX/firefox-104.0b4.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "8bab56839bf4ef774f47de8bf2fbcdce312c99c41066c15175e8f8288cfe7862";
+      sha256 = "c258baf3b8b8b200052b0f2edc9e3f4025b08c4c9924aff2029ae9919b584708";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/et/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/et/firefox-104.0b4.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "a3a185fa567f5779911b686be7a1ffbfa29ed970e699254dbcc29e4f3f93a2e8";
+      sha256 = "9877ed2d4a5b553bcfbd71e3715772f412b2500f7810ed3edc466d3cf0e31c51";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/eu/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/eu/firefox-104.0b4.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "1bfe6e22e4d5e24e1da3137061a3c36132c7681aac9460b34552826a4379de48";
+      sha256 = "3d0b4f3572d897152ad551430fbae012158c8c891ce61394f4c21daea514d4e2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/fa/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/fa/firefox-104.0b4.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "9de9a66d19eec54457ef03601078614cf1197f394527095a4994fc2de06b7ec9";
+      sha256 = "8b445147b436841ae9e6a0af0f4675001b5aa528f59b26a640a33c06bf17ed71";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/ff/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/ff/firefox-104.0b4.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "f99ed708f6268ec293e842613732ab35c37cff12cd1281c055de5684d93ee468";
+      sha256 = "20b1f23cf0d1e43bd2097ce78433ec2717d5b94c8c62415ca8804bca8ec717d2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/fi/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/fi/firefox-104.0b4.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "3be8a59a93639db844fe78e42a8c6175377a67b31ca5c453961d1bb62602b73d";
+      sha256 = "e7bccb02114a10ca1fea93f8bc0f54471966fce619c33a6814665a162056cb52";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/fr/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/fr/firefox-104.0b4.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "453b0a4fcad51f07a07098c72b7350f1da5b3fc0fb4d76bf79ffb30b02992416";
+      sha256 = "16ec25950c42d081b332f382acba01038e177f31f71fa60180689e4d4d5e499f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/fy-NL/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/fy-NL/firefox-104.0b4.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "7324204ef76b6b0e9705d7f5f3902924c6d471c9e43a631c996f7e196e34cba8";
+      sha256 = "c78e15f71bf7a109be7f6708fdd87f3231be4221fd5c336909216c59a229a4a9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/ga-IE/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/ga-IE/firefox-104.0b4.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "99cb484ba8e203759676126409774d291f4975aa401885a417a3343b6d00ea97";
+      sha256 = "cfa530828b5006b9479da07ec9733f996d11ba8d0e7c6a40ad7f8e6abe3c2143";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/gd/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/gd/firefox-104.0b4.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "999bc91b5cc931eb6a3b9390c633466775459b90ecdee6d07fbd7b237754959e";
+      sha256 = "569c0a5e3f774f67f30500b90f9aa6714e94b8cef9681b5d0aed037536c76325";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/gl/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/gl/firefox-104.0b4.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "db79760bf64628e1c61030adc1b50ac604848f944cfeaa4724c7095f97f3fe0b";
+      sha256 = "13631b57018dea7018a99ebad9deb9e948b4691704e6ab29990d5ae10c709a1a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/gn/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/gn/firefox-104.0b4.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "859a37b9861f07d185281faa985337e41f69f2c13d0aa04a75f5fdcef469f044";
+      sha256 = "dfc1c811d62a7c3ad3439d6d7aec42fa38cbc0dc495316008615e09651fe6762";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/gu-IN/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/gu-IN/firefox-104.0b4.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "450edc8c1cb18b7286a495434200777fbe135d064309e51483eecc805aaa0fdb";
+      sha256 = "0dd84d31bd5b189acd27b2235029c038fcfb2032a16a17666ed9a9d8e7c427c0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/he/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/he/firefox-104.0b4.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "64598b9ab469b446cde4451af5c73ffae36163b6db28578a7440051fe0c9bac8";
+      sha256 = "4b06c6a1d333ecffca356a33e09eef73ab2402e4c30a76428a1cdf30b2dc52f8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/hi-IN/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/hi-IN/firefox-104.0b4.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "affde90ee148616a1b1ead33eedf5a271313882355ac72f525b246c5cce334ac";
+      sha256 = "21a7141053ee46f063aed00f8ebd3a43597c7d3badfcc1235a2aaa937d8fbc59";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/hr/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/hr/firefox-104.0b4.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "983c8b206a4ccbf69368b95693395f9f808427c56a37abbede8546e41b24c710";
+      sha256 = "2349492750735c25554fd519eb5e6c7a8d97915a651c42cde9814620d1a311ab";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/hsb/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/hsb/firefox-104.0b4.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "91e34722867ed8e2edb9356819daa7a41a4ee3be2b38a508d94a6a0b224f8af1";
+      sha256 = "b3cae77bf571b16ce3876e7cec9484f4beaeb82c6d2bed844d137a8ad4f0e593";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/hu/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/hu/firefox-104.0b4.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "1acb4bcefded66b75359a573858f0c7bc805e5513011e58bb0ac5d5eca7b0c04";
+      sha256 = "8b6cd10779798589bb0c04b8e7a69987461271df10034efaf487e17de5a64872";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/hy-AM/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/hy-AM/firefox-104.0b4.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "8390a476b7308413557e72feb81b5eca59f46ffd12ea982340c76873441804e5";
+      sha256 = "fd961f32238ef897e05255e6810b2b8cb34254efe53f7ecb9b5539bf0f7d6ceb";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/ia/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/ia/firefox-104.0b4.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "20a3c9b43a9a236d87742907bbde423cb0235a789f04512609b86d86f096f1fc";
+      sha256 = "51c45a0e997b94061640b2ec1ac223b758fb2a691b1929975fa8e063af5fd9a6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/id/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/id/firefox-104.0b4.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "32ba930ff26a11d54a46c6291e4d56b9dfcf211ca0cad4c55ba7144a474920bf";
+      sha256 = "0cc8c7d04c78f081b463ea6fdeb48fd073d23f1274376651a290e3d90d0dccc7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/is/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/is/firefox-104.0b4.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "1d5a7029babadf95c4b208b8793fcb0707ed96b9e77037ad3eda905e5f22a6c0";
+      sha256 = "59aa0699cce771c3fccd0bf0d5e721a29b79c4dca579c0fb37ec2822f739a98f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/it/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/it/firefox-104.0b4.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "9d92a7ff98cce6d8bdf0d94aed9bb731ca05d1a4d7c8acf119b522624fc18406";
+      sha256 = "8d926e44355d588097ce0cb85b22424ea316feeeef71ae981c8587b83ece62ef";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/ja/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/ja/firefox-104.0b4.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "9dbefca1c3df31ecf25a6230196d5bc762fdcb3354ca139ce0071d9f1a736780";
+      sha256 = "9ee9dec2078fef62d4387e13f64f7782ca9962c9f5033cdc2e0435c49800cdd5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/ka/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/ka/firefox-104.0b4.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "7dadb4488a684631e390007f77a9fd471f9dbbd1427bb67485eec0f39519c991";
+      sha256 = "e8136e90fd22380fefcdc98060fd3cd147c2f440de05186f6641fb15a09409d2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/kab/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/kab/firefox-104.0b4.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "79b2c41d6e5314ac7903beb495ec912d58d2316cac544da343dfa38633c265d6";
+      sha256 = "94167db208ff296a581d34043ed1cec524d9585ea3a24ed32422762e01262e5d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/kk/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/kk/firefox-104.0b4.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "37d44a0f78680d299aeeeb41972eb3c11b29b178d80097282c4327e959a6a733";
+      sha256 = "034e58d9f3d7c56e28dc7a9eacffafe2012ad0e3893531533f16d117e72eb78f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/km/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/km/firefox-104.0b4.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "8a5de1f5f4fb80d041ad0e4125ca89bc87f1478ce4500ae0b6929635a651bf70";
+      sha256 = "a794929a312baedc3c2bd5fb311ab07f163961c1f17be1a15bb6f48762370c8f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/kn/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/kn/firefox-104.0b4.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "4c91ec0293ff1a9491eeef31613ac5f6fab049d524de44e75064d6125ef27230";
+      sha256 = "b31abc6998114bc6de4c6a5734c4a34c45bf40bc0c1e6c8ba437b22069b5f96d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/ko/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/ko/firefox-104.0b4.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "fec210d4a272b63a8459341a08c89c32b9427c99631eb39de5e9956ffb2d8737";
+      sha256 = "5e9c20cf032faa414b0f9d410ced8f5ecb8e1aeb31f2d87b2c13284b5aae4d70";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/lij/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/lij/firefox-104.0b4.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "5e0e03c5bc51c5beaf8d01e7ae53119197aac1417ea5ac0a762ca6f591b91cc8";
+      sha256 = "f9b0dc9f37b53bc56d43894a2dbfddb86fd5cf13f62c16b2d0816f8b21b74cd5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/lt/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/lt/firefox-104.0b4.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "5eac17e7673c11cc19573b5bc0a95dc45cfe87f6e26d844fe459bcd50e8549fd";
+      sha256 = "b1b1a9cdfe052e1fb9c9b17e6fe1c53ac774cd9354891e95fe18e171bfeb4d4e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/lv/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/lv/firefox-104.0b4.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "af9eae9a451c019c1df09231af016ed75636c5c082ab32bb88c59bb40d91caea";
+      sha256 = "10f572f2144656c14898a63165ea79f3dee200739262b6865f766859fed8f42e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/mk/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/mk/firefox-104.0b4.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "8093a86d19737a5cfdb28d126adb316b4e1e39fdc1bd5a6ea791f6aafeae5778";
+      sha256 = "ef9e92a316148393b167c1b0a03e0a786cc176f9b9c93f597ebf20b061a9f73d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/mr/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/mr/firefox-104.0b4.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "c43c4f8f9f6a8edbad51955c308418fd180308b894934309c68411b360533a69";
+      sha256 = "2eca68b9e882e64670ef1a9d9f1746b065d86e8d3dd1e333db549f7e84d0a680";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/ms/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/ms/firefox-104.0b4.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "9644c9d90d4b0aed02cb091e7f41031cf43360ebe57030d13b57705fe07de78b";
+      sha256 = "2addcbb78fa1244e11d85c1b888521189a1ae7f74633f55989d1b311419522c7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/my/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/my/firefox-104.0b4.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "8e6c48d27cb34792963701a39404387bcd14c17eddd92b66c74fd26fc226aead";
+      sha256 = "ac3311de2edf57ab4c89d1bd9cccdf95e12f7dba7dce32fa536652602094cf0f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/nb-NO/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/nb-NO/firefox-104.0b4.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "1af7532900e31dfef830c9feb30ecb3f34defa5a0eddf8ca224c7463e8ef261e";
+      sha256 = "b1943bf13816a63b08638313cd23ba3408e269d2456bcf94286c535f1856ba43";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/ne-NP/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/ne-NP/firefox-104.0b4.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "23b9a579457720b5f00f97864c0a54fde75b7f4adbacf3f08d7c9e4e5ca8dad7";
+      sha256 = "2c0772a8771af51ee610c6221cfe09e243eb22aa283e390675a1d71bfe3973ea";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/nl/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/nl/firefox-104.0b4.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "550aeae1b45083cbedcece5711b64ca55baae0e22f434d75727a7ff2f0bb9769";
+      sha256 = "764bc5a5d4f965c36a56caaccde288c0884f3b19437f33c12f5254de6de48fa3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/nn-NO/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/nn-NO/firefox-104.0b4.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "b0f2bb0829ab956d092f6387fdab0c10da8d2855f52622bcca84143731cb1097";
+      sha256 = "9689f22b8029c5b8de797a72bd37b820af24549f290ad6db04f43830b62ff306";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/oc/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/oc/firefox-104.0b4.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "9aae181c22b27c2a1947c47c17f4ac363f66c41c75fb5ea6093964997c84c6db";
+      sha256 = "356c7e409602ee287167df560cdeb75d5430d927ac529bbfec24b22945632d89";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/pa-IN/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/pa-IN/firefox-104.0b4.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "51f880518a5e068752c56efd9cf3fa236a590fc906919bba97117fca2b1b3b34";
+      sha256 = "2a48129cca6a9c3de98ec0b660327dd00a30ba18cc7ed9d2d4b04a8d20ea1944";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/pl/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/pl/firefox-104.0b4.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "b30dfde0dd7e90801c88207db62767ba5680c5a696b95b6a7e9552a716fd8bfc";
+      sha256 = "fab650e64c9063818f9182ac3fb8bbe4a5a7e39e6e90a2ec30936c7d8ba8e303";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/pt-BR/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/pt-BR/firefox-104.0b4.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "3dc197cb0f97918733666e5b4d4712fe21b8ec8a990b02cfaff61b014c6be2fe";
+      sha256 = "27b9d52ff7d07ce2d41977ad7d8562c4c00d00ecba0da30b6e1a646f23fe2274";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/pt-PT/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/pt-PT/firefox-104.0b4.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "358fecfdfb23f68fa906d185829f923dc1a1eabfeb461c09c86b0522cae12184";
+      sha256 = "2f9c3d78fbe40121c47e2888b45ee02038ca9a2978e1b012177b53ba5e5e70a0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/rm/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/rm/firefox-104.0b4.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "b11e907d6e4d97b7c1f926648cf3be2f23f38f944503a53f7ece9e8bb254ff28";
+      sha256 = "ed81cc5f385b6c9221a32ae8397666015f7c4532918f8aac0a974fa3742d2488";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/ro/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/ro/firefox-104.0b4.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "98daa49fcf6db333d8bbce126e5b6af724d31f188c26f5bf5936d541161e4277";
+      sha256 = "017ba440df2e94e5a430de39beb77b25d95cdfb9a1580b9fb62efd4e01966146";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/ru/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/ru/firefox-104.0b4.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "13ffc2eb1184579b86f68b50c8b4bb2e63502cda95968069e739c80512668848";
+      sha256 = "d6ce974efd702e220ec830d1713d2d22d98e23e9a1d19e7b027f3f58a5a448fc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/sco/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/sco/firefox-104.0b4.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "7a81e02f29a12fefd2ca1c85c3df1883965e056f910497fe2e3971c819a75d5b";
+      sha256 = "8f91b0458492885954f478a17755143f9198e045ea5265cb59643814e0f14080";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/si/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/si/firefox-104.0b4.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "8cfe461291f8825050abde5a35f2df99e6a6f4c9cb7e9e116450eb9f49b6c461";
+      sha256 = "572403a8b9e479714e703eb76080cac638ef3e8517f11622043aa70bbea24d1f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/sk/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/sk/firefox-104.0b4.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "aba93a89646fac3664b696f737c3e92e9a8c3568930693a2aa99888d4568bff3";
+      sha256 = "d4b0a274fd1ad8ad957298b8f0422f9740ba266a1a5df519576a37663a6efdb1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/sl/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/sl/firefox-104.0b4.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "b49bc6c9d42788f43aaafd81bb5cdc1311a67f9d9da097cedc7b14c076246ee6";
+      sha256 = "dcea6f1054db52e7191b10f2b90ff80dd0f76420be4ad604417cbda51599e896";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/son/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/son/firefox-104.0b4.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "afa45b6bce6940681a764d8c7830f28cb392414e4c876baf1455a740f9ae1cf0";
+      sha256 = "886b954bb251ced9afc5f4c4917eee91755f4f373bf71d5b8c367465b96c2965";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/sq/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/sq/firefox-104.0b4.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "e0db43e831a5106ca1bbc622a863dd5dcfd0caae63991844abe01bf256e6ee24";
+      sha256 = "f3cfd3201e876017ab466e469e844fd0dbfbb14de293ca88e6f08ca8790a0e62";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/sr/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/sr/firefox-104.0b4.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "c6b372ac6fd3a5d4959d30fc6562122db25c5cdddf03d0624c1d0b523a8785e8";
+      sha256 = "d39dc112211bda4fc82f8049f0d33e237d065fa14f8ac4f35c66186af574b341";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/sv-SE/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/sv-SE/firefox-104.0b4.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "93e6f24f120df821a040f60212e62b2c997d071b975168e6731098444d9e0b8c";
+      sha256 = "7606202a049e4a07ba7b99e53ea46cdfaf28d3d55cd1644243343d943d4a8a5a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/szl/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/szl/firefox-104.0b4.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "870e913195da008465fe5cd16801a14ece36ce8c41225320c2537dd52d098d63";
+      sha256 = "b521e6fe4dd904362172b9e02f57f943359eb016f8f6d38fecc1ec828bb5eb83";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/ta/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/ta/firefox-104.0b4.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "277fa0ba44c92b9574335391e4919208f95ffc155de3f1d25c307e0cace11aa6";
+      sha256 = "b961b9ce0ef9b349453fd2b188d302a782dc32c35ad588c0a32148f2a85a97ac";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/te/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/te/firefox-104.0b4.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "3e96d9cf682164c0c4e4c85a880369b902f0456e5dcf49ac08a2b55f6ed023c2";
+      sha256 = "2b0547891ad7680b5aae276ffe5d1f58c0e7003a93d329ff68a23c8490af8f4d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/th/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/th/firefox-104.0b4.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "74ba53f1e0b1785d3ebac0d3401b5e14503c4ed1f6351c9f4dcbb8145b2a1709";
+      sha256 = "cc3854cb53c2aefc88229c9e4ff709e43c7b07239e2c0e4ec42f39d5381a7564";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/tl/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/tl/firefox-104.0b4.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "9e8ea59bf05809403b83039cace100adb4646962d34c483d918d0136d5966801";
+      sha256 = "ce1b6a4c62cd2ecff661850affa374afdfa5efeafc23a0bc310b2052fd29ed1b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/tr/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/tr/firefox-104.0b4.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "6aeced3d2b61a6bd7a7b360d14391e49d0338ced8e0f1c781ecc3cd1fd9a653d";
+      sha256 = "a263f80cb4d7af852644d964d8e45171824454a0ac218cb397b93352f4d6ed3d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/trs/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/trs/firefox-104.0b4.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "f4410f1e9515b3069328cf4bdac46dcce6db8fe50302de84975f1991e5147870";
+      sha256 = "d7e141c32613610346290b5c332e429d5386275d9a498d94543a072ce728fd67";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/uk/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/uk/firefox-104.0b4.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "02fa904625ee07ba06271b8243d81185656d07e53330ec1892ec06d125271b02";
+      sha256 = "6d4f6ea58d1c8087f965c941d2923c78eadd59b580e92f7c06e610b781fe7c5b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/ur/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/ur/firefox-104.0b4.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "c2122d3c49776208fbe1a5b50ec7aa7eab150de2f90881dd0c930d8a1b704787";
+      sha256 = "a1e6a964d97ff0d24d445acba6121691f47c852336820c77c1424e338558a729";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/uz/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/uz/firefox-104.0b4.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "b98c2cf7b9845ab244ee004c832b38652b6b763191da9426497725973d2d2756";
+      sha256 = "2224e963b6a16b927e84807dc9a8e5c6aed86eae6c721488d585976743baefe0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/vi/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/vi/firefox-104.0b4.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "ac2a21fac5580e7dd1e326e203a2c440128d47f93fca74e47d2004017d8c3df8";
+      sha256 = "470e55224281a62ad4680f885c50bb54d4c19d26ba99f3c3e12709d1c323b878";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/xh/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/xh/firefox-104.0b4.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "49d9734fcb8564eb9a1873a4dc0b76a5aff9ed9a03964b2014b450a4d6e5047f";
+      sha256 = "438b109606810e3b9b598fc20c3ef33b86907eabeb1b1c9b736a6ca6dce5807f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/zh-CN/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/zh-CN/firefox-104.0b4.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "0c3af00b556c38ef9d6a5f4eb29d201f1557e46df4c27605fef7263422fb1cee";
+      sha256 = "33d7e644df3f8ef4881266a5978d7c511735a8237d390688eb5cb26d6bd4fc30";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/103.0b9/linux-i686/zh-TW/firefox-103.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/104.0b4/linux-i686/zh-TW/firefox-104.0b4.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "a03a79c372799d09fa6a3a6f52d60c00d2ac8d3bb38541c7fe4aa7387db4c72e";
+      sha256 = "ee974872df52fabebe26d1bf1985bea810a1b8dc5655988f6218b2f32ab9739e";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,985 +1,985 @@
 {
-  version = "103.0";
+  version = "103.0.1";
   sources = [
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/ach/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/ach/firefox-103.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "eb8c7eb8672b84be98e7eda3eff3203a60930d7bc198b4cc493c3730d7e71f0f";
+      sha256 = "8e6c4419007dc83c142f42b2b61060237c1d1fc87a889c0e23cc375d16ff2337";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/af/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/af/firefox-103.0.1.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "2518d1df8421ab3db1d7191b77ec02ce71bf3b3d274615c5847d313a0884af17";
+      sha256 = "9742e7c4f7785ec33d27197ee894d71b1ad24d8febf55200bbbb95d1b159f8e7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/an/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/an/firefox-103.0.1.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "66c019eee8e63263a914cd4d56b89181e08d45a66a515b8d8154244cc88853b8";
+      sha256 = "a2890b677ceadea8a47d0b64ad823aa84a5b758edc204963a0364f89db2984b6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/ar/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/ar/firefox-103.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "af354d6f109ab30e42eb1a722f48aa059199390a17467804364c8b370843c074";
+      sha256 = "bd4d82890fe58a8597fe4ba5b99930604d19465015bf21bd6b6fa76d98be3638";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/ast/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/ast/firefox-103.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "21ad54db2e6f4ae2181940a95d66da05943133351f6d66eeb312ac3e09c6b4ae";
+      sha256 = "aa98a1eb85990cbee404837cf70de572757f56d1b21cf643329b331013a31806";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/az/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/az/firefox-103.0.1.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "763407d25704116c6b5e86b0dbd5e9f2fc34786961cb71a61785c2ee9639cf6f";
+      sha256 = "98d5043b89b70c4ab04a1a6598f69f86a42ae0dcb091fbf28e7a0c3bc5f2c98e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/be/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/be/firefox-103.0.1.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "f861086f1888bc6e90a22c405d2c3050e2786e994e0ac02e4c96c991e3b60cf3";
+      sha256 = "73d84943b6b6ab8f06eabca0ebe9468a5f0233f8cd8da18998bdc14d5055695f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/bg/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/bg/firefox-103.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "8f50c144f9ee443f14fd4fbb647bbcb468392d539aa6fe68966f8818f2e8df3e";
+      sha256 = "98768c07979a64a00b28ca981f8ceabc3f25366e84b8e84b4f0afe5b368b34b5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/bn/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/bn/firefox-103.0.1.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "a0b8345595210c17cbd37a25f06ea18f7f5b9662253d82f51b1355f6fe27a0a9";
+      sha256 = "6c05f385ff792ea98a477d38f740ba6b0bc3801f2b50365ccaf36ca300a86fbf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/br/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/br/firefox-103.0.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "027918ea6a7fc8453c053fc8500e347a0750f2fe2cd7d9de2a7416e015872f73";
+      sha256 = "26eee23ba331a5118c2fe594d603e9eb99dbe0157c1c94c8f2257195f5f6e85e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/bs/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/bs/firefox-103.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "7034c0d565ca7a6aedf0750972a8f4936029f477191fb3131a09976d4171042e";
+      sha256 = "62c4e1713d69f9e055f59c1e5dcb6ffe4e2699233c861a9cc42b10ab42d8acbf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/ca-valencia/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/ca-valencia/firefox-103.0.1.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "b8b0babfb5a46c5528082238a065e9d4014518e1c0c63ac3d115e0acba557ec8";
+      sha256 = "84c754eac80c913989bd9cb2e17587e221a70cd03b2ee4cb65ba2e1f8480c91d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/ca/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/ca/firefox-103.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "11aa0ffb2fb85faf934c216bd458ff92438f8e7914920102b30625ca42199297";
+      sha256 = "f90b89b49f635e57eb6720b90a03a9d5a51099d9cd45e1ca73cc3213647bfbd4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/cak/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/cak/firefox-103.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "87566d28aeb32352de85a65684a65094ffd6e370efd5cc452534a9b43ed53391";
+      sha256 = "75e63df214f040bfa80bd3cedc9d862c63f4cae5f8d6f4f701e59fc611346415";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/cs/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/cs/firefox-103.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "591853eda3a23dd04e5138cdced189c78b1be769e387eb0cc8184ca0c65cf060";
+      sha256 = "701a8cc642c2d88fdee1b353743d586d1eee0518ba5ee897412d58731bac8abe";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/cy/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/cy/firefox-103.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "eb177bf053e4cb5088a1e0b29df53ca694a15cacd7465305894bad389d2ffa57";
+      sha256 = "f4611b7bffc243f37d241d475412df349f41aab4cb079f5571e36620d6f89d27";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/da/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/da/firefox-103.0.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "98f4ba4036d412c74fdb0c67dea0eec1a7be5bea468d0e41b9bce65c1695aed6";
+      sha256 = "ec82637970f9ebc2cc53b8ab024fb0dea7b7994583ba68ba915cb1408c056bc8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/de/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/de/firefox-103.0.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "548ce35d3503fda0a6ce8f9f68d1ba2a4e6b690a7ec9320994d3db0f8bb31a29";
+      sha256 = "fd47395b1d81e72e1d4747ec2f90c77b2d9548840afe236e01800642f9baa510";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/dsb/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/dsb/firefox-103.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "bb5c6cb90c6f0cdd63c9d75e5c68ff41a76e7e567665a5317dd9e9e5db13db46";
+      sha256 = "25ba165f4c849f590bed775acbe4694124774be6e3301d209a32e6900d6ef164";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/el/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/el/firefox-103.0.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "fb7135260932f9419cfad3a75ea533bad064a3890d30d20a991bec6bf5726714";
+      sha256 = "01f7e4b9b790b7d8d04ceb541a9f5495cadd84487a253a9f0a2f64d95e1f1381";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/en-CA/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/en-CA/firefox-103.0.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "75a95f3a98f7f55964e5e12bd9d94ce0466dfd82c10f5965b0b0bea678e6e525";
+      sha256 = "17637bb32eae9fd62aed77aae1e3688897a229ccbcee8713ddfaad445675970e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/en-GB/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/en-GB/firefox-103.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "5ac6bf77d3e5775ce57ab2d70c471ca80903a0caa77613fe7c44702acf4e2276";
+      sha256 = "3ba09343c64f2d230be54fb06e4da64d4f403244afe01172afe70a625c6308b0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/en-US/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/en-US/firefox-103.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "1610dd8b3ec45b8ebc7b6255da53166a4319ef63f36e32861f3eb3026e86132f";
+      sha256 = "937bdc2a1dab756d1e094380c5508343af680aac05505697080fea1fff839359";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/eo/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/eo/firefox-103.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "e1a7565d992777914610649ee6778edb5afd64a801d6675c393ac96aa7796514";
+      sha256 = "632431880874ab732559156357b61789817d1222c545c0c78d8e5d195db3969a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/es-AR/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/es-AR/firefox-103.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "8b3259a362a29de80dff858f792df721779151c80622b8c1200b4f8a5db136df";
+      sha256 = "28031cb1990fc6e343106561f84370d0211b368aca690a7d7c788fd168189de9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/es-CL/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/es-CL/firefox-103.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "3c1363b1781c3a09a241e336eec517fd4704e0314ef778474042fcbf9e31b394";
+      sha256 = "7976c38ca38e76f48816d398c3afe47ad6a4d809ad82c5f7907eab80ace349b8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/es-ES/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/es-ES/firefox-103.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "637fda4089a68b6d792c4f6f599923e67e9dd20c15bb7f7d9cf4d4a95b96d4e7";
+      sha256 = "047e5b2f93321bf63c7a7a155dae6729b96f72238864f58be849821cec46387e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/es-MX/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/es-MX/firefox-103.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "45dac2d1e0ec4e907a7d39e88afc208b57e5b8a681307f4f66a9931bc486309a";
+      sha256 = "a4e86baf7ac83668ca5aa200e9264ce68ea8da8b0f191eb5cd60692296b9efb2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/et/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/et/firefox-103.0.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "5cd5b7f4d56d98a0aafe5f825ed47f12612f8959550b320e610b681ff1cc0854";
+      sha256 = "fd18c2b7f1ff83b52698850ad0fa462b58aa0dfa9756b00d5ba4771e361bac5e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/eu/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/eu/firefox-103.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "c1d735c3989a683890d0cdfcda38952af75ce1e4cab2a467fcb422f138944767";
+      sha256 = "216ba0cd18c57d47fa8c895709d51cc9cd33a6373fdc79cee1d2beaef7b147cb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/fa/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/fa/firefox-103.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "ca7e1b1a7373fb8283c6e44f8e774aef04c2933d1a83660a5512c1be47deb11c";
+      sha256 = "6e6f3b931a4ca497d0fe251404b1ee29463920e64a64d1bf1d260acd237191c9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/ff/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/ff/firefox-103.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "ee25d82c4d4930c011b61248323729fee93dc86259e83ac3d5f2be31c1c746c0";
+      sha256 = "dd2d979df168f3978ca0380d09b3629be68f6c3008f9caa4f3d7a7969fb54ae7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/fi/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/fi/firefox-103.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "ce744ce7cf26f69a43bd638df3eaa850b6b8a75ec6bea91d0b16ba2c03d7e5fd";
+      sha256 = "07547028d107dbb3ffc9e2990ec7800d4542e9f7474fbe3a7df1643d993292e7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/fr/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/fr/firefox-103.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "1fc112c64e46da1ef29e35a98b2f2e83d906b8475538634ce8097f5f5aa7d5c6";
+      sha256 = "fafa3c09f9845badf02b4df6e26278e3e61a2a04e442a8aa0983f5c0754e72e5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/fy-NL/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/fy-NL/firefox-103.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "7f42a3712c837e6f36d5ce800222945c245f3feb63d4f5b9ea8dc02fceb11719";
+      sha256 = "de9447cc3a805946f8329baa70e6b14131cad4c50ea19fa8e9478fa112d021df";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/ga-IE/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/ga-IE/firefox-103.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "65b555572894c377d257b584891bd343b72f759b12a06115fe66667f4fc76e41";
+      sha256 = "179385dfc332a1a442ee3632069099c52d6b0db67448e62448fbc4f456daca06";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/gd/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/gd/firefox-103.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "da5d0d2d4de810967607e2aebefb6f84842c44e4a523d7151221fd1fda371fbe";
+      sha256 = "667aba0ef539d1406fe3d72bdf1c2719ffccb4f2637cae8cad2f541736c948cc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/gl/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/gl/firefox-103.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "9dfdbdc951c7764d15e2e3528e739a9966557ee912a663fc598e2f46523c0a0a";
+      sha256 = "3dbb032a6a88a2916b56b643325d788ace086b3126ec67066621c4f4a41aa5b4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/gn/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/gn/firefox-103.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "962aa9319f3d6d5e6664673e16beea65c32ed4bb6f511db163204865c913f050";
+      sha256 = "05024810f61e23864f88d3de556407aba5a403f39cde837fb65f1ec71ae2d2ab";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/gu-IN/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/gu-IN/firefox-103.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "0ad5b0e2f2435fb5851abf448f171f1fe172c8da839aa787d3eafa4bfe473a91";
+      sha256 = "d0efb04cfaffa65bcdf70ff61af1d8cd05d8369bbc99e8dda2ef787e45ec7988";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/he/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/he/firefox-103.0.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "f3e2cf1cddcf41fee3f0f209d582322fc5a877f2c7a01160816f157ea0671e16";
+      sha256 = "55cb2ac9cd630f434882972b64d5cd2d0d37a9fda00309643184bd9d8ab2c6ad";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/hi-IN/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/hi-IN/firefox-103.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "7a7a61a11828b28c9df5e13e3826739906e2ff6496a12bc6fb513bd576ca83e0";
+      sha256 = "3fccaf76af32bf1366f18b1804d00d06369a60abd72be3f8198bbda042a7d424";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/hr/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/hr/firefox-103.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "abc48762a6bdabf1692d0fae10f2b0554ee14a58c494b1daeb5b7dfe7bdda8df";
+      sha256 = "b274f938e9fadbb8ad9aa60c47f427041037c0ffb8a5252389268fa6bdadba25";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/hsb/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/hsb/firefox-103.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "70946914b3a0ac8b502e67b960c40e087d75e17c4784ea5dd8c45357266ffd5d";
+      sha256 = "8bdd0060880038340b7723b592914cc5ab6fae2847e3040bb59b9e1d0147e810";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/hu/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/hu/firefox-103.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "ecf36fb5a8a78e660a39e4380d580b17d2e6b12abb986e6917235533fa15133b";
+      sha256 = "adfc3ad5fe53b2e7c223ce66b36e5d11971c06d0784a0b33c1e9920c03b01bd3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/hy-AM/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/hy-AM/firefox-103.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "5e4146c6b3379f0419ae67257cf8b78b987bbd657c829c6df0ee7bac2bbcb61a";
+      sha256 = "b984109ce26763c37e35d6a6bf49f9db68a4999ede4e975966cc9d1e3de9ea5e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/ia/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/ia/firefox-103.0.1.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "869b902d380d08f12204efdb250a47d0eaec20b79bdd21d3e0a532a8fbf6e258";
+      sha256 = "75e12c2fed8c75451118ae69edfd7f6787f6cd3f4de33a9098b64bcd8c6aab9e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/id/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/id/firefox-103.0.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "fb85d75cdda22a060ed8a69ae036572ea00aaa96fcb12eaf54ef8b0652740954";
+      sha256 = "7cde45f9c15dd3b086f21e47cad4419e5800fc5898c1c7d08be3c5d006fb1a5a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/is/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/is/firefox-103.0.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "8bcf92763b049d0b306fd8d5cd15fe46603f7d1ae938831f28bf17567ac7867e";
+      sha256 = "618fdb474001ebabb51fdf3b952c67dfeacf264eca80de4babf7af1689b22fb6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/it/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/it/firefox-103.0.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "4a642ad3c96b21660034e9a352e11a01d5aeed8483a4ee2d992c8891959f6849";
+      sha256 = "b2ed2ac7a77765ca617785de8fd516cd86a2fda66cb221abdf5b0351ae6deec8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/ja/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/ja/firefox-103.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "9c1d0773fabe86c41d6eaf4b31fa8d18fa8f2bcf953bef107e8954f66454ccc2";
+      sha256 = "161ce5a571f61367053eee68a52a7270efad88ec9493020f4384308844263665";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/ka/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/ka/firefox-103.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "353a663ba648a827e92d2aa99e6a4c48632fbc4c9998f2a7c5a128b27e7396a9";
+      sha256 = "d0a8c552e159848a7560983b0e77dc8676daa59f20795c62cdfdbd7c11cf2ec6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/kab/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/kab/firefox-103.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "f70731787d62c97567ad65e0b1dede06063e6f3f4cfbf515c6e5da277cef4ea2";
+      sha256 = "01d6af978dc4a1ea0464c4519c0da2b36e7501d9f34fb8f3e45c62e6c74288b4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/kk/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/kk/firefox-103.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "8f081fa36176c880929f7dfd42d1c863e247e20340efdaec4b67390d65c5bdb6";
+      sha256 = "295af7a0be1677ae4eda9d20929c81fd54fd7be0c3cae55581a029d80bf2efec";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/km/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/km/firefox-103.0.1.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "bceab0e9712c96531ec30c4d8734b0d230632657f3b412614cfbb3f2b97c76af";
+      sha256 = "8329f01d0c3c7bcd74b9d594a54bb044763879bb83813b6ab853c82266dcc077";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/kn/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/kn/firefox-103.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "114a04331de645f53375b7438b4c1e1adc973a7b3d3f5bafc43ee433fddb7bff";
+      sha256 = "689d5a81845b54510d600e8e649dc9720762f72e9c634a21d688837ced77f0eb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/ko/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/ko/firefox-103.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "7702f2b7d5573febaf2e5bc70fcccd5f9110e494e2482d44b8c9d2582840aae2";
+      sha256 = "33e7fe7a1e519842e7f648649f816a08bc3ed4d4852dc818aba6195a593f6cb0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/lij/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/lij/firefox-103.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "5df7c6c15678d5c0f93ba5c2020c60214054622f3d9440deb7afb763ab773e17";
+      sha256 = "923de240095164398bada5baa137f470be7034dd3e660a8f21f212a6116f813a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/lt/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/lt/firefox-103.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "e42dfb5d098afff42af91070229f8c40ecd41a8f504bad7e5e97c3e29baecee3";
+      sha256 = "2df49249b82717d6362c633b205302066ed7aa3eb8fc00c17dbeae3219d01328";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/lv/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/lv/firefox-103.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "f3ef9f935c85c76005dbc02bb672f1b3c19db4af0045f2e6b0aed4c348f52b6a";
+      sha256 = "dafc8282db88f65ab0ed656f3c69660292210f93229810e28a796cd3a7ec1aa0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/mk/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/mk/firefox-103.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "e2766fa37ce4174ee67cbf6d4b70029e5cd8be23fe7010d735cbacc87de08fca";
+      sha256 = "5a192311d8183cfc79e5a71c0fe05d76560e74c0d2b868a808025fb64ab6f990";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/mr/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/mr/firefox-103.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "684699452ae09400f97e522e3d18f663d79111a801b612b273a79197501cef8f";
+      sha256 = "1fca9874f5e3a99c9d1cf2fb479793799cafa3b08754ed2135a2e3ed001363d4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/ms/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/ms/firefox-103.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "4aa73de674b2fc34e9d39e9675669558a5fb89a57b2f060b5d3c78681bdb9ac6";
+      sha256 = "aa524cca0786947ed6052fc5cca4e237e3c74ad8578c4f9af0e4cb01b81cb2c2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/my/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/my/firefox-103.0.1.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "64cae4f2f677f0923e9df65005a005da54db4af0044731cfe40d6ccf8e9fc70f";
+      sha256 = "1e061a215ceadb01b056909fd82a228aaa5e5e574c4c35abf66b2da92ce11195";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/nb-NO/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/nb-NO/firefox-103.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "7a63cfe481744fe107c6c64011ebd724199053f6b6e84495c452053c5cb4b5ba";
+      sha256 = "05d794219ffbf98e3f852d9d4778f1b4ca0927080f859a6a8cff60a909219c29";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/ne-NP/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/ne-NP/firefox-103.0.1.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "3a0f819e2a8f5593592da999d85c97057c666b0c01b0697c2b78b8b3389a1f08";
+      sha256 = "b31923f5c4bc4f85b8d8e0162d41790e05f53756bb7c41eecb1b7f0b499faed8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/nl/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/nl/firefox-103.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "85952a64c85452a4bac7bc50903106ec3fdb921486e2e504abbb41a681be672d";
+      sha256 = "abfb4d6ebe7cc47c0990f4eac284450622f11e0e951ca884461bf8e7e01b1630";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/nn-NO/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/nn-NO/firefox-103.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "d6e9c976d3086ef6e611ea910fae4b506c258cb54735d6d67e57f9583bf2292e";
+      sha256 = "00946bd6cc19030e82d3596fcd6dd11b73bc5304fc18bbfc4477cf3b6e56c8bb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/oc/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/oc/firefox-103.0.1.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "9072653481fc93e79a1253d313375180e23e546e22b54cf5b4206ebf46800278";
+      sha256 = "972624fb50bd180c1315bd33b17be1daf654190c8881817d88d752e161aac601";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/pa-IN/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/pa-IN/firefox-103.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "46bd092c822daa6c6bc43901b6dc7481466bb676dfde3cc940c6dcbdbaa1802d";
+      sha256 = "ccec76c2f28a69d277536d1df430df3f615e0f3612b23e0d9b26ddb3e396ac8b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/pl/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/pl/firefox-103.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "56818db15d8b33862c968d4f6e46991391268fe0529995a3da73eca95dadd22b";
+      sha256 = "776354d0934ffbe363e75b56ca43fac64ddd258532d21c6750c5748729c41d46";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/pt-BR/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/pt-BR/firefox-103.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "95d8bae635156576caa80acb899c84b2cc459376be9931572a51516b69847867";
+      sha256 = "6232d7d6d5a008158765a4dcc1998e4a124b9c9141490241b5bfc19447f92e3d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/pt-PT/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/pt-PT/firefox-103.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "10a638c3450aefe7ae4f5ab065590a60422a803f29d1f79c287a0b7ef4aa8e73";
+      sha256 = "ea84e483b31bca3f94e4eec0343dfd6b26d35b17549476281765784453f2762e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/rm/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/rm/firefox-103.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "0411e71ed3b528b848223f820c0678d6bf498159c6722a11ff56c7b138541030";
+      sha256 = "9b8810422750532fe09751e98ad67b2f5e13034d5780992fcacec2b262d02634";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/ro/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/ro/firefox-103.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "39bfc0f335eaed13f39540dafa7152ace271a6f29a1c9c026aecec53b65aaf0c";
+      sha256 = "ffac0d747bd7ea727269b61a13d952d15f08a8c3225bf1ae6fa3c28a237576ed";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/ru/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/ru/firefox-103.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "9f400589f5bbb9ef3f661dafa3e69447099464808a301495840bea9c7da39407";
+      sha256 = "366d2fc6a8969b90a4da028a2bf1dece5d8d88feef708e2ae866707da393e010";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/sco/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/sco/firefox-103.0.1.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "bd5b317984f28634c0dd07c07eaa31eb654c2f546f98b80b0dcaff87810ceee8";
+      sha256 = "064ae0f46f31b2eea30d92e8b8175ebb6de71a3b7f5bf30a9a8f57ba229ea354";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/si/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/si/firefox-103.0.1.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "60eba119f984711e71a374368d66f2958aa43bb40fd11bfe0a1f66229800dee9";
+      sha256 = "055b3706a1fb58efdc7179268fc6cd00f0f7a2b1b0d0ef8f1d501ec0d9a36118";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/sk/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/sk/firefox-103.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "cb883000480a2b1c754bba6a7ca54bbbb1c55fd70391b862a39960bbdb2f9851";
+      sha256 = "af6a97f5b38401f1af03faab8fe8bb7f0e6a29ad56c1c7b267b7ce7ca9828253";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/sl/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/sl/firefox-103.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "13b49cfdd67f96982287918b3bbff4504edbf6e226c08f43995ea535c335be1f";
+      sha256 = "a56aa117ce2f60b3dbcac69ab7ffc42f152af35500fa965bbfd12e163679dde6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/son/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/son/firefox-103.0.1.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "81dc24a5f8383ed42c572ed690c4cdefe7820898c5d4d60e397250ec95e3baf2";
+      sha256 = "8b69b5ab30a0887c6ea0d9f805d358d20859bc70a742cce9e4d577a43263c29d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/sq/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/sq/firefox-103.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "0db103788bd92c392af8a498521cc105388eda323b62f76150fd569dc2e00106";
+      sha256 = "16c37733a88a6db2ca2827269674fbb5273ab76a7379192f11e1c7d77229a226";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/sr/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/sr/firefox-103.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "28d1b03e952a81fe9311b8bf6380a02f648e316c8d5ae531ab741feb5e273131";
+      sha256 = "56b0eafd53235c55db2deca8cd265187b27c76cc7d7155a1a1db9cdb5954b6a8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/sv-SE/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/sv-SE/firefox-103.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "bbdc6871deba77e3594733f40383fa58778de0ba5c7af91f36ba5808310bbcdb";
+      sha256 = "b11c7da532c0facd76782496153dd509f064f02c5014b17c6106e0a1f353dd37";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/szl/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/szl/firefox-103.0.1.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "576575eea8cb3740afebd260999ef20a72f2ce46adc0895fd80ccc52b93a074e";
+      sha256 = "8516c8d8bdd7876ab3cd48c0507e87df0c7a323958d9218b42858706b3d90784";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/ta/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/ta/firefox-103.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "2ecdddf0746280870bfe9b6893f59b8e562d599fb8687a71ddb1bc17b8c696f5";
+      sha256 = "37b1e5bd0db7654145f70c9cba46c5e541c8d2b4393b47233fe15b4bb76bdf21";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/te/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/te/firefox-103.0.1.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "7e24511777a8588bfd5404884f93fa6482cd97aec437f5c9510833c8607ebe18";
+      sha256 = "be9c1705598f7f0ea4bf049a94cf9b44a3c4b7637b424717198564bbdf8f9f3c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/th/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/th/firefox-103.0.1.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "570b60297dbad82a862920302158bef267ef5c7a42d034748bb8f76a3c978ffe";
+      sha256 = "8cfababd599a8d56438ab1ddbe3d8365f58c727e8f998867a6fcd30b19f870e8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/tl/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/tl/firefox-103.0.1.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "ec6017d8238b5eb717efde72e13ffbd8392c3378feb790750d2453648f29cc63";
+      sha256 = "30d298b7b4c9bfd35f4becba11f280bc52b4134da3fdaec0a6beba4069c0fbb4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/tr/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/tr/firefox-103.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "c589004f5ad8d3c203f40f1604daac3d5121cb75d278305f7f3718ed4926d3d9";
+      sha256 = "ffd47173dd5808f0d835a1ee5ca4b474aa11282d5a6be83d5b0aef61198f78fb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/trs/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/trs/firefox-103.0.1.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "c51261f8540ac3607f7ede96971455855b0fadd904ce74386fd016c2d029daaa";
+      sha256 = "c40501f417f2c2f4a306bdc9ea8815ae967c874baf95aa1781fa8408924d2361";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/uk/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/uk/firefox-103.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "03c331239a9fc714f60151a3d9c59746b1d080edb921de85dc55760a6b2b2f3e";
+      sha256 = "c0a9bf9bb2eec033f8fbcb3df5afe06a01c1e27de9064251bff08710f068a7de";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/ur/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/ur/firefox-103.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "ed475f1ad293c098fe544f05780039e9bc56032a18eeb5de0aff5699163229df";
+      sha256 = "fd2553171d4aff819f0f8b2a369f1bc35f5e5cb0843691134a6a14d1dfbddd2b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/uz/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/uz/firefox-103.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "5c18d6d440a96d557a2b8f6ca6ccf3db2e7f4587d612182ea42972f713338245";
+      sha256 = "d56364be7559354b17cc392b3d8a27f93b6e71cf115a077ad788bad6b07213b8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/vi/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/vi/firefox-103.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "42d71fbde4e8bf5ca560ee996c8ba001947a63c1e58b9c3c04e67a592012f79b";
+      sha256 = "a4198d885b95f4ed35972193be9d4294c1988d3e44e93627b2bdf46c44ad0327";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/xh/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/xh/firefox-103.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "33e5342135c4904822d3bf6294a74050cc8ff5906f4542bd87b8746f8cbb796f";
+      sha256 = "858c0e79ccfbcd29b088833e505fe2fdd58711bebcb5e24f86bd5cc1c3d3104a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/zh-CN/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/zh-CN/firefox-103.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "34da26b962871506b945caa64d601c9d543219e875d0717498e8475c7b5c0a2a";
+      sha256 = "507120ffc2c3d6b4d0f1b6187778916fb2496723a3c85c0a9b2844860bac91b5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/zh-TW/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-x86_64/zh-TW/firefox-103.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "d816e1827e6f24fa3cbd490b870fa9a22830f29c0c392bede574d3b353c51f77";
+      sha256 = "dc224df3e779a450e38539c969146dd7de64a1b6ce0c42747d6d1f6f2b67b795";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/ach/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/ach/firefox-103.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "76b4884cc40c51587d619d13bb2f6d44832b580d005420687c9b92ff5e3232a6";
+      sha256 = "bc30116d137480ce633fb08543813da156945ebb599903343ddfc498aa4f5d74";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/af/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/af/firefox-103.0.1.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "4d9ddb689cbf5dbd59468eb712a6a2b6479c32113ee1f262b7b8c648c3c8a987";
+      sha256 = "5362a70da1394c099c0e92695c650b461d2455a6809b6b9566f4bd8e424fdf87";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/an/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/an/firefox-103.0.1.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "125c0735f4d0be37077b1090f134684ae999fc9fe0fdb1b3e0c247ccf4a0cc0f";
+      sha256 = "089072f7f658d9d21213f4b96421e14813d6e5b694c28b523ad3540489804d5c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/ar/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/ar/firefox-103.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "a5e7b9c34607ab70e0ed13eeb3646ba21ba59b038d5207f46f63931471f44a91";
+      sha256 = "f573f6b297c3b46ae583d113d9a6f0cf3399267a71116f006d97340867fbb85a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/ast/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/ast/firefox-103.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "17036971cc027a9bdc39c2e7f82ac9b56ed40d17ae830bfead97e31b4ef578ac";
+      sha256 = "6f9292124b0e999da646dc1f4624252e71410b0990ed18b691b5a313da696730";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/az/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/az/firefox-103.0.1.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "84b26c7b62de2fbfdfc34cef6b6885984460a100797aed377346d68f85632a1e";
+      sha256 = "669e6cd5ff42df8408be7010aa6f308e7cffd5123ab4bc334219325b30791ec9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/be/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/be/firefox-103.0.1.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "6e3b73bdfbb259ab69be73517b3c8f027ffbb063955b85b0abee604b0cb95523";
+      sha256 = "fbeafbb52047dbc76e7507a2652f25bc28d9c61964bfe9548a7f5b6e06867db5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/bg/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/bg/firefox-103.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "0b256cecb6ddb8855ebda044ea41e1e4eb507492a701b79520c15fca4f2454d8";
+      sha256 = "eb7fcf1a5069b2470a26b2a3b518dd62602cca0008cb6cf8e93ff6582dfcfc74";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/bn/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/bn/firefox-103.0.1.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "906c241d8e9fc5e25771012d65e4ac4abf342afeaa7889d8fb293d707a7a41c6";
+      sha256 = "d2caf2774f0084fc26ffa7caf55621aedb6ca4f0b0a4cc26e49eb437e01f936a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/br/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/br/firefox-103.0.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "61c2c3cb29fea28335d1cce30f73cf56c402abc8ffc89703561285b7e65a6790";
+      sha256 = "9d95ddb999bf3fe058ea200b669d9db1aee8412d4c38aa8f86e124d1161ebb8b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/bs/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/bs/firefox-103.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "49f272e844fa35ef759c271389e24785607619acaba780c604216604c9110e52";
+      sha256 = "2965f90c8b1d88c07f4d19e3e5bc29a0fa5d1f522d0ea274984da799888d076e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/ca-valencia/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/ca-valencia/firefox-103.0.1.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "72ef7eb7b52e359de69359310332ee14c676b5b107a6aa3231128ca8dbd7d2ba";
+      sha256 = "acbc900477542e915b15d9ab0c12a036b8abd543ec3c9da6c262ec3b8b6a5bf8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/ca/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/ca/firefox-103.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "bd97e36fbaf410758cc7f954dff6278e12317eafc3fb851c960080e91574f581";
+      sha256 = "2065cfe31c5ade0fd6eb16f310fce3ab17c7ea7a2303cfcd0e113b56a38758ed";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/cak/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/cak/firefox-103.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "8975643f2eb169f5257e685b091ea7138149ca50b8cf9bd16df9094cdd353b49";
+      sha256 = "92553646de259198eca06b27f1da8ff3414f366bb42f01c0c96bc183a42ce799";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/cs/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/cs/firefox-103.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "2082f5b52a16cd1746215b4fb7b9132436bd7297a7c5596771fa6c512489ee6f";
+      sha256 = "dc20f00d952f39d07eb4a276939383512b6e2c0d7968f0a1f89ada98d493053c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/cy/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/cy/firefox-103.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "a78cb20ee9880c592fbe72225c27e10b8a33e724218e3c9d366ff4e12eb9354d";
+      sha256 = "52506edf1a06b87789c93a0cb31bf0e0040c3f5b5e532cdd8cfa15f3d376c5df";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/da/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/da/firefox-103.0.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "b7234387f8c4f9bf1365c3c958da5b7976bf7c41411998434d99194bc47fe89b";
+      sha256 = "4057240a916614dc5bff3917246e9ce84ff52889e6cc87dc9cfca6e79f5d631c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/de/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/de/firefox-103.0.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "6bd482717f54263fb08964e05c87eebbb358fee0eb4af3e2cb93bebad0e60406";
+      sha256 = "dd7a5f996a6a180b70451568d1ba1a31fe8d23bb16cc7d9d547ea775049515e8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/dsb/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/dsb/firefox-103.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "6cb334bc394647fbd07a013c566e8ffb61e6cac62a613a09c9358b572fd709c5";
+      sha256 = "92ef3c1569f77941a7e7bc2be713cbf5835bd5688c06ef633339321389b8bc23";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/el/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/el/firefox-103.0.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "4ce2ad0d2f824b6d70b7565cf3f9c8af5b43e83775e1c91efa5d7800126b9c65";
+      sha256 = "323078ee70f1b6a891df2a58e62f57a316b487b6b47975bb1bc496c283f6f568";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/en-CA/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/en-CA/firefox-103.0.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "d69211f5c11a47eb38f34632c14c541a9d59c077e60731c1679c079afe170fd9";
+      sha256 = "393297e33f4f8e913b47310403cec9968027bee87953f6e32d3dd0eeb7bdb71d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/en-GB/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/en-GB/firefox-103.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "6c98ea266b12e4dad9dfb6f142ddfa91f9269779e017ea5177193e6d5e943c5d";
+      sha256 = "714e067076b7a506ecb2a3cb1ff9e0dec68f44a95a3d7ba3c4a45925b7712dae";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/en-US/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/en-US/firefox-103.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "3a7285b3ed783526c8238e0b317d99f00784cd89b7675d53d59279a00d246aba";
+      sha256 = "86d8c763a111b79b4a6c57c761cf8f76e94fdcfc075924221bfdda8bf95f2f9d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/eo/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/eo/firefox-103.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "11e04e5459162c34f981c68dc5cbead401557af85093a854088d4ed971a63689";
+      sha256 = "94a244bd694e753e2d071605ad834a0ac1b2d41383eab297adb32242dcb9eb4f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/es-AR/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/es-AR/firefox-103.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "058a23c8f375b1a7880b05ea871d714077c913d08fd00ee3e311030cc74f3109";
+      sha256 = "5cb47e03087b9e4879740f8dfdd06c461db63134e4e6f65917dbdad54cf012e0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/es-CL/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/es-CL/firefox-103.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "31e44996cfac438fe6891c172ca9f614d92a0e1c84fcc7ac5253f29762727e09";
+      sha256 = "d37e420314e20797f48a94769e2c6610183ccc2b51171107938ae434876b20ff";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/es-ES/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/es-ES/firefox-103.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "6cdff302a0592de2702a079d09cf1199518b7697658f888033595b666f6a2436";
+      sha256 = "b24d24ebd5ef2bf82a1db3f905e786cc2820be6ab3f802239c2f28c98a7bf754";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/es-MX/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/es-MX/firefox-103.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "9535ece19dbc1c9c0bc51a3a38a52c10b095486d5722ee8568ef3eeb721f8100";
+      sha256 = "93497b4044727fa84c73bb5710960d46ea2860a66c21b80b10b15e35cae878a3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/et/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/et/firefox-103.0.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "cc7bdbf988fdda826164a8526efee6edb44c18e6abffb5471f838af29a75f238";
+      sha256 = "a66443dda276e1d18d43c17601ad238fb2f82b23ad64672db1093d5627deb7ce";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/eu/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/eu/firefox-103.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "6b9c46be9f1fc8d062e2aebfd2ab1ef5deb8dcee33775604e34bdfd0d2517d58";
+      sha256 = "22e7a857ed7ec2f9d1aa4e5711ea7152f075ce4ad31d22f9fb71efc79371613d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/fa/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/fa/firefox-103.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "f572f796f3f7dba69d2b5a43ab6f1002bd720fb72b0eac5a4d16684b03fd4b8f";
+      sha256 = "ae7e011437853226facaa963e1fac88b1f380c0a309bd7f05b5b0d3955836618";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/ff/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/ff/firefox-103.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "671b70d678419508d7b8c221c756b280926fac2a511ee875254495041da8b367";
+      sha256 = "1af356365209281f9c7f880aa952c363481c3d228c2b8abdb9bb0345d4fa69d8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/fi/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/fi/firefox-103.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "e0ee6fdbb28e50bceaaeb7d2d43780ac4ebae3e98e5078defb0298f0add74461";
+      sha256 = "e9790ed26aca33a69b098db9c3889f296d67f2be3f442203cb62f03e27ab10aa";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/fr/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/fr/firefox-103.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "b83beafa7ba0ce3eb7948b5689b166aca65c82e3b79c824fa848ad3bd0bcb60a";
+      sha256 = "b1a97dc1f4b6c4746803372ad77ae20ff18a5957c3b9a9271de41ed68ec63484";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/fy-NL/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/fy-NL/firefox-103.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "5217e9d77b0cea0717893a240260f63bc697b15cd1483dca8dfca06f9b8c7f8b";
+      sha256 = "533720e6a43be83b9670ca4a3b76f6c1f5dc04dd7a8bc99c4f33890a7abc1135";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/ga-IE/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/ga-IE/firefox-103.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "f0d63ad003520dbf9fb0e96c7f9f7bd7ecc60b687c86d9b80d39849f82c6ab54";
+      sha256 = "4c160962b3f9670941d258c074e56dd8d3a060f35c78c38e171586d6287c5f5f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/gd/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/gd/firefox-103.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "af6ce6699a139d93975f868f6c69e274c3b2ef4dfbb961d1e75da114892db11e";
+      sha256 = "7e7004bd9f83df4f0d74a1417a2c74dc1ff68658d9a40db6754d8d9ffbaa0436";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/gl/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/gl/firefox-103.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "2f9565fee8c3e749989b7789cb6e866ee124b195c30174059623a89baf1a9b52";
+      sha256 = "67acf682a64e23b252b0bc8755b0d9a274a1553926ed1d3777fbb5a80c427dcb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/gn/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/gn/firefox-103.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "8aea197a3d62ee195cd63cb240304f9459c76a886716e54bba4b5255efb00836";
+      sha256 = "43f22510e67a997a7461fece9c737e4d42be0c0b470edf46026a4b62bb04a659";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/gu-IN/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/gu-IN/firefox-103.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "c005d700a77561249502056a53fa4151db1c4ca9a8765d55be68ad9a4abb6152";
+      sha256 = "dfb942f2fe0421c05e3e658fdb7488aee8c01086166e23daa18c586f614bc97b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/he/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/he/firefox-103.0.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "a5c4edf9d23642f24ea2f7e6d10165ed96f78bdcf7f03efe5b0f85e23617df75";
+      sha256 = "a896b4dfbc7815fa5d98daacb85e767b0afbf848ca7738ece7278f58f7133c59";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/hi-IN/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/hi-IN/firefox-103.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "4db9ef4f704bd2518b0fc1a81a28ad8c1b427ef599ed9619a37537b01939001d";
+      sha256 = "be9ae4e1a55e36e6240fd8bdb8656d9e5ce8b75b08ad412117ad3f72e776110a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/hr/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/hr/firefox-103.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "787c92ee194673d0584cdee591a8afa06997d391c6bd0ad4f93c09978735db05";
+      sha256 = "c960508d1b06d52d86b4c5a32107ed85d02fc453587df42593dd62881aa35903";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/hsb/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/hsb/firefox-103.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "214fdfe324d80406252ffd9591a9782e5dca0e80bfaeca03f9c58de08b61ae1c";
+      sha256 = "2acae7859ba6256315a44f7b14e81f94a5f5eb65f8bb59a63ddf3e08beeb7d0d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/hu/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/hu/firefox-103.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "bc94747f0c1bc07dcdd9065cdbf19f3cca0f0c33a5b413ab69c3155e503609ba";
+      sha256 = "a21cca663c84bed5a2be7d3b7cef80a21caa6eaf066692bc2e68d40c0fc2a71e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/hy-AM/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/hy-AM/firefox-103.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "7eab90f1adad103dbd26519f4c4e71d9fad538123765c8be03177c7332aadb2b";
+      sha256 = "ca8ca204c2f0d9ca8f9b378fb14a0a23ab82cec158a3018ee719f94545dbf34f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/ia/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/ia/firefox-103.0.1.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "ff6662c112cfe0a366f0ced9a5e2d26e6e4f35b2a651d71c8fdcb099cf98a87f";
+      sha256 = "efd1459ead331eda306c6df3a74e7170e88a2bbc53556ceb76ce819de793b8b5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/id/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/id/firefox-103.0.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "377cdc09a3ff25e2818d669a1c11ff44cbc42af03579dd1c7e70c61a403d6cac";
+      sha256 = "04c44dc5ab9aef16faf4f6951c918da694cfe7fa72f3b1afcfcb723cf4d31110";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/is/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/is/firefox-103.0.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "0c9528c4b385ba841a96321063256d8d20ac55aabaab0f17ae179d4a41c5e64a";
+      sha256 = "ff8663e78cfb26c62c9d9ba3a9d98167fd16a05c3f6330a97e49daeb3fd02539";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/it/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/it/firefox-103.0.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "875481bfcc5056150af98814464c5877ae09e5c9f263e332b7d14fdc65593bff";
+      sha256 = "86c7b2de8ddfa970e31002bc36257c405c913bcb0bc1e3ec05daec0cb3653eed";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/ja/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/ja/firefox-103.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "8671c941764ceee29c19034a13647a10b952ee26f3d796feced8530bec4f7fc8";
+      sha256 = "476854638fcd9d40ae0821a7223e8293061b6141242bfe894d0f82d4f56fdc14";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/ka/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/ka/firefox-103.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "ec9bffdfdcab2fcba5127a3aaa4b46804c39f39220316b764eb57d3a72852bd2";
+      sha256 = "1ad9ee75b064f7b842c28ad3fb7bb0fb87a4cc2cc6fde2c2e1930383b9ffe950";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/kab/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/kab/firefox-103.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "cc726b972bc2cce1c2deb406bbe4ef32bb318c8464af29d00d1790d8071005db";
+      sha256 = "43f6c3ef52c6aa64f14693abcd789003a13319ee6b6d78e975fecd4d63c6bf91";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/kk/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/kk/firefox-103.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "4427a4dd024dc01ef0a4d0f3affc165ff2e605b4fa42dd7588ed59835adaf12e";
+      sha256 = "be5e3db5f801d7bea19a81c4b693598f6c9d2f5c9b87084fb3cfc5ea562fad30";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/km/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/km/firefox-103.0.1.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "4a0055c1c4b0d66b14bd23f1bf3adc04eec5e896f11fffe28f520c8aed470e66";
+      sha256 = "87d97e0017fa2d570ba174e6efca323c77d9eb119cf7d8872042a0f63a317a35";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/kn/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/kn/firefox-103.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "63a5ca0c7c0d948558d6845637a35b088bb9d9e7e45501544c64c0974ee0887f";
+      sha256 = "4f7bfbb6934ddaa4e32af46cfa23afae8ddbe5fac45634795b51c4b7d4c39ab2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/ko/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/ko/firefox-103.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "70296db99955dc94d4033ed72de89e3a341f04787fa8e05d6189ad27d0f4ab17";
+      sha256 = "07f05724487db57eb94e0e13bde60543130560aeaffbd079304fd1a930a5c456";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/lij/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/lij/firefox-103.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "6e9a759308c28d1c8e48b7013a40bc4b0a1c755a57c62a1088bb9c7cbe922a98";
+      sha256 = "15261b9be5555e3c108d611daf3975ade5490728155c9741b6744495a980bed0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/lt/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/lt/firefox-103.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "a6413567309db4e3aeef3fabacc7c91738eb5a7a9a72d78ff5a656dada250da6";
+      sha256 = "39e287c4c2123ec859638344269f17f2ae2467a4f5cf009fcd0067544f05f2f0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/lv/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/lv/firefox-103.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "1b7f61f1b37f357fe7c56893c1f0c80d3b32aa9eec2a439fc1e2bfdba108f79a";
+      sha256 = "cc18270d8d08b7f78e5e570b12e92c6db2436ad94e03df9bec81e8b70c3ad8a2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/mk/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/mk/firefox-103.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "8872ac6378866e84306c0cb64c357dc36e0bc262a599c59a841009c67fdae9f8";
+      sha256 = "899abaf1abea9226c6f5ed010f52e6b1de5762c26f8e814058d479ff48e82ccc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/mr/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/mr/firefox-103.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "6cbf73dc08bc9b2add46ad28f1adb43db3f429b828b6cfd3f32dc1c899b36677";
+      sha256 = "2d66ab6d14cbc818b3a0fd6223443908c055f521c5c1681d5e072358ee4f3b79";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/ms/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/ms/firefox-103.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "d79d97f97e8a0e11cc92e63fdf15c1d5845975c76fedd6526e7b15de228dc053";
+      sha256 = "b2e1bff83dc9c8a19b28110ec828606ce11ece8ba0e8c80020c8537088b0c673";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/my/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/my/firefox-103.0.1.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "c386f3bf9d6387ff2227cbec25954f62c22d3885acbab432b42a217769adf640";
+      sha256 = "251c29a92f6786e4603e9063554d4d1a448e5575dc996bfd735b21b220bf40cb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/nb-NO/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/nb-NO/firefox-103.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "d7a3dcdee442675a94a77fee609f4f2961e3bc26229fd3d4e59202ef1cbfc0fa";
+      sha256 = "b4d90931b0af0ff5ee3da3f77d78ab7c2d446ed4e791ff0dc50875a75cdff084";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/ne-NP/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/ne-NP/firefox-103.0.1.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "758d2589793e7ce34533c533a3cdd7a54de14937d2432d1bad91d1fbddc1ffc3";
+      sha256 = "b501d73c7833ab785bc175a8e4b104b3aa8cb0f8706aed0b50046d29b775c996";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/nl/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/nl/firefox-103.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "16ef6722ce548962997ccbe59aaa1c0c5368881e0b8f67981f128a838d60302d";
+      sha256 = "f085d6b488a35c6b37c8571168bbacec94d253c59fb07485c2cade4bb1ae3e23";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/nn-NO/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/nn-NO/firefox-103.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "b85e2bfef4d304efe1066de1d9f78b96bc73d4e4dd7649c08a61e5158f4b08d0";
+      sha256 = "4c379f3337ed4f3615f85b1d14d49e1f68e7680bf851f147a4708aadf5353b17";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/oc/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/oc/firefox-103.0.1.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "24f91c693eea656880e01af203c4d2ffec03f8452592a3dc3f96bd5464b72a41";
+      sha256 = "918f9e3d4c2e31c5b569a59688d9e058ede506a946e31868e3c71b7c92bdc7f3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/pa-IN/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/pa-IN/firefox-103.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "6a9f33256540ee2c67842b2d728c23062d79071b4707acc94b6a87fed0e80698";
+      sha256 = "2cae7c5d7e269fedf70fdc0308abadec2997678c429b2a230ae0c7b7d08fe838";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/pl/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/pl/firefox-103.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "a600ec02f552edd15cf8a68d14b563f8fd8d940759c53dc6f495cee8a917b686";
+      sha256 = "72cd07d64df4cb2f02a5634c945a264967a410f0cc1b2a6d592903e61eff55bc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/pt-BR/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/pt-BR/firefox-103.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "564823557a2532790828d5561967b3e1d3163a62638dca02c6246c36c4f75086";
+      sha256 = "ba79744f0287c05a411ede8f0242572719d414ecfd29a4960a588a9a3cdeae5a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/pt-PT/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/pt-PT/firefox-103.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "3e08c366e90e480cf86e67a2313557f4d0162df8643c808a19e49745479f5ab3";
+      sha256 = "3820954a0ef1d7e82402f3869d3717712a039df2cdc427c25b692da4b2813ec7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/rm/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/rm/firefox-103.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "5cf76fd6691b9a299e707386199a9c4236f455e12bf31c30cbeef13283a9fb5c";
+      sha256 = "61d9f286e3750159d6d0f68da755ede28c4f88269abaede7a0196546b79d9bd0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/ro/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/ro/firefox-103.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "1d6dd2a20bb631a9ae211ef25dc46d0ef16c7215aed71c5884d4fe8c50e184ce";
+      sha256 = "9041ed31ab56613142c743d4c6976da446c98cfaf8c030a668a1436a0813600c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/ru/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/ru/firefox-103.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "e9e0fe4cddd34f9d272d228cc61e65398e81959161149ca5cdad53539f17ef24";
+      sha256 = "d29673410cc28dabf10486dbaedfe935b1e02840d796ed9f36b58be76f97155d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/sco/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/sco/firefox-103.0.1.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "aa7eb00518320ffb6ae8b22099f39230bf0bb05a3f6d8c3ac653de6be141ab3c";
+      sha256 = "f1bde45898a0e504e6bbeac0ac44cc8f7c6ae3696e7a11ca25b267dd30486e59";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/si/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/si/firefox-103.0.1.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "570d733a05a0d2c49a8a1cfa6dce9bab8f8c0052b4508e598f0ccad68ddebba0";
+      sha256 = "d8ff70e32896753fbc5c104d444495c3709d5b8aa8f840275dd69f6d147b1c40";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/sk/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/sk/firefox-103.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "ddb13f63fe641356b61ba0cfaca776cdd68540db78da082669ea75f9ae32a2ba";
+      sha256 = "42db038a2d3c07c30afca270cd284d7f7313e79895c0d86f9754a755089675e4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/sl/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/sl/firefox-103.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "cabe1b1784423315017282b280b25ec8efdcfd48d57fca3a958483bdbba42ee3";
+      sha256 = "299cdf6dcaf77c1e2b3da04176d01653b5de24537a128d8b713d6c8938e1ace9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/son/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/son/firefox-103.0.1.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "90f5377e4854f8c63d5eeba573b424b36677410e271f1ef5648f5c05ce9d973d";
+      sha256 = "b3ef9fd3c7312341248e8ce579a61d97f016a66e562213c6b80a03f9662c372a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/sq/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/sq/firefox-103.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "8e462e5a0316bb026c1bebfd2b79beb8c8c2406051b6de492eb02aab2b3acdd7";
+      sha256 = "3ccaa5e0d5887c9fe487e3ac5a200ea64d442c83a0968392cd455da6bc9d0d4a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/sr/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/sr/firefox-103.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "2edf261fcdc8320f22872f0d2e79e2714903f07e0c0445fba9e5547419b4b929";
+      sha256 = "9311209f59d828b68bf169d3323d80e55ef014797f1c8911442a5b5e2b22364d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/sv-SE/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/sv-SE/firefox-103.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "e41dc87a030ca6704af8d3a2fc5cbf4144cf0249ef91ed6bf4676d5190343d38";
+      sha256 = "54b181d0f42fffe9109234d2b7b8dadfd842ae45baab4f173dc54abb921c86e4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/szl/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/szl/firefox-103.0.1.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "ffa0cf56eb17ac2d5161d2a34d557b4eb86300891dde5d84953f5547af9ed718";
+      sha256 = "dfb50ca29d0b2e608e6f2811bee7458cfb73236f19a089c25e4a4d5a9729d019";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/ta/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/ta/firefox-103.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "e7584b8db3c4059b6836289ec729399fa7c4925c461b17e0f31dfdd904ff4ca2";
+      sha256 = "e92795b75ec89022f8ffd6bc1ff3dfe726ff613f91ddd57a16456c23f72e6ffd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/te/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/te/firefox-103.0.1.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "f0da1f8f49c177e6e3d6bc7a60b521329791001abccd5b70e5faa78d44df9f4d";
+      sha256 = "6299af638431afab2c36f883ccc268f719d11a88d50fc5cf2f2dc109fc823539";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/th/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/th/firefox-103.0.1.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "36644f65e50c3341836b81a5eb721e3e949b0fe7b9fb833a1cd97cc11ddbff03";
+      sha256 = "7eb863e5bd9affde9b9bd9d8b993404d95b2b3a0289083325b92f702041f5778";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/tl/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/tl/firefox-103.0.1.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "cc1d773b9a6663deae781a5d438986287fff9195306c310b6d46917aa8eca8ce";
+      sha256 = "23dea1bcdb65a4d5f82a6103313ca1b78514bf6151199d06dbc3fc310f5bd7a7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/tr/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/tr/firefox-103.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "d39daadfd7f9822b19648ebe2f66e4b87b70b7ebe96b812ba564138225e286fe";
+      sha256 = "9f02ea73150ba2920de06dcc2f0df4e8f169accd24d3b38ba535334e98f0799d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/trs/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/trs/firefox-103.0.1.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "c0d5fee961cb846db01b6730f60f2d472b05d193ebf72e06b262b43887533036";
+      sha256 = "e15edb33b266fdbef6a863615ee72a320a43fd186ab5dbeb5a54f8f1dd57b677";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/uk/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/uk/firefox-103.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "72e2dfb14c437f3c778bef81a8b684df47dcc31afc7a9854b957718d36a5c06a";
+      sha256 = "7d9ae43d21e8018a66158c500935bb5918c5c375ddc7fb861024bedd79cd13e7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/ur/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/ur/firefox-103.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "88b267876d2308e24047ce0e6aa1f81af66e1e601774b93035d34fc7a3fcfe03";
+      sha256 = "ee0da7f4e43d5ffccd918155439416a20a0200bc4847aec87e53568afb8e7601";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/uz/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/uz/firefox-103.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "9e28131f56c4e65b1541c7515de903ea3cd88935deda49c61845961205a9e41f";
+      sha256 = "3bcd93f790d0faa4e55a2598900ef5059a3dc511c88ed24e899dd58c602d327f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/vi/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/vi/firefox-103.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "724684001b903b710aa7fbd389f174112d320cc890dc97797b2cc7fc6a1df168";
+      sha256 = "1cba1e1910ba70ad4b739b322daedd726b258c63618d95169f3026f2495f1af6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/xh/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/xh/firefox-103.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "46dbbe78dd5b46d263da701fed899346677cca1ccc557affc38ec24059d8cee5";
+      sha256 = "25ee6d6899524bcd33e0fc4b9820bc93203ed7bc30779f495718f75dd2b3cffb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/zh-CN/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/zh-CN/firefox-103.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "2b154962517f16fcfc32f19ac26d71fbc787d2305c85cc8693c84545c54d184a";
+      sha256 = "4d7a94191dbb2889a75c0f770a1f0b8727c08ee4735a7cd91f5b31759a4b5d82";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0/linux-i686/zh-TW/firefox-103.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/103.0.1/linux-i686/zh-TW/firefox-103.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "9bb0f6c7c1d79b53f22e6d4d86d7d1f38de09599c44e0e9ab43c4da69275e926";
+      sha256 = "bc3863131330c81c2c894ca6b418f6b0dc1719bab58fb66012d71d601a3c0cf3";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -3,10 +3,10 @@
 rec {
   firefox = buildMozillaMach rec {
     pname = "firefox";
-    version = "103.0";
+    version = "103.0.1";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "016c2f276fb94e5174626f7d8b1a821b2de0f5a07f8a10f00a7ea4d4285591b0c23dd3ef45306579de79b3dfa99ccc527224c33f3319f61cf088b1f4bd097f9e";
+      sha512 = "cb487e1d5d602e6b07093b5e722c4e70b9bf39f42c13c25642f263f90f9d3940d02e6fdbab9e8f41b66a50f81d70300acf81c222f08a26eed3ae55777fdc6303";
     };
 
     meta = {


### PR DESCRIPTION
https://www.mozilla.org/en-US/firefox/103.0.1/releasenotes/

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
