### PR TITLE
opam: remove aspcud from runtime

### DIFF
--- a/pkgs/development/tools/ocaml/opam/default.nix
+++ b/pkgs/development/tools/ocaml/opam/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl, makeWrapper, getconf,
-  ocaml, unzip, ncurses, curl, aspcud, bubblewrap
+  ocaml, unzip, ncurses, curl, bubblewrap
 }:
 
 assert lib.versionAtLeast ocaml.version "4.02.3";
@@ -119,7 +119,7 @@ in stdenv.mkDerivation {
     mv $out/bin/opam $out/bin/.opam-wrapped
     makeWrapper $out/bin/.opam-wrapped $out/bin/opam \
       --argv0 "opam" \
-      --suffix PATH : ${aspcud}/bin:${unzip}/bin:${curl}/bin:${lib.optionalString stdenv.isLinux "${bubblewrap}/bin:"}${getconf}/bin \
+      --suffix PATH : ${unzip}/bin:${curl}/bin:${lib.optionalString stdenv.isLinux "${bubblewrap}/bin:"}${getconf}/bin \
       --set OPAM_USER_PATH_RO /run/current-system/sw/bin:/nix/
     $out/bin/opam-installer --prefix=$installer opam-installer.install
   '';

--- a/pkgs/development/tools/ocaml/opam/opam.nix.pl
+++ b/pkgs/development/tools/ocaml/opam/opam.nix.pl
@@ -21,12 +21,12 @@ chomp $OPAM_RELEASE_SHA256;
 
 my $OPAM_BASE_URL = "https://raw.githubusercontent.com/$OPAM_GITHUB_REPO/$OPAM_TAG";
 my $OPAM_OPAM = `curl -L --url \Q$OPAM_BASE_URL\E/opam-devel.opam`;
-my($OCAML_MIN_VERSION) = $OPAM_OPAM =~ /^  "ocaml" {>= "(.*)"}$/m
+my($OCAML_MIN_VERSION) = $OPAM_OPAM =~ /^  "ocaml" \{>= "(.*)"}$/m
   or die "could not parse ocaml version bound\n";
 
 print <<"EOF";
 { stdenv, lib, fetchurl, makeWrapper, getconf,
-  ocaml, unzip, ncurses, curl, aspcud, bubblewrap
+  ocaml, unzip, ncurses, curl, bubblewrap
 }:
 
 assert lib.versionAtLeast ocaml.version "$OCAML_MIN_VERSION";
@@ -114,7 +114,7 @@ print <<'EOF';
     mv $out/bin/opam $out/bin/.opam-wrapped
     makeWrapper $out/bin/.opam-wrapped $out/bin/opam \
       --argv0 "opam" \
-      --suffix PATH : ${aspcud}/bin:${unzip}/bin:${curl}/bin:${lib.optionalString stdenv.isLinux "${bubblewrap}/bin:"}${getconf}/bin \
+      --suffix PATH : ${unzip}/bin:${curl}/bin:${lib.optionalString stdenv.isLinux "${bubblewrap}/bin:"}${getconf}/bin \
       --set OPAM_USER_PATH_RO /run/current-system/sw/bin:/nix/
     $out/bin/opam-installer --prefix=$installer opam-installer.install
   '';


### PR DESCRIPTION
###### Description of changes

see title (& appeased a strictness warning in `opam.nix.pl`); motivation:

* per [opam docs]:
  * external solvers have not been the default recommendation since 1.2.2
  * opam will detect supported solvers at runtime for those with (what are now considered) niche use cases
* drop a transitive build dependency on scons
  * scons in particular has been a common factor amongst breakages following an otherwise innocuous adjustment to cc-wrapper (#181485)
  * minimise ocaml's risk exposure to python ecosystem volatility

result of `nixpkgs-review --rev HEAD`:

    2 packages built:
    dune-release opam

cursory test drive shows that opam still resolves dependencies perfectly competently

[opam docs]: https://opam.ocaml.org/doc/External_solvers.html#Installation-and-compatibility

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

