### PR TITLE
msmtp: resholve queue scripts

### DIFF
--- a/pkgs/applications/networking/msmtp/default.nix
+++ b/pkgs/applications/networking/msmtp/default.nix
@@ -1,53 +1,37 @@
-{ stdenv, lib, fetchurl, autoreconfHook, pkg-config, texinfo
-, netcat-gnu, gnutls, gsasl, libidn2, Security
-, withKeyring ? true, libsecret ? null
-, systemd ? null }:
+{ resholve
+, stdenv
+, symlinkJoin
+, lib
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, bash
+, coreutils
+, gnugrep
+, gnutls
+, gsasl
+, libidn2
+, netcat-gnu
+, texinfo
+, which
+, Security
+, withKeyring ? true
+, libsecret ? null
+, withSystemd ? stdenv.isLinux
+, systemd ? null
+}:
 
 let
-  tester = "n"; # {x| |p|P|n|s}
-  journal = if stdenv.isLinux then "y" else "n";
+  inherit (lib) getBin getExe optionals;
 
-in stdenv.mkDerivation rec {
-  pname = "msmtp";
   version = "1.8.20";
 
-  src = fetchurl {
-    url = "https://marlam.de/${pname}/releases/${pname}-${version}.tar.xz";
-    sha256 = "sha256-2TriqvwPSK99ydCzlN8buABYi4tOjQltizzyJTROsRE=";
+  src = fetchFromGitHub {
+    owner = "marlam";
+    repo = "msmtp-mirror";
+    rev = "msmtp-${version}";
+    hash = "sha256-RcQZ7Vm8UjJJoogkmUmZ+/2fz7C4AcVYY/kTOlfz7+I=";
   };
-
-  patches = [
-    ./paths.patch
-  ];
-
-  buildInputs = [ gnutls gsasl libidn2 ]
-    ++ lib.optional stdenv.isDarwin Security
-    ++ lib.optional withKeyring libsecret;
-
-  nativeBuildInputs = [ autoreconfHook pkg-config texinfo ];
-
-  configureFlags = [ "--sysconfdir=/etc" "--with-libgsasl" ]
-    ++ lib.optional stdenv.isDarwin [ "--with-macosx-keyring" ];
-
-  postInstall = ''
-    install -d $out/share/doc/${pname}/scripts
-    cp -r scripts/{find_alias,msmtpqueue,msmtpq,set_sendmail} $out/share/doc/${pname}/scripts
-    install -Dm644 doc/*.example $out/share/doc/${pname}
-
-    substitute scripts/msmtpq/msmtpq $out/bin/msmtpq \
-      --replace @msmtp@      $out/bin/msmtp \
-      --replace @nc@         ${netcat-gnu}/bin/nc \
-      --replace @journal@    ${journal} \
-      ${lib.optionalString (journal == "y") "--replace @systemdcat@ ${systemd}/bin/systemd-cat" } \
-      --replace @test@       ${tester}
-
-    substitute scripts/msmtpq/msmtp-queue $out/bin/msmtp-queue \
-      --replace @msmtpq@ $out/bin/msmtpq
-
-    ln -s msmtp $out/bin/sendmail
-
-    chmod +x $out/bin/*
-  '';
 
   meta = with lib; {
     description = "Simple and easy to use SMTP client with excellent sendmail compatibility";
@@ -56,4 +40,92 @@ in stdenv.mkDerivation rec {
     maintainers = with maintainers; [ peterhoeg ];
     platforms = platforms.unix;
   };
+
+  binaries = stdenv.mkDerivation rec {
+    pname = "msmtp-binaries";
+    inherit version src meta;
+
+    configureFlags = [ "--sysconfdir=/etc" "--with-libgsasl" ]
+      ++ optionals stdenv.isDarwin [ "--with-macosx-keyring" ];
+
+    buildInputs = [ gnutls gsasl libidn2 ]
+      ++ optionals stdenv.isDarwin [ Security ]
+      ++ optionals withKeyring [ libsecret ];
+
+    nativeBuildInputs = [ autoreconfHook pkg-config texinfo ];
+
+    enableParallelBuilding = true;
+
+    postInstall = ''
+      install -Dm444 -t $out/share/doc/msmtp doc/*.example
+      ln -s msmtp $out/bin/sendmail
+    '';
+  };
+
+  scripts = resholve.mkDerivation rec {
+    pname = "msmtp-scripts";
+    inherit version src meta;
+
+    patches = [ ./paths.patch ];
+
+    postPatch = ''
+      substituteInPlace scripts/msmtpq/msmtpq \
+        --replace @journal@ ${if withSystemd then "Y" else "N"}
+    '';
+
+    dontConfigure = true;
+    dontBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      install -Dm555 -t $out/bin                     scripts/msmtpq/msmtp*
+      install -Dm444 -t $out/share/doc/msmtp/scripts scripts/msmtpq/README*
+      install -Dm444 -t $out/share/doc/msmtp/scripts scripts/{find_alias,msmtpqueue,set_sendmail}/*
+
+      if grep --quiet -E '@.+@' $out/bin/*; then
+        echo "Unsubstituted variables found. Aborting!"
+        grep -E '@.+@' $out/bin/*
+        exit 1
+      fi
+
+      runHook postInstall
+    '';
+
+    solutions = {
+      msmtpq = {
+        scripts = [ "bin/msmtpq" ];
+        interpreter = getExe bash;
+        inputs = [
+          binaries
+          coreutils
+          gnugrep
+          netcat-gnu
+          which
+        ] ++ optionals withSystemd [ systemd ];
+        execer = [
+          "cannot:${getBin binaries}/bin/msmtp"
+          "cannot:${getBin netcat-gnu}/bin/nc"
+        ] ++ optionals withSystemd [
+          "cannot:${getBin systemd}/bin/systemd-cat"
+        ];
+        fix."$MSMTP" = [ "msmtp" ];
+        fake.external = [ "ping" ]
+          ++ optionals (!withSystemd) [ "systemd-cat" ];
+      };
+
+      msmtp-queue = {
+        scripts = [ "bin/msmtp-queue" ];
+        interpreter = getExe bash;
+        inputs = [ "${placeholder "out"}/bin" ];
+        execer = [ "cannot:${placeholder "out"}/bin/msmtpq" ];
+      };
+    };
+  };
+
+in
+symlinkJoin {
+  name = "msmtp-${version}";
+  inherit version meta;
+  paths = [ binaries scripts ];
 }

--- a/pkgs/applications/networking/msmtp/paths.patch
+++ b/pkgs/applications/networking/msmtp/paths.patch
@@ -1,61 +1,40 @@
-diff --git a/scripts/msmtpq/msmtp-queue b/scripts/msmtpq/msmtp-queue
-index 1dc220d..d834241 100755
---- a/scripts/msmtpq/msmtp-queue
-+++ b/scripts/msmtpq/msmtp-queue
-@@ -27,4 +27,4 @@
- ## change the below line to be
- ##   exec /path/to/msmtpq --q-mgmt
- 
--exec msmtpq --q-mgmt "$1"
-+exec @msmtpq@ --q-mgmt "$1"
 diff --git a/scripts/msmtpq/msmtpq b/scripts/msmtpq/msmtpq
-index bdb4fb8..1363a67 100755
+index 1b39fc6..4baa19b 100755
 --- a/scripts/msmtpq/msmtpq
 +++ b/scripts/msmtpq/msmtpq
-@@ -59,7 +59,7 @@ err() { dsp '' "$@" '' ; exit 1 ; }
- ##   enter the location of the msmtp executable  (no quotes !!)
- ##   e.g. ( MSMTP=/path/to/msmtp )
- ##   and uncomment the test for its existence
--MSMTP=msmtp
-+MSMTP=@msmtp@
- #[ -x "$MSMTP" ] || \
- #  log -e 1 "msmtpq : can't find the msmtp executable [ $MSMTP ]"   # if not found - complain ; quit
- ##
-@@ -70,9 +70,9 @@ MSMTP=msmtp
+@@ -70,8 +70,8 @@ MSMTP=msmtp
  ##            ( chmod 0700 msmtp.queue )
  ##
  ## the queue dir - modify this to reflect where you'd like it to be  (no quotes !!)
 -Q=~/.msmtp.queue
 -[ -d "$Q" ] || mkdir -m 0700 "$Q" || \
--  err '' "msmtpq : can't find or create msmtp queue directory [ $Q ]" ''     # if not present - complain ; quit
 +Q=${MSMTP_QUEUE:-~/.msmtp.queue}
 +[ -d "$Q" ] || mkdir -m 0700 -p "$Q" || \
-+   err '' "msmtpq : can't find or create msmtp queue directory [ $Q ]" ''     # if not present - complain ; quit
+   err '' "msmtpq : can't find or create msmtp queue directory [ $Q ]" ''     # if not present - complain ; quit
  ##
  ## set the queue log file var to the location of the msmtp queue log file
- ##   where it is or where you'd like it to be
-@@ -84,7 +83,10 @@ Q=~/.msmtp.queue
+@@ -84,7 +84,10 @@ Q=~/.msmtp.queue
  ##     (doing so would be inadvisable under most conditions, however)
  ##
  ## the queue log file - modify (or comment out) to taste  (but no quotes !!)
 -LOG=~/log/msmtp.queue.log
 +LOG=${MSMTP_LOG:-~/log/msmtp.queue.log}
-+test -d "$(dirname $LOG)" || mkdir -p "$(dirname $LOG)"
++[ -d "$(dirname "$LOG")" ] || mkdir -p "$(dirname "$LOG")"
 +
 +JOURNAL=@journal@
  ## ======================================================================================
  
  ## msmtpq can use the following environment variables :
-@@ -108,7 +110,7 @@ LOG=~/log/msmtp.queue.log
+@@ -108,7 +111,7 @@ LOG=~/log/msmtp.queue.log
  ##
  #EMAIL_CONN_NOTEST=y                 # deprecated ; use below var
  #EMAIL_CONN_TEST={x| |p|P|n|s}       # see settings above for EMAIL_CONN_TEST
 -EMAIL_CONN_TEST=n
-+EMAIL_CONN_TEST=@test@
++EMAIL_CONN_TEST=${MSMTP_CONN_TEST:-n}
  #EMAIL_QUEUE_QUIET=t
  ## ======================================================================================
  
-@@ -138,6 +140,7 @@ on_exit() {                          # unlock the queue on exit if the lock was
+@@ -138,6 +141,7 @@ on_exit() {                          # unlock the queue on exit if the lock was
  ## display msg to user, as well
  ##
  log() {
@@ -63,15 +42,14 @@ index bdb4fb8..1363a67 100755
    local ARG RC PFX
    PFX="$('date' +'%Y %d %b %H:%M:%S')"
                                       # time stamp prefix - "2008 13 Mar 03:59:45 "
-   if [ "$1" = '-e' ] ; then          # there's an error exit code
-@@ -154,10 +157,19 @@ log() {
+@@ -155,10 +159,19 @@ log() {
      done
    fi
  
-+  if [ "$JOURNAL" == "y" ] ; then
++  if [ "$JOURNAL" == "Y" ]; then
 +    for ARG ; do
 +      [ -n "$ARG" ] && \
-+        echo "$PFX : $ARG" | @systemdcat@ -t $NAME -p info
++        echo "$ARG" | systemd-cat -t $NAME -p info
 +    done
 +  fi
 +
@@ -79,20 +57,8 @@ index bdb4fb8..1363a67 100755
      [ -n "$LKD" ] && lock_queue -u   # unlock here (if locked)
      [ -n "$LOG" ] && \
        echo "    exit code = $RC" >> "$LOG" # logging ok ; send exit code to log
-+    [ "$JOURNAL" == "y" ] && \
-+      echo "exit code= $RC" | @systemdcat@ -t $NAME -p emerg
-     exit $RC                         # exit w/return code
++    [ "$JOURNAL" == "Y" ] && \
++      echo "exit code= $RC" | systemd-cat -t $NAME -p emerg
+     exit "$RC"                       # exit w/return code
    fi
  }
-@@ -207,10 +219,7 @@ connect_test() {
-     ping -qnc1 -w4 8.8.8.8 >/dev/null 2>&1 || return 1
- 
-   elif [ "$EMAIL_CONN_TEST" = 'n' ] ; then                     # use netcat (nc) test
--    # must, of course, have netcat (nc) installed
--    which nc >/dev/null 2>&1 || \
--      log -e 1 "msmtpq : can't find netcat executable [ nc ]"  # if not found - complain ; quit
--    'nc' -vz www.debian.org 80 >/dev/null 2>&1 || return 1
-+    @nc@ -vz www.debian.org 80 >/dev/null 2>&1 || return 1
- 
-   elif [ "$EMAIL_CONN_TEST" = 's' ] ; then                     # use sh sockets test
-     # note that this does not work on debian systems

--- a/pkgs/applications/networking/msmtp/paths.patch
+++ b/pkgs/applications/networking/msmtp/paths.patch
@@ -25,15 +25,6 @@ index 1b39fc6..4baa19b 100755
  ## ======================================================================================
  
  ## msmtpq can use the following environment variables :
-@@ -108,7 +111,7 @@ LOG=~/log/msmtp.queue.log
- ##
- #EMAIL_CONN_NOTEST=y                 # deprecated ; use below var
- #EMAIL_CONN_TEST={x| |p|P|n|s}       # see settings above for EMAIL_CONN_TEST
--EMAIL_CONN_TEST=n
-+EMAIL_CONN_TEST=${MSMTP_CONN_TEST:-n}
- #EMAIL_QUEUE_QUIET=t
- ## ======================================================================================
- 
 @@ -138,6 +141,7 @@ on_exit() {                          # unlock the queue on exit if the lock was
  ## display msg to user, as well
  ##


### PR DESCRIPTION
###### Description of changes

Previously, we were doing 3 things to the queueing scripts (msmtpq and
msmtp-queue):

1. replacing binary invocations with @binary@ so we could use
   `substituteInPlace` and friends to set the proper full paths
2. make queueing directory and log file overridable via environment variables
3. add support to the logging function to log to systemd's journal

The handling of the queue scripts (item 1) was very brittle and didn't catch all
impurities (`which` for one), so instead use `resholve` to ensure all paths to
binaries are resolved to their proper paths. That also means less patching.

Item 2 - the connectivity test is now configurable via an environment variable
rather than being forced at build-time.

Items 3 isn't changed.

Additionally, the package has been split into 2 - 1 for binaries and one for
scripts to make it easier to change the scripts without having to rebuild
`msmtp` fully every time.

Fixes: #185164

Cc: @Jayman2000

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
