### PR TITLE
vulkan-caps-viewer: init at 3.24

### DIFF
--- a/pkgs/tools/graphics/vulkan-caps-viewer/default.nix
+++ b/pkgs/tools/graphics/vulkan-caps-viewer/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, qmake
+, vulkan-loader
+, wrapQtAppsHook
+, withX11 ? true
+, qtx11extras
+}:
+
+stdenv.mkDerivation rec {
+  pname = "vulkan-caps-viewer";
+  version = "3.24";
+
+  src = fetchFromGitHub {
+    owner = "SaschaWillems";
+    repo = "VulkanCapsViewer";
+    rev = "${version}";
+    hash = "sha256-BSydAPZ74rGzW4UA/aqL2K/86NTK/eZqc3MZUbdq7iU=";
+    # Note: this derivation strictly requires vulkan-header to be the same it was developed against.
+    # To help they put in a git-submodule.
+    # It works with older vulkan-loaders.
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    qmake
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    vulkan-loader
+  ] ++ lib.lists.optionals withX11 [ qtx11extras ];
+
+  patchPhase = ''
+    substituteInPlace vulkanCapsViewer.pro \
+      --replace '/usr/' "/"
+  '';
+
+  qmakeFlags = [
+    "DEFINES+=wayland"
+    "CONFIG+=release"
+  ]  ++ lib.lists.optionals withX11 [ "DEFINES+=X11" ];
+
+  installFlags = [ "INSTALL_ROOT=$(out)" ];
+
+  meta = with lib; {
+    description = "Vulkan hardware capability viewer";
+    longDescription = ''
+      Client application to display hardware implementation details for GPUs supporting the Vulkan API by Khronos.
+      The hardware reports can be submitted to a public online database that allows comparing different devices, browsing available features, extensions, formats, etc.
+    '';
+    homepage    = "https://vulkan.gpuinfo.org/";
+    platforms   = platforms.unix;
+    license     = licenses.gpl2Only;
+    maintainers = with maintainers; [ pedrohlc ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21634,6 +21634,8 @@ with pkgs;
   vtk = vtk_8;
   vtkWithQt5 = vtk_8_withQt5;
 
+  vulkan-caps-viewer = libsForQt5.callPackage ../tools/graphics/vulkan-caps-viewer { };
+
   vulkan-extension-layer = callPackage ../tools/graphics/vulkan-extension-layer { };
   vulkan-headers = callPackage ../development/libraries/vulkan-headers { };
   vulkan-loader = callPackage ../development/libraries/vulkan-loader { inherit (darwin) moltenvk; };


### PR DESCRIPTION
###### Description of changes

This package allows one to check all the Vulkan-capabilities from your GPU+driver, as well as submit it to https://vulkan.gpuinfo.org.

Repo: https://github.com/SaschaWillems/VulkanCapsViewer

![screenshot](https://user-images.githubusercontent.com/1368952/183465973-0894e40d-5d93-4a15-afca-ab5a60e64c55.png)

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
