### PR TITLE
mesa: 22.1.4 -> 22.1.5

### DIFF
--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -34,8 +34,7 @@ with lib;
 let
   # Release calendar: https://www.mesa3d.org/release-calendar.html
   # Release frequency: https://www.mesa3d.org/releasing.html#schedule
-  # 22.1 on darwin won't build: https://gitlab.freedesktop.org/mesa/mesa/-/issues/6519
-  version = if stdenv.isDarwin then "22.0.4" else "22.1.4";
+  version = "22.1.5";
   branch  = versions.major version;
 
 self = stdenv.mkDerivation {
@@ -49,10 +48,7 @@ self = stdenv.mkDerivation {
       "ftp://ftp.freedesktop.org/pub/mesa/${version}/mesa-${version}.tar.xz"
       "ftp://ftp.freedesktop.org/pub/mesa/older-versions/${branch}.x/${version}/mesa-${version}.tar.xz"
     ];
-    sha256 = {
-      "22.1.4" = "0xhbcjqy3g5dfxhr4flmqncmsjnwljfqm9idx92jm43jifz8q3b7";
-      "22.0.4" = "1m0y8wgy48hmcidsr7sbk5hcw3v0qr8359fd2x34fvl2z9c1z5y7";
-    }.${version};
+    sha256 = "6fd60d38efdd25317948c61494b5117e01d42da695278728b1faef9f5f9a47ba";
   };
 
   # TODO:
@@ -63,11 +59,11 @@ self = stdenv.mkDerivation {
     ./musl.patch
     (fetchpatch {
       url = "https://raw.githubusercontent.com/void-linux/void-packages/b9f58f303ae23754c95d5d1fe87a98b5a2d8f271/srcpkgs/mesa/patches/musl-endian.patch";
-      sha256 = "sha256-eRc91qCaFlVzrxFrNUPpAHd1gsqKsLCCN0IW8pBQcqk=";
+      hash = "sha256-eRc91qCaFlVzrxFrNUPpAHd1gsqKsLCCN0IW8pBQcqk=";
     })
     (fetchpatch {
       url = "https://raw.githubusercontent.com/void-linux/void-packages/b9f58f303ae23754c95d5d1fe87a98b5a2d8f271/srcpkgs/mesa/patches/musl-stacksize.patch";
-      sha256 = "sha256-bEp0AWddsw1Pc3rxdKN8fsrX4x2TQEzMUa5afhLXGsg=";
+      hash = "sha256-bEp0AWddsw1Pc3rxdKN8fsrX4x2TQEzMUa5afhLXGsg=";
     })
 
     ./opencl.patch
@@ -76,6 +72,10 @@ self = stdenv.mkDerivation {
     # Fix aarch64-darwin build, remove when upstreaam supports it out of the box.
     # See: https://gitlab.freedesktop.org/mesa/mesa/-/issues/1020
     ./aarch64-darwin.patch
+  ] ++ optionals stdenv.isDarwin [
+    # 22.1 on darwin won't build: https://gitlab.freedesktop.org/mesa/mesa/-/issues/6519
+    # (already in-tree for 22.2)
+    ./drop-dri2.patch
   ];
 
   postPatch = ''

--- a/pkgs/development/libraries/mesa/drop-dri2.patch
+++ b/pkgs/development/libraries/mesa/drop-dri2.patch
@@ -1,0 +1,40 @@
+diff --git a/a/src/gallium/frontends/dri/dri_util.c b/b/src/gallium/frontends/dri/dri_util.c
+index 8d60526..782360d 100644
+--- a/src/gallium/frontends/dri/dri_util.c
++++ b/src/gallium/frontends/dri/dri_util.c
+@@ -808,35 +808,6 @@ const __DRIcoreExtension driCoreExtension = {
+     .unbindContext              = driUnbindContext
+ };
+ 
+-/** DRI2 interface */
+-const __DRIdri2Extension driDRI2Extension = {
+-    .base = { __DRI_DRI2, 4 },
+-
+-    .createNewScreen            = dri2CreateNewScreen,
+-    .createNewDrawable          = driCreateNewDrawable,
+-    .createNewContext           = driCreateNewContext,
+-    .getAPIMask                 = driGetAPIMask,
+-    .createNewContextForAPI     = driCreateNewContextForAPI,
+-    .allocateBuffer             = dri2AllocateBuffer,
+-    .releaseBuffer              = dri2ReleaseBuffer,
+-    .createContextAttribs       = driCreateContextAttribs,
+-    .createNewScreen2           = driCreateNewScreen2,
+-};
+-
+-const __DRIdri2Extension swkmsDRI2Extension = {
+-    .base = { __DRI_DRI2, 4 },
+-
+-    .createNewScreen            = swkmsCreateNewScreen,
+-    .createNewDrawable          = driCreateNewDrawable,
+-    .createNewContext           = driCreateNewContext,
+-    .getAPIMask                 = driGetAPIMask,
+-    .createNewContextForAPI     = driCreateNewContextForAPI,
+-    .allocateBuffer             = dri2AllocateBuffer,
+-    .releaseBuffer              = dri2ReleaseBuffer,
+-    .createContextAttribs       = driCreateContextAttribs,
+-    .createNewScreen2           = driCreateNewScreen2,
+-};
+-
+ const __DRIswrastExtension driSWRastExtension = {
+     .base = { __DRI_SWRAST, 4 },
+ 


### PR DESCRIPTION
###### Description of changes

1. Bump changes: https://docs.mesa3d.org/relnotes/22.1.5.html

2. Moved patches (that were already using SRI hashes), I've adopted [what the wiki calls the preferred way](https://nixos.wiki/wiki/Nix_Hash#Usage).

3. Added the fix for https://gitlab.freedesktop.org/mesa/mesa/-/issues/6519 as a patch (for darwin only).

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
