### PR TITLE
exiv2: fix build on aarch64-darwin

### DIFF
--- a/pkgs/development/libraries/exiv2/default.nix
+++ b/pkgs/development/libraries/exiv2/default.nix
@@ -87,6 +87,8 @@ stdenv.mkDerivation rec {
       substituteInPlace  ../tests/bash_tests/testcases.py \
         --replace "def io_test(self):" "def io_disabled(self):"
      ''}
+  '' + lib.optionalString (stdenv.isDarwin && stdenv.isAarch64) ''
+    export LC_ALL=C
   '';
 
   # With CMake we have to enable samples or there won't be
@@ -120,6 +122,6 @@ stdenv.mkDerivation rec {
     description = "A library and command-line utility to manage image metadata";
     platforms = platforms.all;
     license = licenses.gpl2Plus;
-    maintainers = [ ];
+    maintainers = with maintainers; [ wegank ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Set `LC_ALL=C` while avoiding mass rebuilds. Closes #184265.

(I have no idea why it does not fail on x86_64-darwin...)

It would, of course, be better setting

```nix
  LC_ALL = "en_US.UTF-8";

  preCheck = ''
    patchShebangs ../test/
    mkdir ../test/tmp

    ${lib.optionalString stdenv.isDarwin ''
      export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH''${DYLD_LIBRARY_PATH:+:}$PWD/lib
      # disable tests that requires loopback networking
      substituteInPlace  ../tests/bash_tests/testcases.py \
        --replace "def io_test(self):" "def io_disabled(self):"
     ''}
  '';
```

But doing that will certainly cause mass rebuilds, and I prefer doing so at 0.27.6.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
