### PR TITLE
asciidoctor-with-extensions: add Java dependency

### DIFF
--- a/pkgs/tools/typesetting/asciidoctor-with-extensions/default.nix
+++ b/pkgs/tools/typesetting/asciidoctor-with-extensions/default.nix
@@ -2,9 +2,13 @@
 , bundlerApp
 , bundlerUpdateScript
 , makeWrapper
+, withJava ? true, jre # Used by asciidoctor-diagram for ditaa and PlantUML
 }:
 
-bundlerApp {
+let
+  path = lib.makeBinPath (lib.optional withJava jre);
+in
+bundlerApp rec {
   pname = "asciidoctor";
   gemdir = ./.;
 
@@ -15,6 +19,13 @@ bundlerApp {
     "asciidoctor-pdf"
     "asciidoctor-revealjs"
   ];
+
+  buildInputs = [ makeWrapper ];
+
+  postBuild = lib.optionalString (path != "") (lib.concatMapStrings (exe: ''
+    wrapProgram $out/bin/${exe} \
+      --prefix PATH : ${path}
+  '') exes);
 
   passthru = {
     updateScript = bundlerUpdateScript "asciidoctor-with-extensions";


### PR DESCRIPTION
###### Description of changes

The `asciidoctor-diagram` extension [bundles a JAR](https://github.com/asciidoctor/asciidoctor-diagram/tree/v2.2.3/deps/ditaa/lib/asciidoctor-diagram/ditaa) and requires a JRE when processing `ditaa` diagrams. It currently fails with:

```console
$ asciidoctor --require asciidoctor-diagram - >/dev/null <<ADOC
[ditaa]
....
+---+   +---+
| A +-->| B |
+---+   +---+
....
ADOC
asciidoctor: ERROR: <stdin>: line 2: Failed to generate image: Could not find Java executable
```

This change adds `jre` with an opt-out.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nixpkgs-review rev asciidoctor-with-extensions/java`.
- [x] Tested basic functionality of all binary files
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
