### PR TITLE
python310Packages.fountains: 1.3.0 -> 2.0.0

### DIFF
--- a/pkgs/development/python-modules/bitlist/default.nix
+++ b/pkgs/development/python-modules/bitlist/default.nix
@@ -9,14 +9,14 @@
 
 buildPythonPackage rec {
   pname = "bitlist";
-  version = "0.8.0";
-  format = "setuptools";
+  version = "1.0.1";
+  format = "pyproject";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-43Oh1ERGsW12HOqpbIa7rzLKrP9tIjckZhHwZSmBypE=";
+    hash = "sha256-rpXQKkV2RUuYza+gfpGEH3kFJ+hjuNGKV2i46eXQUUI=";
   };
 
   propagatedBuildInputs = [
@@ -33,8 +33,8 @@ buildPythonPackage rec {
   ];
 
   postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace " --cov=bitlist --cov-report term-missing" ""
+    substituteInPlace pyproject.toml \
+      --replace "--doctest-modules --ignore=docs --cov=bitlist --cov-report term-missing" ""
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/fe25519/default.nix
+++ b/pkgs/development/python-modules/fe25519/default.nix
@@ -4,21 +4,20 @@
 , fetchPypi
 , fountains
 , parts
-, nose
 , pytestCheckHook
 , pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "fe25519";
-  version = "1.2.0";
-  format = "setuptools";
+  version = "1.3.0";
+  format = "pyproject";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-Hzdt8932WonJAaQPtL346JFPqxFXkNW4XQvbQlSoJJE=";
+    hash = "sha256-/grXAiWERDeTCWgFnNC1Ok8D5I9MBlwd1501TW0yK5c=";
   };
 
   propagatedBuildInputs = [
@@ -28,13 +27,12 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    nose
     pytestCheckHook
   ];
 
   postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace " --cov=fe25519 --cov-report term-missing" ""
+    substituteInPlace pyproject.toml \
+      --replace "--doctest-modules --ignore=docs --cov=fe25519 --cov-report term-missing" ""
   '';
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/fountains/default.nix
+++ b/pkgs/development/python-modules/fountains/default.nix
@@ -7,14 +7,14 @@
 
 buildPythonPackage rec {
   pname = "fountains";
-  version = "1.3.0";
-  format = "setuptools";
+  version = "2.0.0";
+  format = "pyproject";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-c6nw22UtAREYZp0XCEZE6p7GpRvSLukq5y0c9KvVf9w=";
+    hash = "sha256-9ASOgqkE1vwCKGAZXEJaHoABMXomIWTGv3jAsNssdsU=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/ge25519/default.nix
+++ b/pkgs/development/python-modules/ge25519/default.nix
@@ -4,7 +4,6 @@
 , fe25519
 , fetchPypi
 , fountains
-, nose
 , parts
 , pytestCheckHook
 , pythonOlder
@@ -12,14 +11,14 @@
 
 buildPythonPackage rec {
   pname = "ge25519";
-  version = "1.2.0";
-  format = "setuptools";
+  version = "1.3.0";
+  format = "pyproject";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-8GsNY62SusUmQcaqlhKOPHbd0jvZulCaxMxeob37JJM=";
+    hash = "sha256-y9Nv59pLWk1kRjZG3EmalT34Mjx7RLZ4WkvJlRrK5LI=";
   };
 
   propagatedBuildInputs = [
@@ -30,15 +29,13 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    nose
     pytestCheckHook
   ];
 
   postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace " --cov=ge25519 --cov-report term-missing" ""
+    substituteInPlace pyproject.toml \
+      --replace "--doctest-modules --ignore=docs --cov=ge25519 --cov-report term-missing" ""
   '';
-
 
   pythonImportsCheck = [
     "ge25519"


### PR DESCRIPTION
###### Description of changes
Update to latest upstream release 2.0.0
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
