### PR TITLE
trivial-builders.nix: Add input argument `passthru` to makeSetupHook

### DIFF
--- a/pkgs/build-support/setup-hooks/make-binary-wrapper/default.nix
+++ b/pkgs/build-support/setup-hooks/make-binary-wrapper/default.nix
@@ -16,12 +16,14 @@ makeSetupHook {
 
   substitutions = {
     cc = "${cc}/bin/${cc.targetPrefix}cc ${lib.escapeShellArgs (map (s: "-fsanitize=${s}") sanitizers)}";
+  };
 
+  passthru = {
     # Extract the function call used to create a binary wrapper from its embedded docstring
-    passthru.extractCmd = writeShellScript "extract-binary-wrapper-cmd" ''
+    extractCmd = writeShellScript "extract-binary-wrapper-cmd" ''
       strings -dw "$1" | sed -n '/^makeCWrapper/,/^$/ p'
     '';
 
-    passthru.tests = tests.makeBinaryWrapper;
+    tests = tests.makeBinaryWrapper;
   };
 } ./make-binary-wrapper.sh

--- a/pkgs/build-support/setup-hooks/postgresql-test-hook/default.nix
+++ b/pkgs/build-support/setup-hooks/postgresql-test-hook/default.nix
@@ -1,9 +1,8 @@
 { callPackage, makeSetupHook }:
 
-(makeSetupHook {
+makeSetupHook {
   name = "postgresql-test-hook";
-} ./postgresql-test-hook.sh).overrideAttrs (o: {
   passthru.tests = {
     simple = callPackage ./test.nix { };
   };
-})
+} ./postgresql-test-hook.sh

--- a/pkgs/build-support/setup-hooks/wrap-gapps-hook/default.nix
+++ b/pkgs/build-support/setup-hooks/wrap-gapps-hook/default.nix
@@ -36,8 +36,8 @@ makeSetupHook {
     # We use the wrapProgram function.
     makeWrapper
   ];
-  substitutions = {
-    passthru.tests = let
+  passthru = {
+    tests = let
       sample-project = ./tests/sample-project;
 
       testLib = callPackage ./tests/lib.nix { };

--- a/pkgs/build-support/setup-hooks/wrap-gapps-hook/default.nix
+++ b/pkgs/build-support/setup-hooks/wrap-gapps-hook/default.nix
@@ -13,6 +13,7 @@
 }:
 
 makeSetupHook {
+  name = "wrap-gapps-hook";
   deps = lib.optionals (!stdenv.isDarwin) [
     # It is highly probable that a program will use GSettings,
     # at minimum through GTK file chooser dialogue.

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -523,12 +523,22 @@ rec {
    *                 substitutions = { bash = "${pkgs.bash}/bin/bash"; };
    *                 meta.platforms = lib.platforms.linux;
    *               } ./myscript.sh;
+   *
+   * # setup hook with a package test
+   * myhellohookTested = makeSetupHook {
+   *                 deps = [ hello ];
+   *                 substitutions = { bash = "${pkgs.bash}/bin/bash"; };
+   *                 meta.platforms = lib.platforms.linux;
+   *                 passthru.tests.greeting = callPackage ./test { };
+   *               } ./myscript.sh;
    */
-  makeSetupHook = { name ? "hook", deps ? [], substitutions ? {}, meta ? {} }: script:
+  makeSetupHook = { name ? "hook", deps ? [], substitutions ? {}, meta ? {}, passthru ? null }: script:
     runCommand name
       (substitutions // {
         inherit meta;
         strictDeps = true;
+      } // lib.optionalAttrs (passthru != null) {
+        inherit passthru;
       })
       (''
         mkdir -p $out/nix-support

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -863,7 +863,9 @@ with pkgs;
     { deps = [ dieHook ];
       substitutions = {
         shell = targetPackages.runtimeShell;
-        passthru.tests = tests.makeWrapper;
+      };
+      passthru = {
+        tests = tests.makeWrapper;
       };
     }
     ../build-support/setup-hooks/make-wrapper.sh;


### PR DESCRIPTION
This patch add an input argumnet `passthru` to `makeSetupHook`, and enable users to specify `passthru` attributes the way they specify the `meta` attributes in `makeSetupHook`

One significant use case is adding `passthru.tests` to setup-hooks,
and help increase test coverage for mission-critical setup-hooks.

The Nix expression of `postgresqlTestHook` has been updated to make use of the passthru attirbute. (No overrideAttrs are needed now.) This should evaluates to the same output as before.

`wrapGappsHook` could also be updated. However, as it currently passes the `passthru` through `substitutions` (weird enough), the modification would change the derivation hash, resulting in a large-scale rebuild. A successive PR will be made targeting the staging branch as this one gets merged.

Cc: @roberth `postgresqlTestHook` maintainer

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`) (Nothing has changed.)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
