### PR TITLE
gobject-introspection: fix non-meson cross builds

### DIFF
--- a/pkgs/development/libraries/gobject-introspection/wrapper.nix
+++ b/pkgs/development/libraries/gobject-introspection/wrapper.nix
@@ -25,6 +25,7 @@ in
     (
       export bash="${buildPackages.bash}"
       export emulator=${lib.escapeShellArg (stdenv.targetPlatform.emulator buildPackages)}
+      export emulatorwrapper="$dev/bin/g-ir-scanner-qemuwrapper"
       export buildobjdump="${buildPackages.stdenv.cc.bintools}/bin/objdump"
 
       export targetgir="${lib.getDev (targetPackages.gobject-introspection-unwrapped.override argsForTarget)}"
@@ -32,9 +33,8 @@ in
       substituteAll "${./wrappers/g-ir-compiler.sh}" "$dev/bin/g-ir-compiler"
       substituteAll "${./wrappers/g-ir-scanner.sh}" "$dev/bin/g-ir-scanner"
       substituteAll "${./wrappers/g-ir-scanner-lddwrapper.sh}" "$dev/bin/g-ir-scanner-lddwrapper"
-      chmod +x "$dev/bin/g-ir-compiler"
-      chmod +x "$dev/bin/g-ir-scanner"
-      chmod +x "$dev/bin/g-ir-scanner-lddwrapper"
+      substituteAll "${./wrappers/g-ir-scanner-qemuwrapper.sh}" "$dev/bin/g-ir-scanner-qemuwrapper"
+      chmod +x $dev/bin/g-ir-*
     )
   ''
   # when cross-compiling and using the wrapper then when a package looks up the g_ir_X

--- a/pkgs/development/libraries/gobject-introspection/wrappers/g-ir-compiler.sh
+++ b/pkgs/development/libraries/gobject-introspection/wrappers/g-ir-compiler.sh
@@ -1,4 +1,4 @@
 #! @bash@/bin/bash
 # shellcheck shell=bash
 
-exec @emulator@ @targetgir@/bin/g-ir-compiler "$@"
+exec @emulatorwrapper@ @targetgir@/bin/g-ir-compiler "$@"

--- a/pkgs/development/libraries/gobject-introspection/wrappers/g-ir-scanner-qemuwrapper.sh
+++ b/pkgs/development/libraries/gobject-introspection/wrappers/g-ir-scanner-qemuwrapper.sh
@@ -1,0 +1,23 @@
+#! @bash@/bin/bash
+# shellcheck shell=bash
+
+# fixes issues like
+# libdbusmenu-gtk3-aarch64-unknown-linux-gnu> /build/libdbusmenu-16.04.0/libdbusmenu-gtk/tmp-introspect2jhtiwwn/.libs/DbusmenuGtk3-0.4:
+# error while loading shared libraries: libdbusmenu-glib.so.4: cannot open shared object file: No such file or directory
+# in non-meson builds
+
+# see: https://github.com/void-linux/void-packages/blob/master/srcpkgs/gobject-introspection/files/g-ir-scanner-qemuwrapper
+# https://github.com/openembedded/openembedded-core/blob/c5a14f39a6717a99b510cb97aa2fb403d4b98d99/meta/recipes-gnome/gobject-introspection/gobject-introspection_1.72.0.bb#L74
+while read -r d; do \
+    # some meson projects may have subprojects which use makefiles for docs(e.g. gi-docgen), ignore those as they will never be needed
+    if [[ -f "$d/Makefile" && "$d" != *"subproject"* ]]; then
+        GIR_EXTRA_LIBS_PATH="$(readlink -f "$d/.libs"):$GIR_EXTRA_LIBS_PATH"
+        export GIR_EXTRA_LIBS_PATH
+    fi
+done < <(find "$NIX_BUILD_TOP" -type d)
+
+# quoting broke the build of atk
+# shellcheck disable=2086
+exec @emulator@ ${GIR_EXTRA_OPTIONS:-} \
+    ${GIR_EXTRA_LIBS_PATH:+-E LD_LIBRARY_PATH="${GIR_EXTRA_LIBS_PATH}"} \
+    "$@"

--- a/pkgs/development/libraries/gobject-introspection/wrappers/g-ir-scanner.sh
+++ b/pkgs/development/libraries/gobject-introspection/wrappers/g-ir-scanner.sh
@@ -2,6 +2,6 @@
 # shellcheck shell=bash
 
 exec @dev@/bin/.g-ir-scanner-wrapped \
-    --use-binary-wrapper=@emulator@ \
+    --use-binary-wrapper=@emulatorwrapper@ \
     --use-ldd-wrapper=@dev@/bin/g-ir-scanner-lddwrapper \
     "$@"


### PR DESCRIPTION
TODO write msg

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
