### PR TITLE
memray: init at 1.2.0

### DIFF
--- a/pkgs/development/tools/memray/default.nix
+++ b/pkgs/development/tools/memray/default.nix
@@ -1,0 +1,63 @@
+{ lib
+, fetchFromGitHub
+, libunwind
+, lz4
+, pkg-config
+, python3
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "memray";
+  version = "1.2.0";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "bloomberg";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-MZOKo0VaCJM/YyvCByM5Yg7H/8onDKNSufBzr+GsFlo=";
+  };
+
+  buildInputs = [
+    libunwind
+    lz4
+    pkg-config
+  ] ++ (with python3.pkgs; [
+    cython
+  ]);
+
+  propagatedBuildInputs = with python3.pkgs; [
+    jinja2
+    rich
+  ];
+
+  checkInputs = with python3.pkgs; [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "memray"
+  ];
+
+  pytestFlagsArray = [
+    "tests"
+  ];
+
+  disabledTests = [
+    # Import issue
+    "test_header_allocator"
+  ];
+
+  disabledTestPaths = [
+    # Very time-consuming and some tests fails (performance-related?)
+    "tests/integration/test_main.py"
+  ];
+
+  meta = with lib; {
+    description = "Memory profiler for Python";
+    homepage = "https://bloomberg.github.io/memray/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ fab ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20154,6 +20154,8 @@ with pkgs;
     deps = [ memorymapping ];
   } ../development/libraries/memorymapping/setup-hook.sh;
 
+  memray = callPackage ../development/tools/memray { };
+
   memstream = callPackage ../development/libraries/memstream { };
   memstreamHook = makeSetupHook {
     deps = [ memstream ];


### PR DESCRIPTION
###### Description of changes
Memory profiler for Python"

https://bloomberg.github.io/memray/
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
