### PR TITLE
mpvpaper: init at 1.2.1

### DIFF
--- a/pkgs/tools/wayland/mpvpaper/default.nix
+++ b/pkgs/tools/wayland/mpvpaper/default.nix
@@ -1,0 +1,65 @@
+{ stdenv
+, lib
+, meson
+, cmake
+, ninja
+, wlroots
+, wayland
+, wayland-protocols
+, egl-wayland
+, glew-egl
+, mpv
+, pkg-config
+, fetchFromGitHub
+, makeWrapper
+, installShellFiles
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mpvpaper";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "GhostNaN";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-1+noph6iXM5OSNMFQyta/ttGyZQ6F7bWDQi8W190G5E=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    makeWrapper
+    installShellFiles
+  ];
+
+  buildInputs = [
+    wlroots
+    wayland
+    wayland-protocols
+    egl-wayland
+    glew-egl
+    mpv
+  ];
+
+  preInstall = ''
+    mv ../mpvpaper.man ../mpvpaper.1
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/mpvpaper \
+      --prefix PATH : ${lib.makeBinPath [ mpv ]}
+
+    installManPage ../mpvpaper.1
+  '';
+
+  meta = with lib; {
+    description = "A video wallpaper program for wlroots based wayland compositors";
+    homepage = "https://github.com/GhostNaN/mpvpaper";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    mainProgram = "mpvpaper";
+    maintainers = with maintainers; [ atila ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29117,6 +29117,8 @@ with pkgs;
   wrapMpv = callPackage ../applications/video/mpv/wrapper.nix { };
   mpv = wrapMpv mpv-unwrapped {};
 
+  mpvpaper = callPackage ../tools/wayland/mpvpaper { };
+
   mpvScripts = recurseIntoAttrs {
     autoload = callPackage ../applications/video/mpv/scripts/autoload.nix {};
     convert = callPackage ../applications/video/mpv/scripts/convert.nix {};


### PR DESCRIPTION
###### Description of changes

MPVPaper is a wallpaper program for wlroots based wayland compositors, such as sway. That allows you to play videos with mpv as your wallpaper.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
