### PR TITLE
nvidia-x11-beta: mark broken for linux 5.19

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -34,6 +34,7 @@ rec {
     openSha256 = "sha256-1bAr5dWZ4jnY3Uo2JaEz/rhw2HuW9LZ5bACmA1VG068=";
     settingsSha256 = "sha256-j47LtP6FNTPfiXFh9KwXX8vZOQzlytA30ZfW9N5F2PY=";
     persistencedSha256 = "sha256-hULBy0wnVpLH8I0L6O9/HfgvJURtE2whpXOgN/vb3Wo=";
+    broken = kernel.kernelAtLeast "5.19"; # Added at 2022-08-12
   };
 
   # Vulkan developer beta driver


### PR DESCRIPTION
###### Description of changes

Mark `nvidia-x11-beta` broken for `kernel.kernelAtLeast "5.19"`.

###### Things done

Upstream kernel: check for `linuxPackages_latest.nvidia_x11_beta (linuxKernel.packages.linux_5_19.nvidia_x11_beta)` in [this comment](https://github.com/NixOS/nixpkgs/pull/186129#issuecomment-1213350686).

Zen's kernels: check for `linuxPackages_zen.nvidia_x11_beta (linuxKernel.packages.linux_zen.nvidia_x11_beta)` in [this comment](https://github.com/NixOS/nixpkgs/pull/186266#issuecomment-1213068737).

Xanmod: check for `linuxPackages_xanmod_latest.nvidia_x11_beta` in [this comment](https://github.com/NixOS/nixpkgs/pull/183994#issuecomment-1202836376)

-----
For some reason, I'm unable to mark @Kiskae for reviewing this...