### PR TITLE
[Backport release-22.05] electron: use wrapper instead of symlink for bin on darwin

### DIFF
--- a/pkgs/applications/networking/instant-messengers/deltachat-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/deltachat-desktop/default.nix
@@ -33,10 +33,6 @@ let
     };
     patches = [ ./libdeltachat-darwin-dylib.patch ] ++ old.patches;
   });
-  electronExec = if stdenv.isDarwin then
-    "${electron_16}/Applications/Electron.app/Contents/MacOS/Electron"
-  else
-    "${electron_16}/bin/electron";
   esbuild' = esbuild.overrideAttrs (old: rec {
     version = "0.12.29";
     src = fetchFromGitHub {
@@ -95,7 +91,7 @@ in nodejs-14_x.pkgs.deltachat-desktop.override rec {
         $out/lib/node_modules/deltachat-desktop/html-dist/fonts
     done
 
-    makeWrapper ${electronExec} $out/bin/deltachat \
+    makeWrapper ${electron_16}/bin/electron $out/bin/deltachat \
       --set LD_PRELOAD ${sqlcipher}/lib/libsqlcipher${stdenv.hostPlatform.extensions.sharedLibrary} \
       --add-flags $out/lib/node_modules/deltachat-desktop
   '';

--- a/pkgs/applications/networking/instant-messengers/element/element-desktop.nix
+++ b/pkgs/applications/networking/instant-messengers/element/element-desktop.nix
@@ -19,7 +19,6 @@
 let
   pinData = lib.importJSON ./pin.json;
   executableName = "element-desktop";
-  electron_exec = if stdenv.isDarwin then "${electron}/Applications/Electron.app/Contents/MacOS/Electron" else "${electron}/bin/electron";
   keytar = callPackage ./keytar { inherit Security AppKit; };
   seshat = callPackage ./seshat { inherit CoreServices; };
 in
@@ -83,7 +82,7 @@ mkYarnPackage rec {
 
     # executable wrapper
     # LD_PRELOAD workaround for sqlcipher not found: https://github.com/matrix-org/seshat/issues/102
-    makeWrapper '${electron_exec}' "$out/bin/${executableName}" \
+    makeWrapper '${electron}/bin/electron' "$out/bin/${executableName}" \
       --set LD_PRELOAD ${sqlcipher}/lib/libsqlcipher.so \
       --add-flags "$out/share/element/electron" \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--enable-features=UseOzonePlatform --ozone-platform=wayland}}"

--- a/pkgs/applications/networking/instant-messengers/schildichat/schildichat-desktop.nix
+++ b/pkgs/applications/networking/instant-messengers/schildichat/schildichat-desktop.nix
@@ -19,7 +19,6 @@
 let
   pinData = lib.importJSON ./pin.json;
   executableName = "schildichat-desktop";
-  electron_exec = if stdenv.isDarwin then "${electron}/Applications/Electron.app/Contents/MacOS/Electron" else "${electron}/bin/electron";
 in
 stdenv.mkDerivation rec {
   pname = "schildichat-desktop";
@@ -88,7 +87,7 @@ stdenv.mkDerivation rec {
     done
 
     # executable wrapper
-    makeWrapper '${electron_exec}' "$out/bin/${executableName}" \
+    makeWrapper '${electron}/bin/electron' "$out/bin/${executableName}" \
       --add-flags "$out/share/element/electron" \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--enable-features=UseOzonePlatform --ozone-platform=wayland}}"
 

--- a/pkgs/applications/office/micropad/default.nix
+++ b/pkgs/applications/office/micropad/default.nix
@@ -11,10 +11,6 @@
 }:
 let
   executableName = "micropad";
-  electron_exec =
-    if stdenv.isDarwin
-    then "${electron}/Applications/Electron.app/Contents/MacOS/Electron"
-    else "${electron}/bin/electron";
 in
   mkYarnPackage rec {
     pname = "micropad";
@@ -64,7 +60,7 @@ in
       done
 
       # executable wrapper
-      makeWrapper '${electron_exec}' "$out/bin/${executableName}" \
+      makeWrapper '${electron}/bin/electron' "$out/bin/${executableName}" \
         --add-flags "$out/share/micropad" \
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--enable-features=UseOzonePlatform --ozone-platform=wayland}}"
 

--- a/pkgs/development/tools/electron/generic.nix
+++ b/pkgs/development/tools/electron/generic.nix
@@ -103,14 +103,17 @@ let
   };
 
   darwin = {
-    nativeBuildInputs = [ unzip ];
+    nativeBuildInputs = [
+      makeWrapper
+      unzip
+    ];
 
     buildCommand = ''
       mkdir -p $out/Applications
       unzip $src
       mv Electron.app $out/Applications
       mkdir -p $out/bin
-      ln -s $out/Applications/Electron.app/Contents/MacOS/Electron $out/bin/electron
+      makeWrapper $out/Applications/Electron.app/Contents/MacOS/Electron $out/bin/electron
     '';
   };
 in


### PR DESCRIPTION
Backport #185848 to release-22.05