### PR TITLE
writefreely: refactor, nixos/writefreely: init

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -184,6 +184,14 @@
           <link linkend="opt-services.tempo.enable">services.tempo</link>.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          <link xlink:href="https://github.com/writefreely/writefreely">WriteFreely</link>,
+          a clean, Markdown-based publishing platform made for writers.
+          Available as
+          <link linkend="opt-services.writefreely.enable">services.writefreely</link>.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-22.11-incompatibilities">

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -74,6 +74,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [Grafana Tempo](https://www.grafana.com/oss/tempo/), a distributed tracing store. Available as [services.tempo](#opt-services.tempo.enable).
 
+- [WriteFreely](https://github.com/writefreely/writefreely), a clean, Markdown-based publishing platform made for writers. Available as [services.writefreely](#opt-services.writefreely.enable).
+
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ## Backward Incompatibilities {#sec-release-22.11-incompatibilities}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1110,6 +1110,7 @@
   ./services/web-apps/wiki-js.nix
   ./services/web-apps/whitebophir.nix
   ./services/web-apps/wordpress.nix
+  ./services/web-apps/writefreely.nix
   ./services/web-apps/youtrack.nix
   ./services/web-apps/zabbix.nix
   ./services/web-servers/agate.nix

--- a/nixos/modules/services/web-apps/writefreely.nix
+++ b/nixos/modules/services/web-apps/writefreely.nix
@@ -1,0 +1,118 @@
+{config, lib, pkgs, ...}:
+
+with lib;
+
+let
+  cfg = config.services.writefreely;
+  configFile = pkgs.writeText "config.ini" (generators.toINI {} cfg.settings);
+  settingsFormat = pkgs.formats.ini {};
+in {
+  options.services.writefreely = {
+    enable = mkEnableOption "WriteFreely, a Markdown-based publishing platform.";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.writefreely;
+      defaultText = literalExpression "pkgs.writefreely";
+      description = lib.mdDoc ''
+        Overridable attribute of the WriteFreely package to use.
+      '';
+    };
+
+    user = mkOption {
+      type = types.str;
+      default = "writefreely";
+      description = lib.mdDoc "User account under which writefreely runs.";
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = "writefreely";
+      description = lib.mdDoc "Group under which writefreely runs.";
+    };
+
+    dataDir = mkOption {
+      default = "/var/lib/writefreely";
+      type = types.path;
+      description = lib.mdDoc "WriteFreely data directory.";
+    };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = settingsFormat.type;
+      };
+      default = {};
+      defaultText = ''
+        {
+          server = {
+            templates_parent_dir = cfg.package;
+            static_parent_dir = cfg.package;
+            pages_parent_dir = cfg.package;
+
+            keys_parent_dir = cfg.dataDir;
+          };
+          app = {
+            theme = "write";
+          };
+        }
+      '';
+      description = lib.mdDoc ''
+        Configuration for WriteFreely. See the
+        [upstream documentation](https://writefreely.org/docs/latest/admin/config)
+        for available options.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.writefreely.settings = {
+      server = {
+        templates_parent_dir = lib.mkDefault cfg.package;
+        static_parent_dir = lib.mkDefault cfg.package;
+        pages_parent_dir = lib.mkDefault cfg.package;
+        keys_parent_dir = lib.mkDefault cfg.dataDir;
+      };
+      app = {
+        theme = lib.mkDefault "write";
+      };
+    };
+
+    systemd.services.writefreely = {
+      description = lib.mdDoc "WriteFreely, a markdown based publishing platform";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+
+        ExecStartPre = [
+          "${cfg.package}/bin/writefreely -c ${configFile} --gen-keys"
+          "${cfg.package}/bin/writefreely -c ${configFile} --init-db"
+          "${cfg.package}/bin/writefreely -c ${configFile} --migrate"
+        ];
+        ExecStart = "${cfg.package}/bin/writefreely -c ${configFile}";
+        Restart = "on-failure";
+
+        WorkingDirectory = cfg.dataDir;
+        StateDirectory = lib.mkIf
+          (cfg.dataDir == "/var/lib/writefreely")
+          "writefreely";
+        ReadOnlyPaths = [cfg.package];
+        ReadWritePaths = [cfg.dataDir];
+        LimitNOFILE = "1048576";
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectHome = true;
+        ProtectSystem = "strict";
+      };
+    };
+
+    users.users.${cfg.user} = {
+      group = cfg.group;
+      isSystemUser = true;
+    };
+
+    users.groups.${cfg.group} = {};
+  };
+}

--- a/pkgs/applications/misc/writefreely/default.nix
+++ b/pkgs/applications/misc/writefreely/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub, go-bindata }:
+{ lib, buildGoModule, fetchFromGitHub, go-bindata, lessc, nodePackages, stdenv }:
 
 buildGoModule rec {
   pname = "writefreely";
@@ -13,10 +13,35 @@ buildGoModule rec {
 
   vendorSha256 = "sha256-CBPvtc3K9hr1oEmC+yUe3kPSWx20k6eMRqoxsf3NfCE=";
 
+  writefreely-assets = stdenv.mkDerivation {
+    pname = "writefreely-assets";
+    inherit src version;
+
+    nativeBuildInputs = [ lessc ];
+
+    buildPhase = ''
+      export NODE_PATH=${nodePackages.less-plugin-clean-css}/lib/node_modules
+      (
+        cd less
+        make all
+      )
+    '';
+
+    installPhase = ''
+      mkdir $out
+      cp -r templates pages static $out/
+    '';
+  };
+
   nativeBuildInputs = [ go-bindata ];
 
   preBuild = ''
     make assets
+  '';
+
+  postBuild = ''
+    mkdir $out
+    ln -s ${writefreely-assets}/templates ${writefreely-assets}/pages ${writefreely-assets}/static $out/
   '';
 
   ldflags = [ "-s" "-w" "-X github.com/writeas/writefreely.softwareVer=${version}" ];


### PR DESCRIPTION
###### Description of changes
refactor writefreely package to compile `lessc` assets and include templates, pages and static directories in build output (needed for actually running writefreely)
 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
