### PR TITLE
  qgis, qgis-ltr: fix build 

### DIFF
--- a/pkgs/applications/gis/qgis/set-pyqt-package-dirs.patch
+++ b/pkgs/applications/gis/qgis/set-pyqt-package-dirs.patch
@@ -1,0 +1,59 @@
+diff --git a/cmake/FindPyQt5.cmake b/cmake/FindPyQt5.cmake
+index b51fd0075e..87ee317e05 100644
+--- a/cmake/FindPyQt5.cmake
++++ b/cmake/FindPyQt5.cmake
+@@ -25,7 +25,7 @@ ELSE(EXISTS PYQT5_VERSION_STR)
+   IF(SIP_BUILD_EXECUTABLE)
+     # SIP >= 5.0 path
+ 
+-    FILE(GLOB _pyqt5_metadata "${Python_SITEARCH}/PyQt5-*.dist-info/METADATA")
++    FILE(GLOB _pyqt5_metadata "@pyQt5PackageDir@/PyQt5-*.dist-info/METADATA")
+     IF(_pyqt5_metadata)
+       FILE(READ ${_pyqt5_metadata} _pyqt5_metadata_contents)
+       STRING(REGEX REPLACE ".*\nVersion: ([^\n]+).*$" "\\1" PYQT5_VERSION_STR ${_pyqt5_metadata_contents})
+@@ -34,8 +34,8 @@ ELSE(EXISTS PYQT5_VERSION_STR)
+     ENDIF(_pyqt5_metadata)
+ 
+     IF(PYQT5_VERSION_STR)
+-      SET(PYQT5_MOD_DIR "${Python_SITEARCH}/PyQt5")
+-      SET(PYQT5_SIP_DIR "${Python_SITEARCH}/PyQt5/bindings")
++      SET(PYQT5_MOD_DIR "@pyQt5PackageDir@/PyQt5")
++      SET(PYQT5_SIP_DIR "@pyQt5PackageDir@/PyQt5/bindings")
+       FIND_PROGRAM(__pyuic5 "pyuic5")
+       GET_FILENAME_COMPONENT(PYQT5_BIN_DIR ${__pyuic5} DIRECTORY)
+ 
+diff --git a/cmake/FindQsci.cmake b/cmake/FindQsci.cmake
+index 69e41c1fe9..5456c3d59b 100644
+--- a/cmake/FindQsci.cmake
++++ b/cmake/FindQsci.cmake
+@@ -24,7 +24,7 @@ ELSE(QSCI_MOD_VERSION_STR)
+   IF(SIP_BUILD_EXECUTABLE)
+     # SIP >= 5.0 path
+ 
+-    FILE(GLOB _qsci_metadata "${Python_SITEARCH}/QScintilla*.dist-info/METADATA")
++    FILE(GLOB _qsci_metadata "@qsciPackageDir@/QScintilla*.dist-info/METADATA")
+     IF(_qsci_metadata)
+       FILE(READ ${_qsci_metadata} _qsci_metadata_contents)
+       STRING(REGEX REPLACE ".*\nVersion: ([^\n]+).*$" "\\1" QSCI_MOD_VERSION_STR ${_qsci_metadata_contents})
+@@ -33,7 +33,7 @@ ELSE(QSCI_MOD_VERSION_STR)
+     ENDIF(_qsci_metadata)
+ 
+     IF(QSCI_MOD_VERSION_STR)
+-      SET(QSCI_SIP_DIR "${PYQT5_SIP_DIR}")
++      SET(QSCI_SIP_DIR "@qsciPackageDir@/PyQt5/bindings")
+       SET(QSCI_FOUND TRUE)
+     ENDIF(QSCI_MOD_VERSION_STR)
+ 
+diff --git a/python/CMakeLists.txt b/python/CMakeLists.txt
+index 4cd19c3af4..668cc6a5e6 100644
+--- a/python/CMakeLists.txt
++++ b/python/CMakeLists.txt
+@@ -206,7 +206,7 @@ if (WITH_GUI)
+     install(FILES ${QGIS_PYTHON_OUTPUT_DIRECTORY}/_gui.pyi DESTINATION ${QGIS_PYTHON_DIR})
+   endif()
+   if(QSCI_SIP_DIR)
+-    set(SIP_EXTRA_OPTIONS ${SIP_EXTRA_OPTIONS} -I ${QSCI_SIP_DIR})
++    set(SIP_BUILD_EXTRA_OPTIONS ${SIP_BUILD_EXTRA_OPTIONS} --include-dir=${QSCI_SIP_DIR})
+   else()
+     message(STATUS "Qsci sip file not found - disabling bindings for derived classes")
+     set(SIP_DISABLE_FEATURES ${SIP_DISABLE_FEATURES} HAVE_QSCI_SIP)

--- a/pkgs/applications/gis/qgis/unwrapped-ltr.nix
+++ b/pkgs/applications/gis/qgis/unwrapped-ltr.nix
@@ -38,6 +38,8 @@
 , pdal
 , zstd
 , makeWrapper
+, wrapGAppsHook
+, substituteAll
 }:
 
 let
@@ -64,7 +66,9 @@ let
     urllib3
     pygments
     pyqt5
-    sip_4
+    pyqt-builder
+    sip
+    setuptools
     owslib
     six
   ];
@@ -116,29 +120,31 @@ in mkDerivation rec {
     ++ lib.optional withWebKit qtwebkit
     ++ pythonBuildInputs;
 
-  nativeBuildInputs = [ makeWrapper cmake flex bison ninja ];
+  nativeBuildInputs = [ makeWrapper wrapGAppsHook cmake flex bison ninja ];
 
-  # Force this pyqt_sip_dir variable to point to the sip dir in PyQt5
-  #
-  # TODO: Correct PyQt5 to provide the expected directory and fix
-  # build to use PYQT5_SIP_DIR consistently.
-  postPatch = ''
-    substituteInPlace cmake/FindPyQt5.py \
-      --replace 'sip_dir = cfg.default_sip_dir' 'sip_dir = "${py.pkgs.pyqt5}/${py.pkgs.python.sitePackages}/PyQt5/bindings"'
-  '';
+  patches = [
+    (substituteAll {
+      src = ./set-pyqt-package-dirs.patch;
+      pyQt5PackageDir = "${py.pkgs.pyqt5}/${py.pkgs.python.sitePackages}";
+      qsciPackageDir = "${py.pkgs.qscintilla-qt5}/${py.pkgs.python.sitePackages}";
+    })
+  ];
 
   cmakeFlags = [
     "-DWITH_3D=True"
     "-DWITH_PDAL=TRUE"
-    "-DPYQT5_SIP_DIR=${py.pkgs.pyqt5}/${py.pkgs.python.sitePackages}/PyQt5/bindings"
-    "-DQSCI_SIP_DIR=${py.pkgs.qscintilla-qt5}/${py.pkgs.python.sitePackages}/PyQt5/bindings"
   ] ++ lib.optional (!withWebKit) "-DWITH_QTWEBKIT=OFF"
     ++ lib.optional withGrass "-DGRASS_PREFIX7=${grass}/grass78";
 
+  dontWrapGApps = true; # wrapper params passed below
+
   postFixup = lib.optionalString withGrass ''
     # grass has to be availble on the command line even though we baked in
-    # the path at build time using GRASS_PREFIX
+    # the path at build time using GRASS_PREFIX.
+    # using wrapGAppsHook also prevents file dialogs from crashing the program
+    # on non-NixOS
     wrapProgram $out/bin/qgis \
+      "''${gappsWrapperArgs[@]}" \
       --prefix PATH : ${lib.makeBinPath [ grass ]}
   '';
 

--- a/pkgs/applications/gis/qgis/unwrapped.nix
+++ b/pkgs/applications/gis/qgis/unwrapped.nix
@@ -38,6 +38,8 @@
 , pdal
 , zstd
 , makeWrapper
+, wrapGAppsHook
+, substituteAll
 }:
 
 let
@@ -64,7 +66,9 @@ let
     urllib3
     pygments
     pyqt5
-    sip_4
+    pyqt-builder
+    sip
+    setuptools
     owslib
     six
   ];
@@ -116,29 +120,31 @@ in mkDerivation rec {
     ++ lib.optional withWebKit qtwebkit
     ++ pythonBuildInputs;
 
-  nativeBuildInputs = [ makeWrapper cmake flex bison ninja ];
+  nativeBuildInputs = [ makeWrapper wrapGAppsHook cmake flex bison ninja ];
 
-  # Force this pyqt_sip_dir variable to point to the sip dir in PyQt5
-  #
-  # TODO: Correct PyQt5 to provide the expected directory and fix
-  # build to use PYQT5_SIP_DIR consistently.
-  postPatch = ''
-    substituteInPlace cmake/FindPyQt5.py \
-      --replace 'sip_dir = cfg.default_sip_dir' 'sip_dir = "${py.pkgs.pyqt5}/${py.pkgs.python.sitePackages}/PyQt5/bindings"'
-  '';
+  patches = [
+    (substituteAll {
+      src = ./set-pyqt-package-dirs.patch;
+      pyQt5PackageDir = "${py.pkgs.pyqt5}/${py.pkgs.python.sitePackages}";
+      qsciPackageDir = "${py.pkgs.qscintilla-qt5}/${py.pkgs.python.sitePackages}";
+    })
+  ];
 
   cmakeFlags = [
     "-DWITH_3D=True"
     "-DWITH_PDAL=TRUE"
-    "-DPYQT5_SIP_DIR=${py.pkgs.pyqt5}/${py.pkgs.python.sitePackages}/PyQt5/bindings"
-    "-DQSCI_SIP_DIR=${py.pkgs.qscintilla-qt5}/${py.pkgs.python.sitePackages}/PyQt5/bindings"
   ] ++ lib.optional (!withWebKit) "-DWITH_QTWEBKIT=OFF"
     ++ lib.optional withGrass "-DGRASS_PREFIX7=${grass}/grass78";
 
+  dontWrapGApps = true; # wrapper params passed below
+
   postFixup = lib.optionalString withGrass ''
     # grass has to be availble on the command line even though we baked in
-    # the path at build time using GRASS_PREFIX
+    # the path at build time using GRASS_PREFIX.
+    # using wrapGAppsHook also prevents file dialogs from crashing the program
+    # on non-NixOS
     wrapProgram $out/bin/qgis \
+      "''${gappsWrapperArgs[@]}" \
       --prefix PATH : ${lib.makeBinPath [ grass ]}
   '';
 

--- a/pkgs/development/python-modules/sip/default.nix
+++ b/pkgs/development/python-modules/sip/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchPypi, buildPythonPackage, packaging, ply, toml }:
+{ lib, stdenv, fetchPypi, buildPythonPackage, packaging, ply, toml, fetchpatch }:
 
 buildPythonPackage rec {
   pname = "sip";
@@ -15,6 +15,13 @@ buildPythonPackage rec {
     # and PIP will refuse to install the resulting wheel.
     # remove once upstream fixes this, hopefully in 6.5.2
     ./fix-manylinux-version.patch
+
+    # fix issue triggered by QGIS 3.26.x, already fixed upstream
+    # in SIP, waiting for release past 6.6.2
+    (fetchpatch {
+      url = "https://riverbankcomputing.com/hg/sip/raw-diff/323d39a2d602/sipbuild/generator/parser/instantiations.py";
+      hash = "sha256-QEQuRzXA+wK9Dt22U/LgIwtherY9pJURGJYpKpJkiok=";
+    })
   ];
 
   propagatedBuildInputs = [ packaging ply toml ];


### PR DESCRIPTION
###### Description of changes

Fix QGIS by upgrading to latest SIP release. Added changes to SIP and QGIS to accommodate the upgrade. Also added `wrapGAppsHook` to fix the problem of opening a file dialog crashing on non-NixOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
