### PR TITLE
udns: fix darwin build

### DIFF
--- a/pkgs/development/libraries/udns/default.nix
+++ b/pkgs/development/libraries/udns/default.nix
@@ -16,7 +16,20 @@ stdenv.mkDerivation rec {
     sha256 = "0447fv1hmb44nnchdn6p5pd9b44x8p5jn0ahw6crwbqsg7f0hl8i";
   };
 
+  # udns uses a very custom build and hardcodes a .so name in a few places.
+  # Instead of fighting with it to apply the standard dylib script, change
+  # the right place in the Makefile itself.
+  postPatch =
+    if stdenv.isDarwin
+    then
+      ''
+        substituteInPlace Makefile.in \
+          --replace --soname, -install_name,$out/lib/
+      ''
+    else "";
+
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     mkdir -p $out/include
     mkdir -p $out/lib
@@ -30,6 +43,7 @@ stdenv.mkDerivation rec {
     ln -rs $out/lib/libudns.so.0 $out/lib/libudns.so
     cp dnsget.1 rblcheck.1 $out/share/man/man1
     cp udns.3 $out/share/man/man3
+    runHook postInstall
   '';
 
   # keep man3
@@ -40,7 +54,7 @@ stdenv.mkDerivation rec {
     description = "Async-capable DNS stub resolver library";
     license = licenses.lgpl21Plus;
     maintainers = [ maintainers.womfoo ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 
 }


### PR DESCRIPTION
###### Description of changes

Allow udns to build on darwin - fix the library search paths.
Add phase hooks while I'm here.

I'm not sure if this should be linux++darwin or unix, but I don't see an obivous reason why it wouldn't work on other platforms.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
