### PR TITLE
dino: add tests

### DIFF
--- a/pkgs/applications/networking/instant-messengers/dino/default.nix
+++ b/pkgs/applications/networking/instant-messengers/dino/default.nix
@@ -84,7 +84,7 @@ stdenv.mkDerivation rec {
   ./signal-protocol-vala-test
   TEST2=$?
   set +x
-  if [ $TEST1 != 0 ] && [ $TEST2 != 0 ]; then
+  if [ $TEST1 != 0 ] || [ $TEST2 != 0 ]; then
     echo "tests failed"
     exit 1;
   else

--- a/pkgs/applications/networking/instant-messengers/dino/default.nix
+++ b/pkgs/applications/networking/instant-messengers/dino/default.nix
@@ -73,6 +73,26 @@ stdenv.mkDerivation rec {
     libxkbcommon
   ];
 
+  cmakeFlags = ["-DBUILD_TESTS=yes"];
+
+  doCheck = true;
+  checkPhase = ''
+  echo "================= Running built tests ================="
+  set -x
+  ./xmpp-vala-test
+  TEST1=$?
+  ./signal-protocol-vala-test
+  TEST2=$?
+  set +x
+  if [ $TEST1 != 0 ] && [ $TEST2 != 0 ]; then
+    echo "tests failed"
+    exit 1;
+  else
+    echo "tests succeeded"
+  fi
+  echo "================= /Running built tests ================="
+  '';
+
   # Dino looks for plugins with a .so filename extension, even on macOS where
   # .dylib is appropriate, and despite the fact that it builds said plugins with
   # that as their filename extension

--- a/pkgs/applications/networking/instant-messengers/dino/default.nix
+++ b/pkgs/applications/networking/instant-messengers/dino/default.nix
@@ -77,20 +77,11 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
   checkPhase = ''
-  echo "================= Running built tests ================="
-  set -x
-  ./xmpp-vala-test
-  TEST1=$?
-  ./signal-protocol-vala-test
-  TEST2=$?
-  set +x
-  if [ $TEST1 != 0 ] || [ $TEST2 != 0 ]; then
-    echo "tests failed"
-    exit 1;
-  else
-    echo "tests succeeded"
-  fi
-  echo "================= /Running built tests ================="
+    runHook preCheck
+    set -e
+    ./xmpp-vala-test
+    ./signal-protocol-vala-test
+    runHook postCheck
   '';
 
   # Dino looks for plugins with a .so filename extension, even on macOS where

--- a/pkgs/applications/networking/instant-messengers/dino/default.nix
+++ b/pkgs/applications/networking/instant-messengers/dino/default.nix
@@ -78,7 +78,6 @@ stdenv.mkDerivation rec {
   doCheck = true;
   checkPhase = ''
     runHook preCheck
-    set -e
     ./xmpp-vala-test
     ./signal-protocol-vala-test
     runHook postCheck


### PR DESCRIPTION
###### Description of changes
Added tests built by dino.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
