### PR TITLE
tlaplus18: init at 1.8.0

### DIFF
--- a/pkgs/applications/science/logic/tlaplus/tlaplus18.nix
+++ b/pkgs/applications/science/logic/tlaplus/tlaplus18.nix
@@ -1,0 +1,39 @@
+{ lib, stdenv, fetchurl, makeWrapper, jre }:
+
+stdenv.mkDerivation rec {
+  pname = "tlaplus";
+  version = "1.8.0";
+
+  src = fetchurl {
+    url = "https://github.com/tlaplus/tlaplus/releases/download/v${version}/tla2tools.jar";
+    sha256 = "sha256-OXgpd1xuyvhveunlybBi/N6jnxtp/J8Kmp8PYX3eSZ4=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontUnpack = true;
+  installPhase = ''
+    mkdir -p $out/share/java $out/bin
+    cp $src $out/share/java/tla2tools.jar
+
+    makeWrapper ${jre}/bin/java $out/bin/tlc \
+      --add-flags "-XX:+UseParallelGC -cp $out/share/java/tla2tools.jar tlc2.TLC"
+    makeWrapper ${jre}/bin/java $out/bin/tlasany \
+      --add-flags "-XX:+UseParallelGC -cp $out/share/java/tla2tools.jar tla2sany.SANY"
+    makeWrapper ${jre}/bin/java $out/bin/pcal \
+      --add-flags "-XX:+UseParallelGC -cp $out/share/java/tla2tools.jar pcal.trans"
+    makeWrapper ${jre}/bin/java $out/bin/tlatex \
+      --add-flags "-XX:+UseParallelGC -cp $out/share/java/tla2tools.jar tla2tex.TLA"
+    makeWrapper ${jre}/bin/java $out/bin/tlarepl \
+      --add-flags "-XX:+UseParallelGC -cp $out/share/java/tla2tools.jar tlc2.REPL"
+  '';
+
+  meta = {
+    description = "An algorithm specification language with model checking tools";
+    homepage    = "http://lamport.azurewebsites.net/tla/tla.html";
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    license     = lib.licenses.mit;
+    platforms   = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ florentc thoughtpolice mgregson ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38741,6 +38741,7 @@ with pkgs;
   tlaplus = callPackage ../applications/science/logic/tlaplus {
     jre = jre8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
   };
+  tlaplus18 = callPackage ../applications/science/logic/tlaplus/tlaplus18.nix {};
   tlaps = callPackage ../applications/science/logic/tlaplus/tlaps.nix {
     inherit (ocaml-ng.ocamlPackages_4_14_unsafe_string) ocaml;
   };


### PR DESCRIPTION
This is a pre-release of version 1.8 of TLA+. It adds, among other
things, a TLA+ REPL.

Release Notes: https://github.com/tlaplus/tlaplus/releases/tag/v1.8.0

###### Description of changes

This creates the new package `tlaplus18` providing the pre-release TLA+ 1.8.0. It does so by copying the standard `tlaplus` package from `default.nix` to `tlaplus18.nix` and applying the following modifications:
 - changed `version` to 1.8.0
 - updated `sha256` to match the new SHA
 - added the `tlarepl` wrapper to launch the TLA+ REPL

Note that the 1.7.2 release of TLA+ is 2 years newer than the 1.8.0 release. The 1.8.0 release contains new features that I think are worth providing, however.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
