### PR TITLE
samuela packages: add mandatory PR notice

### DIFF
--- a/pkgs/development/python-modules/adjusttext/default.nix
+++ b/pkgs/development/python-modules/adjusttext/default.nix
@@ -1,3 +1,10 @@
+################################################################################
+# WARNING: Changes made to this file MUST go through the usual PR review process
+#          and MUST be approved by a member of `meta.maintainers` before
+#          merging. Commits attempting to circumvent the PR review process -- as
+#          part of python-updates or otheriwse -- will be reverted without
+#          notice.
+################################################################################
 { lib
 , buildPythonPackage
 , fetchFromGitHub

--- a/pkgs/development/python-modules/augmax/default.nix
+++ b/pkgs/development/python-modules/augmax/default.nix
@@ -1,3 +1,10 @@
+################################################################################
+# WARNING: Changes made to this file MUST go through the usual PR review process
+#          and MUST be approved by a member of `meta.maintainers` before
+#          merging. Commits attempting to circumvent the PR review process -- as
+#          part of python-updates or otheriwse -- will be reverted without
+#          notice.
+################################################################################
 { buildPythonPackage
 , einops
 , fetchFromGitHub

--- a/pkgs/development/python-modules/dm-tree/default.nix
+++ b/pkgs/development/python-modules/dm-tree/default.nix
@@ -1,3 +1,10 @@
+################################################################################
+# WARNING: Changes made to this file MUST go through the usual PR review process
+#          and MUST be approved by a member of `meta.maintainers` before
+#          merging. Commits attempting to circumvent the PR review process -- as
+#          part of python-updates or otheriwse -- will be reverted without
+#          notice.
+################################################################################
 { stdenv
 , abseil-cpp
 , absl-py

--- a/pkgs/development/python-modules/fastavro/default.nix
+++ b/pkgs/development/python-modules/fastavro/default.nix
@@ -1,3 +1,10 @@
+################################################################################
+# WARNING: Changes made to this file MUST go through the usual PR review process
+#          and MUST be approved by a member of `meta.maintainers` before
+#          merging. Commits attempting to circumvent the PR review process -- as
+#          part of python-updates or otheriwse -- will be reverted without
+#          notice.
+################################################################################
 { buildPythonPackage
 , cython
 , fetchFromGitHub

--- a/pkgs/development/python-modules/ffcv/default.nix
+++ b/pkgs/development/python-modules/ffcv/default.nix
@@ -1,3 +1,10 @@
+################################################################################
+# WARNING: Changes made to this file MUST go through the usual PR review process
+#          and MUST be approved by a member of `meta.maintainers` before
+#          merging. Commits attempting to circumvent the PR review process -- as
+#          part of python-updates or otheriwse -- will be reverted without
+#          notice.
+################################################################################
 { buildPythonPackage
 , fetchFromGitHub
 , lib

--- a/pkgs/development/python-modules/functorch/default.nix
+++ b/pkgs/development/python-modules/functorch/default.nix
@@ -1,3 +1,10 @@
+################################################################################
+# WARNING: Changes made to this file MUST go through the usual PR review process
+#          and MUST be approved by a member of `meta.maintainers` before
+#          merging. Commits attempting to circumvent the PR review process -- as
+#          part of python-updates or otheriwse -- will be reverted without
+#          notice.
+################################################################################
 { buildPythonPackage
 , expecttest
 , fetchFromGitHub

--- a/pkgs/development/python-modules/hdfs/default.nix
+++ b/pkgs/development/python-modules/hdfs/default.nix
@@ -1,3 +1,10 @@
+################################################################################
+# WARNING: Changes made to this file MUST go through the usual PR review process
+#          and MUST be approved by a member of `meta.maintainers` before
+#          merging. Commits attempting to circumvent the PR review process -- as
+#          part of python-updates or otheriwse -- will be reverted without
+#          notice.
+################################################################################
 { buildPythonPackage
 , docopt
 , fastavro

--- a/pkgs/development/python-modules/in-place/default.nix
+++ b/pkgs/development/python-modules/in-place/default.nix
@@ -1,3 +1,10 @@
+################################################################################
+# WARNING: Changes made to this file MUST go through the usual PR review process
+#          and MUST be approved by a member of `meta.maintainers` before
+#          merging. Commits attempting to circumvent the PR review process -- as
+#          part of python-updates or otheriwse -- will be reverted without
+#          notice.
+################################################################################
 { buildPythonPackage
 , fetchFromGitHub
 , lib

--- a/pkgs/development/python-modules/invocations/default.nix
+++ b/pkgs/development/python-modules/invocations/default.nix
@@ -1,3 +1,10 @@
+################################################################################
+# WARNING: Changes made to this file MUST go through the usual PR review process
+#          and MUST be approved by a member of `meta.maintainers` before
+#          merging. Commits attempting to circumvent the PR review process -- as
+#          part of python-updates or otheriwse -- will be reverted without
+#          notice.
+################################################################################
 { lib
 , buildPythonPackage
 , blessings

--- a/pkgs/development/python-modules/jax/default.nix
+++ b/pkgs/development/python-modules/jax/default.nix
@@ -1,3 +1,10 @@
+################################################################################
+# WARNING: Changes made to this file MUST go through the usual PR review process
+#          and MUST be approved by a member of `meta.maintainers` before
+#          merging. Commits attempting to circumvent the PR review process -- as
+#          part of python-updates or otheriwse -- will be reverted without
+#          notice.
+################################################################################
 { lib
 , absl-py
 , blas

--- a/pkgs/development/python-modules/jaxlib/bin.nix
+++ b/pkgs/development/python-modules/jaxlib/bin.nix
@@ -1,3 +1,11 @@
+################################################################################
+# WARNING: Changes made to this file MUST go through the usual PR review process
+#          and MUST be approved by a member of `meta.maintainers` before
+#          merging. Commits attempting to circumvent the PR review process -- as
+#          part of python-updates or otheriwse -- will be reverted without
+#          notice.
+################################################################################
+
 # For the moment we only support the CPU and GPU backends of jaxlib. The TPU
 # backend will require some additional work. Those wheels are located here:
 # https://storage.googleapis.com/jax-releases/libtpu_releases.html.

--- a/pkgs/development/python-modules/mizani/default.nix
+++ b/pkgs/development/python-modules/mizani/default.nix
@@ -1,3 +1,10 @@
+################################################################################
+# WARNING: Changes made to this file MUST go through the usual PR review process
+#          and MUST be approved by a member of `meta.maintainers` before
+#          merging. Commits attempting to circumvent the PR review process -- as
+#          part of python-updates or otheriwse -- will be reverted without
+#          notice.
+################################################################################
 { lib
 , buildPythonPackage
 , fetchFromGitHub

--- a/pkgs/development/python-modules/ml-collections/default.nix
+++ b/pkgs/development/python-modules/ml-collections/default.nix
@@ -1,3 +1,10 @@
+################################################################################
+# WARNING: Changes made to this file MUST go through the usual PR review process
+#          and MUST be approved by a member of `meta.maintainers` before
+#          merging. Commits attempting to circumvent the PR review process -- as
+#          part of python-updates or otheriwse -- will be reverted without
+#          notice.
+################################################################################
 { absl-py
 , buildPythonPackage
 , contextlib2

--- a/pkgs/development/python-modules/pytorch-pfn-extras/default.nix
+++ b/pkgs/development/python-modules/pytorch-pfn-extras/default.nix
@@ -1,3 +1,10 @@
+################################################################################
+# WARNING: Changes made to this file MUST go through the usual PR review process
+#          and MUST be approved by a member of `meta.maintainers` before
+#          merging. Commits attempting to circumvent the PR review process -- as
+#          part of python-updates or otheriwse -- will be reverted without
+#          notice.
+################################################################################
 { buildPythonPackage
 , fetchFromGitHub
 , lib

--- a/pkgs/development/python-modules/releases/default.nix
+++ b/pkgs/development/python-modules/releases/default.nix
@@ -1,3 +1,10 @@
+################################################################################
+# WARNING: Changes made to this file MUST go through the usual PR review process
+#          and MUST be approved by a member of `meta.maintainers` before
+#          merging. Commits attempting to circumvent the PR review process -- as
+#          part of python-updates or otheriwse -- will be reverted without
+#          notice.
+################################################################################
 { buildPythonPackage
 , fetchFromGitHub
 , lib

--- a/pkgs/development/python-modules/servefile/default.nix
+++ b/pkgs/development/python-modules/servefile/default.nix
@@ -1,3 +1,10 @@
+################################################################################
+# WARNING: Changes made to this file MUST go through the usual PR review process
+#          and MUST be approved by a member of `meta.maintainers` before
+#          merging. Commits attempting to circumvent the PR review process -- as
+#          part of python-updates or otheriwse -- will be reverted without
+#          notice.
+################################################################################
 { stdenv
 , buildPythonPackage
 , fetchFromGitHub

--- a/pkgs/development/python-modules/torch-tb-profiler/default.nix
+++ b/pkgs/development/python-modules/torch-tb-profiler/default.nix
@@ -1,3 +1,10 @@
+################################################################################
+# WARNING: Changes made to this file MUST go through the usual PR review process
+#          and MUST be approved by a member of `meta.maintainers` before
+#          merging. Commits attempting to circumvent the PR review process -- as
+#          part of python-updates or otheriwse -- will be reverted without
+#          notice.
+################################################################################
 { buildPythonPackage
 , fetchFromGitHub
 , lib

--- a/pkgs/development/python-modules/wandb/default.nix
+++ b/pkgs/development/python-modules/wandb/default.nix
@@ -1,3 +1,10 @@
+################################################################################
+# WARNING: Changes made to this file MUST go through the usual PR review process
+#          and MUST be approved by a member of `meta.maintainers` before
+#          merging. Commits attempting to circumvent the PR review process -- as
+#          part of python-updates or otheriwse -- will be reverted without
+#          notice.
+################################################################################
 { lib
 , stdenv
 , azure-core

--- a/pkgs/development/python-modules/yaspin/default.nix
+++ b/pkgs/development/python-modules/yaspin/default.nix
@@ -1,3 +1,10 @@
+################################################################################
+# WARNING: Changes made to this file MUST go through the usual PR review process
+#          and MUST be approved by a member of `meta.maintainers` before
+#          merging. Commits attempting to circumvent the PR review process -- as
+#          part of python-updates or otheriwse -- will be reverted without
+#          notice.
+################################################################################
 { buildPythonPackage
 , fetchFromGitHub
 , lib


### PR DESCRIPTION
###### Description of changes

I frequently find that changes are made to packages that I maintain without my notice or consent. This behavior is intrusive and disruptive to maintenance, esp. considering that these changes are often poorly conceived. This PR simply adds a comment to the beginning of the files of packages that I maintain notifying contributors that changes made to these packages are expected to go through the usual PR process.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
