### PR TITLE
tree-sitter: strip only debug info by default

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammar.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammar.nix
@@ -30,16 +30,18 @@ stdenv.mkDerivation rec {
   CFLAGS = [ "-I${src}/src" "-O2" ];
   CXXFLAGS = [ "-I${src}/src" "-O2" ];
 
+  stripDebugList = [ "parser" ];
+
   # When both scanner.{c,cc} exist, we should not link both since they may be the same but in
   # different languages. Just randomly prefer C++ if that happens.
   buildPhase = ''
     runHook preBuild
     if [[ -e "$src/src/scanner.cc" ]]; then
-      $CXX -c "$src/src/scanner.cc" -o scanner.o $CXXFLAGS
+      $CXX -fPIC -c "$src/src/scanner.cc" -o scanner.o $CXXFLAGS
     elif [[ -e "$src/src/scanner.c" ]]; then
-      $CC -c "$src/src/scanner.c" -o scanner.o $CFLAGS
+      $CC -fPIC -c "$src/src/scanner.c" -o scanner.o $CFLAGS
     fi
-    $CC -c "$src/src/parser.c" -o parser.o $CFLAGS
+    $CC -fPIC -c "$src/src/parser.c" -o parser.o $CFLAGS
     $CXX -shared -o parser *.o
     runHook postBuild
   '';
@@ -49,12 +51,5 @@ stdenv.mkDerivation rec {
     mkdir $out
     mv parser $out/
     runHook postInstall
-  '';
-
-  # Strip failed on darwin: strip: error: symbols referenced by indirect symbol table entries that can't be stripped
-  fixupPhase = lib.optionalString stdenv.isLinux ''
-    runHook preFixup
-    $STRIP $out/parser
-    runHook postFixup
   '';
 }


### PR DESCRIPTION
Noticed use of $STRIP when passed through various uses of $STRIP
in `nixpkgs`. This looked unusual in a way that it strips not just
debugging symbols but also all the rest.

The change switch to debug-only stripping.

While at it switched to expliict use of `-fPIC` for shared library.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
