### PR TITLE
nixos/pam: add options for access.conf (pam_access)

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -469,6 +469,9 @@ let
           ''
             # Account management.
           '' +
+          optionalString config.security.pam.access.enable ''
+            account required pam_access.so accessfile=${accessConf}
+          '' +
           optionalString use_ldap ''
             account sufficient ${pam_ldap}/lib/security/pam_ldap.so
           '' +
@@ -778,6 +781,8 @@ let
   motd = if isNull config.users.motdFile
          then pkgs.writeText "motd" config.users.motd
          else config.users.motdFile;
+
+  accessConf = pkgs.writeText "access.conf" config.security.pam.access.accessConf;
 
   makePAMService = name: service:
     { name = "pam.d/${name}";
@@ -1193,6 +1198,25 @@ in
       use something other than pam_unix to verify user passwords, please remember to
       adjust this PAM service.
     '');
+
+    security.pam.access = {
+      enable = mkEnableOption (lib.mdDoc ''
+        Enables the `pam_access` module, for logdaemon-style login access control.
+
+        If set, the access control table in `accessConf` is
+        consulted when allowing or disallowing specific users or groups to
+        log in from specific hosts or terminals.
+
+        See {manpage}`access.conf(5)`.
+      '');
+      accessConf = mkOption {
+        type = types.lines;
+        description = lib.mdDoc ''
+          The contents of `/etc/security/access.conf`.
+          See {manpage}`access.conf(5)`.
+        '';
+      };
+    };
 
     users.motd = mkOption {
       default = null;


### PR DESCRIPTION
###### Description of changes

The pam_access module gives a way to allow or deny logins to certain users on the local terminal or via the network. See https://linux.die.net/man/5/access.conf

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).