### PR TITLE
bats: Add library support

### DIFF
--- a/pkgs/development/interpreters/bats/default.nix
+++ b/pkgs/development/interpreters/bats/default.nix
@@ -16,6 +16,7 @@
 , callPackages
 , symlinkJoin
 , makeWrapper
+, runCommand
 , doInstallCheck ? true
 }:
 
@@ -127,6 +128,32 @@ resholve.mkDerivation rec {
           --suffix BATS_LIB_PATH : "$out/share/bats"
       '';
     };
+
+  passthru.tests.libraries = runCommand "${bats.name}-with-libraries-test" {
+    testScript = ''
+      setup() {
+        bats_load_library bats-support
+        bats_load_library bats-assert
+
+        bats_require_minimum_version 1.5.0
+      }
+
+      @test echo_hi {
+        run -0 echo hi
+        assert_output "hi"
+      }
+
+      @test cp_failure {
+        run ! cp
+        assert_line --index 0 "cp: missing file operand"
+        assert_line --index 1 "Try 'cp --help' for more information."
+      }
+    '';
+    passAsFile = [ "testScript" ];
+  } ''
+    ${bats.withLibraries (p: [ p.bats-support p.bats-assert ])}/bin/bats "$testScriptPath"
+    touch "$out"
+  '';
 
   passthru.tests.upstream = bats.unresholved.overrideAttrs (old: {
     name = "${bats.name}-tests";

--- a/pkgs/development/interpreters/bats/default.nix
+++ b/pkgs/development/interpreters/bats/default.nix
@@ -13,6 +13,7 @@
 , ps
 , bats
 , lsof
+, callPackages
 , doInstallCheck ? true
 }:
 
@@ -104,6 +105,8 @@ resholve.mkDerivation rec {
       ];
     };
   };
+
+  passthru.libraries = callPackages ./libraries.nix {};
 
   passthru.tests.upstream = bats.unresholved.overrideAttrs (old: {
     name = "${bats.name}-tests";

--- a/pkgs/development/interpreters/bats/libraries.nix
+++ b/pkgs/development/interpreters/bats/libraries.nix
@@ -1,0 +1,70 @@
+{ lib, stdenv, fetchFromGitHub }: {
+  bats-assert = stdenv.mkDerivation {
+    pname = "bats-assert";
+    version = "2.0.0";
+    src = fetchFromGitHub {
+      owner = "bats-core";
+      repo = "bats-assert";
+      rev = "v2.0.0";
+      sha256 = "sha256-whSbAj8Xmnqclf78dYcjf1oq099ePtn4XX9TUJ9AlyQ=";
+    };
+    dontBuild = true;
+    installPhase = ''
+      mkdir -p "$out/share/bats"
+      cp -r . "$out/share/bats/bats-assert"
+    '';
+    meta = {
+      description = "Common assertions for Bats";
+      platforms = lib.platforms.all;
+      homepage = "https://github.com/bats-core/bats-assert";
+      license = lib.licenses.cc0;
+      maintainers = with lib.maintainers; [ infinisil ];
+    };
+  };
+
+  bats-file = stdenv.mkDerivation {
+    pname = "bats-file";
+    version = "0.3.0";
+    src = fetchFromGitHub {
+      owner = "bats-core";
+      repo = "bats-file";
+      rev = "v0.3.0";
+      sha256 = "sha256-3xevy0QpwNZrEe+2IJq58tKyxQzYx8cz6dD2nz7fYUM=";
+    };
+    dontBuild = true;
+    installPhase = ''
+      mkdir -p "$out/share/bats"
+      cp -r . "$out/share/bats/bats-file"
+    '';
+    meta = {
+      description = "Common filesystem assertions for Bats";
+      platforms = lib.platforms.all;
+      homepage = "https://github.com/bats-core/bats-file";
+      license = lib.licenses.cc0;
+      maintainers = with lib.maintainers; [ infinisil ];
+    };
+  };
+
+  bats-support = stdenv.mkDerivation {
+    pname = "bats-support";
+    version = "0.3.0";
+    src = fetchFromGitHub {
+      owner = "bats-core";
+      repo = "bats-support";
+      rev = "v0.3.0";
+      sha256 = "sha256-4N7XJS5XOKxMCXNC7ef9halhRpg79kUqDuRnKcrxoeo=";
+    };
+    dontBuild = true;
+    installPhase = ''
+      mkdir -p "$out/share/bats"
+      cp -r . "$out/share/bats/bats-support"
+    '';
+    meta = {
+      description = "Supporting library for Bats test helpers";
+      platforms = lib.platforms.all;
+      homepage = "https://github.com/bats-core/bats-support";
+      license = lib.licenses.cc0;
+      maintainers = with lib.maintainers; [ infinisil ];
+    };
+  };
+}


### PR DESCRIPTION
###### Description of changes

Split off from https://github.com/NixOS/nixpkgs/pull/185022

The first commit creates packages for the main [bats](https://github.com/bats-core/bats-core) [libraries](https://bats-core.readthedocs.io/en/stable/writing-tests.html?highlight=library#libraries-and-add-ons).

The second commit adds a `bats.withLibraries (p: [ ... ])` function, which creates a `bats` wrapper where the `BATS_LIB_PATH` environment variable contains fallbacks for the given list of libraries.

This allows to e.g. use the [`bats-assert`](https://github.com/bats-core/bats-assert) library (which itself requires the [`bats-support`](https://github.com/bats-core/bats-support) library) with

    bats.withLibraries (p: [ p.bats-support p.bats-assert ])

In a `.bats` file you can then call [`bats_load_library`](https://bats-core.readthedocs.io/en/stable/writing-tests.html?highlight=library#bats-load-library-load-system-wide-libraries) to load the libraries in the `setup()` function:

    setup() {
      bats_load_library bats-support
      bats_load_library bats-assert
    }

Combining this with a `nix-shell` [shebang](https://nixos.org/manual/nix/unstable/command-ref/nix-shell.html#use-as-a--interpreter), a self-sufficient `my-tests.bats` file can look like this:

```bash
#!/usr/bin/env nix-shell
#!nix-shell -i bats -p "bats.withLibraries (p: [ p.bats-support p.bats-assert ])"
# vim: filetype=sh

setup() {
  bats_load_library bats-support
  bats_load_library bats-assert

  bats_require_minimum_version 1.5.0

  # If you need the path to this file
  # DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )"
}

@test echo_hi {
  run -0 echo hi
  assert_output "hi"
}

@test cp_failure {
  run ! cp
  assert_line --index 0 "cp: missing file operand"
  assert_line --index 1 "Try 'cp --help' for more information."
}
```

and can be run with

```
$ ./x.bats
x.bats
 ✓ echo_hi
 ✓ cp_failure

2 tests, 0 failures
```

###### Things done

- [x] Tested by executing the above file