### PR TITLE
python3Packages.rsskey: init at 0.2.0

### DIFF
--- a/pkgs/development/python-modules/markdownify/default.nix
+++ b/pkgs/development/python-modules/markdownify/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+, beautifulsoup4
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "markdownify";
+  version = "0.11.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-crOkiv/M8v7rJd/Tvsq67PU76vTgi+aNzthEcniDKBM=";
+  };
+
+  propagatedBuildInputs = [ beautifulsoup4 six ];
+  checkInputs = [ pytestCheckHook ];
+
+  meta = with lib; {
+    description = "HTML to Markdown converter";
+    homepage = "https://github.com/matthewwithanm/python-markdownify";
+    license = licenses.mit;
+    maintainers = [ maintainers.McSinyx ];
+  };
+}

--- a/pkgs/development/python-modules/rsskey/default.nix
+++ b/pkgs/development/python-modules/rsskey/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, feedparser
+, httpx
+, loca
+, markdownify
+, trio
+}:
+
+buildPythonPackage rec {
+  pname = "rsskey";
+  version = "0.2.0";
+  format = "flit";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-QedLuwd0ES2LWhZ72Cjh3+ZZ7HbRyNsyLN9lNFbY5dQ=";
+  };
+
+  propagatedBuildInputs = [
+    feedparser
+    httpx
+    loca
+    markdownify
+    trio
+  ];
+
+  doCheck = false; # upstream has no test
+  pythonImportsCheck = [ "rsskey" ];
+
+  meta = with lib; {
+    description = "RSS feed mirror on Misskey";
+    homepage = "https://sr.ht/~cnx/rsskey";
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ McSinyx ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9663,6 +9663,8 @@ in {
 
   rsa = callPackage ../development/python-modules/rsa { };
 
+  rsskey = callPackage ../development/python-modules/rsskey { };
+
   rst2ansi = callPackage ../development/python-modules/rst2ansi { };
 
   rstcheck = callPackage ../development/python-modules/rstcheck { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5447,6 +5447,8 @@ in {
 
   markdown-macros = callPackage ../development/python-modules/markdown-macros { };
 
+  markdownify  = callPackage ../development/python-modules/markdownify { };
+
   markdownsuperscript = callPackage ../development/python-modules/markdownsuperscript { };
 
   markerlib = callPackage ../development/python-modules/markerlib { };


### PR DESCRIPTION
###### Description of changes

Add rsskey and its dependency markdownify

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (`python -m rsskey`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).