### PR TITLE
polymc: use LD_LIBRARY_PATH, not GAME_LIBRARY_PATH

### DIFF
--- a/pkgs/games/polymc/default.nix
+++ b/pkgs/games/polymc/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
   in ''
     # xorg.xrandr needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
     wrapQtApp $out/bin/polymc \
-      --set GAME_LIBRARY_PATH /run/opengl-driver/lib:${libpath} \
+      --set LD_LIBRARY_PATH /run/opengl-driver/lib:${libpath} \
       --prefix POLYMC_JAVA_PATHS : ${lib.makeSearchPath "bin/java" jdks} \
       --prefix PATH : ${lib.makeBinPath [ xorg.xrandr ]}
   '';


### PR DESCRIPTION
###### Description of changes

Since 1.4.0, PolyMC simply uses LD_LIBRARY_PATH, rather than a custom GAME_LIBRARY_PATH variable.

This change was made in PolyMC/PolyMC#893, which also fixes the in-tree Nix wrapper script to match. NixOS/nixpkgs#182621 updated our PolyMC to 1.4.0, but did not port the wrapper changes along.

The lack of LD_LIBRARY_PATH causes libpulse to be unavailable, causing the sound issues observed in NixOS/nixpkgs#184189.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).