### PR TITLE
paperless-ngx: update to 1.8.0, python3Packages.django-q: add gador as maintainer, switch to GitHub

### DIFF
--- a/pkgs/development/python-modules/django-q/default.nix
+++ b/pkgs/development/python-modules/django-q/default.nix
@@ -1,24 +1,82 @@
-{ lib, buildPythonPackage, fetchPypi, django-picklefield, arrow
-, blessed, django, future }:
+{ arrow
+, blessed
+, buildPythonPackage
+, croniter
+, django
+, django-redis
+, django-picklefield
+, fetchFromGitHub
+, future
+, lib
+, poetry-core
+, pytest-django
+, pytest-mock
+, pytestCheckHook
+, pkgs
+, stdenv
+}:
 
 buildPythonPackage rec {
   pname = "django-q";
   version = "1.3.9";
+  format = "pyproject";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "5c6b4d530aa3aabf9c6aa57376da1ca2abf89a1562b77038b7a04e52a4a0a91b";
+  src = fetchFromGitHub {
+    owner = "Koed00";
+    repo = "django-q";
+    sha256 = "sha256-gFSrAl3QGoJEJfvTTvLQgViPPjeJ6BfvgEwgLLo+uAA=";
+    rev = "v${version}";
   };
 
+  nativeBuildInputs = [ poetry-core ];
+
   propagatedBuildInputs = [
-    django-picklefield arrow blessed django future
+    django-picklefield
+    arrow
+    blessed
+    django
+    future
   ];
 
-  doCheck = false;
+  # fixes empty version string
+  # analog to https://github.com/NixOS/nixpkgs/pull/171200
+  patches = [
+    ./pep-621.patch
+  ];
+
+  pythonImportsCheck = [
+    "django_q"
+  ];
+
+  preCheck = ''
+    ${pkgs.redis}/bin/redis-server &
+    REDIS_PID=$!
+  '';
+
+  postCheck = ''
+    kill $REDIS_PID
+  '';
+
+  checkInputs = [
+    croniter
+    django-redis
+    pytest-django
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  # don't bother with two more servers to test
+  disabledTests = [
+    "test_disque"
+    "test_mongo"
+  ];
+
+  doCheck = !stdenv.isDarwin;
 
   meta = with lib; {
     description = "A multiprocessing distributed task queue for Django";
     homepage = "https://django-q.readthedocs.org";
     license = licenses.mit;
+    maintainers = with maintainers; [ gador ];
   };
 }

--- a/pkgs/development/python-modules/django-q/pep-621.patch
+++ b/pkgs/development/python-modules/django-q/pep-621.patch
@@ -1,0 +1,32 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index 9a83e90..0cdffaf 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,16 +1,12 @@
+-[tool.poetry]
++[project]
+ name = "django-q"
+ version = "1.3.9"
+ description = "A multiprocessing distributed task queue for Django"
+-authors = ["Ilan Steemers <koed00@gmail.com>"]
+-maintainers = ["Ilan Steemers <koed00@gmail.com>"]
+-license = "MIT"
++authors = [ { name = "Ilan Steemers", email = "koed00@gmail.com"} ]
++maintainers = [ { name = "Ilan Steemers", email = "koed00@gmail.com"} ]
++license.text = "MIT"
+ readme = 'README.rst'
+
+-repository = "https://github.com/koed00/django-q"
+-homepage = "https://django-q.readthedocs.org"
+-documentation = "https://django-q.readthedocs.org"
+-
+ keywords = ["django", "distributed", "multiprocessing", "queue", "scheduler"]
+
+ classifiers = [
+@@ -31,7 +27,6 @@ classifiers = [
+     'Topic :: System :: Distributed Computing',
+     'Topic :: Software Development :: Libraries :: Python Modules',
+ ]
+-include = ['CHANGELOG.md']
+
+ [tool.poetry.plugins] # Optional super table


### PR DESCRIPTION
###### Description of changes

Update paperless-ngx [Changelog](https://github.com/paperless-ngx/paperless-ngx/releases/tag/v1.8.0). I had to switch to `fetchFromGitHub` for django-q, so the override in paperless-ngx works.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
