### PR TITLE
protobuf: 3.21.2 -> 3.21.5

### DIFF
--- a/pkgs/development/libraries/protobuf/3.21.nix
+++ b/pkgs/development/libraries/protobuf/3.21.nix
@@ -1,6 +1,6 @@
 { callPackage, abseil-cpp, ... }:
 
 callPackage ./generic-v3-cmake.nix {
-  version = "3.21.2";
-  sha256 = "sha256-DUv07pWiZV7jNeSA2ClDOz9DY0x/hiJynxkbSTeJOSs=";
+  version = "3.21.5";
+  sha256 = "sha256-bWT2Bak59Ki8Zy8Lf6Gr8ByC//RpEUJ89lStHu1lnWA=";
 }

--- a/pkgs/development/python-modules/grpcio-tools/default.nix
+++ b/pkgs/development/python-modules/grpcio-tools/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, protobuf, grpcio, setuptools }:
+{ lib, buildPythonPackage, fetchPypi, protobuf, grpcio, setuptools, pythonRelaxDepsHook }:
 
 buildPythonPackage rec {
   pname = "grpcio-tools";
@@ -12,6 +12,10 @@ buildPythonPackage rec {
   outputs = [ "out" "dev" ];
 
   enableParallelBuilding = true;
+
+  pythonRelaxDeps = [ "protobuf" ];
+
+  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   propagatedBuildInputs = [ protobuf grpcio setuptools ];
 

--- a/pkgs/development/python-modules/protobuf/default.nix
+++ b/pkgs/development/python-modules/protobuf/default.nix
@@ -14,7 +14,12 @@
 }:
 
 buildPythonPackage {
-  inherit (protobuf) pname src version;
+  inherit (protobuf) pname src;
+  version =
+    if lib.versionAtLeast protobuf.version "3.21" then
+      "4.21.5" # Version source: https://github.com/protocolbuffers/protobuf/blob/v21.5/version.json#L13
+    else protobuf.version;
+
   inherit disabled;
   doCheck = doCheck && !isPy27; # setuptools>=41.4 no longer collects correctly on python2
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20689,7 +20689,7 @@ with pkgs;
 
   prospector = callPackage ../development/tools/prospector { };
 
-  protobuf = protobuf3_19;
+  protobuf = protobuf3_21;
 
   protobuf3_21 = callPackage ../development/libraries/protobuf/3.21.nix { };
   protobuf3_20 = callPackage ../development/libraries/protobuf/3.20.nix { };


### PR DESCRIPTION
* protobuf: 3.21.2 -> 3.21.5
* python310Packages.protobuf: 3.19.4 -> 4.21.5

Pending:
* Pick and add some downstream packages to tests. Suggestions of good picks are welcomed.
  * python310Packages.grpcio-tools
    - netdata
    - or-tools (version is outdated)
  * sysdig 
  * arrow-cpp
  * protoc-gen-rust
* `python310Packages.protobuf` now needs an update script because version cannot be inferred anymore as it is now. Makes sense to wait for next release to figure out the pattern upstream is going to use for this.
* Fix downstream breakage

Testing done:
* Success
  - protoc-gen-rust
  - python310Packages.grpcio-tools
  - netdata
* Failure
  - or-tools is failing. (also version is outdated)
  - arrow-cpp
      > The following tests FAILED:
      >         54 - arrow-flight-test (Failed)
  - **
    - Error:
      > ERROR: Could not find a version that satisfies the requirement protobuf<4.0dev,>=3.12.0 (from grpcio-tools) (from versions: none)
      > ERROR: No matching distribution found for protobuf<4.0dev,>=3.12.0
     - Note: grpcio-tools version 1.48.0 has been 'yanked'. (https://pypi.org/project/grpcio-tools/1.48.0/#history)
