### PR TITLE
buku: fix build failing for bukuserver

### DIFF
--- a/pkgs/applications/misc/buku/default.nix
+++ b/pkgs/applications/misc/buku/default.nix
@@ -1,26 +1,7 @@
 { lib, python3, fetchFromGitHub, withServer ? false }:
 
 let
-  python3' = python3.override {
-    packageOverrides = self: super: {
-      sqlalchemy = super.sqlalchemy.overridePythonAttrs (oldAttrs: rec {
-        version = "1.3.24";
-        src = oldAttrs.src.override {
-          inherit version;
-          hash = "sha256-67t3fL+TEjWbiXv4G6ANrg9ctp+6KhgmXcwYpvXvdRk=";
-        };
-        doCheck = false;
-      });
-      sqlalchemy-utils = super.sqlalchemy-utils.overridePythonAttrs (oldAttrs: rec {
-        version = "0.36.6";
-        src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "0srs5w486wp5zydjs70igi5ypgxhm6h73grb85jz03fqpqaanzvs";
-        };
-      });
-    };
-  };
-  serverRequire = with python3'.pkgs; [
+  serverRequire = with python3.pkgs; [
     requests
     flask
     flask-admin
@@ -36,7 +17,7 @@ let
     toml
   ];
 in
-with python3'.pkgs; buildPythonApplication rec {
+with python3.pkgs; buildPythonApplication rec {
   version = "4.7";
   pname = "buku";
 

--- a/pkgs/applications/misc/buku/default.nix
+++ b/pkgs/applications/misc/buku/default.nix
@@ -35,6 +35,10 @@ with python3.pkgs; buildPythonApplication rec {
     pyyaml
     mypy-extensions
     click
+    pylint
+    flake8
+    pytest-cov
+    pyyaml
   ];
 
   propagatedBuildInputs = [
@@ -45,20 +49,7 @@ with python3.pkgs; buildPythonApplication rec {
     html5lib
   ] ++ lib.optionals withServer serverRequire;
 
-  postPatch = ''
-    # Jailbreak problematic dependencies
-    sed -i \
-      -e "s,'PyYAML.*','PyYAML',g" \
-      -e "/'pytest-cov/d" \
-      -e "/'pylint/d" \
-      -e "/'flake8/d" \
-      setup.py
-  '';
-
   preCheck = ''
-    # Fixes two tests for wrong encoding
-    export PYTHONIOENCODING=utf-8
-
     # Disables a test which requires internet
     substituteInPlace tests/test_bukuDb.py \
       --replace "@pytest.mark.slowtest" "@unittest.skip('skipping')" \


### PR DESCRIPTION
###### Description of changes

SQLAlchemy-Utils v0.36.6 package override build is failing.

This is due to a patch in the original SQLAlchemy-Utils package which
broke the build of this package override:

```bash
> applying patch /nix/store/pd6anhwbf0in3r3jhi3sbn5v2fjs0mf2-skip-database-tests.patch
> patching file conftest.py
> Hunk #1 FAILED at 61.
> Hunk #2 succeeded at 98 (offset -10 lines).
```

These SQLAlchemy package overrides were originaly added to fix
incompatibilities with Flask-Admin.

See commit 05ae01fcea6c7d270cc15374b0a806b09f548a9a

However with Flask-Admin >= v1.5.6, several SQLAlchemy compatibility patches were added:
* https://flask-admin.readthedocs.io/en/latest/changelog/

We can now safely remove these package overrides to make bukuserver work again.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
