### PR TITLE
python3Packages.future-stubs: init at 0.18.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8700,6 +8700,12 @@
       fingerprint = "E90C BA34 55B3 6236 740C  038F 0D94 8CE1 9CF4 9C5F";
     }];
   };
+  mkohler = {
+    email = "mark.kohler@gmail.com";
+    github = "mkohler";
+    githubId = 68706;
+    name = "Mark Kohler";
+  };
   mlieberman85 = {
     email = "mlieberman85@gmail.com";
     github = "mlieberman85";

--- a/pkgs/development/python-modules/future-stubs/001-fix-setup-files.patch
+++ b/pkgs/development/python-modules/future-stubs/001-fix-setup-files.patch
@@ -1,0 +1,24 @@
+diff --git a/setup.cfg b/setup.cfg
+index 2784708..adf5ed7 100644
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -1,6 +1,3 @@
+-[metadata]
+-license_file = LICENSE.txt
+-
+ [bdist_wheel]
+ universal = 1
+
+diff --git a/setup.py b/setup.py
+index 451ecc5..8164f01 100644
+--- a/setup.py
++++ b/setup.py
+@@ -41,7 +41,7 @@ setup(name=NAME,
+       keywords=KEYWORDS,
+       package_dir={'': 'src'},
+       packages=PACKAGES,
+-      install_requires=['python-future>=0.16.0'],
++      install_requires=['future>=0.16.0'],
+       include_package_data=True,
+       python_requires=">=2.6, !=3.0.*, !=3.1.*, !=3.2.*",
+       classifiers=CLASSIFIERS,

--- a/pkgs/development/python-modules/future-stubs/002-add-py.typed-files.patch
+++ b/pkgs/development/python-modules/future-stubs/002-add-py.typed-files.patch
@@ -1,0 +1,16 @@
+diff --git a/MANIFEST.in b/MANIFEST.in
+index 46551ba..cc5b512 100644
+--- a/MANIFEST.in
++++ b/MANIFEST.in
+@@ -3,3 +3,5 @@ prune tests
+ prune stubs
+ recursive-exclude src *.py
+ recursive-include src *.pyi
++include src/future/py.typed
++include src/past/py.typed
+diff --git a/src/future/py.typed b/src/future/py.typed
+new file mode 100644
+index 0000000..e69de29
+diff --git a/src/past/py.typed b/src/past/py.typed
+new file mode 100644
+index 0000000..e69de29

--- a/pkgs/development/python-modules/future-stubs/default.nix
+++ b/pkgs/development/python-modules/future-stubs/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildPythonPackage, fetchPypi, future }:
+
+buildPythonPackage rec {
+  pname = "future-stubs";
+  version = "0.18.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "ae42148268d32d25643bd0f985d528924d17c2830b49a13a5b289e22878ca000";
+  };
+
+  propagatedBuildInputs = [ future ];
+
+  # As packaged in pypi, the future-stubs library had several minor but fatal
+  # packaging problems. These patches fix the problems:
+  # - setup.cfg references a LICENSE.txt file that doesn't exist.
+  # - setup.py install_requires "python-future" instead of "future"
+  # - The package is missing the `py.typed` files that mypy requires.
+  patches = [ ./001-fix-setup-files.patch ./002-add-py.typed-files.patch ];
+
+  meta = with lib; {
+    description = "PEP 561 stubs for python-future";
+    homepage = "https://python-future.org";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mkohler ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3446,6 +3446,8 @@ in {
 
   future-fstrings = callPackage ../development/python-modules/future-fstrings { };
 
+  future-stubs = callPackage ../development/python-modules/future-stubs { };
+
   future-typing = callPackage ../development/python-modules/future-typing { };
 
   fuzzyfinder = callPackage ../development/python-modules/fuzzyfinder { };


### PR DESCRIPTION
###### Description of changes

Add package from pypi that contains type information for the python future library.
https://pypi.org/project/future-stubs/


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
