### PR TITLE
joomscan: init at unstable-2021-06-08

### DIFF
--- a/pkgs/tools/security/joomscan/default.nix
+++ b/pkgs/tools/security/joomscan/default.nix
@@ -1,0 +1,38 @@
+{ lib, stdenv, fetchFromGitHub, perl, makeWrapper }:
+
+let
+  p = perl.withPackages (ps: with ps; [ LWP LWPProtocolHttps ]);
+in
+stdenv.mkDerivation rec {
+  pname = "joomscan";
+  version = "unstable-2021-06-08";
+
+  src = fetchFromGitHub {
+    owner = "owasp";
+    repo = pname;
+    rev = "79315393509caa39895e553c489667636ac31b85";
+    sha256 = "Yg91iUhqbKZyPghiX0UZ7S1ql0DZLtPHOk9VEY1ZZOg=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share
+    cp -r . $out/share/joomscan
+    makeWrapper ${p}/bin/perl $out/bin/joomscan.pl \
+      --add-flags $out/share/joomscan/joomscan.pl
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Joomla Vulnerability Scanner";
+    homepage = "https://wiki.owasp.org/index.php/Category:OWASP_Joomla_Vulnerability_Scanner_Project";
+    mainProgram = "joomscan.pl";
+    maintainers = with maintainers; [ emilytrau ];
+    license = licenses.gpl3Only;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7654,6 +7654,8 @@ with pkgs;
 
   john = callPackage ../tools/security/john { };
 
+  joomscan = callPackage ../tools/security/joomscan { };
+
   joplin = nodePackages.joplin;
 
   joplin-desktop = callPackage ../applications/misc/joplin-desktop { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

OWASP Joomla Vulnerability Scanner Project 

Request from #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
