### PR TITLE
home-assistant: 2022.8.1 -> 2022.8.2

### DIFF
--- a/pkgs/development/python-modules/bellows/default.nix
+++ b/pkgs/development/python-modules/bellows/default.nix
@@ -17,14 +17,14 @@
 
 buildPythonPackage rec {
   pname = "bellows";
-  version = "0.31.2";
+  version = "0.31.3";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "zigpy";
     repo = "bellows";
     rev = "refs/tags/${version}";
-    sha256 = "sha256-CAah1Yu3gbHcqHbTM1nXAVFqGKatdUNYt881sjsCD2o=";
+    sha256 = "sha256-h0hGTT8ipZZ3l/B6I/O74hFpRzaxj5vUBMbM/xX0dq4=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/colorzero/default.nix
+++ b/pkgs/development/python-modules/colorzero/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pkginfo
+, sphinxHook
+, sphinx-rtd-theme
+, pytestCheckHook
+}:
+
+
+buildPythonPackage rec {
+  pname = "colorzero";
+  version = "2.0";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "waveform80";
+    repo = pname;
+    rev = "refs/tags/release-${version}";
+    hash = "sha256-0NoQsy86OHQNLZsTEuF5s2MlRUoacF28jNeHgFKAH14=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "--cov" ""
+  '';
+
+  outputs = [
+    "out"
+    "doc"
+  ];
+
+  nativeBuildInputs = [
+    pkginfo
+    sphinx-rtd-theme
+    sphinxHook
+  ];
+
+  pythonImportsCheck = [
+    "colorzero"
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Yet another Python color library";
+    homepage = "https://github.com/waveform80/colorzero";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/development/python-modules/gpiozero/default.nix
+++ b/pkgs/development/python-modules/gpiozero/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, sphinx-rtd-theme
+, sphinxHook
+, colorzero
+, mock
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "gpiozero";
+  version = "1.6.2";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "gpiozero";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-dmFc3DNTlEajYQ5e8QK2WfehwYwAsWyG2cxKg5ykEaI=";
+  };
+
+  outputs = [
+    "out"
+    "doc"
+  ];
+
+  nativeBuildInputs = [
+    sphinx-rtd-theme
+    sphinxHook
+  ];
+
+  propagatedBuildInputs = [
+    colorzero
+  ];
+
+  pythonImportsCheck = [
+    "gpiozero"
+    "gpiozero.tools"
+  ];
+
+  checkInputs = [
+    mock
+    pytestCheckHook
+  ];
+
+
+  meta = with lib; {
+    description = "A simple interface to GPIO devices with Raspberry Pi";
+    homepage = "https://github.com/gpiozero/gpiozero";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/development/python-modules/greeclimate/default.nix
+++ b/pkgs/development/python-modules/greeclimate/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "greeclimate";
-  version = "1.2.1";
+  version = "1.3.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.6";
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "cmroche";
     repo = "greeclimate";
     rev = "refs/tags/v${version}";
-    hash = "sha256-SvAvLxWk/IIlkv54cUVN6FXj9rrM0QPKHAk36+PuqP0=";
+    hash = "sha256-4kR3Hc5M4FDG/WFtIW20a9d0vwLzmqtrlhd+teMiejA=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/zigpy-zigate/default.nix
+++ b/pkgs/development/python-modules/zigpy-zigate/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, gpiozero
 , mock
 , pyserial
 , pyserial-asyncio
@@ -13,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "zigpy-zigate";
-  version = "0.9.0";
+  version = "0.9.1";
   format = "setuptools";
 
   disabled = pythonOlder "3.8";
@@ -21,11 +22,12 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "zigpy";
     repo = "zigpy-zigate";
-    rev = "v${version}";
-    hash = "sha256-rFmcgfn87XS1fvbSdJG6pItXRMkeogp4faKMe7pCxkM=";
+    rev = "refs/tags/${version}";
+    hash = "sha256-H1R+wNUo/J5ATINHrkC4mJ8KKnBxVZUvF6X7y54aiVQ=";
   };
 
   propagatedBuildInputs = [
+    gpiozero
     pyserial
     pyserial-asyncio
     pyusb

--- a/pkgs/development/python-modules/zigpy/default.nix
+++ b/pkgs/development/python-modules/zigpy/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "zigpy";
-  version = "0.48.0";
+  version = "0.49.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     owner = "zigpy";
     repo = "zigpy";
     rev = "refs/tags/${version}";
-    sha256 = "sha256-usO5d2JLZ7tochQXmxEfRgxaW1KJew3RVbfWnew+bP4=";
+    sha256 = "sha256-mCqRqi7AUsrvfSOHyfK+WVj/4D7/4RDOYFWveS+tS/A=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2022.8.1";
+  version = "2022.8.2";
   components = {
     "abode" = ps: with ps; [
       abodepy
@@ -1048,7 +1048,9 @@
     "graphite" = ps: with ps; [
     ];
     "gree" = ps: with ps; [
+      aiohttp-cors
       greeclimate
+      ifaddr
     ];
     "greeneye_monitor" = ps: with ps; [
       greeneye-monitor
@@ -2235,7 +2237,8 @@
     "remote" = ps: with ps; [
     ];
     "remote_rpi_gpio" = ps: with ps; [
-    ]; # missing inputs: gpiozero pigpio
+      gpiozero
+    ]; # missing inputs: pigpio
     "renault" = ps: with ps; [
       renault-api
     ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -112,9 +112,6 @@ let
       hass-nabucasa = super.hass-nabucasa.overridePythonAttrs (oldAttrs: {
         doCheck = false; # requires aiohttp>=1.0.0
       });
-      pydeconz = super.pydeconz.overridePythonAttrs (oldAttrs: {
-        doCheck = false; # requires pytest-aiohttp>=1.0.0
-      });
       pynws = super.pynws.overridePythonAttrs (oldAttrs: {
         doCheck = false; # requires pytest-aiohttp>=1.0.0
       });
@@ -185,6 +182,20 @@ let
         };
       });
     })
+
+    (self: super: {
+      pydeconz = super.pydeconz.overridePythonAttrs (oldAttrs: rec {
+        version = "102";
+        src = fetchFromGitHub {
+          owner = "Kane610";
+          repo = "deconz";
+          rev = "refs/tags/v${version}";
+          hash = "sha256-Dbhp/+xyyWhFcYp2VRnivn5d1JMR5hBctdArIzLKIjM=";
+        };
+        doCheck = false; # requires pytest-aiohttp>=1.0.0
+      });
+    })
+
 
     (self: super: {
       python-slugify = super.python-slugify.overridePythonAttrs (oldAttrs: rec {
@@ -296,7 +307,7 @@ let
   extraPackagesFile = writeText "home-assistant-packages" (lib.concatMapStringsSep "\n" (pkg: pkg.pname) extraBuildInputs);
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "2022.8.1";
+  hassVersion = "2022.8.2";
 
 in python.pkgs.buildPythonApplication rec {
   pname = "homeassistant";
@@ -314,7 +325,7 @@ in python.pkgs.buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = version;
-    hash = "sha256-0QhWusJ7vSiudigJTo4KiXqO0OWgIlvqkSpiK5FFI+g=";
+    hash = "sha256-82UPZmaSJVO0kmlGuY08vS3y5ai0NtSQ7ntkiOcNc2A=";
   };
 
   # leave this in, so users don't have to constantly update their downstream patch handling

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1894,6 +1894,8 @@ in {
 
   colorthief = callPackage ../development/python-modules/colorthief { };
 
+  colorzero = callPackage ../development/python-modules/colorzero { };
+
   colour = callPackage ../development/python-modules/colour { };
 
   cometblue-lite = callPackage ../development/python-modules/cometblue-lite { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3774,6 +3774,8 @@ in {
 
   gpapi = callPackage ../development/python-modules/gpapi { };
 
+  gpiozero = callPackage ../development/python-modules/gpiozero { };
+
   gplaycli = callPackage ../development/python-modules/gplaycli { };
 
   gpgme = toPythonModule (pkgs.gpgme.override {


### PR DESCRIPTION
https://github.com/home-assistant/core/releases/tag/2022.8.2

zigpy-zigate wanted gpiozero, which wanted colorzero.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
