### PR TITLE
verible: init at 0.0-2172-g238b6df6

### DIFF
--- a/pkgs/development/tools/verible/default.nix
+++ b/pkgs/development/tools/verible/default.nix
@@ -1,0 +1,85 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, buildBazelPackage
+, bazel_4
+, flex
+, bison
+, python3
+}:
+
+buildBazelPackage rec {
+  pname = "verible";
+  version = "0.0-2172-g238b6df6";
+
+  # These environment variables are read in bazel/build-version.py to create
+  # a build string. Otherwise it would attempt to extract it from .git/.
+  GIT_DATE = "2022-08-08";
+  GIT_VERSION = version;
+
+  src = fetchFromGitHub {
+    owner = "chipsalliance";
+    repo = "verible";
+    rev = "v${version}";
+    sha256 = "sha256-iOJhdbipuqqBiYGgk95d1c8bEK6Z16l16GuzYCQRc2g=";
+  };
+
+  patches = [
+    # Patch WORKSPACE file to not include windows-related dependencies,
+    # as they are removed by bazel, breaking the fixed output derivation
+    # TODO: fix upstream
+    ./remove-unused-deps.patch
+  ];
+
+  bazelFlags = [ "--//bazel:use_local_flex_bison" ];
+
+  fetchAttrs = {
+    # Fixed output derivation hash after bazel fetch
+    sha256 = "sha256-XoLdlEeoDJlyWlnXZADHOKu06zKHgHJfgey8UhOt+LM=";
+  };
+
+  nativeBuildInputs = [
+    flex       # We use local flex and bison as WORKSPACE sources fail
+    bison      # .. to compile with newer glibc
+    python3
+  ];
+
+  postPatch = ''
+    patchShebangs bazel/build-version.py \
+      common/util/create_version_header.sh \
+      common/parser/move_yacc_stack_symbols.sh \
+      common/parser/record_syntax_error.sh
+  '';
+
+  removeRulesCC = false;
+  bazelTarget = ":install-binaries";
+  bazelBuildFlags = [
+    "-c opt"
+  ];
+  buildAttrs = {
+    installPhase = ''
+      mkdir -p "$out/bin"
+
+      install bazel-bin/common/tools/verible-patch-tool "$out/bin"
+
+      V_TOOLS_DIR=bazel-bin/verilog/tools
+      install $V_TOOLS_DIR/diff/verible-verilog-diff "$out/bin"
+      install $V_TOOLS_DIR/formatter/verible-verilog-format "$out/bin"
+      install $V_TOOLS_DIR/kythe/verible-verilog-kythe-extractor "$out/bin"
+      install $V_TOOLS_DIR/lint/verible-verilog-lint "$out/bin"
+      install $V_TOOLS_DIR/ls/verible-verilog-ls "$out/bin"
+      install $V_TOOLS_DIR/obfuscator/verible-verilog-obfuscate "$out/bin"
+      install $V_TOOLS_DIR/preprocessor/verible-verilog-preprocessor "$out/bin"
+      install $V_TOOLS_DIR/project/verible-verilog-project "$out/bin"
+      install $V_TOOLS_DIR/syntax/verible-verilog-syntax "$out/bin"
+    '';
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/chipsalliance/verible";
+    description = "Suite of SystemVerilog developer tools. Including a style-linter, indexer, formatter, and language server.";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ hzeller ];
+  };
+}

--- a/pkgs/development/tools/verible/remove-unused-deps.patch
+++ b/pkgs/development/tools/verible/remove-unused-deps.patch
@@ -1,0 +1,22 @@
+diff --git a/WORKSPACE b/WORKSPACE
+index 696cc7ef..55a5bb8a 100644
+--- a/WORKSPACE
++++ b/WORKSPACE
+@@ -81,17 +81,6 @@ load("@com_github_google_rules_install//:setup.bzl", "install_rules_setup")
+ 
+ install_rules_setup()
+ 
+-# Need to load before rules_flex/rules_bison to make sure
+-# win_flex_bison is the chosen toolchain on Windows
+-load("//bazel:win_flex_bison.bzl", "win_flex_configure")
+-
+-win_flex_configure(
+-    name = "win_flex_bison",
+-    sha256 = "095cf65cb3f12ee5888022f93109acbe6264e5f18f6ffce0bda77feb31b65bd8",
+-    # bison 3.3.2, flex 2.6.4
+-    url = "https://github.com/lexxmark/winflexbison/releases/download/v2.5.18/win_flex_bison-2.5.18.zip",
+-)
+-
+ http_archive(
+     name = "rules_m4",
+     sha256 = "c67fa9891bb19e9e6c1050003ba648d35383b8cb3c9572f397ad24040fb7f0eb",

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11827,6 +11827,8 @@ with pkgs;
 
   verco = callPackage ../applications/version-management/verco { };
 
+  verible = callPackage ../development/tools/verible { };
+
   verilator = callPackage ../applications/science/electronics/verilator {};
 
   verilog = callPackage ../applications/science/electronics/verilog {


### PR DESCRIPTION
###### Description of changes

New package: Verible

Verible is a suite of SystemVerilog developer tools, including a parser,
style-linter, formatter, and language server.

https://github.com/chipsalliance/verible

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).