### PR TITLE
machin: init at 0.5.3

### DIFF
--- a/pkgs/tools/misc/machin/default.nix
+++ b/pkgs/tools/misc/machin/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, stdenv
+, nasm
+, fetchFromGitHub
+, rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "machin";
+  version = "0.5.3";
+
+  src = fetchFromGitHub {
+    owner = "mothsart";
+    repo = pname;
+    rev = version;
+    sha256 = "0b1l8gw60zs58wckm82v9jiw1q6b65srr523snyrp7iibh9vnb7d";
+  };
+
+  cargoSha256 = "1afynsf1xpys42bvii3rlrm4p2bl36sziby28r8lrwp7947bs800";
+
+  nativeBuildInputs = [ nasm ];
+
+  postInstall = "make PREFIX=$out copy-data";
+
+  meta = with lib; {
+    description = "A cli program that simplifies file conversions and batch processing. It's inspired from filter/map/reduce";
+    homepage = "https://github.com/mothsart/machin";
+    changelog = "https://github.com/mothsart/machin/releases/tag/${version}";
+    maintainers = with maintainers; [ mothsart ];
+    license = with licenses; [ mit ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4154,6 +4154,8 @@ with pkgs;
 
   lynis = callPackage ../tools/security/lynis { };
 
+  machin = callPackage ../tools/misc/machin { };
+
   maigret = callPackage ../tools/security/maigret { };
 
   maliit-framework = libsForQt5.callPackage ../applications/misc/maliit-framework { };


### PR DESCRIPTION
###### Description of changes

A cli program that simplifies file conversions and batch processing. It's inspired from filter/map/reduce

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
