### PR TITLE
opentrack: 2.1.3 → 2022.3.0

### DIFF
--- a/pkgs/applications/misc/opentrack/default.nix
+++ b/pkgs/applications/misc/opentrack/default.nix
@@ -1,58 +1,79 @@
-{ mkDerivation, lib, callPackage, fetchzip, fetchFromGitHub, cmake, pkg-config
-, ninja, copyDesktopItems, qtbase, qttools, opencv4, procps, eigen, libXdmcp
-, libevdev, makeDesktopItem, fetchurl }:
+{
+  mkDerivation,
+  lib,
+  callPackage,
+  fetchzip,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  ninja,
+  copyDesktopItems,
+  qtbase,
+  qttools,
+  opencv4,
+  procps,
+  eigen,
+  libXdmcp,
+  libevdev,
+  makeDesktopItem,
+  fetchurl,
+}: let
+  version = "2022.3.0";
 
-let
-  version = "2.3.13";
-
-  aruco = callPackage ./aruco.nix { };
+  aruco = callPackage ./aruco.nix {};
 
   # license.txt inside the zip file is MIT
   xplaneSdk = fetchzip {
     url = "https://developer.x-plane.com/wp-content/plugins/code-sample-generation/sample_templates/XPSDK303.zip";
     sha256 = "11wqjsr996c5qhiv2djsd55gc373a9qcq30dvc6rhzm0fys42zba";
   };
+in
+  mkDerivation {
+    pname = "opentrack";
+    inherit version;
 
-in mkDerivation {
-  pname = "opentrack";
-  inherit version;
+    src = fetchFromGitHub {
+      owner = "opentrack";
+      repo = "opentrack";
+      rev = "opentrack-${version}";
+      sha256 = "sha256-8gpNORTJclYUYp57Vw/0YO3XC9Idurt0a79fhqx0+mo=";
+    };
 
-  src = fetchFromGitHub {
-    owner = "opentrack";
-    repo = "opentrack";
-    rev = "opentrack-${version}";
-    sha256 = "1s986lmm5l1pwbwvd1pfiq84n32s1q1dav7a0cbga4d1vcf0v1ay";
-  };
+    nativeBuildInputs = [cmake pkg-config ninja copyDesktopItems];
+    buildInputs = [qtbase qttools opencv4 procps eigen libXdmcp libevdev aruco];
 
-  nativeBuildInputs = [ cmake pkg-config ninja copyDesktopItems ];
-  buildInputs = [ qtbase qttools opencv4 procps eigen libXdmcp libevdev aruco ];
+    NIX_CFLAGS_COMPILE = "-Wall -Wextra -Wpedantic -ffast-math -march=native -O3";
+    dontWrapQtApps = true;
 
-  NIX_CFLAGS_COMPILE = "-Wall -Wextra -Wpedantic -ffast-math -march=native -O3";
+    cmakeFlags = [
+      "-DCMAKE_BUILD_TYPE=RELEASE"
+      "-DSDK_ARUCO_LIBPATH=${aruco}/lib/libaruco.a"
+      "-DSDK_XPLANE=${xplaneSdk}"
+    ];
 
-  cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=RELEASE"
-    "-DSDK_ARUCO_LIBPATH=${aruco}/lib/libaruco.a"
-    "-DSDK_XPLANE=${xplaneSdk}"
-  ];
+    postInstall = ''
+      wrapQtApp $out/bin/opentrack
+    '';
 
-  desktopItems = [
-    (makeDesktopItem rec {
-      name = "opentrack";
-      exec = "opentrack";
-      icon = fetchurl {
-        url = "https://github.com/opentrack/opentrack/raw/opentrack-${version}/gui/images/opentrack.png";
-        sha256 = "0d114zk78f7nnrk89mz4gqn7yk3k71riikdn29w6sx99h57f6kgn";
-      };
-      desktopName = name;
-      genericName = "Head tracking software";
-      categories = [ "Utility" ];
-    })
-  ];
+    desktopItems = [
+      (makeDesktopItem rec {
+        name = "opentrack";
+        exec = "opentrack";
+        icon = fetchurl {
+          url = "https://github.com/opentrack/opentrack/raw/opentrack-${version}/gui/images/opentrack.png";
+          sha256 = "0d114zk78f7nnrk89mz4gqn7yk3k71riikdn29w6sx99h57f6kgn";
+        };
+        desktopName = name;
+        genericName = "Head tracking software";
+        categories = ["Utility"];
+      })
+    ];
 
-  meta = with lib; {
-    homepage = "https://github.com/opentrack/opentrack";
-    description = "Head tracking software for MS Windows, Linux, and Apple OSX";
-    license = licenses.isc;
-    maintainers = with maintainers; [ zaninime ];
-  };
-}
+    meta = with lib; {
+      homepage = "https://github.com/opentrack/opentrack";
+      description = "Head tracking software for MS Windows, Linux, and Apple OSX";
+      changelog = "https://github.com/opentrack/opentrack/releases/tag/${version}";
+      license = licenses.isc;
+      maintainers = with maintainers; [zaninime];
+    };
+  }


### PR DESCRIPTION
###### Description of changes

The package was 6 releases old (1 year and a few months): https://github.com/opentrack/opentrack/releases

This PR also fixes #185520. The hook was wrapping too much (.so files)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
