### PR TITLE
uniscan: init at 6.3

### DIFF
--- a/pkgs/tools/security/uniscan/default.nix
+++ b/pkgs/tools/security/uniscan/default.nix
@@ -1,0 +1,134 @@
+{ lib, stdenv, fetchgit, perl, perlPackages, makeWrapper, copyDesktopItems, makeDesktopItem, xterm }:
+
+let
+  version = "6.3";
+  src = fetchgit {
+    url = "https://git.code.sf.net/p/uniscan/code";
+    rev = "ef359f890ddff036544d6a733d540ebfd9be6981";
+    sha256 = "0rxhps396cpc51svlrzdjg05000wx4craqg700na6393qhngh8iv";
+  };
+
+  metaCommon = with lib; {
+    description = "A simple Remote File Include, Local File Include and Remote Command Execution vulnerability scanner";
+    homepage = "https://sourceforge.net/projects/uniscan/";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ emilytrau ];
+    platforms = platforms.unix;
+  };
+
+  uniscan = perlPackages.buildPerlPackage rec {
+    pname = "uniscan";
+    inherit version src;
+
+    outputs = [ "out" ];
+
+    # Add a helpful message prompting the user to create a config file
+    patches = [ ./missing-config-warning.patch ];
+
+    postPatch = ''
+      substituteAllInPlace Uniscan/Configure.pm
+
+      # Replace relative path to data files with store path
+      substituteInPlace uniscan.pl \
+        --replace '"Files"' "\"$out/share/uniscan/Files\"" \
+        --replace '"Directory"' "\"$out/share/uniscan/Directory\""
+      substituteInPlace Uniscan/Configure.pm \
+        --replace "Languages/" "$out/share/uniscan/Languages/"
+      substituteInPlace Uniscan/FingerPrint.pm \
+        --replace "DB/" "$out/share/uniscan/DB/"
+      substituteInPlace Uniscan/Factory.pm \
+        --replace "Plugins/" "$out/share/uniscan/Plugins/"
+      substituteInPlace Uniscan/Crawler.pm \
+        --replace "./Plugins/" "$out/share/uniscan/Plugins/"
+      substituteInPlace Uniscan/Scan.pm \
+        --replace "./Plugins/" "$out/share/uniscan/Plugins/"
+      substituteInPlace Uniscan/Stress.pm \
+        --replace "./Plugins/" "$out/share/uniscan/Plugins/"
+
+      rm uniscan_gui.pl
+    '';
+
+    nativeBuildInputs = [
+      makeWrapper
+    ];
+
+    buildInputs = with perlPackages; [
+      Moose
+      LWP
+      LWPProtocolHttps
+      DevelOverloadInfo
+    ];
+
+    dontConfigure = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/share
+      cp -r . $out/share/uniscan
+
+      runHook postInstall
+    '';
+
+    postFixup = ''
+      makeWrapper "$out/share/uniscan/uniscan.pl" $out/bin/uniscan.pl \
+        --set PERL5LIB "$PERL5LIB:$out/share/uniscan"
+    '';
+
+    meta = metaCommon // {
+      mainProgram = "uniscan.pl";
+    };
+  };
+
+  uniscan-gui = stdenv.mkDerivation rec {
+    pname = "uniscan-gui";
+    inherit version src;
+
+    postPatch = ''
+      substituteInPlace uniscan_gui.pl \
+        --replace "xterm" "${xterm}/bin/xterm" \
+        --replace "perl uniscan.pl" "${uniscan}/bin/uniscan.pl"
+    '';
+
+    desktopItems = [
+      (makeDesktopItem {
+        name = pname;
+        desktopName = "Uniscan GUI";
+        exec = "uniscan_gui.pl";
+        comment = "A simple Remote File Include, Local File Include and Remote Command Execution vulnerability scanner";
+        categories = [ "Utility" "Security" ];
+        startupNotify = false;
+      })
+    ];
+
+    nativeBuildInputs = [
+      makeWrapper
+      copyDesktopItems
+    ];
+
+    buildInputs = [
+      (perl.withPackages (p: with p; [ Tk ]))
+    ];
+
+    installPhase = ''
+      runHook preInstall
+
+      install -Dm755 uniscan_gui.pl $out/bin/uniscan_gui.pl
+
+      runHook postInstall
+    '';
+
+  postFixup = ''
+    # 1. Ensure that a uniscan.conf exists in the current directory, or instantiate it
+    # 2. Ensure that reports/ exists in the current directory, or instantiate it
+    wrapProgram $out/bin/uniscan_gui.pl \
+      --run "test -f uniscan.conf || (cp ${uniscan}/share/uniscan/uniscan.conf . && chmod +w uniscan.conf)" \
+      --run "test -d report || (cp -r ${uniscan}/share/uniscan/report . && chmod -R +w report)"
+  '';
+
+    meta = metaCommon // {
+      mainProgram = "uniscan_gui.pl";
+    };
+  };
+in
+{ inherit uniscan uniscan-gui; }

--- a/pkgs/tools/security/uniscan/missing-config-warning.patch
+++ b/pkgs/tools/security/uniscan/missing-config-warning.patch
@@ -1,0 +1,13 @@
+diff --git a/Uniscan/Configure.pm b/Uniscan/Configure.pm
+index a12bf41..2c27142 100755
+--- a/Uniscan/Configure.pm
++++ b/Uniscan/Configure.pm
+@@ -18,7 +18,7 @@
+ 		my $self = shift;
+ 		my %conf = ( );
+ 		my $C;
+-		open($C, "<", $self->conffile) or die("ERROR: Could not open ". $self->conffile ." for read: $!\n");
++		open($C, "<", $self->conffile) or die("Couldn't find a configuration file in the current directory!\nCopy the example from @out@/share/uniscan/uniscan.conf\n\nERROR: Could not open ". $self->conffile ." for read: $!\n");
+ 		while(<$C>) {
+ 			my $line = $_;
+ 			chomp $line;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16863,6 +16863,10 @@ with pkgs;
 
   uncrustify = callPackage ../development/tools/misc/uncrustify { };
 
+  uniscan = (callPackage ../tools/security/uniscan { }).uniscan;
+
+  uniscan-gui = (callPackage ../tools/security/uniscan { }).uniscan-gui;
+
   universal-ctags = callPackage ../development/tools/misc/universal-ctags { };
 
   unused = callPackage ../development/tools/misc/unused { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

A simple Remote File Include, Local File Include and Remote Command Execution vulnerability scanner
https://sourceforge.net/projects/uniscan/

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
