### PR TITLE
cinny-desktop: init at 2.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1273,6 +1273,12 @@
     githubId = 1217745;
     name = "Aldwin Vlasblom";
   };
+  aveltras = {
+    email = "romain.viallard@outlook.fr";
+    github = "aveltras";
+    githubId = 790607;
+    name = "Romain Viallard";
+  };
   avery = {
     email = "averyl+nixos@protonmail.com";
     github = "AveryLychee";

--- a/pkgs/applications/networking/instant-messengers/cinny-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/cinny-desktop/default.nix
@@ -1,0 +1,46 @@
+{ stdenv
+, lib
+, dpkg
+, fetchurl
+, autoPatchelfHook
+, glib-networking
+, openssl
+, webkitgtk
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  name = "cinny-desktop";
+  version = "2.1.1";
+
+  src = fetchurl {
+    url = "https://github.com/cinnyapp/cinny-desktop/releases/download/v${version}/Cinny_desktop-x86_64.deb";
+    sha256 = "sha256-4jd+N3a+u+c+XLwgr8BvvdkVLzo+xTBKFdjiQeu7NJU=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+  ];
+
+  buildInputs = [
+    glib-networking
+    openssl
+    webkitgtk
+    wrapGAppsHook
+  ];
+
+  unpackCmd = "dpkg-deb -x $curSrc source";
+
+  installPhase = "mv usr $out";
+
+  meta = with lib; {
+    description = "Yet another matrix client for desktop";
+    homepage = "https://github.com/cinnyapp/cinny-desktop";
+    maintainers = [ maintainers.aveltras ];
+    license = licenses.mit;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    platforms = platforms.linux;
+    mainProgram = "cinny";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3186,6 +3186,8 @@ with pkgs;
 
   cinny = callPackage ../applications/networking/instant-messengers/cinny { stdenv = stdenvNoCC; };
 
+  cinny-desktop = callPackage ../applications/networking/instant-messengers/cinny-desktop { };
+
   ckbcomp = callPackage ../tools/X11/ckbcomp { };
 
   clac = callPackage ../tools/misc/clac {};


### PR DESCRIPTION
###### Description of changes

Added the desktop version of the [cinny](https://cinny.in/) matrix client.
This is an app built with [Tauri](https://github.com/tauri-apps/tauri).
I have used the debian package released on github (didn't manage to get the appimage version to run).
I have added a disableCompositing option to the package as the desktop window is blank is not doing this.
This seems to be an issue with Tauri apps when using nvidia.
Solves #172989

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
