### PR TITLE
python3Packages.django-storages: enable tests

### DIFF
--- a/pkgs/development/python-modules/django-storages/default.nix
+++ b/pkgs/development/python-modules/django-storages/default.nix
@@ -1,5 +1,12 @@
 { lib, buildPythonPackage, fetchPypi
 , django
+
+, azure-storage-blob
+, boto3
+, dropbox
+, google-cloud-storage
+, libcloud
+, paramiko
 }:
 
 buildPythonPackage rec {
@@ -13,8 +20,23 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ django ];
 
-  # django.core.exceptions.ImproperlyConfigured: Requested setting DEFAULT_INDEX_TABLESPACE, but settings are not configured. You must either define the environment variable DJANGO_SETTINGS_MODULE or call settings.configure() before accessing settings.
-  doCheck = false;
+  preCheck = ''
+    export DJANGO_SETTINGS_MODULE=tests.settings
+    # timezone issues https://github.com/jschneier/django-storages/issues/1171
+    substituteInPlace tests/test_sftp.py \
+      --replace 'test_accessed_time' 'dont_test_accessed_time' \
+      --replace 'test_modified_time' 'dont_test_modified_time'
+  '';
+  checkInputs = [
+    azure-storage-blob
+    boto3
+    dropbox
+    google-cloud-storage
+    libcloud
+    paramiko
+  ];
+
+  pythonImportsCheck = [ "storages" ];
 
   meta = with lib; {
     description = "Collection of custom storage backends for Django";


### PR DESCRIPTION
###### Description of changes

Spurred by trying to review #185352 with any confidence.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
