### PR TITLE
fheroes2: install localization and other port-specific files

### DIFF
--- a/pkgs/games/fheroes2/default.nix
+++ b/pkgs/games/fheroes2/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub
-, gettext, libpng, SDL2, SDL2_image, SDL2_mixer, SDL2_ttf, zlib
+, gettext, glibcLocalesUtf8, libpng, SDL2, SDL2_image, SDL2_mixer, SDL2_ttf, zlib
 
 # updater only
 , nix-update-script
@@ -16,18 +16,28 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-I79PoNE6GFvYD4jnsxKo7MsoPgVow8b8fTIiClOGnAI=";
   };
 
-  buildInputs = [ gettext libpng SDL2 SDL2_image SDL2_mixer SDL2_ttf zlib ];
+  buildInputs = [ gettext glibcLocalesUtf8 libpng SDL2 SDL2_image SDL2_mixer SDL2_ttf zlib ];
 
   makeFlags = [
     "FHEROES2_STRICT_COMPILATION=1"
+    "FHEROES2_DATA=\"${placeholder "out"}/share/fheroes2\""
   ];
 
   enableParallelBuilding = true;
+
+  postBuild = ''
+    # Pick guaranteed to be present UTF-8 locale.
+    # Otherwise `iconv` calls fail to produce valid translations.
+    LANG=en_US.UTF_8 make -C files/lang
+  '';
 
   installPhase = ''
     runHook preInstall
 
     install -Dm755 $PWD/src/dist/fheroes2 $out/bin/fheroes2
+
+    install -Dm644 -t $out/share/fheroes2/files/lang $PWD/files/lang/*.mo
+    install -Dm644 -t $out/share/fheroes2/files/data $PWD/files/data/resurrection.h2d
 
     runHook postInstall
   '';


### PR DESCRIPTION
Without the change the game does not provide prompt for locales as it
assumes no locales are available. Let's pull them in by default.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
