### PR TITLE
streamlit: 1.2.0 -> 1.11.1

### DIFF
--- a/pkgs/applications/science/machine-learning/streamlit/default.nix
+++ b/pkgs/applications/science/machine-learning/streamlit/default.nix
@@ -6,16 +6,11 @@
 
   # Build inputs
   altair,
-  astor,
-  base58,
   blinker,
-  boto3,
-  botocore,
   click,
   cachetools,
-  enum-compat,
-  future,
   GitPython,
+  importlib-metadata,
   jinja2,
   pillow,
   pyarrow,
@@ -23,6 +18,8 @@
   pympler,
   protobuf,
   requests,
+  rich,
+  semver,
   setuptools,
   toml,
   tornado,
@@ -31,36 +28,23 @@
   watchdog,
 }:
 
-let
-  click_7 = click.overridePythonAttrs(old: rec {
-    version = "7.1.2";
-    src = old.src.override {
-      inherit version;
-      sha256 = "d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a";
-    };
-  });
-in buildPythonApplication rec {
+buildPythonApplication rec {
   pname = "streamlit";
-  version = "1.2.0";
-  format = "wheel"; # the only distribution available
+  version = "1.11.1";
+  format = "wheel";  # source currently requires pipenv
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "1dzb68a8n8wvjppcmqdaqnh925b2dg6rywv51ac9q09zjxb6z11n";
+    hash = "sha256-+GGuL3UngPDgLOGx9QXUdRJsTswhTg7d6zuvhpp0Mo0=";
   };
 
   propagatedBuildInputs = [
     altair
-    astor
-    base58
     blinker
-    boto3
-    botocore
     cachetools
-    click_7
-    enum-compat
-    future
+    click
     GitPython
+    importlib-metadata
     jinja2
     pillow
     protobuf
@@ -68,6 +52,8 @@ in buildPythonApplication rec {
     pydeck
     pympler
     requests
+    rich
+    semver
     setuptools
     toml
     tornado


### PR DESCRIPTION
###### Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2022-35918

~Leaving this as draft because it's currently impossible to test due to #185082. If you really want to test it, I suggest trying `nixpkgs-review`'s `--checkout commit` option which should work.~

Not knowing much about this package & wanting some certainty that this produces a working package, I temporarily got the test suite working and passing (apart from some fairly irrelevant project-internal tests) on x86_64 linux. However I'm not pushing that test enablement as it's quite ugly and involves pulling the tests _separately_ from github along with adding another ~15 dependencies to `checkInputs`. Will post those changes to another branch if anyone's interested in tidying them up.

Will look at the possibility of patching stable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
