### PR TITLE
rubyPackages: set meta.mainProgram

### DIFF
--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -40,6 +40,10 @@ let
 in
 
 {
+  ZenTest = attrs: {
+    meta.mainProgram = "zentest";
+  };
+
   atk = attrs: {
     dependencies = attrs.dependencies ++ [ "gobject-introspection" ];
     nativeBuildInputs = [ rake bundler pkg-config ]
@@ -241,6 +245,10 @@ in
     '';
   };
 
+  parser = attrs: {
+    meta.mainProgram = "ruby-parse";
+  };
+
   pg_query = attrs: lib.optionalAttrs (attrs.version == "2.0.2") {
     dontBuild = false;
     postPatch = ''
@@ -258,6 +266,10 @@ in
         sha256 = "0f0kshhai0pnkqj0w4kgz3fssnvwidllc31n1fysxjjzdqlr1k48";
       }}';" ext/pg_query/extconf.rb
     '';
+  };
+
+  prettier = attrs: {
+    meta.mainProgram = "rbprettier";
   };
 
   glib2 = attrs: {
@@ -526,6 +538,14 @@ in
     buildInputs = [ openssl ];
   };
 
+  rack = attrs: {
+    meta.mainProgram = "rackup";
+  };
+
+  railties = attrs: {
+    meta.mainProgram = "rails";
+  };
+
   rainbow = attrs: {
     buildInputs = [ rainbow_rake ];
   };
@@ -555,13 +575,25 @@ in
     buildInputs = [ re2 ];
   };
 
+  rest-client = attrs: {
+    meta.mainProgram = "restclient";
+  };
+
   rmagick = attrs: {
     nativeBuildInputs = [ pkg-config ];
     buildInputs = [ imagemagick which ];
   };
 
+  rouge = attrs: {
+    meta.mainProgram = "rougify";
+  };
+
   rpam2 = attrs: {
     buildInputs = [ linux-pam ];
+  };
+
+  rspec-core = attrs: {
+    meta.mainProgram = "rspec";
   };
 
   ruby-libvirt = attrs: {
@@ -661,6 +693,10 @@ in
     buildInputs = [ freetds ];
   };
 
+  treetop = attrs: {
+    meta.mainProgram = "tt";
+  };
+
   typhoeus = attrs: {
     buildInputs = [ curl ];
   };
@@ -681,6 +717,10 @@ in
 
   uuid4r = attrs: {
     buildInputs = [ which libossp_uuid ];
+  };
+
+  whois = attrs: {
+    meta.mainProgram = "whoisrb";
   };
 
   xapian-ruby = attrs: {

--- a/pkgs/development/ruby-modules/gem/default.nix
+++ b/pkgs/development/ruby-modules/gem/default.nix
@@ -250,6 +250,7 @@ stdenv.mkDerivation ((builtins.removeAttrs attrs ["source"]) // {
   meta = {
     # default to Ruby's platforms
     platforms = ruby.meta.platforms;
+    mainProgram = gemName;
   } // meta;
 })
 


### PR DESCRIPTION
###### Description of changes
Continuation of #185618

Set `meta.mainProgram` to be able to use `lib.getExe` on them.

---

There are currently 300 ruby gems in nixpkgs:
``` nix
nix-repl> builtins.length (builtins.attrNames ruby.gems)
300
```

Out of 300 gems, 48 of them have a non empty `${drv}/bin/` directory:
``` nix
let
  gemBinDirs = builtins.mapAttrs (n: v: builtins.readDir "${v}/bin") ruby.gems;
  gemsWithExes = lib.filterAttrs (n: v: v != { } ) gemBinDirs;
in
nix-repl> builtins.length (builtins.attrNames gemsWithExes)
48
```

Out of those 48 gems with executables, 33 of them have an executable with the
same name as their `gemName`:
``` nix
let
  gemExeNames = builtins.mapAttrs (n: v: builtins.attrNames v) gemsWithExes;
  gemsThatHaveAnExeNamedAfterThemselves = lib.filterAttrs (n: v: builtins.elem n v) gemExeNames;
in
nix-repl> builtins.length (builtins.attrNames gemsThatHaveAnExeNamedAfterThemselves)
33
```

So we still need to explicitly set `meta.mainProgram` if applicable for 15 of them:
| gem name | exe names | `meta.mainProgram` | notes |
| -------- | --------- | ---------------------- | ----- |
| ZenTest  | [ "multigem" "multiruby" "unit_diff" "zentest" ] | "zentest" | |
| cocoapods | [ "pod" "sandbox-pod" ] | null | use `pkgs.cocoapods` instead |
| diff-lcs | [ "htmldiff" "ldiff" ] | null | main program could not be determined |
| parser | [ "ruby-parse" "ruby-rewrite" ] | "ruby-parse" | |
| paru | [ "do-pandoc.rb" "pandoc2yaml.rb" ] | null | main program could not be determined |
| prettier | [ "rbprettier" ] | rbprettier | |
| rack | [ "rackup" ] | rackup | |
| railties | [ "rails" ] | rails | |
| rest-client | [ "restclient" ] | restclient | |
| rouge | [ "rougify" ] | rougify | |
| rspec-core | [ "rspec" ] | rspec | |
| ruby-graphviz | [ "dot2ruby" "gem2gv" "git2gv" "ruby2gv" "xml2gv" ] | null | main program could not be determined |
| tiny_tds | [ "defncopy-ttds" "tsql-ttds" ] | null | main program could not be determined |
| treetop | [ "tt" ] | tt | |
| whois | [ "whoisrb" ] | whoisrb | |


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
