### PR TITLE
skipfish: init at 2.10b

### DIFF
--- a/pkgs/tools/security/skipfish/absolute-paths.patch
+++ b/pkgs/tools/security/skipfish/absolute-paths.patch
@@ -1,0 +1,49 @@
+--- a/src/config.h 2012-09-01 07:53:25.000000000 +0200
++++ b/src/config.h 2012-09-05 09:08:37.099387176 +0200
+@@ -35,10 +35,10 @@
+ 
+ /* Default paths to runtime files: */
+ 
+-#define ASSETS_DIR              "assets"
++#define ASSETS_DIR              "@out@/share/skipfish/assets"
+ 
+ /* Default signature file */
+-#define SIG_FILE                "signatures/signatures.conf"
++#define SIG_FILE                "@out@/share/skipfish/signatures/signatures.conf"
+ 
+ /* Various default settings for HTTP client (cmdline override): */
+
+
+--- a/signatures/signatures.conf 2012-09-01 07:53:25.000000000 +0200
++++ b/signatures/signatures.conf 2012-09-05 09:09:10.027968510 +0200
+@@ -6,23 +6,23 @@
+ # The mime signatures warn about server responses that have an interesting
+ # mime. For example anything that is presented as php-source will likely
+ # be interesting
+-include signatures/mime.sigs
++include @out@/share/skipfish/signatures/mime.sigs
+ 
+ # The files signature will use the content to determine if a response
+ # is an interesting file. For example, a SVN file.
+-include signatures/files.sigs
++include @out@/share/skipfish/signatures/files.sigs
+ 
+ # The messages signatures look for interesting server messages. Most
+ # are based on errors, such as caused by incorrect SQL queries or PHP
+ # execution failures.
+-include signatures/messages.sigs
++include @out@/share/skipfish/signatures/messages.sigs
+ 
+ # The apps signatures will help to find pages and applications who's
+ # functionality is a security risk by default. For example, phpinfo()
+ # pages that leak information or CMS admin interfaces.
+-include signatures/apps.sigs
++include @out@/share/skipfish/signatures/apps.sigs
+ 
+ # Context signatures are linked to injection tests. They look for strings
+ # that are relevant to the current injection test and help to highlight
+ # potential vulnerabilities.
+-include signatures/context.sigs
++include @out@/share/skipfish/signatures/context.sigs
+
+  

--- a/pkgs/tools/security/skipfish/default.nix
+++ b/pkgs/tools/security/skipfish/default.nix
@@ -1,0 +1,59 @@
+{ lib, stdenv, fetchurl, fetchpatch, openssl, pcre, libidn, zlib }:
+
+stdenv.mkDerivation rec {
+  pname = "skipfish";
+  version = "2.10b";
+
+  src = fetchurl {
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/skipfish/skipfish-${version}.tgz";
+    sha256 = "17ia6p2q4v6j9achq47lnwkn29j3v4l75sj616brn7rz06fvqkqs";
+  };
+
+  patches = [
+    # Provide absolute store paths to data files
+    ./absolute-paths.patch
+
+    # Fix compilation for modern openssl
+    # https://gitlab.com/kalilinux/packages/skipfish/-/blob/903a0457ee029d3401c515120efae6fe0dcddfa1/debian/patches/Fix-for-openssl-1.1.patch
+    (fetchpatch {
+      url = "https://gitlab.com/kalilinux/packages/skipfish/-/raw/903a0457ee029d3401c515120efae6fe0dcddfa1/debian/patches/Fix-for-openssl-1.1.patch";
+      sha256 = "0cgx7qnfyrf6sc3b6186nrqmssqcl7kf33xblxgmcipzr073r6r2";
+    })
+    # https://gitlab.com/kalilinux/packages/skipfish/-/blob/903a0457ee029d3401c515120efae6fe0dcddfa1/debian/patches/Fix-broken-ciphersuite-evaluation-for-newer-OpenSSLs.patch
+    (fetchpatch {
+      url = "https://gitlab.com/kalilinux/packages/skipfish/-/raw/903a0457ee029d3401c515120efae6fe0dcddfa1/debian/patches/Fix-broken-ciphersuite-evaluation-for-newer-OpenSSLs.patch";
+      sha256 = "1jqj31v8iw638jgs38l1gmh8iyml8bp2fjcn4yips6dq49vgndf1";
+    })
+  ];
+
+  postPatch = ''
+    substituteAllInPlace src/config.h
+    substituteAllInPlace signatures/signatures.conf
+    substituteInPlace signatures/signatures.conf \
+      --replace "include signatures" "include $out/share/skipfish/signatures"
+  '';
+
+  buildInputs = [
+    openssl
+    pcre
+    libidn
+    zlib
+  ];
+
+  hardeningDisable = [ "format" ];
+
+  installPhase = ''
+    install -Dm755 skipfish $out/bin/skipfish
+    install -Dm755 tools/sfscandiff $out/bin/sfscandiff
+    mkdir -p $out/share/skipfish
+    cp -r assets doc signatures config $out/share/skipfish
+  '';
+
+  meta = with lib; {
+    description = "Fully automated, active web application security reconnaissance tool";
+    homepage = "https://code.google.com/archive/p/skipfish/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ emilytrau ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10686,6 +10686,8 @@ with pkgs;
 
   skippy-xd = callPackage ../tools/X11/skippy-xd {};
 
+  skipfish = callPackage ../tools/security/skipfish { };
+
   sks = callPackage ../servers/sks {
     ocamlPackages = ocaml-ng.ocamlPackages_4_12;
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fully automated, active web application security reconnaissance tool
https://code.google.com/archive/p/skipfish/

Request from #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
