### PR TITLE
python310Packages.asgi-csrf: Enable more tests

### DIFF
--- a/pkgs/development/python-modules/asgi-csrf/default.nix
+++ b/pkgs/development/python-modules/asgi-csrf/default.nix
@@ -8,6 +8,7 @@
 , starlette
 , httpx
 , pytest-asyncio
+, asgi-lifespan
 }:
 
 buildPythonPackage rec {
@@ -29,13 +30,18 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
+    asgi-lifespan
     httpx
     pytest-asyncio
     pytestCheckHook
     starlette
   ];
 
-  doCheck = false; # asgi-lifespan missing
+  disabledTests = [
+    # Require network
+    "test_multipart"
+    "test_multipart_failure_wrong_token"
+  ];
 
   pythonImportsCheck = [ "asgi_csrf" ];
 

--- a/pkgs/development/python-modules/asgi-lifespan/default.nix
+++ b/pkgs/development/python-modules/asgi-lifespan/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, sniffio
+, pytestCheckHook
+, starlette
+, trio
+}:
+
+buildPythonPackage rec {
+  pname = "asgi-lifespan";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "florimondmanca";
+    repo = "asgi-lifespan";
+    rev = version;
+    sha256 = "sha256-QooFNxtGQYCRuITvlz3Mkd61XOwnKj6ctBzl1lJkRYE=";
+  };
+
+  postPatch = ''
+    # Remove coverage tests
+    sed -i '21,24d' setup.cfg
+  '';
+
+  propagatedBuildInputs = [
+    sniffio
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    starlette
+    trio
+  ];
+
+  pythonImportsCheck = [ "asgi_lifespan" ];
+
+  meta = with lib; {
+    description = "Programmatic startup/shutdown of ASGI apps";
+    homepage = "https://github.com/florimondmanca/asgi-lifespan";
+    license = licenses.mit;
+    maintainers = with maintainers; [ onny ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -693,6 +693,8 @@ in {
 
   asgi-csrf = callPackage ../development/python-modules/asgi-csrf { };
 
+  asgi-lifespan = callPackage ../development/python-modules/asgi-lifespan { };
+
   asgineer = callPackage ../development/python-modules/asgineer { };
 
   asgiref = callPackage ../development/python-modules/asgiref { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
