### PR TITLE
kwin: don't leak CAP_SYS_NICE

### DIFF
--- a/pkgs/desktops/plasma-5/kwin/0001-Lower-CAP_SYS_NICE-from-the-ambient-set.patch
+++ b/pkgs/desktops/plasma-5/kwin/0001-Lower-CAP_SYS_NICE-from-the-ambient-set.patch
@@ -1,0 +1,40 @@
+From 232e480ab1303f37d37d295b57fdcbb6b6648bca Mon Sep 17 00:00:00 2001
+From: Alois Wohlschlager <alois1@gmx-topmail.de>
+Date: Sun, 7 Aug 2022 16:12:31 +0200
+Subject: [PATCH] Lower CAP_SYS_NICE from the ambient set
+
+The capabilities wrapper raises CAP_SYS_NICE into the ambient set so it
+is inherited by the wrapped program. However, we don't want it to leak
+into the entire desktop environment.
+
+Lower the capability again at startup so that the kernel will clear it
+on exec.
+---
+ src/main_wayland.cpp | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/main_wayland.cpp b/src/main_wayland.cpp
+index 1720e14e7..f2bb446b0 100644
+--- a/src/main_wayland.cpp
++++ b/src/main_wayland.cpp
+@@ -39,7 +39,9 @@
+ #include <QWindow>
+ #include <qplatformdefs.h>
+ 
++#include <linux/capability.h>
+ #include <sched.h>
++#include <sys/prctl.h>
+ #include <sys/resource.h>
+ 
+ #include <iomanip>
+@@ -285,6 +287,7 @@ static QString automaticBackendSelection()
+ 
+ int main(int argc, char *argv[])
+ {
++    prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_LOWER, CAP_SYS_NICE, 0, 0);
+     KWin::Application::setupMalloc();
+     KWin::Application::setupLocalizedString();
+     KWin::gainRealTime();
+-- 
+2.37.1
+

--- a/pkgs/desktops/plasma-5/kwin/default.nix
+++ b/pkgs/desktops/plasma-5/kwin/default.nix
@@ -48,6 +48,7 @@ mkDerivation {
     ./0002-xwayland.patch
     ./0003-plugins-qpa-allow-using-nixos-wrapper.patch
     ./0001-NixOS-Unwrap-executable-name-for-.desktop-search.patch
+    ./0001-Lower-CAP_SYS_NICE-from-the-ambient-set.patch
     # Pass special environments through arguemnts to `kwin_wayland`, bypassing
     # ld.so(8) environment stripping due to `kwin_wayland`'s capabilities.
     # We need this to have `TZDIR` correctly set for `plasmashell`, or


### PR DESCRIPTION
The capability wrapper raises CAP_SYS_NICE into the ambient set. As a
result, not only is kwin_wayland itself granted that capability, but
also all applications started by it (even transitively, i.e. the entire
desktop environment). While CAP_SYS_NICE is not a particularly dangerous
capability, that behaviour is still not great; furthermore it's annoying
because it breaks programs checking that they are not granted any
capabilities (e.g. bubblewrap).

Fix this behaviour by adding a patch that causes kwin_wayland to lower
CAP_SYS_NICE from the ambient capability set at startup. That way,
expected upstream behaviour is restored.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
