### PR TITLE
bun: 0.1.5 -> 0.1.6

### DIFF
--- a/pkgs/development/web/bun/default.nix
+++ b/pkgs/development/web/bun/default.nix
@@ -4,31 +4,31 @@ let
     aarch64-darwin = {
       arch = "aarch64";
       shortName = "darwin";
-      sha256 = "80304f6cf43c6be3db0303bdcb4de4995ace1a394ac6068bbe1e2b6fba32b2e5";
+      sha256 = "c82547d96125bf93ae76dafe203cae5f7cd50d041bfb1cf972f9f0232a0d1cc1";
     };
 
     aarch64-linux = {
       arch = "aarch64";
       shortName = "linux";
-      sha256 = "6b22b6221014fed9e6b6cb432505424e618ef095b2060945ad119cd8f2155fae";
+      sha256 = "3430f3ff456ee86ddb607a46ee937c9c1a02b8e4d2546de52b4493878f66afb8";
     };
 
     x86_64-darwin = {
       arch = "x64";
       shortName = "darwin";
-      sha256 = "33f4c420467af85584ba444606651a0352906c9135d952b266bb6da100ef95bf";
+      sha256 = "51fb5f29b5f00207ede11c892ccf5bb3ab437b77e7420e1c18b7fc91e02e2494";
     };
 
     x86_64-linux = {
       arch = "x64";
       shortName = "linux";
-      sha256 = "524a2d7e51ddda4786799552ae1c18ab8e6173bb30f158f26cae899a7e74f22f";
+      sha256 = "89fe00713a4e0e9f77d8842c5e07f771bd743271746fcb755c5d98cb5c00456e";
     };
   };
   dist = dists.${stdenvNoCC.hostPlatform.system} or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
 in
 stdenvNoCC.mkDerivation rec {
-  version = "0.1.5";
+  version = "0.1.6";
   pname = "bun";
 
   src = fetchurl {


### PR DESCRIPTION
###### Description of changes

Bump version. I'm also hoping to get this back ported as it introduces new non-breaking functionality. 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
