### PR TITLE
fteqw: init at unstable-2022-08-09

### DIFF
--- a/pkgs/games/fteqw/default.nix
+++ b/pkgs/games/fteqw/default.nix
@@ -1,0 +1,90 @@
+{ lib
+, stdenv
+, fetchsvn
+, gzip
+, libvorbis
+, libmad
+, SDL2
+, SDL2_mixer
+, libpng
+, alsa-lib
+, gnutls
+, zlib
+, libjpeg
+, vulkan-loader
+, vulkan-headers
+, speex
+, libopus
+, xorg
+, libGL
+}@attrs:
+{
+  fteqw = import ./generic.nix (rec {
+    pname = "fteqw";
+
+    buildFlags = [ "m-rel" ];
+
+    nativeBuildInputs = [
+      vulkan-headers
+    ];
+
+    buildInputs = [
+      gzip
+      libvorbis
+      libmad
+      SDL2
+      SDL2_mixer
+      libpng
+      alsa-lib
+      gnutls
+      libjpeg
+      vulkan-loader
+      speex
+      libopus
+      xorg.libXrandr
+      xorg.libXcursor
+    ];
+
+    postFixup = ''
+      patchelf $out/bin/${pname} \
+        --add-needed ${SDL2}/lib/libSDL2.so \
+        --add-needed ${libGL}/lib/libGLX.so \
+        --add-needed ${libGL}/lib/libGL.so \
+        --add-needed ${lib.getLib gnutls}/lib/libgnutls.so \
+        --add-needed ${vulkan-loader}/lib/libvulkan.so
+    '';
+
+    description = "A hybrid and versatile game engine";
+  } // attrs);
+
+  fteqw-dedicated = import ./generic.nix (rec {
+    pname = "fteqw-dedicated";
+    releaseFile = "fteqw-sv";
+
+    buildFlags = [ "sv-rel" ];
+
+    buildInputs = [
+      gnutls
+      zlib
+    ];
+
+    postFixup = ''
+      patchelf $out/bin/${pname} \
+        --add-needed ${gnutls}/lib/libgnutls.so \
+    '';
+
+    description = "Dedicated server for FTEQW";
+  } // attrs);
+
+  fteqcc = import ./generic.nix ({
+    pname = "fteqcc";
+
+    buildFlags = [ "qcc-rel" ];
+
+    buildInputs = [
+      zlib
+    ];
+
+    description = "User friendly QuakeC compiler";
+  } // attrs);
+}

--- a/pkgs/games/fteqw/generic.nix
+++ b/pkgs/games/fteqw/generic.nix
@@ -1,0 +1,60 @@
+{ lib
+, fetchsvn
+, stdenv
+, libopus
+, xorg
+, pname
+, releaseFile ? pname
+, buildFlags
+, buildInputs
+, nativeBuildInputs ? []
+, postFixup ? ""
+, description
+, ... }:
+
+stdenv.mkDerivation {
+  inherit pname buildFlags buildInputs nativeBuildInputs postFixup;
+  version = "unstable-2022-08-09";
+
+  src = fetchsvn {
+    url = "https://svn.code.sf.net/p/fteqw/code/trunk";
+    rev = "6303";
+    sha256 = "sha256-tSTFX59iVUvndPRdREayKpkQ+YCYKCMQe2PXZfnTgPQ=";
+  };
+
+  makeFlags = [
+    "PKGCONFIG=$(PKG_CONFIG)"
+    "-C" "engine"
+  ];
+
+  enableParallelBuilding = true;
+  postPatch = ''
+    substituteInPlace ./engine/Makefile \
+      --replace "I/usr/include/opus" "I${libopus.dev}/include/opus"
+    substituteInPlace ./engine/gl/gl_vidlinuxglx.c \
+      --replace 'Sys_LoadLibrary("libXrandr"' 'Sys_LoadLibrary("${xorg.libXrandr}/lib/libXrandr.so"'
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 engine/release/${releaseFile} $out/bin/${pname}
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    inherit description;
+    homepage = "https://fte.triptohell.info";
+    longDescription = ''
+      FTE is a game engine baed on QuakeWorld able to
+      play games such as Quake 1, 2, 3, and Hexen 2.
+      It includes various features such as extended map
+      limits, vulkan and OpenGL renderers, a dedicated
+      server, and fteqcc, for easier QuakeC development
+    '';
+    maintainers = with maintainers; [ necrophcodr ];
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36252,6 +36252,11 @@ with pkgs;
 
   freenukum = callPackage ../games/freenukum { };
 
+  inherit (callPackages ../games/fteqw {})
+    fteqw
+    fteqw-dedicated
+    fteqcc;
+
   gamepad-tool = callPackage ../games/gamepad-tool { };
 
   gnome-hexgl = callPackage ../games/gnome-hexgl { };


### PR DESCRIPTION
###### Description of changes

This adds FTE, the hybrid Quake 1,2 and 3 game engine from https://fte.triptohell.info/

Note that this technically adds 3 packages from the same source tree: fteqw, fteqw-dedicated, and fteqcc. They're all from the same codebase, and same project, and pretty much seem to mostly only work with eachother as far as I can tell, so they've all been added in the same location in all-packages.nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
