### PR TITLE
nixos/boot/tmp: Deprecating tmpOnTmpfsSize

### DIFF
--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -943,6 +943,9 @@ in
             [ "trans=virtio" "version=9p2000.L"  "msize=${toString cfg.msize}" ]
             ++ lib.optional (tag == "nix-store") "cache=loose";
         };
+      legacy = builtins.isBool config.tmpOnTmpfs;
+      tmpOnTmpfs = if legacy then config.tmpOnTmpfs else config.tmpOnTmpfs.enable;
+      tmpOnTmpfsSize = if legacy then config.tmpOnTmpfsSize else config.tmpOnTmpfs.size;
     in
       mkVMOverride (cfg.fileSystems //
       optionalAttrs cfg.useDefaultFilesystems {
@@ -950,13 +953,13 @@ in
         "/".fsType = "ext4";
         "/".autoFormat = true;
       } //
-      optionalAttrs config.boot.tmpOnTmpfs {
+      optionalAttrs tmpOnTmpfs {
         "/tmp" = {
           device = "tmpfs";
           fsType = "tmpfs";
           neededForBoot = true;
           # Sync with systemd's tmp.mount;
-          options = [ "mode=1777" "strictatime" "nosuid" "nodev" "size=${toString config.boot.tmpOnTmpfsSize}" ];
+          options = [ "mode=1777" "strictatime" "nosuid" "nodev" "size=${toString tmpOnTmpfsSize}" ];
         };
       } //
       optionalAttrs cfg.useNixStoreImage {

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -943,9 +943,9 @@ in
             [ "trans=virtio" "version=9p2000.L"  "msize=${toString cfg.msize}" ]
             ++ lib.optional (tag == "nix-store") "cache=loose";
         };
-      legacy = builtins.isBool config.tmpOnTmpfs;
-      tmpOnTmpfs = if legacy then config.tmpOnTmpfs else config.tmpOnTmpfs.enable;
-      tmpOnTmpfsSize = if legacy then config.tmpOnTmpfsSize else config.tmpOnTmpfs.size;
+      legacy = builtins.isBool config.boot.tmpOnTmpfs;
+      tmpOnTmpfs = if legacy then config.boot.tmpOnTmpfs else config.boot.tmpOnTmpfs.enable;
+      tmpOnTmpfsSize = if legacy then config.boot.tmpOnTmpfsSize else config.boot.tmpOnTmpfs.size;
     in
       mkVMOverride (cfg.fileSystems //
       optionalAttrs cfg.useDefaultFilesystems {


### PR DESCRIPTION
###### Description of changes

boot.tmpOnTmpfs and boot.tmpOnTmpfsSize are two options tied and should therefore be one submodule with an enable-option to enable tmpOnTmpfs and a size-option to specify the this, if tmpOnTmpfs is enabled.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

