### PR TITLE
darwin.cctools: 949.0.1 -> 973.0.1

### DIFF
--- a/pkgs/os-specific/darwin/cctools/darwin-no-memstream.patch
+++ b/pkgs/os-specific/darwin/cctools/darwin-no-memstream.patch
@@ -1,0 +1,21 @@
+MacOS SDKs before 10.13 don't support open_memstream. This is already replaced
+by a runtime check in cctools-port, but because we build with SDK 10.12 by
+default, linking still fails for us. Disable it entirely here.
+
+--- a/cctools/include/stuff/diagnostics.h
++++ b/cctools/include/stuff/diagnostics.h
+@@ -60,13 +60,6 @@ void diagnostics_log_msg(enum diagnostic_level level, const char* message);
+  */
+ void diagnostics_write(void);
+ 
+-#if defined(__APPLE__ ) && defined(__has_builtin)
+-#  if __has_builtin(__builtin_available)
+-#    define HAVE_OPENMEMSTREAM_RUNTIME __builtin_available(macOS 10.13, *)
+-#  endif
+-#endif
+-#ifndef HAVE_OPENMEMSTREAM_RUNTIME
+-#  define HAVE_OPENMEMSTREAM_RUNTIME 1
+-#endif
++#define HAVE_OPENMEMSTREAM_RUNTIME 0
+ 
+ #endif /* diagnostics_h */

--- a/pkgs/os-specific/darwin/cctools/port.nix
+++ b/pkgs/os-specific/darwin/cctools/port.nix
@@ -19,13 +19,17 @@ assert (!stdenv.hostPlatform.isDarwin) -> maloader != null;
 
 stdenv.mkDerivation {
   pname = "${targetPrefix}cctools-port";
-  version = "949.0.1";
+  version = "973.0.1";
 
   src = fetchFromGitHub {
     owner  = "tpoechtrager";
     repo   = "cctools-port";
-    rev    = "43f32a4c61b5ba7fde011e816136c550b1b3146f";
-    sha256 = "10yc5smiczzm62q6ijqccc58bwmfhc897f3bwa5i9j98csqsjj0k";
+    # This is the commit before: https://github.com/tpoechtrager/cctools-port/pull/114
+    # That specific change causes trouble for us (see the PR discussion), but
+    # is also currently the last commit on master at the time of writing, so we
+    # can just go back one step.
+    rev    = "457dc6ddf5244ebf94f28e924e3a971f1566bd66";
+    sha256 = "0ns12q7vg9yand4dmdsps1917cavfbw67yl5q7bm6kb4ia5kkx13";
   };
 
   outputs = [ "out" "dev" "man" ];
@@ -35,7 +39,11 @@ stdenv.mkDerivation {
     ++ lib.optionals stdenv.isDarwin [ libobjc ]
     ++ lib.optional enableTapiSupport libtapi;
 
-  patches = [ ./ld-ignore-rpath-link.patch ./ld-rpath-nonfinal.patch ];
+  patches = [
+    ./ld-ignore-rpath-link.patch
+    ./ld-rpath-nonfinal.patch
+  ]
+    ++ lib.optional stdenv.isDarwin ./darwin-no-memstream.patch;
 
   __propagatedImpureHostDeps = [
     # As far as I can tell, otool from cctools is the only thing that depends on these two, and we should fix them
@@ -64,32 +72,99 @@ stdenv.mkDerivation {
       --replace "-isystem /usr/local/include -isystem /usr/pkg/include" "" \
       --replace "-L/usr/local/lib" "" \
 
-    substituteInPlace cctools/include/Makefile \
-      --replace "/bin/" ""
+    # Appears to use new libdispatch API not available in macOS SDK 10.12.
+    substituteInPlace cctools/ld64/src/ld/libcodedirectory.c \
+      --replace "#define LIBCD_PARALLEL 1" ""
 
     patchShebangs tools
     sed -i -e 's/which/type -P/' tools/*.sh
-
-    # Workaround for https://www.sourceware.org/bugzilla/show_bug.cgi?id=11157
-    cat > cctools/include/unistd.h <<EOF
-    #ifdef __block
-    #  undef __block
-    #  include_next "unistd.h"
-    #  define __block __attribute__((__blocks__(byref)))
-    #else
-    #  include_next "unistd.h"
-    #endif
-    EOF
 
     cd cctools
   '';
 
   preInstall = ''
-    pushd include
-    make DSTROOT=$out/include RC_OS=common install
+    installManPage ar/ar.{1,5}
+
+    # The makefile rules for installing headers are missing in 973.0.1.
+    # The below is derived from 949.0.1.
+    mkdir -p $dev/include/mach-o/i386
+    mkdir -p $dev/include/mach-o/ppc
+    mkdir -p $dev/include/mach-o/x86_64
+    mkdir -p $dev/include/mach-o/arm
+    mkdir -p $dev/include/mach-o/arm64
+    mkdir -p $dev/include/mach-o/m68k
+    mkdir -p $dev/include/mach-o/sparc
+    mkdir -p $dev/include/mach-o/hppa
+    mkdir -p $dev/include/mach-o/i860
+    mkdir -p $dev/include/mach-o/m88k
+    mkdir -p $dev/include/dyld
+    mkdir -p $dev/include/cbt
+
+    pushd include/mach-o
+    install -c -m 444  arch.h ldsyms.h reloc.h \
+      stab.h loader.h fat.h swap.h getsect.h nlist.h \
+      ranlib.h $dev/include/mach-o
     popd
 
-    installManPage ar/ar.{1,5}
+    pushd include/mach-o/i386
+    install -c -m 444  swap.h \
+      $dev/include/mach-o/i386
+    popd
+
+    pushd include/mach-o/ppc
+    install -c -m 444  reloc.h swap.h \
+      $dev/include/mach-o/ppc
+    popd
+
+    pushd include/mach-o/x86_64
+    install -c -m 444  reloc.h \
+      $dev/include/mach-o/x86_64
+    popd
+
+    pushd include/mach-o/arm
+    install -c -m 444  reloc.h \
+      $dev/include/mach-o/arm
+    popd
+
+    pushd include/mach-o/arm64
+    install -c -m 444  reloc.h \
+      $dev/include/mach-o/arm64
+    popd
+
+    pushd include/mach-o/m68k
+    install -c -m 444  swap.h \
+      $dev/include/mach-o/m68k
+    popd
+
+    pushd include/mach-o/sparc
+    install -c -m 444  reloc.h swap.h \
+      $dev/include/mach-o/sparc
+    popd
+
+    pushd include/mach-o/hppa
+    install -c -m 444  reloc.h swap.h \
+      $dev/include/mach-o/hppa
+    popd
+
+    pushd include/mach-o/i860
+    install -c -m 444  reloc.h swap.h \
+      $dev/include/mach-o/i860
+    popd
+
+    pushd include/mach-o/m88k
+    install -c -m 444  reloc.h swap.h \
+      $dev/include/mach-o/m88k
+    popd
+
+    pushd include/stuff
+    install -c -m 444  bool.h \
+      $dev/include/dyld
+    popd
+
+    pushd include/cbt
+    install -c -m 444  libsyminfo.h \
+      $dev/include/cbt
+    popd
   '';
 
   passthru = {


### PR DESCRIPTION
###### Description of changes

I originally did this to see if I could fix a linker assertion failure I'm seeing, but it unfortunately didn't help. Still, I believe the upgrade is useful by itself, if only so we take upgrades step-by-step?

Did a successful rebuild of stdenv on x86_64-darwin.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).