### PR TITLE
Fix gdb static compile staging

### DIFF
--- a/pkgs/development/tools/misc/gdb/default.nix
+++ b/pkgs/development/tools/misc/gdb/default.nix
@@ -102,6 +102,7 @@ stdenv.mkDerivation rec {
     "--with-auto-load-safe-path=${builtins.concatStringsSep ":" safePaths}"
   ] ++ lib.optional (!pythonSupport) "--without-python"
     ++ lib.optional stdenv.hostPlatform.isMusl "--disable-nls"
+    ++ lib.optional stdenv.hostPlatform.isStatic "--disable-inprocess-agent"
     ++ lib.optional enableDebuginfod "--with-debuginfod=yes";
 
   postInstall =

--- a/pkgs/development/tools/misc/gdb/default.nix
+++ b/pkgs/development/tools/misc/gdb/default.nix
@@ -92,7 +92,6 @@ stdenv.mkDerivation rec {
 
     "--enable-targets=all" "--enable-64-bit-bfd"
     "--disable-install-libbfd"
-    "--disable-shared" "--enable-static"
     "--with-system-zlib"
     "--with-system-readline"
 


### PR DESCRIPTION
###### Description of changes

This sits on top of https://github.com/NixOS/nixpkgs/pull/185598 (but doesn't strictly speaking need to, only to avoid merge conflicts). The change from this is the commit [gdb: Remove unused "--disable-shared" "--enable-static"](https://github.com/NixOS/nixpkgs/commit/546a99e6793490e5938f0f1819e903cbd78ed127):

    gdb: Remove unused "--disable-shared" "--enable-static"
    
    It is unused as without the previous commit (--disable-inprocess-agent)
    GDB should have failed to compile, and for pkgsStatic the
    `--enable-static` should be automatically added.
    
    These flags were added in f8741c38cd546e3ff18ce9d708de14ff2aae68ab by John Ericson in 2017
    
            binutils, gdb: Do not expose libbfd or libopcodes, and be multitarget
    
            There are separate derivations for these libraries and we don't want
            conflict. Multitarget is generally more useful, and will eventually
            speed up cross builds, so why not?!
    
            [...]
            @@ -58,10 +59,16 @@ stdenv.mkDerivation rec {
               configurePlatforms = [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
    
               configureFlags = with stdenv.lib; [
            -    "--with-gmp=${gmp.dev}" "--with-mpfr=${mpfr.dev}" "--with-system-readline"
            -    "--with-system-zlib" "--with-expat" "--with-libexpat-prefix=${expat.dev}"
            -  ] ++ stdenv.lib.optional (!pythonSupport) "--without-python"
            -    ++ stdenv.lib.optional multitarget "--enable-targets=all";
            +    "--enable-targets=all" "--enable-64-bit-bfd"
            +    "--disable-install-libbfd"
            +    "--disable-shared" "--enable-static"
            +    "--with-system-zlib"
            +    "--with-system-readline"
            +
            +    "--with-gmp=${gmp.dev}"
            +    "--with-mpfr=${mpfr.dev}"
            +    "--with-expat" "--with-libexpat-prefix=${expat.dev}"
            +  ] ++ stdenv.lib.optional (!pythonSupport) "--without-python";
    
               postInstall =
                 '' # Remove Info files already provided by Binutils and other packages.
            [...]

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
