### PR TITLE
blesh: unstable-2022-07-24 -> unstable-2022-07-29, refactor

### DIFF
--- a/nixos/modules/programs/bash/blesh.nix
+++ b/nixos/modules/programs/bash/blesh.nix
@@ -9,7 +9,7 @@ in {
 
   config = mkIf cfg.enable {
     programs.bash.interactiveShellInit = mkBefore ''
-      source ${pkgs.blesh}/share/ble.sh
+      source ${pkgs.blesh}/share/blesh/ble.sh
     '';
   };
   meta.maintainers = with maintainers; [ laalsaas ];

--- a/pkgs/shells/bash/blesh/default.nix
+++ b/pkgs/shells/bash/blesh/default.nix
@@ -1,51 +1,54 @@
 { lib
 , stdenvNoCC
-, fetchFromGitHub
-, git
+, fetchzip
+, runtimeShell
 , bashInteractive
 , glibcLocales
-, runtimeShell
 }:
 
 stdenvNoCC.mkDerivation rec {
   name = "blesh";
-  version = "unstable-2022-07-24";
+  version = "unstable-2022-07-29";
 
-  src = fetchFromGitHub {
-    owner = "akinomyoga";
-    repo = "ble.sh";
-    rev = "0b95d5d900b79a63e7f0834da5aa7276b8332a44";
-    hash = "sha256-s/RQKcAFcCUB3Xd/4uOsIgigOE0lCCeVC9K3dfnP/EQ=";
-    fetchSubmodules = true;
-    leaveDotGit = true;
+  src = fetchzip {
+    url = "https://github.com/akinomyoga/ble.sh/releases/download/nightly/ble-nightly-20220729+a22e145.tar.xz";
+    sha256 = "088jv02y40pjcfzgrbx8n6aksznfh6zl0j5siwfw3pmwn3i16njw";
   };
 
-  nativeBuildInputs = [ git ];
+  dontBuild = true;
 
   doCheck = true;
   checkInputs = [ bashInteractive glibcLocales ];
   preCheck = "export LC_ALL=en_US.UTF-8";
 
-  installFlags = [ "INSDIR=$(out)/share" ];
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/share/blesh/lib"
+
+    cat <<EOF >"$out/share/blesh/lib/_package.sh"
+    _ble_base_package_type=nix
+
+    function ble/base/package:nix/update {
+      echo "Ble.sh is installed by Nix. You can update it there." >&2
+      return 1
+    }
+    EOF
+
+    cp -rv $src/* $out/share/blesh
+
+    runHook postInstall
+  '';
+
   postInstall = ''
     mkdir -p "$out/bin"
     cat <<EOF >"$out/bin/blesh-share"
     #!${runtimeShell}
     # Run this script to find the ble.sh shared folder
     # where all the shell scripts are living.
-    echo "$out/share/ble.sh"
+    echo "$out/share/blesh"
     EOF
     chmod +x "$out/bin/blesh-share"
-
-    mkdir -p "$out/share/lib"
-    cat <<EOF >"$out/share/lib/_package.sh"
-    _ble_base_package_type=nix
-
-    function ble/base/package:nix/update {
-      echo "Ble.sh is installed by Nix. You can update it there." >/dev/stderr
-      return 1
-    }
-    EOF
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

**Update**: unstable-2022-07-24 -> unstable-2022-07-29.

**Refactor**: AFAIK it's better to avoid using `leaveDotGit` if it's possible. Because it looks like `leaveDotGit` can potentially break the determinism of the hash.  see: https://github.com/NixOS/nixpkgs/issues/8567#issuecomment-133409465

As for blesh, it require `.git` in build phase but there are pre-built universal tarball releases to begin with, so I think we can use that to avoid build phase and use of `leaveDotGit`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
