### PR TITLE
etcd_3_5: refactor

### DIFF
--- a/pkgs/servers/etcd/3.5.nix
+++ b/pkgs/servers/etcd/3.5.nix
@@ -1,15 +1,18 @@
 { lib, buildGoModule, fetchFromGitHub, symlinkJoin }:
 
 let
-  etcdVersion = "3.5.4";
-  etcdSrc = fetchFromGitHub {
+  version = "3.5.4";
+
+  src = fetchFromGitHub {
     owner = "etcd-io";
     repo = "etcd";
-    rev = "v${etcdVersion}";
+    rev = "v${version}";
     sha256 = "sha256-mTQHxLLfNiihvHg5zaTeVNWKuzvE0KBiJdY3qMJHMCM=";
   };
 
-  commonMeta = with lib; {
+  CGO_ENABLED = 0;
+
+  meta = with lib; {
     description = "Distributed reliable key-value store for the most critical data of a distributed system";
     license = licenses.asl20;
     homepage = "https://etcd.io/";
@@ -19,60 +22,50 @@ let
 
   etcdserver = buildGoModule rec {
     pname = "etcdserver";
-    version = etcdVersion;
+
+    inherit CGO_ENABLED meta src version;
 
     vendorSha256 = "sha256-4djUQvWp9hScua9l1ZTq298zWSeDYRDojEt2AWmarzw=";
 
-    src = etcdSrc;
     modRoot = "./server";
 
     postBuild = ''
       mv $GOPATH/bin/{server,etcd}
     '';
 
-    CGO_ENABLED = 0;
-
     # We set the GitSHA to `GitNotFound` to match official build scripts when
     # git is unavailable. This is to avoid doing a full Git Checkout of etcd.
     # User facing version numbers are still available in the binary, just not
     # the sha it was built from.
     ldflags = [ "-X go.etcd.io/etcd/api/v3/version.GitSHA=GitNotFound" ];
-
-    meta = commonMeta;
   };
 
   etcdutl = buildGoModule rec {
     pname = "etcdutl";
-    version = etcdVersion;
+
+    inherit CGO_ENABLED meta src version;
 
     vendorSha256 = "sha256-nk56XGpNsDwcGrTKithKGnPCX0NhpQmzNSXHk3vmdtg=";
 
-    src = etcdSrc;
     modRoot = "./etcdutl";
-
-    CGO_ENABLED = 0;
-
-    meta = commonMeta;
   };
 
   etcdctl = buildGoModule rec {
     pname = "etcdctl";
-    version = etcdVersion;
+
+    inherit CGO_ENABLED meta src version;
 
     vendorSha256 = "sha256-WIMYrXfay6DMz+S/tIc/X4ffMizxub8GS1DDgIR40D4=";
 
-    src = etcdSrc;
     modRoot = "./etcdctl";
-
-    CGO_ENABLED = 0;
-
-    meta = commonMeta;
   };
 in
 symlinkJoin {
-  name = "etcd";
-  version = etcdVersion;
-  meta = commonMeta;
+  name = "etcd-${version}";
+
+  inherit meta version;
+
+  passthru = { inherit etcdserver etcdutl etcdctl; };
 
   paths = [
     etcdserver


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

this only causes a rebuild of the symlinkJoin, the internal etcd derivations are unchanged.