### PR TITLE
python3Packages.sphinx: 5.0.2 -> 5.1.1; python3Packages.sphinx-autodoc-typehints: 1.19.1 -> 1.19.2

### DIFF
--- a/pkgs/development/python-modules/sphinx-autodoc-typehints/default.nix
+++ b/pkgs/development/python-modules/sphinx-autodoc-typehints/default.nix
@@ -8,7 +8,7 @@
 
 let
   pname = "sphinx-autodoc-typehints";
-  version = "1.19.1";
+  version = "1.19.2";
 in
 
 buildPythonPackage {
@@ -20,7 +20,7 @@ buildPythonPackage {
   src = fetchPypi {
     pname = "sphinx_autodoc_typehints";
     inherit version;
-    hash = "sha256-bIQdtV4Om+BIP/OWKiFStg55MG9CiNjE5+hqyESGpeo=";
+    hash = "sha256-hy+y17PXlIJsKONu32c56TVJSRRH3KvrB8WIVen5FN4=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/sphinx/default.nix
+++ b/pkgs/development/python-modules/sphinx/default.nix
@@ -4,6 +4,7 @@
 , pythonOlder
 , fetchFromGitHub
 , fetchpatch
+
 # propagatedBuildInputs
 , babel
 , alabaster
@@ -23,7 +24,9 @@
 , sphinxcontrib-qthelp
 , sphinxcontrib-serializinghtml
 , sphinxcontrib-websupport
+
 # check phase
+, cython
 , html5lib
 , pytestCheckHook
 , typed-ast
@@ -31,7 +34,7 @@
 
 buildPythonPackage rec {
   pname = "sphinx";
-  version = "5.0.2";
+  version = "5.1.1";
   format = "setuptools";
 
   disabled = pythonOlder "3.6";
@@ -40,7 +43,7 @@ buildPythonPackage rec {
     owner = "sphinx-doc";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-kdwznYvs4szhC+qoL2Zsib9cU69fag1KhCXl8qIGkZU=";
+    hash = "sha256-dTgQNMRIn7ETm+1HgviOkWWOCmLX7Ez6DM9ChlI32mY=";
     postFetch = ''
       cd $out
       mv tests/roots/test-images/testimäge.png \
@@ -49,19 +52,7 @@ buildPythonPackage rec {
     '';
   };
 
-  patches = [
-    # https://github.com/sphinx-doc/sphinx/pull/10624
-    (fetchpatch {
-      name = "avoid-deprecated-docutils-0.19-api.patch";
-      sha256 = "sha256-QIrLkxnexNcfuI00UOeCpAamMLqqt4wxoVY1VA72jIw=";
-      url = "https://github.com/sphinx-doc/sphinx/commit/8d99168794ab8be0de1e6281d1b76af8177acd3d.patch";
-    })
-  ];
-
   postPatch = ''
-    substituteInPlace setup.py \
-      --replace "docutils>=0.14,<0.19" "docutils>=0.14"
-
     # remove impurity caused by date inclusion
     # https://github.com/sphinx-doc/sphinx/blob/master/setup.cfg#L4-L6
     substituteInPlace setup.cfg \
@@ -95,11 +86,16 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
+    cython
     html5lib
     pytestCheckHook
   ] ++ lib.optionals (pythonOlder "3.8") [
     typed-ast
   ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
 
   disabledTests = [
     # requires network access


### PR DESCRIPTION
https://www.sphinx-doc.org/en/master/changes.html#release-5-1-1-released-jul-26-2022
https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/1.19.2

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
