### PR TITLE
lighthouse: init at 2.5.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10280,6 +10280,14 @@
     githubId = 178496;
     name = "Philipp Middendorf";
   };
+  pmw = {
+    email = "philip@mailworks.org";
+    matrix = "@philip4g:matrix.org";
+    name = "Philip White";
+    keys = [{
+      fingerprint = "9AB0 6C94 C3D1 F9D0 B9D9  A832 BC54 6FB3 B16C 8B0B";
+    }];
+  };
   pmy = {
     email = "pmy@xqzp.net";
     github = "pmeiyu";

--- a/pkgs/applications/blockchains/lighthouse/default.nix
+++ b/pkgs/applications/blockchains/lighthouse/default.nix
@@ -1,0 +1,75 @@
+{ fetchFromGitHub, fetchurl, lib, rustPlatform, stdenv,
+  clang, cmake, darwin, llvmPackages, perl, protobuf }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "lighthouse";
+  version = "v2.5.1";
+
+  src = fetchFromGitHub {
+    owner = "sigp";
+    repo = pname;
+    rev = version;
+    hash = "sha256-o8fntnEDRRtxDHsqHTJ3GoHpFtRpuwPQQJ+kxHV1NKA=";
+  };
+
+  cargoHash = "sha256-C/qDrlUHby57uqi4xGl3nEYhvVsYRg1AP1tCeOnf47Y=";
+
+  # Do not run tests, because currently some tests require ganache (https://www.npmjs.com/package/ganache),
+  # and I haven't figured out how to import ganache into Nixpkgs.
+  doCheck = false;
+
+  cargoBuildFlags = [
+    # Make only the `lighthouse` executable. Without this, the package produces 7 executables.
+    "-p lighthouse"
+  ];
+
+  nativeBuildInputs = [
+    # https://lighthouse-book.sigmaprime.io/installation-source.html
+    clang
+    cmake
+    llvmPackages.libclang
+    perl
+    protobuf
+  ];
+
+  # https://discourse.nixos.org/t/big-sur-frameworks-issue/10810
+  # https://github.com/nix-community/nixpkgs-fmt/issues/7
+  buildInputs = lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.Security
+  ];
+
+  shellHook = lib.optionalString stdenv.isDarwin ''
+    export NIX_LDFLAGS="-F${darwin.apple_sdk.frameworks.Security}/Library/Frameworks -framework Security $NIX_LDFLAGS";
+  '';
+
+  # https://github.com/NixOS/nixpkgs/issues/52447
+  LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+
+  # These two files are needed by https://github.com/sigp/lighthouse/blob/stable/common/deposit_contract/build.rs
+  safe_contracts_file = fetchurl {
+    url = "https://raw.githubusercontent.com/ethereum/eth2.0-specs/v0.12.1/deposit_contract/contracts/validator_registration.json";
+    sha256 = "sha256-ZslAe1wkmkg8Tua/AmmEfBmjqMVcGIiYHwi+WssEwa8=";
+  };
+
+  unsafe_contracts_file = fetchurl {
+    url = "https://raw.githubusercontent.com/sigp/unsafe-eth2-deposit-contract/v0.9.2.1/unsafe_validator_registration.json";
+    sha256 = "sha256-aeTeHRT3QtxBRSNMCITIWmx89vGtox2OzSff8vZ+RYY=";
+  };
+
+  LIGHTHOUSE_DEPOSIT_CONTRACT_SPEC_URL = "file://${safe_contracts_file}";
+  LIGHTHOUSE_DEPOSIT_CONTRACT_TESTNET_URL = "file://${unsafe_contracts_file}";
+  meta = with lib; {
+    description = "An open-source Ethereum consensus client, written in Rust and maintained by Sigma Prime.";
+    homepage = "https://github.com/sigp/lighthouse";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ pmw ];
+  };
+
+  # The following logic provides the Web3signer to avoid a network download in
+  # https://github.com/sigp/lighthouse/blob/stable/testing/web3signer_tests/build.rs
+  LIGHTHOUSE_WEB3SIGNER_VERSION = "22.8.0"; # `tag_name` from https://api.github.com/repos/ConsenSys/web3signer/releases/latest
+  web3signer_file = fetchurl {
+    url = "https://artifacts.consensys.net/public/web3signer/raw/names/web3signer.zip/versions/${LIGHTHOUSE_WEB3SIGNER_VERSION}/web3signer-${LIGHTHOUSE_WEB3SIGNER_VERSION}.zip";
+    sha256 = "sha256-4Fjx8iZEqAzym8EAT8L5TI7aT1I/1IhNURHiX1MADPE=";
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -756,7 +756,6 @@ mapAliases ({
   libva1-full = throw "'libva1-full' has been renamed to/replaced by 'libva1'"; # Converted to throw 2022-02-22
   libwnck3 = libwnck;
   lightdm_gtk_greeter = lightdm-gtk-greeter; # Added 2022-08-01
-  lighthouse = throw "lighthouse has been removed: abandoned by upstream"; # Added 2022-04-24
   lighttable = throw "'lighttable' crashes (SIGSEGV) on startup, has not been updated in years and depends on deprecated GTK2"; # Added 2022-06-15
   lilypond-unstable = lilypond; # Added 2021-03-11
   lilyterm = throw "lilyterm has been removed from nixpkgs, because it was relying on a vte version that depended on python2"; # Added 2022-01-14

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36306,7 +36306,5 @@ with pkgs;
 
   mictray = callPackage ../tools/audio/mictray { };
 
-  swift-corelibs-libdispatch = callPackage ../development/libraries/swift-corelibs-libdispatch { };
-
-  swaysettings = callPackage ../applications/misc/swaysettings { };
+  lighthouse = callPackage ../applications/blockchains/lighthouse { };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
