### PR TITLE
foremost: unbreak on Darwin

### DIFF
--- a/pkgs/tools/system/foremost/default.nix
+++ b/pkgs/tools/system/foremost/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   #   ld: api.o:(.bss+0xbdba0): multiple definition of `wildcard'; main.o:(.bss+0xbd760): first defined here
   NIX_CFLAGS_COMPILE = "-fcommon";
 
-  makeFlags = [ "PREFIX=$(out)" ];
+  makeFlags = [ "PREFIX=$(out)" ] ++ lib.optionals stdenv.isDarwin [ "mac" ];
 
   enableParallelBuilding = true;
 
@@ -39,6 +39,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "http://foremost.sourceforge.net/";
     license = licenses.publicDomain;
-    platforms = platforms.linux;
+    maintainers = [ maintainers.jiegec ];
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/tools/system/foremost/makefile.patch
+++ b/pkgs/tools/system/foremost/makefile.patch
@@ -1,6 +1,15 @@
---- a/Makefile	2015-04-21 00:40:46.949266581 +0200
-+++ b/Makefile	2015-04-21 00:41:38.637165883 +0200
-@@ -24,9 +24,9 @@
+diff --git a/Makefile b/Makefile
+index 1a20f4f..077acdb 100755
+--- a/Makefile
++++ b/Makefile
+@@ -1,5 +1,5 @@
+ 
+-RAW_CC = gcc
++RAW_CC := $(CC)
+ RAW_FLAGS = -Wall -O2
+ LINK_OPT = 
+ VERSION = 1.5.7
+@@ -24,9 +24,9 @@ MAN_PAGES = $(NAME).8.gz
  RAW_FLAGS += -DVERSION=\"$(VERSION)\"
  
  # Where we get installed
@@ -13,7 +22,7 @@
  # Setup for compiling and cross-compiling for Windows
  # The CR_ prefix refers to cross compiling from OSX to Windows
  CR_CC = $(CR_BASE)/gcc
-@@ -120,7 +120,6 @@
+@@ -120,7 +120,6 @@ foremost: $(OBJ)
  install: goals
  	install -m 755 $(NAME) $(BIN)
  	install -m 444 $(MAN_PAGES) $(MAN)


### PR DESCRIPTION
Support darwin build and add jiegec as maintainer.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
