### PR TITLE
fastddsgen: init at 2.2.0

### DIFF
--- a/pkgs/development/tools/fastddsgen/default.nix
+++ b/pkgs/development/tools/fastddsgen/default.nix
@@ -1,0 +1,97 @@
+{ lib, stdenv, runtimeShell, writeText, fetchFromGitHub, gradle_6, openjdk8, git, perl, cmake }:
+let
+  pname = "fastddsgen";
+  version = "2.1.3";
+
+  src = fetchFromGitHub {
+    owner = "eProsima";
+    repo = "Fast-DDS-Gen";
+    rev = "v${version}";
+    fetchSubmodules = true;
+    hash = "sha256-2+zhjdx29T44W7MO5/UDQqjnxb+gdOMf/iS9mmdQHPI=";
+  };
+
+  # fake build to pre-download deps into fixed-output derivation
+  deps = stdenv.mkDerivation {
+    pname = "${pname}-deps";
+    inherit src version;
+    nativeBuildInputs = [ gradle_6 openjdk8 perl ];
+
+    buildPhase = ''
+      export GRADLE_USER_HOME=$(mktemp -d);
+      gradle --no-daemon -x submodulesUpdate assemble
+    '';
+
+    # perl code mavenizes pathes (com.squareup.okio/okio/1.13.0/a9283170b7305c8d92d25aff02a6ab7e45d06cbe/okio-1.13.0.jar -> com/squareup/okio/okio/1.13.0/okio-1.13.0.jar)
+    installPhase = ''
+      find $GRADLE_USER_HOME/caches/modules-2 -type f -regex '.*\.\(jar\|pom\)' \
+        | perl -pe 's#(.*/([^/]+)/([^/]+)/([^/]+)/[0-9a-f]{30,40}/([^/\s]+))$# ($x = $2) =~ tr|\.|/|; "install -Dm444 $1 \$out/$x/$3/$4/$5" #e' \
+        | sh
+    '';
+
+    dontStrip = true;
+
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = "sha256-NcqfODP8QZISSfllap8vIGfGHfzT+wGxRsJvl7OZHcE=";
+  };
+in
+stdenv.mkDerivation {
+  inherit pname src version;
+
+  nativeBuildInputs = [ gradle_6 openjdk8 ];
+
+  # use our offline deps
+  postPatch = ''
+    sed -ie '1i\
+    pluginManagement {\
+      repositories {\
+        maven { url "${deps}" }\
+      }\
+    }' thirdparty/idl-parser/settings.gradle
+    sed -ie "s#mavenCentral()#maven { url '${deps}' }#g" build.gradle
+    sed -ie "s#mavenCentral()#maven { url '${deps}' }#g" thirdparty/idl-parser/idl.gradle
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    export GRADLE_USER_HOME=$(mktemp -d)
+
+    # Run gradle with daemon to make installPhase faster
+    gradle --offline -x submodulesUpdate assemble
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    gradle --offline -x submodulesUpdate install --install_path=$out
+
+    # Override the default start script to use absolute java path
+    cat  <<EOF >$out/bin/fastddsgen
+    #!${runtimeShell}
+    exec ${openjdk8}/bin/java -jar "$out/share/fastddsgen/java/fastddsgen.jar" "\$@"
+    EOF
+    chmod a+x "$out/bin/fastddsgen"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Fast-DDS IDL code generator tool";
+    homepage = "https://github.com/eProsima/Fast-DDS-Gen";
+    license = licenses.asl20;
+    longDescription = ''
+      eProsima Fast DDS-Gen is a Java application that generates
+      eProsima Fast DDS C++ or Python source code using the data types
+      defined in an IDL (Interface Definition Language) file. This
+      generated source code can be used in any Fast DDS application in
+      order to define the data type of a topic, which will later be
+      used to publish or subscribe.
+    '';
+    maintainers = with maintainers; [ wentasah ];
+    platforms = openjdk8.meta.platforms;
+  };
+}

--- a/pkgs/development/tools/fastddsgen/default.nix
+++ b/pkgs/development/tools/fastddsgen/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, runtimeShell, writeText, fetchFromGitHub, gradle, openjdk8, git, perl, cmake }:
+{ lib, stdenv, runtimeShell, writeText, fetchFromGitHub, gradle, openjdk11, git, perl, cmake }:
 let
   pname = "fastddsgen";
   version = "2.2.0";
@@ -15,7 +15,7 @@ let
   deps = stdenv.mkDerivation {
     pname = "${pname}-deps";
     inherit src version;
-    nativeBuildInputs = [ gradle openjdk8 perl ];
+    nativeBuildInputs = [ gradle openjdk11 perl ];
 
     buildPhase = ''
       export GRADLE_USER_HOME=$(mktemp -d);
@@ -39,7 +39,7 @@ in
 stdenv.mkDerivation {
   inherit pname src version;
 
-  nativeBuildInputs = [ gradle openjdk8 ];
+  nativeBuildInputs = [ gradle openjdk11 ];
 
   # use our offline deps
   postPatch = ''
@@ -72,7 +72,7 @@ stdenv.mkDerivation {
     # Override the default start script to use absolute java path
     cat  <<EOF >$out/bin/fastddsgen
     #!${runtimeShell}
-    exec ${openjdk8}/bin/java -jar "$out/share/fastddsgen/java/fastddsgen.jar" "\$@"
+    exec ${openjdk11}/bin/java -jar "$out/share/fastddsgen/java/fastddsgen.jar" "\$@"
     EOF
     chmod a+x "$out/bin/fastddsgen"
 
@@ -92,6 +92,6 @@ stdenv.mkDerivation {
       used to publish or subscribe.
     '';
     maintainers = with maintainers; [ wentasah ];
-    platforms = openjdk8.meta.platforms;
+    platforms = openjdk11.meta.platforms;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16878,6 +16878,8 @@ with pkgs;
 
   faas-cli = callPackage ../development/tools/faas-cli { };
 
+  fastddsgen = callPackage ../development/tools/fastddsgen { };
+
   findbugs = callPackage ../development/tools/analysis/findbugs { };
 
   findnewest = callPackage ../development/tools/misc/findnewest { };


### PR DESCRIPTION
###### Description

[Fast DDS-Gen](https://github.com/eProsima/Fast-DDS-Gen) is a Java application that generates Fast DDS C++ or Python source code using the data types defined in an IDL (Interface Definition Language) file. This generated source code can be used in any Fast DDS application in order to define the data type of a topic, which will later be used to publish or subscribe.

The application is compiled with gradle. The package structure is largely copied from other packages using gradle.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
