### PR TITLE
deckmaster: init at 0.8.0

### DIFF
--- a/pkgs/applications/misc/deckmaster/default.nix
+++ b/pkgs/applications/misc/deckmaster/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, stdenv
+, buildGoModule
+, fetchFromGitHub
+, makeWrapper
+, roboto
+}:
+
+buildGoModule rec {
+  pname = "deckmaster";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "muesli";
+    repo = "deckmaster";
+    rev = "v${version}";
+    sha256 = "sha256-q2rUHfAvTGXBAGrZUtHMuZr6fYWmpha+al2FG8sCC0Y=";
+  };
+
+  vendorSha256 = "sha256-kj4lRHuQ9e0TOC4p4Ak3AB3Lx0JN1jqXaVKlee9EtCg=";
+
+  proxyVendor = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  # Let the app find Roboto-*.ttf files (hard-coded file names).
+  postFixup = ''
+    wrapProgram $out/bin/deckmaster \
+      --prefix XDG_DATA_DIRS : "${roboto.out}/share/" \
+  '';
+
+  meta = with lib; {
+    description = "An application to control your Elgato Stream Deck on Linux";
+    homepage = "https://github.com/muesli/deckmaster";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ianmjones ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7395,6 +7395,8 @@ with pkgs;
 
   bc-decaf = callPackage ../development/libraries/bc-decaf { };
 
+  deckmaster = callPackage ../applications/misc/deckmaster { };
+
   deco = callPackage ../applications/misc/deco { };
 
   decoder = callPackage ../tools/security/decoder { };


### PR DESCRIPTION
###### Description of changes

Adds `deckmaster` CLI application for controlling an Elgato Stream Deck on Linux.

See https://github.com/muesli/deckmaster for usage details, including sample deck config at https://github.com/muesli/deckmaster/tree/master/decks.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
