### PR TITLE
Fix GDB static compile

### DIFF
--- a/pkgs/development/tools/misc/gdb/default.nix
+++ b/pkgs/development/tools/misc/gdb/default.nix
@@ -102,6 +102,7 @@ stdenv.mkDerivation rec {
     "--with-auto-load-safe-path=${builtins.concatStringsSep ":" safePaths}"
   ] ++ lib.optional (!pythonSupport) "--without-python"
     ++ lib.optional stdenv.hostPlatform.isMusl "--disable-nls"
+    ++ lib.optional stdenv.hostPlatform.isStatic "--disable-inprocess-agent"
     ++ lib.optional enableDebuginfod "--with-debuginfod=yes";
 
   postInstall =


### PR DESCRIPTION
###### Description of changes
Fixes the following issue
```console
[host@user:/nix/pkgs]$ nix build .\#pkgsStatic.gdb
checking size of unsigned long long...   CXXLD  libinproctrace.so
/nix/store/gzms61swp55fg5qbvshyqv5jfsnfvybz-x86_64-unknown-linux-musl-binutils-2.38/bin/x86_64-unknown-linux-musl-ld: /nix/store/dnmh1aj0kd60qz8yl4srak8kn2bspbxc-x86_64-unknown-linux-musl-stage-final-gcc-11.3.0/lib/gcc/x86_64-unknown-linux-musl/11.3.0/crtbeginT.o: relocation R_X86_64_32 against hidden symbol `__TMC_END__' can not be used when making a shared object
/nix/store/gzms61swp55fg5qbvshyqv5jfsnfvybz-x86_64-unknown-linux-musl-binutils-2.38/bin/x86_64-unknown-linux-musl-ld: failed to set dynamic section sizes: bad value
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:383: libinproctrace.so] Error 1
make[2]: *** Waiting for unfinished jobs....
8
checking size of unsigned long... make[2]: Leaving directory '/build/gdb-12.1/_build/gdbserver'
make[1]: *** [Makefile:11064: all-gdbserver] Error 2
```

Questions:
- Do we still need `"--disable-shared" "--enable-static"`? (They didn't help here anyway is what I'm asking, and inprocess trace isn't static).
- The result is very large (bin is 611M, lib is ~27M, the rest isn't that big):
  ```console
  [host@user:~]$ du -sh result/bin/* --total
  3.5K    result/bin/gcore
  31M     result/bin/gdb
  8.0K    result/bin/gdb-add-index
  944K    result/bin/gdbserver
  20M     result/bin/run-aarch64
  20M     result/bin/run-arm
  19M     result/bin/run-avr
  20M     result/bin/run-bfin
  20M     result/bin/run-bpf
  20M     result/bin/run-cr16
  20M     result/bin/run-cris
  20M     result/bin/run-d10v
  6.4M    result/bin/run-erc32
  21M     result/bin/run-frv
  20M     result/bin/run-ft32
  21M     result/bin/run-h8300
  20M     result/bin/run-iq2000
  20M     result/bin/run-lm32
  19M     result/bin/run-m32c
  20M     result/bin/run-m32r
  20M     result/bin/run-m68hc11
  20M     result/bin/run-mcore
  20M     result/bin/run-microblaze
  20M     result/bin/run-mips
  20M     result/bin/run-mn10300
  20M     result/bin/run-moxie
  20M     result/bin/run-msp430
  20M     result/bin/run-or1k
  7.6M    result/bin/run-ppc
  20M     result/bin/run-pru
  20M     result/bin/run-riscv
  19M     result/bin/run-rl78
  19M     result/bin/run-rx
  20M     result/bin/run-sh
  20M     result/bin/run-v850
  6.4M    result/bin/sis
  611M    total
  ```
  I'm wondering because of sharing with colleagues if I can presumably just not share the `run-*` binaries.  I don't actually know what the `run-*` binaries do, they take up a lot of space, and presumably not necessary if I'm using OpenOCD (this all came around because I'm wanting to have a static OpenOCD and GDB I can give to colleagues).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
