### PR TITLE
vscode-extensions.2gua.rainbow-brackets: init at 0.0.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2573,6 +2573,12 @@
     githubId = 244239;
     name = "Mauricio Collares";
   };
+  compeng0001 = {
+    email = "sb1501@canterbury.ac.uk";
+    github = "compeng0001";
+    githubId = 40290417;
+    name = "Seb Blair";
+  };
   copumpkin = {
     email = "pumpkingod@gmail.com";
     github = "copumpkin";

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -47,6 +47,21 @@ let
         };
       };
 
+      _2gua.rainbow-brackets = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          publisher = "2gua";
+          name = "Rainbow Brackets";
+          version = "0.0.6";
+          sha256 = "3svGVbaxUh/60NywMdWFsL3fSv+kPgt39bGmPVIu6sI=";
+        };
+        meta = with lib; {
+          description = "Provides rainbow coloured brackets";
+          downloadPage = "https://marketplace.visualstudio.com/items?itemName=2gua.rainbow-brackets";
+          homepage = "https://github.com/lcultx/rainbow-brackets";
+          license = licenses.mit;
+        };
+      };
+
       _4ops.terraform = buildVscodeMarketplaceExtension {
         mktplcRef = {
           publisher = "4ops";
@@ -1858,6 +1873,22 @@ let
           homepage = "https://github.com/phoenixframework/vscode-phoenix";
           license = licenses.mit;
           maintainers = with maintainers; [ superherointj ];
+        };
+      };
+
+      randomfractalsinc.vscode-data-preview = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "Data Preview";
+          publisher = "Random Fractal Inc";
+          version = "2.3.0";
+          shar256 = "DaI1/6IMQ44HrBM9tc04DGZmdlLdk1lVVMkMCa6cMHA=";
+        };
+        meta = with lib; {
+          changelog = "https://github.com/RandomFractals/vscode-data-preview/blob/master/CHANGELOG.md";
+          description = "Data preview for mulitple file extensions";
+          downloadPage = "https://marketplace.visualstudio.com/items?itemName=RandomFractalsInc.vscode-data-preview";
+          homepage = "https://github.com/RandomFractals/vscode-data-preview";
+          license = licenses.asl20;
         };
       };
 

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -1881,7 +1881,7 @@ let
           name = "Data Preview";
           publisher = "Random Fractal Inc";
           version = "2.3.0";
-          shar256 = "DaI1/6IMQ44HrBM9tc04DGZmdlLdk1lVVMkMCa6cMHA=";
+          sha256 = "DaI1/6IMQ44HrBM9tc04DGZmdlLdk1lVVMkMCa6cMHA=";
         };
         meta = with lib; {
           changelog = "https://github.com/RandomFractals/vscode-data-preview/blob/master/CHANGELOG.md";

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -55,7 +55,7 @@ let
           sha256 = "3svGVbaxUh/60NywMdWFsL3fSv+kPgt39bGmPVIu6sI=";
         };
         meta = with lib; {
-          description = "Provides rainbow coloured brackets";
+          description = "A rainbow brackets extension for VS Code";
           downloadPage = "https://marketplace.visualstudio.com/items?itemName=2gua.rainbow-brackets";
           homepage = "https://github.com/lcultx/rainbow-brackets";
           license = licenses.mit;

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -1885,7 +1885,7 @@ let
         };
         meta = with lib; {
           changelog = "https://github.com/RandomFractals/vscode-data-preview/blob/master/CHANGELOG.md";
-          description = "Data preview for mulitple file extensions";
+          description = "A VS Code extension for data preview supporting multiple file extensions";
           downloadPage = "https://marketplace.visualstudio.com/items?itemName=RandomFractalsInc.vscode-data-preview";
           homepage = "https://github.com/RandomFractals/vscode-data-preview";
           license = licenses.asl20;


### PR DESCRIPTION
###### Description of changes

Adds [2gua-rainbow-brackets](https://github.com/lcultx/rainbow-brackets) vscode extension
Adds [RandomFractals-vscode-data-preview](https://github.com/RandomFractals/vscode-data-preview)
Adds CompEng0001 to maintainers list

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
