### PR TITLE
dexed: init at unstable-2022-07-09

### DIFF
--- a/pkgs/applications/audio/dexed/default.nix
+++ b/pkgs/applications/audio/dexed/default.nix
@@ -1,0 +1,107 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, pkg-config
+, libX11
+, libXrandr
+, libXinerama
+, libXext
+, libXcursor
+, freetype
+, alsa-lib
+, libjack2
+, Cocoa
+, WebKit
+, MetalKit
+, simd
+, DiscRecording
+, CoreAudioKit
+}:
+
+stdenv.mkDerivation rec {
+  pname = "dexed";
+  version = "unstable-2022-07-09";
+
+  src = fetchFromGitHub {
+    owner = "asb2m10";
+    repo = "dexed";
+    rev = "2c036316bcd512818aa9cc8129767ad9e0ec7132";
+    fetchSubmodules = true;
+    sha256 = "sha256-6buvA72YRlGjHWLPEZMr45lYYG6ZY+IWmylcHruX27g=";
+  };
+
+  postPatch = ''
+    # needs special setup on Linux, dunno if it can work on Darwin
+    # https://github.com/NixOS/nixpkgs/issues/19098
+    sed -i -e '/juce::juce_recommended_lto_flags/d' Source/CMakeLists.txt
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    libX11
+    libXext
+    libXcursor
+    libXinerama
+    libXrandr
+    freetype
+    alsa-lib
+    libjack2
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    Cocoa
+    WebKit
+    MetalKit
+    simd
+    DiscRecording
+    CoreAudioKit
+  ];
+
+  # JUCE insists on only dlopen'ing these
+  NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isLinux (toString [
+    "-lX11"
+    "-lXext"
+    "-lXcursor"
+    "-lXinerama"
+    "-lXrandr"
+    "-ljack"
+  ]);
+
+  installPhase = let
+    vst3Dir = if stdenv.hostPlatform.isDarwin then "$out/Library/Audio/Plug-Ins/VST3" else "$out/lib/vst3";
+    # this one's a guess, don't know where ppl have agreed to put them yet
+    clapDir = if stdenv.hostPlatform.isDarwin then "$out/Library/Audio/Plug-Ins/CLAP" else "$out/lib/clap";
+    auDir = "$out/Library/Audio/Plug-Ins/Components";
+  in ''
+    runHook preInstall
+
+  '' + (if stdenv.hostPlatform.isDarwin then ''
+    mkdir -p $out/{Applications,bin}
+    mv Source/Dexed_artefacts/Release/Standalone/Dexed.app $out/Applications/
+    ln -s $out/{Applications/Dexed.app/Contents/MacOS,bin}/Dexed
+  '' else ''
+    install -Dm755 {Source/Dexed_artefacts/Release/Standalone,$out/bin}/Dexed
+  '') + ''
+    mkdir -p ${vst3Dir} ${clapDir}
+    mv Source/Dexed_artefacts/Release/VST3/* ${vst3Dir}
+    mv Source/Dexed_artefacts/Release/CLAP/* ${clapDir}
+  '' + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    mkdir -p ${auDir}
+    mv Source/Dexed_artefacts/Release/AU/* ${auDir}
+  '' + ''
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "DX7 FM multi platform/multi format plugin";
+    mainProgram = "Dexed";
+    homepage = "https://asb2m10.github.io/dexed";
+    license = licenses.gpl3Only;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ OPNA2608 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26777,6 +26777,11 @@ with pkgs;
 
   denemo = callPackage ../applications/audio/denemo { };
 
+  dexed = darwin.apple_sdk_11_0.callPackage ../applications/audio/dexed {
+    inherit (darwin.apple_sdk_11_0.frameworks) Cocoa WebKit MetalKit DiscRecording CoreAudioKit;
+    inherit (darwin.apple_sdk_11_0.libs) simd;
+  };
+
   dvdauthor = callPackage ../applications/video/dvdauthor { };
 
   dvdbackup = callPackage ../applications/video/dvdbackup { };


### PR DESCRIPTION
###### Description of changes

Packages [Dexed](https://asb2m10.github.io/dexed/), a cross-platform synth closely modeled after the Yamaha DX7.

TODO:

- ~~Darwin~~ Should work now.
- ~~JUCE meta? (we have previously packaged other JUCE projects that needed Projucer, need to look around how they handled this stuff)~~ Unreleased version added CMake support & JUCE git submodule, separate JUCE is not needed anymore.

As is, standalone binary & VST3 plugin work on x86_64-linux & x86_64-darwin.

![Bildschirmfoto von 2022-08-11 13-46-58](https://user-images.githubusercontent.com/23431373/184212724-1d8ae184-9572-4180-911b-da344122c090.png)
![Bildschirmfoto von 2022-08-11 14-04-20](https://user-images.githubusercontent.com/23431373/184212759-961a2735-e27a-4e76-a4d7-66cf65a8b2a6.png)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).