### PR TITLE
libguestfs: 1.48.0 -> 1.48.4

### DIFF
--- a/pkgs/development/libraries/libguestfs/default.nix
+++ b/pkgs/development/libraries/libguestfs/default.nix
@@ -36,19 +36,18 @@
 , libtirpc
 , appliance ? null
 , javaSupport ? false
-, jdk ? null
+, jdk
 }:
 
 assert appliance == null || lib.isDerivation appliance;
-assert javaSupport -> jdk != null;
 
 stdenv.mkDerivation rec {
   pname = "libguestfs";
-  version = "1.48.0";
+  version = "1.48.4";
 
   src = fetchurl {
     url = "https://libguestfs.org/download/${lib.versions.majorMinor version}-stable/${pname}-${version}.tar.gz";
-    sha256 = "sha256-FoH93t/PSEym3uxUIwMwoy3vvTDCqx+BeI4lLLXQSCk=";
+    sha256 = "sha256-ncIrbFpF8ZwsupEaN7Oo2G9idEUhsQ61PD05B+UIAxI=";
   };
 
   strictDeps = true;
@@ -63,7 +62,7 @@ stdenv.mkDerivation rec {
     makeWrapper
     pkg-config
     qemu
-  ] ++ (with perlPackages; [ perl libintl-perl GetoptLong SysVirt ])
+  ] ++ (with perlPackages; [ perl libintl-perl GetoptLong ModuleBuild ])
   ++ (with ocamlPackages; [ ocaml findlib ]);
   buildInputs = [
     ncurses
@@ -112,10 +111,14 @@ stdenv.mkDerivation rec {
   patches = [
     ./libguestfs-syms.patch
   ];
+
+  createFindlibDestdir = true;
+
   installFlags = [ "REALLY_INSTALL=yes" ];
   enableParallelBuilding = true;
 
   postInstall = ''
+    mv "$out/lib/ocaml/guestfs" "$OCAMLFIND_DESTDIR/guestfs"
     for bin in $out/bin/*; do
       wrapProgram "$bin" \
         --prefix PATH     : "$out/bin:${hivex}/bin:${qemu}/bin" \

--- a/pkgs/development/libraries/libguestfs/default.nix
+++ b/pkgs/development/libraries/libguestfs/default.nix
@@ -1,11 +1,43 @@
-{ lib, stdenv, fetchurl, pkg-config, autoreconfHook, makeWrapper
-, ncurses, cpio, gperf, cdrkit, flex, bison, qemu, pcre2, augeas, libxml2
-, acl, libcap, libcap_ng, libconfig, systemd, fuse, yajl, libvirt, hivex, db
-, gmp, readline, file, numactl, libapparmor, jansson
-, getopt, perlPackages, ocamlPackages
+{ lib
+, stdenv
+, fetchurl
+, pkg-config
+, autoreconfHook
+, makeWrapper
+, ncurses
+, cpio
+, gperf
+, cdrkit
+, flex
+, bison
+, qemu
+, pcre2
+, augeas
+, libxml2
+, acl
+, libcap
+, libcap_ng
+, libconfig
+, systemd
+, fuse
+, yajl
+, libvirt
+, hivex
+, db
+, gmp
+, readline
+, file
+, numactl
+, libapparmor
+, jansson
+, getopt
+, perlPackages
+, ocamlPackages
 , libtirpc
 , appliance ? null
-, javaSupport ? false, jdk ? null }:
+, javaSupport ? false
+, jdk ? null
+}:
 
 assert appliance == null || lib.isDerivation appliance;
 assert javaSupport -> jdk != null;
@@ -21,17 +53,43 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
   nativeBuildInputs = [
-    autoreconfHook bison cdrkit cpio flex getopt gperf makeWrapper pkg-config qemu
+    autoreconfHook
+    bison
+    cdrkit
+    cpio
+    flex
+    getopt
+    gperf
+    makeWrapper
+    pkg-config
+    qemu
   ] ++ (with perlPackages; [ perl libintl-perl GetoptLong SysVirt ])
-    ++ (with ocamlPackages; [ ocaml findlib ]);
+  ++ (with ocamlPackages; [ ocaml findlib ]);
   buildInputs = [
-    ncurses jansson
-    pcre2 augeas libxml2 acl libcap libcap_ng libconfig
-    systemd fuse yajl libvirt gmp readline file hivex db
-    numactl libapparmor perlPackages.ModuleBuild
+    ncurses
+    jansson
+    pcre2
+    augeas
+    libxml2
+    acl
+    libcap
+    libcap_ng
+    libconfig
+    systemd
+    fuse
+    yajl
+    libvirt
+    gmp
+    readline
+    file
+    hivex
+    db
+    numactl
+    libapparmor
+    perlPackages.ModuleBuild
     libtirpc
   ] ++ (with ocamlPackages; [ ocamlbuild ocaml_libvirt gettext-stub ounit ])
-    ++ lib.optional javaSupport jdk;
+  ++ lib.optional javaSupport jdk;
 
   prePatch = ''
     # build-time scripts
@@ -95,7 +153,7 @@ stdenv.mkDerivation rec {
     description = "Tools for accessing and modifying virtual machine disk images";
     license = with licenses; [ gpl2Plus lgpl21Plus ];
     homepage = "https://libguestfs.org/";
-    maintainers = with maintainers; [offline];
+    maintainers = with maintainers; [ offline ];
     platforms = platforms.linux;
     # this is to avoid "output size exceeded"
     hydraPlatforms = if appliance != null then appliance.meta.hydraPlatforms else platforms.linux;


### PR DESCRIPTION
###### Description of changes

* Fix Perl dependencies, so that the Perl bindings will be built
* Move OCaml bindings into the proper place, so they can be picked up

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
