### PR TITLE
python310Packages.cirq-core: 0.15.0 -> 1.0.0

### DIFF
--- a/pkgs/development/python-modules/cirq-aqt/default.nix
+++ b/pkgs/development/python-modules/cirq-aqt/default.nix
@@ -26,4 +26,9 @@ buildPythonPackage rec {
 
   # cirq's importlib hook doesn't work here
   #pythonImportsCheck = [ "cirq_aqt" ];
+
+  disabledTestPaths = [
+    # No need to test the version number
+    "cirq_aqt/_version_test.py"
+  ];
 }

--- a/pkgs/development/python-modules/cirq-core/default.nix
+++ b/pkgs/development/python-modules/cirq-core/default.nix
@@ -87,7 +87,7 @@ buildPythonPackage rec {
   ];
 
   disabledTests = [
-    # tries to import flynt, which isn't in Nixpkgs
+    # Tries to import flynt, which isn't in Nixpkgs
     "test_metadata_search_path"
     # Fails due pandas MultiIndex. Maybe issue with pandas version in nix?
     "test_benchmark_2q_xeb_fidelities"

--- a/pkgs/development/python-modules/cirq-core/default.nix
+++ b/pkgs/development/python-modules/cirq-core/default.nix
@@ -1,5 +1,5 @@
-{ stdenv
-, lib
+{ lib
+, stdenv
 , buildPythonPackage
 , pythonOlder
 , fetchFromGitHub
@@ -31,15 +31,16 @@
 
 buildPythonPackage rec {
   pname = "cirq-core";
-  version = "0.15.0";
+  version = "1.0.0";
+  format = "setuptools";
 
-  disabled = pythonOlder "3.6";
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "quantumlib";
     repo = "cirq";
     rev = "v${version}";
-    sha256 = "sha256-E36zXpv+9WBNYvv/shItS7Q34gYqUyADlqWd+m4Jpps=";
+    hash = "sha256-KJ+z4zGrdGIXcGZzqHtWMf8aAzcn9CtltFawcHVldMQ=";
   };
 
   sourceRoot = "source/${pname}";
@@ -48,8 +49,7 @@ buildPythonPackage rec {
     substituteInPlace requirements.txt \
       --replace "matplotlib~=3.0" "matplotlib" \
       --replace "networkx~=2.4" "networkx" \
-      --replace "numpy~=1.16" "numpy" \
-      --replace "sympy<1.10" "sympy"
+      --replace "numpy~=1.16" "numpy"
   '';
 
   propagatedBuildInputs = [
@@ -80,20 +80,25 @@ buildPythonPackage rec {
   ];
 
   disabledTestPaths = lib.optionals (!withContribRequires) [
-    # requires external (unpackaged) libraries, so untested.
+    # Requires external (unpackaged) libraries, so untested
     "cirq/contrib/"
+    # No need to test the version number
+    "cirq/_version_test.py"
   ];
+
   disabledTests = [
-    "test_metadata_search_path" # tries to import flynt, which isn't in Nixpkgs
-    "test_benchmark_2q_xeb_fidelities" # fails due pandas MultiIndex. Maybe issue with pandas version in nix?
+    # tries to import flynt, which isn't in Nixpkgs
+    "test_metadata_search_path"
+    # Fails due pandas MultiIndex. Maybe issue with pandas version in nix?
+    "test_benchmark_2q_xeb_fidelities"
   ];
 
   meta = with lib; {
-    broken = (stdenv.isLinux && stdenv.isAarch64);
     description = "Framework for creating, editing, and invoking Noisy Intermediate Scale Quantum (NISQ) circuits";
     homepage = "https://github.com/quantumlib/cirq";
     changelog = "https://github.com/quantumlib/Cirq/releases/tag/v${version}";
     license = licenses.asl20;
     maintainers = with maintainers; [ drewrisinger fab ];
+    broken = (stdenv.isLinux && stdenv.isAarch64);
   };
 }

--- a/pkgs/development/python-modules/cirq-google/default.nix
+++ b/pkgs/development/python-modules/cirq-google/default.nix
@@ -2,7 +2,6 @@
 , cirq-core
 , google-api-core
 , protobuf
-# test inputs
 , pytestCheckHook
 , freezegun
 }:
@@ -15,7 +14,8 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace requirements.txt \
-      --replace "google-api-core[grpc] >= 1.14.0, < 2.0.0dev" "google-api-core[grpc] >= 1.14.0, < 3.0.0dev"
+      --replace "google-api-core[grpc] >= 1.14.0, < 2.0.0dev" "google-api-core[grpc] >= 1.14.0, < 3.0.0dev" \
+      --replace "protobuf >= 3.15.0, < 4" "protobuf >= 3.15.0"
   '';
 
   propagatedBuildInputs = [
@@ -29,9 +29,15 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  disabledTestPaths = [
+    # No need to test the version number
+    "cirq_google/_version_test.py"
+  ];
+
   disabledTests = [
     # unittest.mock.InvalidSpecError: Cannot autospec attr 'QuantumEngineServiceClient'
     "test_get_engine_sampler_explicit_project_id"
     "test_get_engine_sampler"
   ];
+
 }

--- a/pkgs/development/python-modules/cirq-ionq/default.nix
+++ b/pkgs/development/python-modules/cirq-ionq/default.nix
@@ -26,4 +26,9 @@ buildPythonPackage rec {
 
   # cirq's importlib hook doesn't work here
   #pythonImportsCheck = [ "cirq_ionq" ];
+
+  disabledTestPaths = [
+    # No need to test the version number
+    "cirq_ionq/_version_test.py"
+  ];
 }

--- a/pkgs/development/python-modules/cirq-pasqal/default.nix
+++ b/pkgs/development/python-modules/cirq-pasqal/default.nix
@@ -26,4 +26,9 @@ buildPythonPackage rec {
 
   # cirq's importlib hook doesn't work here
   #pythonImportsCheck = [ "cirq_pasqal" ];
+
+  disabledTestPaths = [
+    # No need to test the version number
+    "cirq_pasqal/_version_test.py"
+  ];
 }

--- a/pkgs/development/python-modules/cirq-rigetti/default.nix
+++ b/pkgs/development/python-modules/cirq-rigetti/default.nix
@@ -75,6 +75,11 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  disabledTestPaths = [
+    # No need to test the version number
+    "cirq_rigetti/_version_test.py"
+  ];
+
   # cirq's importlib hook doesn't work here
   #pythonImportsCheck = [ "cirq_rigetti" ];
 }

--- a/pkgs/development/python-modules/cirq-web/default.nix
+++ b/pkgs/development/python-modules/cirq-web/default.nix
@@ -19,4 +19,9 @@ buildPythonPackage rec {
 
   # cirq's importlib hook doesn't work here
   #pythonImportsCheck = [ "cirq_web" ];
+
+  disabledTestPaths = [
+    # No need to test the version number
+    "cirq_web/_version_test.py"
+  ];
 }


### PR DESCRIPTION
###### Description of changes
https://github.com/quantumlib/Cirq/releases/tag/v1.0.0
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
