### PR TITLE
emacs: allow disabling compressed install

### DIFF
--- a/pkgs/applications/editors/emacs/generic.nix
+++ b/pkgs/applications/editors/emacs/generic.nix
@@ -32,6 +32,7 @@
 , withPgtk ? false
 , withXinput2 ? false
 , withImageMagick ? lib.versionOlder version "27" && (withX || withNS)
+, withCompressInstall ? true
 , toolkit ? (
   if withGTK2 then "gtk2"
   else if withGTK3 then "gtk3"
@@ -163,6 +164,7 @@ let emacs = stdenv.mkDerivation (lib.optionalAttrs nativeComp {
     ++ lib.optional withPgtk "--with-pgtk"
     ++ lib.optional withXinput2 "--with-xinput2"
     ++ lib.optional (!withToolkitScrollBars) "--without-toolkit-scroll-bars"
+    ++ lib.optional (!withCompressInstall) "--without-compress-install"
   ;
 
   installTargets = [ "tags" "install" ];


### PR DESCRIPTION
###### Description of changes

See https://github.com/syl20bnr/spacemacs/issues/11585 and
https://mail.gnu.org/archive/html/emacs-devel/2022-08/msg00234.html
for motivation.

It's common for Emacs configs to have a line such as
`(setq file-name-handler-alist nil)`, which optimizes early loading of packages,
until a further point where the variable is restored. Both Spacemacs and Doom
Emacs do this. However, it means anything other than plain text (e. g. compressed
.el.gz files) cannot be understood by Emacs until the value is reset. It used to
due to a bug where compressed files where treated differently regardless of
`file-name-alist`, but that's recently been fixed, breaking compressed install
such as nix's with a cryptic `(void-variable \233)` error. This not an issue for
the Emacs 28 present in this repo, but emacs-overlay has been broken for quite
a while now.

This allows the user to opt out of compression, making the optimization work again.
It should probably be mentioned in the manual or emacs-overlay as well.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).