### PR TITLE
nut: fix search modes not finding dynamic libs

### DIFF
--- a/pkgs/applications/misc/nut/default.nix
+++ b/pkgs/applications/misc/nut/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, pkg-config, neon, libusb-compat-0_1, openssl, udev, avahi, freeipmi
+{ lib, stdenv, fetchurl, substituteAll, pkg-config, neon, libusb-compat-0_1, openssl, udev, avahi, freeipmi
 , libtool, makeWrapper, autoreconfHook, fetchpatch
 }:
 
@@ -16,6 +16,13 @@ stdenv.mkDerivation rec {
       # Fix build with openssl >= 1.1.0
       url = "https://github.com/networkupstools/nut/commit/612c05efb3c3b243da603a3a050993281888b6e3.patch";
       sha256 = "0jdbii1z5sqyv24286j5px65j7b3gp8zk3ahbph83pig6g46m3hs";
+    })
+    (substituteAll {
+      src = ./hardcode-paths.patch;
+      avahi = "${avahi}/lib";
+      freeipmi = "${freeipmi}/lib";
+      libusb = "${libusb-compat-0_1}/lib";
+      neon = "${neon}/lib";
     })
   ];
 
@@ -37,11 +44,6 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   NIX_CFLAGS_COMPILE = [ "-std=c++14" ];
-
-  postInstall = ''
-    wrapProgram $out/bin/nut-scanner --prefix LD_LIBRARY_PATH : \
-      "$out/lib:${neon}/lib:${libusb-compat-0_1.out}/lib:${avahi}/lib:${freeipmi}/lib"
-  '';
 
   meta = with lib; {
     description = "Network UPS Tools";

--- a/pkgs/applications/misc/nut/hardcode-paths.patch
+++ b/pkgs/applications/misc/nut/hardcode-paths.patch
@@ -1,0 +1,13 @@
+--- a/tools/nut-scanner/nutscan-init.c
++++ b/tools/nut-scanner/nutscan-init.c
+@@ -44,6 +44,10 @@ int nutscan_load_upsclient_library(const char *libname_path);
+ 
+ /* FIXME: would be good to get more from /etc/ld.so.conf[.d] */
+ char * search_paths[] = {
++	"@avahi@",
++	"@freeipmi@",
++	"@libusb@",
++	"@neon@",
+ 	LIBDIR,
+ 	"/usr/lib64",
+ 	"/lib64",


### PR DESCRIPTION
###### Description of changes

Fixes https://github.com/NixOS/nixpkgs/issues/91730 (nut-scanner can't find dynamic libraries at runtime).

On a `nixos-22.05` system:

```
$ nut-scanner -a
OLDNUT
USB
XML
AVAHI
IPMI
EATON_SERIAL
```

I only have a USB UPS to test with, but I confirmed `nut-scanner` can find it now. I did not test all 62 binaries in `result/bin`, but this patch should only affect `nut-scanner`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
