### PR TITLE
cargo-feature-set: init at 0.5.0

### DIFF
--- a/pkgs/development/tools/rust/cargo-feature-set/default.nix
+++ b/pkgs/development/tools/rust/cargo-feature-set/default.nix
@@ -1,0 +1,23 @@
+{ lib, stdenv, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-feature-set";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "badboy";
+    repo = "cargo-feature-set";
+    rev = "v${version}";
+    sha256 = "sha256-hKdH+vWtigKtD1rgnOEEULZ9dxh/U/QALmocxOJdEG4=";
+  };
+
+  cargoSha256 = "sha256-J7iJ//9q785jGaL143jxbhvr8UWBk7NN8S3Hh65dieA=";
+
+  meta = with lib; {
+    description = "Extract the features for every compiled crate from cargo metadata";
+    homepage = "https://github.com/badboy/cargo-feature-set";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ matthiasbeyer ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16506,6 +16506,8 @@ with pkgs;
     inherit (linuxPackages) perf;
   };
 
+  cargo-feature-set = callPackage ../development/tools/rust/cargo-feature-set { };
+
   defaultCrateOverrides = callPackage ../build-support/rust/default-crate-overrides.nix { };
 
   cargo-about = callPackage ../development/tools/rust/cargo-about { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

