### PR TITLE
python310Packages.extractcode: disable failing test

### DIFF
--- a/pkgs/development/python-modules/extractcode/default.nix
+++ b/pkgs/development/python-modules/extractcode/default.nix
@@ -1,14 +1,14 @@
 { lib
-, fetchPypi
 , buildPythonPackage
+, extractcode-7z
+, extractcode-libarchive
+, fetchPypi
+, patch
+, pytest-xdist
+, pytestCheckHook
+, pythonOlder
 , setuptools-scm
 , typecode
-, patch
-, extractcode-libarchive
-, extractcode-7z
-, pytestCheckHook
-, pytest-xdist
-, pythonOlder
 }:
 
 buildPythonPackage rec {
@@ -41,21 +41,23 @@ buildPythonPackage rec {
     pytest-xdist
   ];
 
-  # CLI test tests the cli which we can't do until after install
   disabledTestPaths = [
+    # CLI test tests the CLI which we can't do until after install
     "tests/test_extractcode_cli.py"
   ];
 
-  # test_uncompress_* wants to use a binary to extract instead of the provided library
   disabledTests = [
+    # test_uncompress_* wants to use a binary to extract instead of the provided library
     "test_uncompress_lz4_basic"
     "test_extract_tarlz4_basic"
     "test_extract_rar_with_trailing_data"
-    # tries to parse /boot/vmlinuz-*, which is not available in the nix sandbox
+    # Tries to parse /boot/vmlinuz-*, which is not available in the nix sandbox
     "test_can_extract_qcow2_vm_image_as_tarball"
     "test_can_extract_qcow2_vm_image_not_as_tarball"
     "test_can_listfs_from_qcow2_image"
     "test_get_extractor_qcow2"
+    # WARNING  patch:patch.py:450 inconsistent line ends in patch hunks
+    "test_patch_info_patch_patches_windows_plugin_explorer_patch"
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
###### Description of changes
Fix build (https://hydra.nixos.org/build/186222562)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
