### PR TITLE
python3Packages.flask-basicauth: init at 0.2.0

### DIFF
--- a/pkgs/development/python-modules/flask-basicauth/default.nix
+++ b/pkgs/development/python-modules/flask-basicauth/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, flask
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "flask-basicauth";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "jpvanhal";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-han0OjMI1XmuWKHGVpk+xZB+/+cpV1I+659zOG3hcPY=";
+  };
+
+  patches = [
+    (fetchpatch {
+      # The unit tests fail due to an invalid import:
+      #   from flask.ext.basicauth import BasicAuth
+      #
+      # This patch replaces it with the correct import:
+      #   from flask_basicauth import BasicAuth
+      #
+      # The patch uses the changes from this pull request,
+      # and therefore can be removed once this pull request
+      # has been merged:
+      #   https://github.com/jpvanhal/flask-basicauth/pull/29
+      name = "fix-test-flask-ext-imports.patch";
+      url = "https://github.com/jpvanhal/flask-basicauth/commit/23f57dc1c3d85ea6fc7f468e8d8c6f19348a0a81.patch";
+      sha256 = "sha256-njUYjO0TRe3vr5D0XjIfCNcsFlShbGxtFV/DJerAKDE=";
+    })
+  ];
+
+  propagatedBuildInputs = [ flask ];
+
+  checkPhase = ''
+    runHook preCheck
+    ${python.interpreter} -m unittest discover
+    runHook postCheck
+  '';
+
+  pythonImportsCheck = [ "flask_basicauth" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/jpvanhal/flask-basicauth";
+    description = "HTTP basic access authentication for Flask";
+    license = licenses.mit;
+    maintainers = with maintainers; [ wesnel ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3280,6 +3280,8 @@ in {
 
   flask-babelex = callPackage ../development/python-modules/flask-babelex { };
 
+  flask-basicauth = callPackage ../development/python-modules/flask-basicauth { };
+
   flask-bcrypt = callPackage ../development/python-modules/flask-bcrypt { };
 
   flask-bootstrap = callPackage ../development/python-modules/flask-bootstrap { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR is very similar to #90762, except in this PR I was able to get the package's test suite to run successfully. In the other PR, the tests were skipped instead. I got the tests to run by incorporating a patch from jpvanhal/flask-basicauth#29. Thanks for reviewing this PR!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
