### PR TITLE
deluge: 2.0.5 -> 2.1.1

### DIFF
--- a/pkgs/applications/networking/p2p/deluge/default.nix
+++ b/pkgs/applications/networking/p2p/deluge/default.nix
@@ -1,9 +1,8 @@
 { lib
 , fetchurl
-, fetchpatch
 , intltool
 , libtorrent-rasterbar
-, pythonPackages
+, python3Packages
 , gtk3
 , glib
 , gobject-introspection
@@ -11,62 +10,95 @@
 , wrapGAppsHook
 }:
 
-pythonPackages.buildPythonPackage rec {
-  pname = "deluge";
-  version = "2.0.5";
+let
+  inherit (lib) optionals;
 
-  src = fetchurl {
-    url = "http://download.deluge-torrent.org/source/2.0/${pname}-${version}.tar.xz";
-    sha256 = "sha256-xL0Eq/0hG2Uhi+A/PEbSb0QCSITeEOAYWfuFb91vJdg=";
-  };
+  pypkgs = python3Packages;
 
-  propagatedBuildInputs = with pythonPackages; [
-    twisted
-    Mako
-    chardet
-    pyxdg
-    pyopenssl
-    service-identity
-    libtorrent-rasterbar.dev
-    libtorrent-rasterbar.python
-    setuptools
-    setproctitle
-    pillow
-    rencode
-    six
-    zope_interface
-    dbus-python
-    pygobject3
-    pycairo
-    gtk3
-    gobject-introspection
-    librsvg
-  ];
+  generic = { pname, withGUI }:
+    pypkgs.buildPythonPackage rec {
+      inherit pname;
+      version = "2.1.1";
 
-  nativeBuildInputs = [ gobject-introspection intltool wrapGAppsHook glib ];
+      src = fetchurl {
+        url = "http://download.deluge-torrent.org/source/${lib.versions.majorMinor version}/deluge-${version}.tar.xz";
+        hash = "sha256-do3TGYAuQkN6s3lOvnW0lxQuCO1bD7JQO61izvRC3/c=";
+      };
 
-  checkInputs = with pythonPackages; [
-    pytestCheckHook
-    pytest-twisted
-    pytest-cov
-    mock
-    mccabe
-    pylint
-  ];
+      propagatedBuildInputs = with pypkgs; [
+        twisted
+        Mako
+        chardet
+        pyxdg
+        pyopenssl
+        service-identity
+        libtorrent-rasterbar.dev
+        libtorrent-rasterbar.python
+        setuptools
+        setproctitle
+        pillow
+        rencode
+        six
+        zope_interface
+        dbus-python
+        pycairo
+        librsvg
+      ] ++ optionals withGUI [
+        gtk3
+        gobject-introspection
+        pygobject3
+      ];
 
-  doCheck = false; # until pytest-twisted is packaged
+      nativeBuildInputs = [
+        intltool
+        glib
+      ] ++ optionals withGUI [
+        gobject-introspection
+        wrapGAppsHook
+      ];
 
-  postInstall = ''
-    mkdir -p $out/share
-    cp -R deluge/ui/data/{icons,pixmaps} $out/share/
-    install -Dm444 -t $out/share/applications deluge/ui/data/share/applications/deluge.desktop
-  '';
+      checkInputs = with pypkgs; [
+        pytestCheckHook
+        pytest-twisted
+        pytest-cov
+        mock
+        mccabe
+        pylint
+      ];
 
-  meta = with lib; {
-    homepage = "https://deluge-torrent.org";
-    description = "Torrent client";
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ domenkozar ebzzry ];
-    platforms = platforms.all;
-  };
+      doCheck = false; # tests are not working at all
+
+      postInstall = ''
+        install -Dm444 -t $out/lib/systemd/system packaging/systemd/*.service
+      '' + (if withGUI
+      then ''
+        mkdir -p $out/share
+        cp -R deluge/ui/data/{icons,pixmaps} $out/share/
+        install -Dm444 -t $out/share/applications deluge/ui/data/share/applications/deluge.desktop
+      '' else ''
+        rm -r $out/bin/deluge-gtk
+        rm -r $out/lib/${python3Packages.python.libPrefix}/site-packages/deluge/ui/gtk3
+        rm -r $out/share/{icons,man/man1/deluge-gtk*,pixmaps}
+      '');
+
+      postFixup = ''
+        for f in $out/lib/systemd/system/*; do
+          substituteInPlace $f --replace /usr/bin $out/bin
+        done
+      '';
+
+      meta = with lib; {
+        description = "Torrent client";
+        homepage = "https://deluge-torrent.org";
+        license = licenses.gpl3Plus;
+        maintainers = with maintainers; [ domenkozar ebzzry ];
+        platforms = platforms.all;
+      };
+    };
+
+in
+rec {
+  deluge-gtk = generic { pname = "deluge-gtk"; withGUI = true; };
+  deluged = generic { pname = "deluged"; withGUI = false; };
+  deluge = deluge-gtk;
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5436,11 +5436,14 @@ with pkgs;
 
   ddrutility = callPackage ../tools/system/ddrutility { };
 
-  deluge-2_x = callPackage ../applications/networking/p2p/deluge {
-    pythonPackages = python3Packages;
+  inherit (callPackages ../applications/networking/p2p/deluge {
     libtorrent-rasterbar = libtorrent-rasterbar-1_2_x.override { python = python3; };
-  };
-  deluge = deluge-2_x;
+  })
+    deluge-gtk
+    deluged
+    deluge;
+
+  deluge-2_x = deluge;
 
   desktop-file-utils = callPackage ../tools/misc/desktop-file-utils { };
 


### PR DESCRIPTION
###### Description of changes

We also split this into 2:
 - deluge-gtk
 - deluged
   
Deluge is by no means light-weight but at least we no longer bring along gtk3 if we are just interested in the main daemon and web interface.

It could of course be split even further (separate out web as an example), but I think this works as a starting point.

```
$ nix path-info -Sh /nix/store/7yf5pbp8rjs69bdc718ilvczrz150x6z-python3.10-deluge-gtk-2.1.1
/nix/store/7yf5pbp8rjs69bdc718ilvczrz150x6z-python3.10-deluge-gtk-2.1.1  610.5M
$ nix path-info -Sh /nix/store/mbhxzab1s7pn8sc4bvadqwwzfxp321i1-python3.10-deluged-2.1.1   
/nix/store/mbhxzab1s7pn8sc4bvadqwwzfxp321i1-python3.10-deluged-2.1.1     468.3M
```

Fixes #136069

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
