### PR TITLE
editorconfig-core-c: 0.12.1 → 0.12.5

### DIFF
--- a/pkgs/development/tools/misc/editorconfig-core-c/default.nix
+++ b/pkgs/development/tools/misc/editorconfig-core-c/default.nix
@@ -1,22 +1,39 @@
-{ lib, stdenv, fetchFromGitHub, cmake, pcre, doxygen }:
+{ lib, stdenv, fetchpatch, fetchFromGitHub, cmake, pcre2, doxygen }:
 
 stdenv.mkDerivation rec {
   pname = "editorconfig-core-c";
-  version = "0.12.1";
+  version = "0.12.5";
+
+  outputs = [ "out" "dev" ];
 
   src = fetchFromGitHub {
     owner = "editorconfig";
     repo = "editorconfig-core-c";
     rev = "v${version}";
-    sha256 = "sha256-pFsbyqIt7okfaiOwlYN8EXm1SFlCUnsHVbOgyIZZlys=";
+    sha256 = "sha256-4p8bomeXtA+zJ3IvWW0UZixdMnjYWYu7yeA6JUwwRb8=";
     fetchSubmodules = true;
   };
 
-  buildInputs = [ pcre ];
-  nativeBuildInputs = [ cmake doxygen ];
+  patches = [
+    # Fox broken paths in pkg-config.
+    # https://github.com/editorconfig/editorconfig-core-c/pull/81
+    (fetchpatch {
+      url = "https://github.com/editorconfig/editorconfig-core-c/commit/e0ead79d3bb4179fe9bccd3e5598ed47cc0863a3.patch";
+      sha256 = "t/DiPVyyYoMwFpNG6sD+rLWHheFCbMaILXyey6inGdc=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    doxygen
+  ];
+
+  buildInputs = [
+    pcre2
+  ];
 
   # Multiple doxygen can not generate man pages in the same base directory in
-  # parallel: https://bugzilla.gnome.org/show_bug.cgi?id=791153
+  # parallel: https://github.com/doxygen/doxygen/issues/6293
   enableParallelBuilding = false;
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

Ported to PCRE2.

https://github.com/editorconfig/editorconfig-core-c/releases/tag/v0.12.2
https://github.com/editorconfig/editorconfig-core-c/releases/tag/v0.12.3
https://github.com/editorconfig/editorconfig-core-c/releases/tag/v0.12.4
https://github.com/editorconfig/editorconfig-core-c/releases/tag/v0.12.5

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

- [x] Verified that the EditorConfig plug-in of `pantheon.elementary-code` works.
    1. Opened pandoc checkout in Elementary Code, since it contains [`.editorconfig` file](https://github.com/jgm/pandoc/blob/7a35e7ee684ce40b4d3875da17ce74cfcae0475f/.editorconfig).
    2. Created new file.
    3. Saved the empty file into the pandoc directory.
    4. Checked that the “4 Spaces” button in the header bar turned into “2 Spaces”.
- [x] It does not seem to work well in existing files (maybe it conflicts with detection of indentation from the file contents) but that does not appear to be a regression.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
