### PR TITLE
sile: 0.13.3 → 0.14.1

### DIFF
--- a/pkgs/tools/typesetting/sile/default.nix
+++ b/pkgs/tools/typesetting/sile/default.nix
@@ -33,7 +33,6 @@ let
     luasocket
     luautf8
     penlight
-    stdlib
     vstruct
   ] ++ lib.optionals (lib.versionOlder lua.luaversion "5.2") [
     bit32
@@ -44,11 +43,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "sile";
-  version = "0.13.3";
+  version = "0.14.0";
 
   src = fetchurl {
     url = "https://github.com/sile-typesetter/sile/releases/download/v${version}/${pname}-${version}.tar.xz";
-    sha256 = "0x8w63xr3nd0is1pv55dlgnv7fkn8s5ny6453wn84h44i7qwdc8s";
+    sha256 = "0k3kp0ncs73q0m4mngy51mvqjwdxncbp9m5bhlpvd5in7crzlync";
   };
 
   configureFlags = [

--- a/pkgs/tools/typesetting/sile/default.nix
+++ b/pkgs/tools/typesetting/sile/default.nix
@@ -43,11 +43,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "sile";
-  version = "0.14.0";
+  version = "0.14.1";
 
   src = fetchurl {
     url = "https://github.com/sile-typesetter/sile/releases/download/v${version}/${pname}-${version}.tar.xz";
-    sha256 = "0k3kp0ncs73q0m4mngy51mvqjwdxncbp9m5bhlpvd5in7crzlync";
+    sha256 = "1l0cl5rwpndn2zmcrydnd80cznpfr8m6v3s4qkx6n6q0lrcnxa56";
   };
 
   configureFlags = [


### PR DESCRIPTION
Relatively big release but the build system is mostly the same. The luastd dependency was dropped. Some of the .so library modules moved but autotools should take care of it. Nothing else should affect the Nix build. See [upstream release notes](https://github.com/sile-typesetter/sile/releases/tag/v0.14.0).

Closes #185552