### PR TITLE
vgo2nix: mark as not broken as it builds correctly

### DIFF
--- a/pkgs/development/tools/vgo2nix/default.nix
+++ b/pkgs/development/tools/vgo2nix/default.nix
@@ -17,8 +17,7 @@ buildGoModule {
     sha256 = "0n9pf0i5y59kiiv6dq8h8w1plaz9w6s67rqr2acqgxa45iq36mkh";
   };
 
-  vendorSha256 = "1xgl4avq0rblzqqpaxl4dwg4ysrhacwhfd21vb0v9ffr3zcpdw9n";
-  proxyVendor = true;
+  vendorSha256 = "sha256-e5n0QhgffzC1igZX1zS18IX5oF5F0Zy/s8jWyNOD8NM=";
 
   subPackages = [ "." ];
 
@@ -36,8 +35,5 @@ buildGoModule {
     license = licenses.mit;
     maintainers = with maintainers; [ adisbladis ];
     mainProgram = "vgo2nix";
-    # vendoring fails with cryptic error:
-    # reading file:///nix/store/..../github.com/orivej/e/@v/v0.0.0-20180728214217-ac3492690fda.zip: no such file or directory
-    broken = true;
   };
 }


### PR DESCRIPTION
###### Description of changes

vgo2nix is not broken. See build output (run from root of this repo on latest `master`):

```
$ nix-build -A vgo2nix
this derivation will be built:
  /nix/store/vqfsj40m0z8ws3ywb7smkilv0dssssk4-vgo2nix-unstable-2020-11-07.drv
these 3 paths will be fetched (13.23 MiB download, 14.77 MiB unpacked):
  /nix/store/ijk04rpm1j49015rp554p6xp48jxmhck-source
  /nix/store/lwbpw7ggzjkrjfsq9jgmkfz9qzzgj8p2-nix-prefetch-git
  /nix/store/njryw1dchsnkvrmj8h0ddpsfzn4c9r26-vgo2nix-unstable-2020-11-07-go-modules
copying path '/nix/store/ijk04rpm1j49015rp554p6xp48jxmhck-source' from 'https://cache.nixos.org'...
copying path '/nix/store/njryw1dchsnkvrmj8h0ddpsfzn4c9r26-vgo2nix-unstable-2020-11-07-go-modules' from 'https://cache.nixos.org'...
copying path '/nix/store/lwbpw7ggzjkrjfsq9jgmkfz9qzzgj8p2-nix-prefetch-git' from 'https://cache.nixos.org'...
building '/nix/store/vqfsj40m0z8ws3ywb7smkilv0dssssk4-vgo2nix-unstable-2020-11-07.drv'...
unpacking sources
unpacking source archive /nix/store/ijk04rpm1j49015rp554p6xp48jxmhck-source
source root is source
patching sources
configuring
building
Building subPackage ./.
go: downloading golang.org/x/mod v0.3.0
go: downloading github.com/orivej/go-nix v0.0.0-20180830055821-dae45d921a44
go: downloading golang.org/x/tools v0.0.0-20200904185747-39188db58858
go: downloading github.com/orivej/e v0.0.0-20180728214217-ac3492690fda
go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
golang.org/x/mod/semver
golang.org/x/xerrors/internal
github.com/orivej/e
golang.org/x/xerrors
github.com/orivej/go-nix/nix/parser
golang.org/x/tools/go/vcs
golang.org/x/mod/module
github.com/orivej/go-nix/nix/eval
github.com/nix-community/vgo2nix
running tests
?       github.com/nix-community/vgo2nix        [no test files]
installing
post-installation fixup
shrinking RPATHs of ELF executables and libraries in /nix/store/3lhybidm00lda8jrdi0anjjvlvp4m07a-vgo2nix-unstable-2020-11-07
shrinking /nix/store/3lhybidm00lda8jrdi0anjjvlvp4m07a-vgo2nix-unstable-2020-11-07/bin/.vgo2nix-wrapped
strip is /nix/store/2vqbkw1s50pvk970k06wkzialgk7jp7v-gcc-wrapper-11.3.0/bin/strip
stripping (with command strip and flags -S) in /nix/store/3lhybidm00lda8jrdi0anjjvlvp4m07a-vgo2nix-unstable-2020-11-07/bin
patching script interpreter paths in /nix/store/3lhybidm00lda8jrdi0anjjvlvp4m07a-vgo2nix-unstable-2020-11-07
checking for references to /build/ in /nix/store/3lhybidm00lda8jrdi0anjjvlvp4m07a-vgo2nix-unstable-2020-11-07...
/nix/store/3lhybidm00lda8jrdi0anjjvlvp4m07a-vgo2nix-unstable-2020-11-07
```

I can also run it just fine:

```
$ /nix/store/3lhybidm00lda8jrdi0anjjvlvp4m07a-vgo2nix-unstable-2020-11-07/bin/vgo2nix -h
Usage of /nix/store/3lhybidm00lda8jrdi0anjjvlvp4m07a-vgo2nix-unstable-2020-11-07/bin/vgo2nix:
  -dir string
    	Go project directory (default "./")
  -infile string
    	deps.nix input file (relative to project directory) (default "deps.nix")
  -jobs int
    	Number of parallel jobs (default 20)
  -keep-going
    	Whether to panic or not if a rev cannot be resolved (default "false")
  -outfile string
    	deps.nix output file (relative to project directory) (default "deps.nix")
```

Signed-off-by: Sumner Evans <me@sumnerevans.com>

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
