### PR TITLE
gopsuinfo: init at 0.1.1

### DIFF
--- a/pkgs/tools/system/gopsuinfo/default.nix
+++ b/pkgs/tools/system/gopsuinfo/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "gopsuinfo";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "nwg-piotr";
+    repo = "gopsuinfo";
+    rev = "v${version}";
+    sha256 = "sha256-lEc5k89L0ViihcbYh6I5m+Z6Q/rhLFGwftc3WD2EJ/M=";
+  };
+
+  vendorSha256 = "sha256-RsplFwUL4KjWaXE6xvURX+4wkNG+i+1oyBXwLyVcb2Q=";
+
+  # Remove installing of binary from the Makefile (already taken care of by
+  # `buildGoModule`)
+  patches = [
+    ./no_bin_install.patch
+  ];
+
+  # Fix absolute path of icons in the code
+  postPatch = ''
+    substituteInPlace gopsuinfo.go \
+      --replace "/usr/share/gopsuinfo" "$out/usr/share/gopsuinfo"
+  '';
+
+  # Install icons
+  postInstall = '' make install DESTDIR=$out '';
+
+  meta = with lib; {
+    description = "A gopsutil-based command to display system usage info";
+    homepage = "https://github.com/nwg-piotr/gopsuinfo";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ otini ];
+  };
+}

--- a/pkgs/tools/system/gopsuinfo/default.nix
+++ b/pkgs/tools/system/gopsuinfo/default.nix
@@ -36,5 +36,6 @@ buildGoModule rec {
     homepage = "https://github.com/nwg-piotr/gopsuinfo";
     license = licenses.bsd2;
     maintainers = with maintainers; [ otini ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/system/gopsuinfo/no_bin_install.patch
+++ b/pkgs/tools/system/gopsuinfo/no_bin_install.patch
@@ -1,0 +1,12 @@
+diff --git a/Makefile b/Makefile
+index d33866c..e0aafb4 100644
+--- a/Makefile
++++ b/Makefile
+@@ -8,7 +8,6 @@ install:
+ 	mkdir -p "${DESTDIR}/usr/share/gopsuinfo" "${DESTDIR}/usr/bin"
+ 	cp -R icons_light "${DESTDIR}/usr/share/gopsuinfo"
+ 	cp -R icons_dark "${DESTDIR}/usr/share/gopsuinfo"
+-	cp bin/gopsuinfo "${DESTDIR}/usr/bin/"
+ 
+ uninstall:
+ 	rm -r "${DESTDIR}/usr/share/gopsuinfo"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1432,6 +1432,8 @@ with pkgs;
 
   goldberg-emu = callPackage ../applications/emulators/goldberg-emu { };
 
+  gopsuinfo = callPackage ../tools/system/gopsuinfo { };
+
   gxemul = callPackage ../applications/emulators/gxemul { };
 
   hatari = callPackage ../applications/emulators/hatari { };


### PR DESCRIPTION
###### Description of changes

Add [gpopsuinfo](https://github.com/nwg-piotr/gopsuinfo), a gopsutil-based command to display system usage info as text in panels like Waybar or icon/text in tint2 and nwg-panel executors.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
