### PR TITLE
nvimpager: unbreak darwin

### DIFF
--- a/pkgs/tools/misc/bat-extras/default.nix
+++ b/pkgs/tools/misc/bat-extras/default.nix
@@ -139,6 +139,7 @@ in
   batdiff = script "batdiff" ([ less coreutils gitMinimal ] ++ optionalDep withDelta delta);
   batgrep = script "batgrep" [ less coreutils ripgrep ];
   batman = script "batman" [ util-linux ];
+  batpipe = script "batpipe" [ less ];
   batwatch = script "batwatch" ([ less coreutils ] ++ optionalDep withEntr entr);
   prettybat = script "prettybat" ([]
     ++ optionalDep withShFmt shfmt

--- a/pkgs/tools/misc/bat-extras/default.nix
+++ b/pkgs/tools/misc/bat-extras/default.nix
@@ -3,6 +3,10 @@
 , coreutils
 , getconf
 , less
+# tests
+, bash
+, zsh
+, fish
 # batgrep
 , ripgrep
 # prettybat
@@ -51,7 +55,7 @@ let
 
     # Run the library tests as they don't have external dependencies
     doCheck = true;
-    checkInputs = lib.optionals stdenv.isDarwin [ getconf ];
+    checkInputs = [ bash fish zsh ] ++ (lib.optionals stdenv.isDarwin [ getconf ]);
     checkPhase = ''
       runHook preCheck
       # test list repeats suites. Unique them
@@ -59,12 +63,12 @@ let
       while read -r action arg _; do
         [[ "$action" == "test_suite" && "$arg" == lib_* ]] &&
         test_suites+=(["$arg"]=1)
-      done <<<"$(bash ./test.sh --compiled --list --porcelain)"
+      done <<<"$(./test.sh --compiled --list --porcelain)"
       (( ''${#test_suites[@]} != 0 )) || {
         echo "Couldn't find any library test suites"
         exit 1
       }
-      bash ./test.sh --compiled $(printf -- "--suite %q\n" "''${!test_suites[@]}")
+      ./test.sh --compiled $(printf -- "--suite %q\n" "''${!test_suites[@]}")
       runHook postCheck
     '';
 
@@ -108,7 +112,7 @@ let
       dontBuild = true; # we've already built
 
       doCheck = true;
-      checkInputs = lib.optionals stdenv.isDarwin [ getconf ];
+      checkInputs = [ bash fish zsh ] ++ (lib.optionals stdenv.isDarwin [ getconf ]);
       checkPhase = ''
         runHook preCheck
         bash ./test.sh --compiled --suite ${name}


### PR DESCRIPTION
Breakage was caused by a call to `script -c` which is unique to util-linux.
Use a naked call instead on darwin.