### PR TITLE
pista: init at 0.1.5-unstable-2023-02-20

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2474,6 +2474,12 @@
     github = "benhiemer";
     githubId = 16649926;
   };
+  benjajaja = {
+    email = "ste3ls@gmail.com";
+    github = "benjajaja";
+    githubId = 310215;
+    name = "Benjamin Große";
+  };
   benjaminedwardwebb = {
     name = "Ben Webb";
     email = "benjaminedwardwebb@gmail.com";

--- a/pkgs/by-name/pi/pista/package.nix
+++ b/pkgs/by-name/pi/pista/package.nix
@@ -1,0 +1,35 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  darwin,
+  zlib,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "pista";
+  version = "unstable-2023-02-20";
+
+  src = fetchFromGitHub {
+    owner = "oppiliappan";
+    repo = "pista";
+    rev = "378535f3e7e138110b6225616e0dc61066a5605a";
+    hash = "sha256-FlWDKz5B/sC+VCtJNmtCJTkxzeOJOMT9gZlG6UVGzKU=";
+    fetchSubmodules = true;
+  };
+
+  cargoHash = "sha256-ADollmF60nJN8tnOZRCi755enFhf6A6M/1xqow9z110=";
+
+  buildInputs = lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.Security
+    zlib
+  ];
+
+  meta = {
+    description = "Simple {bash, zsh} prompt for programmers";
+    homepage = "https://github.com/oppiliappan/pista";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ benjajaja ];
+  };
+}

--- a/pkgs/by-name/pi/pista/package.nix
+++ b/pkgs/by-name/pi/pista/package.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage rec {
     darwin.apple_sdk.frameworks.Security
     zlib
   ];
-
+  doCheck = false; # no tests
   meta = {
     description = "Simple {bash, zsh} prompt for programmers";
     homepage = "https://github.com/oppiliappan/pista";

--- a/pkgs/by-name/pi/pista/package.nix
+++ b/pkgs/by-name/pi/pista/package.nix
@@ -21,8 +21,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-ADollmF60nJN8tnOZRCi755enFhf6A6M/1xqow9z110=";
 
-  buildInputs = lib.optionals stdenv.isDarwin [
-    darwin.apple_sdk.frameworks.Security
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     zlib
   ];
   doCheck = false; # no tests

--- a/pkgs/by-name/pi/pista/package.nix
+++ b/pkgs/by-name/pi/pista/package.nix
@@ -9,7 +9,7 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "pista";
-  version = "unstable-2023-02-20";
+  version = "0.1.5-unstable-2023-02-20";
 
   src = fetchFromGitHub {
     owner = "oppiliappan";
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage rec {
     fetchSubmodules = true;
   };
 
-  cargoHash = "sha256-ADollmF60nJN8tnOZRCi755enFhf6A6M/1xqow9z110=";
+  cargoHash = "sha256-Wforq2PHruQPFFLIiXzhulh+pZen6fFCfTktHJgt+Vw=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     zlib


### PR DESCRIPTION
a simple {bash, zsh} prompt for programmers

###### Description of changes

https://github.com/nerdypepper/pista

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
