### PR TITLE
python3Packages.dvc-task: init at 0.1.2

### DIFF
--- a/pkgs/development/python-modules/dvc-task/default.nix
+++ b/pkgs/development/python-modules/dvc-task/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, setuptools-scm
+, kombu
+, shortuuid
+, celery
+, funcy
+, pytest-celery
+, pytest-mock
+, pytest-test-utils
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "dvc-task";
+  version = "0.1.2";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "iterative";
+    repo = pname;
+    rev = version;
+    hash = "sha256-LXjfFuLifgzU+3/EevycVCR7LhYBOoN6xg4YeNo5R4M=";
+  };
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    kombu
+    shortuuid
+    celery
+    funcy
+  ];
+
+  checkInputs = [
+    pytest-celery
+    pytest-mock
+    pytest-test-utils
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "dvc_task"
+  ];
+
+  meta = with lib; {
+    description = "Celery task queue used in DVC";
+    homepage = "https://github.com/iterative/dvc-task";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ anthonyroussel ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2701,6 +2701,8 @@ in {
 
   dvc-render = callPackage ../development/python-modules/dvc-render {  };
 
+  dvc-task = callPackage ../development/python-modules/dvc-task {  };
+
   dvclive = callPackage ../development/python-modules/dvclive {  };
 
   dwdwfsapi = callPackage ../development/python-modules/dwdwfsapi { };


### PR DESCRIPTION
###### Description of changes

See https://github.com/iterative/dvc-task

dvc-task v0.1 is required to upgrade dvc to v2.14.0
So we're blocked for the dvc v2.14.0 upgrade, see https://github.com/NixOS/nixpkgs/pull/185127#issuecomment-1206259122

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).