### PR TITLE
ocamlPackages.faraday-async: fix build with OCaml < 4.11

### DIFF
--- a/pkgs/development/ocaml-modules/faraday/async.nix
+++ b/pkgs/development/ocaml-modules/faraday/async.nix
@@ -1,15 +1,15 @@
-{ buildDunePackage, fetchpatch, faraday, core, async }:
+{ buildDunePackage, lib, fetchpatch, faraday, core, async }:
 
 buildDunePackage rec {
   pname = "faraday-async";
-  inherit (faraday) version src useDune2;
+  inherit (faraday) version src;
 
-  patches = fetchpatch {
+  patches = lib.optional (lib.versionAtLeast async.version "0.15") (fetchpatch {
     url = "https://github.com/inhabitedtype/faraday/commit/31c3fc7f91ecca0f1deea10b40fd5e33bcd35f75.patch";
     sha256 = "05z5gk7hxq7qvwg6f73hdhfcnx19p1dq6wqh8prx667y8zsaq2zj";
-  };
+  });
 
-  minimumOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.08";
 
   propagatedBuildInputs = [ faraday core async ];
 


### PR DESCRIPTION
###### Description of changes

Apply the patch only when it is relevant.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
