### PR TITLE
treewide: fix platforms

### DIFF
--- a/pkgs/applications/audio/ssrc/default.nix
+++ b/pkgs/applications/audio/ssrc/default.nix
@@ -36,6 +36,6 @@ stdenv.mkDerivation rec {
     homepage = "http://shibatch.sourceforge.net/";
     license = licenses.gpl2;
     maintainers = with maintainers; [ leenaars];
-    platforms = with platforms; [ linux ] ;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/misc/masterpdfeditor/default.nix
+++ b/pkgs/applications/misc/masterpdfeditor/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     homepage = "https://code-industry.net/free-pdf-editor/";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfreeRedistributable;
-    platforms = with platforms; [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ cmcdragonkai ];
   };
 }

--- a/pkgs/applications/misc/masterpdfeditor4/default.nix
+++ b/pkgs/applications/misc/masterpdfeditor4/default.nix
@@ -39,6 +39,6 @@ stdenv.mkDerivation rec {
     homepage = "https://code-industry.net/free-pdf-editor/";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfreeRedistributable;
-    platforms = with platforms; [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/applications/radio/welle-io/default.nix
+++ b/pkgs/applications/radio/welle-io/default.nix
@@ -41,6 +41,6 @@ mkDerivation rec {
     homepage = "https://www.welle.io/";
     maintainers = with maintainers; [ ck3d markuskowa ];
     license = licenses.gpl2Only;
-    platforms = with platforms; [ "x86_64-linux" "i686-linux" ] ++ darwin;
+    platforms = [ "x86_64-linux" "i686-linux" ] ++ platforms.darwin;
   };
 }

--- a/pkgs/applications/science/biology/spades/default.nix
+++ b/pkgs/applications/science/biology/spades/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     description = "St. Petersburg genome assembler: assembly toolkit containing various assembly pipelines";
     license = licenses.gpl2Only;
     homepage = "http://cab.spbu.ru/software/spades/";
-    platforms = with platforms; [ "x86_64-linux" "x86_64-darwin"];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
     maintainers = [ maintainers.bzizou ];
   };
 }

--- a/pkgs/development/compilers/bupc/default.nix
+++ b/pkgs/development/compilers/bupc/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://upc.lbl.gov/";
     license = licenses.mit;
-    platforms = with platforms; [ linux ];
+    platforms = platforms.linux;
     maintainers = with maintainers; [ zimbatm ];
   };
 }

--- a/pkgs/development/compilers/dale/default.nix
+++ b/pkgs/development/compilers/dale/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/tomhrr/dale";
     license = licenses.bsd3;
     maintainers = with maintainers; [ amiloradovsky ];
-    platforms = with platforms; [ "i686-linux" "x86_64-linux" ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
     # failed on Darwin: linker couldn't find the FFI lib
     # failed on AArch64: because LLVM 3.5 is failed there
   };

--- a/pkgs/development/compilers/gnatboot/default.nix
+++ b/pkgs/development/compilers/gnatboot/default.nix
@@ -46,6 +46,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.gnu.org/software/gnat";
     license = licenses.gpl3;
     maintainers = with maintainers; [ ethindp ];
-    platforms = with platforms; [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/development/libraries/libwhereami/default.nix
+++ b/pkgs/development/libraries/libwhereami/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     description = "Library to report hypervisor information from inside a VM";
     license = licenses.asl20;
     maintainers = [ maintainers.womfoo ];
-    platforms = with platforms; [ "i686-linux" "x86_64-linux" "x86_64-darwin" ]; # fails on aarch64
+    platforms = [ "i686-linux" "x86_64-linux" "x86_64-darwin" ]; # fails on aarch64
   };
 
 }

--- a/pkgs/games/keeperrl/default.nix
+++ b/pkgs/games/keeperrl/default.nix
@@ -70,6 +70,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     maintainers = with maintainers; [ ];
     # TODO: Add OS X
-    platforms = with platforms; [ "i686-linux" "x86_64-linux" ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
   };
 }

--- a/pkgs/games/tome4/default.nix
+++ b/pkgs/games/tome4/default.nix
@@ -71,6 +71,6 @@ stdenv.mkDerivation rec {
     homepage = "https://te4.org/";
     license = licenses.gpl3;
     maintainers = with maintainers; [ peterhoeg ];
-    platforms = with platforms; [ "i686-linux" "x86_64-linux" ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
   };
 }

--- a/pkgs/tools/security/b2sum/default.nix
+++ b/pkgs/tools/security/b2sum/default.nix
@@ -26,6 +26,6 @@ stdenv.mkDerivation {
     license = with licenses; [ asl20 cc0 openssl ];
     maintainers = with maintainers; [ kirelagin ];
     # "This code requires at least SSE2."
-    platforms = with platforms; [ "x86_64-linux" "i686-linux" ] ++ darwin;
+    platforms = [ "x86_64-linux" "i686-linux" ] ++ platforms.darwin;
   };
 }


### PR DESCRIPTION
###### Description of changes

There's almost no reason to write anything starting with `with platforms; [`, since

- `with platforms; [ linux ]` is clearly wrong (and it happens!), and,
- `with platforms; [ "x86_64-linux" ]` is essentially `[ "x86_64-linux" ]`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
