### PR TITLE
linuxPackages.lttng-modules: 2.13.2 -> 2.13.4

### DIFF
--- a/pkgs/os-specific/linux/lttng-modules/default.nix
+++ b/pkgs/os-specific/linux/lttng-modules/default.nix
@@ -1,13 +1,40 @@
-{ lib, stdenv, fetchurl, kernel }:
+{ lib, stdenv, fetchgit, fetchpatch, kernel }:
 
 stdenv.mkDerivation rec {
   pname = "lttng-modules-${kernel.version}";
-  version = "2.13.2";
+  version = "2.13.4";
 
-  src = fetchurl {
-    url = "https://lttng.org/files/lttng-modules/lttng-modules-${version}.tar.bz2";
-    sha256 = "sha256-39VH2QQcjFRa5be/7z8O8tnyUg1qtEGIyeqN5W1dKYo=";
+  src = fetchgit {
+    url = "https://git.lttng.org/lttng-modules.git";
+    rev = "v${version}";
+    hash = "sha256-J2Tr1vOiCAilmnf3attF3bz8Irn9IQ2QbapdXJ4MUSg=";
   };
+
+  patches = [
+    # fix: mm/page_alloc: fix tracepoint mm_page_alloc_zone_locked() (v5.19)
+    (fetchpatch {
+      url = "https://git.lttng.org/?p=lttng-modules.git;a=patch;h=6229bbaa423832f6b7c7a658ad11e1d4242752ff";
+      hash = "sha256-pqbKxBzjfN20wfsqSeBLXNQ+/U+3qk9RfTiT32OwSIc=";
+    })
+
+    # fix: fs: Remove flags parameter from aops->write_begin (v5.19)
+    (fetchpatch {
+      url = "https://git.lttng.org/?p=lttng-modules.git;a=patch;h=5e2f832d59d51589ab69479c7db43c7581fb9346";
+      hash = "sha256-auoCbvFEVR76sOCLjIe+q/Q+vunQlR3G3gVcjqAGGPk=";
+    })
+
+    # fix: workqueue: Fix type of cpu in trace event (v5.19)
+    (fetchpatch {
+      url = "https://git.lttng.org/?p=lttng-modules.git;a=patch;h=c6da9604b1666780ea4725b3b3d1bfa1548f9c89";
+      hash = "sha256-qoTwy+P32qg1L+JctqM1+70OkeTbnbL3QJ9LwaBq/bw=";
+    })
+
+    # fix: net: skb: introduce kfree_skb_reason() (v5.15.58..v5.16)
+    (fetchpatch {
+      url = "https://git.lttng.org/?p=lttng-modules.git;a=patch;h=96c477dabaaf6cd1734bebe0972fef877e5a463b";
+      hash = "sha256-b7BhrYZ5SZqeRVGEu0Eo9GfbcZdDPrgEnOl2XU3z+ds=";
+    })
+  ];
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
@@ -30,6 +57,5 @@ stdenv.mkDerivation rec {
     license = with licenses; [ lgpl21Only gpl2Only mit ];
     platforms = platforms.linux;
     maintainers = [ maintainers.bjornfor ];
-    broken = kernel.kernelAtLeast "5.18";
   };
 }


### PR DESCRIPTION
###### Description of changes

fix build for 5.18+

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
