### PR TITLE
credential-detector: 1.7.0 -> 1.11.0

### DIFF
--- a/pkgs/tools/security/credential-detector/default.nix
+++ b/pkgs/tools/security/credential-detector/default.nix
@@ -5,16 +5,16 @@
 
 buildGoModule rec {
   pname = "credential-detector";
-  version = "1.7.0";
+  version = "1.11.0";
 
   src = fetchFromGitHub {
     owner = "ynori7";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1g5ja32rsf1b7y9gvmy29qz2ymyyvgh53wzd6vvknfla1df0slab";
+    sha256 = "sha256-zUQRzlp/7gZhCm5JYu9kYxcoFjDldCYKarRorOHa3E0=";
   };
 
-  vendorSha256 = "1mn3sysvdz4b94804gns1yssk2q08djq3kq3cd1h7gm942zwrnq4";
+  vendorSha256 = "sha256-VWmfATUbfnI3eJbFTUp6MR1wGESuI15PHZWuon5M5rg=";
 
   meta = with lib; {
     description = "Tool to detect potentially hard-coded credentials";


### PR DESCRIPTION
###### Description of changes
- https://github.com/ynori7/credential-detector/releases/tag/v1.7.1
- https://github.com/ynori7/credential-detector/releases/tag/v1.7.2
- https://github.com/ynori7/credential-detector/releases/tag/v1.7.3
- https://github.com/ynori7/credential-detector/releases/tag/v1.7.4
- https://github.com/ynori7/credential-detector/releases/tag/v1.8.0
- https://github.com/ynori7/credential-detector/releases/tag/v1.9.0
- https://github.com/ynori7/credential-detector/releases/tag/v1.9.1
- https://github.com/ynori7/credential-detector/releases/tag/v1.10.0
- https://github.com/ynori7/credential-detector/releases/tag/v1.10.1
- https://github.com/ynori7/credential-detector/releases/tag/v1.11.0

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).