### PR TITLE
fetchgit: allow disabling cone mode for sparse checkouts

### DIFF
--- a/doc/builders/fetchers.chapter.md
+++ b/doc/builders/fetchers.chapter.md
@@ -91,7 +91,7 @@ Used with Git. Expects `url` to a Git repo, `rev`, and `sha256`. `rev` in this c
 
 Additionally, the following optional arguments can be given: `fetchSubmodules = true` makes `fetchgit` also fetch the submodules of a repository. If `deepClone` is set to true, the entire repository is cloned as opposing to just creating a shallow clone. `deepClone = true` also implies `leaveDotGit = true` which means that the `.git` directory of the clone won't be removed after checkout.
 
-If only parts of the repository are needed, `sparseCheckout` can be used. This will prevent git from fetching unnecessary blobs from server, see [git sparse-checkout](https://git-scm.com/docs/git-sparse-checkout) and [git clone --filter](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---filterltfilter-specgt) for more information:
+If only parts of the repository are needed, `sparseCheckout` can be used. This will prevent git from fetching unnecessary blobs from server, see [git sparse-checkout](https://git-scm.com/docs/git-sparse-checkout) for more information:
 
 ```nix
 { stdenv, fetchgit }:
@@ -101,8 +101,8 @@ stdenv.mkDerivation {
   src = fetchgit {
     url = "https://...";
     sparseCheckout = ''
-      path/to/be/included
-      another/path
+      directory/to/be/included
+      another/directory
     '';
     sha256 = "0000000000000000000000000000000000000000000000000000";
   };

--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -233,6 +233,18 @@
       </listitem>
       <listitem>
         <para>
+          The <literal>fetchgit</literal> fetcher now uses
+          <link xlink:href="https://www.git-scm.com/docs/git-sparse-checkout/2.37.0#_internalscone_mode_handling">cone
+          mode</link> by default for sparse checkouts.
+          <link xlink:href="https://www.git-scm.com/docs/git-sparse-checkout/2.37.0#_internalsnon_cone_problems">Non-cone
+          mode</link> can be enabled by passing
+          <literal>nonConeMode = true</literal>, but note that non-cone
+          mode is deprecated and this option may be removed alongside a
+          future Git update without notice.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <literal>bsp-layout</literal> no longer uses the command
           <literal>cycle</literal> to switch to other window layouts, as
           it got replaced by the commands <literal>previous</literal>

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -92,6 +92,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - The `isPowerPC` predicate, found on `platform` attrsets (`hostPlatform`, `buildPlatform`, `targetPlatform`, etc) has been removed in order to reduce confusion.  The predicate was was defined such that it matches only the 32-bit big-endian members of the POWER/PowerPC family, despite having a name which would imply a broader set of systems.  If you were using this predicate, you can replace `foo.isPowerPC` with `(with foo; isPower && is32bit && isBigEndian)`.
 
+- The `fetchgit` fetcher now uses [cone mode](https://www.git-scm.com/docs/git-sparse-checkout/2.37.0#_internalscone_mode_handling) by default for sparse checkouts. [Non-cone mode](https://www.git-scm.com/docs/git-sparse-checkout/2.37.0#_internalsnon_cone_problems) can be enabled by passing `nonConeMode = true`, but note that non-cone mode is deprecated and this option may be removed alongside a future Git update without notice.
+
 - `bsp-layout` no longer uses the command `cycle` to switch to other window layouts, as it got replaced by the commands `previous` and `next`.
 
 - The Barco ClickShare driver/client package `pkgs.clickshare-csc1` and the option `programs.clickshare-csc1.enable` have been removed,

--- a/pkgs/applications/misc/nerd-font-patcher/default.nix
+++ b/pkgs/applications/misc/nerd-font-patcher/default.nix
@@ -13,7 +13,7 @@ python3Packages.buildPythonApplication rec {
       font-patcher
       /src/glyphs
     '';
-    sha256 = "sha256-ePBlEVjzAJ7g6iAGIqPfgZ8bwtNILmyEVm0zD+xNN6k=";
+    sha256 = "sha256-06dn6M2wCFO/uBHDR7VZHNHIybT4h/VGD9nHc4G0EKA=";
   };
 
   propagatedBuildInputs = with python3Packages; [ fontforge ];

--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -20,6 +20,7 @@
 , gzip # needed at runtime by gitweb.cgi
 , withSsh ? false
 , doInstallCheck ? !stdenv.isDarwin  # extremely slow on darwin
+, tests
 }:
 
 assert osxkeychainSupport -> stdenv.isDarwin;
@@ -374,6 +375,7 @@ stdenv.mkDerivation (finalAttrs: {
         doInstallCheck = true;
       });
       buildbot-integration = nixosTests.buildbot;
+      inherit (tests) fetchgit;
     };
   };
 

--- a/pkgs/build-support/fetchgit/builder.sh
+++ b/pkgs/build-support/fetchgit/builder.sh
@@ -12,6 +12,7 @@ $SHELL $fetcher --builder --url "$url" --out "$out" --rev "$rev" \
   ${deepClone:+--deepClone} \
   ${fetchSubmodules:+--fetch-submodules} \
   ${sparseCheckout:+--sparse-checkout "$sparseCheckout"} \
+  ${nonConeMode:+--non-cone-mode} \
   ${branchName:+--branch-name "$branchName"}
 
 runHook postFetch

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -16,6 +16,7 @@ in
 , fetchSubmodules ? true, deepClone ? false
 , branchName ? null
 , sparseCheckout ? ""
+, nonConeMode ? false
 , name ? urlToName url rev
 , # Shell code executed after the file has been fetched
   # successfully. This can do things like check or transform the file.
@@ -54,6 +55,7 @@ in
 */
 
 assert deepClone -> leaveDotGit;
+assert nonConeMode -> (sparseCheckout != "");
 
 if md5 != "" then
   throw "fetchgit does not support md5 anymore, please use sha256"
@@ -77,7 +79,7 @@ stdenvNoCC.mkDerivation {
   else
     lib.fakeSha256;
 
-  inherit url rev leaveDotGit fetchLFS fetchSubmodules deepClone branchName sparseCheckout postFetch;
+  inherit url rev leaveDotGit fetchLFS fetchSubmodules deepClone branchName sparseCheckout nonConeMode postFetch;
 
   postHook = if netrcPhase == null then null else ''
     ${netrcPhase}

--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -49,6 +49,7 @@ Options:
       --hash h        Expected hash.
       --branch-name   Branch name to check out into
       --sparse-checkout Only fetch and checkout part of the repository.
+      --non-cone-mode Use non-cone mode for sparse checkouts.
       --deepClone     Clone the entire repository.
       --no-deepClone  Make a shallow clone of just the required ref.
       --leave-dotGit  Keep the .git directories.
@@ -77,6 +78,7 @@ for arg; do
             --branch-name) argfun=set_branchName;;
             --deepClone) deepClone=true;;
             --sparse-checkout) argfun=set_sparseCheckout;;
+            --non-cone-mode) nonConeMode=true;;
             --quiet) QUIET=true;;
             --no-deepClone) deepClone=;;
             --leave-dotGit) leaveDotGit=true;;
@@ -116,7 +118,7 @@ init_remote(){
     clean_git remote add origin "$url"
     if [ -n "$sparseCheckout" ]; then
         git config remote.origin.partialclonefilter "blob:none"
-        echo "$sparseCheckout" | git sparse-checkout set --stdin
+        echo "$sparseCheckout" | git sparse-checkout set --stdin ${nonConeMode:+--no-cone}
     fi
     ( [ -n "$http_proxy" ] && clean_git config http.proxy "$http_proxy" ) || true
 }

--- a/pkgs/build-support/fetchgit/tests.nix
+++ b/pkgs/build-support/fetchgit/tests.nix
@@ -16,6 +16,18 @@
       src
       tests
     '';
+    sha256 = "sha256-g1PHGTWgAcd/+sXHo1o6AjVWCvC6HiocOfMbMh873LQ=";
+  };
+
+  sparseCheckoutNonConeMode = testers.invalidateFetcherByDrvHash fetchgit {
+    name = "nix-source";
+    url = "https://github.com/NixOS/nix";
+    rev = "9d9dbe6ed05854e03811c361a3380e09183f4f4a";
+    sparseCheckout = ''
+      src
+      tests
+    '';
+    nonConeMode = true;
     sha256 = "sha256-FknO6C/PSnMPfhUqObD4vsW4PhkwdmPa9blNzcNvJQ4=";
   };
 }

--- a/pkgs/data/fonts/noto-fonts/default.nix
+++ b/pkgs/data/fonts/noto-fonts/default.nix
@@ -117,14 +117,14 @@ in
     typeface = "Sans";
     version = "2.004";
     rev = "9f7f3c38eab63e1d1fddd8d50937fe4f1eacdb1d";
-    sha256 = "sha256-11d/78i21yuzxrfB5t2VQN9OBz/qZKeozuS6BrLFjzw=";
+    sha256 = "sha256-PWpcTBnBRK87ZuRI/PsGp2UMQgCCyfkLHwvB1mOl5K0=";
   };
 
   noto-fonts-cjk-serif = mkNotoCJK {
     typeface = "Serif";
     version = "2.000";
     rev = "9f7f3c38eab63e1d1fddd8d50937fe4f1eacdb1d";
-    sha256 = "sha256-G+yl3LZvSFpbEUuuvattPDctKTzBCshOi970DcbPliE=";
+    sha256 = "sha256-1w66Ge7DZjbONGhxSz69uFhfsjMsDiDkrGl6NsoB7dY=";
   };
 
   noto-fonts-emoji = let

--- a/pkgs/data/icons/beauty-line-icon-theme/default.nix
+++ b/pkgs/data/icons/beauty-line-icon-theme/default.nix
@@ -21,7 +21,7 @@ stdenvNoCC.mkDerivation rec {
     sparseCheckout = ''
       BeautyLine-V3
     '';
-    sha256 = "sha256-IkkypAj250+OXbf19TampCnqYsSbJVIjeYlxJoyhpzk=";
+    sha256 = "sha256-VEQWMY77cVz6UDn7FeMYYyYgXmXl1lLYs8MlFUuGRZE=";
   };
 
   sourceRoot = "${src.name}/BeautyLine-V3";

--- a/pkgs/games/itch/default.nix
+++ b/pkgs/games/itch/default.nix
@@ -35,14 +35,13 @@ stdenvNoCC.mkDerivation rec {
     sha256 = "sha256-5MP6X33Jfu97o5R1n6Og64Bv4ZMxVM0A8lXeQug+bNA=";
   };
 
-  icons = let sparseCheckout = "/release/images/itch-icons"; in
-    fetchFromGitHub {
-        owner = "itchio";
-        repo = pname;
-        rev = "v${version}";
-        hash = "sha256-1L6STTBHA9xL9IaERaH2OTvurTSng1D+P3KoW0ucEJc=";
-        inherit sparseCheckout;
-      } + sparseCheckout;
+  icons = fetchFromGitHub {
+    owner = "itchio";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-DZBmf8fe0zw5uiQjNKXw8g/vU2hjNDa87z/7XuhyXog=";
+    sparseCheckout = "release/images/itch-icons";
+  };
 
   nativeBuildInputs = [ copyDesktopItems makeWrapper ];
 
@@ -69,7 +68,7 @@ stdenvNoCC.mkDerivation rec {
     install -Dm644 LICENSE -t "$out/share/licenses/$pkgname/"
     install -Dm644 LICENSES.chromium.html -t "$out/share/licenses/$pkgname/"
 
-    for icon in $icons/icon*.png
+    for icon in $icons/release/images/itch-icons/icon*.png
     do
       iconsize="''${icon#$icons/icon}"
       iconsize="''${iconsize%.png}"


### PR DESCRIPTION
###### Description of changes

Git v2.37.0 enabled *cone mode* by default for sparse checkouts.

Per the `git-sparse-checkout` [manual page](https://www.git-scm.com/docs/git-sparse-checkout/2.37.0):
> By default, the input list is considered a list of directories, matching the output of `git ls-tree -d --name-only`. This includes interpreting pathnames that begin with a double quote (") as C-style quoted strings. Note that all files under the specified directories (at any depth) will be included in the sparse checkout, as well as files that are siblings of either the given directory or any of its ancestors... In the past, this was not the default, and `--cone` needed to be specified or `core.sparseCheckoutCone` needed to be enabled.

> When `--no-cone` is passed, the input list is considered a list of patterns. This mode has a number of drawbacks, including not working with some options like `--sparse-index`. As explained in the "Non-cone Problems" section below, we do not recommend using it.

This PR introduces a way to disable cone mode (while Git still allows it) to `fetchgit`, as well as converting all of the usages of `sparseCheckout` to build correctly with cone mode.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
