### PR TITLE
dirbuster: init at 1.0-RC1

### DIFF
--- a/pkgs/by-name/di/dirbuster/package.nix
+++ b/pkgs/by-name/di/dirbuster/package.nix
@@ -1,0 +1,72 @@
+{ lib
+, stdenv
+, fetchurl
+, makeBinaryWrapper
+, copyDesktopItems
+, makeDesktopItem
+, unzip
+, jdk8
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dirbuster";
+  version = "1.0-RC1";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/dirbuster/DirBuster%20(jar%20%2B%20lists)/${finalAttrs.version}/DirBuster-${finalAttrs.version}.tar.bz2";
+    hash = "sha256-UoEt1NkaLsKux3lr+AB+TZCCshQs2hIo63igT39V68E=";
+  };
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "dirbuster";
+      desktopName = "OWASP DirBuster";
+      exec = "dirbuster";
+      icon = "dirbuster";
+      comment = "Web Application Brute Forcing";
+      categories = [ "Network" ];
+    })
+  ];
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+    copyDesktopItems
+    unzip
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    export JAR=$out/share/java/dirbuster.jar
+    install -Dm444 DirBuster-${finalAttrs.version}.jar $JAR
+    makeWrapper ${jdk8}/bin/java $out/bin/dirbuster \
+      --add-flags "-Duser.dir=$out/share/dirbuster/" \
+      --add-flags "-Xmx256M" \
+      --add-flags "-jar $JAR"
+
+    cp -r lib/ $out/share/java/lib/
+
+    # Copy wordlists
+    mkdir -p $out/share/dirbuster
+    for f in *.txt; do
+      cp $f $out/share/dirbuster/
+    done
+
+    # Extract embedded desktop icon
+    mkdir -p $out/share/pixmaps
+    unzip $JAR
+    strings com/sittinglittleduck/DirBuster/ImageCreator.class | grep iVBORw0KG | base64 -d > $out/share/pixmaps/dirbuster.png
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Brute force directories and files names on web/application servers";
+    homepage = "https://wiki.owasp.org/index.php/Category:OWASP_DirBuster_Project";
+    license = lib.licenses.lgpl21Only;
+    mainProgram = "dirbuster";
+    maintainers = with lib.maintainers; [ emilytrau ];
+    platforms = lib.platforms.all;
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+  };
+})


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Brute force directories and files names on web/application servers

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
