### PR TITLE
cargo-tauri: init at 1.0.5

### DIFF
--- a/pkgs/development/tools/rust/cargo-tauri/default.nix
+++ b/pkgs/development/tools/rust/cargo-tauri/default.nix
@@ -8,9 +8,11 @@
 , gtk3
 , webkitgtk
 }:
+
 rustPlatform.buildRustPackage rec {
   pname = "tauri";
   version = "1.0.5";
+
   src = fetchFromGitHub {
     owner = "tauri-apps";
     repo = pname;
@@ -28,7 +30,7 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [ pkg-config ];
 
   meta = with lib; {
-    description = "Build smaller, faster, and more secure desktop applications with a web frontend.";
+    description = "Build smaller, faster, and more secure desktop applications with a web frontend";
     homepage = "https://tauri.app/";
     license = with licenses; [ asl20 /* or */ mit ];
     maintainers = with maintainers; [ dit7ya ];

--- a/pkgs/development/tools/rust/cargo-tauri/default.nix
+++ b/pkgs/development/tools/rust/cargo-tauri/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, glibc
+, libsoup
+, cairo
+, gtk3
+, webkitgtk
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "tauri";
+  version = "1.0.5";
+  src = fetchFromGitHub {
+    owner = "tauri-apps";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-mp9U46H03NTMumUkx5kjsh9LnbPBrvlhh3yCH6FYdbE=";
+  };
+
+  # Manually specify the sourceRoot since this crate depends on other crates in the workspace. Relevant info at
+  # https://discourse.nixos.org/t/difficulty-using-buildrustpackage-with-a-src-containing-multiple-cargo-workspaces/10202
+  sourceRoot = "source/tooling/cli";
+
+  cargoSha256 = "sha256-iFXuVrxE/QmM+TAZmN8Ivt6Le19NWYIfVn1PNPvmhZo=";
+
+  buildInputs = [ glibc libsoup cairo gtk3 webkitgtk ];
+  nativeBuildInputs = [ pkg-config ];
+
+  meta = with lib; {
+    description = "Build smaller, faster, and more secure desktop applications with a web frontend.";
+    homepage = "https://tauri.app/";
+    license = with licenses; [ asl20 /* or */ mit ];
+    maintainers = with maintainers; [ dit7ya ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14298,6 +14298,9 @@ with pkgs;
   cargo-udeps = callPackage ../development/tools/rust/cargo-udeps {
     inherit (darwin.apple_sdk.frameworks) CoreServices Security SystemConfiguration;
   };
+
+  cargo-tauri = callPackage ../development/tools/rust/cargo-tauri { };
+
   cargo-valgrind = callPackage ../development/tools/rust/cargo-valgrind { };
   cargo-watch = callPackage ../development/tools/rust/cargo-watch {
     inherit (darwin.apple_sdk.frameworks) CoreServices Foundation;


### PR DESCRIPTION
###### Description of changes

Adds the `cargo-tauri` package, used for building Tauri projects - https://github.com/tauri-apps/tauri


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
