### PR TITLE
motrix: init at 1.6.11

### DIFF
--- a/pkgs/tools/networking/motrix/default.nix
+++ b/pkgs/tools/networking/motrix/default.nix
@@ -6,23 +6,21 @@
 let
   pname = "motrix";
   version = "1.6.11";
-  sha256 = "sha256-tE2Q7NM+cQOg+vyqyfRwg05EOMQWhhggTA6S+VT+SkM=";
-  name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://github.com/agalwood/Motrix/releases/download/v${version}/Motrix-${version}.AppImage";
-    inherit sha256;
+    sha256 = "sha256-tE2Q7NM+cQOg+vyqyfRwg05EOMQWhhggTA6S+VT+SkM=";
   };
 
   appimageContents = appimageTools.extractType2 {
-    inherit name src;
+    inherit pname src;
   };
 in
 appimageTools.wrapType2 rec {
-  inherit name src;
+  inherit pname version src;
 
   extraInstallCommands = ''
-    mv $out/bin/${name} $out/bin/${pname}
+    mv $out/bin/${pname}-${version} $out/bin/${pname}
     install -m 444 -D ${appimageContents}/${pname}.desktop -t $out/share/applications
     cp -r ${appimageContents}/usr/share/icons $out/share
   '';

--- a/pkgs/tools/networking/motrix/default.nix
+++ b/pkgs/tools/networking/motrix/default.nix
@@ -1,7 +1,6 @@
 { lib
 , appimageTools
 , fetchurl
-, makeDesktopItem
 }:
 let
   pname = "motrix";
@@ -13,7 +12,7 @@ let
   };
 
   appimageContents = appimageTools.extractType2 {
-    inherit pname src;
+    inherit pname version src;
   };
 in
 appimageTools.wrapType2 rec {
@@ -23,12 +22,15 @@ appimageTools.wrapType2 rec {
     mv $out/bin/${pname}-${version} $out/bin/${pname}
     install -m 444 -D ${appimageContents}/${pname}.desktop -t $out/share/applications
     cp -r ${appimageContents}/usr/share/icons $out/share
+  substituteInPlace $out/share/applications/${pname}.desktop \
+    --replace 'Exec=AppRun' 'Exec=${pname}'
   '';
 
   meta = with lib; {
     description = "A full-featured download manager";
     homepage = "https://motrix.app";
     license = licenses.mit;
+    platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ dit7ya ];
   };
 }

--- a/pkgs/tools/networking/motrix/default.nix
+++ b/pkgs/tools/networking/motrix/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, appimageTools
+, fetchurl
+, makeDesktopItem
+}:
+let
+  pname = "motrix";
+  version = "1.6.11";
+  sha256 = "sha256-tE2Q7NM+cQOg+vyqyfRwg05EOMQWhhggTA6S+VT+SkM=";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/agalwood/Motrix/releases/download/v${version}/Motrix-${version}.AppImage";
+    inherit sha256;
+  };
+
+  appimageContents = appimageTools.extractType2 {
+    inherit name src;
+  };
+in
+appimageTools.wrapType2 rec {
+  inherit name src;
+
+  extraInstallCommands = ''
+    mv $out/bin/${name} $out/bin/${pname}
+    install -m 444 -D ${appimageContents}/${pname}.desktop -t $out/share/applications
+    cp -r ${appimageContents}/usr/share/icons $out/share
+  '';
+
+  meta = with lib; {
+    description = "A full-featured download manager";
+    homepage = "https://motrix.app";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dit7ya ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8763,6 +8763,8 @@ with pkgs;
 
   mosh = callPackage ../tools/networking/mosh { };
 
+  motrix = callPackage ../tools/networking/motrix { };
+
   mpage = callPackage ../tools/text/mpage { };
 
   mprime = callPackage ../tools/misc/mprime { };


### PR DESCRIPTION
###### Description of changes

Resolves #157984.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
