### PR TITLE
audacious: migrate to meson build system, refactor

### DIFF
--- a/pkgs/applications/audio/audacious/0001-Set-plugindir-to-PREFIX-lib-audacious.patch
+++ b/pkgs/applications/audio/audacious/0001-Set-plugindir-to-PREFIX-lib-audacious.patch
@@ -1,0 +1,25 @@
+From b64b03be9edf23a80fce0c76de61ffff0914ddce Mon Sep 17 00:00:00 2001
+From: Thiago Kenji Okada <thiagokokada@gmail.com>
+Date: Mon, 8 Aug 2022 10:28:33 +0100
+Subject: [PATCH] Set plugindir to $PREFIX/lib/audacious
+
+---
+ meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index 3f7996f72..ab09d6476 100644
+--- a/meson.build
++++ b/meson.build
+@@ -160,7 +160,7 @@ if (cxx.has_header('libintl.h'))
+ endif
+ 
+ 
+-install_plugindir = audacious_dep.get_variable(pkgconfig: 'plugin_dir')
++install_plugindir = join_paths(get_option('prefix'), 'lib/audacious')
+ 
+ 
+ conf.set_quoted('INSTALL_PLUGINDIR', install_plugindir)
+-- 
+2.36.0
+

--- a/pkgs/applications/audio/audacious/default.nix
+++ b/pkgs/applications/audio/audacious/default.nix
@@ -1,15 +1,16 @@
-{
-  mkDerivation, lib, fetchurl, fetchpatch,
-  gettext, pkg-config,
-  qtbase,
-  alsa-lib, curl, faad2, ffmpeg, flac, fluidsynth, gdk-pixbuf, lame, libbs2b,
-  libcddb, libcdio, libcdio-paranoia, libcue, libjack2, libmad, libmms, libmodplug,
-  libmowgli, libnotify, libogg, libpulseaudio, libsamplerate, libsidplayfp,
-  libsndfile, libvorbis, libxml2, lirc, mpg123, neon, qtmultimedia, soxr,
-  wavpack, libopenmpt
+{ lib
+, stdenv
+, audacious-plugins
+, fetchurl
+, gettext
+, meson
+, ninja
+, pkg-config
+, qtbase
+, wrapQtAppsHook
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "audacious";
   version = "4.2";
 
@@ -17,54 +18,39 @@ mkDerivation rec {
     url = "http://distfiles.audacious-media-player.org/audacious-${version}.tar.bz2";
     sha256 = "sha256-/rME5HCkgf4rPEyhycs7I+wmJUDBLQ0ebCKl62JeBLM=";
   };
-  pluginsSrc = fetchurl {
-    url = "http://distfiles.audacious-media-player.org/audacious-plugins-${version}.tar.bz2";
-    sha256 = "sha256-b6D2nDoQQeuHfDcQlROrSioKVqd9nowToVgc8UOaQX8=";
-  };
 
-  nativeBuildInputs = [ gettext pkg-config ];
-
-  buildInputs = [
-    # Core dependencies
-    qtbase
-
-    # Plugin dependencies
-    alsa-lib curl faad2 ffmpeg flac fluidsynth gdk-pixbuf lame libbs2b libcddb
-    libcdio libcdio-paranoia libcue libjack2 libmad libmms libmodplug libmowgli
-    libnotify libogg libpulseaudio libsamplerate libsidplayfp libsndfile
-    libvorbis libxml2 lirc mpg123 neon qtmultimedia soxr wavpack
-    libopenmpt
+  nativeBuildInputs = [
+    gettext
+    meson
+    ninja
+    pkg-config
+    wrapQtAppsHook
   ];
 
-  configureFlags = [ "--disable-gtk" ];
+  buildInputs = [
+    qtbase
+  ];
 
-  # Here we build both audacious and audacious-plugins in one
-  # derivation, since they really expect to be in the same prefix.
-  # This is slighly tricky.
-  builder = builtins.toFile "builder.sh" ''
-    # First build audacious.
-    (
-      source $stdenv/setup
-      genericBuild
-    )
-    # Then build the plugins.
-    (
-      nativeBuildInputs="$out $nativeBuildInputs" # to find audacious
-      source $stdenv/setup
-      rm -rfv audacious-*
-      src=$pluginsSrc
-      genericBuild
-    )
+  mesonFlags = [
+    "-Dgtk=false"
+    "-Dbuildstamp=NixOS"
+  ];
+
+  postInstall = lib.optionalString (audacious-plugins != null) ''
+    ln -s ${audacious-plugins}/lib/audacious $out/lib
   '';
 
   meta = with lib; {
-    description = "Audio player";
+    description = "A lightweight and versatile audio player";
     homepage = "https://audacious-media-player.org/";
-    maintainers = with maintainers; [ eelco ramkromberg ttuegel ];
+    maintainers = with maintainers; [ eelco ramkromberg ttuegel thiagokokada ];
     platforms = with platforms; linux;
     license = with licenses; [
-      bsd2 bsd3 #https://github.com/audacious-media-player/audacious/blob/master/COPYING
-      gpl2 gpl3 lgpl2Plus #http://redmine.audacious-media-player.org/issues/46
+      bsd2
+      bsd3 #https://github.com/audacious-media-player/audacious/blob/master/COPYING
+      gpl2
+      gpl3
+      lgpl2Plus #http://redmine.audacious-media-player.org/issues/46
     ];
   };
 }

--- a/pkgs/applications/audio/audacious/plugins.nix
+++ b/pkgs/applications/audio/audacious/plugins.nix
@@ -1,0 +1,109 @@
+{ stdenv
+, fetchurl
+, alsa-lib
+, audacious
+, curl
+, faad2
+, ffmpeg
+, flac
+, fluidsynth
+, gdk-pixbuf
+, gettext
+, lame
+, libbs2b
+, libcddb
+, libcdio
+, libcdio-paranoia
+, libcue
+, libjack2
+, libmad
+, libmms
+, libmodplug
+, libmowgli
+, libnotify
+, libogg
+, libopenmpt
+, libpulseaudio
+, libsamplerate
+, libsidplayfp
+, libsndfile
+, libvorbis
+, libxml2
+, lirc
+, meson
+, mpg123
+, neon
+, ninja
+, pkg-config
+, qtbase
+, qtmultimedia
+, soxr
+, wavpack
+}:
+
+stdenv.mkDerivation rec {
+  pname = "audacious-plugins";
+  version = "4.2";
+
+  src = fetchurl {
+    url = "http://distfiles.audacious-media-player.org/audacious-plugins-${version}.tar.bz2";
+    sha256 = "sha256-b6D2nDoQQeuHfDcQlROrSioKVqd9nowToVgc8UOaQX8=";
+  };
+
+  patches = [ ./0001-Set-plugindir-to-PREFIX-lib-audacious.patch ];
+
+  nativeBuildInputs = [
+    gettext
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    audacious
+    alsa-lib
+    curl
+    faad2
+    ffmpeg
+    flac
+    fluidsynth
+    gdk-pixbuf
+    lame
+    libbs2b
+    libcddb
+    libcdio
+    libcdio-paranoia
+    libcue
+    libjack2
+    libmad
+    libmms
+    libmodplug
+    libmowgli
+    libnotify
+    libogg
+    libpulseaudio
+    libsamplerate
+    libsidplayfp
+    libsndfile
+    libvorbis
+    libxml2
+    lirc
+    mpg123
+    neon
+    qtbase
+    qtmultimedia
+    soxr
+    wavpack
+    libopenmpt
+  ];
+
+  mesonFlags = [
+    "-Dgtk=false"
+  ];
+
+  dontWrapQtApps = true;
+
+  meta = audacious.meta // {
+    description = "Plugins for Audacious music player";
+  };
+}

--- a/pkgs/applications/audio/audacious/plugins.nix
+++ b/pkgs/applications/audio/audacious/plugins.nix
@@ -37,6 +37,7 @@
 , pkg-config
 , qtbase
 , qtmultimedia
+, qtx11extras
 , soxr
 , wavpack
 }:
@@ -92,6 +93,7 @@ stdenv.mkDerivation rec {
     neon
     qtbase
     qtmultimedia
+    qtx11extras
     soxr
     wavpack
     libopenmpt

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25959,6 +25959,10 @@ with pkgs;
   aucatctl = callPackage ../applications/audio/aucatctl { };
 
   audacious = libsForQt5.callPackage ../applications/audio/audacious { };
+  audacious-plugins = libsForQt5.callPackage ../applications/audio/audacious/plugins.nix {
+    # Avoid circular dependency
+    audacious = audacious.override { audacious-plugins = null; };
+  };
   audaciousQt5 = audacious;
 
   audacity-gtk2 = callPackage ../applications/audio/audacity { wxGTK = wxGTK31-gtk2; };


### PR DESCRIPTION
###### Description of changes

Separate the derivation in `audacious` and `audacious-plugins`. Since one derivation depends on the other, we first build `audacious` without the `audacious-plugins`, them we build `audacious-plugins` and finally we build the final version of `audacious`.

Also, add myself as maintainer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
