### PR TITLE
spamassassin: install default rules

### DIFF
--- a/pkgs/servers/mail/spamassassin/default.nix
+++ b/pkgs/servers/mail/spamassassin/default.nix
@@ -3,10 +3,15 @@
 perlPackages.buildPerlPackage rec {
   pname = "SpamAssassin";
   version = "4.0.0";
+  rulesRev = "r1905950";
 
   src = fetchurl {
     url = "mirror://apache/spamassassin/source/Mail-${pname}-${version}.tar.bz2";
     hash = "sha256-5aoXBQowvHK6qGr9xgSMrepNHsLsxh14dxegWbgxnog=";
+  };
+  defaultRulesSrc = fetchurl {
+    url = "mirror://apache/spamassassin/source/Mail-${pname}-rules-${version}.${rulesRev}.tgz";
+    hash = "sha256-rk/7uRfrx/76ckD8W7UVHdpmP45AWRYa18m0Lu0brG0=";
   };
 
   patches = [
@@ -52,6 +57,10 @@ perlPackages.buildPerlPackage rec {
   postInstall = ''
     mkdir -p $out/share/spamassassin
     mv "rules/"* $out/share/spamassassin/
+
+    tar -xzf ${defaultRulesSrc} -C $out/share/spamassassin/
+    local moduleversion="$(${perlPackages.perl}/bin/perl -I lib -e 'use Mail::SpamAssassin; print $Mail::SpamAssassin::VERSION')"
+    sed -i -e "s/@@VERSION@@/$moduleversion/" $out/share/spamassassin/*.cf
 
     for n in "$out/bin/"*; do
       # Skip if this isn't a perl script


### PR DESCRIPTION
###### Description of changes

Currently if you install the spamassassin package (not using the service, but rather just the `spamassassin` standalone command) it won't produce any meaningful scores when filtering because it has no rules configured. We can install the default rules inside the package. This lets spamassassin filter spam out of the box, without having to invoke `sa-update` first. 

The Fedora package does this:
https://src.fedoraproject.org/rpms/spamassassin/blob/a8d44efc109614b43977b8db06f26e39881ce5e5/f/spamassassin.spec#_271

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).