### PR TITLE
python3Packages.batchgenerators: 0.21 -> 0.24

### DIFF
--- a/pkgs/development/python-modules/batchgenerators/default.nix
+++ b/pkgs/development/python-modules/batchgenerators/default.nix
@@ -15,7 +15,7 @@
 
 buildPythonPackage rec {
   pname = "batchgenerators";
-  version = "0.21";
+  version = "0.24";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     owner = "MIC-DKFZ";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-q8mBWcy+PkJcfiKtq8P2bnTw56FE1suVS0zUgUEmc5k=";
+    hash = "sha256-47jAeHMJPBk7GpUvXtQuJchgiSy6M50anftsuXWk2ag=";
   };
 
   propagatedBuildInputs = [
@@ -37,26 +37,26 @@ buildPythonPackage rec {
     threadpoolctl
   ];
 
-  checkInputs = [
-    pytestCheckHook
-  ];
-
-  patches = [
-    # Remove deprecated unittest2, https://github.com/MIC-DKFZ/batchgenerators/pull/78
-    (fetchpatch {
-      name = "remove-unittest2.patch";
-      url = "https://github.com/MIC-DKFZ/batchgenerators/commit/87a9437057df8a7550aa3b3eaf840871cc0d5cef.patch";
-      sha256 = "sha256-vozBK7g2dLxx9din/R2vU28Mm+LoGAO/BmQlt/ShmEo=";
-    })
-  ];
-
+  # see https://github.com/MIC-DKFZ/batchgenerators/pull/78
   postPatch = ''
     substituteInPlace setup.py \
       --replace '"unittest2",' ""
   '';
 
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  # see https://github.com/MIC-DKFZ/batchgenerators/pull/78
+  disabledTestPaths = [ "tests/test_axis_mirroring.py" ];
+
   pythonImportsCheck = [
     "batchgenerators"
+    "batchgenerators.augmentations"
+    "batchgenerators.dataloading"
+    "batchgenerators.datasets"
+    "batchgenerators.transforms"
+    "batchgenerators.utilities"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [NA] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [NA] (Package updates) Added a release notes entry if the change is major or breaking
  - [NA] (Module updates) Added a release notes entry if the change is significant
  - [NA] (Module addition) Added a release notes entry if adding a new NixOS module
  - [NA] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [NA] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
