### PR TITLE
cargo-llvm-cov: init at 0.4.13

### DIFF
--- a/pkgs/development/tools/rust/cargo-llvm-cov/default.nix
+++ b/pkgs/development/tools/rust/cargo-llvm-cov/default.nix
@@ -1,0 +1,36 @@
+{ lib, rustPlatform, fetchCrate, fetchFromGitHub, libllvm, makeBinaryWrapper }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-llvm-cov";
+  version = "0.4.14";
+
+  src = fetchCrate {
+    inherit pname version;
+    sha256 = "sha256-DY5eBSx/PSmKaG7I6scDEbyZQ5hknA/pfl0KjTNqZlo=";
+  };
+
+  postPatch = ''
+    rm tests/test.rs
+  '';
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+  buildInputs = [ libllvm ];
+
+  LLVM_COV = "${rustPlatform.rust.rustc.llvmPackages.llvm}/bin/llvm-cov";
+  LLVM_PROFDATA = "${rustPlatform.rust.rustc.llvmPackages.llvm}/bin/llvm-profdata";
+
+  postInstall = ''
+    wrapProgram $out/bin/cargo-llvm-cov \
+      --set LLVM_COV "${rustPlatform.rust.rustc.llvmPackages.llvm}/bin/llvm-cov" \
+      --set LLVM_PROFDATA "${rustPlatform.rust.rustc.llvmPackages.llvm}/bin/llvm-profdata"
+  '';
+
+  cargoSha256 = "sha256-MGI1wV0QEZRxea6Q3fh2TJVPmI4eb9O6/DwpKkWrToE=";
+
+  meta = with lib; {
+    description = "Cargo subcommand to gather source-based code coverage using LLVM";
+    homepage = "https://github.com/taiki-e/cargo-llvm-cov";
+    license = with licenses; [ mit asl20 ];
+    maintainers = with maintainers; [ DieracDelta matthiasbeyer ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14251,6 +14251,7 @@ with pkgs;
   cargo-kcov = callPackage ../development/tools/rust/cargo-kcov { };
   cargo-graph = callPackage ../development/tools/rust/cargo-graph { };
   cargo-license = callPackage ../development/tools/rust/cargo-license { };
+  cargo-llvm-cov = callPackage ../development/tools/rust/cargo-llvm-cov { };
   cargo-llvm-lines = callPackage ../development/tools/rust/cargo-llvm-lines { };
   cargo-outdated = callPackage ../development/tools/rust/cargo-outdated {
     inherit (darwin.apple_sdk.frameworks) Security SystemConfiguration;


### PR DESCRIPTION
Closes #170938
Supersedes #170938


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

