### PR TITLE
[22.05] libwebp: 1.2.1 -> 1.2.3

### DIFF
--- a/pkgs/development/libraries/libwebp/default.nix
+++ b/pkgs/development/libraries/libwebp/default.nix
@@ -5,7 +5,6 @@
 , jpegSupport ? true, libjpeg # JPEG image format
 , tiffSupport ? true, libtiff # TIFF image format
 , gifSupport ? true, giflib # GIF image format
-#, wicSupport ? true # Windows Imaging Component
 , alignedSupport ? false # Force aligned memory operations
 , swap16bitcspSupport ? false # Byte swap for 16bit color spaces
 , experimentalSupport ? false # Experimental code
@@ -14,55 +13,49 @@
 , libwebpdecoderSupport ? true # Build libwebpdecoder
 }:
 
-let
-  mkFlag = optSet: flag: if optSet then "--enable-${flag}" else "--disable-${flag}";
-in
-
-with lib;
 stdenv.mkDerivation rec {
   pname = "libwebp";
-  version = "1.2.1";
+  version = "1.2.2";
 
   src = fetchFromGitHub {
     owner  = "webmproject";
     repo   = pname;
     rev    = "v${version}";
-    hash   = "sha256-KrvB5d3KNmujbfekWaevz2JZrWtK3PjEG9NEzRBYIDw=";
+    hash   = "sha256-WF2HZPS7mbotk+d1oLM/JC5l/FWfkrk+T3Z6EW9oYEI=";
   };
 
   prePatch = "patchShebangs .";
 
   configureFlags = [
-    (mkFlag threadingSupport "threading")
-    (mkFlag openglSupport "gl")
-    (mkFlag pngSupport "png")
-    (mkFlag jpegSupport "jpeg")
-    (mkFlag tiffSupport "tiff")
-    (mkFlag gifSupport "gif")
-    #(mkFlag (wicSupport && stdenv.isCygwin) "wic")
-    (mkFlag alignedSupport "aligned")
-    (mkFlag swap16bitcspSupport "swap-16bit-csp")
-    (mkFlag experimentalSupport "experimental")
-    (mkFlag libwebpmuxSupport "libwebpmux")
-    (mkFlag libwebpdemuxSupport "libwebpdemux")
-    (mkFlag libwebpdecoderSupport "libwebpdecoder")
+    (lib.enableFeature threadingSupport "threading")
+    (lib.enableFeature openglSupport "gl")
+    (lib.enableFeature pngSupport "png")
+    (lib.enableFeature jpegSupport "jpeg")
+    (lib.enableFeature tiffSupport "tiff")
+    (lib.enableFeature gifSupport "gif")
+    (lib.enableFeature alignedSupport "aligned")
+    (lib.enableFeature swap16bitcspSupport "swap-16bit-csp")
+    (lib.enableFeature experimentalSupport "experimental")
+    (lib.enableFeature libwebpmuxSupport "libwebpmux")
+    (lib.enableFeature libwebpdemuxSupport "libwebpdemux")
+    (lib.enableFeature libwebpdecoderSupport "libwebpdecoder")
   ];
 
   nativeBuildInputs = [ autoreconfHook libtool ];
   buildInputs = [ ]
-    ++ optionals openglSupport [ freeglut libGL libGLU ]
-    ++ optional pngSupport libpng
-    ++ optional jpegSupport libjpeg
-    ++ optional tiffSupport libtiff
-    ++ optional gifSupport giflib;
+    ++ lib.optionals openglSupport [ freeglut libGL libGLU ]
+    ++ lib.optionals pngSupport [ libpng ]
+    ++ lib.optionals jpegSupport [ libjpeg ]
+    ++ lib.optionals tiffSupport [ libtiff ]
+    ++ lib.optionals gifSupport [ giflib ];
 
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with lib; {
     description = "Tools and library for the WebP image format";
     homepage = "https://developers.google.com/speed/webp/";
     license = licenses.bsd3;
     platforms = platforms.all;
-    maintainers = with maintainers; [ codyopel ];
+    maintainers = with maintainers; [ ajs124 ];
   };
 }

--- a/pkgs/development/libraries/libwebp/default.nix
+++ b/pkgs/development/libraries/libwebp/default.nix
@@ -15,13 +15,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libwebp";
-  version = "1.2.2";
+  version = "1.2.3";
 
   src = fetchFromGitHub {
     owner  = "webmproject";
     repo   = pname;
     rev    = "v${version}";
-    hash   = "sha256-WF2HZPS7mbotk+d1oLM/JC5l/FWfkrk+T3Z6EW9oYEI=";
+    hash   = "sha256-t27d+eJR4iTHSLlI3J7RqHgsWACThjsI9O6R2Zb9F1g=";
   };
 
   prePatch = "patchShebangs .";


### PR DESCRIPTION
###### Description of changes
backport of #179574 and #184343

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).