### PR TITLE
python3Packages.{cryptolyzer,cryptoparser}: init at {0.8.1,0.8.0}

### DIFF
--- a/pkgs/development/python-modules/cryptolyzer/default.nix
+++ b/pkgs/development/python-modules/cryptolyzer/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, certvalidator
+, attrs
+, six
+, urllib3
+, cryptoparser
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "cryptolyzer";
+  version = "0.8.1";
+
+  src = fetchPypi {
+    pname = "CryptoLyzer";
+    inherit version;
+    sha256 = "sha256-FbxSjKxhzlpj3IezuLCQvoeZMG1q+OE/yn5vB/XE1rI=";
+  };
+
+  propagatedBuildInputs = [
+    certvalidator
+    attrs
+    six
+    urllib3
+    cryptoparser
+    requests
+  ];
+
+  doCheck = false; # Tests require networking
+
+  pythonImportsCheck = [ "cryptolyzer" ];
+
+  meta = with lib; {
+    description = "Fast and flexible cryptographic protocol analyzer";
+    homepage = "https://gitlab.com/coroner/cryptolyzer";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ kranzes ];
+  };
+}

--- a/pkgs/development/python-modules/cryptoparser/default.nix
+++ b/pkgs/development/python-modules/cryptoparser/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, attrs
+, six
+, asn1crypto
+, python-dateutil
+}:
+
+buildPythonPackage rec {
+  pname = "cryptoparser";
+  version = "0.8.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-kJg8d1PoGIC0feefbJM8oyXcRyMGdg1wWkQUl/nSNCo=";
+  };
+
+  propagatedBuildInputs = [
+    attrs
+    six
+    asn1crypto
+    python-dateutil
+  ];
+
+  pythonImportsCheck = [ "cryptoparser" ];
+
+  meta = with lib; {
+    description = "Fast and flexible security protocol parser and generator";
+    homepage = "https://gitlab.com/coroner/cryptoparser";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ kranzes ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2027,6 +2027,8 @@ in {
     inherit (pkgs.darwin.apple_sdk.frameworks) Security;
   };
 
+  cryptoparser = callPackage ../development/python-modules/cryptoparser { };
+
   crytic-compile = callPackage ../development/python-modules/crytic-compile { };
 
   csrmesh  = callPackage ../development/python-modules/csrmesh { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2027,6 +2027,8 @@ in {
     inherit (pkgs.darwin.apple_sdk.frameworks) Security;
   };
 
+  cryptolyzer = callPackage ../development/python-modules/cryptolyzer { };
+
   cryptoparser = callPackage ../development/python-modules/cryptoparser { };
 
   crytic-compile = callPackage ../development/python-modules/crytic-compile { };


### PR DESCRIPTION
###### Description of changes
- [python3Packages.cryptoparser: init at 0.8.0](https://github.com/NixOS/nixpkgs/commit/4e94825dd2c12e4e47f210d6885f2d47d6a8fe21)
- [python3Packages.cryptolyzer: init at 0.8.1](https://github.com/NixOS/nixpkgs/commit/b8e47201f8b3d2a35858f9af72de7d8e515a1557)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
