### PR TITLE
sigal: fix crash when building gallery

### DIFF
--- a/pkgs/applications/misc/sigal/copytree-permissions.patch
+++ b/pkgs/applications/misc/sigal/copytree-permissions.patch
@@ -1,0 +1,16 @@
+diff -Nurp sigal-2.3.orig/sigal/writer.py sigal-2.3/sigal/writer.py
+--- sigal-2.3.orig/sigal/writer.py	2022-08-08 19:43:10.934707194 +0200
++++ sigal-2.3/sigal/writer.py	2022-08-08 19:44:57.542382532 +0200
+@@ -103,7 +103,11 @@ class AbstractWriter:
+             os.path.join(THEMES_PATH, 'default', 'static'),
+             os.path.join(self.theme, 'static'),
+         ):
+-            shutil.copytree(static_path, self.theme_path, dirs_exist_ok=True)
++            # https://stackoverflow.com/a/17022146/4935114
++            orig_copystat = shutil.copystat
++            shutil.copystat = lambda x, y: x
++            shutil.copytree(static_path, self.theme_path, dirs_exist_ok=True, copy_function=shutil.copy)
++            shutil.copystat = orig_copystat
+ 
+         if self.settings["user_css"]:
+             if not os.path.exists(self.settings["user_css"]):

--- a/pkgs/applications/misc/sigal/default.nix
+++ b/pkgs/applications/misc/sigal/default.nix
@@ -14,6 +14,8 @@ python3.pkgs.buildPythonApplication rec {
     hash = "sha256-4Zsb/OBtU/jV0gThEYe8bcrb+6hW+hnzQS19q1H409Q=";
   };
 
+  patches = [ ./copytree-permissions.patch ];
+
   propagatedBuildInputs = with python3.pkgs; [
     # install_requires
     jinja2


### PR DESCRIPTION
###### Description of changes

When building a gallery using `sigal build` the process would error out with an message along the lines of

    shutil.Error: [('/nix/store/…/static/css',
                    '/…/_build/static/css',
                    "[Errno 13] Permission denied: '/…/_build/static/css'"),
                   …
                  ]

This is caused by `shutil.copytree` copying the permissions (555) of the directories in the Nix store and then attempting to make
modifications to the copied directory. The patch makes the copy ignore the permissions of directories.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).