### PR TITLE
juliaup: init at 1.6.12

### DIFF
--- a/pkgs/development/tools/juliaup/default.nix
+++ b/pkgs/development/tools/juliaup/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "juliaup";
+  version = "1.6.12";
+
+  src = fetchFromGitHub {
+    owner = "JuliaLang";
+    repo = "juliaup";
+    rev = "v${version}";
+    sha256 = "sha256-nOhOLB79Cz+78sgK7c6pIpwMXfeWSoB+9MmNvfrtGsw=";
+  };
+
+  cargoSha256 = "sha256-u2yWr4CEq62nK2Bfdwj/zON2xMGdvN87Dz5HklDOfZw=";
+  verifyCargoDeps = true;
+
+  buildFeatures = [ "selfupdate" ];
+  
+  # Needs internet
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Julia installer and version multiplexer";
+    homepage = "https://github.com/JuliaLang/juliaup";
+    license = licenses.mit;
+    maintainers = with maintainers; [ shamilton ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13714,7 +13714,10 @@ with pkgs;
 
   julia-lts-bin = julia_16-bin;
   julia-stable-bin = julia_17-bin;
+
   julia-bin = julia-stable-bin;
+
+  juliaup = callPackage ../development/tools/juliaup { };
 
   jwasm =  callPackage ../development/compilers/jwasm { };
 


### PR DESCRIPTION
###### Description of changes
Fixes https://github.com/NixOS/nixpkgs/issues/184186

###### Things done
Tested `juliaup add 1.5.1`. (Once I've made it the default version, I can't uninstall it though...)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
