### PR TITLE
wasmedge: init at 0.10.1

### DIFF
--- a/pkgs/development/tools/wasmedge/default.nix
+++ b/pkgs/development/tools/wasmedge/default.nix
@@ -6,6 +6,7 @@
 , gtest
 , spdlog
 }:
+
 llvmPackages.stdenv.mkDerivation rec {
   pname = "wasmedge";
   version = "0.10.1";

--- a/pkgs/development/tools/wasmedge/default.nix
+++ b/pkgs/development/tools/wasmedge/default.nix
@@ -1,12 +1,12 @@
 { lib
 , fetchFromGitHub
-, llvmPackages_12
+, llvmPackages
 , boost
 , cmake
 , gtest
 , spdlog
 }:
-llvmPackages_12.stdenv.mkDerivation rec {
+llvmPackages.stdenv.mkDerivation rec {
   pname = "wasmedge";
   version = "0.10.1";
 
@@ -20,10 +20,10 @@ llvmPackages_12.stdenv.mkDerivation rec {
   buildInputs = [
     boost
     spdlog
-    llvmPackages_12.llvm
+    llvmPackages.llvm
   ];
 
-  nativeBuildInputs = [ cmake llvmPackages_12.lld ];
+  nativeBuildInputs = [ cmake llvmPackages.lld ];
 
   checkInputs = [ gtest ];
 

--- a/pkgs/development/tools/wasmedge/default.nix
+++ b/pkgs/development/tools/wasmedge/default.nix
@@ -1,14 +1,12 @@
 { lib
-, stdenv
 , fetchFromGitHub
-, llvm_11
+, llvmPackages_12
 , boost
 , cmake
-, lld
 , gtest
 , spdlog
 }:
-stdenv.mkDerivation rec {
+llvmPackages_12.stdenv.mkDerivation rec {
   pname = "wasmedge";
   version = "0.10.1";
 
@@ -22,10 +20,10 @@ stdenv.mkDerivation rec {
   buildInputs = [
     boost
     spdlog
-    llvm_11
+    llvmPackages_12.llvm
   ];
 
-  nativeBuildInputs = [ cmake lld ];
+  nativeBuildInputs = [ cmake llvmPackages_12.lld ];
 
   checkInputs = [ gtest ];
 

--- a/pkgs/development/tools/wasmedge/default.nix
+++ b/pkgs/development/tools/wasmedge/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  llvm_12,
+  lld,
+  boost,
+  cmake,
+  gtest,
+  spdlog,
+}:
+stdenv.mkDerivation rec {
+  pname = "wasmedge";
+  version = "0.10.1";
+
+  src = fetchFromGitHub {
+    owner = "WasmEdge";
+    repo = "WasmEdge";
+    rev = version;
+    sha256 = "sha256-SJi8CV0sa+g+Ngvdw8+SxV3kHqoiKBhYUwDLZM4+jX0=";
+  };
+
+  buildInputs = [
+    boost
+    llvm_12
+  ];
+
+  nativeBuildInputs = [cmake lld boost gtest spdlog];
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DWASMEDGE_BUILD_TESTS=OFF" # Tests are downloaded using git
+    "-DWASMEDGE_BUILD_AOT_RUNTIME=OFF" # Fails otherwise
+  ];
+
+  meta = with lib; {
+    homepage = "https://wasmedge.org/";
+    license = with licenses; [asl20];
+    description = "A lightweight, high-performance, and extensible WebAssembly runtime for cloud native, edge, and decentralized applications";
+    maintainers = with maintainers; [dit7ya];
+  };
+}

--- a/pkgs/development/tools/wasmedge/default.nix
+++ b/pkgs/development/tools/wasmedge/default.nix
@@ -1,13 +1,12 @@
-{
-  lib,
-  stdenv,
-  fetchFromGitHub,
-  llvm_12,
-  lld,
-  boost,
-  cmake,
-  gtest,
-  spdlog,
+{ lib
+, stdenv
+, fetchFromGitHub
+, llvm_11
+, boost
+, cmake
+, lld
+, gtest
+, spdlog
 }:
 stdenv.mkDerivation rec {
   pname = "wasmedge";
@@ -22,21 +21,23 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     boost
-    llvm_12
+    spdlog
+    llvm_11
   ];
 
-  nativeBuildInputs = [cmake lld boost gtest spdlog];
+  nativeBuildInputs = [ cmake lld ];
+
+  checkInputs = [ gtest ];
 
   cmakeFlags = [
     "-DCMAKE_BUILD_TYPE=Release"
     "-DWASMEDGE_BUILD_TESTS=OFF" # Tests are downloaded using git
-    "-DWASMEDGE_BUILD_AOT_RUNTIME=OFF" # Fails otherwise
   ];
 
   meta = with lib; {
     homepage = "https://wasmedge.org/";
-    license = with licenses; [asl20];
+    license = with licenses; [ asl20 ];
     description = "A lightweight, high-performance, and extensible WebAssembly runtime for cloud native, edge, and decentralized applications";
-    maintainers = with maintainers; [dit7ya];
+    maintainers = with maintainers; [ dit7ya ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11689,7 +11689,9 @@ with pkgs;
     nodejs = nodejs_latest;
   };
 
-  wasmedge = callPackage ../development/tools/wasmedge { };
+  wasmedge = callPackage ../development/tools/wasmedge { 
+    llvmPackages = llvmPackages_12;
+  };
 
   welkin = callPackage ../tools/graphics/welkin {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11689,7 +11689,7 @@ with pkgs;
     nodejs = nodejs_latest;
   };
 
-  wasmedge = callPackage ../development/tools/wasmedge { 
+  wasmedge = callPackage ../development/tools/wasmedge {
     llvmPackages = llvmPackages_12;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11689,6 +11689,8 @@ with pkgs;
     nodejs = nodejs_latest;
   };
 
+  wasmedge = callPackage ../development/tools/wasmedge { };
+
   welkin = callPackage ../tools/graphics/welkin {};
 
   wemux = callPackage ../tools/misc/wemux { };


### PR DESCRIPTION
###### Description of changes

Note to reviewers: I could not figure out why the build is failing when `-DWASMEDGE_BUILD_AOT_RUNTIME` is `ON` with something like the following. Would be great if you can fix that.

```
/nix/store/0gzd0049bywqhzi5anbydsxil7r1lfrj-binutils-2.38/bin/ld: ../../lib/api/libwasmedge_c.so: undefined reference to `llvm::codegen::InitTargetOptionsFromCodeGenFlags()'
/nix/store/0gzd0049bywqhzi5anbydsxil7r1lfrj-binutils-2.38/bin/ld: ../../lib/api/libwasmedge_c.so: undefined reference to `llvm::codegen::InitTargetOptionsFromCodeGenFlags()'
collect2: error: ld returned 1 exit status
collect2: error: ld returned 1 exit status
make[2]: *** [tools/wasmedge/CMakeFiles/wasmedgec.dir/build.make:98: tools/wasmedge/wasmedgec] Error 1
make[2]: *** [tools/wasmedge/CMakeFiles/wasmedge.dir/build.make:98: tools/wasmedge/wasmedge] Error 1
make[1]: *** [CMakeFiles/Makefile2:1019: tools/wasmedge/CMakeFiles/wasmedgec.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:1045: tools/wasmedge/CMakeFiles/wasmedge.dir/all] Error 2
```

Resolves #184726.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
