### PR TITLE
rusty-psn, rusty-psn-gui: init at 0.1.2

### DIFF
--- a/pkgs/applications/misc/rusty-psn/default.nix
+++ b/pkgs/applications/misc/rusty-psn/default.nix
@@ -1,0 +1,80 @@
+{ lib 
+, stdenv
+, rustPlatform
+, fetchFromGitHub
+, makeDesktopItem
+, copyDesktopItems
+, pkg-config
+, openssl
+, xorg
+, libGL
+, gui ? false # build GUI version
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rusty-psn";
+  version = "0.1.2";
+  
+  src = fetchFromGitHub {
+    owner = "RainbowCookie32";
+    repo = "rusty-psn";
+    rev = "v${version}";
+    sha256 = "14li5fsaj4l5al6lcxy07g3gzmi0l3cyiczq44q7clq4myhykhhb";
+  };
+
+  cargoSha256 = "0kjaq3ik3lwaz7rjb5jaxavpahzp33j7vln3zyifql7j7sbr300f";
+
+  nativeBuildInputs = [
+    pkg-config
+    copyDesktopItems
+  ];
+
+  dependencies = if gui then [
+    openssl
+    xorg.libxcb
+    xorg.libX11
+    xorg.libXcursor
+    xorg.libXrandr
+    xorg.libXi
+    xorg.libxcb
+    libGL
+    libGL.dev
+  ] else [
+  	openssl
+  ];
+  buildInputs = dependencies;
+
+  buildNoDefaultFeatures = true;
+  buildFeatures = [ (if gui then "egui" else "cli") ];
+
+  postFixup = ''
+    patchelf --set-rpath "${lib.makeLibraryPath dependencies}" $out/bin/rusty-psn
+    ${if gui then "mv $out/bin/rusty-psn $out/bin/rusty-psn-gui" else ""}
+  '';
+
+  desktopItem = if gui then makeDesktopItem {
+    name = "rusty-psn";
+    desktopName = "rusty-psn";
+    exec = "rusty-psn-gui";
+    comment = "A simple tool to grab updates for PS3 games, directly from Sony's servers using their updates API.";
+    categories = [
+      "Network"
+    ];
+    keywords = [
+      "psn"
+      "ps3"
+      "sony"
+      "playstation"
+      "update"
+    ];
+  } else "";
+  desktopItems = if gui then [ desktopItem ] else [];
+
+  meta = with lib; {
+    description = "A simple tool to grab updates for PS3 games, directly from Sony's servers using their updates API";
+    homepage = "";
+    license = licenses.mit;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ AngryAnt ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30214,7 +30214,7 @@ with pkgs;
 
   rusty-psn = callPackage ../applications/misc/rusty-psn {};
 
-  rusty-psn-gui = rusty-psn.override { gui = true; };
+  rusty-psn-gui = rusty-psn.override { withGui = true; };
 
   rymcast = callPackage ../applications/audio/rymcast {
     inherit (gnome) zenity;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30212,6 +30212,10 @@ with pkgs;
 
   runc = callPackage ../applications/virtualization/runc {};
 
+  rusty-psn = callPackage ../applications/misc/rusty-psn {};
+
+  rusty-psn-gui = rusty-psn.override { gui = true; };
+
   rymcast = callPackage ../applications/audio/rymcast {
     inherit (gnome) zenity;
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

A simple tool to grab updates for PS3 games, directly from Sony's servers using their updates API.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
