### PR TITLE
libcxxabi: remove link with build libcxxabi

### DIFF
--- a/pkgs/development/compilers/llvm/10/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/10/libcxxabi/default.nix
@@ -42,11 +42,21 @@ stdenv.mkDerivation {
 
   preInstall = lib.optionalString stdenv.isDarwin ''
     for file in lib/*.dylib; do
+      # Fix up the install name. Preserve the basename, just replace the path.
+      installName="$out/lib/$(basename $(otool -D $file | tail -n 1))"
+
       # this should be done in CMake, but having trouble figuring out
       # the magic combination of necessary CMake variables
       # if you fancy a try, take a look at
       # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
-      install_name_tool -id $out/$file $file
+      ${stdenv.cc.targetPrefix}install_name_tool -id $installName $file
+
+      # cc-wrapper passes '-lc++abi' to all c++ link steps, but that causes
+      # libcxxabi to sometimes link against a different version of itself.
+      # Here we simply make that second reference point to ourselves.
+      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+        ${stdenv.cc.targetPrefix}install_name_tool -change $other $installName $file
+      done
     done
   '';
 

--- a/pkgs/development/compilers/llvm/11/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/11/libcxxabi/default.nix
@@ -46,11 +46,21 @@ stdenv.mkDerivation {
 
   preInstall = lib.optionalString stdenv.isDarwin ''
     for file in lib/*.dylib; do
+      # Fix up the install name. Preserve the basename, just replace the path.
+      installName="$out/lib/$(basename $(otool -D $file | tail -n 1))"
+
       # this should be done in CMake, but having trouble figuring out
       # the magic combination of necessary CMake variables
       # if you fancy a try, take a look at
       # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
-      install_name_tool -id $out/$file $file
+      ${stdenv.cc.targetPrefix}install_name_tool -id $installName $file
+
+      # cc-wrapper passes '-lc++abi' to all c++ link steps, but that causes
+      # libcxxabi to sometimes link against a different version of itself.
+      # Here we simply make that second reference point to ourselves.
+      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+        ${stdenv.cc.targetPrefix}install_name_tool -change $other $installName $file
+      done
     done
   '';
 

--- a/pkgs/development/compilers/llvm/12/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/12/libcxxabi/default.nix
@@ -44,11 +44,21 @@ stdenv.mkDerivation {
 
   preInstall = lib.optionalString stdenv.isDarwin ''
     for file in lib/*.dylib; do
+      # Fix up the install name. Preserve the basename, just replace the path.
+      installName="$out/lib/$(basename $(otool -D $file | tail -n 1))"
+
       # this should be done in CMake, but having trouble figuring out
       # the magic combination of necessary CMake variables
       # if you fancy a try, take a look at
       # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
-      install_name_tool -id $out/$file $file
+      ${stdenv.cc.targetPrefix}install_name_tool -id $installName $file
+
+      # cc-wrapper passes '-lc++abi' to all c++ link steps, but that causes
+      # libcxxabi to sometimes link against a different version of itself.
+      # Here we simply make that second reference point to ourselves.
+      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+        ${stdenv.cc.targetPrefix}install_name_tool -change $other $installName $file
+      done
     done
   '';
 

--- a/pkgs/development/compilers/llvm/13/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/13/libcxxabi/default.nix
@@ -41,11 +41,21 @@ stdenv.mkDerivation rec {
 
   preInstall = lib.optionalString stdenv.isDarwin ''
     for file in lib/*.dylib; do
+      # Fix up the install name. Preserve the basename, just replace the path.
+      installName="$out/lib/$(basename $(otool -D $file | tail -n 1))"
+
       # this should be done in CMake, but having trouble figuring out
       # the magic combination of necessary CMake variables
       # if you fancy a try, take a look at
       # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
-      install_name_tool -id $out/$file $file
+      ${stdenv.cc.targetPrefix}install_name_tool -id $installName $file
+
+      # cc-wrapper passes '-lc++abi' to all c++ link steps, but that causes
+      # libcxxabi to sometimes link against a different version of itself.
+      # Here we simply make that second reference point to ourselves.
+      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+        ${stdenv.cc.targetPrefix}install_name_tool -change $other $installName $file
+      done
     done
   '';
 

--- a/pkgs/development/compilers/llvm/14/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/14/libcxxabi/default.nix
@@ -52,12 +52,23 @@ stdenv.mkDerivation rec {
   installPhase = if stdenv.isDarwin
     then ''
       for file in lib/*.dylib; do
+        # Fix up the install name. Preserve the basename, just replace the path.
+        installName="$out/lib/$(basename $(otool -D $file | tail -n 1))"
+
         # this should be done in CMake, but having trouble figuring out
         # the magic combination of necessary CMake variables
         # if you fancy a try, take a look at
         # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
-        install_name_tool -id $out/$file $file
+        ${stdenv.cc.targetPrefix}install_name_tool -id $installName $file
+
+        # cc-wrapper passes '-lc++abi' to all c++ link steps, but that causes
+        # libcxxabi to sometimes link against a different version of itself.
+        # Here we simply make that second reference point to ourselves.
+        for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+          ${stdenv.cc.targetPrefix}install_name_tool -change $other $installName $file
+        done
       done
+
       make install
       install -d 755 $out/include
       install -m 644 ../include/*.h $out/include

--- a/pkgs/development/compilers/llvm/5/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/5/libcxxabi/default.nix
@@ -27,11 +27,21 @@ stdenv.mkDerivation {
 
   preInstall = lib.optionalString stdenv.isDarwin ''
     for file in lib/*.dylib; do
+      # Fix up the install name. Preserve the basename, just replace the path.
+      installName="$out/lib/$(basename $(otool -D $file | tail -n 1))"
+
       # this should be done in CMake, but having trouble figuring out
       # the magic combination of necessary CMake variables
       # if you fancy a try, take a look at
       # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
-      install_name_tool -id $out/$file $file
+      ${stdenv.cc.targetPrefix}install_name_tool -id $installName $file
+
+      # cc-wrapper passes '-lc++abi' to all c++ link steps, but that causes
+      # libcxxabi to sometimes link against a different version of itself.
+      # Here we simply make that second reference point to ourselves.
+      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+        ${stdenv.cc.targetPrefix}install_name_tool -change $other $installName $file
+      done
     done
   '';
 

--- a/pkgs/development/compilers/llvm/6/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/6/libcxxabi/default.nix
@@ -27,11 +27,21 @@ stdenv.mkDerivation {
 
   preInstall = lib.optionalString stdenv.isDarwin ''
     for file in lib/*.dylib; do
+      # Fix up the install name. Preserve the basename, just replace the path.
+      installName="$out/lib/$(basename $(otool -D $file | tail -n 1))"
+
       # this should be done in CMake, but having trouble figuring out
       # the magic combination of necessary CMake variables
       # if you fancy a try, take a look at
       # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
-      install_name_tool -id $out/$file $file
+      ${stdenv.cc.targetPrefix}install_name_tool -id $installName $file
+
+      # cc-wrapper passes '-lc++abi' to all c++ link steps, but that causes
+      # libcxxabi to sometimes link against a different version of itself.
+      # Here we simply make that second reference point to ourselves.
+      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+        ${stdenv.cc.targetPrefix}install_name_tool -change $other $installName $file
+      done
     done
   '';
 

--- a/pkgs/development/compilers/llvm/7/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/7/libcxxabi/default.nix
@@ -46,11 +46,21 @@ stdenv.mkDerivation {
 
   preInstall = lib.optionalString stdenv.isDarwin ''
     for file in lib/*.dylib; do
+      # Fix up the install name. Preserve the basename, just replace the path.
+      installName="$out/lib/$(basename $(otool -D $file | tail -n 1))"
+
       # this should be done in CMake, but having trouble figuring out
       # the magic combination of necessary CMake variables
       # if you fancy a try, take a look at
       # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
-      install_name_tool -id $out/$file $file
+      ${stdenv.cc.targetPrefix}install_name_tool -id $installName $file
+
+      # cc-wrapper passes '-lc++abi' to all c++ link steps, but that causes
+      # libcxxabi to sometimes link against a different version of itself.
+      # Here we simply make that second reference point to ourselves.
+      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+        ${stdenv.cc.targetPrefix}install_name_tool -change $other $installName $file
+      done
     done
   '';
 

--- a/pkgs/development/compilers/llvm/8/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/8/libcxxabi/default.nix
@@ -42,11 +42,21 @@ stdenv.mkDerivation {
 
   preInstall = lib.optionalString stdenv.isDarwin ''
     for file in lib/*.dylib; do
+      # Fix up the install name. Preserve the basename, just replace the path.
+      installName="$out/lib/$(basename $(otool -D $file | tail -n 1))"
+
       # this should be done in CMake, but having trouble figuring out
       # the magic combination of necessary CMake variables
       # if you fancy a try, take a look at
       # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
-      install_name_tool -id $out/$file $file
+      ${stdenv.cc.targetPrefix}install_name_tool -id $installName $file
+
+      # cc-wrapper passes '-lc++abi' to all c++ link steps, but that causes
+      # libcxxabi to sometimes link against a different version of itself.
+      # Here we simply make that second reference point to ourselves.
+      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+        ${stdenv.cc.targetPrefix}install_name_tool -change $other $installName $file
+      done
     done
   '';
 

--- a/pkgs/development/compilers/llvm/9/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/9/libcxxabi/default.nix
@@ -42,11 +42,21 @@ stdenv.mkDerivation {
 
   preInstall = lib.optionalString stdenv.isDarwin ''
     for file in lib/*.dylib; do
+      # Fix up the install name. Preserve the basename, just replace the path.
+      installName="$out/lib/$(basename $(otool -D $file | tail -n 1))"
+
       # this should be done in CMake, but having trouble figuring out
       # the magic combination of necessary CMake variables
       # if you fancy a try, take a look at
       # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
-      install_name_tool -id $out/$file $file
+      ${stdenv.cc.targetPrefix}install_name_tool -id $installName $file
+
+      # cc-wrapper passes '-lc++abi' to all c++ link steps, but that causes
+      # libcxxabi to sometimes link against a different version of itself.
+      # Here we simply make that second reference point to ourselves.
+      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+        ${stdenv.cc.targetPrefix}install_name_tool -change $other $installName $file
+      done
     done
   '';
 

--- a/pkgs/development/compilers/llvm/git/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/git/libcxxabi/default.nix
@@ -70,11 +70,21 @@ stdenv.mkDerivation rec {
 
   preInstall = lib.optionalString stdenv.isDarwin ''
     for file in lib/*.dylib; do
+      # Fix up the install name. Preserve the basename, just replace the path.
+      installName="$out/lib/$(basename $(otool -D $file | tail -n 1))"
+
       # this should be done in CMake, but having trouble figuring out
       # the magic combination of necessary CMake variables
       # if you fancy a try, take a look at
       # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
-      install_name_tool -id $out/$file $file
+      ${stdenv.cc.targetPrefix}install_name_tool -id $installName $file
+
+      # cc-wrapper passes '-lc++abi' to all c++ link steps, but that causes
+      # libcxxabi to sometimes link against a different version of itself.
+      # Here we simply make that second reference point to ourselves.
+      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+        ${stdenv.cc.targetPrefix}install_name_tool -change $other $installName $file
+      done
     done
   '';
 


### PR DESCRIPTION
###### Description of changes

This is a fix for the issue seen in https://github.com/NixOS/nixpkgs/pull/181485#issuecomment-1209068948.

I updated the snippet across all LLVM versions, but that probably implies a Darwin stdenv rebuild (via v11). I've not yet tested this, just the library build itself on v13 (and verified `otool -L` output).

The previous snippet did a for-loop over `lib/*.dylib`, but all but one of those are symlinks. This also meant the final install name was whatever it processed last. It now preserves the exact basename.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
