### PR TITLE
sysbench: add macOS support

### DIFF
--- a/pkgs/development/tools/misc/sysbench/default.nix
+++ b/pkgs/development/tools/misc/sysbench/default.nix
@@ -1,5 +1,14 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config
-, libmysqlclient, libaio
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, libmysqlclient
+, libaio
+, luajit
+# For testing:
+, testers
+, sysbench
 }:
 
 stdenv.mkDerivation rec {
@@ -7,7 +16,7 @@ stdenv.mkDerivation rec {
   version = "1.0.20";
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
-  buildInputs = [ libmysqlclient libaio ];
+  buildInputs = [ libmysqlclient luajit ] ++ lib.optionals stdenv.isLinux [ libaio ];
 
   src = fetchFromGitHub {
     owner = "akopytov";
@@ -18,10 +27,31 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  configureFlags = [
+    # The bundled version does not build on aarch64-darwin:
+    # https://github.com/akopytov/sysbench/issues/416
+    "--with-system-luajit"
+  ];
+
+  passthru.tests = {
+    versionTest = testers.testVersion {
+      package = sysbench;
+    };
+  };
+
   meta = {
     description = "Modular, cross-platform and multi-threaded benchmark tool";
+    longDescription = ''
+      sysbench is a scriptable multi-threaded benchmark tool based on LuaJIT.
+      It is most frequently used for database benchmarks, but can also be used
+      to create arbitrarily complex workloads that do not involve a database
+      server.
+    '';
     homepage = "https://github.com/akopytov/sysbench";
+    downloadPage = "https://github.com/akopytov/sysbench/releases/tag/${version}";
+    changelog = "https://github.com/akopytov/sysbench/blob/${version}/ChangeLog";
     license = lib.licenses.gpl2;
-    platforms = lib.platforms.linux;
+    mainProgram = pname;
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/development/tools/misc/sysbench/default.nix
+++ b/pkgs/development/tools/misc/sysbench/default.nix
@@ -51,7 +51,6 @@ stdenv.mkDerivation rec {
     downloadPage = "https://github.com/akopytov/sysbench/releases/tag/${version}";
     changelog = "https://github.com/akopytov/sysbench/blob/${version}/ChangeLog";
     license = lib.licenses.gpl2;
-    mainProgram = pname;
     platforms = lib.platforms.unix;
   };
 }


### PR DESCRIPTION
###### Description of changes

Fix `sysbench` on macOS by:
  - gating the `libaio` dep on Linux
  - using the nixpkg for `luajit` instead of the bundled one (which [fails to build on aarch64 macOS](https://github.com/akopytov/sysbench/issues/416))

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).