### PR TITLE
p910nd: cleanups

### DIFF
--- a/pkgs/servers/p910nd/default.nix
+++ b/pkgs/servers/p910nd/default.nix
@@ -1,28 +1,29 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenv, fetchFromGitHub, installShellFiles }:
 
 stdenv.mkDerivation rec {
   pname = "p910nd";
   version = "0.97";
 
-  src = fetchurl {
-    sha256 = "0vy2qf386dif1nqznmy3j953mq7c4lk6j2hgyzkbmfi4msiq1jaa";
-    url = "mirror://sourceforge/p910nd/${pname}-${version}.tar.bz2";
+  src = fetchFromGitHub {
+    owner = "kenyapcomau";
+    repo = "p910nd";
+    rev = version;
+    hash = "sha256-MM4o7d3L3XIRYWJ/KPM2OltlVfVA/BgMuyhJMm/BS3c=";
   };
 
-  postPatch = ''
-    substituteInPlace Makefile --replace "/usr" ""
-    substituteInPlace Makefile --replace "gcc" "${stdenv.cc.targetPrefix}cc"
-  '';
+  nativeBuildInputs = [ installShellFiles ];
 
-  makeFlags = [ "DESTDIR=$(out)" "BINDIR=/bin" ];
+  enableParallelBuilding = true;
 
-  postInstall = ''
-    # Match the man page:
-    mv $out/etc/init.d/p910nd{,.sh}
+  # instead of mucking around with the Makefile, just install the bits we need
+  installPhase = ''
+    runHook preInstall
 
-    # The legacy init script is useful only (and even then...) as an example:
-    mkdir -p $out/share/doc/examples
-    mv $out/etc $out/share/doc/examples
+    install -Dm555 -t $out/bin p910nd
+    install -Dm444 -t $out/share/doc/p910nd *.md
+    installManPage p910nd.?
+
+    runHook postInstall
   '';
 
   meta = with lib; {
@@ -37,9 +38,9 @@ stdenv.mkDerivation rec {
       the AppSocket protocol and has the scheme socket://. LPRng also supports
       this protocol and the syntax is lp=remotehost%9100 in /etc/printcap.
     '';
-    homepage = "http://p910nd.sourceforge.net/";
-    downloadPage = "https://sourceforge.net/projects/p910nd/";
-    license = licenses.gpl2;
+    homepage = "https://github.com/kenyapcomau/p910nd";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ peterhoeg ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Description of changes

Local cleanups.

Trying to get rid of local patches.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
