### PR TITLE
crc32c: don't install gtest

### DIFF
--- a/pkgs/development/libraries/crc32c/default.nix
+++ b/pkgs/development/libraries/crc32c/default.nix
@@ -28,6 +28,7 @@ stdenv.mkDerivation rec {
     "-DCRC32C_BUILD_TESTS=1"
     "-DCRC32C_BUILD_BENCHMARKS=0"
     "-DCRC32C_USE_GLOG=0"
+    "-DINSTALL_GTEST=0"
     "-DBUILD_SHARED_LIBS=${if staticOnly then "0" else "1"}"
   ];
 
@@ -42,20 +43,7 @@ stdenv.mkDerivation rec {
     runHook postInstallCheck
   '';
 
-  postInstallCheck = ''
-    # without removing these libraries, dependents will look for
-    # libgtest/libgmock etc here, which can result in link time errors
-    rm $out/lib/libg*
-  '';
-
   postFixup = ''
-    # dependents shouldn't be able to find gtest libraries as dependencies of
-    # this package
-    rm -r $out/lib/pkgconfig
-
-    # remove GTest cmake config files
-    rm -r $out/lib/cmake/GTest
-
     # fix bogus include paths
     for f in $(find $out/lib/cmake -name '*.cmake'); do
       substituteInPlace "$f" --replace "\''${_IMPORT_PREFIX}/$out/include" "\''${_IMPORT_PREFIX}/include"


### PR DESCRIPTION
###### Description of changes

The desired behavior can be controlled with a configuration option instead of manually cleaning the output afterwards.
This is a prerequisite for bumping google-cloud-cpp because the headers weren't removed and will cause conflicts for packages that depend on both gtest and crc32c.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
