### PR TITLE
kerf_1: init at unstable-2022-08-05

### DIFF
--- a/pkgs/development/interpreters/kerf/default.nix
+++ b/pkgs/development/interpreters/kerf/default.nix
@@ -1,0 +1,92 @@
+{ lib, stdenv, fetchFromGitHub
+, libedit, zlib, ncurses, expect
+
+# darwin only below
+, Accelerate, CoreGraphics, CoreVideo
+}:
+
+stdenv.mkDerivation rec {
+  pname = "kerf";
+  version = "unstable-2022-08-05";
+
+  src = fetchFromGitHub {
+    owner = "kevinlawler";
+    repo  = "kerf1";
+    rev   = "4ec5b592b310b96d33654d20d6a511e6fffc0f9d";
+    hash  = "sha256-0sU2zOk5I69lQyrn1g0qsae7S/IBT6eA/911qp0GNkk=";
+  };
+
+  sourceRoot = "source/src";
+  buildInputs = [ libedit zlib ncurses ]
+    ++ lib.optional stdenv.isDarwin ([
+      Accelerate
+    ] ++ lib.optional stdenv.isx86_64 /* && isDarwin */ [
+      CoreGraphics CoreVideo
+    ]);
+
+  checkInputs = [ expect ];
+  doCheck = true;
+
+  makeFlags = [ "kerf" "kerf_test" ];
+
+  # avoid a huge amount of warnings to make failures clearer
+  NIX_CFLAGS_COMPILE = map (x: "-Wno-${x}") [
+    "void-pointer-to-int-cast"
+    "format"
+    "implicit-function-declaration"
+    "gnu-variable-sized-type-not-at-end"
+    "unused-result"
+  ] ++ lib.optional stdenv.isDarwin [ "-fcommon" ];
+
+  patchPhase = ''
+    substituteInPlace ./Makefile \
+      --replace 'CPUS ?=' 'CPUS = $(NIX_BUILD_CORES) #' \
+      --replace 'termcap' 'ncurses'
+  '';
+
+  # the kerf executable uses ncurses to create a fancy terminal for input and
+  # reads terminal keystrokes directly, so it doesn't read from stdin as
+  # expected, hence why we use this fancy expect script to run the test exe and
+  # send 'quit' to the prompt after it finishes.
+  checkPhase = ''
+    expect <<EOD
+      set timeout 60
+      spawn ./kerf_test
+      expect {
+        "Passed" {}
+        "Failed" { exit 1 }
+        timeout { exit 1 }
+      }
+      expect {
+        "KeRF> " {send "quit\r"}
+        timeout { exit 1 }
+      }
+      expect {
+        "\[DEBUG\] OK: Done OK." {}
+        "\[DEBUG\] FAILED: Debug failure." { exit 1 }
+        timeout { exit 1 }
+      }
+      exit 0
+    EOD
+  '';
+
+  installPhase = "install -D kerf $out/bin/kerf";
+
+  meta = with lib; {
+    description = "Columnar tick database and time-series language";
+    longDescription = ''
+      Kerf is a columnar tick database and small programming
+      language that is a superset of JSON and SQL. It can be
+      used for local analytics, timeseries, logfile processing,
+      and more.
+    '';
+    license = with licenses; [ bsd2 ];
+    homepage = "https://github.com/kevinlawler/kerf1";
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ thoughtpolice ];
+
+    # aarch64-linux seems hopeless, with over 2,000 warnings
+    # generated?
+    broken = (stdenv.isLinux && stdenv.isAarch64);
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2639,6 +2639,14 @@ with pkgs;
 
   goku = callPackage ../os-specific/darwin/goku { };
 
+  kerf   = kerf_1; /* kerf2 is WIP */
+  kerf_1 = callPackage ../development/interpreters/kerf {
+    stdenv = clangStdenv;
+    inherit (darwin.apple_sdk.frameworks)
+      Accelerate CoreGraphics CoreVideo
+    ;
+  };
+
   kwakd = callPackage ../servers/kwakd { };
 
   kwm = callPackage ../os-specific/darwin/kwm { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] ~~aarch64-linux~~
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
