### PR TITLE
[22.05] unbound: fix CVE-2022-30698 and CVE-2022-30699

### DIFF
--- a/pkgs/tools/networking/unbound/default.nix
+++ b/pkgs/tools/networking/unbound/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchurl
+, fetchpatch
 , openssl
 , nettle
 , expat
@@ -106,6 +107,16 @@ stdenv.mkDerivation rec {
   checkInputs = [ bison ];
 
   doCheck = true;
+
+  patches = [
+    # Fix CVE-2022-30698 and CVE-2022-30699
+    (fetchpatch {
+      url = "https://github.com/NLnetLabs/unbound/commit/f6753a0f1018133df552347a199e0362fc1dac68.patch";
+      name = "CVE-2022-30698.CVE-2022-30699.patch";
+      hash = "sha256-tLHkQoAbtYqLr3ASYfYX6pGtjD2TWT4B5NUubT4EN90=";
+      excludes = [ "doc/Changelog" ];
+    })
+  ];
 
   postPatch = lib.optionalString withPythonModule ''
     substituteInPlace Makefile.in \

--- a/pkgs/tools/networking/unbound/python.nix
+++ b/pkgs/tools/networking/unbound/python.nix
@@ -5,7 +5,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "pyunbound";
-  inherit (unbound) version src;
+  inherit (unbound) version src patches;
 
   nativeBuildInputs = [ swig ];
 


### PR DESCRIPTION
###### Description of changes
https://lists.nlnetlabs.nl/pipermail/unbound-users/2022-August/007851.html

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).