### PR TITLE
nix-bisect: add patch from upstream to fix crashes

### DIFF
--- a/pkgs/development/tools/misc/nix-bisect/default.nix
+++ b/pkgs/development/tools/misc/nix-bisect/default.nix
@@ -25,6 +25,11 @@ python3.pkgs.buildPythonApplication {
       url = "https://github.com/timokau/nix-bisect/commit/01eefe174b740cb90e48b06d67d5582d51786b96.patch";
       hash = "sha256-Gls/NtHH7LujdEgLbcIRZ12KsJDrasXIMcHeeBVns4A=";
     })
+    (fetchpatch {
+      # Fixes TypeError crashes associated with drvs_failed inconsistency
+      url = "https://github.com/timokau/nix-bisect/commit/9f3a17783046baae64c16f9e2be917c2603977fc.patch";
+      hash = "sha256-U9NUtgwslcgIf/wvH/WE7t0HGs2OP3wvYDKrb5j+lp0=";
+    })
   ];
 
   propagatedBuildInputs = with python3.pkgs; [


### PR DESCRIPTION
###### Description of changes

This fixes crashes with the following message when handling build failures:

    TypeError: 'set' object is not subscriptable

See timokau/nix-bisect#20

cc: @mweinelt

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### nixpkgs-review

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>nix-bisect</li>
  </ul>
</details>