### PR TITLE
nixos/teeworlds: migrate to rfc42 settings

### DIFF
--- a/nixos/modules/services/games/teeworlds.nix
+++ b/nixos/modules/services/games/teeworlds.nix
@@ -4,93 +4,119 @@ with lib;
 
 let
   cfg = config.services.teeworlds;
-  register = cfg.register;
-
-  teeworldsConf = pkgs.writeText "teeworlds.cfg" ''
-    sv_port ${toString cfg.port}
-    sv_register ${if cfg.register then "1" else "0"}
-    ${optionalString (cfg.name != null) "sv_name ${cfg.name}"}
-    ${optionalString (cfg.motd != null) "sv_motd ${cfg.motd}"}
-    ${optionalString (cfg.password != null) "password ${cfg.password}"}
-    ${optionalString (cfg.rconPassword != null) "sv_rcon_password ${cfg.rconPassword}"}
-    ${concatStringsSep "\n" cfg.extraOptions}
-  '';
-
+  configFile = pkgs.writeText "teeworlds.conf" (concatStringsSep "\n" (mapAttrsToList (key: value: "${key} ${toString value}") cfg.settings));
 in
 {
-  options = {
-    services.teeworlds = {
-      enable = mkEnableOption (lib.mdDoc "Teeworlds Server");
+  imports = [
+    (mkRenamedOptionModule
+      [ "services" "teeworlds" "name" ]
+      [ "services" "teeworlds" "settings" "sv_name" ])
+    (mkRenamedOptionModule
+      [ "services" "teeworlds" "register" ]
+      [ "services" "teeworlds" "settings" "sv_register" ])
+    (mkRenamedOptionModule
+      [ "services" "teeworlds" "motd" ]
+      [ "services" "teeworlds" "settings" "sv_motd" ])
+    (mkRenamedOptionModule
+      [ "services" "teeworlds" "password" ]
+      [ "services" "teeworlds" "settings" "password" ])
+    (mkRenamedOptionModule
+      [ "services" "teeworlds" "rcon_password" ]
+      [ "services" "teeworlds" "settings" "sv_rcon_password" ])
+    (mkRenamedOptionModule
+      [ "services" "teeworlds" "port" ]
+      [ "services" "teeworlds" "settings" "sv_port" ])
+    (mkRemovedOptionModule [ "services" "teeworlds" "extraOptions" ]
+      "Use services.teeworlds.settings instead.")
+  ];
 
-      openPorts = mkOption {
-        type = types.bool;
-        default = false;
-        description = lib.mdDoc "Whether to open firewall ports for Teeworlds";
-      };
+  options.services.teeworlds = {
+    enable = mkEnableOption (lib.mdDoc "Teeworlds Server");
 
-      name = mkOption {
-        type = types.nullOr types.str;
-        default = null;
-        description = lib.mdDoc ''
-          Name of the server. Defaults to 'unnamed server'.
-        '';
-      };
+    openPorts = mkOption {
+      type = types.bool;
+      default = false;
+      description = lib.mdDoc ''
+        Whether to open firewall ports for Teeworlds
+      '';
+    };
 
-      register = mkOption {
-        type = types.bool;
-        example = true;
-        default = false;
-        description = lib.mdDoc ''
-          Whether the server registers as public server in the global server list. This is disabled by default because of privacy.
-        '';
-      };
+    settings = mkOption {
+      default = {};
+      example = ''
+        {
+          sv_motd = "Welcome to this teeworlds ctf server!";
+          sv_map = "ctf1";
+          sv_gametype = "ctf";
+        }
+      '';
+      description = lib.mdDoc ''
+        See [Teeworlds Documentation](https://www.teeworlds.com/?page=docs&wiki=server_settings) for all configuration options.
+      '';
+      type = lib.types.submodule {
+        freeformType = with lib.types; attrsOf (nullOr (oneOf [ str int bool ]));
 
-      motd = mkOption {
-        type = types.nullOr types.str;
-        default = null;
-        description = lib.mdDoc ''
-          Set the server message of the day text.
-        '';
-      };
+        options = {
+          sv_name = mkOption {
+            type = types.nullOr types.str;
+            default = null;
+            description = lib.mdDoc ''
+              Name of the server. Defaults to 'unnamed server'.
+            '';
+          };
 
-      password = mkOption {
-        type = types.nullOr types.str;
-        default = null;
-        description = lib.mdDoc ''
-          Password to connect to the server.
-        '';
-      };
+          sv_register = mkOption {
+            type = types.int;
+            example = 1;
+            default = 0;
+            description = lib.mdDoc ''
+              Whether the server registers as public server in the global server list. This is disabled (0) by default because of privacy.
+            '';
+          };
 
-      rconPassword = mkOption {
-        type = types.nullOr types.str;
-        default = null;
-        description = lib.mdDoc ''
-          Password to access the remote console. If not set, a randomly generated one is displayed in the server log.
-        '';
-      };
+          sv_motd = mkOption {
+            type = types.nullOr types.str;
+            default = null;
+            description = lib.mdDoc ''
+              Set the server message of the day text.
+            '';
+          };
 
-      port = mkOption {
-        type = types.port;
-        default = 8303;
-        description = lib.mdDoc ''
-          Port the server will listen on.
-        '';
-      };
+          password = mkOption {
+            type = types.nullOr types.str;
+            default = null;
+            description = lib.mdDoc ''
+              Password to connect to the server.
+            '';
+          };
 
-      extraOptions = mkOption {
-        type = types.listOf types.str;
-        default = [];
-        description = lib.mdDoc ''
-          Extra configuration lines for the {file}`teeworlds.cfg`. See [Teeworlds Documentation](https://www.teeworlds.com/?page=docs&wiki=server_settings).
-        '';
-        example = [ "sv_map dm1" "sv_gametype dm" ];
+          sv_rcon_password = mkOption {
+            type = types.nullOr types.str;
+            default = null;
+            description = lib.mdDoc ''
+              Password to access the remote console. If not set, a randomly generated one is displayed in the server log.
+            '';
+          };
+
+          sv_port = mkOption {
+            type = types.port;
+            default = 8303;
+            description = lib.mdDoc ''
+              Port the server will listen on.
+            '';
+          };
+        };
       };
+      apply = value:
+        if isBool value
+        then (if value then 1 else 0)
+        else value;
     };
   };
 
   config = mkIf cfg.enable {
     networking.firewall = mkIf cfg.openPorts {
-      allowedUDPPorts = [ cfg.port ];
+      allowedUDPPorts = [ cfg.settings.sv_port ];
     };
 
     systemd.services.teeworlds = {
@@ -100,7 +126,7 @@ in
 
       serviceConfig = {
         DynamicUser = true;
-        ExecStart = "${pkgs.teeworlds}/bin/teeworlds_srv -f ${teeworldsConf}";
+        ExecStart = "${pkgs.teeworlds}/bin/teeworlds_srv -f ${configFile}";
 
         # Hardening
         CapabilityBoundingSet = false;


### PR DESCRIPTION
###### Description of changes
related: https://github.com/NixOS/nixpkgs/issues/144575
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
