### PR TITLE
python3Packages:django_4: 4.0.7 -> 4.1

### DIFF
--- a/pkgs/development/python-modules/diskcache/default.nix
+++ b/pkgs/development/python-modules/diskcache/default.nix
@@ -43,6 +43,8 @@ buildPythonPackage rec {
     "test_incr_version"
     "test_get_or_set"
     "test_get_many"
+    # see https://github.com/grantjenks/python-diskcache/issues/260
+    "test_cache_write_unpicklable_object"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/django-js-asset/default.nix
+++ b/pkgs/development/python-modules/django-js-asset/default.nix
@@ -7,14 +7,14 @@
 
 buildPythonPackage rec {
   pname = "django-js-asset";
-  version = "unstable-2021-06-07";
+  version = "2.0";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "matthiask";
     repo = pname;
-    rev = "a186aa0b5721ca95da6cc032a2fb780a152f581b";
-    sha256 = "141zxng0wwxalsi905cs8pdppy3ad717y3g4fkdxw4n3pd0fjp8r";
+    rev = "refs/tags/${version}";
+    hash = "sha256-YDOmbqB0xDBAlOSO1UBYJ8VfRjJ8Z6Hw1i24DNSrnjw=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/django/4.nix
+++ b/pkgs/development/python-modules/django/4.nix
@@ -6,6 +6,7 @@
 , substituteAll
 
 # patched in
+, fetchpatch
 , geos
 , gdal
 , withGdal ? false
@@ -39,23 +40,32 @@
 
 buildPythonPackage rec {
   pname = "Django";
-  version = "4.0.7";
+  version = "4.1";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-nG1a02vnmOVi3cqmsXscP/LTxPUppHQytp+5ow+EdGE=";
+    hash = "sha256-Ay+Kb8fPBczRIU5KLiHfzWojudV1xlc8rMjGeCjb5kI=";
   };
 
-  patches = lib.optional withGdal
+  patches = [
+    (fetchpatch {
+      # Fix regression in sqlite backend introduced in 4.1.
+      # https://github.com/django/django/pull/15925
+      url = "https://github.com/django/django/commit/c0beff21239e70cbdcc9597e5be09e505bb8f76c.patch";
+      hash = "sha256-QE7QnfYAK74wvK8gDJ15FtQ+BCIWRQKAVvM7v1FzwlE=";
+      excludes = [ "docs/releases/4.1.1.txt" ];
+    })
+  ] ++ lib.optionals withGdal [
     (substituteAll {
       src = ./django_4_set_geos_gdal_lib.patch;
       geos = geos;
       gdal = gdal;
       extension = stdenv.hostPlatform.extensions.sharedLibrary;
-    });
+    })
+  ];
 
   propagatedBuildInputs = [
     asgiref


### PR DESCRIPTION
###### Description of changes

Update of django_4 building on top of #185536. 
 Django_4 had a regression in the sqlite backend. The patches fixes it. The [original fix](https://github.com/django/django/pull/15925) couldn't be included with `fetchPatch`  because it altered the release docs and they aren't included in the package. Therefore it is manually added to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).