### PR TITLE
armcord: init at 3.0.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13976,6 +13976,15 @@
     github = "wr0belj";
     githubId = 40501814;
   };
+  wrmilling = {
+    name = "Winston R. Milling";
+    email = "Winston@Milli.ng";
+    github = "WRMilling";
+    githubId = 6162814;
+    keys = [{
+      fingerprint = "21E1 6B8D 2EE8 7530 6A6C  9968 D830 77B9 9F8C 6643";
+    }];
+  };
   wscott = {
     email = "wsc9tt@gmail.com";
     github = "wscott";

--- a/pkgs/applications/networking/instant-messengers/armcord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/armcord/default.nix
@@ -1,0 +1,129 @@
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, dpkg
+, makeWrapper
+, alsa-lib
+, at-spi2-atk
+, at-spi2-core
+, atk
+, cairo
+, cups
+, dbus
+, expat
+, ffmpeg
+, fontconfig
+, freetype
+, gdk-pixbuf
+, glib
+, gtk3
+, libappindicator-gtk3
+, libdbusmenu
+, libdrm
+, libnotify
+, libpulseaudio
+, libsecret
+, libuuid
+, libxkbcommon
+, mesa
+, nss
+, pango
+, systemd
+, xdg-utils
+, xorg
+}:
+
+stdenv.mkDerivation rec {
+  pname = "armcord";
+  version = "3.0.7";
+
+  src = let
+    base = "https://github.com/ArmCord/ArmCord/releases/download";
+  in {
+    x86_64-linux = fetchurl {
+      url = "${base}/v${version}/ArmCord_${version}_amd64.deb";
+      sha256 = "b2a583e6abbc6e5dc3f7370a33f21fc4e7963c6cbe7555e954156c77e9577261";
+    };
+    aarch64-linux = fetchurl {
+      url = "${base}/v${version}/ArmCord_${version}_arm64.deb";
+      sha256 = "8c32a14ab8e5bdf865a6523cb4b5cec8f3f870b95f99be9661a4dd0df33aae1d";
+    };
+  }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  nativeBuildInputs = [ autoPatchelfHook dpkg makeWrapper ];
+
+  buildInputs = [
+    alsa-lib
+    at-spi2-atk
+    at-spi2-core
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    ffmpeg
+    fontconfig
+    freetype
+    gdk-pixbuf
+    glib
+    gtk3
+    pango
+    systemd
+    mesa # for libgbm
+    nss
+    libuuid
+    libdrm
+    libnotify
+    libsecret
+    libpulseaudio
+    libxkbcommon
+    libappindicator-gtk3
+    xorg.libX11
+    xorg.libxcb
+    xorg.libXcomposite
+    xorg.libXcursor
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXi
+    xorg.libXrandr
+    xorg.libXrender
+    xorg.libXScrnSaver
+    xorg.libxshmfence
+    xorg.libXtst
+  ];
+
+  sourceRoot = ".";
+  unpackCmd = "dpkg-deb -x $src .";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/bin"
+    cp -R "opt" "$out"
+    cp -R "usr/share" "$out/share"
+    chmod -R g-w "$out"
+
+    # Wrap the startup command
+    makeWrapper $out/opt/ArmCord/armcord $out/bin/armcord \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath buildInputs}" \
+      --prefix PATH : ${lib.makeBinPath [ xdg-utils ]} \
+      "''${gappsWrapperArgs[@]}"
+
+    # Fix desktop link
+    substituteInPlace $out/share/applications/armcord.desktop \
+      --replace /opt/ArmCord/ $out/bin/
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Lightweight, alternative desktop client for Discord";
+    homepage = "https://github.com/ArmCord/ArmCord";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = licenses.osl3;
+    maintainers = with maintainers; [ wrmilling ];
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26046,6 +26046,8 @@ with pkgs;
   };
 
 
+  armcord = callPackage ../applications/networking/instant-messengers/armcord { };
+
   aumix = callPackage ../applications/audio/aumix {
     gtkGUI = false;
   };


### PR DESCRIPTION
###### Description of changes

[ArmCord](https://github.com/ArmCord/ArmCord) is a custom client designed to enhance your Discord experience while keeping everything lightweight. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
