### PR TITLE
lib/modules: Throw better function-in-list error

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -16,6 +16,7 @@ let
     foldl'
     getAttrFromPath
     head
+    init
     id
     imap1
     isAttrs
@@ -782,11 +783,22 @@ rec {
     defsFinal = defsFinal'.values;
 
     # Type-check the remaining definitions, and merge them. Or throw if no definitions.
-    mergedValue =
+    mergedValue = _mergedValueWithContext "unspecified";
+
+    # internal, unstable interface, only used locally
+    _mergedValueWithContext = parentTypeName:
       if isDefined then
         if all (def: type.check def.value) defsFinal then type.merge loc defsFinal
         else let allInvalid = filter (def: ! type.check def.value) defsFinal;
-        in throw "A definition for option `${showOption loc}' is not of type `${type.description}'. Definition values:${showDefs allInvalid}"
+        in if parentTypeName == "listOf" && type.name != "functionTo" && any (def: isFunction def.value) defsFinal
+        then throw ''
+          A list element definition for option `${showOption (init loc)}' is not of type `${type.description}', but a function. Definition values:${showDefs allInvalid}
+          Did you mean to apply the function to the next element instead? Add parenthesis to do so, e.g. like this:
+              ${showOption (init loc)} = [
+                (neovim.override { vimAlias = true; })
+              ]''
+        else
+          throw "A definition for option `${showOption loc}' is not of type `${type.description}'. Definition values:${showDefs allInvalid}"
       else
         # (nixos-option detects this specific error message and gives it special
         # handling.  If changed here, please change it there too.)
@@ -796,6 +808,12 @@ rec {
 
     optionalValue =
       if isDefined then { value = mergedValue; }
+      else {};
+
+    # internal, unstable interface, currently only used by the listOf type to
+    # provide a better error message
+    _optionalValueWithContext = parentTypeName:
+      if isDefined then { value = _mergedValueWithContext parentTypeName; }
       else {};
   };
 

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -412,7 +412,7 @@ rec {
               (loc ++ ["[definition ${toString n}-entry ${toString m}]"])
               elemType
               [{ inherit (def) file; value = def'; }]
-            ).optionalValue
+            )._optionalValueWithContext "listOf"
           ) def.value
         ) defs)));
       emptyValue = { value = []; };


### PR DESCRIPTION
###### Description of changes

This improves the error message for one of the most common errors when
configuring a NixOS system, where users try to add a customization to an
installed package like this:

    environment.systemPackages = with pkgs; [
      pass.override { x11Support = false; }
    ];

unfortunately spaces act as a list separator in this case, creating two
separate list elements and a rather poor error message:

    error: A definition for option `environment.systemPackages.[definition 1-entry 1]' is not of type `package'. Definition values:
           - In `/home/infinisil/src/nixpkgs/config.nix': <function, args: {buildEnv, coreutils, dmenu?, dmenu-wayland?, dmenuSupport?, fetchurl, findutils, getopt, git, gnugrep, gnupg, gnused, lib, makeWrapper, openssl, pass, pkgs, procps, qrencode, stdenv, symlinkJoin, tombPluginSupport?, tree, waylandSupport?, which, wl-clipboard?, x11Support?, xclip?, xdotool?, ydotool?}>

This commit improves this error message to the following:

    error: A list element definition for option `environment.systemPackages' is not of type `package', but a function. Definition values:
           - In `/home/infinisil/src/nixpkgs/config.nix': <function, args: {buildEnv, coreutils, dmenu?, dmenu-wayland?, dmenuSupport?, fetchurl, findutils, getopt, git, gnugrep, gnupg, gnused, lib, makeWrapper, openssh, openssl, pass, pkgs, procps, qrencode, stdenv, symlinkJoin, tombPluginSupport?, tree, waylandSupport?, which, wl-clipboard?, x11Support?, xclip?, xdotool?, ydotool?}>
           Did you mean to apply the function to the next element instead? Add parenthesis to do so, e.g. like this:
               environment.systemPackages = [
                 (neovim.override { vimAlias = true; })
               ]

I'd appreciate suggestions for improved wording/display of this error

###### Things done

- [x] Manually tested this error message
- [ ] Added a test case for this