### PR TITLE
gtklock: init at 2.0.1

### DIFF
--- a/pkgs/tools/wayland/gtklock/default.nix
+++ b/pkgs/tools/wayland/gtklock/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkgs
+, pam
+, scdoc
+, gtk3
+, pkg-config
+, gtk-layer-shell
+, glib
+, wayland
+, wayland-scanner
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gtklock";
+  version = "2.0.1";
+
+  src = fetchFromGitHub {
+    owner = "jovanlanik";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-W+GyeGxlfp1YZtSFEZYXuHmvTVZ8mU1oBcsrWN1yvjU=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    scdoc
+    pkg-config
+    wayland-scanner
+    glib
+  ];
+
+  buildInputs = [
+    wayland
+    gtk3
+    pam
+    gtk-layer-shell
+  ];
+
+  installFlags = [
+    "DESTDIR=$(out)"
+    "PREFIX="
+  ];
+
+  meta = with lib; {
+    description = "GTK-based lockscreen for Wayland";
+    longDescription = ''
+      Important note: for gtklock to work you need to set "security.pam.services.gtklock = {};" manually.
+    ''; # Following  nixpkgs/pkgs/applications/window-managers/sway/lock.nix
+    homepage = "https://github.com/jovanlanik/gtklock";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ dit7ya ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27708,6 +27708,8 @@ with pkgs;
 
   gtk2fontsel = callPackage ../applications/misc/gtk2fontsel { };
 
+  gtklock = callPackage ../tools/wayland/gtklock { };
+
   guardian-agent = callPackage ../tools/networking/guardian-agent { };
 
   gv = callPackage ../applications/misc/gv { };


### PR DESCRIPTION
###### Description of changes

gtklock is a GTK-based lockscreen for Wayland
https://github.com/jovanlanik/gtklock

NOTE to reviewers: I could not figure out anything simpler than asking the user to set `security.pam.services.gtklock = {};` manually in the longDescription.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
