### PR TITLE
open-watcom-*: bump v2, improve bin meta, passthru.prettyName for wrapper

### DIFF
--- a/pkgs/development/compilers/open-watcom/bin.nix
+++ b/pkgs/development/compilers/open-watcom/bin.nix
@@ -85,9 +85,8 @@ let
 
 in
 stdenvNoCC.mkDerivation rec {
-  pname = "open-watcom-bin";
+  pname = "${passthru.prettyName}-unwrapped";
   version = "1.9";
-  name = "${pname}-unwrapped-${version}";
 
   src = fetchurl {
     url = "http://ftp.openwatcom.org/install/open-watcom-c-linux-${version}";
@@ -112,6 +111,8 @@ stdenvNoCC.mkDerivation rec {
       wrapInPlace "$e"
     done
   '';
+
+  passthru.prettyName = "open-watcom-bin";
 
   meta = with lib; {
     description = "A project to maintain and enhance the Watcom C, C++, and Fortran cross compilers and tools";

--- a/pkgs/development/compilers/open-watcom/bin.nix
+++ b/pkgs/development/compilers/open-watcom/bin.nix
@@ -114,7 +114,8 @@ stdenvNoCC.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "A C/C++ Compiler (binary distribution)";
+    description = "A project to maintain and enhance the Watcom C, C++, and Fortran cross compilers and tools";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     homepage = "http://www.openwatcom.org/";
     license = licenses.watcom;
     platforms = [ "x86_64-linux" "i686-linux" ];

--- a/pkgs/development/compilers/open-watcom/v2.nix
+++ b/pkgs/development/compilers/open-watcom/v2.nix
@@ -12,14 +12,14 @@
 
 stdenv.mkDerivation rec {
   pname = "open-watcom-v2";
-  version = "unstable-2022-05-04";
+  version = "unstable-2022-08-02";
   name = "${pname}-unwrapped-${version}";
 
   src = fetchFromGitHub {
     owner = "open-watcom";
     repo = "open-watcom-v2";
-    rev = "01662ab4eb50c0757969fa53bd4270dbbba45dc5";
-    sha256 = "Nl5mcPDCr08XkVMWqkbbgTP/YjpfwMOo2GVu43FQQ3Y=";
+    rev = "4bdb73995b871982dd106838296903701ded29c2";
+    sha256 = "sha256-Ay/f+gnj8EklN8T/uP0a+Zji6HEHAoPLdkrSTQaC9Rs=";
   };
 
   postPatch = ''

--- a/pkgs/development/compilers/open-watcom/v2.nix
+++ b/pkgs/development/compilers/open-watcom/v2.nix
@@ -11,9 +11,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "open-watcom-v2";
+  pname = "${passthru.prettyName}-unwrapped";
   version = "unstable-2022-08-02";
-  name = "${pname}-unwrapped-${version}";
 
   src = fetchFromGitHub {
     owner = "open-watcom";
@@ -82,8 +81,11 @@ stdenv.mkDerivation rec {
   # Stripping breaks many tools
   dontStrip = true;
 
-  passthru.updateScript = unstableGitUpdater {
-    url = "https://github.com/open-watcom/open-watcom-v2.git";
+  passthru = {
+    prettyName = "open-watcom-v2";
+    updateScript = unstableGitUpdater {
+      url = "https://github.com/open-watcom/open-watcom-v2.git";
+    };
   };
 
   meta = with lib; {

--- a/pkgs/development/compilers/open-watcom/wrapper.nix
+++ b/pkgs/development/compilers/open-watcom/wrapper.nix
@@ -29,7 +29,7 @@ let
       ++ lib.optional isWindows "h/nt"
       ++ lib.optional isLinux "lh";
       listToDirs = list: lib.strings.concatMapStringsSep ":" (dir: "${placeholder "out"}/${dir}") list;
-      name = "${open-watcom.pname}-${open-watcom.version}";
+      name = "${open-watcom.passthru.prettyName}-${open-watcom.version}";
     in
     symlinkJoin {
       inherit name;


### PR DESCRIPTION
###### Description of changes

Closes #174466

CC @SuperSandro2000 (https://github.com/NixOS/nixpkgs/pull/174466#discussion_r933359820)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
