### PR TITLE
cloudflare-warp: 2022.02.24 -> 2022.7.421

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1167,6 +1167,12 @@
     githubId = 453170;
     name = "Alastair Pharo";
   };
+  astevenstaylor = {
+    email = "git@stevenstaylor.dev";
+    github = "astevenstaylor";
+    githubId = 1410338;
+    name = "Ahren Stevens-Taylor";
+  };
   astro = {
     email = "astro@spaceboyz.net";
     github = "astro";

--- a/pkgs/tools/networking/cloudflare-warp/default.nix
+++ b/pkgs/tools/networking/cloudflare-warp/default.nix
@@ -2,11 +2,12 @@
 
 stdenv.mkDerivation rec {
   pname = "cloudflare-warp";
-  version = "2022.02.24";
+  version = "2022.7.421";
 
   src = fetchurl {
-    url = "https://pkg.cloudflareclient.com/uploads/cloudflare_warp_2022_2_288_1_amd64_a0be7b47b3.deb";
-    sha256 = "sha256-gBXF0EfFMT6BC6ts/6PQYJH3AAQSDsFoZGK3RZIqmOA=";
+    #https://pkg.cloudflareclient.com/packages/cloudflare-warp Ubuntu Focal amd64
+    url = "https://pkg.cloudflareclient.com/pool/dists/focal/main/cloudflare_warp_2022_7_472_1_amd64_77aa79eba3_amd64.deb";
+    sha256 = "sha256-lbT3uH0kUbFpSvEYcfdh5jnpaKINwXotD3iePwXHAsY=";
   };
 
   nativeBuildInputs = [
@@ -27,7 +28,7 @@ stdenv.mkDerivation rec {
     runHook preInstall
 
     mv usr $out
-    mv lib $out
+    cp -a lib $out && rm -rf lib
     mv bin $out
 
     runHook postInstall
@@ -36,6 +37,8 @@ stdenv.mkDerivation rec {
   postInstall = ''
     substituteInPlace $out/lib/systemd/system/warp-svc.service \
       --replace "ExecStart=" "ExecStart=$out"
+    substituteInPlace $out/lib/systemd/user/warp-taskbar.service \
+      --replace "ExecStart=" "ExecStart=$out"
   '';
 
   meta = with lib; {
@@ -43,7 +46,7 @@ stdenv.mkDerivation rec {
     homepage = "https://pkg.cloudflareclient.com/packages/cloudflare-warp";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
-    maintainers = with maintainers; [ wolfangaukang ];
+    maintainers = with maintainers; [ wolfangaukang astevenstaylor ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/tools/networking/cloudflare-warp/default.nix
+++ b/pkgs/tools/networking/cloudflare-warp/default.nix
@@ -28,7 +28,8 @@ stdenv.mkDerivation rec {
     runHook preInstall
 
     mv usr $out
-    cp -a lib $out && rm -rf lib
+    cp -a lib $out
+    rm -rf lib
     mv bin $out
 
     runHook postInstall


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Updates from changelog.gz
```
cloudflare-warp (2022.7.472) unstable; urgency=medium

  * Fixed issue where OS version and device name may not update in ZT Dashboard
  * Prevent users from brute forcing admin override code
  * Prevent disable-on-wifi feature for ZT customers
  * Add support for environment variables in device posture files paths
  * Prevent flushing all nftable rulesets when WARP is disabled
  * Fix incorrect output in "include-only" mode
  * Fix routing issues when running microk8s
  * Fix issue with wildcard expansion on domain fallback and split tunnel rules
  * Fix issue with `warp-diag feedback` failing to upload
  * Prevent hangs and failures on network traffic when in proxy-mode
  * Prevent log files from growing too large
  * Add "Don't Fragment" bit to encapsulated traffic
  * Ensure our DNS servers stay set if another program tries to change them
  * Add ability to upload device state to API for ZT customers

cloudflare-warp (2022.5.346) unstable; urgency=medium

  * Fixed issue where all nftables rulesets were flushed after warp-cli disconnect
  * Fixed false positives when attempting to detect a captive portal
  * Fixed issue where OS version would not be updated in dash after OS update
  * Added support for DNS over TCP
  * Fixed issue where updated posture checks might not take effect until restart
  * Fixed issue with warp-cli where enable/disable with wifi was allowed in Zero Trust mode
  * Fixed issue where too many DNS requests could result in the following error
    appearing in logs: WARN warp::dns: Shedding DNS load
  * Bug fixes and enhancements

 -- Matt Schulte <mschulte@cloudflare.com> Fri, 17 Jun 2022 15:00:00 -0700

cloudflare-warp (2022.4.235) unstable; urgency=medium

  * Removed periodic tunnel checks
  * Changed `warp-cli connect` to mimic 'warp-cli enable-always-on`
  * Changed `warp-cli disconnect` to mimic `warp-cli disable-always-on`
  * Added a simple taskbar icon to show status
  * Added virtual network switching support via warp-cli (`warp-cli
    get-virtual-networks` and `warp-cli set-virtual-network`).
  * Bug fixes and enhancements

 -- Matt Schulte <mschulte@cloudflare.com> Mon, 18 April 2022 12:00:00 -0700

cloudflare-warp (2022.3.253) unstable; urgency=medium

  * `warp-cli delete` run as root will remove the user for an organization
    even if "Allowed To Leave" is disabled in Zero Trust dashboard.
  * Added `warp-cli disable-connectivity-checks` and `warp-cli
    enabled-connectivity-checks` to control connectivity checks
  * Fixed issue with `warp-cli teams-enroll` on platforms where the default
    browser is installed with snap.
  * Added "Device Posture Only" support

 -- Matt Schulte <mschulte@cloudflare.com> Wed, 40 March 2022 15:30:00 -0700

cloudflare-warp (2022.2.288) unstable; urgency=medium

  * Fixed an issue where the organization name became case sensitive and could
    cause a device to lose registration

 -- Matt Schulte <mschulte@cloudflare.com> Thu, 24 Feb 2022 10:10:00 -0800

cloudflare-warp (2022.2.29) unstable; urgency=medium

  * Fixed issue with warp working on distros with v248 of systemd or newer
  * Fixed issue with device posture application checks detecting running
    processes
  * Now that settings exist in the Zero Trust Dashboard the Client UI should
    behave the same regardless of if you manually joined to a Team or if you
    were forced to by local mdm.xml policy
  * Fixed issue where the WARP Client might not get updated settings when it
    initial starts
  * Fixed issue where the Last Seen value was not updated properly in the Zero
    Trust Dashboard while in "doh" mode
  * Fixed issue where device name was not updated in the Zero trust Dashboard if
    the computer name changed after initial registration
  * Added the ability for daemon to parse mdm.xml file on Linux
  * Shows the Zero Trust Terms of Service when user joins an organization

 -- Matt Schulte <mschulte@cloudflare.com> Wed, 9 Feb 2022 14:07:00 -0800
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
