### PR TITLE
ocamlPackages.graphql: 0.13.0 → 0.14.0

### DIFF
--- a/pkgs/development/ocaml-modules/graphql/default.nix
+++ b/pkgs/development/ocaml-modules/graphql/default.nix
@@ -3,7 +3,7 @@
 buildDunePackage rec {
   pname = "graphql";
 
-  inherit (graphql_parser) version useDune2 src;
+  inherit (graphql_parser) version src;
 
   propagatedBuildInputs = [ graphql_parser rresult yojson ];
 

--- a/pkgs/development/ocaml-modules/graphql/lwt.nix
+++ b/pkgs/development/ocaml-modules/graphql/lwt.nix
@@ -3,7 +3,7 @@
 buildDunePackage rec {
   pname = "graphql-lwt";
 
-  inherit (graphql) version useDune2 src;
+  inherit (graphql) version src;
 
   propagatedBuildInputs = [ graphql ocaml_lwt ];
 

--- a/pkgs/development/ocaml-modules/graphql/parser.nix
+++ b/pkgs/development/ocaml-modules/graphql/parser.nix
@@ -1,16 +1,14 @@
-{ lib, buildDunePackage, fetchurl, alcotest, fmt, menhir, re }:
+{ lib, buildDunePackage, ocaml, fetchurl, alcotest, fmt, menhir, re }:
 
 buildDunePackage rec {
   pname = "graphql_parser";
-  version = "0.13.0";
+  version = "0.14.0";
 
-  useDune2 = true;
-
-  minimumOCamlVersion = "4.03";
+  minimalOCamlVersion = "4.05";
 
   src = fetchurl {
     url = "https://github.com/andreas/ocaml-graphql-server/releases/download/${version}/graphql-${version}.tbz";
-    sha256 = "0gb5y99ph0nz5y3pc1gxq1py4wji2hyf2ydbp0hv23v00n50hpsm";
+    sha256 = "sha256-v4v1ueF+NV7LvYIVinaf4rE450Z1P9OiMAito6/NHAY=";
   };
 
   nativeBuildInputs = [ menhir ];
@@ -18,7 +16,7 @@ buildDunePackage rec {
 
   checkInputs = [ alcotest ];
 
-  doCheck = true;
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
 
   meta = {
     homepage = "https://github.com/andreas/ocaml-graphql-server";

--- a/pkgs/development/ocaml-modules/irmin/graphql.nix
+++ b/pkgs/development/ocaml-modules/irmin/graphql.nix
@@ -24,6 +24,7 @@ buildDunePackage rec {
 
   meta = irmin.meta // {
     description = "GraphQL server for Irmin";
+    broken = true; # Not compatible with graphql 0.14
   };
 
 }


### PR DESCRIPTION

###### Description of changes

Compatibility with `yojson` ≥ 2.0: https://github.com/andreas/ocaml-graphql-server/blob/0.14.0/CHANGES.md#0140-2022-07-08

ocamlPackages.irmin-graphql: mark as broken

Next version of `irmin-graphql` shall be compatible with `graphql` 0.14: https://github.com/mirage/irmin/commit/c41eadf823dbe813aee62402662bace3885092d0

cc maintainer @sternenseemann

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
