### PR TITLE
python3Packages.jupyter-repo2docker: add chardet dependency

### DIFF
--- a/pkgs/development/python-modules/jupyter-repo2docker/default.nix
+++ b/pkgs/development/python-modules/jupyter-repo2docker/default.nix
@@ -1,5 +1,6 @@
 { lib
 , buildPythonPackage
+, chardet
 , docker
 , entrypoints
 , escapism
@@ -30,6 +31,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
+    chardet
     docker
     entrypoints
     escapism


### PR DESCRIPTION
python3Packages.jupyter-repo2docker: add chardet dependency

This fix is necessary to avoid failed build at #177560