### PR TITLE
electron: use wrapper instead of symlink for bin on darwin

### DIFF
--- a/pkgs/applications/networking/instant-messengers/deltachat-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/deltachat-desktop/default.nix
@@ -32,10 +32,6 @@ let
       hash = "sha256-4rpoDQ3o0WdWg/TmazTI+J0hL/MxwHcNMXWMq7GE7Tk=";
     };
   });
-  electronExec = if stdenv.isDarwin then
-    "${electron_18}/Applications/Electron.app/Contents/MacOS/Electron"
-  else
-    "${electron_18}/bin/electron";
   esbuild' = esbuild.override {
     buildGoModule = args: buildGoModule (args // rec {
       version = "0.12.29";
@@ -102,7 +98,7 @@ in nodePackages.deltachat-desktop.override rec {
         $out/lib/node_modules/deltachat-desktop/html-dist/fonts
     done
 
-    makeWrapper ${electronExec} $out/bin/deltachat \
+    makeWrapper ${electron_18}/bin/electron $out/bin/deltachat \
       --set LD_PRELOAD ${sqlcipher}/lib/libsqlcipher${stdenv.hostPlatform.extensions.sharedLibrary} \
       --add-flags $out/lib/node_modules/deltachat-desktop
   '';

--- a/pkgs/applications/networking/instant-messengers/element/element-desktop.nix
+++ b/pkgs/applications/networking/instant-messengers/element/element-desktop.nix
@@ -19,7 +19,6 @@
 let
   pinData = lib.importJSON ./pin.json;
   executableName = "element-desktop";
-  electron_exec = if stdenv.isDarwin then "${electron}/Applications/Electron.app/Contents/MacOS/Electron" else "${electron}/bin/electron";
   keytar = callPackage ./keytar { inherit Security AppKit; };
   seshat = callPackage ./seshat { inherit CoreServices; };
 in
@@ -83,7 +82,7 @@ mkYarnPackage rec {
 
     # executable wrapper
     # LD_PRELOAD workaround for sqlcipher not found: https://github.com/matrix-org/seshat/issues/102
-    makeWrapper '${electron_exec}' "$out/bin/${executableName}" \
+    makeWrapper '${electron}/bin/electron' "$out/bin/${executableName}" \
       --set LD_PRELOAD ${sqlcipher}/lib/libsqlcipher.so \
       --add-flags "$out/share/element/electron" \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--enable-features=UseOzonePlatform --ozone-platform=wayland}}"

--- a/pkgs/applications/networking/instant-messengers/schildichat/schildichat-desktop.nix
+++ b/pkgs/applications/networking/instant-messengers/schildichat/schildichat-desktop.nix
@@ -19,7 +19,6 @@
 let
   pinData = lib.importJSON ./pin.json;
   executableName = "schildichat-desktop";
-  electron_exec = if stdenv.isDarwin then "${electron}/Applications/Electron.app/Contents/MacOS/Electron" else "${electron}/bin/electron";
 in
 stdenv.mkDerivation rec {
   pname = "schildichat-desktop";
@@ -88,7 +87,7 @@ stdenv.mkDerivation rec {
     done
 
     # executable wrapper
-    makeWrapper '${electron_exec}' "$out/bin/${executableName}" \
+    makeWrapper '${electron}/bin/electron' "$out/bin/${executableName}" \
       --add-flags "$out/share/element/electron" \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--enable-features=UseOzonePlatform --ozone-platform=wayland}}"
 

--- a/pkgs/applications/office/micropad/default.nix
+++ b/pkgs/applications/office/micropad/default.nix
@@ -11,10 +11,6 @@
 }:
 let
   executableName = "micropad";
-  electron_exec =
-    if stdenv.isDarwin
-    then "${electron}/Applications/Electron.app/Contents/MacOS/Electron"
-    else "${electron}/bin/electron";
 in
   mkYarnPackage rec {
     pname = "micropad";
@@ -64,7 +60,7 @@ in
       done
 
       # executable wrapper
-      makeWrapper '${electron_exec}' "$out/bin/${executableName}" \
+      makeWrapper '${electron}/bin/electron' "$out/bin/${executableName}" \
         --add-flags "$out/share/micropad" \
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--enable-features=UseOzonePlatform --ozone-platform=wayland}}"
 

--- a/pkgs/development/tools/electron/generic.nix
+++ b/pkgs/development/tools/electron/generic.nix
@@ -104,14 +104,17 @@ let
   };
 
   darwin = {
-    nativeBuildInputs = [ unzip ];
+    nativeBuildInputs = [
+      makeWrapper
+      unzip
+    ];
 
     buildCommand = ''
       mkdir -p $out/Applications
       unzip $src
       mv Electron.app $out/Applications
       mkdir -p $out/bin
-      ln -s $out/Applications/Electron.app/Contents/MacOS/Electron $out/bin/electron
+      makeWrapper $out/Applications/Electron.app/Contents/MacOS/Electron $out/bin/electron
     '';
   };
 in


### PR DESCRIPTION
###### Description of changes

Electron fails to run through a symlink:

```
GPU process isn't usable. Goodbye.
```

This change replaces the symlink with a wrapper script and removes the special case for running electron on Darwin (in all packages).

Alternative replacement for #185050.

**Verified on x86_64-darwin:**
- element-desktop
- micropad
- nix-tour
- schildichat-desktop
- uivonim (window opens, but fails with JS exception - also fails on Linux)
- vieb

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).