### PR TITLE
nixos/test/systemd-machinectl: Add auto-start test

### DIFF
--- a/nixos/tests/systemd-machinectl.nix
+++ b/nixos/tests/systemd-machinectl.nix
@@ -33,11 +33,11 @@ import ./make-test-python.nix (
       networking.useNetworkd = true;
       networking.useDHCP = false;
 
-      # open DHCP server on interface to container
-      networking.firewall.trustedInterfaces = [ "ve-+" ];
-
       # do not try to access cache.nixos.org
       nix.settings.substituters = lib.mkForce [ ];
+
+      # auto-start container
+      systemd.targets.machines.wants = [ "systemd-nspawn@${containerName}.service" ];
 
       virtualisation.additionalPaths = [ containerSystem ];
     };
@@ -59,8 +59,19 @@ import ./make-test-python.nix (
       machine.succeed("machinectl start ${containerName}");
       machine.wait_until_succeeds("systemctl -M ${containerName} is-active default.target");
 
+      # Test nss_mymachines without nscd
+      machine.succeed('LD_LIBRARY_PATH="/run/current-system/sw/lib" getent -s hosts:mymachines hosts ${containerName}');
+
+      # Test failing nss_mymachines via nscd
+      # nscd has not enough rights to connect to systemd bus
+      # via sd_bus_open_system() in
+      # https://github.com/systemd/systemd/blob/main/src/nss-mymachines/nss-mymachines.c#L287
+      machine.fail("getent hosts ${containerName}");
+
       # Test systemd-nspawn network configuration
-      machine.succeed("ping -n -c 1 ${containerName}");
+      machine.succeed("systemctl stop nscd");
+      machine.succeed('LD_LIBRARY_PATH="/run/current-system/sw/lib" ping -n -c 1 ${containerName}');
+      machine.succeed("systemctl start nscd");
 
       # Test systemd-nspawn uses a user namespace
       machine.succeed("test $(machinectl status ${containerName} | grep 'UID Shift: ' | wc -l) = 1")
@@ -72,6 +83,14 @@ import ./make-test-python.nix (
       # Test machinectl reboot
       machine.succeed("machinectl reboot ${containerName}");
       machine.wait_until_succeeds("systemctl -M ${containerName} is-active default.target");
+
+      # Restart machine
+      machine.shutdown()
+      machine.start()
+      machine.wait_for_unit("default.target");
+
+      # Test auto-start
+      machine.succeed("machinectl show ${containerName}")
 
       # Test machinectl stop
       machine.succeed("machinectl stop ${containerName}");


### PR DESCRIPTION
###### Description of changes

Add test for auto-start a nspawn container.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
