### PR TITLE
roundcubePlugins.contextmenu: init at 3.3.1

### DIFF
--- a/pkgs/servers/roundcube/plugins/contextmenu/default.nix
+++ b/pkgs/servers/roundcube/plugins/contextmenu/default.nix
@@ -1,0 +1,11 @@
+{ roundcubePlugin, fetchzip }:
+
+roundcubePlugin rec {
+  pname = "contextmenu";
+  version = "3.3.1";
+
+  src = fetchzip {
+    url = "https://github.com/johndoh/roundcube-contextmenu/archive/refs/tags/${version}.tar.gz";
+    sha256 = "0aya3nv8jwfvd9rlvxfxnyfpdcpw858745xal362l3zzkbkhcrmb";
+  };
+}

--- a/pkgs/servers/roundcube/plugins/plugins.nix
+++ b/pkgs/servers/roundcube/plugins/plugins.nix
@@ -6,5 +6,6 @@
   roundcubePlugin = callPackage ./roundcube-plugin.nix { };
 
   carddav = callPackage ./carddav { };
+  contextmenu = callPackage ./contextmenu { };
   persistent_login = callPackage ./persistent_login { };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adding another roundcube mail plugin: contextmenu.
I added it in the same way the other existing plugins were added, which seem a really stripped down `default.nix` inside the `plugins` folder of the roundcube package.

Original plugin is maintained on github at https://github.com/johndoh/roundcube-contextmenu

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Successfully tested it on an nginx virtualhost using:
```
root = pkgs.roundcube.withPlugins (plugins: with plugins; [ contextmenu ]);
```