### PR TITLE
gcc: extend stripping of .a libraries and .o objects

### DIFF
--- a/pkgs/build-support/setup-hooks/strip.sh
+++ b/pkgs/build-support/setup-hooks/strip.sh
@@ -44,7 +44,7 @@ stripDirs() {
 
     local d
     for d in ${dirs}; do
-        if [ -d "$prefix/$d" ]; then
+        if [ -e "$prefix/$d" ]; then
             dirsNew="${dirsNew} $prefix/$d "
         fi
     done

--- a/pkgs/development/compilers/gcc/common/strip-attributes.nix
+++ b/pkgs/development/compilers/gcc/common/strip-attributes.nix
@@ -8,7 +8,9 @@
   # Example ARM breakage by x86_64 strip: https://bugs.gentoo.org/697428
   #
   # Let's recap the file layout for directories with object files for a
-  # cross-compiler (host != target):
+  # cross-compiler:
+  #
+  # $out (host != target)
   # `- bin: HOST
   #    lib/*.{a,o}: HOST
   #      `- gcc/<TARGET>/<VERSION>/*.{a,o}: TARGET
@@ -17,10 +19,16 @@
   #  `- libexec/: HOST
   #  `- <TARGET>/: TARGET
   #
-  # (host == target) has identical directory layout.
+  # $out (host == target) has identical directory layout.
+  #
+  # $lib (host != target):
+  # `- <TARGET>/lib/*.{la,so}: TARGET
+  #
+  # $lib (host == target):
+  # `- lib/*.{la,so}: HOST
 
   # The rest of stripDebugList{Host,Target} will be populated in
-  # postInstall.
+  # postInstall to disambiguate lib/ object files.
   stripDebugList = [ "bin" "libexec" ];
   stripDebugListTarget = [ stdenv.targetPlatform.config ];
 
@@ -32,21 +40,28 @@
       shopt -s nullglob
 
       pushd $out
-
-      local -ar hostFiles=(
-        lib{,32,64}/*.{a.o}
+      local -ar outHostFiles=(
+        lib{,32,64}/*.{a,o,so*}
         lib{,32,64}/gcc/${stdenv.targetPlatform.config}/*/plugin
       )
-      local -ar targetFiles=(
-        lib{,32,64}/gcc/${stdenv.targetPlatform.config}/*/*.{a.o}
+      local -ar outTargetFiles=(
+        lib{,32,64}/gcc/${stdenv.targetPlatform.config}/*/*.{a,o,so*}
       )
+      popd
 
-      stripDebugList="$stripDebugList ''${hostFiles[*]}"
-      stripDebugListTarget="$stripDebugListTarget ''${targetFiles[*]}"
-
+      pushd $lib
+      local -ar libHostFiles=(
+        lib{,32,64}/*.{a,o,so*}
+      )
+      local -ar libTargetFiles=(
+        lib{,32,64}/${stdenv.targetPlatform.config}/*.{a,o,so*}
+      )
       popd
 
       eval "$oldOpts"
+
+      stripDebugList="$stripDebugList ''${outHostFiles[*]} ''${libHostFiles[*]}"
+      stripDebugListTarget="$stripDebugListTarget ''${outTargetFiles[*]} ''${libTargetFiles[*]}"
     }
     updateDebugListPaths
   '';


### PR DESCRIPTION
The initial intent was to strip .a and .o files, not .a.o files.
While at it expanded stripping for $lib output as well.

Without the change `libgcc.a` was not stripped and `.debug*` sections
made into final binaries. It's not a problem on it's own, but it's an
unintended side-effect. Noticed on `crystal_1_0` test failure where
`crystal` was not able to handle `dwarf-5`.

While at it allowed absolute file names to be passed to stripDebugList
and friends.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
