### PR TITLE
komga: init at 0.157.0

### DIFF
--- a/pkgs/servers/komga/default.nix
+++ b/pkgs/servers/komga/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, stdenvNoCC
+, fetchurl
+, makeWrapper
+, jdk11_headless
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "komga";
+  version = "0.157.0";
+
+  src = fetchurl {
+    url = "https://github.com/gotson/${pname}/releases/download/v${version}/${pname}-${version}.jar";
+    sha256 = "sha256-PkQL61fKplt6h1jcFCIMER+ZfzowDP466dR1AaDHw5Q=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  buildCommand = ''
+    makeWrapper ${jdk11_headless}/bin/java $out/bin/komga --add-flags "-jar $src"
+  '';
+
+  meta = with lib; {
+    description = "Free and open source comics/mangas server";
+    homepage = "https://komga.org/";
+    license = licenses.mit;
+    platforms = jdk11_headless.meta.platforms;
+    maintainers = with maintainers; [ govanify ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4085,6 +4085,8 @@ with pkgs;
 
   klog = qt5.callPackage ../applications/radio/klog { };
 
+  komga = callPackage ../servers/komga { };
+
   krapslog = callPackage ../tools/misc/krapslog { };
 
   krelay = callPackage ../applications/networking/cluster/krelay { };


### PR DESCRIPTION
###### Description of changes

Komga is a self hosted open source comic book/manga viewer. See https://komga.org .

This packages the released jar as, from what I see, packaging gradle is still a mighty pain.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).