### PR TITLE
nixos/osk-sdl: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1246,6 +1246,7 @@
   ./system/boot/luksroot.nix
   ./system/boot/modprobe.nix
   ./system/boot/networkd.nix
+  ./system/boot/osk-sdl.nix
   ./system/boot/plymouth.nix
   ./system/boot/resolved.nix
   ./system/boot/shutdown.nix

--- a/nixos/modules/profiles/qemu-guest.nix
+++ b/nixos/modules/profiles/qemu-guest.nix
@@ -4,7 +4,7 @@
 { config, lib, ... }:
 
 {
-  boot.initrd.availableKernelModules = [ "virtio_net" "virtio_pci" "virtio_mmio" "virtio_blk" "virtio_scsi" "9p" "9pnet_virtio" ];
+  boot.initrd.availableKernelModules = [ "virtio_net" "virtio_pci" "virtio_mmio" "virtio_blk" "virtio_scsi" "virtio_gpu" "9p" "9pnet_virtio" ];
   boot.initrd.kernelModules = [ "virtio_balloon" "virtio_console" "virtio_rng" ];
 
   boot.initrd.postDeviceCommands = lib.mkIf (!config.boot.initrd.systemd.enable)

--- a/nixos/modules/system/boot/osk-sdl.nix
+++ b/nixos/modules/system/boot/osk-sdl.nix
@@ -1,0 +1,86 @@
+{ config, lib, pkgs, utils, ... }:
+
+with lib;
+
+let
+  cfg = config.boot.initrd.osk-sdl;
+in
+{
+  options.boot.initrd.osk-sdl = {
+    enable = mkEnableOption (lib.mdDoc "osk-sdl in initrd") // {
+      description = lib.mdDoc ''
+        Whether to enable the osk-sdl on-screen keyboard in initrd to unlock LUKS.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    meta.maintainers = with maintainers; [ tomfitzhenry ];
+    assertions = [
+      {
+        assertion = cfg.enable -> config.boot.initrd.systemd.enable;
+        message = "boot.initrd.osk-sdl is only supported with boot.initrd.systemd.";
+      }
+    ];
+    boot.initrd.availableKernelModules = [
+      "evdev" # for entering pw
+    ];
+
+    boot.initrd.systemd = {
+      storePaths = with pkgs; [
+        dejavu_fonts
+        gnugrep
+        libGL
+        mesa.drivers
+        osk-sdl
+        "${systemd}/lib/systemd/systemd-reply-password"
+      ];
+      services = {
+        osk-sdl-ask-password = {
+          description = "Forward Password Requests to OSK-SDL";
+          conflicts = [
+            "shutdown.target"
+            "emergency.service"
+          ];
+          unitConfig.DefaultDependencies = false;
+          after = [
+            "systemd-vconsole-setup.service"
+          ];
+          before = [
+            "shutdown.target"
+          ];
+          script = ''
+            mkdir -p /run/opengl-driver/
+            cp -r ${pkgs.mesa.drivers}/* /run/opengl-driver/
+
+            for file in `ls /run/systemd/ask-password/*`; do
+              socket="$(cat "$file" | ${pkgs.gnugrep}/bin/grep "Socket=" | cut -d= -f2)"
+              ${pkgs.osk-sdl}/bin/osk-sdl -c ${pkgs.osk-sdl}/etc/osk.conf -d x -n x -k -s | ${pkgs.systemd}/lib/systemd/systemd-reply-password 1 "$socket"
+            done
+          '';
+        };
+      };
+
+      paths = {
+        osk-sdl-ask-password = {
+          description = "Forward Password Requests to OSK-SDL";
+          conflicts = [
+            "shutdown.target"
+            "emergency.service"
+          ];
+          unitConfig.DefaultDependencies = false;
+          before = [
+            "shutdown.target"
+            "paths.target"
+            "cryptsetup.target"
+          ];
+          wantedBy = [ "sysinit.target" ];
+          pathConfig = {
+            DirectoryNotEmpty = "/run/systemd/ask-password";
+            MakeDirectory = true;
+          };
+        };
+      };
+    };
+  };
+}

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -211,7 +211,7 @@ let
             ''
               mkdir $out
               diskImage=$out/disk.img
-              ${qemu}/bin/qemu-img create -f qcow2 $diskImage "60M"
+              ${qemu}/bin/qemu-img create -f qcow2 $diskImage "${toString config.virtualisation.bootPartitionSize}M"
               ${if cfg.useEFIBoot then ''
                 efiVars=$out/efi-vars.fd
                 cp ${cfg.efi.variables} $efiVars
@@ -364,6 +364,16 @@ in
         description =
           lib.mdDoc ''
             The disk to be used for the root filesystem.
+          '';
+      };
+
+    virtualisation.bootPartitionSize =
+      mkOption {
+        type = types.ints.positive;
+        default = 60;
+        description =
+          lib.mdDoc ''
+            The partition size in megabytes of the boot partition.
           '';
       };
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -608,6 +608,7 @@ in {
   systemd-initrd-btrfs-raid = handleTest ./systemd-initrd-btrfs-raid.nix {};
   systemd-initrd-luks-fido2 = handleTest ./systemd-initrd-luks-fido2.nix {};
   systemd-initrd-luks-keyfile = handleTest ./systemd-initrd-luks-keyfile.nix {};
+  systemd-initrd-luks-osk-sdl = handleTest ./systemd-initrd-luks-osk-sdl.nix {};
   systemd-initrd-luks-password = handleTest ./systemd-initrd-luks-password.nix {};
   systemd-initrd-luks-tpm2 = handleTest ./systemd-initrd-luks-tpm2.nix {};
   systemd-initrd-modprobe = handleTest ./systemd-initrd-modprobe.nix {};

--- a/nixos/tests/systemd-initrd-luks-osk-sdl.nix
+++ b/nixos/tests/systemd-initrd-luks-osk-sdl.nix
@@ -1,0 +1,66 @@
+import ./make-test-python.nix ({ lib, pkgs, ... }: let
+  passphrase = "supersecret";
+in {
+  name = "systemd-initrd-luks-osk-sdl";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ tomfitzhenry ];
+  };
+
+  enableOCR = true;
+
+  nodes.machine = { pkgs, ... }: {
+    virtualisation = {
+      # Make room for GL in the initrd.
+      bootPartitionSize = 250;
+      emptyDiskImages = [ 512 512 ];
+      useBootLoader = true;
+      useEFIBoot = true;
+      qemu.options = [
+        "-vga virtio"
+      ];
+    };
+    boot.loader.systemd-boot.enable = true;
+
+    environment.systemPackages = with pkgs; [ cryptsetup ];
+    boot.initrd = {
+      systemd.enable = true;
+      osk-sdl.enable = true;
+    };
+
+    specialisation.boot-luks.configuration = {
+      boot.initrd.luks.devices = lib.mkVMOverride {
+        # We have two disks and only type one password - key reuse is in place
+        cryptroot.device = "/dev/vdc";
+        cryptroot2.device = "/dev/vdd";
+      };
+      virtualisation.bootDevice = "/dev/mapper/cryptroot";
+    };
+  };
+
+  testScript = ''
+    # Create encrypted volume
+    machine.wait_for_unit("multi-user.target")
+    machine.succeed("echo -n ${passphrase} | cryptsetup luksFormat -q --iter-time=1 /dev/vdc -")
+    machine.succeed("echo -n ${passphrase} | cryptsetup luksFormat -q --iter-time=1 /dev/vdd -")
+
+    # Boot from the encrypted disk
+    machine.succeed("bootctl set-default nixos-generation-1-specialisation-boot-luks.conf")
+    machine.succeed("sync")
+    machine.crash()
+
+    # Boot and decrypt the disk
+    machine.start()
+    import time
+    machine.wait_for_text("Enter disk decryption passphrase")
+    machine.screenshot("prompt")
+    for c in "${passphrase}":
+        machine.send_chars(c)
+        time.sleep(1)
+    machine.screenshot("pw")
+    machine.send_chars("\n")
+    machine.wait_for_unit("multi-user.target")
+
+    assert "/dev/mapper/cryptroot on / type ext4" in machine.succeed("mount")
+
+  '';
+})

--- a/pkgs/tools/misc/osk-sdl/default.nix
+++ b/pkgs/tools/misc/osk-sdl/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, stdenv
+, cryptsetup
+, dejavu_fonts
+, fetchFromGitLab
+, meson
+, ninja
+, pkg-config
+, scdoc
+, SDL2
+, SDL2_ttf
+}:
+stdenv.mkDerivation rec {
+  pname = "osk-sdl";
+  version = "0.67.1";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.com";
+    owner = "postmarketOS";
+    repo = pname;
+    rev = version;
+    hash = "sha256-IgtSGxMKqzm8iIILnJ1ZEXSW0R4k6Ffm734XGH+P58w=";
+  };
+
+  postPatch = ''
+    substituteInPlace osk.conf \
+      --replace /usr/share/fonts/ttf-dejavu/DejaVuSans.ttf ${dejavu_fonts}/share/fonts/truetype/DejaVuSans.ttf
+  '';
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    scdoc
+  ];
+
+  buildInputs = [
+    cryptsetup
+    dejavu_fonts
+    SDL2
+    SDL2_ttf
+  ];
+
+  meta = with lib; {
+    description = "SDL2 On-screen Keyboard";
+    homepage = "https://gitlab.com/postmarketOS/osk-sdl";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ tomfitzhenry ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/misc/osk-sdl/default.nix
+++ b/pkgs/tools/misc/osk-sdl/default.nix
@@ -1,4 +1,5 @@
 { lib
+, nixosTests
 , stdenv
 , cryptsetup
 , dejavu_fonts
@@ -40,6 +41,8 @@ stdenv.mkDerivation rec {
     SDL2
     SDL2_ttf
   ];
+
+  passthru.tests = nixosTests.systemd-initrd-luks-osk-sdl;
 
   meta = with lib; {
     description = "SDL2 On-screen Keyboard";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21695,6 +21695,8 @@ with pkgs;
 
   orcania = callPackage ../development/libraries/orcania { };
 
+  osk-sdl = callPackage ../tools/misc/osk-sdl { };
+
   osm-gps-map = callPackage ../development/libraries/osm-gps-map { };
 
   osmid = callPackage ../applications/audio/osmid {};


### PR DESCRIPTION
###### Description of changes

This PR introduces:
* a module `boot.initrd.osk-sdl`, which provides an on-screen keyboard to unlock LUKS volumes during initrd, using [osk-sdl](https://gitlab.com/postmarketOS/osk-sdl) acting as a [systemd pasword agent](https://systemd.io/PASSWORD_AGENTS/). This allows osk-sdl to act as one password agent amongst many (TPM, FIDO, console, etc.)
* the osk-sdl package itself
* a test covering osk-sdl: `systemd-initrd-luks-osk-sdl`. See below for screenshots.

osk-sdl is already packaged on [Debian](https://tracker.debian.org/pkg/osk-sdl), [PostmarketOS](https://gitlab.com/postmarketOS/pmaports/-/tree/master/main/osk-sdl), and [more](https://repology.org/project/osk-sdl/versions).

Limitations:

* Currently only supported on `boot.initrd.systemd`, the systemd-based initrd. Additional support can be added later.
* The test is failing on aarch64-linux, as with all other aarch64-linux tests that use systemd-boot: https://github.com/NixOS/nixpkgs/issues/199843.

## Tests performed

Working on:

* a x86_64 physical machine
* a Pinephone
* QEMU x86_64.

Screenshots below.

<details>
  <summary>QEMU x86_64</summary>

![prompt](https://user-images.githubusercontent.com/61303/200154530-354647d8-0c01-4e6f-833c-84ca95af641c.png)

![pw](https://user-images.githubusercontent.com/61303/200154531-51feab1a-7a77-426e-8616-75137577814b.png)

</details>

<details>
  <summary>Pinephone booting</summary>

![pinephone](https://user-images.githubusercontent.com/61303/200248025-7756fdce-0d51-4d46-aa2f-5e0b858241b3.jpeg)

</details>

<details>
  <summary>A physical x86_64 machine</summary>

![x86_64_desktop_prompt](https://user-images.githubusercontent.com/61303/200155189-1a8a6661-4d38-4dc4-95e7-b63eeb086959.jpeg)
![x86_64_desktop_pw](https://user-images.githubusercontent.com/61303/200155192-f6c9682a-6871-4e67-ac20-bd1abe83a77d.jpeg)

</details>



###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).