### PR TITLE
wrapJavaJar: init

### DIFF
--- a/doc/languages-frameworks/java.section.md
+++ b/doc/languages-frameworks/java.section.md
@@ -36,7 +36,23 @@ Private JARs should be installed in a location like
 `$out/share/package-name`.
 
 If your Java package provides a program, you need to generate a wrapper
-script to run it using a JRE. You can use `makeWrapper` for this:
+script to run it using a JRE. A function named `wrapJavaJar` can be used
+to do this automatically. Any attributes given will be passed to
+`mkDerivation`. It also accepts the following optional attributes:
+
+* `javaExecutable`. This refers to the path of the java executable to
+create the wrapper with. By default, `${jre}/bin/java` is used.
+* `makeWrapperArgs`. Pass extra flags to `makeWrapper`.
+
+```nix
+wrapJavaJar {
+  name = "foo";
+  src = fetchurl { ... };
+}
+```
+
+This will copy `src` to `share/java/foo.jar`, and a wrapper to it will
+be created at `bin/foo`. You can also use `makeWrapper` to do it manually:
 
 ```nix
 nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/build-support/java/wrap-jar.nix
+++ b/pkgs/build-support/java/wrap-jar.nix
@@ -1,0 +1,25 @@
+{ lib
+, runCommandLocal
+, makeWrapper
+, jre
+}:
+
+{ pname ? name # Default to eachother to allow either
+, name ? pname
+, src
+, javaExecutable ? "${jre}/bin/java"
+, ...
+} @ inputs:
+
+runCommandLocal name ({
+  nativeBuildInputs = inputs.nativeBuildInputs or [ ] ++ [ makeWrapper ];
+  meta = {
+    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
+  } // inputs.meta or { };
+} // builtins.removeAttrs inputs [ "nativeBuildInputs" "meta" ]) ''
+  mkdir -p $out/{bin,share/java}
+  cp $src $out/share/java/$name.jar
+  makeWrapper ${javaExecutable} $out/bin/$name \
+    ''${makeWrapperArgs[@]-} \
+    --add-flags "-jar $out/share/java/$name.jar"
+''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -975,6 +975,8 @@ with pkgs;
 
   wrapGAppsNoGuiHook = wrapGAppsHook.override { isGraphical = false; };
 
+  wrapJavaJar = callPackage ../build-support/java/wrap-jar.nix { };
+
   separateDebugInfo = makeSetupHook { } ../build-support/setup-hooks/separate-debug-info.sh;
 
   setupDebugInfoDirs = makeSetupHook { } ../build-support/setup-hooks/setup-debug-info-dirs.sh;


### PR DESCRIPTION
This adds a function to automatically wrap java jars, as I noticed a lot of packages do it manually right now. Usage should look something like this:

```nix
wrapJavaJar {
  pname = "foo";
  version = "1.0";

  src =  fetchurl { ... };
}
```
Which will create the following directory structure:
```
├── bin
│   └── foo
└── share
    └── java
        └── foo.jar
```
Where `bin/foo` is a simple wrapper that executes `java -jar $out/share/java/foo.jar`, which gets copied from `src`. It also has a few optional flags, refer to the added documentation for more info.

This should make packaging java applications contained in a single `jar` take significantly less effort. If it gets merged, I plan to switch over the derivations i know are doing this manually.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
