### PR TITLE
Cinnamon updates 2022-08-10

### DIFF
--- a/pkgs/applications/video/xplayer/default.nix
+++ b/pkgs/applications/video/xplayer/default.nix
@@ -34,13 +34,13 @@ in
 
 stdenv.mkDerivation rec {
   pname = "xplayer";
-  version = "2.4.3";
+  version = "2.4.4";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    sha256 = "sha256-0hQHhf2me28YTTKOzEkzoxRoSoHLwtiaHPKNPJ/Fg+0=";
+    sha256 = "sha256-o2vLNIELd1EYWG26t5gOpnamJrBJeg4P6fcLirkcmfM=";
   };
 
   # configure wants to find gst-inspect-1.0 via pkgconfig but

--- a/pkgs/desktops/cinnamon/cinnamon-common/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-common/default.nix
@@ -53,13 +53,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-common";
-  version = "5.4.8";
+  version = "5.4.9";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "cinnamon";
     rev = version;
-    hash = "sha256-Z+BbvLgH4gOsLMSC0r5Hp9yDZz4XMH7NR/A9to+/djA=";
+    hash = "sha256-nM87NO/dwOd+hN5/3zX7XUjyKvXh4uDhLcGFcKE9ccA=";
   };
 
   patches = [

--- a/pkgs/desktops/cinnamon/cinnamon-control-center/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-control-center/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , pkg-config
 , glib
 , gettext
@@ -18,6 +17,7 @@
 , libgnomekbd
 , libxklavier
 , networkmanager
+, libgudev
 , libwacom
 , gnome
 , wrapGAppsHook
@@ -36,22 +36,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-control-center";
-  version = "5.4.4";
-
-  patches = [
-    # Add missing gio-unix-2.0 dependency, can be removed on next update
-    # https://github.com/linuxmint/cinnamon-control-center/pull/294
-    (fetchpatch {
-      url = "https://github.com/linuxmint/cinnamon-control-center/commit/7f5ba6e7a691547840f8482445c09c729e10a397.patch";
-      sha256 = "sha256-xcf/O/DfhOvCpWJl0XZD+xAwWs4STAeCaFMZ9Lftv2w=";
-    })
-  ];
+  version = "5.4.6";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-c2JbRAMcTnqaqt8MXQl4AxnENVmfYyHcCteWBWQUSO0=";
+    hash = "sha256-8BDmQT/xDnpwR2YC0TGaqWPnZ61IBmVvft2Mcf6YN+A=";
   };
 
   buildInputs = [
@@ -66,6 +57,7 @@ stdenv.mkDerivation rec {
     libxklavier
     colord
     cinnamon-settings-daemon
+    libgudev
     libwacom
     gnome-online-accounts
     tzdata
@@ -98,6 +90,8 @@ stdenv.mkDerivation rec {
   '';
 
   mesonFlags = [
+    # TODO: https://github.com/NixOS/nixpkgs/issues/36468
+    "-Dc_args=-I${glib.dev}/include/gio-unix-2.0"
     # use locales from cinnamon-translations
     "--localedir=${cinnamon-translations}/share/locale"
   ];

--- a/pkgs/desktops/cinnamon/cinnamon-screensaver/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-screensaver/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , pkg-config
 , meson
 , ninja
@@ -30,22 +29,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-screensaver";
-  version = "5.4.1";
-
-  patches = [
-    # Add missing gio-unix-2.0 dependency, can be removed on next update
-    # https://github.com/linuxmint/cinnamon-screensaver/pull/411
-    (fetchpatch {
-      url = "https://github.com/linuxmint/cinnamon-screensaver/commit/8d658e7f313879579322dce666551f132795540b.patch";
-      sha256 = "sha256-HjVQSX2yYqgZVIio2I8GBWLYOddvaFiqZzf0zaYf+OE=";
-    })
-  ];
+  version = "5.4.2";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-PpBtLAIboXMnX5V/u06aoZ6WfPrn4mdCu0NXTGb6pAE=";
+    hash = "sha256-GRa3ChUCL/AFDg1F01DNwkC4tmrNaOWoOXwFvwpvSck=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/cinnamon/cinnamon-settings-daemon/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-settings-daemon/default.nix
@@ -21,7 +21,6 @@
 , polkit
 , librsvg
 , libwacom
-, xf86_input_wacom
 , xorg
 , fontconfig
 , tzdata
@@ -33,13 +32,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-settings-daemon";
-  version = "5.4.3";
+  version = "5.4.5";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-3ELsb0hH7GjMjwjsIg2m8k/EBCHIQGW3O7eDaqT2V7I=";
+    hash = "sha256-qjI1z1MuaI5JFqjHap/+aYDQ0YuP9VNnnY6vy/AaKqs=";
   };
 
   patches = [
@@ -65,11 +64,9 @@ stdenv.mkDerivation rec {
     polkit
     librsvg
     libwacom
-    xf86_input_wacom
     xorg.libXext
     xorg.libX11
     xorg.libXi
-    xorg.libXtst
     xorg.libXfixes
     fontconfig
     nss

--- a/pkgs/desktops/cinnamon/mint-themes/default.nix
+++ b/pkgs/desktops/cinnamon/mint-themes/default.nix
@@ -8,14 +8,14 @@
 
 stdenv.mkDerivation rec {
   pname = "mint-themes";
-  version = "2.0.3";
+  version = "2.0.4";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     # they don't exactly do tags, it's just a named commit
-    rev = "38b5606c3889a9a0bac0e2ab39196f675496982c";
-    hash = "sha256-Cc5p9WWLFPQ8K0CpL236LilAgBuO6HdfGt/rb0wiVpc=";
+    rev = "73d6cfea807ea84a645f43424c60916cb6214693";
+    hash = "sha256-WyEabE3K7xuBzXuLqJO0N4nxrc67bKT5YD9yn/bELl0=";
   };
 
   nativeBuildInputs = [
@@ -29,8 +29,10 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out
     mv usr/share $out
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/desktops/cinnamon/mint-y-icons/default.nix
+++ b/pkgs/desktops/cinnamon/mint-y-icons/default.nix
@@ -9,14 +9,14 @@
 
 stdenv.mkDerivation rec {
   pname = "mint-y-icons";
-  version = "1.6.0";
+  version = "1.6.1";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     # they don't exactly do tags, it's just a named commit
-    rev = "6294c4538a08a2a6c5fd68e223472d9c144ff8b0";
-    hash = "sha256-6tR3OFvU1ID61n4gr0R6pJyo3CjKvu8mgtXzMOINgq0=";
+    rev = "57d16eb85f2af40be17e2232d279bb65b689f5b7";
+    hash = "sha256-voFYz0MiuqyNSngi4QZUJKDIjggQWOAV5B30zMP8iTk=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/desktops/cinnamon/muffin/default.nix
+++ b/pkgs/desktops/cinnamon/muffin/default.nix
@@ -35,7 +35,7 @@
 
 stdenv.mkDerivation rec {
   pname = "muffin";
-  version = "5.4.4";
+  version = "5.4.5";
 
   outputs = [ "out" "dev" "man" ];
 
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-u3PNSyjxtPLFdA+2Iz+NuqlcQC9IwsFb7Tb5eVAJunY=";
+    hash = "sha256-gtki0MTIMI1JggtVn0dAhkq364hkTuH7Zf7CF32Lc8E=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/cinnamon/xviewer/default.nix
+++ b/pkgs/desktops/cinnamon/xviewer/default.nix
@@ -27,13 +27,13 @@
 
 stdenv.mkDerivation rec {
   pname = "xviewer";
-  version = "3.2.9";
+  version = "3.2.10";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    sha256 = "sha256-sDDQ/LGhHH13gRjVfpTyHYsYhelp80KNE75I8AlskoU=";
+    sha256 = "sha256-c3K9yjeaAlyXqgxzHgnLXgqwaB5Fdw+mS9jricy8QA8=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes

I will probably add myself as maintainer after some PRs. I try to make sure this is up-to-date when possible so we don't review too much stuff when doing real mass update like #181918.

Closes https://github.com/bobby285271/what-changed/issues/3
Closes #186065

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
