### PR TITLE
ibus-engines.stt-vosk: init at 0.2.0

### DIFF
--- a/pkgs/development/libraries/gst-vosk/default.nix
+++ b/pkgs/development/libraries/gst-vosk/default.nix
@@ -1,0 +1,45 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchurl
+, meson
+, ninja
+, pkg-config
+, gst_all_1
+, vosk-api
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gst-vosk";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "PhilippeRo";
+    repo = "gst-vosk";
+    rev = version;
+    sha256 = "Ez0TS/WMexj45h1rpvrNAsl6ZKPuwsG9bqZBxrBE4jo=";
+  };
+
+  patches = [
+    ./unvendor-vosk.patch
+  ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    gst_all_1.gstreamer
+    vosk-api
+  ];
+
+  meta = with lib; {
+    description = "GStreamer plug-in for VOSK";
+    homepage = "https://github.com/PhilippeRo/gst-vosk";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ jtojnar ];
+    platforms = vosk-api.meta.platforms;
+  };
+}

--- a/pkgs/development/libraries/gst-vosk/unvendor-vosk.patch
+++ b/pkgs/development/libraries/gst-vosk/unvendor-vosk.patch
@@ -1,0 +1,49 @@
+diff --git a/meson.build b/meson.build
+index 866d5b3..f46f94f 100644
+--- a/meson.build
++++ b/meson.build
+@@ -42,5 +42,4 @@ configure_file(
+ )
+ 
+ subdir('src')
+-subdir('vosk')
+ subdir('po')
+diff --git a/src/gstvosk.c b/src/gstvosk.c
+index ffc9340..47a5cb9 100644
+--- a/src/gstvosk.c
++++ b/src/gstvosk.c
+@@ -25,7 +25,6 @@
+ #include <gst/gst.h>
+ 
+ #include "gstvosk.h"
+-#include "vosk-api.h"
+ #include "../gst-vosk-config.h"
+ 
+ GST_DEBUG_CATEGORY_STATIC (gst_vosk_debug);
+diff --git a/src/gstvosk.h b/src/gstvosk.h
+index 855e5c1..b7cbbff 100644
+--- a/src/gstvosk.h
++++ b/src/gstvosk.h
+@@ -23,7 +23,7 @@
+ #include <gio/gio.h>
+ #include <gst/gst.h>
+ 
+-#include "vosk-api.h"
++#include "vosk_api.h"
+ 
+ G_BEGIN_DECLS
+ 
+diff --git a/src/meson.build b/src/meson.build
+index a1e5ea0..df0da58 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -4,8 +4,7 @@ gst_vosk_sources = [
+ 
+ vosk_libdir = meson.project_source_root() / 'vosk'
+ vosk_dep = declare_dependency(
+-	dependencies : cc.find_library('vosk', dirs : vosk_libdir),
+-	include_directories : include_directories('../vosk/'),
++	dependencies : cc.find_library('vosk'),
+ )
+ 
+ gstvosk = library('gstvosk',

--- a/pkgs/tools/audio/kaldi/default.nix
+++ b/pkgs/tools/audio/kaldi/default.nix
@@ -23,21 +23,21 @@ let
 in
 stdenv.mkDerivation {
   pname = "kaldi";
-  version = "2021-12-03";
+  version = "2022-07-20";
 
   src = fetchFromGitHub {
     owner = "kaldi-asr";
     repo = "kaldi";
-    rev = "2b016ab8cb018e031ab3bf01ec36cc2950c7e509";
-    sha256 = "sha256-R8CrY7cwU5XfeGEgeFuZ0ApsEcEmWN/lrZaCjz85tyk=";
+    rev = "9af2c5c16389e141f527ebde7ee432a0c1df9fb9";
+    sha256 = "sha256-+gX9cm5iUmeuufofxB6VZpjDjPp7+Lr/bhCSRypB0cU=";
   };
 
   cmakeFlags = [
     "-DKALDI_BUILD_TEST=off"
     "-DBUILD_SHARED_LIBS=on"
+    "-DLAPACK_LIBRARIES=-llapack"
+    "-DBLAS_LIBRARIES=-lblas"
   ];
-
-  enableParallelBuilding = true;
 
   preConfigure = ''
     mkdir bin

--- a/pkgs/tools/audio/vosk-api/default.nix
+++ b/pkgs/tools/audio/vosk-api/default.nix
@@ -1,0 +1,61 @@
+{ stdenv
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, kaldi
+, openblas
+, python3
+, lib
+}:
+
+stdenv.mkDerivation rec {
+  name = "vosk-api";
+  version = "0.3.43";
+
+  src = fetchFromGitHub {
+    owner = "alphacep";
+    repo = "vosk-api";
+    rev = "v${version}";
+    sha256 = "SbCZx+G5q/W7CBVbmGZYf2ubhUJXtSTzaFAwQEJEt3Y=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    (kaldi.overrideAttrs (attrs: {
+      patches = attrs.patches or [ ] ++ [
+        # Vosk patches: https://github.com/kaldi-asr/kaldi/compare/master...alphacep:kaldi:vosk
+        # https://github.com/alphacep/vosk-api/issues/1082
+        (fetchpatch {
+          url = "https://github.com/kaldi-asr/kaldi/commit/1612ee9afa41e141061e53615fffa2a7cfdf94ac.patch";
+          sha256 = "owqmOIhh4ylR2mOBc9fxV0yrMVYtV4bobnvl2Quis2A=";
+        })
+        (fetchpatch {
+          url = "https://github.com/kaldi-asr/kaldi/commit/8f96991720beb0685fba15ffcea9ac89d33b8d23.patch";
+          sha256 = "IyFwezIdpfvvSRThJacb4spy9EZVDsRzvJlmglB/caw=";
+        })
+      ];
+    }))
+    openblas
+  ];
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS:BOOL=on"
+  ];
+
+  passthru = {
+    tests = {
+      python = python3.pkgs.vosk-python;
+    };
+  };
+
+  meta = with lib; {
+    description = "Offline speech recognition API";
+    homepage = "https://github.com/alphacep/vosk-api";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jtojnar ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-stt-vosk/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-stt-vosk/default.nix
@@ -1,0 +1,69 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, meson
+, ninja
+, pkg-config
+, gst_all_1
+, gst-vosk
+, ibus
+, pango
+, gtk4
+, libadwaita
+, python3
+, gobject-introspection
+, wrapGAppsHook4
+, desktop-file-utils
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ibus-stt-vosk";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "PhilippeRo";
+    repo = "IBus-Speech-To-Text";
+    rev = version;
+    sha256 = "K3l9glsnaX0G/O/kXUlh6KpQ/dr2mipRqSOdjOhoROM=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    gobject-introspection # for setup hook
+    wrapGAppsHook4
+    desktop-file-utils
+  ];
+
+  buildInputs = [
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base # for audioconvert
+    gst_all_1.gst-plugins-good # for pulsesrc
+    gst-vosk
+    ibus
+    pango
+    gtk4
+    libadwaita
+    (python3.withPackages (ps: [
+      ps.pygobject3
+      ps.gst-python
+      ps.babel
+      (ps.toPythonModule ibus)
+    ]))
+  ];
+
+  postPatch = ''
+    substituteInPlace engine/meson.build --replace 'meson.project_license()' 'meson.project_license()[0]'
+    patchShebangs build-aux/meson_post_install.py
+  '';
+
+  meta = with lib; {
+    isIbusEngine = true;
+    description = "Speech to text IBus engine using VOSK";
+    homepage = "https://github.com/PhilippeRo/IBus-Speech-To-Text";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ jtojnar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18108,6 +18108,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) AudioToolbox AVFoundation Cocoa CoreFoundation CoreMedia CoreServices CoreVideo DiskArbitration Foundation IOKit MediaToolbox OpenGL VideoToolbox;
   });
 
+  gst-vosk = callPackage ../development/libraries/gst-vosk { };
+
   gusb = callPackage ../development/libraries/gusb { };
 
   qt-mobility = callPackage ../development/libraries/qt-mobility {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5113,6 +5113,8 @@ with pkgs;
 
     rime = callPackage ../tools/inputmethods/ibus-engines/ibus-rime { };
 
+    stt-vosk = callPackage ../tools/inputmethods/ibus-engines/ibus-stt-vosk { };
+
     table = callPackage ../tools/inputmethods/ibus-engines/ibus-table { };
 
     table-chinese = callPackage ../tools/inputmethods/ibus-engines/ibus-table-chinese {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1319,6 +1319,8 @@ with pkgs;
 
   vopono = callPackage ../tools/networking/vopono { };
 
+  vosk-api = callPackage ../tools/audio/vosk-api { };
+
   winbox = callPackage ../tools/admin/winbox {
     wine = wineWowPackages.staging;
     use64 = true;


### PR DESCRIPTION
###### Description of changes

Alternative to https://github.com/NixOS/nixpkgs/pull/185148, using vosk as ibus input method, rather than a low-level input manipulator.

Alternative to https://github.com/NixOS/nixpkgs/pull/173847, using Vosk instead of Coqui stt.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
