### PR TITLE
WIP: Try using bats for running lib/tests/modules.sh

### DIFF
--- a/lib/tests/modules.bats
+++ b/lib/tests/modules.bats
@@ -1,0 +1,185 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bats -p "bats.withLibraries (p: [ p.bats-support p.bats-assert p.file ])" -I nixpkgs=../..
+# vim: filetype=sh
+
+setup() {
+  bats_load_library bats-support
+  bats_load_library bats-assert
+  bats_load_library bats-file
+
+  bats_require_minimum_version 1.5.0
+
+  DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )"
+  cd "$DIR"/modules
+}
+
+evalConfig() {
+  local attr=$1
+  shift
+  local script="import ./default.nix { modules = [ $* ];}"
+  nix-instantiate --timeout 1 -E "$script" -A "$attr" --eval-only --show-trace --read-write-mode
+}
+
+# Check boolean option.
+@test boolean_1 {
+  run -0 evalConfig config.enable ./declare-enable.nix
+  assert_output 'false'
+}
+
+@test boolean_2 {
+  run ! evalConfig config.enable ./define-enable.nix
+  assert_line --index 0 --regexp 'The option .* does not exist. Definition values:'
+  assert_line --index 1 --regexp '\s*- In .*: true'
+}
+
+@test submodule_1 {
+  run -0 evalConfig config.bare-submodule.nested ./declare-bare-submodule.nix ./declare-bare-submodule-nested-option.nix
+  assert_output 1
+}
+
+@test submodule_2 {
+  run -0 evalConfig config.bare-submodule.deep ./declare-bare-submodule.nix ./declare-bare-submodule-deep-option.nix
+  assert_output 2
+}
+
+@test submodule_3 {
+  run -0 evalConfig config.bare-submodule.nested ./declare-bare-submodule.nix ./declare-bare-submodule-nested-option.nix ./declare-bare-submodule-deep-option.nix ./define-bare-submodule-values.nix
+  assert_output 42
+}
+
+@test submodule_4 {
+  run -0 evalConfig config.bare-submodule.deep ./declare-bare-submodule.nix ./declare-bare-submodule-nested-option.nix ./declare-bare-submodule-deep-option.nix ./define-bare-submodule-values.nix
+  assert_output 420
+}
+
+@test submodule_5 {
+  run -0 evalConfig config.bare-submodule.deep ./declare-bare-submodule.nix ./declare-bare-submodule-deep-option.nix ./define-shorthandOnlyDefinesConfig-true.nix
+  assert_output 2
+}
+
+@test submodule_6 {
+  run ! evalConfig config.bare-submodule.deep ./declare-bare-submodule.nix ./declare-bare-submodule-deep-option.nix  ./declare-bare-submodule-deep-option-duplicate.nix
+  assert_output --regexp 'The option .bare-submodule.deep. in .*/declare-bare-submodule-deep-option.nix. is already declared in .*/declare-bare-submodule-deep-option-duplicate.nix'
+}
+
+# Check integer types.
+# unsigned
+@test integer_1 {
+  run -0 evalConfig config.value ./declare-int-unsigned-value.nix ./define-value-int-positive.nix
+  assert_output 42
+}
+
+@test integer_2 {
+  run ! evalConfig config.value ./declare-int-unsigned-value.nix ./define-value-int-negative.nix
+  assert_line --index 0 --regexp 'A definition for option .* is not of type.*unsigned integer.*. Definition values:'
+  assert_line --index 1 --regexp '\s*- In .*: -23'
+}
+
+# positive
+@test integer_3 {
+  run ! evalConfig config.value ./declare-int-positive-value.nix ./define-value-int-zero.nix
+  assert_line --index 0 --regexp 'A definition for option .* is not of type.*positive integer.*. Definition values:'
+  assert_line --index 1 --regexp '\s*- In .*: 0'
+}
+
+# between
+@test integer_4 {
+  run -0 evalConfig config.value ./declare-int-between-value.nix ./define-value-int-positive.nix
+  assert_output 42
+}
+
+@test integer_5 {
+  run ! evalConfig config.value ./declare-int-between-value.nix ./define-value-int-negative.nix
+  assert_line --index 0 --regexp 'A definition for option .* is not of type.*between.*-21 and 43.*inclusive.*. Definition values:'
+  assert_line --index 1 --regexp '\s*- In .*: -23'
+}
+
+# Check either types
+# types.either
+@test either_1 {
+  run -0 evalConfig config.value ./declare-either.nix ./define-value-int-positive.nix
+  assert_output 42
+}
+
+@test either_2 {
+  run -0 evalConfig config.value ./declare-either.nix ./define-value-string.nix
+  assert_output '"24"'
+}
+
+# types.oneOf
+@test oneOf_1 {
+  run -0 evalConfig config.value ./declare-oneOf.nix ./define-value-int-positive.nix
+  assert_output 42
+}
+
+@test oneOf_2 {
+  run -0 evalConfig config.value ./declare-oneOf.nix ./define-value-list.nix
+  assert_output '[ ]'
+}
+
+@test oneOf_3 {
+  run -0 evalConfig config.value ./declare-oneOf.nix ./define-value-string.nix
+  assert_output '"24"'
+}
+
+# Check mkForce without submodules.
+@test mkForce_1 {
+  run -0 evalConfig config.enable ./declare-enable.nix ./define-enable.nix
+  assert_output true
+}
+
+@test mkForce_2 {
+  run -0 evalConfig config.enable ./declare-enable.nix ./define-enable.nix ./define-force-enable.nix
+  assert_output false
+}
+
+@test mkForce_3 {
+  run -0 evalConfig config.enable ./declare-enable.nix ./define-enable.nix ./define-enable-force.nix
+  assert_output false
+}
+
+# Check mkForce with option and submodules.
+@test mkForce_4 {
+  run ! evalConfig config.attrsOfSub.foo.enable ./declare-attrsOfSub-any-enable.nix
+  assert_output --regexp 'attribute .*foo.* .* not found'
+}
+
+@test mkForce_5 {
+  run -0 evalConfig config.attrsOfSub.foo.enable ./declare-attrsOfSub-any-enable.nix ./define-attrsOfSub-foo.nix
+  assert_output false
+}
+
+@test mkForce_6 {
+  run -0 evalConfig config.attrsOfSub.foo.enable ./declare-attrsOfSub-any-enable.nix ./define-attrsOfSub-foo-enable.nix
+  assert_output true
+}
+
+@test mkForce_7 {
+  run -0 evalConfig config.attrsOfSub.foo.enable ./declare-attrsOfSub-any-enable.nix ./define-attrsOfSub-foo-enable.nix ./define-force-attrsOfSub-foo-enable.nix
+  assert_output false
+}
+
+@test mkForce_8 {
+  run -0 evalConfig config.attrsOfSub.foo.enable ./declare-attrsOfSub-any-enable.nix ./define-attrsOfSub-foo-enable.nix
+  assert_output true
+}
+
+@test mkForce_9 {
+  run -0 evalConfig config.attrsOfSub.foo.enable ./declare-attrsOfSub-any-enable.nix ./define-attrsOfSub-foo-enable.nix ./define-force-attrsOfSub-foo-enable.nix
+  assert_output false
+}
+
+@test mkForce_10 {
+  run -0 evalConfig config.attrsOfSub.foo.enable ./declare-attrsOfSub-any-enable.nix ./define-attrsOfSub-foo-enable.nix ./define-attrsOfSub-force-foo-enable.nix
+  assert_output false
+}
+
+@test mkForce_11 {
+  run -0 evalConfig config.attrsOfSub.foo.enable ./declare-attrsOfSub-any-enable.nix ./define-attrsOfSub-foo-enable.nix ./define-attrsOfSub-foo-force-enable.nix
+  assert_output false
+}
+
+@test mkForce_12 {
+  run -0 evalConfig config.attrsOfSub.foo.enable ./declare-attrsOfSub-any-enable.nix ./define-attrsOfSub-foo-enable.nix ./define-attrsOfSub-foo-enable-force.nix
+  assert_output false
+}

--- a/pkgs/development/interpreters/bats/default.nix
+++ b/pkgs/development/interpreters/bats/default.nix
@@ -13,6 +13,7 @@
 , ps
 , bats
 , lsof
+, callPackages
 , doInstallCheck ? true
 }:
 
@@ -104,6 +105,8 @@ resholve.mkDerivation rec {
       ];
     };
   };
+
+  passthru.libraries = callPackages ./libraries.nix {};
 
   passthru.tests.upstream = bats.unresholved.overrideAttrs (old: {
     name = "${bats.name}-tests";

--- a/pkgs/development/interpreters/bats/libraries.nix
+++ b/pkgs/development/interpreters/bats/libraries.nix
@@ -1,0 +1,70 @@
+{ lib, stdenv, fetchFromGitHub }: {
+  bats-assert = stdenv.mkDerivation {
+    pname = "bats-assert";
+    version = "2.0.0";
+    src = fetchFromGitHub {
+      owner = "bats-core";
+      repo = "bats-assert";
+      rev = "v2.0.0";
+      sha256 = "sha256-whSbAj8Xmnqclf78dYcjf1oq099ePtn4XX9TUJ9AlyQ=";
+    };
+    dontBuild = true;
+    installPhase = ''
+      mkdir -p "$out/share/bats"
+      cp -r . "$out/share/bats/bats-assert"
+    '';
+    meta = {
+      description = "Common assertions for Bats";
+      platforms = lib.platforms.all;
+      homepage = "https://github.com/bats-core/bats-assert";
+      license = lib.licenses.cc0;
+      maintainers = with lib.maintainers; [ infinisil ];
+    };
+  };
+
+  bats-file = stdenv.mkDerivation {
+    pname = "bats-file";
+    version = "0.3.0";
+    src = fetchFromGitHub {
+      owner = "bats-core";
+      repo = "bats-file";
+      rev = "v0.3.0";
+      sha256 = "sha256-3xevy0QpwNZrEe+2IJq58tKyxQzYx8cz6dD2nz7fYUM=";
+    };
+    dontBuild = true;
+    installPhase = ''
+      mkdir -p "$out/share/bats"
+      cp -r . "$out/share/bats/bats-file"
+    '';
+    meta = {
+      description = "Common filesystem assertions for Bats";
+      platforms = lib.platforms.all;
+      homepage = "https://github.com/bats-core/bats-file";
+      license = lib.licenses.cc0;
+      maintainers = with lib.maintainers; [ infinisil ];
+    };
+  };
+
+  bats-support = stdenv.mkDerivation {
+    pname = "bats-support";
+    version = "0.3.0";
+    src = fetchFromGitHub {
+      owner = "bats-core";
+      repo = "bats-support";
+      rev = "v0.3.0";
+      sha256 = "sha256-4N7XJS5XOKxMCXNC7ef9halhRpg79kUqDuRnKcrxoeo=";
+    };
+    dontBuild = true;
+    installPhase = ''
+      mkdir -p "$out/share/bats"
+      cp -r . "$out/share/bats/bats-support"
+    '';
+    meta = {
+      description = "Supporting library for Bats test helpers";
+      platforms = lib.platforms.all;
+      homepage = "https://github.com/bats-core/bats-support";
+      license = lib.licenses.cc0;
+      maintainers = with lib.maintainers; [ infinisil ];
+    };
+  };
+}


### PR DESCRIPTION
###### Description of changes

This is an initial attempt at using [bats](https://github.com/bats-core/bats-core) to run `lib/tests/modules.sh` (but hopefully more in the future). By using bats we don't have to hand-roll our testing setup, it can take care of things like capturing exit status, command output, counting and reporting test failures. It also allows easily restructuring tests into a directory structure instead of having them all in a single file. It can also give names to tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
