### PR TITLE
blink1-tool: 2.2.0 -> 2.3.0

### DIFF
--- a/pkgs/tools/misc/blink1-tool/default.nix
+++ b/pkgs/tools/misc/blink1-tool/default.nix
@@ -3,44 +3,62 @@
 , fetchFromGitHub
 , pkg-config
 , libusb1
+, darwin
+, blink1-tool
+, testers
 }:
 
 stdenv.mkDerivation rec {
-  pname = "blink1";
-  version = "2.2.0";
+  pname = "blink1-tool";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "todbot";
     repo = "blink1-tool";
     rev = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-xuCjPSQUQ/KOcdsie/ndecUiEt+t46m4eI33PXJoAAY=";
+    hash = "sha256-gwfz67vza+XoZk+zG3zEo4hW3R1GFrw9FzCzmN1mPkM=";
   };
 
   postPatch = ''
     substituteInPlace Makefile \
-      --replace "@git submodule update --init" "true"
+      --replace-fail "CFLAGS += -arch x86_64 -arch arm64" ""
+  '';
+  preInstall = ''
+    mkdir -p $out/lib $out/bin
+  '';
+
+  postInstall = ''
+    mkdir -p $out/lib/udev/rules.d
+    cp 51-blink1.rules $out/lib/udev/rules.d
   '';
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ libusb1 ];
+  buildInputs = [ libusb1 ] ++ lib.optional stdenv.hostPlatform.isDarwin darwin.apple_sdk.frameworks.AppKit;
 
   makeFlags = [
     "GIT_TAG=v${version}"
-    "USBLIB_TYPE=HIDAPI"
-    "HIDAPI_TYPE=LIBUSB"
+    "BLINK1_VERSION=${version}"
   ];
 
   hardeningDisable = [ "format" ];
 
   installFlags = [ "PREFIX=${placeholder "out"}" ];
 
-  meta = with lib; {
+  passthru = {
+    tests = {
+      version = testers.testVersion {
+        package = blink1-tool;
+      };
+    };
+  };
+
+  meta = {
     description = "Command line client for the blink(1) notification light";
     homepage = "https://blink1.thingm.com/";
-    license = with licenses; [ cc-by-sa-40 ];
-    maintainers = with maintainers; [ cransom ];
-    platforms = platforms.linux;
+    license = with lib.licenses; [ cc-by-sa-40 ];
+    maintainers = with lib.maintainers; [ cransom ];
+    platforms = lib.platforms.unix;
     mainProgram = "blink1-tool";
   };
 }


### PR DESCRIPTION
###### Description of changes

The auto update bot noticed 2.3.0 and I didn't realize that macos was never made a supported platform. After a few changes, it's now building under aarch64-darwin and the binary even works. I verified it under x86_64 linux as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
