### PR TITLE
javaPackages.compiler.{semeru8,semeru11,semeru17,semeru18}: init

### DIFF
--- a/pkgs/development/compilers/semeru-bin/generate-sources.py
+++ b/pkgs/development/compilers/semeru-bin/generate-sources.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env nix-shell
+#!nix-shell --pure -i python3 -p "python3.withPackages (ps: with ps; [ requests ])"
+
+import json
+import re
+import requests
+import sys
+
+releases = ("semeru8", "semeru11", "semeru17", "semeru18")
+oses = ("linux", "mac")
+variants = ("openj9",)
+types = ("jre", "jdk")
+
+arch_to_nixos = {
+    "x64": ("x86_64",),
+    "aarch64": ("aarch64",),
+    "ppc64le": ("powerpc64le",),
+}
+
+
+def generate_sources(release, assets):
+    assets = assets["assets"]
+    out = {}
+
+    for asset in assets:
+        name = asset["name"]
+        url = asset["browser_download_url"]
+
+        if not name.endswith(".tar.gz.json"):
+            continue
+
+        resp = requests.get(url)
+        if resp.status_code != 200:
+            print(
+                f"error: could not fetch data for asset {name} (code {resp.status_code})",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        info = resp.json()
+        if info["os"] not in oses:
+            continue
+        if info["arch"] not in arch_to_nixos:
+            continue
+        if info["variant"] not in variants:
+            continue
+        if info["binary_type"] not in types:
+            continue
+
+        # examples: 11.0.1+13, 8.0.222+10
+        version, build = info["version"]["semver"].split("+")
+
+        type_map = out.setdefault(info["os"], {})
+        impl_map = type_map.setdefault(info["binary_type"], {})
+        arch_map = impl_map.setdefault(
+            info["variant"],
+            {
+                "packageType": info["binary_type"],
+                "vmType": info["variant"],
+            },
+        )
+        for nixos_arch in arch_to_nixos[info["arch"]]:
+            arch_map[nixos_arch] = {
+                "url": url.removesuffix(".json"),
+                "sha256": info["sha256"],
+                "version": version,
+                "build": build,
+            }
+
+    return out
+
+
+out = {}
+for release in releases:
+    resp = requests.get(
+        f"https://api.github.com/repos/ibmruntimes/{release}-binaries/releases/latest"
+    )
+    if resp.status_code != 200:
+        print(
+            f"error: could not fetch data for release {release} (code {resp.status_code})",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    out[release] = generate_sources(release, resp.json())
+
+with open("sources.json", "w") as f:
+    json.dump(out, f, indent=2, sort_keys=True)
+    f.write("\n")

--- a/pkgs/development/compilers/semeru-bin/jdk-darwin-base.nix
+++ b/pkgs/development/compilers/semeru-bin/jdk-darwin-base.nix
@@ -1,0 +1,64 @@
+{ sourcePerArch, knownVulnerabilities ? [] }:
+
+{ swingSupport ? true # not used for now
+, lib, stdenv
+, fetchurl
+, setJavaClassPath
+}:
+
+let cpuName = stdenv.hostPlatform.parsed.cpu.name;
+    result = stdenv.mkDerivation {
+  pname = if sourcePerArch.packageType == "jdk"
+    then "semeru-${sourcePerArch.vmType}-bin"
+    else "semeru-${sourcePerArch.packageType}-${sourcePerArch.vmType}-bin";
+  version = sourcePerArch.${cpuName}.version or (throw "unsupported CPU ${cpuName}");
+
+  src = fetchurl {
+    inherit (sourcePerArch.${cpuName}) url sha256;
+  };
+
+  # See: https://github.com/NixOS/patchelf/issues/10
+  dontStrip = 1;
+
+  installPhase = ''
+    cd ..
+
+    mv $sourceRoot $out
+
+    # jni.h expects jni_md.h to be in the header search path.
+    ln -s $out/Contents/Home/include/darwin/*_md.h $out/Contents/Home/include/
+
+    rm -rf $out/Home/demo
+
+    # Remove some broken manpages.
+    rm -rf $out/Home/man/ja*
+
+    ln -s $out/Contents/Home/* $out/
+
+    # Propagate the setJavaClassPath setup hook from the JDK so that
+    # any package that depends on the JDK has $CLASSPATH set up
+    # properly.
+    mkdir -p $out/nix-support
+    printWords ${setJavaClassPath} > $out/nix-support/propagated-build-inputs
+
+    # Set JAVA_HOME automatically.
+    cat <<EOF >> $out/nix-support/setup-hook
+    if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out; fi
+    EOF
+  '';
+
+  # FIXME: use multiple outputs or return actual JRE package
+  passthru.jre = result;
+
+  passthru.home = result;
+
+  meta = with lib; {
+    license = licenses.gpl2Classpath;
+    description = "A family of cloud-based runtimes for your Java applications";
+    platforms = lib.mapAttrsToList (arch: _: arch + "-darwin") sourcePerArch; # some inherit jre.meta.platforms
+    maintainers = with lib.maintainers; [ nickcao ];
+    inherit knownVulnerabilities;
+    mainProgram = "java";
+  };
+
+}; in result

--- a/pkgs/development/compilers/semeru-bin/jdk-linux-base.nix
+++ b/pkgs/development/compilers/semeru-bin/jdk-linux-base.nix
@@ -1,0 +1,123 @@
+{ sourcePerArch, knownVulnerabilities ? [] }:
+
+{ stdenv
+, lib
+, fetchurl
+, autoPatchelfHook
+, makeWrapper
+, setJavaClassPath
+# minimum dependencies
+, alsa-lib
+, fontconfig
+, freetype
+, libffi
+, xorg
+, zlib
+# runtime dependencies
+, cups
+# runtime dependencies for GTK+ Look and Feel
+, gtkSupport ? true
+, cairo
+, glib
+, gtk3
+}:
+
+let
+  cpuName = stdenv.hostPlatform.parsed.cpu.name;
+  runtimeDependencies = [
+    cups
+  ] ++ lib.optionals gtkSupport [
+    cairo glib gtk3
+  ];
+  runtimeLibraryPath = lib.makeLibraryPath runtimeDependencies;
+in
+
+let result = stdenv.mkDerivation rec {
+  pname = if sourcePerArch.packageType == "jdk"
+    then "semeru-${sourcePerArch.vmType}-bin"
+    else "semeru-${sourcePerArch.packageType}-${sourcePerArch.vmType}-bin";
+
+  version = sourcePerArch.${cpuName}.version or (throw "unsupported CPU ${cpuName}");
+
+  src = fetchurl {
+    inherit (sourcePerArch.${cpuName}) url sha256;
+  };
+
+  buildInputs = [
+    alsa-lib # libasound.so wanted by lib/libjsound.so
+    fontconfig
+    freetype
+    stdenv.cc.cc.lib # libstdc++.so.6
+    xorg.libX11
+    xorg.libXext
+    xorg.libXi
+    xorg.libXrender
+    xorg.libXtst
+    zlib
+  ] ++ lib.optional stdenv.isAarch32 libffi;
+
+  nativeBuildInputs = [ autoPatchelfHook makeWrapper ];
+
+  # See: https://github.com/NixOS/patchelf/issues/10
+  dontStrip = 1;
+
+  installPhase = ''
+    cd ..
+
+    mv $sourceRoot $out
+
+    # jni.h expects jni_md.h to be in the header search path.
+    ln -s $out/include/linux/*_md.h $out/include/
+
+    rm -rf $out/demo
+
+    # Remove some broken manpages.
+    rm -rf $out/man/ja*
+
+    # Remove embedded freetype to avoid problems like
+    # https://github.com/NixOS/nixpkgs/issues/57733
+    find "$out" -name 'libfreetype.so*' -delete
+
+    # Propagate the setJavaClassPath setup hook from the JDK so that
+    # any package that depends on the JDK has $CLASSPATH set up
+    # properly.
+    mkdir -p $out/nix-support
+    printWords ${setJavaClassPath} > $out/nix-support/propagated-build-inputs
+
+    # Set JAVA_HOME automatically.
+    cat <<EOF >> "$out/nix-support/setup-hook"
+    if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out; fi
+    EOF
+
+    # We cannot use -exec since wrapProgram is a function but not a command.
+    #
+    # jspawnhelper is executed from JVM, so it doesn't need to wrap it, and it
+    # breaks building OpenJDK (#114495).
+    for bin in $( find "$out" -executable -type f -not -name jspawnhelper ); do
+      if patchelf --print-interpreter "$bin" &> /dev/null; then
+        wrapProgram "$bin" --prefix LD_LIBRARY_PATH : "${runtimeLibraryPath}"
+      fi
+    done
+  '';
+
+  preFixup = ''
+    find "$out" -name libfontmanager.so -exec \
+      patchelf --add-needed libfontconfig.so {} \;
+  '';
+
+  # FIXME: use multiple outputs or return actual JRE package
+  passthru.jre = result;
+
+  passthru.home = result;
+
+  meta = with lib; {
+    license = licenses.gpl2Classpath;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode binaryBytecode ];
+    description = "A family of cloud-based runtimes for your Java applications";
+    platforms = lib.mapAttrsToList (arch: _: arch + "-linux") sourcePerArch; # some inherit jre.meta.platforms
+    maintainers = with lib.maintainers; [ nickcao ];
+    inherit knownVulnerabilities;
+    mainProgram = "java";
+  };
+
+}; in result

--- a/pkgs/development/compilers/semeru-bin/jdk11-darwin.nix
+++ b/pkgs/development/compilers/semeru-bin/jdk11-darwin.nix
@@ -1,0 +1,9 @@
+{ lib }:
+
+let
+  sources = lib.importJSON ./sources.json;
+in
+{
+  jdk-openj9 = import ./jdk-darwin-base.nix { sourcePerArch = sources.semeru11.mac.jdk.openj9; };
+  jre-openj9 = import ./jdk-darwin-base.nix { sourcePerArch = sources.semeru11.mac.jre.openj9; };
+}

--- a/pkgs/development/compilers/semeru-bin/jdk11-linux.nix
+++ b/pkgs/development/compilers/semeru-bin/jdk11-linux.nix
@@ -1,0 +1,9 @@
+{ lib }:
+
+let
+  sources = lib.importJSON ./sources.json;
+in
+{
+  jdk-openj9 = import ./jdk-linux-base.nix { sourcePerArch = sources.semeru11.linux.jdk.openj9; };
+  jre-openj9 = import ./jdk-linux-base.nix { sourcePerArch = sources.semeru11.linux.jre.openj9; };
+}

--- a/pkgs/development/compilers/semeru-bin/jdk17-darwin.nix
+++ b/pkgs/development/compilers/semeru-bin/jdk17-darwin.nix
@@ -1,0 +1,9 @@
+{ lib }:
+
+let
+  sources = lib.importJSON ./sources.json;
+in
+{
+  jdk-openj9 = import ./jdk-darwin-base.nix { sourcePerArch = sources.semeru17.mac.jdk.openj9; };
+  jre-openj9 = import ./jdk-darwin-base.nix { sourcePerArch = sources.semeru17.mac.jre.openj9; };
+}

--- a/pkgs/development/compilers/semeru-bin/jdk17-linux.nix
+++ b/pkgs/development/compilers/semeru-bin/jdk17-linux.nix
@@ -1,0 +1,9 @@
+{ lib }:
+
+let
+  sources = lib.importJSON ./sources.json;
+in
+{
+  jdk-openj9 = import ./jdk-linux-base.nix { sourcePerArch = sources.semeru17.linux.jdk.openj9; };
+  jre-openj9 = import ./jdk-linux-base.nix { sourcePerArch = sources.semeru17.linux.jre.openj9; };
+}

--- a/pkgs/development/compilers/semeru-bin/jdk18-darwin.nix
+++ b/pkgs/development/compilers/semeru-bin/jdk18-darwin.nix
@@ -1,0 +1,9 @@
+{ lib }:
+
+let
+  sources = lib.importJSON ./sources.json;
+in
+{
+  jdk-openj9 = import ./jdk-darwin-base.nix { sourcePerArch = sources.semeru18.mac.jdk.openj9; };
+  jre-openj9 = import ./jdk-darwin-base.nix { sourcePerArch = sources.semeru18.mac.jre.openj9; };
+}

--- a/pkgs/development/compilers/semeru-bin/jdk18-linux.nix
+++ b/pkgs/development/compilers/semeru-bin/jdk18-linux.nix
@@ -1,0 +1,9 @@
+{ lib }:
+
+let
+  sources = lib.importJSON ./sources.json;
+in
+{
+  jdk-openj9 = import ./jdk-linux-base.nix { sourcePerArch = sources.semeru18.linux.jdk.openj9; };
+  jre-openj9 = import ./jdk-linux-base.nix { sourcePerArch = sources.semeru18.linux.jre.openj9; };
+}

--- a/pkgs/development/compilers/semeru-bin/jdk8-darwin.nix
+++ b/pkgs/development/compilers/semeru-bin/jdk8-darwin.nix
@@ -1,0 +1,9 @@
+{ lib }:
+
+let
+  sources = lib.importJSON ./sources.json;
+in
+{
+  jdk-openj9 = import ./jdk-darwin-base.nix { sourcePerArch = sources.semeru8.mac.jdk.openj9; };
+  jre-openj9 = import ./jdk-darwin-base.nix { sourcePerArch = sources.semeru8.mac.jre.openj9; };
+}

--- a/pkgs/development/compilers/semeru-bin/jdk8-linux.nix
+++ b/pkgs/development/compilers/semeru-bin/jdk8-linux.nix
@@ -1,0 +1,9 @@
+{ lib }:
+
+let
+  sources = lib.importJSON ./sources.json;
+in
+{
+  jdk-openj9 = import ./jdk-linux-base.nix { sourcePerArch = sources.semeru8.linux.jdk.openj9; };
+  jre-openj9 = import ./jdk-linux-base.nix { sourcePerArch = sources.semeru8.linux.jre.openj9; };
+}

--- a/pkgs/development/compilers/semeru-bin/sources.json
+++ b/pkgs/development/compilers/semeru-bin/sources.json
@@ -1,0 +1,350 @@
+{
+  "semeru11": {
+    "linux": {
+      "jdk": {
+        "openj9": {
+          "aarch64": {
+            "build": "8",
+            "sha256": "488739171f84e3949df6ccb1c40eaf1b73541748b123d88780329648d6b383d0",
+            "url": "https://github.com/ibmruntimes/semeru11-binaries/releases/download/jdk-11.0.16%2B8_openj9-0.33.0/ibm-semeru-open-jdk_aarch64_linux_11.0.16_8_openj9-0.33.0.tar.gz",
+            "version": "11.0.16"
+          },
+          "packageType": "jdk",
+          "powerpc64le": {
+            "build": "8",
+            "sha256": "6dd634e1a8c9ac660767c15a6e1ce945c28db55df7d78c08307902b6d5013a90",
+            "url": "https://github.com/ibmruntimes/semeru11-binaries/releases/download/jdk-11.0.16%2B8_openj9-0.33.0/ibm-semeru-open-jdk_ppc64le_linux_11.0.16_8_openj9-0.33.0.tar.gz",
+            "version": "11.0.16"
+          },
+          "vmType": "openj9",
+          "x86_64": {
+            "build": "8",
+            "sha256": "eeca01d4e245a001d01663c5c20a8d50ef3d572b47a9b3689a5154f2a37bf005",
+            "url": "https://github.com/ibmruntimes/semeru11-binaries/releases/download/jdk-11.0.16%2B8_openj9-0.33.0/ibm-semeru-open-jdk_x64_linux_11.0.16_8_openj9-0.33.0.tar.gz",
+            "version": "11.0.16"
+          }
+        }
+      },
+      "jre": {
+        "openj9": {
+          "aarch64": {
+            "build": "8",
+            "sha256": "49dc05a3e9f3f99c5f8fa466261aa3e33a753694c67cabfa7d3f682e5a2e3685",
+            "url": "https://github.com/ibmruntimes/semeru11-binaries/releases/download/jdk-11.0.16%2B8_openj9-0.33.0/ibm-semeru-open-jre_aarch64_linux_11.0.16_8_openj9-0.33.0.tar.gz",
+            "version": "11.0.16"
+          },
+          "packageType": "jre",
+          "powerpc64le": {
+            "build": "8",
+            "sha256": "552da889577571881ac58eb06877ca2fdadc12397f433b553b319674ee10a02d",
+            "url": "https://github.com/ibmruntimes/semeru11-binaries/releases/download/jdk-11.0.16%2B8_openj9-0.33.0/ibm-semeru-open-jre_ppc64le_linux_11.0.16_8_openj9-0.33.0.tar.gz",
+            "version": "11.0.16"
+          },
+          "vmType": "openj9",
+          "x86_64": {
+            "build": "8",
+            "sha256": "ba09711193b8b8664478f3f949b5320232f65c1bdf61f32a885d84de73c02767",
+            "url": "https://github.com/ibmruntimes/semeru11-binaries/releases/download/jdk-11.0.16%2B8_openj9-0.33.0/ibm-semeru-open-jre_x64_linux_11.0.16_8_openj9-0.33.0.tar.gz",
+            "version": "11.0.16"
+          }
+        }
+      }
+    },
+    "mac": {
+      "jdk": {
+        "openj9": {
+          "aarch64": {
+            "build": "8",
+            "sha256": "6d6760e9751cc8b711716207c527a660e5274320b0da67c3fc16aa767dc53db8",
+            "url": "https://github.com/ibmruntimes/semeru11-binaries/releases/download/jdk-11.0.16%2B8_openj9-0.33.0/ibm-semeru-open-jdk_aarch64_mac_11.0.16_8_openj9-0.33.0.tar.gz",
+            "version": "11.0.16-ea"
+          },
+          "packageType": "jdk",
+          "vmType": "openj9",
+          "x86_64": {
+            "build": "8",
+            "sha256": "8638735d2cae3efff212f898728685380355bb0a298076e9e46244d0bf3d4a64",
+            "url": "https://github.com/ibmruntimes/semeru11-binaries/releases/download/jdk-11.0.16%2B8_openj9-0.33.0/ibm-semeru-open-jdk_x64_mac_11.0.16_8_openj9-0.33.0.tar.gz",
+            "version": "11.0.16"
+          }
+        }
+      },
+      "jre": {
+        "openj9": {
+          "aarch64": {
+            "build": "8",
+            "sha256": "6b95572cf175d4242aabff3e7a5e512633145ee515ce067772114a52f91123df",
+            "url": "https://github.com/ibmruntimes/semeru11-binaries/releases/download/jdk-11.0.16%2B8_openj9-0.33.0/ibm-semeru-open-jre_aarch64_mac_11.0.16_8_openj9-0.33.0.tar.gz",
+            "version": "11.0.16-ea"
+          },
+          "packageType": "jre",
+          "vmType": "openj9",
+          "x86_64": {
+            "build": "8",
+            "sha256": "92f87a3c2fb5fe60d3d51020ff95b9c234b2ae2677b79aebbe749dda717c9cdd",
+            "url": "https://github.com/ibmruntimes/semeru11-binaries/releases/download/jdk-11.0.16%2B8_openj9-0.33.0/ibm-semeru-open-jre_x64_mac_11.0.16_8_openj9-0.33.0.tar.gz",
+            "version": "11.0.16"
+          }
+        }
+      }
+    }
+  },
+  "semeru17": {
+    "linux": {
+      "jdk": {
+        "openj9": {
+          "aarch64": {
+            "build": "8",
+            "sha256": "18d291411ee4a956018b4dcefe436971e73694128782617f1b44beca991956c5",
+            "url": "https://github.com/ibmruntimes/semeru17-binaries/releases/download/jdk-17.0.4%2B8_openj9-0.33.0/ibm-semeru-open-jdk_aarch64_linux_17.0.4_8_openj9-0.33.0.tar.gz",
+            "version": "17.0.4"
+          },
+          "packageType": "jdk",
+          "powerpc64le": {
+            "build": "8",
+            "sha256": "8f69c221fe25a37d645415819ce01d81dfaef5073d87b237e4108d28486dd5f4",
+            "url": "https://github.com/ibmruntimes/semeru17-binaries/releases/download/jdk-17.0.4%2B8_openj9-0.33.0/ibm-semeru-open-jdk_ppc64le_linux_17.0.4_8_openj9-0.33.0.tar.gz",
+            "version": "17.0.4"
+          },
+          "vmType": "openj9",
+          "x86_64": {
+            "build": "8",
+            "sha256": "78ae15d9e01fce3a473f4d6a90c331fb766211b950931088c2a85590f178ad39",
+            "url": "https://github.com/ibmruntimes/semeru17-binaries/releases/download/jdk-17.0.4%2B8_openj9-0.33.0/ibm-semeru-open-jdk_x64_linux_17.0.4_8_openj9-0.33.0.tar.gz",
+            "version": "17.0.4"
+          }
+        }
+      },
+      "jre": {
+        "openj9": {
+          "aarch64": {
+            "build": "8",
+            "sha256": "6c40c1e0d7ee0509c44465e9f26dd970904137a95fd751e6447b1d6a9ef5092a",
+            "url": "https://github.com/ibmruntimes/semeru17-binaries/releases/download/jdk-17.0.4%2B8_openj9-0.33.0/ibm-semeru-open-jre_aarch64_linux_17.0.4_8_openj9-0.33.0.tar.gz",
+            "version": "17.0.4"
+          },
+          "packageType": "jre",
+          "powerpc64le": {
+            "build": "8",
+            "sha256": "cd08290e32fad704e003449b2fc933ac298fe38099484e4f82eb7b97ef2af69e",
+            "url": "https://github.com/ibmruntimes/semeru17-binaries/releases/download/jdk-17.0.4%2B8_openj9-0.33.0/ibm-semeru-open-jre_ppc64le_linux_17.0.4_8_openj9-0.33.0.tar.gz",
+            "version": "17.0.4"
+          },
+          "vmType": "openj9",
+          "x86_64": {
+            "build": "8",
+            "sha256": "b2c176f8aa8cc7138d4c22ce9298d8f49597e1d8e3fdd33125898e5ee0182c93",
+            "url": "https://github.com/ibmruntimes/semeru17-binaries/releases/download/jdk-17.0.4%2B8_openj9-0.33.0/ibm-semeru-open-jre_x64_linux_17.0.4_8_openj9-0.33.0.tar.gz",
+            "version": "17.0.4"
+          }
+        }
+      }
+    },
+    "mac": {
+      "jdk": {
+        "openj9": {
+          "aarch64": {
+            "build": "8",
+            "sha256": "bf22628b54115dff9939b94751531544ab735b7cbbc8d6ddfe83d1b04df3a532",
+            "url": "https://github.com/ibmruntimes/semeru17-binaries/releases/download/jdk-17.0.4%2B8_openj9-0.33.0/ibm-semeru-open-jdk_aarch64_mac_17.0.4_8_openj9-0.33.0.tar.gz",
+            "version": "17.0.4-ea"
+          },
+          "packageType": "jdk",
+          "vmType": "openj9",
+          "x86_64": {
+            "build": "8",
+            "sha256": "66e89f946081c558abbc8371478df907f21fa71037a8ec80056d88c91f498ec9",
+            "url": "https://github.com/ibmruntimes/semeru17-binaries/releases/download/jdk-17.0.4%2B8_openj9-0.33.0/ibm-semeru-open-jdk_x64_mac_17.0.4_8_openj9-0.33.0.tar.gz",
+            "version": "17.0.4"
+          }
+        }
+      },
+      "jre": {
+        "openj9": {
+          "aarch64": {
+            "build": "8",
+            "sha256": "4057c94cd46b814cc5a4d683d5f0b95dbd0b9e13e8c2e11155561ad0d8bec85b",
+            "url": "https://github.com/ibmruntimes/semeru17-binaries/releases/download/jdk-17.0.4%2B8_openj9-0.33.0/ibm-semeru-open-jre_aarch64_mac_17.0.4_8_openj9-0.33.0.tar.gz",
+            "version": "17.0.4-ea"
+          },
+          "packageType": "jre",
+          "vmType": "openj9",
+          "x86_64": {
+            "build": "8",
+            "sha256": "dd5a65c3bd2a6d62ca2710fa5487cc908748eee93295a0ed53ea9ce9f93209de",
+            "url": "https://github.com/ibmruntimes/semeru17-binaries/releases/download/jdk-17.0.4%2B8_openj9-0.33.0/ibm-semeru-open-jre_x64_mac_17.0.4_8_openj9-0.33.0.tar.gz",
+            "version": "17.0.4"
+          }
+        }
+      }
+    }
+  },
+  "semeru18": {
+    "linux": {
+      "jdk": {
+        "openj9": {
+          "aarch64": {
+            "build": "102",
+            "sha256": "c1ef383b12460857dcc358284bda8fb1632d62b614a81d8b115903b53d294cc1",
+            "url": "https://github.com/ibmruntimes/semeru18-binaries/releases/download/jdk-18.0.1.1%2B2_openj9-0.32.0/ibm-semeru-open-jdk_aarch64_linux_18.0.1.1_2_openj9-0.32.0.tar.gz",
+            "version": "18.0.1"
+          },
+          "packageType": "jdk",
+          "powerpc64le": {
+            "build": "102",
+            "sha256": "355e54e53f1b6578f4168a83de663707b65cd2f47645b4da914a815cccbf41b6",
+            "url": "https://github.com/ibmruntimes/semeru18-binaries/releases/download/jdk-18.0.1.1%2B2_openj9-0.32.0/ibm-semeru-open-jdk_ppc64le_linux_18.0.1.1_2_openj9-0.32.0.tar.gz",
+            "version": "18.0.1"
+          },
+          "vmType": "openj9",
+          "x86_64": {
+            "build": "102",
+            "sha256": "708d7d7b5ac3c793f7fa9b045024276b54f973dcb833cccc0be697261884db4a",
+            "url": "https://github.com/ibmruntimes/semeru18-binaries/releases/download/jdk-18.0.1.1%2B2_openj9-0.32.0/ibm-semeru-open-jdk_x64_linux_18.0.1.1_2_openj9-0.32.0.tar.gz",
+            "version": "18.0.1"
+          }
+        }
+      },
+      "jre": {
+        "openj9": {
+          "aarch64": {
+            "build": "102",
+            "sha256": "86bf05dae9510bd0679bf7489378b1411cf816885adbde7108d52e3b85d76d84",
+            "url": "https://github.com/ibmruntimes/semeru18-binaries/releases/download/jdk-18.0.1.1%2B2_openj9-0.32.0/ibm-semeru-open-jre_aarch64_linux_18.0.1.1_2_openj9-0.32.0.tar.gz",
+            "version": "18.0.1"
+          },
+          "packageType": "jre",
+          "powerpc64le": {
+            "build": "102",
+            "sha256": "5b5e650847c39efa65e294df46c073091e9089579decdb125867af8e4bae2cb5",
+            "url": "https://github.com/ibmruntimes/semeru18-binaries/releases/download/jdk-18.0.1.1%2B2_openj9-0.32.0/ibm-semeru-open-jre_ppc64le_linux_18.0.1.1_2_openj9-0.32.0.tar.gz",
+            "version": "18.0.1"
+          },
+          "vmType": "openj9",
+          "x86_64": {
+            "build": "102",
+            "sha256": "761807f0c13500b1e94824928050c3485932cb596e2a499935f67b734c644c97",
+            "url": "https://github.com/ibmruntimes/semeru18-binaries/releases/download/jdk-18.0.1.1%2B2_openj9-0.32.0/ibm-semeru-open-jre_x64_linux_18.0.1.1_2_openj9-0.32.0.tar.gz",
+            "version": "18.0.1"
+          }
+        }
+      }
+    },
+    "mac": {
+      "jdk": {
+        "openj9": {
+          "aarch64": {
+            "build": "102",
+            "sha256": "38f9b44bcaf1d472720beac31f6b76b29b6a73db8e5631f685eca70787c58200",
+            "url": "https://github.com/ibmruntimes/semeru18-binaries/releases/download/jdk-18.0.1.1%2B2_openj9-0.32.0/ibm-semeru-open-jdk_aarch64_mac_18.0.1.1_2_openj9-0.32.0.tar.gz",
+            "version": "18.0.1-ea"
+          },
+          "packageType": "jdk",
+          "vmType": "openj9",
+          "x86_64": {
+            "build": "102",
+            "sha256": "d6f262cb6077af35d18f0405b4133c9cf4014d4909589d8bdf0af0f350be9abc",
+            "url": "https://github.com/ibmruntimes/semeru18-binaries/releases/download/jdk-18.0.1.1%2B2_openj9-0.32.0/ibm-semeru-open-jdk_x64_mac_18.0.1.1_2_openj9-0.32.0.tar.gz",
+            "version": "18.0.1"
+          }
+        }
+      },
+      "jre": {
+        "openj9": {
+          "aarch64": {
+            "build": "102",
+            "sha256": "a18df33b31b0598ea44b01fede6c81f2d25523473fa1b2d1c5489993cb3ef745",
+            "url": "https://github.com/ibmruntimes/semeru18-binaries/releases/download/jdk-18.0.1.1%2B2_openj9-0.32.0/ibm-semeru-open-jre_aarch64_mac_18.0.1.1_2_openj9-0.32.0.tar.gz",
+            "version": "18.0.1-ea"
+          },
+          "packageType": "jre",
+          "vmType": "openj9",
+          "x86_64": {
+            "build": "102",
+            "sha256": "3a3943fd85c471997d6d173c832df465ffbc884fcba092860a0a265f3f00e727",
+            "url": "https://github.com/ibmruntimes/semeru18-binaries/releases/download/jdk-18.0.1.1%2B2_openj9-0.32.0/ibm-semeru-open-jre_x64_mac_18.0.1.1_2_openj9-0.32.0.tar.gz",
+            "version": "18.0.1"
+          }
+        }
+      }
+    }
+  },
+  "semeru8": {
+    "linux": {
+      "jdk": {
+        "openj9": {
+          "aarch64": {
+            "build": "9",
+            "sha256": "f1a27166eb8063e848074896f3973bc3fc1e50d6518dde9817e86ebc36a10296",
+            "url": "https://github.com/ibmruntimes/semeru8-binaries/releases/download/jdk8u332-b09_openj9-0.32.0/ibm-semeru-open-jdk_aarch64_linux_8u332b09_openj9-0.32.0.tar.gz",
+            "version": "8.0.332"
+          },
+          "packageType": "jdk",
+          "powerpc64le": {
+            "build": "9",
+            "sha256": "b23fd5d6d7b50e9d1f182f68f3d0179e4e2810a3d9fffb98e96565ced527364c",
+            "url": "https://github.com/ibmruntimes/semeru8-binaries/releases/download/jdk8u332-b09_openj9-0.32.0/ibm-semeru-open-jdk_ppc64le_linux_8u332b09_openj9-0.32.0.tar.gz",
+            "version": "8.0.332"
+          },
+          "vmType": "openj9",
+          "x86_64": {
+            "build": "9",
+            "sha256": "beff2d92bcf32525692557c13a0695a3cd21967bd5efba370192a8ce184775c7",
+            "url": "https://github.com/ibmruntimes/semeru8-binaries/releases/download/jdk8u332-b09_openj9-0.32.0/ibm-semeru-open-jdk_x64_linux_8u332b09_openj9-0.32.0.tar.gz",
+            "version": "8.0.332"
+          }
+        }
+      },
+      "jre": {
+        "openj9": {
+          "aarch64": {
+            "build": "9",
+            "sha256": "0c8842db66c0b4052db8c29846f05292e16d9fedad4d709f31ba890f315337a2",
+            "url": "https://github.com/ibmruntimes/semeru8-binaries/releases/download/jdk8u332-b09_openj9-0.32.0/ibm-semeru-open-jre_aarch64_linux_8u332b09_openj9-0.32.0.tar.gz",
+            "version": "8.0.332"
+          },
+          "packageType": "jre",
+          "powerpc64le": {
+            "build": "9",
+            "sha256": "617d1cf32797865a11ff5287f977c811d5896c4ba4bbd6e30dd1656ff77ebadf",
+            "url": "https://github.com/ibmruntimes/semeru8-binaries/releases/download/jdk8u332-b09_openj9-0.32.0/ibm-semeru-open-jre_ppc64le_linux_8u332b09_openj9-0.32.0.tar.gz",
+            "version": "8.0.332"
+          },
+          "vmType": "openj9",
+          "x86_64": {
+            "build": "9",
+            "sha256": "2acd73ad996814b8e3814049827de8e20ac0fbf49d336606ee67e0bfb5d4642a",
+            "url": "https://github.com/ibmruntimes/semeru8-binaries/releases/download/jdk8u332-b09_openj9-0.32.0/ibm-semeru-open-jre_x64_linux_8u332b09_openj9-0.32.0.tar.gz",
+            "version": "8.0.332"
+          }
+        }
+      }
+    },
+    "mac": {
+      "jdk": {
+        "openj9": {
+          "packageType": "jdk",
+          "vmType": "openj9",
+          "x86_64": {
+            "build": "9",
+            "sha256": "f4b1ec4b1ba3eb318642ddcbb0c02d67e6edfc9e37a7c3bfb13630e4806942e2",
+            "url": "https://github.com/ibmruntimes/semeru8-binaries/releases/download/jdk8u332-b09_openj9-0.32.0/ibm-semeru-open-jdk_x64_mac_8u332b09_openj9-0.32.0.tar.gz",
+            "version": "8.0.332"
+          }
+        }
+      },
+      "jre": {
+        "openj9": {
+          "packageType": "jre",
+          "vmType": "openj9",
+          "x86_64": {
+            "build": "9",
+            "sha256": "b2ca05ba54901babc4350534a2f1d80d7cf0eb47e6cc5174443378b3a45d322a",
+            "url": "https://github.com/ibmruntimes/semeru8-binaries/releases/download/jdk8u332-b09_openj9-0.32.0/ibm-semeru-open-jre_x64_mac_8u332b09_openj9-0.32.0.tar.gz",
+            "version": "8.0.332"
+          }
+        }
+      }
+    }
+  }
+}

--- a/pkgs/top-level/java-packages.nix
+++ b/pkgs/top-level/java-packages.nix
@@ -27,6 +27,19 @@ in {
       headless = true;
     };
 
+    mkSemeru = path-linux: path-darwin: let
+      package-linux  = import path-linux { inherit lib; };
+      package-darwin = import path-darwin { inherit lib; };
+      package = if stdenv.isLinux
+        then package-linux
+        else package-darwin;
+    in rec {
+      inherit package-linux package-darwin;
+
+      jdk-openj9  = callPackage package.jdk-openj9  {};
+      jre-openj9  = callPackage package.jre-openj9  {};
+    };
+
     mkAdoptopenjdk = path-linux: path-darwin: let
       package-linux  = import path-linux { inherit lib; };
       package-darwin = import path-darwin { inherit lib; };
@@ -65,6 +78,22 @@ in {
       abort "OpenJDK ${builtins.toString version} is currently not supported on Darwin by nixpkgs.";
 
   in rec {
+
+    semeru8 = mkSemeru
+      ../development/compilers/semeru-bin/jdk8-linux.nix
+      ../development/compilers/semeru-bin/jdk8-darwin.nix;
+
+    semeru11 = mkSemeru
+      ../development/compilers/semeru-bin/jdk11-linux.nix
+      ../development/compilers/semeru-bin/jdk11-darwin.nix;
+
+    semeru17 = mkSemeru
+      ../development/compilers/semeru-bin/jdk17-linux.nix
+      ../development/compilers/semeru-bin/jdk17-darwin.nix;
+
+    semeru18 = mkSemeru
+      ../development/compilers/semeru-bin/jdk18-linux.nix
+      ../development/compilers/semeru-bin/jdk18-darwin.nix;
 
     adoptopenjdk-8 = mkAdoptopenjdk
       ../development/compilers/adoptopenjdk-bin/jdk8-linux.nix


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
