### PR TITLE
ocamlPackages.crunch: 3.1.0 → 3.3.1

### DIFF
--- a/pkgs/development/ocaml-modules/cmdliner/1_1.nix
+++ b/pkgs/development/ocaml-modules/cmdliner/1_1.nix
@@ -1,5 +1,8 @@
 { lib, stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg, result }:
 
+lib.throwIfNot (lib.versionAtLeast ocaml.version "4.08")
+  "cmdliner 1.1 is not available for OCaml ${ocaml.version}"
+
 stdenv.mkDerivation rec {
   pname = "cmdliner";
   version = "1.1.1";
@@ -9,7 +12,6 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-oa6Hw6eZQO+NHdWfdED3dtHckm4BmEbdMiAuRkYntfs=";
   };
 
-  minimalOCamlVersion = "4.08";
   nativeBuildInputs = [ ocaml ];
 
   makeFlags = [ "PREFIX=$(out)" ];

--- a/pkgs/development/tools/ocaml/crunch/default.nix
+++ b/pkgs/development/tools/ocaml/crunch/default.nix
@@ -1,18 +1,18 @@
-{ lib, buildDunePackage, fetchurl, ocaml, cmdliner, ptime }:
+{ lib, buildDunePackage, fetchurl, ocaml, cmdliner_1_1, ptime }:
 
 buildDunePackage rec {
 
   pname = "crunch";
-  version = "3.1.0";
-
-  useDune2 = true;
+  version = "3.3.1";
 
   src = fetchurl {
-    url = "https://github.com/mirage/ocaml-crunch/releases/download/v${version}/crunch-v${version}.tbz";
-    sha256 = "0d26715a4h9r1wibnc12xy690m1kan7hrcgbb5qk8x78zsr67lnf";
+    url = "https://github.com/mirage/ocaml-crunch/releases/download/v${version}/crunch-${version}.tbz";
+    sha256 = "sha256-LFug1BELy7dzHLpOr7bESnSHw/iMGtR0AScbaf+o7Wo=";
   };
 
-  propagatedBuildInputs = [ cmdliner ptime ];
+  buildInputs = [ cmdliner_1_1 ];
+
+  propagatedBuildInputs = [ ptime ];
 
   outputs = [ "lib" "bin" "out" ];
 


### PR DESCRIPTION
###### Description of changes

Fixes & improvements: https://github.com/mirage/ocaml-crunch/blob/v3.3.1/CHANGES.md#v331-2022-08-05

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
