### PR TITLE
nixos/klipper: add OOMScoreAdjust -999

### DIFF
--- a/nixos/modules/services/misc/klipper.nix
+++ b/nixos/modules/services/misc/klipper.nix
@@ -130,6 +130,10 @@ in
           SupplementaryGroups = [ "dialout" ];
           WorkingDirectory = "${cfg.package}/lib";
           OOMScoreAdjust = "-999";
+          CPUSchedulingPolicy = "rr";
+          CPUSchedulingPriority = 99;
+          IOSchedulingClass = "realtime";
+          IOSchedulingPriority = 0;
         } // (if cfg.user != null then {
           Group = cfg.group;
           User = cfg.user;

--- a/nixos/modules/services/misc/klipper.nix
+++ b/nixos/modules/services/misc/klipper.nix
@@ -129,6 +129,7 @@ in
           RuntimeDirectory = "klipper";
           SupplementaryGroups = [ "dialout" ];
           WorkingDirectory = "${cfg.package}/lib";
+          OOMScoreAdjust = "-999";
         } // (if cfg.user != null then {
           Group = cfg.group;
           User = cfg.user;


### PR DESCRIPTION
to make it unlikely that klipper gets killed by OOM killer.


CC @lovesegfault @vtuan10 