### PR TITLE
cc-wrapper, clang-tools: move libcxx before cflags

### DIFF
--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -122,10 +122,10 @@ fi
 
 if [[ "$isCxx" = 1 ]]; then
     if [[ "$cxxInclude" = 1 ]]; then
-        NIX_CFLAGS_COMPILE_@suffixSalt@+=" $NIX_CXXSTDLIB_COMPILE_@suffixSalt@"
+        NIX_CFLAGS_COMPILE_@suffixSalt@="$NIX_CXXSTDLIB_COMPILE_@suffixSalt@ $NIX_CFLAGS_COMPILE_@suffixSalt@"
     fi
     if [[ "$cxxLibrary" = 1 ]]; then
-        NIX_CFLAGS_LINK_@suffixSalt@+=" $NIX_CXXSTDLIB_LINK_@suffixSalt@"
+        NIX_CFLAGS_LINK_@suffixSalt@="$NIX_CXXSTDLIB_LINK_@suffixSalt@ $NIX_CFLAGS_LINK_@suffixSalt@"
     fi
 fi
 

--- a/pkgs/development/tools/clang-tools/wrapper
+++ b/pkgs/development/tools/clang-tools/wrapper
@@ -20,8 +20,8 @@ buildcpath() {
 
 export CPATH=${CPATH}${CPATH:+':'}$(buildcpath ${NIX_CFLAGS_COMPILE} \
                                                $(<@clang@/nix-support/libc-cflags)):@clang@/resource-root/include
-export CPLUS_INCLUDE_PATH=${CPLUS_INCLUDE_PATH}${CPLUS_INCLUDE_PATH:+':'}$(buildcpath ${NIX_CFLAGS_COMPILE} \
-                                                                                      $(<@clang@/nix-support/libcxx-cxxflags) \
+export CPLUS_INCLUDE_PATH=${CPLUS_INCLUDE_PATH}${CPLUS_INCLUDE_PATH:+':'}$(buildcpath $(<@clang@/nix-support/libcxx-cxxflags) \
+                                                                                      ${NIX_CFLAGS_COMPILE} \
                                                                                       $(<@clang@/nix-support/libc-cflags)):@clang@/resource-root/include
 
 exec -a "$0" @unwrapped@/bin/$(basename $0) "$@"


### PR DESCRIPTION
**This is #169962 rebased against the `staging` branch.**

---

This fixes #163052, where the xcbuild build fails on Darwin after
libSystem is added as a dependency of IOSurface.

Even though cc-wrapper adds libc to NIX_CFLAGS_COMPILE using the
-idirafter flag, ensuring it comes after the C++ standard library,
and the clang-tools wrapper respects -idirafter when it parses
arguments, it appears that "-isystem libc" can make its way onto
NIX_CFLAGS_COMPILE too.

In honesty, I have not been able to figure out how NIX_CFLAGS_COMPILE
inherits "-isystem libSystem", or how it influences the xcbuild build
itself. However:

1. This change does appear to fix the xcbuild build.

2. If NIX_CFLAGS_COMPILE does have "-isystem libSystem" added to it
   somehow, it _should_ probably come after the C++ standard library.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).