### PR TITLE
Offpunk: 1.4 -> 1.5

### DIFF
--- a/pkgs/applications/networking/browsers/offpunk/default.nix
+++ b/pkgs/applications/networking/browsers/offpunk/default.nix
@@ -5,7 +5,6 @@
   makeWrapper,
   offpunk,
   python3,
-  ripgrep,
   stdenv,
   timg,
   xdg-utils,
@@ -24,7 +23,6 @@ let
   ];
   otherDependencies = [
     less
-    ripgrep
     timg
     xdg-utils
     xsel
@@ -32,14 +30,14 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "offpunk";
-  version = "1.4";
+  version = "1.5";
 
   src = fetchFromGitea {
     domain = "notabug.org";
     owner = "ploum";
     repo = "offpunk";
     rev = "v${finalAttrs.version}";
-    sha256 = "04dzkzsan1cnrslsvfgn1whpwald8xy34wqzvq81hd2mvw9a2n69";
+    sha256 = "1zg13wajsfrl3hli6sihn47db08w037jjq9vgr6m5sjh8r1jb9iy";
   };
 
   buildInputs = [ makeWrapper ] ++ otherDependencies ++ pythonDependencies;

--- a/pkgs/applications/networking/browsers/offpunk/default.nix
+++ b/pkgs/applications/networking/browsers/offpunk/default.nix
@@ -6,6 +6,7 @@
   offpunk,
   python3,
   stdenv,
+  testVersion,
   timg,
   xdg-utils,
   xsel,
@@ -53,6 +54,8 @@ stdenv.mkDerivation (finalAttrs: {
 
    runHook postInstall
   '';
+
+  passthru.tests.version = testVersion { package = offpunk; };
 
   meta = with lib; {
     description = "An Offline-First browser for the smolnet ";


### PR DESCRIPTION
###### Description of changes

From the author:

```
1.5 is a minor release. No major changes.

- Removed optional dependency to ripgrep. "grep --color=auto" is good 
   enough.
- "open url" to open current URL in a browser with xdg-open
- "redirect" now replaces "set redirects" to improve discoverability
- "redirect" now allows urls to be blocked. By default, facebook.com and google-analytics.com
are blocked
- Fixed a bug when trying to download base64 image

With 1.5, I want to thank packagers working hard to make offpunk 
available to others. Your work is very important to me.

=> gemini://rawtext.club/~ploum/2022-08-04-offpunk15.gmi
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
