### PR TITLE
treewide: remove myself as maintainer from some pkgs

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -43,7 +43,7 @@ in rec {
       name = "nixos-${nixos.channel.version}";
       meta = {
         description = "Release-critical builds for the NixOS channel";
-        maintainers = with pkgs.lib.maintainers; [ eelco fpletz ];
+        maintainers = with pkgs.lib.maintainers; [ eelco ];
       };
       constituents = pkgs.lib.concatLists [
         [ "nixos.channel" ]

--- a/nixos/tests/couchdb.nix
+++ b/nixos/tests/couchdb.nix
@@ -20,7 +20,7 @@ with lib;
 {
   name = "couchdb";
   meta = with pkgs.lib.maintainers; {
-    maintainers = [ fpletz ];
+    maintainers = [ ];
   };
 
   nodes = {

--- a/nixos/tests/privacyidea.nix
+++ b/nixos/tests/privacyidea.nix
@@ -3,7 +3,7 @@
 import ./make-test-python.nix ({ pkgs, ...} : rec {
   name = "privacyidea";
   meta = with pkgs.lib.maintainers; {
-    maintainers = [ fpletz ];
+    maintainers = [ ];
   };
 
   nodes.machine = { ... }: {

--- a/pkgs/applications/blockchains/masari/default.nix
+++ b/pkgs/applications/blockchains/masari/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     description = "scalability-focused, untraceable, secure, and fungible cryptocurrency using the RingCT protocol";
     homepage = "https://www.getmasari.org/";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ fpletz ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/blockchains/sumokoin/default.nix
+++ b/pkgs/applications/blockchains/sumokoin/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     description = "A fork of Monero and a truely fungible cryptocurrency";
     homepage = "https://www.sumokoin.org/";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ fpletz ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/misc/kanboard/default.nix
+++ b/pkgs/applications/misc/kanboard/default.nix
@@ -22,6 +22,6 @@ stdenv.mkDerivation rec {
     description = "Kanban project management software";
     homepage = "https://kanboard.net";
     license = licenses.mit;
-    maintainers = with maintainers; [ fpletz lheckemann ];
+    maintainers = with maintainers; [ lheckemann ];
   };
 }

--- a/pkgs/applications/misc/xmr-stak/default.nix
+++ b/pkgs/applications/misc/xmr-stak/default.nix
@@ -35,6 +35,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/fireice-uk/xmr-stak";
     license = licenses.gpl3Plus;
     platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [ fpletz bfortz ];
+    maintainers = with maintainers; [ bfortz ];
   };
 }

--- a/pkgs/applications/misc/xmrig/default.nix
+++ b/pkgs/applications/misc/xmrig/default.nix
@@ -33,6 +33,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/xmrig/xmrig";
     license = licenses.gpl3Plus;
     platforms   = [ "x86_64-linux" "x86_64-darwin" ];
-    maintainers = with maintainers; [ fpletz kim0 ];
+    maintainers = with maintainers; [ kim0 ];
   };
 }

--- a/pkgs/applications/networking/cluster/minishift/default.nix
+++ b/pkgs/applications/networking/cluster/minishift/default.nix
@@ -59,7 +59,7 @@ in buildGoPackage rec {
       or develop with it, day-to-day, on your local host.
     '';
     homepage = "https://github.com/minishift/minishift";
-    maintainers = with maintainers; [ fpletz vdemeester ];
+    maintainers = with maintainers; [ vdemeester ];
     platforms = platforms.linux;
     license = licenses.asl20;
   };

--- a/pkgs/applications/networking/errbot/default.nix
+++ b/pkgs/applications/networking/errbot/default.nix
@@ -63,7 +63,7 @@ in python3.pkgs.buildPythonApplication rec {
   meta = with lib; {
     description = "Chatbot designed to be simple to extend with plugins written in Python";
     homepage = "http://errbot.io/";
-    maintainers = with maintainers; [ fpletz globin ];
+    maintainers = with maintainers; [ globin ];
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
     # flaky on darwin, "RuntimeError: can't start new thread"

--- a/pkgs/applications/networking/opsdroid/default.nix
+++ b/pkgs/applications/networking/opsdroid/default.nix
@@ -29,7 +29,7 @@ python3Packages.buildPythonPackage rec {
   meta = with lib; {
     description = "An open source chat-ops bot framework";
     homepage = "https://opsdroid.dev";
-    maintainers = with maintainers; [ fpletz globin willibutz ];
+    maintainers = with maintainers; [ globin willibutz ];
     license = licenses.asl20;
     platforms = platforms.unix;
   };

--- a/pkgs/applications/version-management/gitlab/default.nix
+++ b/pkgs/applications/version-management/gitlab/default.nix
@@ -203,7 +203,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     homepage = "http://www.gitlab.com/";
     platforms = platforms.linux;
-    maintainers = with maintainers; [ fpletz globin krav talyz yayayayaka yuka ];
+    maintainers = with maintainers; [ globin krav talyz yayayayaka yuka ];
   } // (if gitlabEnterprise then
     {
       license = licenses.unfreeRedistributable; # https://gitlab.com/gitlab-org/gitlab-ee/raw/master/LICENSE

--- a/pkgs/applications/version-management/gitlab/gitaly/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/default.nix
@@ -52,7 +52,7 @@ buildGoModule {
     homepage = "https://gitlab.com/gitlab-org/gitaly";
     description = "A Git RPC service for handling all the git calls made by GitLab";
     platforms = platforms.linux ++ [ "x86_64-darwin" ];
-    maintainers = with maintainers; [ roblabla globin fpletz talyz yayayayaka ];
+    maintainers = with maintainers; [ roblabla globin talyz yayayayaka ];
     license = licenses.mit;
   };
 }

--- a/pkgs/applications/version-management/gitlab/gitlab-shell/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-shell/default.nix
@@ -26,7 +26,7 @@ buildGoModule rec {
     description = "SSH access and repository management app for GitLab";
     homepage = "http://www.gitlab.com/";
     platforms = platforms.linux;
-    maintainers = with maintainers; [ fpletz globin talyz yayayayaka ];
+    maintainers = with maintainers; [ globin talyz yayayayaka ];
     license = licenses.mit;
   };
 }

--- a/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
@@ -24,7 +24,7 @@ buildGoModule rec {
   meta = with lib; {
     homepage = "http://www.gitlab.com/";
     platforms = platforms.linux;
-    maintainers = with maintainers; [ fpletz globin talyz yayayayaka ];
+    maintainers = with maintainers; [ globin talyz yayayayaka ];
     license = licenses.mit;
   };
 }

--- a/pkgs/development/compilers/zulu/8.nix
+++ b/pkgs/development/compilers/zulu/8.nix
@@ -112,7 +112,7 @@ in stdenv.mkDerivation {
       Certified builds of OpenJDK that can be deployed across multiple
       operating systems, containers, hypervisors and Cloud platforms.
     '';
-    maintainers = with maintainers; [ fpletz ];
+    maintainers = with maintainers; [ ];
     platforms = [ "x86_64-linux" "x86_64-darwin" ];
     mainProgram = "java";
   };

--- a/pkgs/development/compilers/zulu/default.nix
+++ b/pkgs/development/compilers/zulu/default.nix
@@ -117,7 +117,7 @@ in stdenv.mkDerivation {
       Certified builds of OpenJDK that can be deployed across multiple
       operating systems, containers, hypervisors and Cloud platforms.
     '';
-    maintainers = with maintainers; [ fpletz ];
+    maintainers = with maintainers; [ ];
     platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
     mainProgram = "java";
   };

--- a/pkgs/development/libraries/gnutls/default.nix
+++ b/pkgs/development/libraries/gnutls/default.nix
@@ -124,7 +124,7 @@ stdenv.mkDerivation rec {
 
     homepage = "https://gnutls.org/";
     license = licenses.lgpl21Plus;
-    maintainers = with maintainers; [ eelco fpletz ];
+    maintainers = with maintainers; [ eelco ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/jose/default.nix
+++ b/pkgs/development/libraries/jose/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "C-language implementation of Javascript Object Signing and Encryption";
     homepage = "https://github.com/latchset/jose";
-    maintainers = with lib.maintainers; [ fpletz ];
+    maintainers = with lib.maintainers; [ ];
     license = lib.licenses.asl20;
   };
 }

--- a/pkgs/development/libraries/lame/default.nix
+++ b/pkgs/development/libraries/lame/default.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
     description = "A high quality MPEG Audio Layer III (MP3) encoder";
     homepage    = "http://lame.sourceforge.net";
     license     = licenses.lgpl2;
-    maintainers = with maintainers; [ codyopel fpletz ];
+    maintainers = with maintainers; [ codyopel ];
     platforms   = platforms.all;
   };
 }

--- a/pkgs/development/libraries/mbedtls/default.nix
+++ b/pkgs/development/libraries/mbedtls/default.nix
@@ -44,6 +44,6 @@ stdenv.mkDerivation rec {
     description = "Portable cryptographic and TLS library, formerly known as PolarSSL";
     license = licenses.asl20;
     platforms = platforms.all;
-    maintainers = with maintainers; [ fpletz ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/mitmproxy/default.nix
+++ b/pkgs/development/python-modules/mitmproxy/default.nix
@@ -121,6 +121,6 @@ buildPythonPackage rec {
     description = "Man-in-the-middle proxy";
     homepage = "https://mitmproxy.org/";
     license = licenses.mit;
-    maintainers = with maintainers; [ kamilchm ];
+    maintainers = with maintainers; [ kamilchm SuperSandro2000 ];
   };
 }

--- a/pkgs/development/python-modules/mitmproxy/default.nix
+++ b/pkgs/development/python-modules/mitmproxy/default.nix
@@ -121,6 +121,6 @@ buildPythonPackage rec {
     description = "Man-in-the-middle proxy";
     homepage = "https://mitmproxy.org/";
     license = licenses.mit;
-    maintainers = with maintainers; [ fpletz kamilchm ];
+    maintainers = with maintainers; [ kamilchm ];
   };
 }

--- a/pkgs/development/tools/continuous-integration/jenkins/default.nix
+++ b/pkgs/development/tools/continuous-integration/jenkins/default.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
     homepage = "https://jenkins-ci.org";
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.mit;
-    maintainers = with maintainers; [ coconnor fpletz earldouglas nequissimus ];
+    maintainers = with maintainers; [ coconnor earldouglas nequissimus ];
     mainProgram = "jenkins-cli";
     platforms = platforms.all;
   };

--- a/pkgs/development/tools/lazygit/default.nix
+++ b/pkgs/development/tools/lazygit/default.nix
@@ -21,6 +21,6 @@ buildGoModule rec {
     homepage = "https://github.com/jesseduffield/lazygit";
     changelog = "https://github.com/jesseduffield/lazygit/releases/tag/v${version}";
     license = licenses.mit;
-    maintainers = with maintainers; [ fpletz equirosa Br1ght0ne ];
+    maintainers = with maintainers; [ equirosa Br1ght0ne ];
   };
 }

--- a/pkgs/games/bzflag/default.nix
+++ b/pkgs/games/bzflag/default.nix
@@ -20,6 +20,6 @@ stdenv.mkDerivation rec {
     homepage = "https://bzflag.org/";
     license = licenses.lgpl21Plus;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ fpletz ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/games/urbanterror/default.nix
+++ b/pkgs/games/urbanterror/default.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "http://www.urbanterror.info";
     license = licenses.unfreeRedistributable;
-    maintainers = with maintainers; [ astsmtl fpletz ];
+    maintainers = with maintainers; [ astsmtl ];
     platforms = platforms.linux;
     hydraPlatforms = [];
   };

--- a/pkgs/misc/screensavers/electricsheep/default.nix
+++ b/pkgs/misc/screensavers/electricsheep/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Electric Sheep, a distributed screen saver for evolving artificial organisms";
     homepage = "https://electricsheep.org/";
-    maintainers = with maintainers; [ fpletz ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
     license = licenses.gpl1;
   };

--- a/pkgs/os-specific/linux/lxc/default.nix
+++ b/pkgs/os-specific/linux/lxc/default.nix
@@ -94,6 +94,6 @@ stdenv.mkDerivation rec {
     '';
 
     platforms = platforms.linux;
-    maintainers = with maintainers; [ fpletz ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/os-specific/linux/lxcfs/default.nix
+++ b/pkgs/os-specific/linux/lxcfs/default.nix
@@ -46,6 +46,6 @@ stdenv.mkDerivation rec {
     changelog = "https://linuxcontainers.org/lxcfs/news/";
     license = licenses.asl20;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ mic92 fpletz ];
+    maintainers = with maintainers; [ mic92 ];
   };
 }

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -203,7 +203,7 @@ let
         changelog = "https://github.com/openzfs/zfs/releases/tag/zfs-${version}";
         license = lib.licenses.cddl;
         platforms = lib.platforms.linux;
-        maintainers = with lib.maintainers; [ hmenke jcumming jonringer wizeman fpletz globin ];
+        maintainers = with lib.maintainers; [ hmenke jcumming jonringer wizeman globin ];
         mainProgram = "zfs";
         # If your Linux kernel version is not yet supported by zfs, try zfsUnstable.
         # On NixOS set the option boot.zfs.enableUnstable.

--- a/pkgs/servers/atlassian/confluence.nix
+++ b/pkgs/servers/atlassian/confluence.nix
@@ -52,6 +52,6 @@ optionalWarning (crowdProperties != null) "Using `crowdProperties` is deprecated
     homepage = "https://www.atlassian.com/software/confluence";
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.unfree;
-    maintainers = with maintainers; [ fpletz globin willibutz ciil techknowlogick ma27 ];
+    maintainers = with maintainers; [ globin willibutz ciil techknowlogick ma27 ];
   };
 })

--- a/pkgs/servers/atlassian/crowd.nix
+++ b/pkgs/servers/atlassian/crowd.nix
@@ -51,6 +51,6 @@ optionalWarning (openidPassword != "WILL_NEVER_BE_SET") "Using `crowdProperties`
     description = "Single sign-on and identity management tool";
     homepage = "https://www.atlassian.com/software/crowd";
     license = licenses.unfree;
-    maintainers = with maintainers; [ fpletz globin ];
+    maintainers = with maintainers; [ globin ];
   };
 })

--- a/pkgs/servers/atlassian/jira.nix
+++ b/pkgs/servers/atlassian/jira.nix
@@ -39,6 +39,6 @@ stdenv.mkDerivation rec {
     description = "Proprietary issue tracking product, also providing project management functions";
     homepage = "https://www.atlassian.com/software/jira";
     license = licenses.unfree;
-    maintainers = with maintainers; [ fpletz globin ciil megheaiulian techknowlogick ma27 ];
+    maintainers = with maintainers; [ globin ciil megheaiulian techknowlogick ma27 ];
   };
 }

--- a/pkgs/servers/bird/default.nix
+++ b/pkgs/servers/bird/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     description = "BIRD Internet Routing Daemon";
     homepage = "http://bird.network.cz";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ fpletz globin ];
+    maintainers = with maintainers; [ globin ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/servers/freeradius/default.nix
+++ b/pkgs/servers/freeradius/default.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation rec {
     homepage = "https://freeradius.org/";
     description = "A modular, high performance free RADIUS suite";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ sheenobu willibutz fpletz lheckemann ];
+    maintainers = with maintainers; [ sheenobu willibutz lheckemann ];
     platforms = with platforms; linux;
   };
 }

--- a/pkgs/servers/irc/charybdis/default.nix
+++ b/pkgs/servers/irc/charybdis/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     description = "IRCv3 server designed to be highly scalable";
     homepage    = "https://github.com/charybdis-ircd/charybdis";
     license     = licenses.gpl2;
-    maintainers = with maintainers; [ lassulus fpletz ];
+    maintainers = with maintainers; [ lassulus ];
     platforms   = platforms.unix;
   };
 

--- a/pkgs/servers/mattermost/default.nix
+++ b/pkgs/servers/mattermost/default.nix
@@ -45,6 +45,6 @@ buildGoModule rec {
     description = "Mattermost is an open source platform for secure collaboration across the entire software development lifecycle";
     homepage = "https://www.mattermost.org";
     license = with licenses; [ agpl3 asl20 ];
-    maintainers = with maintainers; [ fpletz ryantm numinit kranzes ];
+    maintainers = with maintainers; [ ryantm numinit kranzes ];
   };
 }

--- a/pkgs/servers/mattermost/matterircd.nix
+++ b/pkgs/servers/mattermost/matterircd.nix
@@ -19,7 +19,7 @@ buildGoModule rec {
     inherit (src.meta) homepage;
     description = "Minimal IRC server bridge to Mattermost";
     license = licenses.mit;
-    maintainers = with maintainers; [ fpletz ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/servers/monitoring/prometheus/collectd-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/collectd-exporter.nix
@@ -20,7 +20,7 @@ buildGoPackage rec {
     description = "Relay server for exporting metrics from collectd to Prometheus";
     homepage = "https://github.com/prometheus/collectd_exporter";
     license = licenses.asl20;
-    maintainers = with maintainers; [ benley fpletz ];
+    maintainers = with maintainers; [ benley ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/servers/monitoring/prometheus/haproxy-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/haproxy-exporter.nix
@@ -19,7 +19,7 @@ buildGoModule rec {
     description = "HAProxy Exporter for the Prometheus monitoring system";
     homepage = "https://github.com/prometheus/haproxy_exporter";
     license = licenses.asl20;
-    maintainers = with maintainers; [ benley fpletz ];
+    maintainers = with maintainers; [ benley ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/servers/monitoring/prometheus/openvpn-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/openvpn-exporter.nix
@@ -18,6 +18,6 @@ buildGoModule rec {
     description = "Prometheus exporter for OpenVPN";
     broken = true;
     license = licenses.asl20;
-    maintainers = with maintainers; [ fpletz globin ];
+    maintainers = with maintainers; [ globin ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/pushgateway.nix
+++ b/pkgs/servers/monitoring/prometheus/pushgateway.nix
@@ -42,7 +42,7 @@ buildGoPackage rec {
     description = "Allows ephemeral and batch jobs to expose metrics to Prometheus";
     homepage = "https://github.com/prometheus/pushgateway";
     license = licenses.asl20;
-    maintainers = with maintainers; [ benley fpletz ];
+    maintainers = with maintainers; [ benley ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/servers/mpd/default.nix
+++ b/pkgs/servers/mpd/default.nix
@@ -185,7 +185,7 @@ let
         description = "A flexible, powerful daemon for playing music";
         homepage    = "https://www.musicpd.org/";
         license     = licenses.gpl2Only;
-        maintainers = with maintainers; [ astsmtl ehmry fpletz tobim ];
+        maintainers = with maintainers; [ astsmtl ehmry tobim ];
         platforms   = platforms.unix;
 
         longDescription = ''

--- a/pkgs/servers/nextcloud/default.nix
+++ b/pkgs/servers/nextcloud/default.nix
@@ -25,7 +25,7 @@ let
     meta = with lib; {
       description = "Sharing solution for files, calendars, contacts and more";
       homepage = "https://nextcloud.com";
-      maintainers = with maintainers; [ schneefux bachp globin fpletz ma27 ];
+      maintainers = with maintainers; [ schneefux bachp globin ma27 ];
       license = licenses.agpl3Plus;
       platforms = with platforms; unix;
       knownVulnerabilities = extraVulnerabilities

--- a/pkgs/servers/sks/default.nix
+++ b/pkgs/servers/sks/default.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
     inherit (src.meta) homepage;
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ fpletz globin ];
+    maintainers = with maintainers; [ globin ];
   };
 }
 

--- a/pkgs/servers/squid/default.nix
+++ b/pkgs/servers/squid/default.nix
@@ -35,6 +35,6 @@ stdenv.mkDerivation rec {
     homepage = "http://www.squid-cache.org";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ fpletz raskin ];
+    maintainers = with maintainers; [ raskin ];
   };
 }

--- a/pkgs/servers/varnish/default.nix
+++ b/pkgs/servers/varnish/default.nix
@@ -42,7 +42,7 @@ let
         description = "Web application accelerator also known as a caching HTTP reverse proxy";
         homepage = "https://www.varnish-cache.org";
         license = licenses.bsd2;
-        maintainers = with maintainers; [ fpletz ];
+        maintainers = with maintainers; [ ];
         platforms = platforms.unix;
       };
     };

--- a/pkgs/servers/web-apps/searx/default.nix
+++ b/pkgs/servers/web-apps/searx/default.nix
@@ -70,6 +70,6 @@ toPythonModule (buildPythonApplication rec {
     homepage = "https://github.com/searx/searx";
     description = "A privacy-respecting, hackable metasearch engine";
     license = licenses.agpl3Plus;
-    maintainers = with maintainers; [ matejc fpletz globin danielfullmer ];
+    maintainers = with maintainers; [ matejc globin danielfullmer ];
   };
 })

--- a/pkgs/servers/xmpp/prosody/default.nix
+++ b/pkgs/servers/xmpp/prosody/default.nix
@@ -82,6 +82,6 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     homepage = "https://prosody.im";
     platforms = platforms.linux;
-    maintainers = with maintainers; [ fpletz globin ];
+    maintainers = with maintainers; [ globin ];
   };
 }

--- a/pkgs/tools/admin/lxd/default.nix
+++ b/pkgs/tools/admin/lxd/default.nix
@@ -62,7 +62,7 @@ buildGoPackage rec {
     homepage = "https://linuxcontainers.org/lxd/";
     changelog = "https://github.com/lxc/lxd/releases/tag/lxd-${version}";
     license = licenses.asl20;
-    maintainers = with maintainers; [ fpletz marsam ];
+    maintainers = with maintainers; [ marsam ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/audio/darkice/default.nix
+++ b/pkgs/tools/audio/darkice/default.nix
@@ -32,6 +32,6 @@ stdenv.mkDerivation rec {
     homepage = "http://darkice.org/";
     description = "Live audio streamer";
     license = lib.licenses.gpl3;
-    maintainers = with lib.maintainers; [ ikervagyok fpletz ];
+    maintainers = with lib.maintainers; [ ikervagyok ];
   };
 }

--- a/pkgs/tools/networking/babeld/default.nix
+++ b/pkgs/tools/networking/babeld/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     homepage = "http://www.irif.fr/~jch/software/babel/";
     description = "Loop-avoiding distance-vector routing protocol";
     license = licenses.mit;
-    maintainers = with maintainers; [ fpletz hexa ];
+    maintainers = with maintainers; [ hexa ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/networking/dhcpcd/default.nix
+++ b/pkgs/tools/networking/dhcpcd/default.nix
@@ -64,6 +64,6 @@ stdenv.mkDerivation rec {
     homepage = "https://roy.marples.name/projects/dhcpcd";
     platforms = platforms.linux;
     license = licenses.bsd2;
-    maintainers = with maintainers; [ eelco fpletz ];
+    maintainers = with maintainers; [ eelco ];
   };
 }

--- a/pkgs/tools/networking/quicktun/default.nix
+++ b/pkgs/tools/networking/quicktun/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
     broken = stdenv.isDarwin;
     description = "Very simple, yet secure VPN software";
     homepage = "http://wiki.ucis.nl/QuickTun";
-    maintainers = [ maintainers.fpletz ];
+    maintainers = [ ];
     platforms = platforms.unix;
     license = licenses.bsd2;
   };

--- a/pkgs/tools/networking/tinc/pre.nix
+++ b/pkgs/tools/networking/tinc/pre.nix
@@ -39,6 +39,6 @@ stdenv.mkDerivation rec {
     homepage="http://www.tinc-vpn.org/";
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ fpletz lassulus mic92 ];
+    maintainers = with maintainers; [ lassulus mic92 ];
   };
 }

--- a/pkgs/tools/security/clamav/default.nix
+++ b/pkgs/tools/security/clamav/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.clamav.net";
     description = "Antivirus engine designed for detecting Trojans, viruses, malware and other malicious threats";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ robberer qknight fpletz globin ];
+    maintainers = with maintainers; [ robberer qknight globin ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/security/clevis/default.nix
+++ b/pkgs/tools/security/clevis/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Automated Encryption Framework";
     homepage = "https://github.com/latchset/clevis";
-    maintainers = with lib.maintainers; [ fpletz ];
+    maintainers = with lib.maintainers; [ ];
     license = lib.licenses.gpl3Plus;
   };
 }

--- a/pkgs/tools/security/fail2ban/default.nix
+++ b/pkgs/tools/security/fail2ban/default.nix
@@ -80,7 +80,7 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://www.fail2ban.org/";
     description = "A program that scans log files for repeated failing login attempts and bans IP addresses";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ eelco lovek323 fpletz ];
+    maintainers = with maintainers; [ eelco lovek323 ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/security/nitrokey-app/default.nix
+++ b/pkgs/tools/security/nitrokey-app/default.nix
@@ -37,6 +37,6 @@ stdenv.mkDerivation rec {
     '';
     homepage         = "https://github.com/Nitrokey/nitrokey-app";
     license          = licenses.gpl3;
-    maintainers      = with maintainers; [ kaiha fpletz ];
+    maintainers      = with maintainers; [ kaiha ];
   };
 }

--- a/pkgs/tools/security/signing-party/default.nix
+++ b/pkgs/tools/security/signing-party/default.nix
@@ -220,7 +220,7 @@ in stdenv.mkDerivation rec {
       * gpg-key2latex: generate LaTeX file with fingerprint paper slips
     '';
     license = with licenses; [ bsd2 bsd3 gpl2 gpl2Plus gpl3Plus ];
-    maintainers = with maintainers; [ fpletz primeos ];
+    maintainers = with maintainers; [ primeos ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/system/collectd/default.nix
+++ b/pkgs/tools/system/collectd/default.nix
@@ -61,6 +61,6 @@ stdenv.mkDerivation rec {
     homepage = "https://collectd.org";
     license = licenses.gpl2;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ bjornfor fpletz ];
+    maintainers = with maintainers; [ bjornfor ];
   };
 }

--- a/pkgs/tools/system/syslog-ng/default.nix
+++ b/pkgs/tools/system/syslog-ng/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.syslog-ng.com";
     description = "Next-generation syslogd with advanced networking and filtering capabilities";
     license = with licenses; [ gpl2Plus lgpl21Plus ];
-    maintainers = with maintainers; [ fpletz ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Description of changes

Only packages I'm not able to maintain anymore as of today. Mostly because I'm haven't been using them in a while.

cc @mweinelt :smile_cat: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
