### PR TITLE
haskell.compilers.ghc941: 9.4.0.20220721 -> 9.4.1

### DIFF
--- a/pkgs/development/compilers/ghc/9.4.1.nix
+++ b/pkgs/development/compilers/ghc/9.4.1.nix
@@ -264,6 +264,13 @@ stdenv.mkDerivation (rec {
           --replace '*-android*|*-gnueabi*)' \
                     '*-android*|*-gnueabi*|*-musleabi*)'
       done
+  ''
+  # HACK: allow bootstrapping with GHC 8.10 which works fine, as we don't have
+  # binary 9.0 packaged. Bootstrapping with 9.2 is broken without hadrian.
+  + ''
+    substituteInPlace configure --replace \
+      'MinBootGhcVersion="9.0"' \
+      'MinBootGhcVersion="8.10"'
   '';
 
   # TODO(@Ericson2314): Always pass "--target" and always prefix.

--- a/pkgs/development/compilers/ghc/9.4.1.nix
+++ b/pkgs/development/compilers/ghc/9.4.1.nix
@@ -177,32 +177,27 @@ assert buildTargetLlvmPackages.llvm == llvmPackages.llvm;
 assert stdenv.targetPlatform.isDarwin -> buildTargetLlvmPackages.clang == llvmPackages.clang;
 
 stdenv.mkDerivation (rec {
-  version = "9.4.0.20220721";
+  version = "9.4.1";
   pname = "${targetPrefix}ghc${variantSuffix}";
 
   src = fetchurl {
-    url = "https://downloads.haskell.org/ghc/9.4.1-rc1/ghc-${version}-src.tar.xz";
-    sha256 = "bca8c52f76d8747a66291181de2de7bdf9ff80093808fe39bf5cbff0f116c426";
+    url = "https://downloads.haskell.org/ghc/${version}/ghc-${version}-src.tar.xz";
+    sha256 = "sha256-y/7UZAvfAl4zulVDPa+M32mPTgSZrnqADd5EqC5zluM=";
   };
 
   enableParallelBuilding = true;
 
   outputs = [ "out" "doc" ];
 
+
   patches = [
-    # fix hyperlinked haddock sources: https://github.com/haskell/haddock/pull/1482
+    # add missing profiling targets in make build system
     (fetchpatch {
-      url = "https://patch-diff.githubusercontent.com/raw/haskell/haddock/pull/1482.patch";
-      sha256 = "sha256-8w8QUCsODaTvknCDGgTfFNZa8ZmvIKaKS+2ZJZ9foYk=";
-      extraPrefix = "utils/haddock/";
-      stripLen = 1;
+      name = "ghc-9.4.1-fix-bootstrapping-with-profiling-1.patch";
+      url = "https://gitlab.haskell.org/ghc/ghc/-/commit/47b4fea08bd0ef1476b8d134c7baf06157fe5fa5.diff";
+      sha256 = "sha256-oYQWg9cK0RNL9I+kap8KER+iiKim73zG6URQs8BeAXU=";
     })
-    # fix race condition in make build system
-    (fetchpatch {
-      name = "ghc-hs-boot-copying-fix.patch";
-      url = "https://gitlab.haskell.org/ghc/ghc/-/commit/4f17eff0cbd125eca55b68f4927befdd45008eb6.diff";
-      sha256 = "0anq3w9z9mhxb0wx6rvxac3n7rl3apcma9zk3r9zz9hj9v7vkqzx";
-    })
+    ./ghc-9.4.1-fix-bootstrapping-with-profiling-2.patch
   ];
 
   postPatch = "patchShebangs .";
@@ -240,14 +235,6 @@ stdenv.mkDerivation (rec {
   '' + ''
 
     echo -n "${buildMK}" > mk/build.mk
-    # GHC 9.4.1-rc1 tarball is not properly prepared, also the boot script has been renamed
-    # https://gitlab.haskell.org/ghc/ghc/-/issues/21626#note_444654
-    # TODO(@sternenseemann): make source-dist rules include all boot-generated files
-    ./boot.source
-
-    # Too restrictive upper bound on Cabal the make build system chokes on
-    # XXX(@sternenseemann): this should be upstreamed
-    substituteInPlace utils/ghc-cabal/ghc-cabal.cabal --replace "3.8" "3.9"
 
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
   '' + lib.optionalString (stdenv.isLinux && hostPlatform.libc == "glibc") ''

--- a/pkgs/development/compilers/ghc/ghc-9.4.1-fix-bootstrapping-with-profiling-2.patch
+++ b/pkgs/development/compilers/ghc/ghc-9.4.1-fix-bootstrapping-with-profiling-2.patch
@@ -1,0 +1,18 @@
+diff --git a/ghc.mk b/ghc.mk
+index dd65e7adfe..b91af56078 100644
+--- a/ghc.mk
++++ b/ghc.mk
+@@ -509,11 +509,13 @@ libraries/containers/containers/dist-install/build/Data/IntMap/Internal.o: libra
+ libraries/containers/containers/dist-install/build/Data/Graph.o: libraries/template-haskell/dist-install/build/Language/Haskell/TH/Lib/Internal.hi
+ libraries/containers/containers/dist-install/build/Data/Set/Internal.o: libraries/template-haskell/dist-install/build/Language/Haskell/TH/Lib/Internal.hi
+ libraries/containers/containers/dist-install/build/Data/IntSet/Internal.o: libraries/template-haskell/dist-install/build/Language/Haskell/TH/Lib/Internal.hi
++libraries/containers/containers/dist-install/build/Data/Sequence/Internal.o: libraries/template-haskell/dist-install/build/Language/Haskell/TH/Lib/Internal.hi
+ 
+ libraries/containers/containers/dist-install/build/Data/IntMap/Internal.p_o: libraries/template-haskell/dist-install/build/Language/Haskell/TH/Lib/Internal.p_hi
+ libraries/containers/containers/dist-install/build/Data/Graph.p_o: libraries/template-haskell/dist-install/build/Language/Haskell/TH/Lib/Internal.p_hi
+ libraries/containers/containers/dist-install/build/Data/Set/Internal.p_o: libraries/template-haskell/dist-install/build/Language/Haskell/TH/Lib/Internal.p_hi
+ libraries/containers/containers/dist-install/build/Data/IntSet/Internal.p_o: libraries/template-haskell/dist-install/build/Language/Haskell/TH/Lib/Internal.p_hi
++libraries/containers/containers/dist-install/build/Data/Sequence/Internal.p_o: libraries/template-haskell/dist-install/build/Language/Haskell/TH/Lib/Internal.p_hi
+ 
+ ifeq "$(BIGNUM_BACKEND)" "gmp"
+ GMP_ENABLED = YES

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -157,10 +157,16 @@ in {
     };
     ghc941 = callPackage ../development/compilers/ghc/9.4.1.nix {
       bootPkgs =
-        # TODO(@sternenseemann): Package 9.0.2 bindist or wait for upstream fix
-        # Need to use 902 due to
+        # 9.2 is broken due to
         # https://gitlab.haskell.org/ghc/ghc/-/issues/21914
-          packages.ghc902;
+        # Use 8.10 as a workaround, TODO: maybe package binary 9.0?
+        # aarch ghc8107Binary exceeds max output size on hydra
+        if stdenv.hostPlatform.isAarch then
+          packages.ghc8107BinaryMinimal
+        else if stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian then
+          packages.ghc8107
+        else
+          packages.ghc8107Binary;
       inherit (buildPackages.python3Packages) sphinx;
       # Need to use apple's patched xattr until
       # https://github.com/xattr/xattr/issues/44 and


### PR DESCRIPTION
Tried to start with this. The patches don’t apply any more, so I removed them.

I get the following build error after 10 minutes:

```
ghc> GHC error in desugarer lookup in Data.IntSet.Internal:
ghc>   Failed to load interface for ‘Language.Haskell.TH.Lib.Internal’
ghc>   Perhaps you haven't installed the profiling libraries for package ‘template-haskell’?
ghc>   Use -v (or `:set -v` in ghci) to see a list of the files searched for.
ghc> ghc-stage1: panic! (the 'impossible' happened)
ghc>   GHC version 9.4.1:
ghc> 	initDs
ghc> 
ghc> Please report this as a GHC bug:  https://www.haskell.org/ghc/reportabug
ghc> 
ghc> make[1]: *** [libraries/containers/containers/ghc.mk:4: libraries/containers/containers/dist-install/build/Data/IntSet/Internal.p_o] Error 1
ghc> make[1]: *** Waiting for unfinished jobs....
ghc> GHC error in desugarer lookup in Data.Set.Internal:
ghc>   Failed to load interface for ‘Language.Haskell.TH.Lib.Internal’
ghc>   Perhaps you haven't installed the profiling libraries for package ‘template-haskell’?
ghc>   Use -v (or `:set -v` in ghci) to see a list of the files searched for.
ghc> ghc-stage1: panic! (the 'impossible' happened)
ghc>   GHC version 9.4.1:
ghc> 	initDs
ghc> 
ghc> Please report this as a GHC bug:  https://www.haskell.org/ghc/reportabug
ghc> 
ghc> make[1]: *** [libraries/containers/containers/ghc.mk:4: libraries/containers/containers/dist-install/build/Data/Set/Internal.p_o] Error 1
ghc> GHC error in desugarer lookup in Data.Sequence.Internal:
ghc>   Failed to load interface for ‘Language.Haskell.TH.Lib.Internal’
ghc>   Perhaps you haven't installed the profiling libraries for package ‘template-haskell’?
ghc>   Use -v (or `:set -v` in ghci) to see a list of the files searched for.
ghc> ghc-stage1: panic! (the 'impossible' happened)
ghc>   GHC version 9.4.1:
ghc> 	initDs
ghc> 
ghc> Please report this as a GHC bug:  https://www.haskell.org/ghc/reportabug
ghc> 
ghc> make[1]: *** [libraries/containers/containers/ghc.mk:4: libraries/containers/containers/dist-install/build/Data/Sequence/Internal.p_o] Error 1
ghc> make: *** [Makefile:128: all] Error 2
error: builder for '/nix/store/gp2536ki3xk4hm0v2v1ry7x3w9lg1rn7-ghc-9.4.1.drv' failed with exit code 2;
       last 10 log lines:
       >   Perhaps you haven't installed the profiling libraries for package ‘template-haskell’?
       >   Use -v (or `:set -v` in ghci) to see a list of the files searched for.
       > ghc-stage1: panic! (the 'impossible' happened)
       >   GHC version 9.4.1:
       > 	initDs
       >
       > Please report this as a GHC bug:  https://www.haskell.org/ghc/reportabug
       >
       > make[1]: *** [libraries/containers/containers/ghc.mk:4: libraries/containers/containers/dist-install/build/Data/Sequence/Internal.p_o] Error 1
       > make: *** [Makefile:128: all] Error 2
       For full logs, run 'nix log /nix/store/gp2536ki3xk4hm0v2v1ry7x3w9lg1rn7-ghc-9.4.1.drv'.
error: 1 dependencies of derivation '/nix/store/mdxpgzhravp5smkzm74kihbbp80zx4m5-hscolour-1.24.4.drv' failed to build
┏━ Dependency Graph:
┃ ┌─ ⏳︎︎︎ hscolour-1.24.4 waiting for 1 failed
┃ ├─ ⚠︎ ghc-9.4.1 failed with exit code 2 after ⏱︎ 10m4s in buildPhase
┃ ⏳︎︎︎ hscolour-1.24.4
┣━━━ Builds          
┗━ ∑ ▶︎ 0 │ ✔︎ 0 │ ⏳︎︎︎ 2 │ ⚠︎ Exited after 1 build failures at 00:58:19 after 10m10s
```