### PR TITLE
Vulkan: 1.3.211.0 -> 1.3.216.0

### DIFF
--- a/pkgs/development/compilers/glslang/default.nix
+++ b/pkgs/development/compilers/glslang/default.nix
@@ -9,13 +9,13 @@
 }:
 stdenv.mkDerivation rec {
   pname = "glslang";
-  version = "1.3.211.0";
+  version = "1.3.216.0";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "glslang";
     rev = "sdk-${version}";
-    sha256 = "sha256-YLn/Mxuk6mXPGtBBgfwky5Nl1TCAW6i2g+AZLzqVz+A=";
+    hash = "sha256-sjidkiPtRADhyOEKDb2cHCBXnFjLwk2F5Lppv5/fwNQ=";
   };
 
   # These get set at all-packages, keep onto them for child drvs

--- a/pkgs/development/libraries/spirv-headers/default.nix
+++ b/pkgs/development/libraries/spirv-headers/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "spirv-headers";
-  version = "1.3.211.0";
+  version = "1.3.216.0";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "SPIRV-Headers";
     rev = "sdk-${version}";
-    sha256 = "sha256-LkIrTFWYvZffLVJJW3152um5LTEsMJEDEsIhBAdhBlk=";
+    hash = "sha256-qYhFoRrQOlvYvVXhIFsa3dZuORDpZyVC5peeYmGNimw=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/vulkan-headers/default.nix
+++ b/pkgs/development/libraries/vulkan-headers/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, cmake }:
 stdenv.mkDerivation rec {
   pname = "vulkan-headers";
-  version = "1.3.211.0";
+  version = "1.3.216.0";
 
   nativeBuildInputs = [ cmake ];
 
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     owner = "KhronosGroup";
     repo = "Vulkan-Headers";
     rev = "sdk-${version}";
-    sha256 = "sha256-FqrcFHsUS8e4ZgZpxVc8nNZWdNltniFmMjyyWVoNc7w=";
+    hash = "sha256-jHzW3m9smuzEGbZrSyBI74K9rFozxiG3M5Xql/WOw7U=";
   };
 
   meta = with lib; {

--- a/pkgs/development/libraries/vulkan-loader/default.nix
+++ b/pkgs/development/libraries/vulkan-loader/default.nix
@@ -3,14 +3,14 @@
 
 stdenv.mkDerivation rec {
   pname = "vulkan-loader";
-  version = "1.3.211.0";
+  version = "1.3.216.0";
 
   src = (assert version == vulkan-headers.version;
     fetchFromGitHub {
       owner = "KhronosGroup";
       repo = "Vulkan-Loader";
       rev = "sdk-${version}";
-      sha256 = "sha256-NQu98wA7UK231rpoKDs1yQ6pEyB4wZg7MjFC3JwS2BY=";
+      hash = "sha256-EcsJzY/R9rreWvYTgoxHNloR5n2xaR/0rouDJVAGaxs=";
     });
 
   patches = [ ./fix-pkgconfig.patch ];

--- a/pkgs/development/tools/spirv-tools/default.nix
+++ b/pkgs/development/tools/spirv-tools/default.nix
@@ -2,14 +2,16 @@
 
 stdenv.mkDerivation rec {
   pname = "spirv-tools";
-  version = "1.3.211.0";
+  version = "1.3.216.0";
 
-  src = fetchFromGitHub {
-    owner = "KhronosGroup";
-    repo = "SPIRV-Tools";
-    rev = "sdk-${version}";
-    sha256 = "sha256-DoE+UCJOTB8JidC208wgfV1trZC4r9uFvwRPUhJVaII=";
-  };
+  src = (assert version == spirv-headers.version;
+    fetchFromGitHub {
+      owner = "KhronosGroup";
+      repo = "SPIRV-Tools";
+      rev = "sdk-${version}";
+      hash = "sha256-NWpFSRoxtYWi+hLUt9gpw0YScM3shcUwv9yUmbivRb0=";
+    }
+  );
 
   nativeBuildInputs = [ cmake python3 ];
 

--- a/pkgs/development/tools/vulkan-validation-layers/default.nix
+++ b/pkgs/development/tools/vulkan-validation-layers/default.nix
@@ -22,7 +22,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "vulkan-validation-layers";
-  version = "1.3.211.0";
+  version = "1.3.216.0";
 
   # If we were to use "dev" here instead of headers, the setupHook would be
   # placed in that output instead of "out".
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
       owner = "KhronosGroup";
       repo = "Vulkan-ValidationLayers";
       rev = "sdk-${version}";
-      sha256 = "sha256-NGpFfekZtB0rvnGxYVDo808xzgBuo8ZC4bjXjQnTpxU=";
+      hash = "sha256-ri6ImAuskbvYL/ZM8kaVDZRP2v1qfSaafVacwwRF424=";
     });
 
   # Include absolute paths to layer libraries in their associated

--- a/pkgs/tools/graphics/vulkan-extension-layer/default.nix
+++ b/pkgs/tools/graphics/vulkan-extension-layer/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "vulkan-extension-layer";
-  version = "1.3.211.0";
+  version = "1.3.216.0";
 
   src = (assert version == vulkan-headers.version;
     fetchFromGitHub {
       owner = "KhronosGroup";
       repo = "Vulkan-ExtensionLayer";
       rev = "sdk-${version}";
-      sha256 = "sha256-ixCfHnp6YAOuR4NMTGjhhqkfm0H7ZcO/8xKFJqw16YE=";
+      hash = "sha256-h38LxV8G72Xxh44212IoGKQ0tKXwBnSpBjTB2gsr1zA=";
     });
 
   nativeBuildInputs = [ cmake jq ];

--- a/pkgs/tools/graphics/vulkan-tools-lunarg/default.nix
+++ b/pkgs/tools/graphics/vulkan-tools-lunarg/default.nix
@@ -23,14 +23,14 @@
 stdenv.mkDerivation rec {
   pname = "vulkan-tools-lunarg";
   # The version must match that in vulkan-headers
-  version = "1.3.211.0";
+  version = "1.3.216.0";
 
   src = (assert version == vulkan-headers.version;
     fetchFromGitHub {
       owner = "LunarG";
       repo = "VulkanTools";
       rev = "sdk-${version}";
-      sha256 = "sha256-Pkz2FV0AnTKm/4jVmkQNkYzpxpKJaSoy2fRAhVh5OKU=";
+      hash = "sha256-NhYQSL5iU7iSO5Q6lp1iwhbi5GEfD11MDmBn9Uk1jm0=";
       fetchSubmodules = true;
     });
 

--- a/pkgs/tools/graphics/vulkan-tools/default.nix
+++ b/pkgs/tools/graphics/vulkan-tools/default.nix
@@ -21,7 +21,7 @@
 
 stdenv.mkDerivation rec {
   pname = "vulkan-tools";
-  version = "1.3.211.0";
+  version = "1.3.216.0";
 
   # It's not strictly necessary to have matching versions here, however
   # since we're using the SDK version we may as well be consistent with
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
       owner = "KhronosGroup";
       repo = "Vulkan-Tools";
       rev = "sdk-${version}";
-      sha256 = "sha256-iXsWTKNllPZy1Kpo3JHzEEus3Hu9LofvMB3c4Gn6/DM=";
+      hash = "sha256-VEMeURNboiOwPGrtFGUt9ZyChj8pV0xcpydrarcwtF0=";
     });
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes

> This SDK supports Vulkan API revision 1.3.216. The prior SDK supported Vulkan API revision 1.3.211.
> https://vulkan.lunarg.com/doc/sdk/1.3.216.0/linux/release_notes.html

1. This is from June, so we're only two months late to the party.

2. Like the previous PR, this one updates:
  - glslang
  - spirv-headers
  - spirv-toools
  - vulkan-extension-layer
  - vulkan-headers
  - vulkan-loader
  - vulkan-tools
  - vulkan-tools-lunarg
  - vulkan-validation-layers

3. The past PR triggered 5k+ rebuilds, so I preferred applying it to staging this time.

4. I've added an assertion so the spirv-tools is always in built against compatible headers.

5. Since we're using "SRI hashes", adopt [what the wiki calls the preferred way](https://nixos.wiki/wiki/Nix_Hash#Usage).

###### Things done

Tested building `vulkan-tools`, which built `vulkan-headers-1.3.216.0`, `vulkan-loader-1.3.216`, and `glslang-1.3.216`. Building `vulkan-tools-lunarg` builds `vulkan-validation-layers-1.3.216`, that builds the spirv stack. I've built `vulkan-extension-layer` and that closed the testing...

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
