### PR TITLE
[Backport] goofys: unstable-2021-03-26 -> unstable-2022-04-21

### DIFF
--- a/pkgs/tools/filesystems/goofys/default.nix
+++ b/pkgs/tools/filesystems/goofys/default.nix
@@ -6,17 +6,17 @@
 
 buildGoModule {
   pname = "goofys";
-  version = "unstable-2021-03-26";
+  version = "unstable-2022-04-21";
 
   src = fetchFromGitHub {
     owner = "kahing";
     repo = "goofys";
     # Same as v0.24.0 but migrated to Go modules
-    rev = "0c993271269b539196330a18716a33fbeeebd624";
-    sha256 = "18is5sv2a9wmsm0qpakly988z1qyl2b2hf2105lpxrgl659sf14p";
+    rev = "829d8e5ce20faa3f9f6f054077a14325e00e9249";
+    sha256 = "sha256-6yVMNSwwPZlADXuPBDRlgoz4Stuz2pgv6r6+y2/C8XY=";
   };
 
-  vendorSha256 = "15yq0msh9icxd5n2zkkqrlwxifizhpa99d4aznv8clg32ybs61fj";
+  vendorSha256 = "sha256-2N8MshBo9+2q8K00eTW5So6d8ZNRzOfQkEKmxR428gI=";
 
   subPackages = [ "." ];
 
@@ -30,8 +30,7 @@ buildGoModule {
     description = "A high-performance, POSIX-ish Amazon S3 file system written in Go.";
     license = [ lib.licenses.mit ];
     maintainers = [ lib.maintainers.adisbladis ];
-    # does not build with go 1.17
-    broken = true;
+    broken = stdenv.isDarwin; # needs to update gopsutil to at least v3.21.3 to include https://github.com/shirou/gopsutil/pull/1042
   };
 
 }


### PR DESCRIPTION
###### Description of changes

Backport due to broken package.

Cherry-picked from 9e2d1c849242a6c26902230ae292464dd27f0f69
Package has been broken since caa2b2ee685f71f9c4d96de02234c42eb4e9343d

Original PR:
https://github.com/NixOS/nixpkgs/pull/176255

This is my first backport PR, no idea if I'm doing this right :slightly_smiling_face: 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
