### PR TITLE
guestfs-tools: init at 1.48.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13368,6 +13368,15 @@
     github = "twitchyliquid64";
     githubId = 6328589;
   };
+  twz123 = {
+    name = "Tom Wieczorek";
+    email = "tom@bibbu.net";
+    github = "twz123";
+    githubId = 1215104;
+    keys = [{
+      fingerprint = "B1FD 4E2A 84B2 2379 F4BF  2EF5 FE33 A228 2371 E831";
+    }];
+  };
   typetetris = {
     email = "ericwolf42@mail.com";
     github = "typetetris";

--- a/pkgs/development/tools/guestfs-tools/default.nix
+++ b/pkgs/development/tools/guestfs-tools/default.nix
@@ -1,0 +1,116 @@
+{ lib
+, stdenv
+, fetchurl
+, autoreconfHook
+, bison
+, cdrkit
+, cpio
+, flex
+, getopt
+, makeWrapper
+, pkg-config
+, qemu
+, ocamlPackages
+, perlPackages
+, bash-completion
+, jansson
+, libvirt
+, libxcrypt
+, libxml2
+, ncurses
+, pcre2
+, xz
+, hivex
+, libguestfs
+, guestfs-tools
+, callPackage
+, appliance ? null
+}:
+
+assert appliance == null || lib.isDerivation appliance;
+
+stdenv.mkDerivation rec {
+  pname = "guestfs-tools";
+  version = "1.48.2";
+
+  src = fetchurl {
+    url = "https://download.libguestfs.org/${pname}/${lib.versions.majorMinor version}-stable/${pname}-${version}.tar.gz";
+    sha256 = "sha256-G9l5sG5g5kMlSXzg0GX8+Et7M9/k2dRLMBgsMI4MaxA=";
+  };
+
+  strictDeps = true;
+  nativeBuildInputs = [
+    autoreconfHook
+    bison
+    cdrkit
+    cpio
+    flex
+    getopt
+    hivex
+    makeWrapper
+    pkg-config
+    qemu
+    perlPackages.perl
+  ] ++ (with ocamlPackages; [
+    ocaml
+    ocamlbuild
+    findlib
+    gettext-stub
+  ]);
+
+  buildInputs = [
+    bash-completion
+    hivex
+    jansson
+    libvirt
+    libxcrypt
+    libxml2
+    ncurses
+    pcre2
+    xz
+    perlPackages.perl
+  ] ++ (with ocamlPackages; [
+    gettext-stub
+    ounit2
+  ]);
+
+  propagatedBuildInputs = [
+    hivex
+    (libguestfs.override { inherit appliance; })
+  ] ++ (with perlPackages; [
+    libintl-perl
+    ModuleBuild
+  ]);
+
+  postPatch = ''
+    for file in {*.sh.in,run.in}; do
+      substituteInPlace "$file" --replace '#!/bin/bash' '#!${stdenv.shell}'
+    done
+
+    patchShebangs .
+  '';
+
+  makeFlags = [
+    "BASH_COMPLETIONS_DIR=${placeholder "out"}/share/bash-completion/completions"
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/virt-win-reg \
+      --prefix PERL5LIB : "$PERL5LIB"
+  '';
+
+  passthru.tests = callPackage ./tests.nix {
+    libguestfs = libguestfs.override { inherit appliance; };
+    guestfs-tools = guestfs-tools.override { inherit appliance; };
+  };
+
+  meta = with lib; {
+    description = "Tools for accessing and modifying guest disk images.";
+    license = with licenses; [ gpl2Plus lgpl21Plus ];
+    homepage = "https://libguestfs.org/";
+    maintainers = with maintainers; [ twz123 ];
+    platforms = platforms.linux;
+    # this is to avoid "output size exceeded"
+    hydraPlatforms = if appliance != null then appliance.meta.hydraPlatforms else platforms.linux;
+  };
+}

--- a/pkgs/development/tools/guestfs-tools/tests.nix
+++ b/pkgs/development/tools/guestfs-tools/tests.nix
@@ -1,0 +1,35 @@
+{ guestfs-tools
+, libguestfs
+, runCommand
+}:
+
+let
+  inherit (guestfs-tools) pname version;
+in
+{
+  version-tests = runCommand "${pname}-version-tests"
+    {
+      VERSION = version;
+      GUESTFS_TOOLS = "${guestfs-tools}";
+      LIBGUESTFS_PNAME = libguestfs.pname;
+      LIBGUESTFS_VERSION = libguestfs.version;
+
+      meta.timeout = 60;
+    } ''
+    for bin in "$GUESTFS_TOOLS"/bin/*; do
+      expected="''${bin##*/} $VERSION"
+      case "''${bin##*/}" in
+      virt-win-reg) expected="$(printf '%s\n%s %s' "$expected" "$LIBGUESTFS_PNAME" "$LIBGUESTFS_VERSION")" ;;
+      esac
+      actual="$("$bin" --version)"
+      if [ "$actual" != "$expected" ]; then
+        echo Error: program version does not match package version >&2
+        echo Expected: "$expected" >&2
+        echo Actual: "$actual" >&2
+        exit 1
+      fi
+    done
+
+    touch -- "$out"
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34929,6 +34929,14 @@ with pkgs;
     buildGoModule = buildGo117Module;
   };
 
+  guestfs-tools = callPackage ../development/tools/guestfs-tools {
+    autoreconfHook = buildPackages.autoreconfHook264;
+  };
+  guestfs-tools-with-appliance = guestfs-tools.override {
+    appliance = libguestfs-appliance;
+    autoreconfHook = buildPackages.autoreconfHook264;
+  };
+
   guetzli = callPackage ../applications/graphics/guetzli { };
 
   gummi = callPackage ../applications/misc/gummi { };


### PR DESCRIPTION
###### Description of changes

Follow-up to #185015.

As of [libguestfs 1.46](https://github.com/libguestfs/libguestfs/blob/ab2d624f46b6cb69a332f513ea32a1f7c9170ca5/docs/guestfs-release-notes-1.46.pod), many of the CLI tools have moved to the new [guestfs-tools](https://github.com/rwmjones/guestfs-tools) project.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).