### PR TITLE
obs-gstreamer: 0.3.3 -> 0.3.4

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/obs-gstreamer.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-gstreamer.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "An OBS Studio source, encoder and video filter plugin to use GStreamer elements/pipelines in OBS Studio";
     homepage = "https://github.com/fzwoch/obs-gstreamer";
-    maintainers = with maintainers; [ ahuzik ];
+    maintainers = with maintainers; [ ahuzik pedrohlc ];
     license = licenses.gpl2Plus;
     platforms = [ "x86_64-linux" "i686-linux" ];
   };

--- a/pkgs/applications/video/obs-studio/plugins/obs-gstreamer.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-gstreamer.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation rec {
   pname = "obs-gstreamer";
-  version = "0.3.3";
+  version = "0.3.4";
 
   src = fetchFromGitHub {
     owner = "fzwoch";
     repo = "obs-gstreamer";
     rev = "v${version}";
-    hash = "sha256-KhSBZcV2yILTf5+aNoYWDfNwPiJoyYPeIOQMDFvOusg=";
+    hash = "sha256-CDtWe4bx1M06nfqvVmIZaLQoKAsXFnG0Xy/mhiSbMgU=";
   };
 
   nativeBuildInputs = [ pkg-config meson ninja ];

--- a/pkgs/applications/video/obs-studio/plugins/obs-gstreamer.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-gstreamer.nix
@@ -22,6 +22,25 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config meson ninja ];
   buildInputs = with gst_all_1; [ gstreamer gst-plugins-base obs-studio ];
 
+  # - We need "getLib" instead of default derivation, otherwise it brings gstreamer-bin;
+  # - without gst-plugins-base it won't even show proper errors in logs;
+  # - Without gst-plugins-bad it won't find element "h264parse";
+  # - gst-vaapi adds "VA-API" to "Encoder type";
+  # - gst-plugins-ugly adds "x264" to "Encoder type";
+  # Tip: "could not link appsrc to videoconvert1" can mean a lot of things, enable GST_DEBUG=2 for help.
+  passthru.obsWrapperArguments =
+    let
+      gstreamerHook = package: "--prefix GST_PLUGIN_SYSTEM_PATH_1_0 : ${lib.getLib package}/lib/gstreamer-1.0";
+    in
+    with gst_all_1; builtins.map gstreamerHook [
+      gstreamer
+      gst-plugins-base
+      gst-plugins-bad
+
+      gst-plugins-ugly
+      gst-vaapi
+    ];
+
   meta = with lib; {
     description = "An OBS Studio source, encoder and video filter plugin to use GStreamer elements/pipelines in OBS Studio";
     homepage = "https://github.com/fzwoch/obs-gstreamer";


### PR DESCRIPTION
###### Description of changes

Bump changes:
- Adds support for more color formats;
- Fix a crash when output scaling is enabled.
- The rest is not really relevant. Changelog: https://github.com/fzwoch/obs-gstreamer/compare/v0.3.3...v0.3.4

Extra work:
- Documented all the required gstreamer derivations for it to properly work.
- Added some code for the wrapOBS to automatically include the gstreamer derivations and the required envvar.

###### Things done

(I'll remove from draft once built & tested)

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
