### PR TITLE
nixos/activation: merge `/bin` into `/usr`

### DIFF
--- a/nixos/doc/manual/development/activation-script.section.md
+++ b/nixos/doc/manual/development/activation-script.section.md
@@ -57,7 +57,8 @@ There are some snippets NixOS enables by default because disabling them would
 most likely break your system. This section lists a few of them and what they
 do:
 
-- `binsh` creates `/bin/sh` which points to the runtime shell
+- `usrbin` creates `/usr/bin/env` and `/bin/sh` (which points to the runtime
+  shell), with `/bin` being a symbolic link to `/usr/bin`
 - `etc` sets up the contents of `/etc`, this includes systemd units and
   excludes `/etc/passwd`, `/etc/group`, and `/etc/shadow` (which are managed by
   the `users` snippet)
@@ -67,6 +68,5 @@ do:
 - `specialfs` is responsible for mounting filesystems like `/proc` and `sys`
 - `users` creates and removes users and groups by managing `/etc/passwd`,
   `/etc/group` and `/etc/shadow`. This also creates home directories
-- `usrbinenv` creates `/usr/bin/env`
 - `var` creates some directories in `/var` that are not service-specific
 - `wrappers` creates setuid wrappers like `ping` and `sudo`

--- a/nixos/doc/manual/from_md/development/activation-script.section.xml
+++ b/nixos/doc/manual/from_md/development/activation-script.section.xml
@@ -79,8 +79,11 @@ system.activationScripts.my-activation-script = {
     <itemizedlist spacing="compact">
       <listitem>
         <para>
-          <literal>binsh</literal> creates <literal>/bin/sh</literal>
-          which points to the runtime shell
+          <literal>usrbin</literal> creates
+          <literal>/usr/bin/env</literal> and <literal>/bin/sh</literal>
+          (which points to the runtime shell), with
+          <literal>/bin</literal> being a symbolic link to
+          <literal>/usr/bin</literal>
         </para>
       </listitem>
       <listitem>
@@ -125,12 +128,6 @@ system.activationScripts.my-activation-script = {
           <literal>/etc/group</literal> and
           <literal>/etc/shadow</literal>. This also creates home
           directories
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>usrbinenv</literal> creates
-          <literal>/usr/bin/env</literal>
         </para>
       </listitem>
       <listitem>

--- a/nixos/modules/config/shells-environment.nix
+++ b/nixos/modules/config/shells-environment.nix
@@ -210,15 +210,6 @@ in
         ''}
       '';
 
-    system.activationScripts.binsh = stringAfter [ "stdio" ]
-      ''
-        # Create the required /bin/sh symlink; otherwise lots of things
-        # (notably the system() function) won't work.
-        mkdir -m 0755 -p /bin
-        ln -sfn "${cfg.binsh}" /bin/.sh.tmp
-        mv /bin/.sh.tmp /bin/sh # atomically replace /bin/sh
-      '';
-
   };
 
 }


### PR DESCRIPTION
Following the discussion in https://github.com/NixOS/nixpkgs/issues/184826 and https://github.com/systemd/systemd/issues/24191, fix the situation in NixOS by making `/bin` a symbolic link to `/usr/bin`.

Before migrating existing setups, check that `/bin` only contains `sh` to avoid deleting things a user might have put in `/bin` (although they shouldn't have!). I'm not sure whether we should error out in this scenario or just continue with the activation.

Note that reverting a merged-`/usr` system to an unmerged configuration has no effect, since `mkdir -p` will succeed if `/bin` is a symlink.

Also, replacing the `/bin` directory with a symlink isn't an atomic operation so `/bin/sh` will be gone for a short time on the first migration, and AFAICT there's no easy way around that since removing a non-empty directory is not a primitive operation.

Tested on my machine.