### PR TITLE
gnutls: officially adopt the package

### DIFF
--- a/pkgs/development/libraries/gnutls/default.nix
+++ b/pkgs/development/libraries/gnutls/default.nix
@@ -124,7 +124,7 @@ stdenv.mkDerivation rec {
 
     homepage = "https://gnutls.org/";
     license = licenses.lgpl21Plus;
-    maintainers = with maintainers; [ eelco ];
+    maintainers = with maintainers; [ vcunat ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
I've been keeping an eye on it for years due to day job at knot-resolver

Eelco apparently hasn't touched gnutls since 2016, so let's drop him from the list.