### PR TITLE
cmctl: fix version encoded inside binary

### DIFF
--- a/pkgs/applications/networking/cluster/cmctl/default.nix
+++ b/pkgs/applications/networking/cluster/cmctl/default.nix
@@ -7,8 +7,8 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "cert-manager";
     repo = "cert-manager";
-    rev = "v${version}";
-    hash = "sha256-Z1aJ18X4mfJPlCPBC7QgfdX5Tk4+PK8mYoJZhGwz9ec=";
+    rev = "4486c01f726f17d2790a8a563ae6bc6e98465505";
+    sha256 = "1rzm6dn88nc2c8kayg1y9r7gkmbx42s0ph93ji7z56gqqpbqjmk7";
   };
 
   vendorSha256 = "sha256-45+tZZAEHaLdTN1NQCueJVTx5x2IanwDl+Y9MELqdBE=";
@@ -19,6 +19,8 @@ buildGoModule rec {
     "-s" "-w"
     "-X github.com/cert-manager/cert-manager/cmd/ctl/pkg/build.name=cmctl"
     "-X github.com/cert-manager/cert-manager/cmd/ctl/pkg/build/commands.registerCompletion=true"
+    "-X github.com/cert-manager/cert-manager/pkg/util.AppVersion=v${version}"
+    "-X github.com/cert-manager/cert-manager/pkg/util.AppGitCommit=${src.rev}"
   ];
 
   nativeBuildInputs = [ installShellFiles ];
@@ -49,4 +51,3 @@ buildGoModule rec {
     maintainers = with maintainers; [ joshvanl superherointj ];
   };
 }
-

--- a/pkgs/applications/networking/cluster/cmctl/update.sh
+++ b/pkgs/applications/networking/cluster/cmctl/update.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnugrep gnused jq
+
+set -x -eu -o pipefail
+
+NIXPKGS_PATH="$(git rev-parse --show-toplevel)"
+CMCTL_PATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+
+OLD_VERSION="$(nix-instantiate --eval -E "with import $NIXPKGS_PATH {}; cmctl.version or (builtins.parseDrvName cmctl.name).version" | tr -d '"')"
+LATEST_TAG="$(curl -s ${GITHUB_TOKEN:+"-u \":$GITHUB_TOKEN\""} "https://api.github.com/repos/cert-manager/cert-manager/releases" | jq '.[].tag_name' --raw-output | sed '/-/d' | sort --version-sort -r | head -n 1)"
+LATEST_VERSION="${LATEST_TAG:1}"
+
+if [ ! "$OLD_VERSION" = "$LATEST_VERSION" ]; then
+    SHA256=$(nix-prefetch-url --quiet --unpack https://github.com/cert-manager/cert-manager/archive/refs/tags/${LATEST_TAG}.tar.gz)
+    TAG_SHA=$(curl -s ${GITHUB_TOKEN:+"-u \":$GITHUB_TOKEN\""}  "https://api.github.com/repos/cert-manager/cert-manager/git/ref/tags/${LATEST_TAG}" | jq -r '.object.sha')
+    TAG_COMMIT_SHA=$(curl -s ${GITHUB_TOKEN:+"-u \":$GITHUB_TOKEN\""} "https://api.github.com/repos/cert-manager/cert-manager/git/tags/${TAG_SHA}" | jq '.object.sha' --raw-output)
+
+    setKV () {
+        sed -i "s|$1 = \".*\"|$1 = \"${2:-}\"|" "${CMCTL_PATH}/default.nix"
+    }
+
+    setKV version ${LATEST_VERSION}
+    setKV sha256 "${SHA256}"
+    setKV rev ${TAG_COMMIT_SHA}
+    setKV vendorSha256 "0000000000000000000000000000000000000000000000000000" # The same as lib.fakeSha256
+
+    set +e
+    VENDOR_SHA256=$(nix-build --no-out-link -A cmctl $NIXPKGS_PATH 2>&1 >/dev/null | grep "got:" | cut -d':' -f2 | sed 's| ||g')
+    set -e
+
+    if [ -n "${VENDOR_SHA256:-}" ]; then
+        setKV vendorSha256 ${VENDOR_SHA256}
+    else
+        echo "Update failed. VENDOR_SHA256 is empty."
+        exit 1
+    fi
+
+    echo "updated cmctl to $LATEST_VERSION, please commit changes."
+else
+    echo "cmctl is already up-to-date at $OLD_VERSION"
+fi


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Currently `cmctl` displays no real version with the `cmctl version` command.

This PR includes ld flags to encode the version and git commit when building so they are correctly displayed.

Cross reference git commit [here](https://github.com/cert-manager/cert-manager/releases/tag/v1.9.1)

Before PR:

```terminal
$ cmctl version --client
Client Version: util.Version{GitVersion:"canary", GitCommit:"", GitTreeState:"", GoVersion:"go1.18.4", Compiler:"gc", Platform:"linux/amd64"}
```

After PR:

```terminal
$ [nix-shell:~/.cache/nixpkgs-review/rev-a9a6c5d102305af758fb1ca094a8d5323799c1d4-dirty]$ ./results/cmctl/bin/cmctl version --client
Client Version: util.Version{GitVersion:"v1.9.1", GitCommit:"4486c01f726f17d2790a8a563ae6bc6e98465505", GitTreeState:"", GoVersion:"go1.18.4", Compiler:"gc", Platform:"linux/amd64"}
```

This is the same output when downloading the [releases version](https://github.com/cert-manager/cert-manager/releases/tag/v1.9.1):

```terminal
$ ./cmctl version --client
Client Version: util.Version{GitVersion:"v1.9.1", GitCommit:"4486c01f726f17d2790a8a563ae6bc6e98465505", GitTreeState:"", GoVersion:"go1.18.3", Compiler:"gc", Platform:"linux/amd64"}
```

---

**Note**: I've gone and hard coded the git commit. I do not know of a way to reference a GitHub tagged revision, and then be able to reference the resulting git _commit_. Perhaps there is a trick I am missing.

/assign @superherointj 


--- 

    Adds an `update.sh` script which can be used to update the version of
    cmctl. Will automatically fetch the latest semvar release of cmctl, and
    update hashes accordingly in `default.nix`.

---


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
~- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))~
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
