### PR TITLE
linuxPackages.dddvb: 0.9.38-pre.4 -> 0.9.38-pre.6

### DIFF
--- a/pkgs/os-specific/linux/dddvb/default.nix
+++ b/pkgs/os-specific/linux/dddvb/default.nix
@@ -1,19 +1,28 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , kernel
 }:
 
 stdenv.mkDerivation rec {
   pname = "dddvb";
-  version = "0.9.38-pre.4";
+  version = "0.9.38-pre.6";
 
   src = fetchFromGitHub {
     owner = "DigitalDevices";
     repo = "dddvb";
-    rev = "e9ccab3578965234c0ea38c5b30969f33600561d";
-    sha256 = "sha256-gOG+dAeQ++kTC5xaEpsr3emz3s6FXiKeCHmA9shYBJk=";
+    rev = "refs/tags/${version}";
+    hash = "sha256-bt/vMnqRWDDChZ6R4JbCr77cz3nlSPkx6siC9KLSEqs=";
   };
+
+  patches = [
+    (fetchpatch {
+      # pci_*_dma_mask no longer exists in 5.18
+      url = "https://github.com/DigitalDevices/dddvb/commit/871821d6a0be147313bb52570591ce3853b3d370.patch";
+      hash = "sha256-wY05HrsduvsIdp/KpS9NWfL3hR9IvGjuNCDljFn7dd0=";
+    })
+  ];
 
   postPatch = ''
     sed -i '/depmod/d' Makefile
@@ -35,6 +44,5 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ hexa ];
     platforms = platforms.linux;
-    broken = kernel.kernelAtLeast "5.18";
   };
 }


### PR DESCRIPTION
Update and apply patch to unbreak on 5.18+.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
