### PR TITLE
gnome.gnome-system-monitor: Fix privileged operations

### DIFF
--- a/pkgs/desktops/gnome/core/gnome-system-monitor/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-system-monitor/default.nix
@@ -30,6 +30,11 @@ stdenv.mkDerivation rec {
     sha256 = "EyOdIgMiAaIr0pgzxXW2hIFnANLeFooVMCI1d8XAddw=";
   };
 
+  patches = [
+    # Fix pkexec detection on NixOS.
+    ./fix-paths.patch
+  ];
+
   nativeBuildInputs = [
     pkg-config
     gettext

--- a/pkgs/desktops/gnome/core/gnome-system-monitor/fix-paths.patch
+++ b/pkgs/desktops/gnome/core/gnome-system-monitor/fix-paths.patch
@@ -1,0 +1,13 @@
+diff --git a/src/gsm_pkexec.cpp b/src/gsm_pkexec.cpp
+index 868969ba..51eb93b5 100644
+--- a/src/gsm_pkexec.cpp
++++ b/src/gsm_pkexec.cpp
+@@ -33,6 +33,7 @@ gboolean gsm_pkexec_create_root_password_dialog(const char *command)
+ gboolean
+ procman_has_pkexec(void)
+ {
+-    return g_file_test("/usr/bin/pkexec", G_FILE_TEST_EXISTS);
++    return g_file_test("/run/wrappers/bin/pkexec", G_FILE_TEST_EXISTS)
++        || g_file_test("/usr/bin/pkexec", G_FILE_TEST_EXISTS);
+ }
+ 


### PR DESCRIPTION
###### Description of changes

It was checking /usr/bin/pkexec, which is not available on NixOS. Instead, we need to look for the setuid wrapper in /run/wrappers/bin/pkexec.

Fixes:  https://github.com/NixOS/nixpkgs/issues/185764

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
