### PR TITLE
sommelier: init at 104.0

### DIFF
--- a/pkgs/applications/window-managers/sommelier/default.nix
+++ b/pkgs/applications/window-managers/sommelier/default.nix
@@ -1,0 +1,35 @@
+{ lib, stdenv, fetchzip, meson, ninja, pkg-config, wayland-scanner
+, libxkbcommon, mesa, pixman, xorg, wayland, gtest
+}:
+
+stdenv.mkDerivation {
+  pname = "sommelier";
+  version = "104.0";
+
+  src = fetchzip rec {
+    url = "https://chromium.googlesource.com/chromiumos/platform2/+archive/${passthru.rev}/vm_tools/sommelier.tar.gz";
+    passthru.rev = "af5434fd9903936a534e1316cbd22361e67949ec";
+    stripRoot = false;
+    sha256 = "LungQqHQorHIKpye2SDBLuMHPt45C1cPYcs9o5Hc3cw=";
+  };
+
+  nativeBuildInputs = [ meson ninja pkg-config wayland-scanner ];
+  buildInputs = [ libxkbcommon mesa pixman wayland xorg.libxcb ];
+
+  doCheck = true;
+  checkInputs = [ gtest ];
+
+  postInstall = ''
+    rm $out/bin/sommelier_test # why does it install the test binary? o_O
+  '';
+
+  passthru.updateScript = ./update.py;
+
+  meta = with lib; {
+    homepage = "https://chromium.googlesource.com/chromiumos/platform2/+/refs/heads/main/vm_tools/sommelier/";
+    description = "Nested Wayland compositor with support for X11 forwarding";
+    maintainers = with maintainers; [ qyliss ];
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/window-managers/sommelier/update.py
+++ b/pkgs/applications/window-managers/sommelier/update.py
@@ -1,0 +1,58 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -p common-updater-scripts python3
+#! nix-shell -i python
+
+import csv
+import json
+import re
+import shlex
+import subprocess
+from os.path import abspath, dirname, splitext
+from urllib.request import urlopen
+
+# CrOS version numbers look like this:
+# [<chrome-major-version>.]<tip-build>.<branch-build>.<branch-branch-build>
+#
+# As far as I can tell, branches are where internal Google
+# modifications are added to turn Chromium OS into Chrome OS, and
+# branch branches are used for fixes for specific devices.  So for
+# Chromium OS they will always be 0.  This is a best guess, and is not
+# documented.
+with urlopen('https://chromiumdash.appspot.com/cros/download_serving_builds_csv?deviceCategory=ChromeOS') as resp:
+    reader = csv.reader(map(bytes.decode, resp))
+    header = reader.__next__()
+    cr_stable_index = header.index('cr_stable')
+    cros_stable_index = header.index('cros_stable')
+    chrome_version = []
+    platform_version = []
+
+    for line in reader:
+        this_chrome_version = list(map(int, line[cr_stable_index].split('.')))
+        this_platform_version = list(map(int, line[cros_stable_index].split('.')))
+        chrome_version = max(chrome_version, this_chrome_version)
+        platform_version = max(platform_version, this_platform_version)
+
+chrome_major_version = chrome_version[0]
+chromeos_tip_build = platform_version[0]
+release_branch = f'release-R{chrome_major_version}-{chromeos_tip_build}.B'
+
+# Determine the git revision.
+with urlopen(f'https://chromium.googlesource.com/chromiumos/platform2/+/refs/heads/{release_branch}?format=JSON') as resp:
+    resp.readline() # Remove )]}' header
+    rev = json.load(resp)['commit']
+
+# Determine the patch version by counting the commits that have been
+# added to the release branch since it forked off the chromeos branch.
+with urlopen(f'https://chromium.googlesource.com/chromiumos/platform2/+log/refs/heads/main..{rev}/vm_tools/sommelier?format=JSON') as resp:
+    resp.readline() # Remove )]}' header
+    branch_commits = json.load(resp)['log']
+    version = f'{chrome_major_version}.{len(branch_commits)}'
+
+# Update the version, git revision, and hash in sommelier's default.nix.
+subprocess.run(['update-source-version', 'sommelier', f'--rev={rev}', version])
+
+# Find the path to sommelier's default.nix, so Cargo.lock can be written
+# into the same directory.
+argv = ['nix-instantiate', '--eval', '--json', '-A', 'sommelier.meta.position']
+position = json.loads(subprocess.check_output(argv).decode('utf-8'))
+filename = re.match(r'[^:]*', position)[0]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30314,6 +30314,8 @@ with pkgs;
 
   snixembed = callPackage ../applications/misc/snixembed { };
 
+  sommelier = callPackage ../applications/window-managers/sommelier { };
+
   sooperlooper = callPackage ../applications/audio/sooperlooper { };
 
   sops = callPackage ../tools/security/sops { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Since virtio-gpu context types are now in upstream kernels, it is now
possible to use Sommelier without patching it or using custom kernels,
so I think it's finally suitable for inclusion in Nixpkgs.

I'm using the same versioning scheme I made up for crosvm here.
Figuring out the version is handled by the update script, which I
adapted from the crosvm one.  Sadly there's too many differences
between them to easily merge them into one, so reducing duplication
between them is left as further work.

Closes: https://github.com/NixOS/nixpkgs/pull/95874

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
