### PR TITLE
woodpecker-cli: patch out spurious CA certs errors

### DIFF
--- a/pkgs/development/tools/continuous-integration/woodpecker/cli.nix
+++ b/pkgs/development/tools/continuous-integration/woodpecker/cli.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, callPackage, fetchFromGitHub }:
+{ lib, buildGoModule, callPackage, fetchFromGitHub, fetchpatch }:
 let
   common = callPackage ./common.nix { };
 in
@@ -6,6 +6,16 @@ buildGoModule {
   pname = "woodpecker-cli";
   inherit (common) version src ldflags postBuild;
   vendorSha256 = null;
+
+  patches = [
+    # Fixes https://github.com/NixOS/nixpkgs/issues/184875, until a new version
+    # is released.
+    (fetchpatch {
+      name = "display-system-ca-error-only-if-there-is-an-error.patch";
+      url = "https://github.com/woodpecker-ci/woodpecker/commit/1fb800329488de74c9db7cfc5dc43fb5a4efbad8.patch";
+      sha256 = "sha256-wKI/7PhbxsAD/qrl4nnkHyyQhQcvGlySysnxytGJzfU=";
+    })
+  ];
 
   subPackages = "cmd/cli";
 


### PR DESCRIPTION
Closes #184875.

###### Description of changes

Closes #184875.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).