### PR TITLE
mangohud: 0.6.7-1 → 0.6.8

### DIFF
--- a/pkgs/tools/graphics/mangohud/default.nix
+++ b/pkgs/tools/graphics/mangohud/default.nix
@@ -1,28 +1,26 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , fetchurl
 , substituteAll
 , coreutils
 , curl
-, gawk
 , glxinfo
 , gnugrep
 , gnused
-, lsof
 , xdg-utils
 , dbus
 , hwdata
 , libX11
 , mangohud32
 , vulkan-headers
+, appstream
 , glslang
 , makeWrapper
+, Mako
 , meson
 , ninja
 , pkg-config
-, python3Packages
 , unzip
 , vulkan-loader
 , libXNVCtrl
@@ -43,24 +41,24 @@ let
     src = fetchFromGitHub {
       owner = "ocornut";
       repo = "imgui";
-      rev = "v${version}";
-      hash = "sha256-rRkayXk3xz758v6vlMSaUu5fui6NR8Md3njhDB0gJ18=";
+      rev = "refs/tags/v${version}";
+      sha256 = "sha256-rRkayXk3xz758v6vlMSaUu5fui6NR8Md3njhDB0gJ18=";
     };
     patch = fetchurl {
       url = "https://wrapdb.mesonbuild.com/v2/imgui_${version}-1/get_patch";
-      hash = "sha256-bQC0QmkLalxdj4mDEdqvvOFtNwz2T1MpTDuMXGYeQ18=";
+      sha256 = "sha256-bQC0QmkLalxdj4mDEdqvvOFtNwz2T1MpTDuMXGYeQ18=";
     };
   };
 in stdenv.mkDerivation rec {
   pname = "mangohud";
-  version = "0.6.7-1";
+  version = "0.6.8";
 
   src = fetchFromGitHub {
     owner = "flightlessmango";
     repo = "MangoHud";
-    rev = "v${version}";
+    rev = "refs/tags/v${version}";
     fetchSubmodules = true;
-    sha256 = "sha256-60cZYo+d679KRggLBGbpLYM5Iu1XySEEGp+MxZs6wF0=";
+    sha256 = "sha256-jfmgN90kViHa7vMOjo2x4bNY2QbLk93uYEvaA4DxYvg=";
   };
 
   outputs = [ "out" "doc" "man" ];
@@ -81,22 +79,14 @@ in stdenv.mkDerivation rec {
       path = lib.makeBinPath [
         coreutils
         curl
-        gawk
         glxinfo
         gnugrep
         gnused
-        lsof
         xdg-utils
       ];
 
       libdbus = dbus.lib;
       inherit hwdata libX11;
-    })
-
-    (fetchpatch {
-      name = "allow-system-nlohmann-json.patch";
-      url = "https://github.com/flightlessmango/MangoHud/commit/e1ffa0f85820abea44639438fca2152290c87ee8.patch";
-      sha256 = "sha256-CaJb0RpXmNGCBidMXM39VJVLIXb6NbN5HXWkH/5Sfvo=";
     })
   ] ++ lib.optional (stdenv.hostPlatform.system == "x86_64-linux") [
     # Support 32bit OpenGL applications by appending the mangohud32
@@ -124,13 +114,13 @@ in stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [
+    appstream
     glslang
     makeWrapper
+    Mako
     meson
     ninja
     pkg-config
-    python3Packages.Mako
-    python3Packages.python
     unzip
     vulkan-loader
   ];

--- a/pkgs/tools/graphics/mangohud/hardcode-dependencies.patch
+++ b/pkgs/tools/graphics/mangohud/hardcode-dependencies.patch
@@ -1,15 +1,3 @@
-From 56a191f6db6d530c2bc89d9d3395b4c9768d108f Mon Sep 17 00:00:00 2001
-From: Atemu <atemu.main@gmail.com>
-Date: Tue, 17 May 2022 16:58:08 +0200
-Subject: [PATCH 1/2] hardcode dependencies
-
----
- src/dbus.cpp               | 2 +-
- src/loaders/loader_x11.cpp | 2 +-
- src/logging.cpp            | 7 +++++++
- src/pci_ids.cpp            | 6 ++----
- 4 files changed, 11 insertions(+), 6 deletions(-)
-
 diff --git a/src/dbus.cpp b/src/dbus.cpp
 index 3b3cccb..1405725 100644
 --- a/src/dbus.cpp
@@ -34,21 +22,18 @@ index 4db6f78..c60d08c 100644
 -std::shared_ptr<libx11_loader> g_x11(new libx11_loader("libX11.so.6"));
 +std::shared_ptr<libx11_loader> g_x11(new libx11_loader("@libX11@/lib/libX11.so.6"));
 diff --git a/src/logging.cpp b/src/logging.cpp
-index b27f21e..48f5e03 100644
+index 1668226..f0c8df5 100644
 --- a/src/logging.cpp
 +++ b/src/logging.cpp
-@@ -22,7 +22,14 @@ string exec(string command) {
+@@ -24,7 +24,11 @@ string exec(string command) {
  #endif
      std::array<char, 128> buffer;
      std::string result;
 +
 +    char* originalPath = getenv("PATH");
 +    setenv("PATH", "@path@", 1);
-+
      std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(command.c_str(), "r"), pclose);
-+
 +    setenv("PATH", originalPath, 1);
-+
      if (!pipe) {
        return "popen failed!";
      }
@@ -70,6 +55,3 @@ index feec222..6baa707 100644
      }
  
      std::string line;
--- 
-2.36.0
-

--- a/pkgs/tools/graphics/mangohud/opengl32-nix-workaround.patch
+++ b/pkgs/tools/graphics/mangohud/opengl32-nix-workaround.patch
@@ -1,24 +1,12 @@
-From 1ac93cbf0eed951af6967a81f731a0f418ea0b3d Mon Sep 17 00:00:00 2001
-From: Atemu <atemu.main@gmail.com>
-Date: Tue, 17 May 2022 16:58:45 +0200
-Subject: [PATCH 2/2] opengl32 nix workaround
-
----
- bin/mangohud.in | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
 diff --git a/bin/mangohud.in b/bin/mangohud.in
-index 8ec21de..f65304a 100755
+index e13da99..086443c 100755
 --- a/bin/mangohud.in
 +++ b/bin/mangohud.in
 @@ -23,6 +23,6 @@ fi
  # figure out whether the 32 or 64 bit version should be used, and will search
  # for it in the correct directory
- LD_PRELOAD="${LD_PRELOAD}:${MANGOHUD_LIB_NAME}"
--LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:@ld_libdir_mangohud@"
-+LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:@ld_libdir_mangohud@:@mangohud32@/lib/mangohud"
+ LD_PRELOAD="${LD_PRELOAD}${LD_PRELOAD:+:}${MANGOHUD_LIB_NAME}"
+-LD_LIBRARY_PATH="${LD_LIBRARY_PATH}${LD_LIBRARY_PATH:+:}@ld_libdir_mangohud@"
++LD_LIBRARY_PATH="${LD_LIBRARY_PATH}${LD_LIBRARY_PATH:+:}@ld_libdir_mangohud@:@mangohud32@/lib/mangohud"
  
  exec env MANGOHUD=1 LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" LD_PRELOAD="${LD_PRELOAD}" "$@"
--- 
-2.36.0
-

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8571,6 +8571,7 @@ with pkgs;
   mangohud = callPackage ../tools/graphics/mangohud {
     libXNVCtrl = linuxPackages.nvidia_x11.settings.libXNVCtrl;
     mangohud32 = pkgsi686Linux.mangohud;
+    inherit (python3Packages) Mako;
   };
 
   manix = callPackage ../tools/nix/manix {


### PR DESCRIPTION
###### Description of changes

Update to the latest version: https://github.com/flightlessmango/MangoHud/releases/tag/v0.6.8

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).