### PR TITLE
orbuculum: init at 2.0.0

### DIFF
--- a/pkgs/development/embedded/orbuculum/default.nix
+++ b/pkgs/development/embedded/orbuculum/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, czmq
+, libusb1
+, ncurses
+}:
+
+stdenv.mkDerivation rec {
+  pname = "orbuculum";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "orbcode";
+    repo = pname;
+    rev = "V${version}";
+    sha256 = "sha256-aMMXfrBQQ9oOx17MUKmqe5vdTpxhBGM5mVfAel0y0a0=";
+  };
+
+  buildInputs = [
+    czmq
+    libusb1
+    ncurses
+  ];
+
+  installFlags = [
+    "INSTALL_ROOT=$(out)/"
+  ];
+
+  postInstall = ''
+    mkdir -p $out/etc/udev/rules.d/
+    cp $src/Support/60-orbcode.rules $out/etc/udev/rules.d/
+  '';
+
+  meta = with lib; {
+    description = "Cortex M SWO SWV Demux and Postprocess for the ORBTrace";
+    homepage = "https://orbcode.org";
+    changelog = "https://github.com/orbcode/orbuculum/blob/V${version}/CHANGES.md";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ newam ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25692,6 +25692,8 @@ with pkgs;
 
   orbitron = callPackage ../data/fonts/orbitron { };
 
+  orbuculum = callPackage ../development/embedded/orbuculum { };
+
   orchis-theme = callPackage ../data/themes/orchis-theme { };
 
   orion = callPackage ../data/themes/orion {};


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add orbuculum, Cortex M SWO SWV Demux and Postprocess for the ORBTrace probe.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - N/A x86_64-darwin
  - N/A aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
