### PR TITLE
xdp-tools: init at 1.2.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13010,6 +13010,12 @@
     githubId = 1292007;
     name = "Sébastien Maccagnoni";
   };
+  tirex = {
+    email = "szymon@kliniewski.pl";
+    name = "Szymon Kliniewski";
+    github = "NoneTirex";
+    githubId = 26038207;
+  };
   titanous = {
     email = "jonathan@titanous.com";
     github = "titanous";

--- a/pkgs/tools/networking/xdp-tools/default.nix
+++ b/pkgs/tools/networking/xdp-tools/default.nix
@@ -1,0 +1,67 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, libbpf
+, elfutils
+, libelf
+, zlib
+, libpcap
+, clang
+, llvm
+, gnumake
+, gcc
+, pkgconfig
+, m4
+, emacs-nox
+, wireshark-cli
+}:
+stdenv.mkDerivation rec {
+  pname = "xdp-tools";
+  version = "1.2.5";
+
+  src = fetchFromGitHub {
+    owner = "xdp-project";
+    repo = "xdp-tools";
+    rev = "v${version}";
+    sha256 = "sha256-Kyay5j+87nOZ9C+DI8MI6zhkWqspIHiTfW9Di5uVWzY=";
+  };
+
+  buildInputs = [
+    libbpf
+    elfutils
+    libelf
+    libpcap
+    zlib
+  ];
+
+  nativeBuildInputs = [
+    clang
+    llvm
+    gnumake
+    gcc
+    pkgconfig
+    m4
+    emacs-nox
+    wireshark-cli
+  ];
+
+  BPF_CFLAGS = "-fno-stack-protector -Wno-error=unused-command-line-argument";
+  PRODUCTION = 1;
+  DYNAMIC_LIBXDP = 1;
+  FORCE_SYSTEM_LIBBPF = 1;
+  FORCE_EMACS = 1;
+
+  installPhase = ''
+    export PREFIX=$out
+
+    make install
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/xdp-project/xdp-tools";
+    description = "Library and utilities for use with XDP";
+    license = with licenses; [ gpl2 lgpl21 bsd2 ];
+    maintainers = with maintainers; [ tirex ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/networking/xdp-tools/default.nix
+++ b/pkgs/tools/networking/xdp-tools/default.nix
@@ -1,19 +1,17 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , libbpf
 , elfutils
-, libelf
 , zlib
 , libpcap
-, clang
-, llvm
-, gnumake
-, gcc
-, pkgconfig
+, llvmPackages
+, pkg-config
 , m4
 , emacs-nox
 , wireshark-cli
+, nukeReferences
 }:
 stdenv.mkDerivation rec {
   pname = "xdp-tools";
@@ -26,42 +24,57 @@ stdenv.mkDerivation rec {
     sha256 = "xKxR20Jz+pGKzazFoZe0i0pv7AuaxdL8Yt3IE4JAje8=";
   };
 
+  outputs = [ "out" "lib" ];
+
+  patches = [
+    (fetchpatch {
+      # Compat with libbpf 1.0: https://github.com/xdp-project/xdp-tools/pull/221
+      url = "https://github.com/xdp-project/xdp-tools/commit/f8592d0609807f5b2b73d27eb3bd623da4bd1997.diff";
+      sha256 = "+NpR0d5YE1TMFeyidBuXCDkcBTa2W0094nqYiEWKpY4=";
+    })
+  ];
+
   buildInputs = [
     libbpf
     elfutils
-    libelf
     libpcap
     zlib
   ];
 
   nativeBuildInputs = [
-    clang
-    llvm
-    gnumake
-    gcc
-    pkgconfig
+    llvmPackages.clang
+    llvmPackages.llvm
+    pkg-config
     m4
-    emacs-nox
-    wireshark-cli
+    emacs-nox # to generate man pages from .org
+    nukeReferences
+  ];
+  checkInputs = [
+    wireshark-cli # for tshark
   ];
 
+  # When building BPF, the default CC wrapper is interfering a bit too much.
   BPF_CFLAGS = "-fno-stack-protector -Wno-error=unused-command-line-argument";
+
   PRODUCTION = 1;
   DYNAMIC_LIBXDP = 1;
   FORCE_SYSTEM_LIBBPF = 1;
   FORCE_EMACS = 1;
 
-  installPhase = ''
-    export PREFIX=$out
+  makeFlags = [ "PREFIX=$(out)" "LIBDIR=$(lib)/lib" ];
 
-    make install
+  postInstall = ''
+    # Note that even the static libxdp would refer to BPF_OBJECT_DIR ?=$(LIBDIR)/bpf
+    rm "$lib"/lib/*.a
+    # Drop unfortunate references to glibc.dev/include at least from $lib
+    nuke-refs "$lib"/lib/bpf/*.o
   '';
 
   meta = with lib; {
     homepage = "https://github.com/xdp-project/xdp-tools";
     description = "Library and utilities for use with XDP";
     license = with licenses; [ gpl2 lgpl21 bsd2 ];
-    maintainers = with maintainers; [ tirex ];
+    maintainers = with maintainers; [ tirex vcunat ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/networking/xdp-tools/default.nix
+++ b/pkgs/tools/networking/xdp-tools/default.nix
@@ -17,13 +17,13 @@
 }:
 stdenv.mkDerivation rec {
   pname = "xdp-tools";
-  version = "1.2.5";
+  version = "1.2.6";
 
   src = fetchFromGitHub {
     owner = "xdp-project";
     repo = "xdp-tools";
     rev = "v${version}";
-    sha256 = "sha256-Kyay5j+87nOZ9C+DI8MI6zhkWqspIHiTfW9Di5uVWzY=";
+    sha256 = "xKxR20Jz+pGKzazFoZe0i0pv7AuaxdL8Yt3IE4JAje8=";
   };
 
   buildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11987,6 +11987,8 @@ with pkgs;
 
   xdg-launch = callPackage ../applications/misc/xdg-launch { };
 
+  xdp-tools = callPackage ../tools/networking/xdp-tools { };
+
   xkbvalidate = callPackage ../tools/X11/xkbvalidate { };
 
   xkeysnail = callPackage ../tools/X11/xkeysnail { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11987,7 +11987,9 @@ with pkgs;
 
   xdg-launch = callPackage ../applications/misc/xdg-launch { };
 
-  xdp-tools = callPackage ../tools/networking/xdp-tools { };
+  xdp-tools = callPackage ../tools/networking/xdp-tools {
+    llvmPackages = llvmPackages_14;
+  };
 
   xkbvalidate = callPackage ../tools/X11/xkbvalidate { };
 


### PR DESCRIPTION
###### Description of changes

Add xdp-tools package to repository.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).