### PR TITLE
davtest: init at 1.0

### DIFF
--- a/pkgs/tools/security/davtest/default.nix
+++ b/pkgs/tools/security/davtest/default.nix
@@ -1,0 +1,40 @@
+{ lib, stdenv, perl, perlPackages, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "davtest";
+  version = "1.0";
+
+  src = fetchurl {
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/davtest/davtest-${version}.tar.bz2";
+    sha256 = "0kigcgv1bbnan9yr5481s4b9islmvzl2arpg1ig1i39sxrna06y7";
+  };
+
+  postPatch = ''
+    substituteInPlace davtest.pl \
+      --replace "backdoors/" "$out/share/davtest/backdoors/" \
+      --replace "tests/" "$out/share/davtest/tests/"
+  '';
+
+  buildInputs = [
+    (perl.withPackages (p: with p; [ HTTPDAV ]))
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 davtest.pl $out/bin/davtest.pl
+    mkdir -p $out/share/davtest
+    cp -r backdoors/ tests/ $out/share/davtest/
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Tests WebDAV servers by uploading test files, and then optionally testing for command execution or other actions directly on the target";
+    homepage = "https://code.google.com/p/davtest/";
+    mainProgram = "davtest.pl";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ emilytrau ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33571,6 +33571,8 @@ with pkgs;
 
   dalfox = callPackage ../tools/security/dalfox { };
 
+  davtest = callPackage ../tools/security/davtest { };
+
   dcm2niix = callPackage ../applications/science/biology/dcm2niix { };
 
   deepdiff = with python3Packages; toPythonApplication deepdiff;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Tests WebDAV enabled servers by uploading test executable files, and then (optionally) uploading files which allow for command execution or other actions directly on the target
https://code.google.com/p/davtest/

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
