### PR TITLE
touchosc: init at 1.1.4.143

### DIFF
--- a/pkgs/applications/audio/touchosc/default.nix
+++ b/pkgs/applications/audio/touchosc/default.nix
@@ -1,0 +1,108 @@
+{ lib
+, stdenv
+, fetchurl
+, makeWrapper
+, autoPatchelfHook
+, dpkg
+, alsa-lib
+, curl
+, avahi
+, jack2
+, libxcb
+, libX11
+, libXcursor
+, libXext
+, libXi
+, libXinerama
+, libXrandr
+, libXrender
+, libXxf86vm
+, libglvnd
+, gnome
+}:
+
+let
+  runLibDeps = [
+    curl
+    avahi
+    jack2
+    libxcb
+    libX11
+    libXcursor
+    libXext
+    libXi
+    libXinerama
+    libXrandr
+    libXrender
+    libXxf86vm
+    libglvnd
+  ];
+
+  runBinDeps = [
+    gnome.zenity
+  ];
+in
+
+stdenv.mkDerivation rec {
+  pname = "touchosc";
+  version = "1.1.4.143";
+
+  suffix = {
+    aarch64-linux = "linux-arm64";
+    armv7l-linux  = "linux-armhf";
+    x86_64-linux  = "linux-x86_64";
+  }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  src = fetchurl {
+    url = "https://hexler.net/pub/${pname}/${pname}-${version}-${suffix}.deb";
+    hash = {
+      aarch64-linux = "sha256-BLPTCaFtsvYzesFvOJVCCofgRVpT2hCvrpYbceh95J4=";
+      armv7l-linux  = "sha256-RpHAXj2biZDqeE9xy3Q+fcGTIvCXfTJNn/jMObfL44g=";
+      x86_64-linux  = "sha256-CD8JR1QVMBe//MyrNfo8RE1ogoVU0H87IU5rTg5rDAU=";
+    }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+  };
+
+  unpackCmd = "mkdir root; dpkg-deb -x $curSrc root";
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+    autoPatchelfHook
+    dpkg
+  ];
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+    alsa-lib
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -r usr/share $out/share
+
+    mkdir -p $out/bin
+    cp opt/touchosc/TouchOSC $out/bin/TouchOSC
+
+    wrapProgram $out/bin/TouchOSC \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath runLibDeps} \
+      --prefix PATH : ${lib.makeBinPath runBinDeps}
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://hexler.net/touchosc";
+    description = "Next generation modular control surface";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = licenses.unfree;
+    maintainers = with maintainers; [ lilyinstarlight ];
+    platforms = [ "aarch64-linux" "armv7l-linux" "x86_64-linux" ];
+    mainProgram = "TouchOSC";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35678,6 +35678,8 @@ with pkgs;
 
   thinkfan = callPackage ../tools/system/thinkfan { };
 
+  touchosc = callPackage ../applications/audio/touchosc {};
+
   tp-auto-kbbl = callPackage ../tools/system/tp-auto-kbbl { };
 
   tup = callPackage ../development/tools/build-managers/tup { };


### PR DESCRIPTION
###### Description of changes

Add version 1.1.4.143 based on the updated Kodelife package (#185794)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).