### PR TITLE
gamescope: rename libseat to seatd

### DIFF
--- a/pkgs/applications/window-managers/gamescope/default.nix
+++ b/pkgs/applications/window-managers/gamescope/default.nix
@@ -15,7 +15,7 @@
 , udev
 , pixman
 , libinput
-, libseat
+, seatd
 , xwayland
 , glslang
 , stb
@@ -65,7 +65,7 @@ stdenv.mkDerivation {
     wayland-protocols
     wlroots
     xwayland
-    libseat
+    seatd
     libinput
     libxkbcommon
     udev


### PR DESCRIPTION
Wait. Still trying to understand this.

* gamescope: rename libseat to seatd

Fixing downstream breakage revealed at #186086

> `error: Function called without required argument "libseat" at /home/intj/.cache/nixpkgs-review/pr-186086 /nixpkgs/pkgs/applications/window-managers/gamescope/default.nix:18, did you mean "libXext", "libjcat" or "libnet"?
> (use '--show-trace' to show detailed location information)`


Note: That PR targets staging and not master. Which the alias has been removed.