### PR TITLE
netbird: init at 0.8.6

### DIFF
--- a/pkgs/tools/networking/netbird/default.nix
+++ b/pkgs/tools/networking/netbird/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, pkg-config
+, xorg
+, gtk3
+, libayatana-appindicator-gtk3
+}:
+buildGoModule rec {
+  pname = "netbird";
+  version = "0.8.6";
+
+  src = fetchFromGitHub {
+    owner = "netbirdio";
+    repo = "netbird";
+    rev = "v${version}";
+    sha256 = "sha256-O/RfaDHiyzY3h4ubIFRgb6Tgge+bnZSfUb3X0wKGAnA";
+  };
+
+  buildInputs = [
+    xorg.libX11
+    xorg.libXcursor
+    xorg.libXrandr
+    xorg.libXxf86vm
+    xorg.libXinerama
+    gtk3
+    libayatana-appindicator-gtk3
+  ];
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  vendorSha256 = "sha256-KtRQwrCBsOX7Jk9mKdDNOD7zfssADfBXCO1RPZbp5Aw=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/netbirdio/netbird/client/system.version=${version}"
+    "-X main.commit=${src.rev}"
+  ];
+
+  doCheck = false;
+
+  postInstall = ''
+    mv $out/bin/client $out/bin/netbird
+    mv $out/bin/management $out/bin/netbird-mgmt
+    mv $out/bin/migration $out/bin/netbird-migration
+    mv $out/bin/signal $out/bin/netbird-signal
+    mv $out/bin/ui $out/bin/netbird-ui
+  '';
+
+  meta = with lib; {
+    description = "Connect your devices into a single secure private WireGuard®-based mesh network";
+    homepage = "https://netbird.io/";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ dit7ya ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24077,6 +24077,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) AppKit Security;
   };
 
+  netbird = callPackage ../tools/networking/netbird { };
+
   nettools = if stdenv.isLinux
     then callPackage ../os-specific/linux/net-tools { }
     else unixtools.nettools;


### PR DESCRIPTION
###### Description of changes


NetBird is an open-source VPN management platform built on top of WireGuard® making it easy to create secure private networks for your organization or home.

https://github.com/netbirdio/netbird

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
