### PR TITLE
xcbuild: various improvements

### DIFF
--- a/pkgs/development/tools/xcbuild/wrapper.nix
+++ b/pkgs/development/tools/xcbuild/wrapper.nix
@@ -1,4 +1,4 @@
-{ stdenv, makeWrapper, writeText, runCommand
+{ stdenv, makeWrapper, writeText, writeShellScriptBin, runCommand
 , CoreServices, ImageIO, CoreGraphics
 , runtimeShell, callPackage
 , xcodePlatform ? stdenv.targetPlatform.xcodePlatform or "MacOSX"
@@ -50,8 +50,7 @@ while [ $# -gt 0 ]; do
 done
   '';
 
-  xcrun = writeText "xcrun" ''
-#!${runtimeShell}
+  xcrun = writeShellScriptBin "xcrun" ''
 while [ $# -gt 0 ]; do
    case "$1" in
          --sdk | -sdk) shift ;;
@@ -90,7 +89,7 @@ runCommand "xcodebuild-${xcbuild.version}" {
   propagatedBuildInputs = [ "${toolchains}/XcodeDefault.xctoolchain" ];
 
   passthru = {
-    inherit xcbuild;
+    inherit xcbuild xcrun;
     toolchain = "${toolchains}/XcodeDefault.xctoolchain";
     sdk = "${sdks}/${sdkName}";
     platform = "${platforms}/${xcodePlatform}.platform";
@@ -127,8 +126,7 @@ runCommand "xcodebuild-${xcbuild.version}" {
     --subst-var-by DEVELOPER_DIR $out/Applications/Xcode.app/Contents/Developer
   chmod +x $out/bin/xcode-select
 
-  substitute ${xcrun} $out/bin/xcrun
-  chmod +x $out/bin/xcrun
+  cp ${xcrun}/bin/xcrun $out/bin/xcrun
 
   for bin in PlistBuddy actool builtin-copy builtin-copyPlist \
              builtin-copyStrings builtin-copyTiff \

--- a/pkgs/development/tools/xcbuild/wrapper.nix
+++ b/pkgs/development/tools/xcbuild/wrapper.nix
@@ -55,7 +55,8 @@ done
 while [ $# -gt 0 ]; do
    case "$1" in
          --sdk | -sdk) shift ;;
-         --find | -find)
+         --toolchain | -toolchain) shift ;;
+         --find | -find | -f)
            shift
            command -v $1 ;;
          --log | -log) ;; # noop


### PR DESCRIPTION
###### Description of changes

These tweaks specifically target LLVM compiler-rt, which I need to modify for Darwin.

The LLVM build tries to call `xcrun` but we currently don't make it available and ignore the errors. That's disabling critical functionality however. A change in this PR makes `xcrun` available separately, which is just a bunch of files and shell scripts. That makes it much easier to put it in the closure of stdenv on Darwin.

The other change is to actually check the `-sdk` flag if passed. The LLVM build calls `xcrun` multiple times to detect different SDKs, but it should only succeed for the target platform.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).