### PR TITLE
nixos/switch-to-configuration: replace Net::DBus with busctl

### DIFF
--- a/nixos/modules/system/activation/switch-to-configuration.pl
+++ b/nixos/modules/system/activation/switch-to-configuration.pl
@@ -18,7 +18,8 @@ use Config::IniFiles;
 use File::Path qw(make_path);
 use File::Basename;
 use File::Slurp qw(read_file write_file edit_file);
-use Net::DBus;
+use JSON::PP;
+use IPC::Cmd;
 use Sys::Syslog qw(:standard :macros);
 use Cwd qw(abs_path);
 
@@ -124,12 +125,29 @@ EOF
 # virtual console 1 and we restart the "tty1" unit.
 $SIG{PIPE} = "IGNORE";
 
+# Replacement for Net::DBus that calls busctl of the current systemd, parses
+# it's json output and returns the response using only core modules to reduce
+# dependencies on perlPackages in baseSystem
+sub busctl_call_systemd1_mgr {
+    my (@args) = @_;
+    my $cmd = [
+        "$cur_systemd/busctl", "--json=short", "call", "org.freedesktop.systemd1",
+        "/org/freedesktop/systemd1", "org.freedesktop.systemd1.Manager",
+        @args
+    ];
+
+    my ($ok, $err, undef, $stdout) = IPC::Cmd::run(command => $cmd);
+    die $err unless $ok;
+
+    my $res = decode_json(join "", @$stdout);
+    return $res;
+}
+
 # Asks the currently running systemd instance via dbus which units are active.
 # Returns a hash where the key is the name of each unit and the value a hash
 # of load, state, substate.
 sub get_active_units {
-    my $mgr = Net::DBus->system->get_service("org.freedesktop.systemd1")->get_object("/org/freedesktop/systemd1");
-    my $units = $mgr->ListUnitsByPatterns([], []);
+    my $units = busctl_call_systemd1_mgr("ListUnitsByPatterns", "asas", 0, 0)->{data}->[0];
     my $res = {};
     for my $item (@{$units}) {
         my ($id, $description, $load_state, $active_state, $sub_state,
@@ -149,9 +167,7 @@ sub get_active_units {
 # Takes the name of the unit as an argument and returns a bool whether the unit is active or not.
 sub unit_is_active {
     my ($unit_name) = @_;
-
-    my $mgr = Net::DBus->system->get_service("org.freedesktop.systemd1")->get_object("/org/freedesktop/systemd1");
-    my $units = $mgr->ListUnitsByNames([$unit_name]);
+    my $units = busctl_call_systemd1_mgr("ListUnitsByNames", "as", 1, $unit_name)->{data}->[0];
     if (scalar(@{$units}) == 0) {
         return 0;
     }

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -124,7 +124,7 @@ let
     configurationName = config.boot.loader.grub.configurationName;
 
     # Needed by switch-to-configuration.
-    perl = pkgs.perl.withPackages (p: with p; [ ConfigIniFiles FileSlurp NetDBus ]);
+    perl = pkgs.perl.withPackages (p: with p; [ ConfigIniFiles FileSlurp ]);
   };
 
   # Handle assertions and warnings


### PR DESCRIPTION
###### Description of changes

Call dbus by using `$cur_systemd/busctl --json=...` and core modules `JSON::PP` and `IPC::Cmd`, instead of using `Net::DBus`, to try to slim down dependencies for baseSystem.

Motivation: 
`perlPackages.NetDBus` pulls in quite a few other dependencies, like `XML::Twig`, `XML::Parser`, `LWP`, and until recently `HTTP::Daemon`, etc. These are not really necessary for s-t-c, and updates to them have caused issues with cross builds. For example a security update https://github.com/NixOS/nixpkgs/pull/181632 caused https://github.com/NixOS/nixpkgs/issues/182287, https://github.com/NixOS/nixpkgs/issues/182502, and more

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
