### PR TITLE
deploy-rs: 2022-05-26 -> 2022-08-05

### DIFF
--- a/pkgs/tools/package-management/deploy-rs/default.nix
+++ b/pkgs/tools/package-management/deploy-rs/default.nix
@@ -1,17 +1,17 @@
 { stdenv, lib, fetchFromGitHub, rustPlatform, CoreServices, SystemConfiguration }:
 
 rustPlatform.buildRustPackage rec {
-  pname = "deploy-rs-unstable";
-  version = "2022-05-26";
+  pname = "deploy-rs";
+  version = "unstable-2022-08-05";
 
   src = fetchFromGitHub {
     owner = "serokell";
     repo = "deploy-rs";
-    rev = "184349d8149436748986d1bdba087e4149e9c160";
-    sha256 = "sha256-kJ0ENmnQJ4qL2FeYKZba9kvv1KmIuB3NVpBwMeI7AJQ=";
+    rev = "41f15759dd8b638e7b4f299730d94d5aa46ab7eb";
+    sha256 = "sha256-1ZxuK67TL29YLw88vQ18Y2Y6iYg8Jb7I6/HVzmNB6nM=";
   };
 
-  cargoHash = "sha256-Ocb1kwNDfODGceCaCJ16CTGGTxIQacgHQ3I6HIR/EUo=";
+  cargoHash = "sha256-IXmcpYcWmTGBVNwNCk1TMDOcLxkZytlEIILknUle3Rg=";
 
   buildInputs = lib.optionals stdenv.isDarwin [ CoreServices SystemConfiguration ];
 


### PR DESCRIPTION
###### Description of changes
- Fixed `pname` and `version` string, leftover from #182950 
- Changelog: https://github.com/serokell/deploy-rs/compare/184349d8149436748986d1bdba087e4149e9c160...41f15759dd8b638e7b4f299730d94d5aa46ab7eb



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
