### PR TITLE
surelog: init at 1.35

### DIFF
--- a/pkgs/development/compilers/surelog/default.nix
+++ b/pkgs/development/compilers/surelog/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, python310Packages
+, jdk11
+, libunwind
+, libuuid
+, gperftools
+}:
+
+stdenv.mkDerivation rec {
+  pname = "surelog";
+  version = "1.35";
+
+  src = fetchFromGitHub {
+    owner = "chipsalliance";
+    repo = "Surelog";
+    rev = "b2e6116912c4de39fdcdcb753695fd5b0481b2cb";
+    hash = "sha256-2ktVE3XHV4+KEe7AtvqqpJKnpi1Pvwnt13t8MeL/g9Q=";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [
+    libunwind
+    libuuid
+    gperftools                # tcmalloc for more performant parsing
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    jdk11                     # For antlr grammar code generation
+    python310Packages.python  # For various surelog/UHDM code generation
+    python310Packages.orderedmultidict
+    python310Packages.psutil
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+  ];
+
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+    make -j $NIX_BUILD_CORES UnitTests
+    ctest --output-on-failure
+    runHook postCheck
+    '';
+
+  meta = with lib; {
+    homepage = "https://github.com/chipsalliance/Surelog";
+    description = "SystemVerilog 2017 Pre-processor, Parser, Elaborator, UHDM Compiler";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ hzeller ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30772,6 +30772,8 @@ with pkgs;
 
   subunit = callPackage ../development/libraries/subunit { };
 
+  surelog = callPackage ../development/compilers/surelog { };
+
   surf = callPackage ../applications/networking/browsers/surf { gtk = gtk2; };
 
   surge = callPackage ../applications/audio/surge {


### PR DESCRIPTION
###### Description of changes

New package.

Surelog is a SystemVerilog 2017 Pre-processor, Parser,
Elaborator, and UHDM Compiler.

URL: https://github.com/chipsalliance/Surelog

It is used to parse the hardware description language
SystemVerilog and provide an intermediate format (UHDM) that
then can be used in other tools that need SystemVerilog
support for FPGAs and ASICs. There is a plug-in for Yosys
that can use it (will package separately)

Part of an effort to get more hardware development software readily
installable in nixos.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable
     - included `checkPhase`, that runs the unit tests.
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage) 
_does not apply, new package, no dependencies yet_
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
