### PR TITLE
pythonPackages.unittestCheckHook: init

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -734,6 +734,16 @@ work in any of the formats supported by `buildPythonPackage` currently,
 with the exception of `other` (see `format` in
 [`buildPythonPackage` parameters](#buildpythonpackage-parameters) for more details).
 
+### Using unittestCheckHook {#using-unittestcheckhook}
+
+`unittestCheckHook` is a hook which will substitute the setuptools `test` command for a `checkPhase` which runs `python -m unittest discover`:
+
+```
+  checkInputs = [ unittestCheckHook ];
+
+  unittestFlags = [ "-s" "tests" "-v" ];
+```
+
 ### Develop local package {#develop-local-package}
 
 As a Python developer you're likely aware of [development mode](http://setuptools.readthedocs.io/en/latest/setuptools.html#development-mode)
@@ -1270,6 +1280,7 @@ are used in `buildPythonPackage`.
   with the `pipInstallHook`.
 - `pythonRelaxDepsHook` will relax Python dependencies restrictions for the package.
   See [example usage](#using-pythonrelaxdepshook).
+- `unittestCheckHook` will run tests with `python -m unittest discover`. See [example usage](#using-unittestcheckhook).
 
 ### Development mode {#development-mode}
 

--- a/pkgs/applications/audio/whipper/default.nix
+++ b/pkgs/applications/audio/whipper/default.nix
@@ -37,6 +37,7 @@ in python3.pkgs.buildPythonApplication rec {
   nativeBuildInputs = with python3.pkgs; [
     setuptools-scm
     docutils
+    setuptoolsCheckHook
   ];
 
   propagatedBuildInputs = with python3.pkgs; [
@@ -64,14 +65,12 @@ in python3.pkgs.buildPythonApplication rec {
     export SETUPTOOLS_SCM_PRETEND_VERSION="${version}"
   '';
 
-  checkPhase = ''
-    runHook preCheck
+  preCheck = ''
     # disable tests that require internet access
     # https://github.com/JoeLametta/whipper/issues/291
     substituteInPlace whipper/test/test_common_accurip.py \
       --replace "test_AccurateRipResponse" "dont_test_AccurateRipResponse"
-    HOME=$TMPDIR ${python3.interpreter} -m unittest discover
-    runHook postCheck
+    export HOME=$TMPDIR
   '';
 
   passthru.tests.version = testers.testVersion {

--- a/pkgs/applications/misc/haxor-news/default.nix
+++ b/pkgs/applications/misc/haxor-news/default.nix
@@ -52,11 +52,9 @@ buildPythonApplication rec {
   # will fail without pre-seeded config files
   doCheck = false;
 
-  checkInputs = [ mock ];
+  checkInputs = [ unittestCheckHook mock ];
 
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover -s tests -v
-  '';
+  unittestFlagsArray = [ "-s" "tests" "-v" ];
 
   meta = with lib; {
     homepage = "https://github.com/donnemartin/haxor-news";

--- a/pkgs/applications/misc/pyditz/default.nix
+++ b/pkgs/applications/misc/pyditz/default.nix
@@ -15,9 +15,7 @@ in buildPythonApplication rec {
   nativeBuildInputs = [ setuptools-scm ];
   propagatedBuildInputs = [ pyyaml six jinja2 cerberus_1_1 ];
 
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover
-  '';
+  checkInputs = [ unittestCheckHook ];
 
   meta = with lib; {
     homepage = "https://pythonhosted.org/pyditz/";

--- a/pkgs/applications/misc/topydo/default.nix
+++ b/pkgs/applications/misc/topydo/default.nix
@@ -1,4 +1,4 @@
-{ lib, python3Packages, fetchFromGitHub, glibcLocales }:
+{ lib, python3Packages, fetchFromGitHub, glibcLocales, unittestCheckHook }:
 
 with python3Packages;
 
@@ -22,16 +22,15 @@ buildPythonApplication rec {
     watchdog
   ];
 
-  checkInputs = [ mock freezegun pylint ];
+  checkInputs = [ unittestCheckHook mock freezegun pylint ];
 
   # Skip test that has been reported multiple times upstream without result:
   # bram85/topydo#271, bram85/topydo#274.
-  checkPhase = ''
+  preCheck = ''
     substituteInPlace test/test_revert_command.py --replace 'test_revert_ls' 'dont_test_revert_ls'
-    python -m unittest discover
   '';
 
-  LC_ALL="en_US.UTF-8";
+  LC_ALL = "en_US.UTF-8";
 
   meta = with lib; {
     description = "A cli todo application compatible with the todo.txt format";

--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -164,6 +164,14 @@ in rec {
       };
     } ./setuptools-check-hook.sh) {};
 
+  unittestCheckHook = callPackage ({ }:
+    makeSetupHook {
+      name = "unittest-check-hook";
+      substitutions = {
+        inherit pythonCheckInterpreter;
+      };
+    } ./unittest-check-hook.sh) {};
+
   venvShellHook = disabledIf (!isPy3k) (callPackage ({ }:
     makeSetupHook {
       name = "venv-shell-hook";

--- a/pkgs/development/interpreters/python/hooks/unittest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/unittest-check-hook.sh
@@ -1,0 +1,29 @@
+# Setup hook for unittest.
+echo "Sourcing unittest-check-hook"
+
+unittestCheckPhase() {
+    echo "Executing unittestCheckPhase"
+    runHook preCheck
+
+    eval "@pythonCheckInterpreter@ -m unittest discover $unittestFlagsArray"
+
+    runHook postCheck
+    echo "Finished executing unittestCheckPhase"
+}
+
+if [ -z "${dontUseUnittestCheck-}" ] && [ -z "${installCheckPhase-}" ]; then
+    echo "Using unittestCheckPhase"
+    preDistPhases+=" unittestCheckPhase"
+
+    # It's almost always the case that setuptoolsCheckPhase should not be ran
+    # when the unittestCheckHook is being ran
+    if [ -z "${useSetuptoolsCheck-}" ]; then
+        dontUseSetuptoolsCheck=1
+
+        # Remove command if already injected into preDistPhases
+        if [[ "$preDistPhases" =~ "setuptoolsCheckPhase" ]]; then
+            echo "Removing setuptoolsCheckPhase"
+            preDistPhases=${preDistPhases/setuptoolsCheckPhase/}
+        fi
+    fi
+fi

--- a/pkgs/development/python-modules/aioitertools/default.nix
+++ b/pkgs/development/python-modules/aioitertools/default.nix
@@ -12,7 +12,7 @@
 , typing-extensions
 
 # tests
-, python
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -35,13 +35,13 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
+  checkInputs = [
+    unittestCheckHook
+  ];
+
   pythonImportsCheck = [
     "aioitertools"
   ];
-
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover
-  '';
 
   meta = with lib; {
     description = "Implementation of itertools, builtins, and more for AsyncIO and mixed-type iterables";

--- a/pkgs/development/python-modules/arxiv2bib/default.nix
+++ b/pkgs/development/python-modules/arxiv2bib/default.nix
@@ -1,5 +1,8 @@
-{ buildPythonPackage, python, lib, fetchFromGitHub
+{ buildPythonPackage
+, lib
+, fetchFromGitHub
 , mock
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -14,9 +17,8 @@ buildPythonPackage rec {
     sha256 = "1kp2iyx20lpc9dv4qg5fgwf83a1wx6f7hj1ldqyncg0kn9xcrhbg";
   };
 
-  checkInputs = [ mock ];
-
-  checkPhase = "${python.interpreter} -m unittest discover -s tests";
+  checkInputs = [ unittestCheckHook mock ];
+  unittestFlagsArray = [ "-s" "tests" ];
 
   meta = with lib; {
     description = "Get a BibTeX entry from an arXiv id number, using the arxiv.org API";

--- a/pkgs/development/python-modules/awesome-slugify/default.nix
+++ b/pkgs/development/python-modules/awesome-slugify/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, unidecode, regex, python }:
+{ lib, buildPythonPackage, fetchPypi, unidecode, regex, unittestCheckHook }:
 
 buildPythonPackage rec {
   pname = "awesome-slugify";
@@ -20,9 +20,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ unidecode regex ];
 
-  checkPhase = ''
-      ${python.interpreter} -m unittest discover
-  '';
+  checkInputs = [ unittestCheckHook ];
 
   meta = with lib; {
     homepage = "https://github.com/dimka665/awesome-slugify";

--- a/pkgs/development/python-modules/backports_abc/default.nix
+++ b/pkgs/development/python-modules/backports_abc/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, python
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -13,9 +13,7 @@ buildPythonPackage rec {
     sha256 = "033be54514a03e255df75c5aee8f9e672f663f93abb723444caec8fe43437bde";
   };
 
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover
-  '';
+  checkInputs = [ unittestCheckHook ];
 
   meta = {
     homepage = "https://github.com/cython/backports_abc";

--- a/pkgs/development/python-modules/backports_tempfile/default.nix
+++ b/pkgs/development/python-modules/backports_tempfile/default.nix
@@ -1,5 +1,5 @@
 { lib
-, python
+, unittestCheckHook
 , buildPythonPackage
 , fetchPypi
 , setuptools-scm
@@ -19,12 +19,12 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ backports_weakref ];
 
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover -s tests
-  '';
-
   # requires https://pypi.org/project/backports.test.support
   doCheck = false;
+
+  checkInputs = [ unittestCheckHook ];
+
+  unittestFlagsArray = [ "-s" "tests" ];
 
   meta = {
     description = "Backport of new features in Python's tempfile module";

--- a/pkgs/development/python-modules/backports_weakref/default.nix
+++ b/pkgs/development/python-modules/backports_weakref/default.nix
@@ -3,7 +3,7 @@
 , fetchPypi
 , setuptools-scm
 # , backports
-, python
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -20,9 +20,9 @@ buildPythonPackage rec {
   # Requires backports package
   doCheck = false;
 
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover tests
-  '';
+  checkInputs = [ unittestCheckHook ];
+
+  unittestFlagsArray = [ "tests" ];
 
   meta = with lib; {
     description = "Backports of new features in Python’s weakref module";

--- a/pkgs/development/python-modules/bitstring/default.nix
+++ b/pkgs/development/python-modules/bitstring/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, python
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -15,10 +15,9 @@ buildPythonPackage rec {
     sha256 = "0y2kcq58psvl038r6dhahhlhp1wjgr5zsms45wyz1naq6ri8x9qa";
   };
 
-  checkPhase = ''
-    cd test
-    ${python.interpreter} -m unittest discover
-  '';
+  checkInputs = [ unittestCheckHook ];
+
+  unittestFlagsArray = [ "-s" "test" ];
 
   pythonImportsCheck = [ "bitstring" ];
 

--- a/pkgs/development/python-modules/clevercsv/default.nix
+++ b/pkgs/development/python-modules/clevercsv/default.nix
@@ -9,6 +9,7 @@
 , regex
 , tabview
 , python
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -33,26 +34,29 @@ buildPythonPackage rec {
     tabview
   ];
 
+  checkInputs = [ unittestCheckHook ];
+
   pythonImportsCheck = [
     "clevercsv"
     "clevercsv.cparser"
   ];
 
-  checkPhase = ''
+  preCheck = ''
     # by linking the installed version the tests also have access to compiled native libraries
     rm -r clevercsv
     ln -s $out/${python.sitePackages}/clevercsv/ clevercsv
-    # their ci only runs unit tests, there are also integration and fuzzing tests
-    ${python.interpreter} -m unittest discover -v -f -s ./tests/test_unit
   '';
+
+  # their ci only runs unit tests, there are also integration and fuzzing tests
+  unittestFlagsArray = [ "-v" "-f" "-s" "./tests/test_unit" ];
 
   meta = with lib; {
     description = "CleverCSV is a Python package for handling messy CSV files";
     longDescription = ''
-       CleverCSV is a Python package for handling messy CSV files. It provides
-       a drop-in replacement for the builtin CSV module with improved dialect
-       detection, and comes with a handy command line application for working
-       with CSV files.
+      CleverCSV is a Python package for handling messy CSV files. It provides
+      a drop-in replacement for the builtin CSV module with improved dialect
+      detection, and comes with a handy command line application for working
+      with CSV files.
     '';
     homepage = "https://github.com/alan-turing-institute/CleverCSV";
     changelog = "https://github.com/alan-turing-institute/CleverCSV/blob/master/CHANGELOG.md";

--- a/pkgs/development/python-modules/contextlib2/default.nix
+++ b/pkgs/development/python-modules/contextlib2/default.nix
@@ -3,6 +3,7 @@
 , fetchPypi
 , python
 , pythonOlder
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -17,11 +18,7 @@ buildPythonPackage rec {
     hash = "sha256-qx4r/h0B2Wjht+jZAjvFHvNQm7ohe7cwzuOCfh7oKGk=";
   };
 
-  checkPhase = ''
-    runHook preCheck
-    ${python.interpreter} -m unittest discover
-    runHook postCheck
-  '';
+  checkInputs = [ unittestCheckHook ];
 
   pythonImportsCheck = [
     "contextlib2"

--- a/pkgs/development/python-modules/cvxopt/default.nix
+++ b/pkgs/development/python-modules/cvxopt/default.nix
@@ -3,8 +3,10 @@
 , fetchPypi
 , isPyPy
 , python
-, blas, lapack # build segfaults with 64-bit blas
+, blas
+, lapack # build segfaults with 64-bit blas
 , suitesparse
+, unittestCheckHook
 , glpk ? null
 , gsl ? null
 , fftw ? null
@@ -49,9 +51,9 @@ buildPythonPackage rec {
     export CVXOPT_FFTW_INC_DIR=${fftw.dev}/include
   '';
 
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover -s tests
-  '';
+  checkInputs = [ unittestCheckHook ];
+
+  unittestFlagsArray = [ "-s" "tests" ];
 
   meta = with lib; {
     homepage = "http://cvxopt.org/";

--- a/pkgs/development/python-modules/cyclonedx-python-lib/default.nix
+++ b/pkgs/development/python-modules/cyclonedx-python-lib/default.nix
@@ -14,6 +14,7 @@
 , toml
 , types-setuptools
 , types-toml
+, unittestCheckHook
 , xmldiff
 }:
 
@@ -47,6 +48,7 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
+    unittestCheckHook
     jsonschema
     lxml
     xmldiff
@@ -56,13 +58,9 @@ buildPythonPackage rec {
     "cyclonedx"
   ];
 
- checkPhase = ''
-   runHook preCheck
-   # Tests require network access
-   rm tests/test_output_json.py
-   ${python.interpreter} -m unittest discover -s tests -v
-   runHook postCheck
- '';
+  preCheck = ''
+    rm tests/test_output_json.py
+  '';
 
   meta = with lib; {
     description = "Python library for generating CycloneDX SBOMs";

--- a/pkgs/development/python-modules/cymem/default.nix
+++ b/pkgs/development/python-modules/cymem/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , cython
-, python
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -25,10 +25,9 @@ buildPythonPackage rec {
       --replace "wheel>=0.32.0,<0.33.0" "wheel>=0.31.0"
   '';
 
-  checkPhase = ''
-    cd cymem/tests
-    ${python.interpreter} -m unittest discover -p "*test*"
-  '';
+  checkInputs = [ unittestCheckHook ];
+
+  unittestFlagsArray = [ "-s" "cymem/tests" "-p" "*test*" ];
 
   meta = with lib; {
     description = "Cython memory pool for RAII-style memory management";

--- a/pkgs/development/python-modules/deprecation/default.nix
+++ b/pkgs/development/python-modules/deprecation/default.nix
@@ -5,6 +5,7 @@
 , pythonAtLeast
 , pythonOlder
 , unittest2
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -29,13 +30,9 @@ buildPythonPackage rec {
 
   # avoiding mass rebuilds for python3.9, but no longer
   # needed with patch
-  checkInputs = lib.optional (pythonOlder "3.10") [
+  checkInputs = [ unittestCheckHook ] ++ lib.optional (pythonOlder "3.10") [
     unittest2
   ];
-
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover
-  '';
 
   meta = with lib; {
     description = "A library to handle automated deprecations";

--- a/pkgs/development/python-modules/emailthreads/default.nix
+++ b/pkgs/development/python-modules/emailthreads/default.nix
@@ -1,5 +1,5 @@
 { lib, fetchFromGitHub, buildPythonPackage
-, python, isPy3k }:
+, python, isPy3k, unittestCheckHook }:
 
 buildPythonPackage rec {
   pname = "emailthreads";
@@ -14,11 +14,9 @@ buildPythonPackage rec {
     sha256 = "sha256-7BhYS1DQCW9QpG31asPCq5qPyJy+WW2onZpvEHhwQCs=";
   };
 
-  PKGVER = version;
+  checkInputs = [ unittestCheckHook ];
 
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover test
-  '';
+  PKGVER = version;
 
   meta = with lib; {
     homepage = "https://github.com/emersion/python-emailthreads";

--- a/pkgs/development/python-modules/enum34/default.nix
+++ b/pkgs/development/python-modules/enum34/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , pythonAtLeast
-, python
+, unittestCheckHook
 }:
 
 if pythonAtLeast "3.4" then null else buildPythonPackage rec {
@@ -14,9 +14,7 @@ if pythonAtLeast "3.4" then null else buildPythonPackage rec {
     sha256 = "cce6a7477ed816bd2542d03d53db9f0db935dd013b70f336a95c73979289f248";
   };
 
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover
-  '';
+  checkInputs = [ unittestCheckHook ];
 
   meta = with lib; {
     homepage = "https://pypi.python.org/pypi/enum34";

--- a/pkgs/development/python-modules/fastimport/default.nix
+++ b/pkgs/development/python-modules/fastimport/default.nix
@@ -2,7 +2,7 @@
 , pythonOlder
 , buildPythonPackage
 , fetchPypi
-, python
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -16,9 +16,7 @@ buildPythonPackage rec {
     sha256 = "6ac99dda4e7b0b3ae831507b6d0094802e6dd95891feafde8cc5c405b6c149ca";
   };
 
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover
-  '';
+  checkInputs = [ unittestCheckHook ];
 
   pythonImportsCheck = [ "fastimport" ];
 

--- a/pkgs/development/python-modules/fido2/default.nix
+++ b/pkgs/development/python-modules/fido2/default.nix
@@ -5,6 +5,7 @@
 , cryptography
 , mock
 , pyfakefs
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -18,17 +19,9 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ six cryptography ];
 
-  checkInputs = [ mock pyfakefs ];
+  checkInputs = [ unittestCheckHook mock pyfakefs ];
 
-  # Testing with `python setup.py test` doesn't work:
-  # https://github.com/Yubico/python-fido2/issues/108#issuecomment-763513576
-  checkPhase = ''
-    runHook preCheck
-
-    python -m unittest discover -v
-
-    runHook postCheck
-  '';
+  unittestFlagsArray = [ "-v" ];
 
   pythonImportsCheck = [ "fido2" ];
 

--- a/pkgs/development/python-modules/flask-babel/default.nix
+++ b/pkgs/development/python-modules/flask-babel/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, python
+, unittestCheckHook
 , fetchPypi
 , flask
 , babel
@@ -26,9 +26,7 @@ buildPythonPackage rec {
     speaklater
   ];
 
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover -s tests
-  '';
+  unittestFlagsArray = [ "-s" "tests" ];
 
   meta = with lib; {
     description = "Adds i18n/l10n support to Flask applications";

--- a/pkgs/development/python-modules/flask-bcrypt/default.nix
+++ b/pkgs/development/python-modules/flask-bcrypt/default.nix
@@ -3,7 +3,7 @@
 , fetchFromGitHub
 , flask
 , bcrypt
-, python
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -22,11 +22,7 @@ buildPythonPackage rec {
     bcrypt
   ];
 
-  checkPhase = ''
-    runHook preCheck
-    ${python.interpreter} -m unittest discover
-    runHook postCheck
-  '';
+  checkInputs = [ unittestCheckHook ];
 
   pythonImportsCheck = [
     "flask_bcrypt"

--- a/pkgs/development/python-modules/flask-migrate/default.nix
+++ b/pkgs/development/python-modules/flask-migrate/default.nix
@@ -6,7 +6,7 @@
 , flask
 , flask_script
 , flask-sqlalchemy
-, python
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -33,14 +33,9 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
+    unittestCheckHook
     flask_script
   ];
-
-  checkPhase = ''
-    runHook preCheck
-    ${python.interpreter} -m unittest discover
-    runHook postCheck
-  '';
 
   meta = with lib; {
     description = "SQLAlchemy database migrations for Flask applications using Alembic";

--- a/pkgs/development/python-modules/flask-seasurf/default.nix
+++ b/pkgs/development/python-modules/flask-seasurf/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, buildPythonPackage, isPy3k, flask, mock, python }:
+{ lib, fetchFromGitHub, buildPythonPackage, isPy3k, flask, mock, unittestCheckHook }:
 
 buildPythonPackage rec {
   pname = "Flask-SeaSurf";
@@ -15,14 +15,9 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ flask ];
 
   checkInputs = [
+    unittestCheckHook
     mock
   ];
-
-  checkPhase = ''
-    runHook preCheck
-    ${python.interpreter} -m unittest discover
-    runHook postCheck
-  '';
 
   pythonImportsCheck = [ "flask_seasurf" ];
 

--- a/pkgs/development/python-modules/gb-io/default.nix
+++ b/pkgs/development/python-modules/gb-io/default.nix
@@ -4,6 +4,7 @@
 , buildPythonPackage
 , rustPlatform
 , setuptools-rust
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -31,9 +32,7 @@ buildPythonPackage rec {
     rust.rustc
   ]);
 
-  checkPhase = ''
-    python -m unittest discover
-  '';
+  checkInputs = [ unittestCheckHook ];
 
   pythonImportsCheck = [ "gb_io" ];
 

--- a/pkgs/development/python-modules/greenlet/default.nix
+++ b/pkgs/development/python-modules/greenlet/default.nix
@@ -2,31 +2,29 @@
 , buildPythonPackage
 , fetchPypi
 , isPyPy
-, python
+, unittestCheckHook
 }:
 
 
 buildPythonPackage rec {
   pname = "greenlet";
   version = "1.1.2";
-  disabled = isPyPy;  # builtin for pypy
+  disabled = isPyPy; # builtin for pypy
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "e30f5ea4ae2346e62cedde8794a56858a67b878dd79f7df76a0767e356b1744a";
   };
 
-  checkPhase = ''
-    runHook preCheck
-    ${python.interpreter} -m unittest discover -v greenlet.tests
-    runHook postCheck
-  '';
+  checkInputs = [ unittestCheckHook ];
+
+  unittestFlagsArray = [ "-v" "greenlet.tests" ];
 
   meta = with lib; {
     homepage = "https://github.com/python-greenlet/greenlet";
     description = "Module for lightweight in-process concurrent programming";
     license = with licenses; [
-      psfl  # src/greenlet/slp_platformselect.h & files in src/greenlet/platform/ directory
+      psfl # src/greenlet/slp_platformselect.h & files in src/greenlet/platform/ directory
       mit
     ];
   };

--- a/pkgs/development/python-modules/gruut-ipa/default.nix
+++ b/pkgs/development/python-modules/gruut-ipa/default.nix
@@ -4,6 +4,7 @@
 , espeak
 , numpy
 , python
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -29,11 +30,7 @@ buildPythonPackage rec {
     numpy
   ];
 
-  checkPhase = ''
-    runHook preCheck
-    ${python.interpreter} -m unittest discover
-    runHook postCheck
-  '';
+  checkInputs = [ unittestCheckHook ];
 
   pythonImportsCheck = [
     "gruut_ipa"

--- a/pkgs/development/python-modules/importlib-resources/default.nix
+++ b/pkgs/development/python-modules/importlib-resources/default.nix
@@ -6,7 +6,7 @@
 , importlib-metadata
 , typing ? null
 , pythonOlder
-, python
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -31,9 +31,9 @@ buildPythonPackage rec {
     typing
   ];
 
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover
-  '';
+  checkInputs = [
+    unittestCheckHook
+  ];
 
   pythonImportsCheck = [
     "importlib_resources"

--- a/pkgs/development/python-modules/isodate/default.nix
+++ b/pkgs/development/python-modules/isodate/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, python
+, unittestCheckHook
 , six
 }:
 
@@ -16,9 +16,9 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ six ];
 
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover -s src/isodate/tests
-  '';
+  checkInputs = [ unittestCheckHook ];
+
+  unittestFlagsArray = [ "-s" "src/isodate/tests" ];
 
   meta = with lib; {
     description = "ISO 8601 date/time parser";

--- a/pkgs/development/python-modules/jxmlease/default.nix
+++ b/pkgs/development/python-modules/jxmlease/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , lxml
-, python
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -22,11 +22,9 @@ buildPythonPackage rec {
   # https://github.com/Juniper/jxmlease/issues/26
   doCheck = false;
 
-  checkPhase = ''
-    runHook preCheck
-    ${python.interpreter} -m unittest discover -v
-    runHook postCheck
-  '';
+  checkInputs = [ unittestCheckHook ];
+
+  unittestFlagsArray = [ "-v" ];
 
   meta = with lib; {
     description = "Converts between XML and intelligent Python data structures";

--- a/pkgs/development/python-modules/karton-asciimagic/default.nix
+++ b/pkgs/development/python-modules/karton-asciimagic/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , karton-core
-, python
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -20,11 +20,7 @@ buildPythonPackage rec {
     karton-core
   ];
 
-  checkPhase = ''
-    runHook preCheck
-    ${python.interpreter} -m unittest discover
-    runHook postCheck
-  '';
+  checkInputs = [ unittestCheckHook ];
 
   pythonImportsCheck = [ "karton.asciimagic" ];
 

--- a/pkgs/development/python-modules/karton-core/default.nix
+++ b/pkgs/development/python-modules/karton-core/default.nix
@@ -2,7 +2,7 @@
 , boto3
 , buildPythonPackage
 , fetchFromGitHub
-, python
+, unittestCheckHook
 , redis
 }:
 
@@ -22,11 +22,7 @@ buildPythonPackage rec {
     redis
   ];
 
-  checkPhase = ''
-    runHook preCheck
-    ${python.interpreter} -m unittest discover
-    runHook postCheck
-  '';
+  checkInputs = [ unittestCheckHook ];
 
   pythonImportsCheck = [
     "karton.core"

--- a/pkgs/development/python-modules/karton-yaramatcher/default.nix
+++ b/pkgs/development/python-modules/karton-yaramatcher/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , karton-core
-, python
+, unittestCheckHook
 , yara-python
 }:
 
@@ -22,11 +22,7 @@ buildPythonPackage rec {
     yara-python
   ];
 
-  checkPhase = ''
-    runHook preCheck
-    ${python.interpreter} -m unittest discover
-    runHook postCheck
-  '';
+  checkInputs = [ unittestCheckHook ];
 
   pythonImportsCheck = [ "karton.yaramatcher" ];
 

--- a/pkgs/development/python-modules/kbcstorage/default.nix
+++ b/pkgs/development/python-modules/kbcstorage/default.nix
@@ -12,7 +12,7 @@
 
 # tests
 , responses
-, python
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -44,14 +44,9 @@ buildPythonPackage rec {
     doCheck = false;
 
     checkInputs = [
+      unittestCheckHook
       responses
     ];
-
-    checkPhase = ''
-      runHook preCheck
-      ${python.interpreter} -m unittest discover
-      runHook postCheck
-    '';
 
     pythonImportsCheck = [
       "kbcstorage"

--- a/pkgs/development/python-modules/markdown/default.nix
+++ b/pkgs/development/python-modules/markdown/default.nix
@@ -4,7 +4,7 @@
 , fetchPypi
 , importlib-metadata
 , pyyaml
-, python
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -25,11 +25,7 @@ buildPythonPackage rec {
     importlib-metadata
   ];
 
-  checkInputs = [ pyyaml ];
-
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover
-  '';
+  checkInputs = [ unittestCheckHook pyyaml ];
 
   pythonImportsCheck = [ "markdown" ];
 

--- a/pkgs/development/python-modules/mat2/default.nix
+++ b/pkgs/development/python-modules/mat2/default.nix
@@ -1,7 +1,7 @@
 { lib
 , stdenv
 , buildPythonPackage
-, python
+, unittestCheckHook
 , pythonOlder
 , fetchFromGitLab
 , substituteAll
@@ -17,7 +17,8 @@
 , mutagen
 , pygobject3
 , pycairo
-, dolphinIntegration ? false, plasma5Packages
+, dolphinIntegration ? false
+, plasma5Packages
 }:
 
 buildPythonPackage rec {
@@ -92,9 +93,9 @@ buildPythonPackage rec {
     install -Dm 444 dolphin/mat2.desktop -t "$out/share/kservices5/ServiceMenus"
   '';
 
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover -v
-  '';
+  checkInputs = [ unittestCheckHook ];
+
+  unittestFlagsArray = [ "-v" ];
 
   meta = with lib; {
     description = "A handy tool to trash your metadata";

--- a/pkgs/development/python-modules/maxcube-api/default.nix
+++ b/pkgs/development/python-modules/maxcube-api/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , pythonOlder
 , fetchFromGitHub
-, python
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -22,16 +22,12 @@ buildPythonPackage rec {
     substituteInPlace setup.py --replace "license=license" "license='MIT'"
   '';
 
+  checkInputs = [ unittestCheckHook ];
+
   pythonImportsCheck = [
     "maxcube"
     "maxcube.cube"
   ];
-
-  checkPhase = ''
-    runHook preCheck
-    ${python.interpreter} -m unittest discover
-    runHook postCheck
-  '';
 
   meta = with lib; {
     description = "eQ-3/ELV MAX! Cube Python API";

--- a/pkgs/development/python-modules/mdutils/default.nix
+++ b/pkgs/development/python-modules/mdutils/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, python
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -15,11 +15,7 @@ buildPythonPackage rec {
     sha256 = "sha256-regIrMWbGmW574dfojxZFJoivpaqOpN1I6YsqLEp8BM=";
   };
 
-  checkPhase = ''
-    runHook preCheck
-    ${python.interpreter} -m unittest discover
-    runHook postCheck
-  '';
+  checkInputs = [ unittestCheckHook ];
 
   meta = with lib; {
     description = "Set of basic tools that can help to create Markdown files";

--- a/pkgs/development/python-modules/mkdocs/default.nix
+++ b/pkgs/development/python-modules/mkdocs/default.nix
@@ -18,7 +18,7 @@
   # testing deps
 , babel
 , mock
-, pytestCheckHook
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -47,20 +47,12 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
+    unittestCheckHook
     babel
     mock
   ];
 
-
-  checkPhase = ''
-    set -euo pipefail
-
-    runHook preCheck
-
-    python -m unittest discover -v -p '*tests.py' mkdocs --top-level-directory .
-
-    runHook postCheck
-  '';
+  unittestFlagsArray = [ "-v" "-p" "'*tests.py'" "mkdocs" ];
 
   pythonImportsCheck = [ "mkdocs" ];
 

--- a/pkgs/development/python-modules/mock/default.nix
+++ b/pkgs/development/python-modules/mock/default.nix
@@ -5,6 +5,7 @@
 , python
 , pythonOlder
 , pytest
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -26,11 +27,8 @@ buildPythonPackage rec {
     })
   ];
 
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover
-  '';
-
   checkInputs = [
+    unittestCheckHook
     pytest
   ];
 

--- a/pkgs/development/python-modules/mwdblib/default.nix
+++ b/pkgs/development/python-modules/mwdblib/default.nix
@@ -6,7 +6,7 @@
 , fetchFromGitHub
 , humanize
 , keyring
-, python
+, unittestCheckHook
 , python-dateutil
 , pythonOlder
 , requests
@@ -36,11 +36,7 @@ buildPythonPackage rec {
     requests
   ];
 
-  checkPhase = ''
-    runHook preCheck
-    ${python.interpreter} -m unittest discover
-    runHook postCheck
-  '';
+  checkInputs = [ unittestCheckHook ];
 
   pythonImportsCheck = [
     "mwdblib"

--- a/pkgs/development/python-modules/mypy/extensions.nix
+++ b/pkgs/development/python-modules/mypy/extensions.nix
@@ -2,7 +2,7 @@
 , fetchFromGitHub
 , buildPythonPackage
 , typing
-, python
+, unittestCheckHook
 , pythonOlder
 }:
 
@@ -19,9 +19,9 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = lib.optional (pythonOlder "3.5") typing;
 
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover tests
-  '';
+  checkInputs = [ unittestCheckHook ];
+
+  unittestFlagsArray = [ "tests" ];
 
   pythonImportsCheck = [ "mypy_extensions" ];
 

--- a/pkgs/development/python-modules/nix-prefetch-github/default.nix
+++ b/pkgs/development/python-modules/nix-prefetch-github/default.nix
@@ -4,6 +4,7 @@
 , git
 , which
 , pythonOlder
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -19,11 +20,8 @@ buildPythonPackage rec {
     sha256 = "GHUH3Oog800qrdgXs5AEa4O6ovZ1LT0k3P4YwEHfwlY=";
   };
 
-  checkInputs = [ git which ];
+  checkInputs = [ unittestCheckHook git which ];
 
-  checkPhase = ''
-    python -m unittest discover
-  '';
   # ignore tests which are impure
   DISABLED_TESTS = "network requires_nix_build";
 

--- a/pkgs/development/python-modules/pathlib/default.nix
+++ b/pkgs/development/python-modules/pathlib/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, python
+, unittestCheckHook
 , pythonAtLeast
 }:
 
@@ -15,9 +15,7 @@ buildPythonPackage rec {
     sha256 = "17zajiw4mjbkkv6ahp3xf025qglkj0805m9s41c45zryzj6p2h39";
   };
 
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover
-  '';
+  checkInputs = [ unittestCheckHook ];
 
   meta = {
     description = "Object-oriented filesystem paths";

--- a/pkgs/development/python-modules/pgsanity/default.nix
+++ b/pkgs/development/python-modules/pgsanity/default.nix
@@ -2,7 +2,9 @@
 , python
 , fetchPypi
 , buildPythonPackage
-, postgresql }:
+, postgresql
+, unittestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "pgsanity";
@@ -13,11 +15,7 @@ buildPythonPackage rec {
     sha256 = "de0bbd6fe4f98bf5139cb5f466eac2e2abaf5a7b050b9e4867b87bf360873173";
   };
 
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover -s test
-  '';
-
-  checkInputs = [ postgresql ];
+  checkInputs = [ unittestCheckHook postgresql ];
   propagatedBuildInputs = [ postgresql ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/plac/default.nix
+++ b/pkgs/development/python-modules/plac/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, python
+, unittestCheckHook
 , pythonOlder
 }:
 
@@ -17,10 +17,9 @@ buildPythonPackage rec {
     hash = "sha256-OL3YZNBFD7dIGTqoF7nEWKj1MZ+/l7ImEVHPwKWBIJA=";
   };
 
-  checkPhase = ''
-    cd doc
-    ${python.interpreter} -m unittest discover -p "*test_plac*"
-  '';
+  checkInputs = [ unittestCheckHook ];
+
+  unittestFlagsArray = [ "-s" "doc" "-p" "*test_plac*" ];
 
   pythonImportsCheck = [
     "plac"

--- a/pkgs/development/python-modules/pulsectl/default.nix
+++ b/pkgs/development/python-modules/pulsectl/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, libpulseaudio, glibc, substituteAll, stdenv, pulseaudio, python }:
+{ lib, buildPythonPackage, fetchPypi, libpulseaudio, glibc, substituteAll, stdenv, pulseaudio, unittestCheckHook }:
 
 buildPythonPackage rec {
   pname = "pulsectl";
@@ -22,11 +22,10 @@ buildPythonPackage rec {
     "pulsectl"
   ];
 
-  checkInputs = [ pulseaudio ];
+  checkInputs = [ unittestCheckHook pulseaudio ];
 
-  checkPhase = ''
+  preCheck = ''
     export HOME=$TMPDIR
-    ${python.interpreter} -m unittest discover
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pycparser/default.nix
+++ b/pkgs/development/python-modules/pycparser/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, python }:
+{ lib, buildPythonPackage, fetchPypi, unittestCheckHook }:
 
 buildPythonPackage rec {
   pname = "pycparser";
@@ -9,9 +9,9 @@ buildPythonPackage rec {
     sha256 = "e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206";
   };
 
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover -s tests
-  '';
+  checkInputs = [ unittestCheckHook ];
+
+  unittestFlagsArray = [ "-s" "tests" ];
 
   meta = with lib; {
     description = "C parser in Python";

--- a/pkgs/development/python-modules/pypdf2/default.nix
+++ b/pkgs/development/python-modules/pypdf2/default.nix
@@ -4,7 +4,7 @@
 , pythonOlder
 , glibcLocales
 , typing-extensions
-, python
+, unittestCheckHook
 , isPy3k
 }:
 
@@ -24,12 +24,10 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover
-  '';
-
   # Tests broken on Python 3.x
   #doCheck = !(isPy3k);
+
+  checkInputs = [ unittestCheckHook ];
 
   meta = with lib; {
     description = "A Pure-Python library built as a PDF toolkit";

--- a/pkgs/development/python-modules/pyrad/default.nix
+++ b/pkgs/development/python-modules/pyrad/default.nix
@@ -5,7 +5,7 @@
 , poetry-core
 , netaddr
 , six
-, python
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -43,11 +43,9 @@ buildPythonPackage rec {
       --replace "def testBindv6(self):" "def dontTestBindv6(self):"
   '';
 
-  checkPhase = ''
-    runHook preCheck
-    ${python.interpreter} -m unittest discover
-    runHook postCheck
-  '';
+  checkInputs = [
+    unittestCheckHook
+  ];
 
   pythonImportsCheck = [
     "pyrad"

--- a/pkgs/development/python-modules/pysensors/default.nix
+++ b/pkgs/development/python-modules/pysensors/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, python, fetchFromGitHub, lm_sensors }:
+{ lib, buildPythonPackage, unittestCheckHook, fetchFromGitHub, lm_sensors }:
 buildPythonPackage {
   version = "2017-07-13";
   pname = "pysensors";
@@ -17,10 +17,9 @@ buildPythonPackage {
   # due to sandboxing
   doCheck = false;
 
-  checkPhase = ''
-    cd tests
-    ${python.interpreter} -m unittest discover
-  '';
+  checkInputs = [ unittestCheckHook ];
+
+  unittestFlagsArray = [ "-s" "tests" ];
 
   meta = with lib; {
     maintainers = with maintainers; [ guibou ];

--- a/pkgs/development/python-modules/pyserial/default.nix
+++ b/pkgs/development/python-modules/pyserial/default.nix
@@ -2,7 +2,7 @@
 , stdenv
 , buildPythonPackage
 , fetchPypi
-, python
+, unittestCheckHook
 , pythonOlder
 , isPy3k
 }:
@@ -27,11 +27,9 @@ buildPythonPackage rec {
 
   doCheck = !stdenv.hostPlatform.isDarwin; # broken on darwin
 
-  checkPhase = ''
-    runHook preCheck
-    ${python.interpreter} -m unittest discover -s test
-    runHook postCheck
-  '';
+  checkInputs = [ unittestCheckHook ];
+
+  unittestFlagsArray = [ "-s" "test" ];
 
   pythonImportsCheck = [
     "serial"

--- a/pkgs/development/python-modules/pystache/default.nix
+++ b/pkgs/development/python-modules/pystache/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, python, fetchPypi, isPy3k, glibcLocales }:
+{ lib, buildPythonPackage, unittestCheckHook, fetchPypi, isPy3k, glibcLocales }:
 
 buildPythonPackage rec {
   pname = "pystache";
@@ -13,13 +13,11 @@ buildPythonPackage rec {
 
   buildInputs = [ glibcLocales ];
 
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover
-  '';
-
   # SyntaxError Python 3
   # https://github.com/defunkt/pystache/issues/181
   doCheck = !isPy3k;
+
+  checkInputs = [ unittestCheckHook ];
 
   meta = with lib; {
     description = "A framework-agnostic, logic-free templating system inspired by ctemplate and et";

--- a/pkgs/development/python-modules/python-keycloak/default.nix
+++ b/pkgs/development/python-modules/python-keycloak/default.nix
@@ -4,6 +4,7 @@
 , requests
 , python-jose
 , httmock
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -23,12 +24,9 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
+    unittestCheckHook
     httmock
   ];
-
-  checkPhase = ''
-    python -m unittest discover
-  '';
 
   pythonImportsCheck = [ "keycloak" ];
 

--- a/pkgs/development/python-modules/python-snappy/default.nix
+++ b/pkgs/development/python-modules/python-snappy/default.nix
@@ -4,7 +4,7 @@
 , isPyPy
 , snappy
 , cffi
-, python
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -21,11 +21,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = lib.optional isPyPy cffi;
 
-  checkPhase = ''
-    runHook preCheck
-    ${python.interpreter} -m unittest discover
-    runHook postCheck
-  '';
+  checkInputs = [ unittestCheckHook ];
 
   meta = with lib; {
     description = "Python library for the snappy compression library from Google";

--- a/pkgs/development/python-modules/pytidylib/default.nix
+++ b/pkgs/development/python-modules/pytidylib/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, buildPythonPackage, fetchPypi, python, html-tidy }:
+{ lib, stdenv, buildPythonPackage, fetchPypi, unittestCheckHook, html-tidy }:
 
 buildPythonPackage rec {
   pname = "pytidylib";
@@ -21,9 +21,7 @@ buildPythonPackage rec {
         $'    @unittest.skip("")\n    def test_large_document(self):'
   '';
 
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover
-  '';
+  checkInputs = [ unittestCheckHook ];
 
   meta = with lib; {
     description = "Python wrapper for HTML Tidy (tidylib) on Python 2 and 3";

--- a/pkgs/development/python-modules/pytz/default.nix
+++ b/pkgs/development/python-modules/pytz/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, python }:
+{ lib, buildPythonPackage, fetchPypi, unittestCheckHook }:
 
 buildPythonPackage rec {
   pname = "pytz";
@@ -9,9 +9,9 @@ buildPythonPackage rec {
     sha256 = "sha256-HnYOL+aoFjvAs9mhnE+ENCr6Cir/6/qoSwG5eKAuyqc=";
   };
 
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover -s pytz/tests
-  '';
+  checkInputs = [ unittestCheckHook ];
+
+  unittestFlagsArray = [ "-s" "pytz/tests" ];
 
   pythonImportsCheck = [ "pytz" ];
 

--- a/pkgs/development/python-modules/readlike/default.nix
+++ b/pkgs/development/python-modules/readlike/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, python
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -15,9 +15,9 @@ buildPythonPackage rec {
     sha256 = "1mw8j8ads8hqdbz42siwpffi4wi5s33z9g14a5c2i7vxp8m68qc1";
   };
 
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover -s tests
-  '';
+  checkInputs = [ unittestCheckHook ];
+
+  unittestFlagsArray = [ "-s" "tests" ];
 
   meta = with lib; {
     description = "GNU Readline-like line editing module";

--- a/pkgs/development/python-modules/sjcl/default.nix
+++ b/pkgs/development/python-modules/sjcl/default.nix
@@ -3,7 +3,7 @@
 , fetchFromGitHub
 , pythonOlder
 , pycryptodome
-, python
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -23,11 +23,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ pycryptodome ];
 
-  checkPhase = ''
-    runHook preCheck
-    ${python.interpreter} -m unittest discover
-    runHook postCheck
-  '';
+  checkInputs = [ unittestCheckHook ];
 
   pythonImportsCheck = [
     "sjcl"

--- a/pkgs/development/python-modules/sphinx-testing/default.nix
+++ b/pkgs/development/python-modules/sphinx-testing/default.nix
@@ -4,7 +4,7 @@
 , mock
 , sphinx
 , six
-, python
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -16,12 +16,10 @@ buildPythonPackage rec {
     sha256 = "ef661775b5722d7b00f67fc229104317d35637a4fb4434bf2c005afdf1da4d09";
   };
 
-  checkInputs = [ mock ];
+  checkInputs = [ unittestCheckHook mock ];
   propagatedBuildInputs = [ sphinx six ];
 
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover -s tests
-  '';
+  unittestFlagsArray = [ "-s" "tests" ];
 
   # Test failures https://github.com/sphinx-doc/sphinx-testing/issues/5
   doCheck = false;

--- a/pkgs/development/python-modules/sphinxcontrib-blockdiag/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-blockdiag/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, python
+, unittestCheckHook
 , mock
 , sphinx-testing
 , sphinx
@@ -22,9 +22,10 @@ buildPythonPackage rec {
 
   # Seems to look for files in the wrong dir
   doCheck = false;
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover -s tests
-  '';
+
+  checkInputs = [ unittestCheckHook ];
+
+  unittestFlagsArray = [ "-s" "tests" ];
 
   meta = with lib; {
     description = "Sphinx blockdiag extension";

--- a/pkgs/development/python-modules/tabview/default.nix
+++ b/pkgs/development/python-modules/tabview/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, python
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -17,9 +17,7 @@ buildPythonPackage rec {
     sha256 = "1d1l8fhdn3w2zg7wakvlmjmgjh9lh9h5fal1clgyiqmhfix4cn4m";
   };
 
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover
-  '';
+  checkInputs = [ unittestCheckHook ];
 
   meta = with lib; {
     description = "Python curses command line CSV and tabular data viewer";

--- a/pkgs/development/python-modules/tomli/default.nix
+++ b/pkgs/development/python-modules/tomli/default.nix
@@ -3,9 +3,9 @@
 , callPackage
 , fetchFromGitHub
 , flit-core
-, python
+, unittestCheckHook
 
-# important downstream dependencies
+  # important downstream dependencies
 , flit
 , black
 , mypy
@@ -26,13 +26,9 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ flit-core ];
 
-  pythonImportsCheck = [ "tomli" ];
+  checkInputs = [ unittestCheckHook ];
 
-  checkPhase = ''
-    runHook preCheck
-    ${python.interpreter} -m unittest discover
-    runHook postCheck
-  '';
+  pythonImportsCheck = [ "tomli" ];
 
   passthru.tests = {
     # test downstream dependencies

--- a/pkgs/development/python-modules/tornado/4.nix
+++ b/pkgs/development/python-modules/tornado/4.nix
@@ -1,25 +1,26 @@
 { lib
-, python
+, unittestCheckHook
 , buildPythonPackage
 , fetchPypi
 , isPy27
+, pythonAtLeast
 }:
 
 buildPythonPackage rec {
   pname = "tornado";
   version = "4.5.3";
-  disabled = isPy27 || python.pythonAtLeast "3.10";
-
-  # We specify the name of the test files to prevent
-  # https://github.com/NixOS/nixpkgs/issues/14634
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover *_test.py
-  '';
+  disabled = isPy27 || pythonAtLeast "3.10";
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "02jzd23l4r6fswmwxaica9ldlyc2p6q8dk6dyff7j58fmdzf853d";
   };
+
+  checkInputs = [ unittestCheckHook ];
+
+  # We specify the name of the test files to prevent
+  # https://github.com/NixOS/nixpkgs/issues/14634
+  unittestFlagsArray = [ "*_test.py" ];
 
   __darwinAllowLocalNetworking = true;
 

--- a/pkgs/development/python-modules/tornado/5.nix
+++ b/pkgs/development/python-modules/tornado/5.nix
@@ -1,5 +1,5 @@
 { lib
-, python
+, unittestCheckHook
 , buildPythonPackage
 , fetchPypi
 , isPy27
@@ -11,16 +11,16 @@ buildPythonPackage rec {
   version = "5.1.1";
   disabled = isPy27 || pythonAtLeast "3.10";
 
-  # We specify the name of the test files to prevent
-  # https://github.com/NixOS/nixpkgs/issues/14634
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover *_test.py
-  '';
-
   src = fetchPypi {
     inherit pname version;
     sha256 = "4e5158d97583502a7e2739951553cbd88a72076f152b4b11b64b9a10c4c49409";
   };
+
+  checkInputs = [ unittestCheckHook ];
+
+  # We specify the name of the test files to prevent
+  # https://github.com/NixOS/nixpkgs/issues/14634
+  unittestFlagsArray = [ "*_test.py" ];
 
   __darwinAllowLocalNetworking = true;
 

--- a/pkgs/development/python-modules/trytond/default.nix
+++ b/pkgs/development/python-modules/trytond/default.nix
@@ -18,8 +18,9 @@
 , weasyprint
 , gevent
 , pillow
-, withPostgresql ? true, psycopg2
-, python
+, withPostgresql ? true
+, psycopg2
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -54,20 +55,19 @@ buildPythonPackage rec {
     gevent
     pillow
   ] ++ relatorio.optional-dependencies.fodt
-    ++ passlib.optional-dependencies.bcrypt
-    ++ passlib.optional-dependencies.argon2
-    ++ lib.optional withPostgresql psycopg2;
+  ++ passlib.optional-dependencies.bcrypt
+  ++ passlib.optional-dependencies.argon2
+  ++ lib.optional withPostgresql psycopg2;
 
-  checkPhase = ''
-    runHook preCheck
+  checkInputs = [ unittestCheckHook ];
 
+  preCheck = ''
     export HOME=$(mktemp -d)
     export TRYTOND_DATABASE_URI="sqlite://"
     export DB_NAME=":memory:";
-    ${python.interpreter} -m unittest discover -s trytond.tests
-
-    runHook postCheck
   '';
+
+  unittestFlagsArray = [ "-s" "trytond.tests" ];
 
   meta = with lib; {
     description = "The server of the Tryton application platform";

--- a/pkgs/development/python-modules/txrequests/default.nix
+++ b/pkgs/development/python-modules/txrequests/default.nix
@@ -4,7 +4,7 @@
 , twisted
 , requests
 , cryptography
-, python
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -21,9 +21,7 @@ buildPythonPackage rec {
   # Require network access
   doCheck = false;
 
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover
-  '';
+  checkInputs = [ unittestCheckHook ];
 
   meta = with lib; {
     description = "Asynchronous Python HTTP for Humans.";

--- a/pkgs/development/python-modules/u-msgpack-python/default.nix
+++ b/pkgs/development/python-modules/u-msgpack-python/default.nix
@@ -2,7 +2,7 @@
 , lib
 , fetchPypi
 , glibcLocales
-, python
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -18,9 +18,7 @@ buildPythonPackage rec {
 
   buildInputs = [ glibcLocales ];
 
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover
-  '';
+  checkInputs = [ unittestCheckHook ];
 
   meta = {
     description = "A portable, lightweight MessagePack serializer and deserializer written in pure Python";

--- a/pkgs/development/python-modules/unidiff/default.nix
+++ b/pkgs/development/python-modules/unidiff/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, python }:
+{ lib, buildPythonPackage, fetchPypi, unittestCheckHook }:
 
 buildPythonPackage rec {
   pname = "unidiff";
@@ -9,9 +9,9 @@ buildPythonPackage rec {
     sha256 = "2bbcbc986e1fb97f04b1d7b864aa6002ab02f4d8a996bf03aa6e5a81447d1fc5";
   };
 
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover -s tests/
-  '';
+  checkInputs = [ unittestCheckHook ];
+
+  unittestFlagsArray = [ "-s" "tests" ];
 
   pythonImportsCheck = [ "unidiff" ];
 

--- a/pkgs/development/python-modules/unify/default.nix
+++ b/pkgs/development/python-modules/unify/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , untokenize
-, python
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ untokenize ];
 
-  checkPhase = "${python.interpreter} -m unittest discover";
+  checkInputs = [ unittestCheckHook ];
 
   meta = with lib; {
     description = "Modifies strings to all use the same quote where possible";

--- a/pkgs/development/python-modules/untangle/default.nix
+++ b/pkgs/development/python-modules/untangle/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchFromGitHub, python, defusedxml }:
+{ lib, buildPythonPackage, fetchFromGitHub, unittestCheckHook, defusedxml }:
 
 buildPythonPackage rec {
   pname = "untangle";
@@ -16,9 +16,9 @@ buildPythonPackage rec {
     defusedxml
   ];
 
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover -s tests
-  '';
+  checkInputs = [ unittestCheckHook ];
+
+  unittestFlagsArray = [ "-s" "tests" ];
 
   meta = with lib; {
     description = "Convert XML documents into Python objects";

--- a/pkgs/development/python-modules/untokenize/default.nix
+++ b/pkgs/development/python-modules/untokenize/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, python
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -13,7 +13,7 @@ buildPythonPackage rec {
     sha256 = "3865dbbbb8efb4bb5eaa72f1be7f3e0be00ea8b7f125c69cbd1f5fda926f37a2";
   };
 
-  checkPhase = "${python.interpreter} -m unittest discover";
+  checkInputs = [ unittestCheckHook ];
 
   meta = with lib; {
     description = "Transforms tokens into original source code while preserving whitespace";

--- a/pkgs/development/python-modules/vapoursynth/default.nix
+++ b/pkgs/development/python-modules/vapoursynth/default.nix
@@ -1,4 +1,4 @@
-{ vapoursynth, cython, buildPythonPackage, python }:
+{ vapoursynth, cython, buildPythonPackage, unittestCheckHook }:
 
 buildPythonPackage {
   pname = "vapoursynth";
@@ -13,9 +13,11 @@ buildPythonPackage {
     vapoursynth
   ];
 
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover -s $src/test -p "*test.py"
-  '';
+  checkInputs = [
+    unittestCheckHook
+  ];
+
+  unittestFlagsArray = [ "-s" "$src/test" "-p" "'*test.py'" ];
 
   inherit (vapoursynth) meta;
 }

--- a/pkgs/development/python-modules/webcolors/default.nix
+++ b/pkgs/development/python-modules/webcolors/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , pythonOlder
-, python
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -17,9 +17,9 @@ buildPythonPackage rec {
     hash = "sha256-FtBD06CP1qGxt+Pp5iZA0JeQ3OgNK91HkqF1s1/nlKk=";
   };
 
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover -s tests
-  '';
+  checkInputs = [ unittestCheckHook ];
+
+  unittestFlagsArray = [ "-s" "tests" ];
 
   pythonImportsCheck = [
     "webcolors"

--- a/pkgs/development/python-modules/websockets/default.nix
+++ b/pkgs/development/python-modules/websockets/default.nix
@@ -2,7 +2,7 @@
 , stdenv
 , buildPythonPackage
 , fetchFromGitHub
-, python
+, unittestCheckHook
 , pythonOlder
 }:
 
@@ -44,11 +44,7 @@ buildPythonPackage rec {
     done
   '';
 
-  checkPhase = ''
-    runHook preCheck
-    ${python.interpreter} -m unittest discover
-    runHook postCheck
-  '';
+  checkInputs = [ unittestCheckHook ];
 
   pythonImportsCheck = [
     "websockets"

--- a/pkgs/development/python-modules/zake/default.nix
+++ b/pkgs/development/python-modules/zake/default.nix
@@ -4,7 +4,7 @@
 , kazoo
 , six
 , testtools
-, python
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -18,13 +18,14 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ kazoo six ];
   buildInputs = [ testtools ];
-  checkPhase = ''
+  checkInputs = [ unittestCheckHook ];
+  preCheck = ''
     # Skip test - fails with our new kazoo version
     substituteInPlace zake/tests/test_client.py \
       --replace "test_child_watch_no_create" "_test_child_watch_no_create"
-
-    ${python.interpreter} -m unittest discover zake/tests
   '';
+
+  unittestFlagsArray = [ "zake/tests" ];
 
   meta = with lib; {
     homepage = "https://github.com/yahoo/Zake";

--- a/pkgs/development/python-modules/zope_copy/default.nix
+++ b/pkgs/development/python-modules/zope_copy/default.nix
@@ -5,6 +5,7 @@
 , zope_interface
 , zope_location
 , zope_schema
+, unittestCheckHook
 }:
 
 
@@ -20,11 +21,9 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ zope_interface ];
 
   doCheck = !isPy27; # namespace conflicts
-  checkInputs = [ zope_location zope_schema ];
+  checkInputs = [ unittestCheckHook zope_location zope_schema ];
 
-  checkPhase = ''
-    python -m unittest discover -s src/zope/copy
-  '';
+  unittestFlagsArray = [ "-s" "src/zope/copy" ];
 
   meta = {
     maintainers = with lib.maintainers; [ domenkozar ];

--- a/pkgs/development/python2-modules/mock/default.nix
+++ b/pkgs/development/python2-modules/mock/default.nix
@@ -5,7 +5,7 @@
 , funcsigs
 , six
 , pbr
-, python
+, unittestCheckHook
 , pytest
 }:
 
@@ -27,11 +27,8 @@ buildPythonPackage rec {
   #doCheck = !(python.isPyPy && python.isPy27);
   doCheck = false; # Infinite recursion pytest
 
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover
-  '';
-
   checkInputs = [
+    unittestCheckHook
     pytest
   ];
 

--- a/pkgs/development/python2-modules/typing/default.nix
+++ b/pkgs/development/python2-modules/typing/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, pythonOlder, isPy3k, isPyPy, python
+{ lib, buildPythonPackage, fetchPypi, pythonOlder, isPy3k, isPyPy, unittestCheckHook
 , pythonAtLeast }:
 
 let
@@ -20,10 +20,9 @@ in buildPythonPackage rec {
   # Also, don't bother on PyPy: AssertionError: TypeError not raised
   doCheck = pythonOlder "3.6" && !isPyPy;
 
-  checkPhase = ''
-    cd ${testDir}
-    ${python.interpreter} -m unittest discover
-  '';
+  checkInputs = [ unittestCheckHook ];
+
+  unittestFlagsArray = [ "-s" testDir ];
 
   meta = with lib; {
     description = "Backport of typing module to Python versions older than 3.5";

--- a/pkgs/servers/monitoring/prometheus/xmpp-alerts.nix
+++ b/pkgs/servers/monitoring/prometheus/xmpp-alerts.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , python3Packages
 , prometheus-alertmanager
+, unittestCheckHook
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -25,12 +26,9 @@ python3Packages.buildPythonApplication rec {
   ]);
 
   checkInputs = with python3Packages; [
+    unittestCheckHook
     pytz
   ];
-
-  checkPhase = ''
-    ${python3Packages.python.interpreter} -m unittest discover
-  '';
 
   meta = {
     description = "XMPP Web hook for Prometheus";

--- a/pkgs/tools/networking/wifite2/default.nix
+++ b/pkgs/tools/networking/wifite2/default.nix
@@ -42,8 +42,7 @@ python3.pkgs.buildPythonApplication rec {
     pixiewps
   ];
 
-  checkInputs = propagatedBuildInputs;
-  checkPhase = "python -m unittest discover tests -v";
+  checkInputs = propagatedBuildInputs ++ [ python3.pkgs.unittestCheckHook ];
 
   meta = with lib; {
     homepage = "https://github.com/kimocoder/wifite2";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -125,6 +125,7 @@ in {
     pythonRemoveTestsDirHook
     setuptoolsBuildHook
     setuptoolsCheckHook
+    unittestCheckHook
     venvShellHook
     wheelUnpackHook;
 


### PR DESCRIPTION
###### Description of changes

This adds a new hook, `unittestCheckHook`, that runs `python -m unittest discover`, as well as migrating the majority of packages that use `unittest` to it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
