### PR TITLE
manticoresearch: init at 5.0.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6221,6 +6221,12 @@
     githubId = 117874;
     name = "Jeroen de Haas";
   };
+  jdelStrother = {
+    email = "me@delstrother.com";
+    github = "jdelStrother";
+    githubId = 2377;
+    name = "Jonathan del Strother";
+  };
   jdreaver = {
     email = "johndreaver@gmail.com";
     github = "jdreaver";

--- a/pkgs/servers/search/manticoresearch/default.nix
+++ b/pkgs/servers/search/manticoresearch/default.nix
@@ -1,0 +1,70 @@
+{ lib, stdenv, fetchFromGitHub, fetchurl
+, bison, cmake, flex, pkg-config
+, boost, icu, libstemmer, mariadb-connector-c, re2
+}:
+let
+  columnar = stdenv.mkDerivation rec {
+    pname = "columnar";
+    version = "c16-s5"; # see NEED_COLUMNAR_API/NEED_SECONDARY_API in Manticore's GetColumnar.cmake
+    src = fetchFromGitHub {
+      owner = "manticoresoftware";
+      repo = "columnar";
+      rev = version;
+      sha256 = "sha256-iHB82FeA0rq9eRuDzY+AT/MiaRIGETsnkNPCqKRXgq8=";
+    };
+    nativeBuildInputs = [ cmake ];
+    cmakeFlags = [ "-DAPI_ONLY=ON" ];
+    meta = {
+      description = "A column-oriented storage and secondary indexing library";
+      homepage = "https://github.com/manticoresoftware/columnar/";
+      license = lib.licenses.asl20;
+      platforms = lib.platforms.all;
+    };
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "manticoresearch";
+  version = "5.0.3";
+
+  src = fetchFromGitHub {
+    owner = "manticoresoftware";
+    repo = "manticoresearch";
+    rev = version;
+    sha256 = "sha256-samZYwDYgI9jQ7jcoMlpxulSFwmqyt5bkxG+WZ9eXuk=";
+  };
+
+  nativeBuildInputs = [
+    bison
+    cmake
+    flex
+    pkg-config
+  ];
+
+  buildInputs = [
+    boost
+    columnar
+    icu.dev
+    libstemmer
+    mariadb-connector-c
+    re2
+  ];
+
+  postPatch = ''
+    sed -i 's/set ( Boost_USE_STATIC_LIBS ON )/set ( Boost_USE_STATIC_LIBS OFF )/' src/CMakeLists.txt
+
+    # supply our own packages rather than letting manticore download dependencies during build
+    sed -i 's/^with_get/with_menu/' CMakeLists.txt
+  '';
+
+  cmakeFlags = [
+    "-DWITH_GALERA=0"
+  ];
+
+  meta = with lib; {
+    description = "Easy to use open source fast database for search";
+    homepage = "https://manticoresearch.com";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ jdelStrother ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20914,6 +20914,7 @@ with pkgs;
     boost = boost175;
   };
 
+  manticoresearch = callPackage ../servers/search/manticoresearch { };
 
   marisa = callPackage ../development/libraries/marisa {};
 


### PR DESCRIPTION
###### Description of changes

This adds a new manticoresearch package for [Manticore](https://manticoresearch.com). Manticore is a fork/spiritual successor to [Sphinx](https://github.com/NixOS/nixpkgs/blob/master/pkgs/servers/search/sphinxsearch/default.nix)



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
