### PR TITLE
libguestfs: fix virt-* wrappers

### DIFF
--- a/pkgs/development/libraries/libguestfs/default.nix
+++ b/pkgs/development/libraries/libguestfs/default.nix
@@ -3,7 +3,7 @@
 , fetchurl
 , pkg-config
 , autoreconfHook
-, makeWrapper
+, makeBinaryWrapper
 , ncurses
 , cpio
 , gperf
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
     flex
     getopt
     gperf
-    makeWrapper
+    makeBinaryWrapper
     pkg-config
     qemu
   ] ++ (with perlPackages; [ perl libintl-perl GetoptLong ModuleBuild ])
@@ -120,9 +120,14 @@ stdenv.mkDerivation rec {
   postInstall = ''
     mv "$out/lib/ocaml/guestfs" "$OCAMLFIND_DESTDIR/guestfs"
     for bin in $out/bin/*; do
-      wrapProgram "$bin" \
-        --prefix PATH     : "$out/bin:${hivex}/bin:${qemu}/bin" \
-        --prefix PERL5LIB : "$out/${perlPackages.perl.libPrefix}"
+      if isScript "$bin"; then
+        substituteInPlace "$bin" \
+          --replace guestfish "$out/bin/guestfish"
+      elif isELF "$bin"; then
+        wrapProgram "$bin" \
+          --prefix PATH     : "$out/bin:${hivex}/bin:${qemu}/bin" \
+          --prefix PERL5LIB : "$out/${perlPackages.perl.libPrefix}"
+      fi
     done
   '';
 


### PR DESCRIPTION
###### Description of changes

Follow-up to #185015.

The virt-* scripts provided by upstream rely on a correct `$0`, so they cannot be wrapped themselves. The scripts call the guestfish binary, which is wrapped itself.

Fix this by not wrapping the scripts, but use `substituteInPlace` to call the binary guestfish wrapper, which can be execed with an overridden `$0` and will set all the required environment variables.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).