### PR TITLE
volatility: 2.6.1 -> unstable-2020-12-12, fix the build

### DIFF
--- a/pkgs/development/python-modules/distorm3/default.nix
+++ b/pkgs/development/python-modules/distorm3/default.nix
@@ -10,8 +10,6 @@ buildPythonPackage rec {
   pname = "distorm3";
   version = "3.5.2";
 
-  disabled = pythonOlder "3.5";
-
   src = fetchFromGitHub {
     owner = "gdabah";
     repo = "distorm";
@@ -35,6 +33,6 @@ buildPythonPackage rec {
     description = "Disassembler library for x86/AMD64";
     homepage = "https://github.com/gdabah/distorm";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ fab ];
+    maintainers = with maintainers; [ fab emilytrau ];
   };
 }

--- a/pkgs/development/python-modules/yara-python/default.nix
+++ b/pkgs/development/python-modules/yara-python/default.nix
@@ -11,8 +11,6 @@ buildPythonPackage rec {
   version = "4.2.0";
   format = "setuptools";
 
-  disabled = pythonOlder "3.7";
-
   src = fetchFromGitHub {
     owner = "VirusTotal";
     repo = "yara-python";
@@ -44,6 +42,6 @@ buildPythonPackage rec {
     description = "Python interface for YARA";
     homepage = "https://github.com/VirusTotal/yara-python";
     license = with licenses; [ asl20 ];
-    maintainers = with maintainers; [ fab ];
+    maintainers = with maintainers; [ fab emilytrau ];
   };
 }

--- a/pkgs/development/python2-modules/openpyxl/default.nix
+++ b/pkgs/development/python2-modules/openpyxl/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytest
+, jdcal
+, et_xmlfile
+, lxml
+}:
+
+buildPythonPackage rec {
+  pname = "openpyxl";
+  version = "2.6.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1qzjj8nwj4dn0mhq1j64f136afiqqb81lvqiikipz3g1g0b80lqx";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ jdcal et_xmlfile lxml ];
+
+  postPatch = ''
+    # LICENSE.rst is missing, and setup.cfg currently doesn't contain anything useful anyway
+    # This should likely be removed in the next update
+    rm setup.cfg
+  '';
+
+  # Tests are not included in archive.
+  # https://bitbucket.org/openpyxl/openpyxl/issues/610
+  doCheck = false;
+  pythonImportsCheck = [ "openpyxl" ];
+
+  meta = {
+    description = "A Python library to read/write Excel 2007 xlsx/xlsm files";
+    homepage = "https://openpyxl.readthedocs.org";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ lihop emilytrau ];
+  };
+}

--- a/pkgs/tools/security/volatility/default.nix
+++ b/pkgs/tools/security/volatility/default.nix
@@ -2,23 +2,32 @@
 
 python2Packages.buildPythonApplication rec {
   pname = "volatility";
-  version = "2.6.1";
+  version = "unstable-2020-12-12";
 
   src = fetchFromGitHub {
     owner = "volatilityfoundation";
     repo = pname;
-    rev = version;
-    sha256 = "1v92allp3cv3akk71kljcwxr27h1k067dsq7j9h8jnlwk9jxh6rf";
+    rev = "a438e768194a9e05eb4d9ee9338b881c0fa25937";
+    sha256 = "U/iWPztn47/Tcz/etVduG7V/Nu5Z1jb+i0mutaKr9sM=";
   };
 
   doCheck = false;
+  pythonImportsCheck = [ "volatility" ];
 
-  propagatedBuildInputs = with python2Packages; [ pycrypto distorm3 pillow ];
+  propagatedBuildInputs = with python2Packages; [
+    pycrypto
+    distorm3
+    yara-python
+    openpyxl
+    # pillow is needed for the screenshot plugin but is marked insecure
+    # pillow
+  ];
 
   meta = with lib; {
     homepage = "https://www.volatilityfoundation.org/";
     description = "Advanced memory forensics framework";
-    maintainers = with maintainers; [ bosu ];
+    mainProgram = "vol.py";
+    maintainers = with maintainers; [ bosu emilytrau ];
     license = lib.licenses.gpl2Plus;
   };
 }

--- a/pkgs/top-level/python2-packages.nix
+++ b/pkgs/top-level/python2-packages.nix
@@ -62,6 +62,8 @@ with self; with super; {
 
   numpy = callPackage ../development/python2-modules/numpy { };
 
+  openpyxl = callPackage ../development/python2-modules/openpyxl { };
+
   packaging = callPackage ../development/python2-modules/packaging { };
 
   pillow = callPackage ../development/python2-modules/pillow {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Volatility is a memory forensics tool. Although it has been superseded by volatility3, volatility2 still sees regular use. As python2 support is dropping from its dependencies, this will need further future maintenance  as long as the tool is yet to be obsoleted. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
