### PR TITLE
ymuse: init at 0.20

### DIFF
--- a/pkgs/applications/audio/ymuse/default.nix
+++ b/pkgs/applications/audio/ymuse/default.nix
@@ -1,0 +1,71 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, buildGoModule
+, wrapGAppsHook
+, pkg-config
+, glib
+, gobject-introspection
+, gtk3
+, gdk-pixbuf
+, gettext
+, librsvg
+}:
+
+buildGoModule rec {
+  pname = "ymuse";
+  version = "0.20";
+
+  src = fetchFromGitHub {
+    owner = "yktoo";
+    repo = "ymuse";
+    rev = "v${version}";
+    sha256 = "sha256-wDQjNBxwxFVFdSswubp4AVD35aXKJ8i0ahk/tgRsDRc=";
+  };
+  vendorSha256 = "sha256-Ap/nf0NT0VkP2k9U1HzEiptDfLjKkBopP5h0czP3vis=";
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook
+    glib
+    gobject-introspection
+    gdk-pixbuf
+    gettext
+  ];
+
+  buildInputs = [
+    gtk3
+    librsvg
+  ];
+
+  postInstall = ''
+    install -Dm644 ./resources/ymuse.desktop -t $out/share/applications
+    cp -r ./resources/icons $out/share
+
+    app_id="ymuse"
+    find ./resources/i18n -type f -name '*.po' |
+    while read file; do
+        # Language is the filename without the extension
+        lang="$(basename "$file")"
+        lang="''${lang%.*}"
+
+        # Create the target dir if needed
+        target_dir="$out/share/locale/$lang/LC_MESSAGES"
+        mkdir -p "$target_dir"
+
+        # Compile the .po into a .mo
+        echo "Compiling $file" into "$target_dir/$app_id.mo"
+        msgfmt "$file" -o "$target_dir/$app_id.mo"
+    done
+  '';
+
+  # IDK how to deal with tests that open up display.
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://yktoo.com/en/software/ymuse/";
+    description = "GTK client for Music Player Daemon (MPD)";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ foo-dogsquared ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36296,6 +36296,8 @@ with pkgs;
 
   xmcp = callPackage ../tools/X11/xmcp { };
 
+  ymuse = callPackage ../applications/audio/ymuse { };
+
   zk = callPackage ../applications/office/zk {};
 
   zktree = callPackage ../applications/misc/zktree {};


### PR DESCRIPTION
###### Description of changes

Add [ymuse](https://yktoo.com/en/software/ymuse/), a graphical MPD client.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
