### PR TITLE
mangohud: statically link spdlog

### DIFF
--- a/pkgs/tools/graphics/mangohud/default.nix
+++ b/pkgs/tools/graphics/mangohud/default.nix
@@ -27,7 +27,6 @@
 , vulkan-loader
 , libXNVCtrl
 , wayland
-, spdlog
 , glew
 , glfw
 , nlohmann_json
@@ -51,6 +50,27 @@ let
       hash = "sha256-bQC0QmkLalxdj4mDEdqvvOFtNwz2T1MpTDuMXGYeQ18=";
     };
   };
+
+  # Derived from subprojects/spdlog.wrap
+  #
+  # NOTE: We only statically link spdlog due to a bug in pressure-vessel:
+  # https://github.com/ValveSoftware/steam-runtime/issues/511
+  #
+  # Once this fix is released upstream, we should switch back to using
+  # the system provided spdlog
+  spdlog = rec {
+    version = "1.8.5";
+    src = fetchFromGitHub {
+      owner = "gabime";
+      repo = "spdlog";
+      rev = "refs/tags/v${version}";
+      sha256 = "sha256-D29jvDZQhPscaOHlrzGN1s7/mXlcsovjbqYpXd7OM50=";
+    };
+    patch = fetchurl {
+      url = "https://wrapdb.mesonbuild.com/v2/spdlog_${version}-1/get_patch";
+      sha256 = "sha256-PDjyddV5KxKGORECWUMp6YsXc3kks0T5gxKrCZKbdL4=";
+    };
+  };
 in stdenv.mkDerivation rec {
   pname = "mangohud";
   version = "0.6.7-1";
@@ -69,7 +89,7 @@ in stdenv.mkDerivation rec {
   postUnpack = ''(
     cd "$sourceRoot/subprojects"
     cp -R --no-preserve=mode,ownership ${imgui.src} imgui-${imgui.version}
-    unzip ${imgui.patch}
+    cp -R --no-preserve=mode,ownership ${spdlog.src} spdlog-${spdlog.version}
   )'';
 
   patches = [
@@ -112,11 +132,16 @@ in stdenv.mkDerivation rec {
     })
   ];
 
+  postPatch = ''(
+    cd subprojects
+    unzip ${imgui.patch}
+    unzip ${spdlog.patch}
+  )'';
+
   mesonFlags = [
     "-Duse_system_vulkan=enabled"
     "-Dvulkan_datadir=${vulkan-headers}/share"
     "-Dwith_wayland=enabled"
-    "-Duse_system_spdlog=enabled"
   ] ++ lib.optionals gamescopeSupport [
     "-Dmangoapp_layer=true"
     "-Dmangoapp=true"
@@ -140,7 +165,6 @@ in stdenv.mkDerivation rec {
     libX11
     libXNVCtrl
     wayland
-    spdlog
   ] ++ lib.optionals gamescopeSupport [
     glew
     glfw


### PR DESCRIPTION
###### Description of changes

Works around bug in pressure-vessel where it wasn't including necessary vulkan layer dependencies defined through `DT_RUNPATH` in the sandbox.

https://github.com/ValveSoftware/steam-runtime/issues/511

This workaround is intended to be temporary until the upstream fix is released.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).