### PR TITLE
adguardhome: 0.107.8 - 0.107.9

### DIFF
--- a/pkgs/servers/adguardhome/bins.nix
+++ b/pkgs/servers/adguardhome/bins.nix
@@ -1,23 +1,23 @@
 { fetchurl, fetchzip }:
 {
 x86_64-darwin = fetchzip {
-  sha256 = "sha256-PYq6AKX3Ifo8vMnPYGjqHwFejOBuQjhfDG5nXnccfvE=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.8/AdGuardHome_darwin_amd64.zip";
+  sha256 = "sha256-SLGzciTzzvW0DTG8v6lNb1IovbOjxBFgFVjNY6MEyKY=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.9/AdGuardHome_darwin_amd64.zip";
 };
 aarch64-darwin = fetchzip {
-  sha256 = "sha256-ep5/VMO7LmfD6+chG2SGwkc5awoeqACQeP04YpMXI1s=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.8/AdGuardHome_darwin_arm64.zip";
+  sha256 = "sha256-d7hnCM7BJuYfSH89jv516uVyKTMueQmVKQxEeTGIDUE=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.9/AdGuardHome_darwin_arm64.zip";
 };
 i686-linux = fetchurl {
-  sha256 = "sha256-rD5UDkAMeBfnrEpxfZWgDQEUN+82D6Ul2gjclS8A8CU=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.8/AdGuardHome_linux_386.tar.gz";
+  sha256 = "sha256-wTmUF6NHWis4dyw/bPjAjvZ0aQ1l1BCDlm6eLu4m/0o=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.9/AdGuardHome_linux_386.tar.gz";
 };
 x86_64-linux = fetchurl {
-  sha256 = "sha256-buBp5WZ1jIzQDbxzVOZC/t3iv1Dw0P/PN3wGBbGaYvU=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.8/AdGuardHome_linux_amd64.tar.gz";
+  sha256 = "sha256-Mxe9Gb1ErrZZl3a+0SqC/0ghoeV51X93YxIOs9gM2lY=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.9/AdGuardHome_linux_amd64.tar.gz";
 };
 aarch64-linux = fetchurl {
-  sha256 = "sha256-d6Z46L6qeXi5UNPY3/nlTJvVCuQ0lamtR49Z73O87Wc=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.8/AdGuardHome_linux_arm64.tar.gz";
+  sha256 = "sha256-SyHuzXAe24Nf0v9Ds3Z+cbXoIVLCJSj243I6B0XWBlM=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.9/AdGuardHome_linux_arm64.tar.gz";
 };
 }

--- a/pkgs/servers/adguardhome/default.nix
+++ b/pkgs/servers/adguardhome/default.nix
@@ -7,7 +7,7 @@ in
 
 stdenv.mkDerivation rec {
   pname = "adguardhome";
-  version = "0.107.8";
+  version = "0.107.9";
   src = sources.${system} or (throw "Source for ${pname} is not available for ${system}");
 
   installPhase = ''


### PR DESCRIPTION
###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

