### PR TITLE
hyfetch: 1.1.2 -> 1.3.0

### DIFF
--- a/pkgs/tools/misc/hyfetch/default.nix
+++ b/pkgs/tools/misc/hyfetch/default.nix
@@ -1,24 +1,25 @@
-{ lib, python3Packages, fetchFromGitHub }:
+{ lib, buildPythonPackage, fetchFromGitHub, typing-extensions, setuptools }:
 
-python3Packages.buildPythonPackage rec {
+buildPythonPackage rec {
   pname = "HyFetch";
-  version = "1.1.2";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     repo = "hyfetch";
     owner = "hykilpikonna";
-    rev = "92623417f90f0cf006c0dd2adcf3f24f4308fe0c";
-    sha256 = "sha256-26L2qt+RarRf3+L6+mMy/ZJNVBVirKs5oEclEsImtC0=";
+    rev = version;
+    sha256 = "sha256-8Mp3MV9HVzXzT/W6F/lD34tT0uOgqyydg31PlR3sMUA=";
   };
 
-  propagatedBuildInputs = with python3Packages; [
+  # TODO: Remove with next release bump since it has been fixed upstream (hykilpikonna/hyfetch@d797a8c)
+  postPatch = ''
+    chmod +x neofetch
+  '';
+
+  propagatedBuildInputs = [
     typing-extensions
     setuptools
   ];
-
-  preCheck = ''
-    rm -rf hyfetch/color_scale_numpy.py
-  '';
 
   meta = with lib; {
     description = "neofetch with pride flags <3";
@@ -34,9 +35,6 @@ python3Packages.buildPythonPackage rec {
     homepage = "https://github.com/hykilpikonna/HyFetch";
     license = licenses.mit;
     mainProgram = "hyfetch";
-    maintainers = [
-      maintainers.yisuidenghua
-    ];
-
+    maintainers = with maintainers; [ yisuidenghua ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34861,7 +34861,7 @@ with pkgs;
 
   hplipWithPlugin = hplip.override { withPlugin = true; };
 
-  hyfetch = callPackage ../tools/misc/hyfetch { };
+  hyfetch = python3Packages.callPackage ../tools/misc/hyfetch { };
 
   hyperfine = callPackage ../tools/misc/hyperfine {
     inherit (darwin.apple_sdk.frameworks) Security;


### PR DESCRIPTION
###### Description of changes

Release notes: https://github.com/hykilpikonna/hyfetch/releases/tag/1.3.0

Changes:
* I made it a bit easier to override deps by passing them directly instead of only passing in `python3Packages`
* The file `color_scale_numpy.py` no longer exists in the repo
* The file `neofetch` lost its executable bit when it got moved around in the repo, but that has since been fixed upstream (hykilpikonna/hyfetch@d797a8c)

cc: @YisuiDenghua 

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### nixpkgs-review

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>hyfetch</li>
  </ul>
</details>