### PR TITLE
atsi: init at 0.0.11

### DIFF
--- a/pkgs/tools/misc/atsi/default.nix
+++ b/pkgs/tools/misc/atsi/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, pkg-config
+, openssl
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "atsi";
+  version = "0.0.11";
+
+  src = fetchFromGitHub {
+    owner = "queer";
+    repo = pname;
+    rev = "0baf045c4de4862943e10d9a7bc28881f4706c71";
+    sha256 = "sha256-k0kD98MHN6AuX+W8VeiX6ExyaLTTZlE4/+5nQQF/x/g=";
+  };
+
+  cargoSha256 = "sha256-Wsiyq57gwO6aZIzIj3YVJ5d/FFcqn1D5xGAIz+ZFh7w=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl ];
+
+  meta = with lib; {
+    description = "Instant rootless Alpine shells";
+    homepage = "https://github.com/queer/atsi";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ dit7ya ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -244,6 +244,8 @@ with pkgs;
 
   _0x =  callPackage ../tools/misc/0x { };
 
+  atsi = callPackage ../tools/misc/atsi { };
+
   atuin = callPackage ../tools/misc/atuin {
     inherit (darwin.apple_sdk.frameworks) Security SystemConfiguration;
   };


### PR DESCRIPTION
###### Description of changes

@ (atsi, "at-sign") is a tool for instantly provisioning interactive rootless Alpine containers. Think of it a little like nix-shell for Alpine.

https://github.com/queer/atsi

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
