### PR TITLE
stratisd: init at 3.2.2

### DIFF
--- a/pkgs/tools/filesystems/stratisd/default.nix
+++ b/pkgs/tools/filesystems/stratisd/default.nix
@@ -1,0 +1,105 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, rustPlatform
+, pkg-config
+, asciidoc
+, dbus
+, cryptsetup
+, util-linux
+, udev
+, systemd
+, xfsprogs
+, thin-provisioning-tools
+, clevis
+, jose
+, jq
+, curl
+, tpm2-tools
+, coreutils
+, clevisSupport ? false
+}:
+
+stdenv.mkDerivation rec {
+  pname = "stratisd";
+  version = "3.2.2";
+
+  src = fetchFromGitHub {
+    owner = "stratis-storage";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-dNbbKGRLSYVnPdKfxlLIwXNEf7P6EvGbOp8sfpaw38g=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    hash = "sha256-tJT0GKLpZtiQ/AZACkNeC3zgso54k/L03dFI0m1Jbls=";
+  };
+
+  patches = [
+    # Allow overriding BINARIES_PATHS with environment variable at compile time
+    ./paths.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace udev/61-stratisd.rules \
+      --replace stratis-base32-decode "$out/lib/udev/stratis-base32-decode" \
+      --replace stratis-str-cmp       "$out/lib/udev/stratis-str-cmp"
+
+    substituteInPlace systemd/stratis-fstab-setup \
+      --replace stratis-min           "$out/bin/stratis-min" \
+      --replace systemd-ask-password  "${systemd}/bin/systemd-ask-password" \
+      --replace sleep                 "${coreutils}/bin/sleep" \
+      --replace udevadm               "${udev}/bin/udevadm"
+  '';
+
+  nativeBuildInputs = with rustPlatform; [
+    cargoSetupHook
+    bindgenHook
+    rust.cargo
+    rust.rustc
+    pkg-config
+    asciidoc
+  ];
+
+  buildInputs = [
+    dbus
+    cryptsetup
+    util-linux
+    udev
+  ];
+
+  BINARIES_PATHS = lib.makeBinPath ([
+    xfsprogs
+    thin-provisioning-tools
+    udev
+  ] ++ lib.optionals clevisSupport [
+    clevis
+    jose
+    jq
+    cryptsetup
+    curl
+    tpm2-tools
+    coreutils
+  ]);
+
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+  buildFlags = [ "release" "release-min" "docs/stratisd.8" ];
+
+  doCheck = true;
+  checkTarget = "test";
+
+  # remove files for supporting dracut
+  postInstall = ''
+    rm -r "$out/lib/dracut"
+    rm -r "$out/lib/systemd/system-generators"
+  '';
+
+  meta = with lib; {
+    description = "Easy to use local storage management for Linux";
+    homepage = "https://stratis-storage.github.io";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ nickcao ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/tools/filesystems/stratisd/paths.patch
+++ b/pkgs/tools/filesystems/stratisd/paths.patch
@@ -1,0 +1,42 @@
+diff --git a/src/engine/strat_engine/cmd.rs b/src/engine/strat_engine/cmd.rs
+index daaff70f..ed528f7f 100644
+--- a/src/engine/strat_engine/cmd.rs
++++ b/src/engine/strat_engine/cmd.rs
+@@ -39,8 +39,6 @@ use crate::{
+ // The maximum allowable size of the thinpool metadata device
+ const MAX_META_SIZE: MetaBlocks = MetaBlocks(255 * ((1 << 14) - 64));
+ 
+-const BINARIES_PATHS: [&str; 4] = ["/usr/sbin", "/sbin", "/usr/bin", "/bin"];
+-
+ /// Find the binary with the given name by looking in likely locations.
+ /// Return None if no binary was found.
+ /// Search an explicit list of directories rather than the user's PATH
+@@ -49,7 +47,7 @@ const BINARIES_PATHS: [&str; 4] = ["/usr/sbin", "/sbin", "/usr/bin", "/bin"];
+ fn find_binary(name: &str) -> Option<PathBuf> {
+     BINARIES_PATHS
+         .iter()
+-        .map(|pre| [pre, name].iter().collect::<PathBuf>())
++        .map(|pre| [pre, &name.into()].iter().collect::<PathBuf>())
+         .find(|path| path.exists())
+ }
+ 
+@@ -147,6 +145,10 @@ lazy_static! {
+         .and_then(|mut hm| hm
+             .remove(CLEVIS)
+             .and_then(|c| hm.remove(JOSE).map(|j| (c, j))));
++    static ref BINARIES_PATHS: Vec<PathBuf> = match std::option_env!("BINARIES_PATHS") {
++        Some(paths) => std::env::split_paths(paths).collect(),
++        None => ["/usr/sbin", "/sbin", "/usr/bin", "/bin"].iter().map(|p| p.into()).collect(),
++    };
+ }
+ 
+ /// Verify that all binaries that the engine might invoke are available at some
+@@ -160,7 +162,7 @@ pub fn verify_binaries() -> StratisResult<()> {
+             name,
+             BINARIES_PATHS
+                 .iter()
+-                .map(|p| format!("\"{}\"", p))
++                .map(|p| format!("\"{}\"", p.display()))
+                 .collect::<Vec<_>>()
+                 .join(", "),
+         ))),

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5847,6 +5847,8 @@ with pkgs;
 
   soupault = callPackage ../tools/typesetting/soupault { };
 
+  stratisd = callPackage ../tools/filesystems/stratisd { };
+
   strawberry = libsForQt5.callPackage ../applications/audio/strawberry { };
 
   schildichat-desktop = callPackage ../applications/networking/instant-messengers/schildichat/schildichat-desktop.nix {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
