### PR TITLE
fancy-motd: unstable-2022-06-06 -> unstable-2022-11-08 

### DIFF
--- a/pkgs/tools/system/fancy-motd/default.nix
+++ b/pkgs/tools/system/fancy-motd/default.nix
@@ -1,21 +1,21 @@
-{ stdenv, lib, fetchFromGitHub, bc, curl, figlet, fortune, gawk, iproute2, procps }:
+{ stdenv, lib, fetchFromGitHub, bc, curl, figlet, fortune, gawk, iproute2, lm_sensors, procps }:
 
 stdenv.mkDerivation rec {
   pname = "fancy-motd";
-  version = "unstable-2022-06-06";
+  version = "unstable-2022-11-08";
 
   src = fetchFromGitHub {
     owner = "bcyran";
     repo = pname;
-    rev = "812c58f04f65053271f866f3797baa2eba7324f5";
-    sha256 = "sha256-O/euB63Dyj+NyfZK42egSEYwZhL8B0jCxSSDYoT4cpo=";
+    rev = "1573a60d780ff12f03dbff602ceaf97755910079";
+    sha256 = "sha256-mPd2aum/wsdlvEhjikeJNwZN/BArwX4h0VQROF925hg=";
   };
 
-  buildInputs = [ bc curl figlet fortune gawk iproute2 ];
+  buildInputs = [ bc curl figlet fortune gawk iproute2 lm_sensors ];
 
   postPatch = ''
     substituteInPlace motd.sh \
-      --replace 'BASE_DIR="$(dirname "$(readlink -f "$0")")"' "BASE_DIR=\"$out/lib\""
+      --replace 'BASE_DIR=$(dirname "$(readlink -f "$0")")' "BASE_DIR=\"$out/lib\""
 
     substituteInPlace modules/20-uptime \
       --replace "uptime -p" "${procps}/bin/uptime -p"


### PR DESCRIPTION
###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
