### PR TITLE
subedit: init at 1.2.2

### DIFF
--- a/pkgs/tools/text/subedit/default.nix
+++ b/pkgs/tools/text/subedit/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, lib, fetchFromGitHub, makeWrapper, libuchardet, dos2unix, file }:
+
+stdenv.mkDerivation {
+  pname = "subedit";
+  version = "1.2.2";
+
+  src = fetchFromGitHub {
+    owner = "helixarch";
+    repo = "subedit";
+    rev = "74e11816d7b4813064a2434a5abc0f78f66c0e53";
+    sha256 = "sha256-3ywBBCWbwDqNNkxRupNJX6mYKxVFnoCFKav3Hc4E+8A=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [ libuchardet dos2unix file ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -m555 subedit $out/bin/
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/subedit --prefix PATH : "${lib.makeBinPath [ libuchardet dos2unix file ]}"
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/helixarch/subedit";
+    description = "Command-line subtitle editor written in BASH";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ ppom ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10954,6 +10954,8 @@ with pkgs;
 
   subberthehut = callPackage ../tools/misc/subberthehut { };
 
+  subedit = callPackage ../tools/text/subedit { };
+
   subgit = callPackage ../applications/version-management/git-and-tools/subgit { };
 
   subsurface = libsForQt514.callPackage ../applications/misc/subsurface { };


### PR DESCRIPTION
###### Description of changes

Command-line subtitle editor written in BASH. https://github.com/helixarch/subedit

Since [subtitleeditor is broken](https://github.com/NixOS/nixpkgs/issues/170186), I needed another subtitle editor and found this, useful to shift subtitles times etc.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
