### PR TITLE
telepresence: fix homepage link

### DIFF
--- a/pkgs/tools/networking/telepresence2/default.nix
+++ b/pkgs/tools/networking/telepresence2/default.nix
@@ -31,7 +31,7 @@ buildGoModule rec {
 
   meta = with lib; {
     description = "Local development against a remote Kubernetes or OpenShift cluster";
-    homepage = "https://www.getambassador.io/docs/telepresence/2.1/quick-start/";
+    homepage = "https://telepresence.io";
     license = licenses.asl20;
     maintainers = with maintainers; [ mausch ];
     mainProgram = "telepresence";


### PR DESCRIPTION
The current homepage gives a 404:

    [~]$ curl -v https://www.getambassador.io/docs/telepresence/2.1/quick-start/ 2>&1 | grep -A15 '< HTTP/2'
    < HTTP/2 404
    < age: 102
    < cache-control: public, max-age=0, must-revalidate
    < content-type: text/html; charset=utf-8
    < date: Fri, 12 Aug 2022 00:04:41 GMT
    < etag: 1500322315-ssl
    < referrer-policy: same-origin
    < server: Netlify
    < strict-transport-security: max-age=31536000
    < x-content-type-options: nosniff
    < x-frame-options: DENY
    < x-nf-request-id: 01GA7NZ6Y5BPQJ4B215ZEMRZ5T
    < x-xss-protection: 1; mode=block
    < content-length: 633903
    <
    { [5 bytes data]

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
