### PR TITLE
raspa, raspa-data: init at 2.0.47

### DIFF
--- a/pkgs/applications/science/molecular-dynamics/raspa/data.nix
+++ b/pkgs/applications/science/molecular-dynamics/raspa/data.nix
@@ -1,0 +1,33 @@
+{ lib
+, stdenvNoCC
+, gzip
+, raspa
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "raspa-data";
+  inherit (raspa) version src;
+
+  outputs = [ "out" "doc" ];
+
+  nativeBuildInpuhs = [ gzip ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out/share/raspa"
+    mv examples "$out/share/raspa"
+    mkdir -p "$doc/share/raspa"
+    mv -T "Docs" "$doc/share/raspa/doc"
+    runHook postInstall
+  '';
+
+  # Keep the shebangs of the examples from being patched
+  dontPatchShebangs = true;
+
+  meta = with lib; {
+    inherit (raspa.meta) homepage license maintainers;
+    description = "Example packs and documentation of RASPA";
+    outputsToInstall = [ "out" "doc" ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/applications/science/molecular-dynamics/raspa/default.nix
+++ b/pkgs/applications/science/molecular-dynamics/raspa/default.nix
@@ -1,0 +1,79 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, makeWrapper
+, fftw
+, lapack
+, openblas
+, runCommandLocal
+, raspa
+, raspa-data
+}:
+stdenv.mkDerivation rec {
+  pname = "raspa";
+  version = "2.0.47";
+
+  src = fetchFromGitHub {
+    owner = "iRASPA";
+    repo = "RASPA2";
+    rev = "v${version}";
+    hash = "sha256-i8Y+pejiOuyPNJto+/0CmRoAnMljCrnDFx8qDh4I/68=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    fftw
+    lapack
+    openblas
+  ];
+
+  # Prepare for the Python binding packaging.
+  strictDeps = true;
+
+  enableParallelBuilding = true;
+
+  preAutoreconf = ''
+    mkdir "m4"
+  '';
+
+  postAutoreconf = ''
+    automake --add-missing
+    autoconf
+  '';
+
+  doCheck = true;
+
+  # Wrap with RASPA_DIR
+  # so that users can run $out/bin/simulate directly
+  # without the need of a `run` srcipt.
+  postInstall = ''
+    wrapProgram "$out/bin/simulate" \
+      --set RASPA_DIR "$out"
+  '';
+
+  passthru.tests.run-an-example = runCommandLocal "raspa-test-run-an-example" { }
+    ''
+      set -eu -o pipefail
+      exampleDir="${raspa-data}/share/raspa/examples/Basic/1_MC_Methane_in_Box"
+      exampleDirWritable="$(basename "$exampleDir")"
+      cp -rT "$exampleDir" "./$exampleDirWritable"
+      chmod u+rw -R "$exampleDirWritable"
+      cd "$exampleDirWritable"
+      ${raspa}/bin/simulate
+      touch "$out"
+    '';
+
+  meta = with lib; {
+    description = "A general purpose classical molecular simulation package";
+    homepage = "https://iraspa.org/raspa/";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ ShamrockLee ];
+    mainProgram = "simulate";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37875,6 +37875,10 @@ with pkgs;
 
   pspp = callPackage ../applications/science/math/pspp { };
 
+  raspa = callPackage ../applications/science/molecular-dynamics/raspa { };
+
+  raspa-data = callPackage ../applications/science/molecular-dynamics/raspa/data.nix { };
+
   ssw = callPackage ../applications/misc/ssw { };
 
   pynac = callPackage ../applications/science/math/pynac { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
ca-->

[RASPA](https://github.com/iRASPA/RASPA2) is a classical molecular dynamic simulation software.

The executable `$out/bin/simulate` is wrapped with environment variable `RASPA_DIR` set to `$out`, and both `LD_LIBRARY_PATH` and `DYLD_LIBRARY_PATH` prefixed with `$out/lib`. This way, the user don't have to write another script (`run`) just to set those variables and call the executable as instructed by the documentation.

The Nix expression `run-examples.nix` can be called to produce a package that runs the specified examples using GNU Parallel as a package test. As Monte Carlo itself is computationally expensive, the package test added to `passthru.tests` only runs one short example.

The project comes with a Python binding called `raspa2`, which I'm not sure how to package correctly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
