### PR TITLE
xsser: init at 1.8.4

### DIFF
--- a/pkgs/tools/security/xsser/default.nix
+++ b/pkgs/tools/security/xsser/default.nix
@@ -1,0 +1,64 @@
+{ lib, buildPythonApplication, fetchFromGitHub, wrapGAppsHook, gobject-introspection, gtk3, pango
+, pillow, pycurl, beautifulsoup4, pygeoip, pygobject3, cairocffi, selenium }:
+
+buildPythonApplication rec {
+  pname = "xsser";
+  version = "1.8.4";
+
+  src = fetchFromGitHub {
+    owner = "epsylon";
+    repo = pname;
+    rev = "478242e6d8e1ca921e0ba8fa59b50106fa2f7312";
+    sha256 = "MsQu/r1C6uXawpuVTuBGhWNqCSZ9S2DIx15Lpo7L4RI=";
+  };
+
+  postPatch = ''
+    # Replace relative path with absolute store path
+    find . -type f -exec sed -i "s|core/fuzzing/user-agents.txt|$out/share/xsser/fuzzing/user-agents.txt|g" {} +
+
+    # Replace absolute path references with store paths
+    substituteInPlace core/main.py --replace /usr $out
+    substituteInPlace gtk/xsser.desktop --replace /usr $out
+    substituteInPlace setup.py --replace /usr/share share
+  '';
+
+  # Temporary fix
+  # See https://github.com/NixOS/nixpkgs/issues/56943
+  strictDeps = false;
+
+  nativeBuildInputs = [ wrapGAppsHook gobject-introspection ];
+
+  buildInputs = [
+    gtk3
+    pango
+  ];
+
+  propagatedBuildInputs = [
+    pillow
+    pycurl
+    beautifulsoup4
+    pygeoip
+    pygobject3
+    cairocffi
+    selenium
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  dontWrapGApps = true;
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  postInstall = ''
+    install -D core/fuzzing/user-agents.txt $out/share/xsser/fuzzing/user-agents.txt
+  '';
+
+  meta = with lib; {
+    description = "Automatic framework to detect, exploit and report XSS vulnerabilities in web-based applications";
+    homepage = "https://xsser.03c8.net/";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ emilytrau ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35834,6 +35834,8 @@ with pkgs;
     sane-backends = sane-backends.override { libpng = libpng12; };
   };
 
+  xsser = python3Packages.callPackage ../tools/security/xsser { };
+
   xsw = callPackage ../applications/misc/xsw {
     # Enable the next line to use this in terminal.
     # Note that it requires sixel capable terminals such as mlterm


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Automatic framework to detect, exploit and report XSS vulnerabilities in web-based applications

Request from #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
