### PR TITLE
libpanel: init at 1.0.alpha1

### DIFF
--- a/pkgs/development/libraries/libpanel/default.nix
+++ b/pkgs/development/libraries/libpanel/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, cmake
+, pkg-config
+, glib
+, gtk4
+, libadwaita
+, gobject-introspection
+, meson
+, ninja
+, vala
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libpanel";
+  version = "1.0.alpha1";
+
+  # outputs = [ "out" "dev" "devdoc" ];
+  # outputBin = "devdoc"; # demo app
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "GNOME";
+    repo = pname;
+    rev = version;
+    hash = "sha256-jN+NIJxvrAtuH8DN/pdWEmy+/BfXR7Cw2X/MBbLlT/s=";
+  };
+
+  nativeBuildInputs = [
+    # cmake
+    pkg-config
+    glib
+    meson
+    ninja
+    vala
+  ];
+
+  buildInputs = [
+    gtk4
+    libadwaita
+    gobject-introspection
+  ];
+
+  meta = with lib; {
+    description = "A dock/panel library for GTK 4";
+    homepage = "https://gitlab.gnome.org/GNOME/libpanel";
+    license = licenses.lgpl3Plus;
+    maintainers = teams.gnome.members ++ (with maintainers; [ magnetophon ]);
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19626,6 +19626,8 @@ with pkgs;
 
   libpostal = callPackage ../development/libraries/libpostal { };
 
+  libpanel = callPackage ../development/libraries/libpanel { };
+
   libpaper = callPackage ../development/libraries/libpaper { };
 
   libpfm = callPackage ../development/libraries/libpfm { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
