### PR TITLE
[DRAFT] python310Packages.conda: 4.3.16 -> 4.14.0

### DIFF
--- a/pkgs/development/python-modules/conda/default.nix
+++ b/pkgs/development/python-modules/conda/default.nix
@@ -1,11 +1,13 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , pycosat
 , requests
 , ruamel-yaml
 , isPy3k
 , enum34
+, pytestCheckHook
+, ruamel-yaml-conda
 }:
 
 # Note: this installs conda as a library. The application cannot be used.
@@ -13,22 +15,35 @@
 
 buildPythonPackage rec {
   pname = "conda";
-  version = "4.3.16";
+  version = "4.14.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "a91ef821343dea3ba9670f3d10b36c1ace4f4c36d70c175d8fc8886e94285953";
+  src = fetchFromGitHub {
+    owner = "conda";
+    repo = "conda";
+    rev = version;
+    sha256 = "sha256-nmQP6K2eyT0t7KKKSE4hUVsxIhMoCCEpN5ktcs5I+Sk=";
   };
 
-  propagatedBuildInputs = [ pycosat requests ruamel-yaml ] ++ lib.optional (!isPy3k) enum34;
+  postPatch = ''
+    echo ${version} > conda/.version
+  '';
 
-  # No tests
-  doCheck = false;
+  propagatedBuildInputs = [
+    pycosat
+    requests
+    ruamel-yaml
+    ruamel-yaml-conda
+  ] ++ lib.optional (!isPy3k) enum34;
 
-  meta = {
+  checkInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "conda" ];
+
+  meta = with lib; {
     description = "OS-agnostic, system-level binary package manager";
     homepage = "https://github.com/conda/conda";
-    license = lib.licenses.bsd3;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ onny ];
   };
 
 }

--- a/pkgs/development/python-modules/ruamel-yaml-conda/default.nix
+++ b/pkgs/development/python-modules/ruamel-yaml-conda/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, cython
+, ruamel-base
+, ruamel-yaml
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "ruamel-yaml-conda";
+  version = "0.15.80";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "ruamel_yaml_conda";
+    sha256 = "sha256-0NPzPfxACF5G3mcptkwnknVVBKiZ7xqy5VIz+ILflWY=";
+  };
+
+  nativeBuildInputs = [ cython ];
+
+  propagatedBuildInputs = [
+    ruamel-base
+    ruamel-yaml
+  ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "ruamel-yaml-conda" ];
+
+  meta = with lib; {
+    description = ''
+      YAML parser/emitter that supports roundtrip preservation of comments,
+      seq/map flow style, and map key order
+    '';
+    homepage = "https://pypi.org/project/ruamel-yaml-conda";
+    license = licenses.mit;
+    maintainers = with maintainers; [ onny ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9519,6 +9519,8 @@ in {
 
   ruamel-yaml-clib = callPackage ../development/python-modules/ruamel-yaml-clib { };
 
+  ruamel-yaml-conda = callPackage ../development/python-modules/ruamel-yaml-conda { };
+
   rubymarshal = callPackage ../development/python-modules/rubymarshal { };
 
   ruffus = callPackage ../development/python-modules/ruffus { };


### PR DESCRIPTION
###### Description of changes

Currently conda tests fail with https://github.com/conda/conda/issues/7931
```
[...]
  File "/nix/store/xz8645jq7fkz3d7hrxd80854iscj6d8a-python3.10-pytest-7.1.2/lib/python3.10/site-packages/_pytest/assertion/rewrite.py", line 168, in exec_module
    exec(co, module.__dict__)
  File "/build/source/conda/testing/fixtures.py", line 8, in <module>
    from conda.gateways.disk.create import TemporaryDirectory
  File "/build/source/conda/gateways/disk/create.py", line 18, in <module>
    from .delete import path_is_clean, rm_rf
  File "/build/source/conda/gateways/disk/delete.py", line 16, in <module>
    from .link import islink, lexists
  File "/build/source/conda/gateways/disk/link.py", line 15, in <module>
    from ...exceptions import CondaOSError, ParseError
  File "/build/source/conda/exceptions.py", line 19, in <module>
    from .models.channel import Channel
  File "/build/source/conda/models/channel.py", line 13, in <module>
    from ..base.context import context, Context
  File "/build/source/conda/base/context.py", line 51, in <module>
    from ..common.configuration import (Configuration, ConfigurationLoadError, MapParameter,
  File "/build/source/conda/common/configuration.py", line 33, in <module>
    from .serialize import yaml_round_trip_load
  File "/build/source/conda/common/serialize.py", line 45, in <module>
    yaml.representer.RoundTripRepresenter.add_representer(odict, represent_ordereddict)
AttributeError: module 'ruamel_yaml' has no attribute 'representer'. Did you mean: 'Representer'?
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
