### PR TITLE
[22.05] libtirpc: apply patch for CVE-2021-46828

### DIFF
--- a/pkgs/development/libraries/ti-rpc/default.nix
+++ b/pkgs/development/libraries/ti-rpc/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, lib, stdenv, autoreconfHook, libkrb5 }:
+{ fetchurl, lib, stdenv, autoreconfHook, libkrb5, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "libtirpc";
@@ -11,6 +11,16 @@ stdenv.mkDerivation rec {
   };
 
   outputs = [ "out" "dev" ];
+
+  patches = [
+    # https://nvd.nist.gov/vuln/detail/CVE-2021-46828
+    (fetchpatch {
+      name = "CVE-2021-46828.patch";
+      url = "https://git.linux-nfs.org/?p=steved/libtirpc.git;a=patch;h=86529758570cef4c73fb9b9c4104fdc510f701ed";
+      sha256 = "sha256-7dOICbAGq1NMl0zV/RdzXkxrcE5NRDylfyiadwIIMtM=";
+      excludes = [ "INSTALL" ];
+    })
+  ];
 
   postPatch = ''
     sed '1i#include <stdint.h>' -i src/xdr_sizeof.c


### PR DESCRIPTION


###### Description of changes
https://nvd.nist.gov/vuln/detail/CVE-2021-46828

See #185778 for the change against master.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
