### PR TITLE
garage: 0.7.0 -> 0.7.3

### DIFF
--- a/pkgs/tools/filesystems/garage/default.nix
+++ b/pkgs/tools/filesystems/garage/default.nix
@@ -1,22 +1,41 @@
-{ lib, stdenv, rustPlatform, fetchFromGitea, protobuf, testers, Security, garage }:
+{ lib, stdenv, rustPlatform, fetchFromGitea, openssl, pkg-config, protobuf
+, testers, Security, garage }:
 
 rustPlatform.buildRustPackage rec {
   pname = "garage";
-  version = "0.7.0";
+  version = "0.7.3";
 
   src = fetchFromGitea {
     domain = "git.deuxfleurs.fr";
     owner = "Deuxfleurs";
     repo = "garage";
     rev = "v${version}";
-    sha256 = "sha256-gs0TW431YUrdsdJ+PYrJgnLiBmDPYnUR0iVnQ/YqIfU=";
+    sha256 = "sha256-WDhe2L+NalMoIy2rhfmv8KCNDMkcqBC9ezEKKocihJg=";
   };
 
-  cargoSha256 = "sha256-XGSenT2q3VXNcIT1Lg1e5HTOkEdOb1o3H07ahteQM/o=";
+  cargoSha256 = "sha256-5m4c8/upBYN8nuysDhGKEnNVJjEGC+yLrraicrAQOfI=";
 
-  nativeBuildInputs = [ protobuf ];
+  nativeBuildInputs = [ protobuf pkg-config ];
 
-  buildInputs = lib.optional stdenv.isDarwin Security;
+  buildInputs = [
+    openssl
+  ] ++ lib.optional stdenv.isDarwin Security;
+
+  OPENSSL_NO_VENDOR = true;
+
+  # See https://git.deuxfleurs.fr/Deuxfleurs/garage/src/tag/v0.7.2/default.nix#L84-L98
+  # on version changes for checking if changes are required here
+  buildFeatures = [
+    "kubernetes-discovery"
+  ];
+
+  # To make integration tests pass, we include the optional k2v feature here,
+  # but not in buildFeatures. See:
+  # https://garagehq.deuxfleurs.fr/documentation/reference-manual/k2v/
+  checkFeatures = [
+    "k2v"
+    "kubernetes-discovery"
+  ];
 
   passthru = {
     tests.version = testers.testVersion { package = garage; };


### PR DESCRIPTION
###### Description of changes
https://git.deuxfleurs.fr/Deuxfleurs/garage/compare/v0.7.0...v0.7.3

Added `checkFeatures` and `checkInputs`, required to pass integration tests.
Upstream's [shell.nix](https://git.deuxfleurs.fr/Deuxfleurs/garage/src/tag/v0.7.2/shell.nix) helped me figure out why tests suddenly started failing while doing a minor version bump. For future reference, failures looked like this:
```
---- k2v::item::test_item_return_format stdout ----
thread 'k2v::item::test_item_return_format' panicked at 'called `Result::unwrap()` on an `Err` value: hyper::Error(Connect, ConnectError("tcp connect error", Os { code: 111, kind: ConnectionRefused, me>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
I also tried to address this in a comment. 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
