### PR TITLE
opensk-udev-rules: init at ctap2.0

### DIFF
--- a/pkgs/os-specific/linux/opensk-udev-rules/55-opensk.rules
+++ b/pkgs/os-specific/linux/opensk-udev-rules/55-opensk.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="hidraw", SUBSYSTEMS=="usb", ATTRS{idVendor}=="1915", ATTRS{idProduct}=="521f", ATTRS{product}=="OpenSK", MODE="0660", GROUP="logindev", TAG+="uaccess"

--- a/pkgs/os-specific/linux/opensk-udev-rules/default.nix
+++ b/pkgs/os-specific/linux/opensk-udev-rules/default.nix
@@ -1,0 +1,24 @@
+{ lib
+, stdenv
+}:
+## Usage
+# In NixOS, simply add this package to services.udev.packages:
+#   services.udev.packages = [ pkgs.opensk-udev-rules ];
+stdenv.mkDerivation rec {
+  pname = "opensk-udev-rules";
+  version = "ctap2.0";
+  udevRules = ./55-opensk.rules;
+  dontUnpack = true;
+
+  installPhase = ''
+    install -Dm 644 "${udevRules}" $out/lib/udev/rules.d/55-opensk.rules
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/google/OpenSK";
+    description = "Official OpenSK udev rules list";
+    platforms = platforms.linux;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ oluceps ];
+  };
+}

--- a/pkgs/os-specific/linux/opensk-udev-rules/update.sh
+++ b/pkgs/os-specific/linux/opensk-udev-rules/update.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+wget -O 55-opensk.rules "https://raw.githubusercontent.com/google/OpenSK/stable/rules.d/55-opensk.rules"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25653,6 +25653,8 @@ with pkgs;
 
   open-sans = callPackage ../data/fonts/open-sans { };
 
+  opensk-udev-rules = callPackage ../os-specific/linux/opensk-udev-rules { };
+
   openmoji-color = callPackage ../data/fonts/openmoji { variant = "color"; };
 
   openmoji-black = callPackage ../data/fonts/openmoji { variant = "black"; };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
