### PR TITLE
auslogger init at 0.1.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3485,9 +3485,10 @@
     }];
   };
   drzoidberg = {
-    email = "jakob@mast3rsoft.com";
+    email = "jakobneufeld@tutanota.com";
     github = "jakobneufeld";
     githubId = 24791219;
+    matrix = "@dzoidberg:matrix.org";
     name = "Jakob Neufeld";
   };
   dsalaza4 = {

--- a/pkgs/applications/misc/auslogger/default.nix
+++ b/pkgs/applications/misc/auslogger/default.nix
@@ -1,0 +1,76 @@
+{ lib
+, rustPlatform
+, fetchFromSourcehut
+, fetchpatch
+, libGL
+, vulkan-loader
+, wayland
+, wayland-protocols
+, libxkbcommon
+, libX11
+, libXrandr
+, libXi
+, libXcursor
+, scdoc
+, installShellFiles
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "auslogger";
+  version = "0.1.4";
+
+  src = fetchFromSourcehut {
+    owner = "~mastersoft";
+    vc = "git";
+    repo = "Auslogger";
+    rev = "v${version}";
+    sha256 = "sha256-Tw3KL90RUkXtYBuV4JtbyAywRFFYH+K5korKoUEqCcQ=";
+  };
+
+  cargoSha256 = "sha256-7YZJ9EhUn4CvXQQILpUcjTQrOv/ZHwh2Wx1HYlD6rgo=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  buildInputs = [
+    wayland
+    wayland-protocols
+    libxkbcommon
+    libX11
+    libXrandr
+    libXi
+    libXcursor
+  ];
+
+  preFixup = ''
+    runHook preInstall
+    installManPage man/auslogger.1
+    runHook postInstall
+  '';
+
+  postFixup =
+    let
+      libPath = lib.makeLibraryPath [
+        libGL
+        vulkan-loader
+        wayland
+        wayland-protocols
+        libxkbcommon
+        libX11
+        libXrandr
+        libXi
+        libXcursor
+      ];
+    in
+    ''
+      patchelf --set-rpath "${libPath}" "$out/bin/auslogger"
+    '';
+
+  meta = with lib; {
+    # Linux only
+    platforms = lib.platforms.unix;
+    description = "A simple program for locking, restarting and shutting down. Designed for tiling window managers.";
+    homepage = "https://sr.ht/~mastersoft/Auslogger";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ drzoidberg ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1085,6 +1085,8 @@ with pkgs;
 
   aescrypt = callPackage ../tools/misc/aescrypt { };
 
+  auslogger = callPackage ../applications/misc/auslogger { };
+
   aether-lv2 = callPackage ../applications/audio/aether-lv2 { };
 
   acme-client = callPackage ../tools/networking/acme-client {


### PR DESCRIPTION
###### Description of changes

I added myself as a maintainer and added the auslogger package!
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
