### PR TITLE
kodelife: 0.9.8.143 -> 1.0.5.161

### DIFF
--- a/pkgs/applications/graphics/kodelife/default.nix
+++ b/pkgs/applications/graphics/kodelife/default.nix
@@ -1,15 +1,51 @@
-{ lib, stdenv
-, fetchzip
+{ lib
+, stdenv
+, fetchurl
+, makeWrapper
+, autoPatchelfHook
+, dpkg
 , alsa-lib
-, glib
-, gst_all_1
-, libGLU, libGL
-, xorg
+, curl
+, avahi
+, gstreamer
+, gst-plugins-base
+, libxcb
+, libX11
+, libXcursor
+, libXext
+, libXi
+, libXinerama
+, libXrandr
+, libXrender
+, libXxf86vm
+, libglvnd
+, gnome
 }:
+
+let
+  runLibDeps = [
+    curl
+    avahi
+    libxcb
+    libX11
+    libXcursor
+    libXext
+    libXi
+    libXinerama
+    libXrandr
+    libXrender
+    libXxf86vm
+    libglvnd
+  ];
+
+  runBinDeps = [
+    gnome.zenity
+  ];
+in
 
 stdenv.mkDerivation rec {
   pname = "kodelife";
-  version = "0.9.8.143";
+  version = "1.0.5.161";
 
   suffix = {
     aarch64-linux = "linux-arm64";
@@ -17,51 +53,55 @@ stdenv.mkDerivation rec {
     x86_64-linux  = "linux-x86_64";
   }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
-  src = fetchzip {
-    url = "https://hexler.net/pub/${pname}/${pname}-${version}-${suffix}.zip";
-    sha256 = {
-      aarch64-linux = "0ryjmpzpfqdqrvqpq851vvrjd8ld5g91gcigpv9rxp3z1b7qdand";
-      armv7l-linux  = "08nlwn8ixndqil4m7j6c8gjxmwx8zi3in86arnwf13shk6cds5nb";
-      x86_64-linux  = "0kbz7pvh4i4a3pj1vzbzzslha825i888isvsigcqsqvipjr4798q";
+  src = fetchurl {
+    url = "https://hexler.net/pub/${pname}/${pname}-${version}-${suffix}.deb";
+    hash = {
+      aarch64-linux = "sha256-6QZ5jCxINCH46GQx+V68FpkIAOIOFw4Kd0tUQTKBRzU=";
+      armv7l-linux  = "sha256-eToNjPttY62EzNuRSVvJsHttO6Ux6LXRPRuuIKnvaxM=";
+      x86_64-linux  = "sha256-5M2tgpF74RmrCLI44RBNXK5t0hMAOHtmcjWu7fypc0U=";
     }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
   };
 
-  dontConfigure = true;
-  dontBuild = true;
-  dontStrip = true;
-  dontPatchELF = true;
-  preferLocalBuild = true;
+  unpackCmd = "mkdir root; dpkg-deb -x $curSrc root";
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+    autoPatchelfHook
+    dpkg
+  ];
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+    alsa-lib
+    gstreamer
+    gst-plugins-base
+  ];
 
   installPhase = ''
     runHook preInstall
+
+    mkdir -p $out
+    cp -r usr/share $out/share
+
     mkdir -p $out/bin
-    mv KodeLife $out/bin
+    cp opt/kodelife/KodeLife $out/bin/KodeLife
+
+    wrapProgram $out/bin/KodeLife \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath runLibDeps} \
+      --prefix PATH : ${lib.makeBinPath runBinDeps}
+
     runHook postInstall
   '';
 
-  preFixup = let
-    libPath = lib.makeLibraryPath [
-      stdenv.cc.cc.lib
-      alsa-lib
-      glib
-      gst_all_1.gstreamer
-      gst_all_1.gst-plugins-base
-      libGLU libGL
-      xorg.libX11
-    ];
-  in ''
-    patchelf \
-      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      --set-rpath "${libPath}" \
-      $out/bin/KodeLife
-  '';
-
   meta = with lib; {
-    homepage = "https://hexler.net/products/kodelife";
+    homepage = "https://hexler.net/kodelife";
     description = "Real-time GPU shader editor";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
-    maintainers = with maintainers; [ prusnak ];
+    maintainers = with maintainers; [ prusnak lilyinstarlight ];
     platforms = [ "aarch64-linux" "armv7l-linux" "x86_64-linux" ];
+    mainProgram = "KodeLife";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36227,7 +36227,9 @@ with pkgs;
 
   uhubctl = callPackage ../tools/misc/uhubctl {};
 
-  kodelife = callPackage ../applications/graphics/kodelife {};
+  kodelife = callPackage ../applications/graphics/kodelife {
+    inherit (gst_all_1) gstreamer gst-plugins-base;
+  };
 
   bunnyfetch = callPackage ../tools/misc/bunnyfetch {};
 


### PR DESCRIPTION
###### Description of changes

Updates:
* bump kodelife version to 1.0.5.161
* use the .deb package download to get a desktop file, icons, and stuff in the output
* make sure newer deps that it expects to be able to `dlopen` or `exec` at runtime are available
* use `autoPatchelfHook`
* set `mainProgram` to allow running `NIXPKGS_ALLOW_UNFREE=1 nix run --impure nixpkgs#kodelife`

cc: @prusnak 

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).