### PR TITLE
python3Packages.dbus-python: add missing egg-info

### DIFF
--- a/pkgs/applications/networking/instant-messengers/matrix-commander/default.nix
+++ b/pkgs/applications/networking/instant-messengers/matrix-commander/default.nix
@@ -36,11 +36,6 @@ buildPythonApplication rec {
       -e '/asyncio/d' \
       -e '/datetime/d' \
       setup.cfg requirements.txt
-
-    # Dependencies not correctly detected
-    sed -i \
-      -e '/dbus-python/d' \
-      setup.cfg requirements.txt
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/applications/terminal-emulators/terminator/default.nix
+++ b/pkgs/applications/terminal-emulators/terminator/default.nix
@@ -50,9 +50,6 @@ python3.pkgs.buildPythonApplication rec {
 
   postPatch = ''
     patchShebangs tests po
-    # dbus-python is correctly passed in propagatedBuildInputs, but for some reason setup.py complains.
-    # The wrapped terminator has the correct path added, so ignore this.
-    substituteInPlace setup.py --replace "'dbus-python'," ""
   '';
 
   doCheck = false;

--- a/pkgs/development/python-modules/dbus/default.nix
+++ b/pkgs/development/python-modules/dbus/default.nix
@@ -35,6 +35,10 @@ buildPythonPackage rec {
   doCheck = isPy3k;
   checkInputs = [ dbus.out pygobject3 ];
 
+  postInstall = ''
+    cp -r dbus_python.egg-info $out/${python.sitePackages}/
+  '';
+
   meta = with lib; {
     description = "Python DBus bindings";
     license = licenses.mit;

--- a/pkgs/development/python-modules/python-dbusmock/default.nix
+++ b/pkgs/development/python-modules/python-dbusmock/default.nix
@@ -21,11 +21,6 @@ buildPythonPackage rec {
     sha256 = "sha256-LV94F2f0Ir2Ayzk2YLL76TqeUuC0f7e+bH3vC/xKgfU=";
   };
 
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace '"dbus-python"' ""
-  '';
-
   SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/swspotify/default.nix
+++ b/pkgs/development/python-modules/swspotify/default.nix
@@ -35,12 +35,6 @@ buildPythonPackage rec {
     requests
   ];
 
-  postPatch = ''
-    # Detection of the  platform doesn't always works with 1.2.3
-    substituteInPlace pyproject.toml \
-      --replace 'dbus-python = {version = "^1.2.16", platform = "linux"}' ""
-  '';
-
   # Tests want to use Dbus
   doCheck = false;
 


### PR DESCRIPTION
###### Description of changes
So that setuptools and friends can take it into consideration when locating dependencies.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
