### PR TITLE
python310Packages.colormath: 3.0.0 -> unstable-2021-04-17

### DIFF
--- a/pkgs/development/python-modules/colormath/default.nix
+++ b/pkgs/development/python-modules/colormath/default.nix
@@ -8,19 +8,25 @@
 
 buildPythonPackage rec {
   pname = "colormath";
-  version = "3.0.0";
+  # Switch to unstable which fixes an deprecation issue with newer numpy
+  # versions, should be included in versions > 3.0
+  # https://github.com/gtaylor/python-colormath/issues/104
+  version = "unstable-2021-04-17";
 
   src = fetchFromGitHub {
     owner = "gtaylor";
-    rev = "3.0.0";
     repo = "python-colormath";
-    sha256 = "1nqf5wy8ikx2g684khzvjc4iagkslmbsxxwilbv4jpaznr9lahdl";
+    rev = "4a076831fd5136f685aa7143db81eba27b2cd19a";
+    sha256 = "sha256-eACVPIQFgiGiVmQ/PjUxP/UH/hBOsCywz5PlgpA4dk4=";
   };
 
   propagatedBuildInputs = [ networkx numpy ];
 
   checkInputs = [ nose ];
+
   checkPhase = "nosetests";
+
+  pythonImportsCheck = [ "colormath" ];
 
   meta = with lib; {
     description = "Color math and conversion library";


### PR DESCRIPTION
###### Description of changes

fix broken build with new numpy version https://hydra.nixos.org/build/186141553/nixlog/2
fixes should be included in versions later 3.0.
a single patch to solve this issue isn't available upstream, too many changes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
