### PR TITLE
discord: remove ldesgoui from maintainers

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -53,7 +53,7 @@ let
     downloadPage = "https://discordapp.com/download";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
-    maintainers = with maintainers; [ ldesgoui MP2E devins2518 ];
+    maintainers = with maintainers; [ MP2E devins2518 ];
     platforms = [ "x86_64-linux" "x86_64-darwin" ]
       ++ lib.optionals (branch != "stable") [ "aarch64-darwin" ];
   };


### PR DESCRIPTION
I haven't had this package installed for a long time, it remains annoying to deal with and I don't really enjoy having to deal with the notifications