### PR TITLE
[22.05] clhep: init at 2.4.5.3

### DIFF
--- a/pkgs/development/libraries/physics/clhep/default.nix
+++ b/pkgs/development/libraries/physics/clhep/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, stdenv
+, fetchurl
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "clhep";
+  version = "2.4.5.3";
+
+  src = fetchurl {
+    url = "https://proj-clhep.web.cern.ch/proj-clhep/dist1/clhep-${version}.tgz";
+    hash = "sha256-RfY+6wl/Av5nuGp9rb8Q1Am0AcKKGj4XLbNiUsMJfBM=";
+  };
+
+  prePatch = ''
+    cd CLHEP
+  '';
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace "clhep_ensure_out_of_source_build()" ""
+  '';
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  meta = with lib; {
+    description = "Set of HEP-specific foundation and utility classes such as random generators, physics vectors, geometry and linear algebra";
+    homepage = "https://cern.ch/clhep";
+    license = with licenses; [ gpl3Only lgpl3Only ];
+    maintainers = with maintainers; [ veprbl ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/physics/geant4/default.nix
+++ b/pkgs/development/libraries/physics/geant4/default.nix
@@ -12,7 +12,7 @@
 , lib, stdenv, fetchurl, fetchpatch, cmake
 
 # Optional system packages, otherwise internal GEANT4 packages are used.
-, clhep ? null # not packaged currently
+, clhep
 , expat
 , zlib
 
@@ -86,7 +86,7 @@ stdenv.mkDerivation rec {
 
   dontWrapQtApps = !enableQT;
 
-  buildInputs = [ libGLU xlibsWrapper libXmu ]
+  buildInputs = [ clhep libGLU xlibsWrapper libXmu ]
     ++ lib.optionals enableInventor [ libXpm coin3d soxt motif ]
     ++ lib.optionals enablePython [ boost_python python3 ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33835,6 +33835,8 @@ with pkgs;
 
   cernlib = callPackage ../development/libraries/physics/cernlib { };
 
+  clhep = callPackage ../development/libraries/physics/clhep { };
+
   hepmc2 = callPackage ../development/libraries/physics/hepmc2 { };
 
   hepmc3 = callPackage ../development/libraries/physics/hepmc3 {


### PR DESCRIPTION
(cherry picked from commit 8d10015d3a99f1978805a8e4f6848a8ebbe16176)

###### Description of changes

backport of #181777
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
