### PR TITLE
bmake: 20220208 -> 20220726

### DIFF
--- a/pkgs/development/tools/build-managers/bmake/default.nix
+++ b/pkgs/development/tools/build-managers/bmake/default.nix
@@ -10,11 +10,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "bmake";
-  version = "20220208";
+  version = "20220726";
 
   src = fetchurl {
     url = "http://www.crufty.net/ftp/pub/sjg/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
-    hash = "sha256-ewDB4UYrLh5Upk2ND88n/HfursPxOSDv+NlST/BZ1to=";
+    hash = "sha256-G/N3B4lyJyHcp7C/+K/EqVINog8CGbt7xSNQrwEz8KA=";
   };
 
   # Make tests work with musl
@@ -60,10 +60,15 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # Disabled tests:
+  # opt-chdir: ofborg complains about it somehow
+  # opt-keep-going-indirect: not yet known
   # varmod-localtime: musl doesn't support TZDIR and this test relies on impure,
   # implicit paths
-  # opt-chdir: ofborg complains about it somehow
-  BROKEN_TESTS = "varmod-localtime opt-chdir";
+  BROKEN_TESTS = builtins.concatStringsSep " " [
+    "opt-chdir"
+    "opt-keep-going-indirect"
+    "varmod-localtime"
+  ];
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/development/tools/build-managers/bmake/default.nix
+++ b/pkgs/development/tools/build-managers/bmake/default.nix
@@ -110,7 +110,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.bsd3;
     maintainers = with maintainers; [ thoughtpolice AndersonTorres ];
     platforms = platforms.unix;
-    broken = with stdenv; isAarch64 && !isDarwin; # ofborg complains
   };
 
   passthru.tests.bmakeMusl = pkgsMusl.bmake;

--- a/pkgs/development/tools/build-managers/bmake/default.nix
+++ b/pkgs/development/tools/build-managers/bmake/default.nix
@@ -8,12 +8,12 @@
 , pkgsMusl # for passthru.tests
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "bmake";
   version = "20220208";
 
   src = fetchurl {
-    url = "http://www.crufty.net/ftp/pub/sjg/${pname}-${version}.tar.gz";
+    url = "http://www.crufty.net/ftp/pub/sjg/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
     hash = "sha256-ewDB4UYrLh5Upk2ND88n/HfursPxOSDv+NlST/BZ1to=";
   };
 
@@ -109,5 +109,5 @@ stdenv.mkDerivation rec {
   };
 
   passthru.tests.bmakeMusl = pkgsMusl.bmake;
-}
+})
 # TODO: report the quirks and patches to bmake devteam (especially the Musl one)


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
