### PR TITLE
wizer: init at 1.4.0

### DIFF
--- a/pkgs/development/tools/wizer/default.nix
+++ b/pkgs/development/tools/wizer/default.nix
@@ -1,0 +1,31 @@
+{ lib, rustPlatform, fetchCrate }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "wizer";
+  version = "1.4.0";
+
+  src = fetchCrate {
+    inherit pname version;
+
+    sha256 = "sha256-3Hc3KKqtbZtvD+3lb/W7+AyrwPukJyxpUe94KGQlzBI=";
+  };
+
+  cargoSha256 = "sha256-zv36/W7dNpIupYn8TS+NaF7uX+BVjrI6AW6Hrlqr8Xg=";
+
+  cargoBuildFlags = [ "--bin" pname ];
+
+  buildFeatures = [ "env_logger" "structopt" ];
+
+  # Setting $HOME to a temporary directory is necessary to prevent checks from failing, as
+  # the test suite creates a cache directory at $HOME/Library/Caches/BytecodeAlliance.wasmtime.
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  meta = with lib; {
+    description = "The WebAssembly pre-initializer";
+    homepage = "https://github.com/bytecodealliance/wizer";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ lucperkins ];
+  };
+}

--- a/pkgs/development/tools/wizer/default.nix
+++ b/pkgs/development/tools/wizer/default.nix
@@ -27,5 +27,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/bytecodealliance/wizer";
     license = licenses.asl20;
     maintainers = with maintainers; [ lucperkins ];
+    broken = stdenv.isx86_64 && stdenv.isDarwin;
   };
 }

--- a/pkgs/development/tools/wizer/default.nix
+++ b/pkgs/development/tools/wizer/default.nix
@@ -1,4 +1,4 @@
-{ lib, rustPlatform, fetchCrate }:
+{ lib, stdenv, rustPlatform, fetchCrate }:
 
 rustPlatform.buildRustPackage rec {
   pname = "wizer";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35751,6 +35751,8 @@ with pkgs;
 
   with-shell = callPackage ../applications/misc/with-shell { };
 
+  wizer = darwin.apple_sdk_11_0.callPackage ../development/tools/wizer {};
+
   wmutils-core = callPackage ../tools/X11/wmutils-core { };
 
   wmutils-libwm = callPackage ../tools/X11/wmutils-libwm { };


### PR DESCRIPTION
###### Description of changes

This PR adds a package for [Wizer](https://github.com/bytecodealliance/wizer), a WebAssembly pre-initializer from the ByteCode Alliance.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
