### PR TITLE
python310Packages.pikepdf: 5.3.1 -> 5.4.2

### DIFF
--- a/pkgs/development/python-modules/ocrmypdf/default.nix
+++ b/pkgs/development/python-modules/ocrmypdf/default.nix
@@ -27,7 +27,7 @@
 
 buildPythonPackage rec {
   pname = "ocrmypdf";
-  version = "13.6.0";
+  version = "13.7.0";
 
   src = fetchFromGitHub {
     owner = "ocrmypdf";
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     postFetch = ''
       rm "$out/.git_archival.txt"
     '';
-    hash = "sha256-EY0dXma6tyXLT8XogS5iFdVgJPrtwB9YVrplhDT4gWw=";
+    hash = "sha256-cw2wZMPhWzxRpeM90g9NmuYBYpU13R2iDzs7a8SS/CY=";
   };
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;

--- a/pkgs/development/python-modules/ocrmypdf/paths.patch
+++ b/pkgs/development/python-modules/ocrmypdf/paths.patch
@@ -1,8 +1,8 @@
 diff --git a/src/ocrmypdf/_exec/ghostscript.py b/src/ocrmypdf/_exec/ghostscript.py
-index 4da65483..af750249 100644
+index 9e21c33c..21f134b3 100644
 --- a/src/ocrmypdf/_exec/ghostscript.py
 +++ b/src/ocrmypdf/_exec/ghostscript.py
-@@ -35,15 +35,7 @@ log = logging.getLogger(__name__)
+@@ -32,15 +32,7 @@ log = logging.getLogger(__name__)
  # Most reliable what to get the bitness of Python interpreter, according to Python docs
  _IS_64BIT = sys.maxsize > 2**32
  
@@ -20,10 +20,10 @@ index 4da65483..af750249 100644
  
  def version():
 diff --git a/src/ocrmypdf/_exec/jbig2enc.py b/src/ocrmypdf/_exec/jbig2enc.py
-index 2e8a058b..65a09088 100644
+index 0f8f7392..db792b10 100644
 --- a/src/ocrmypdf/_exec/jbig2enc.py
 +++ b/src/ocrmypdf/_exec/jbig2enc.py
-@@ -14,7 +14,7 @@ from ocrmypdf.subprocess import get_version, run
+@@ -12,7 +12,7 @@ from ocrmypdf.subprocess import get_version, run
  
  
  def version():
@@ -32,7 +32,7 @@ index 2e8a058b..65a09088 100644
  
  
  def available():
-@@ -27,7 +27,7 @@ def available():
+@@ -25,7 +25,7 @@ def available():
  
  def convert_group(*, cwd, infiles, out_prefix):
      args = [
@@ -41,7 +41,7 @@ index 2e8a058b..65a09088 100644
          '-b',
          out_prefix,
          '-s',  # symbol mode (lossy)
-@@ -46,7 +46,7 @@ def convert_group_mp(args):
+@@ -44,7 +44,7 @@ def convert_group_mp(args):
  
  
  def convert_single(*, cwd, infile, outfile):
@@ -51,10 +51,10 @@ index 2e8a058b..65a09088 100644
          proc = run(args, cwd=cwd, stdout=fstdout, stderr=PIPE)
      proc.check_returncode()
 diff --git a/src/ocrmypdf/_exec/pngquant.py b/src/ocrmypdf/_exec/pngquant.py
-index ca8a4542..d0544174 100644
+index 64e91139..ab5b9c49 100644
 --- a/src/ocrmypdf/_exec/pngquant.py
 +++ b/src/ocrmypdf/_exec/pngquant.py
-@@ -19,7 +19,7 @@ from ocrmypdf.subprocess import get_version, run
+@@ -17,7 +17,7 @@ from ocrmypdf.subprocess import get_version, run
  
  
  def version():
@@ -63,7 +63,7 @@ index ca8a4542..d0544174 100644
  
  
  def available():
-@@ -46,7 +46,7 @@ def input_as_png(input_file: Path):
+@@ -44,7 +44,7 @@ def input_as_png(input_file: Path):
  def quantize(input_file: Path, output_file: Path, quality_min: int, quality_max: int):
      with input_as_png(input_file) as input_stream:
          args = [
@@ -73,10 +73,10 @@ index ca8a4542..d0544174 100644
              '--skip-if-larger',
              '--quality',
 diff --git a/src/ocrmypdf/_exec/tesseract.py b/src/ocrmypdf/_exec/tesseract.py
-index 01177cac..665f1145 100644
+index ad98836a..a12d3002 100644
 --- a/src/ocrmypdf/_exec/tesseract.py
 +++ b/src/ocrmypdf/_exec/tesseract.py
-@@ -114,7 +114,7 @@ class TesseractVersion(Version):
+@@ -111,7 +111,7 @@ class TesseractVersion(Version):
  
  
  def version() -> str:
@@ -84,8 +84,8 @@ index 01177cac..665f1145 100644
 +    return get_version('@tesseract@', regex=r'tesseract\s(.+)')
  
  
- def has_user_words():
-@@ -141,7 +141,7 @@ def get_languages():
+ def has_user_words() -> bool:
+@@ -138,7 +138,7 @@ def get_languages() -> set[str]:
          msg += output
          return msg
  
@@ -94,20 +94,20 @@ index 01177cac..665f1145 100644
      try:
          proc = run(
              args_tess,
-@@ -163,7 +163,7 @@ def get_languages():
+@@ -160,7 +160,7 @@ def get_languages() -> set[str]:
  
  
- def tess_base_args(langs: List[str], engine_mode: Optional[int]) -> List[str]:
+ def tess_base_args(langs: list[str], engine_mode: int | None) -> list[str]:
 -    args = ['tesseract']
 +    args = ['@tesseract@']
      if langs:
          args.extend(['-l', '+'.join(langs)])
      if engine_mode is not None:
 diff --git a/src/ocrmypdf/_exec/unpaper.py b/src/ocrmypdf/_exec/unpaper.py
-index 479959ef..cc15fdec 100644
+index d7f24265..d14f85de 100644
 --- a/src/ocrmypdf/_exec/unpaper.py
 +++ b/src/ocrmypdf/_exec/unpaper.py
-@@ -69,7 +69,7 @@ class UnpaperImageTooLargeError(Exception):
+@@ -66,7 +66,7 @@ class UnpaperImageTooLargeError(Exception):
  
  
  def version() -> str:
@@ -115,13 +115,13 @@ index 479959ef..cc15fdec 100644
 +    return get_version('@unpaper@')
  
  
- SUFFIXES = {'1': '.pbm', 'L': '.pgm', 'RGB': '.ppm'}
-@@ -123,7 +123,7 @@ def _setup_unpaper_io(input_file: Path) -> Iterator[Tuple[Path, Path, Path]]:
+ SUPPORTED_MODES = {'1', 'L', 'RGB'}
+@@ -120,7 +120,7 @@ def _setup_unpaper_io(input_file: Path) -> Iterator[tuple[Path, Path, Path]]:
  def run_unpaper(
-     input_file: Path, output_file: Path, *, dpi: DecFloat, mode_args: List[str]
+     input_file: Path, output_file: Path, *, dpi: DecFloat, mode_args: list[str]
  ) -> None:
 -    args_unpaper = ['unpaper', '-v', '--dpi', str(round(dpi, 6))] + mode_args
 +    args_unpaper = ['@unpaper@', '-v', '--dpi', str(round(dpi, 6))] + mode_args
  
-     with _setup_unpaper_io(input_file) as (input_pnm, output_pnm, tmpdir):
+     with _setup_unpaper_io(input_file) as (input_png, output_pnm, tmpdir):
          # To prevent any shenanigans from accepting arbitrary parameters in

--- a/pkgs/development/python-modules/pikepdf/default.nix
+++ b/pkgs/development/python-modules/pikepdf/default.nix
@@ -24,7 +24,7 @@
 
 buildPythonPackage rec {
   pname = "pikepdf";
-  version = "5.3.1";
+  version = "5.4.2";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     postFetch = ''
       rm "$out/.git_archival.txt"
     '';
-    hash = "sha256-QYSI0oWuDw19EF8pwh3t1+VOY3Xe/AZxL1uARufg/nE=";
+    hash = "sha256-b4QUn+wfkk6Yx74ViBg6yaE1+bXtxidoyXYgBaJ9iiM=";
   };
 
   patches = [


### PR DESCRIPTION

###### Description of changes
https://github.com/pikepdf/pikepdf/blob/v5.4.2/docs/releasenotes/version5.rst

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
