### PR TITLE
pipectl: 0.3.0 -> 0.4.1

### DIFF
--- a/pkgs/tools/misc/pipectl/default.nix
+++ b/pkgs/tools/misc/pipectl/default.nix
@@ -2,20 +2,25 @@
 , lib
 , fetchFromGitHub
 , cmake
+, scdoc
 }:
 
 stdenv.mkDerivation rec {
   pname = "pipectl";
-  version = "0.3.0";
+  version = "0.4.1";
 
   src = fetchFromGitHub {
     owner = "Ferdi265";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-+o5hIDtDAh4r+AKCUhueQ3GBYf2sZtMATGX73Qg+tbo=";
+    hash = "sha256-dWRem9VHzMwVo+ahUagZB2r4Ag8PyBef5X41vVpZcAc=";
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake scdoc ];
+
+  cmakeFlags = [
+    "-DINSTALL_DOCUMENTATION=ON"
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/Ferdi265/pipectl";


### PR DESCRIPTION
###### Description of changes

Update `pipectl` to 0.4.1.

This adds a new dependency on `scdoc` and adds a manual page for `pipectl`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

This PR obsoletes #183735 (automatic update of pipectl to latest) since that PR does not add the new depencency.

cc @Synthetica9