### PR TITLE
bundler: 2.3.9 -> 2.3.20

### DIFF
--- a/pkgs/development/ruby-modules/bundler/default.nix
+++ b/pkgs/development/ruby-modules/bundler/default.nix
@@ -4,8 +4,8 @@ buildRubyGem rec {
   inherit ruby;
   name = "${gemName}-${version}";
   gemName = "bundler";
-  version = "2.3.9";
-  source.sha256 = "sha256-VZiKuSDP3sSoBXUPcPmwHR/GbZs47NIF+ZlXtHSZWzg=";
+  version = "2.3.20";
+  source.sha256 = "sha256-gJJ3vHzrJo6XpHS1iwLb77jd9ZB39GGLcOJQSrgaBHw=";
   dontPatchShebangs = true;
 
   postFixup = ''


### PR DESCRIPTION
###### Description of changes

See https://github.com/rubygems/rubygems/blob/master/bundler/CHANGELOG.md

* https://github.com/rubygems/rubygems/blob/3.3/bundler/CHANGELOG.md#2320-august-10-2022
* https://github.com/rubygems/rubygems/blob/3.3/bundler/CHANGELOG.md#2319-july-27-2022
* https://github.com/rubygems/rubygems/blob/3.3/bundler/CHANGELOG.md#2318-july-14-2022
* https://github.com/rubygems/rubygems/blob/3.3/bundler/CHANGELOG.md#2317-june-29-2022
* https://github.com/rubygems/rubygems/blob/3.3/bundler/CHANGELOG.md#2316-june-15-2022
* https://github.com/rubygems/rubygems/blob/3.3/bundler/CHANGELOG.md#2315-june-1-2022
* https://github.com/rubygems/rubygems/blob/3.3/bundler/CHANGELOG.md#2314-may-18-2022
* https://github.com/rubygems/rubygems/blob/3.3/bundler/CHANGELOG.md#2313-may-4-2022
* https://github.com/rubygems/rubygems/blob/3.3/bundler/CHANGELOG.md#2312-april-20-2022
* https://github.com/rubygems/rubygems/blob/3.3/bundler/CHANGELOG.md#2311-april-7-2022
* https://github.com/rubygems/rubygems/blob/3.3/bundler/CHANGELOG.md#2310-march-23-2022


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
