### PR TITLE
ffmpeg_5,ffmpeg_5-full: cherry-pick IPFS default gateway removal

### DIFF
--- a/pkgs/development/libraries/ffmpeg/5.nix
+++ b/pkgs/development/libraries/ffmpeg/5.nix
@@ -9,4 +9,10 @@ callPackage ./generic.nix (rec {
   branch = version;
   sha256 = "sha256-MrVvsBzpDUUpWK4l6RyVZKv0ntVFPBJ77CPGPlMKqPo=";
   darwinFrameworks = [ Cocoa CoreMedia VideoToolbox ];
+
+  # Newly introduced IPFS support in ffmpeg 5.1 relies on untrusted third
+  # party services, leading to consent and privacy issues. See upstream
+  # discussion for more information:
+  # https://ffmpeg.org/pipermail/ffmpeg-devel/2022-August/299924.html
+  patches = [ ./ipfs-remove-default-gateway.patch ];
 } // args)

--- a/pkgs/development/libraries/ffmpeg/ipfs-remove-default-gateway.patch
+++ b/pkgs/development/libraries/ffmpeg/ipfs-remove-default-gateway.patch
@@ -1,0 +1,37 @@
+A gateway can see everything, and we should not be shipping a hardcoded
+default from a third party company; it's a security risk.
+
+Signed-off-by: Derek Buitenhuis <derek.buitenhuis@gmail.com>
+---
+ libavformat/ipfsgateway.c | 11 ++++-------
+ 1 file changed, 4 insertions(+), 7 deletions(-)
+
+diff --git a/libavformat/ipfsgateway.c b/libavformat/ipfsgateway.c
+index 5a5178c563..907b61b017 100644
+--- a/libavformat/ipfsgateway.c
++++ b/libavformat/ipfsgateway.c
+@@ -240,13 +240,8 @@ static int translate_ipfs_to_http(URLContext *h, const char *uri, int flags, AVD
+         ret = populate_ipfs_gateway(h);
+ 
+         if (ret < 1) {
+-            // We fallback on dweb.link (managed by Protocol Labs).
+-            snprintf(c->gateway_buffer, sizeof(c->gateway_buffer), "https://dweb.link");
+-
+-            av_log(h, AV_LOG_WARNING,
+-                   "IPFS does not appear to be running. "
+-                   "You’re now using the public gateway at dweb.link.\n");
+-            av_log(h, AV_LOG_INFO,
++            av_log(h, AV_LOG_ERROR,
++                   "IPFS does not appear to be running.\n\n"
+                    "Installing IPFS locally is recommended to "
+                    "improve performance and reliability, "
+                    "and not share all your activity with a single IPFS gateway.\n"
+@@ -259,6 +254,8 @@ static int translate_ipfs_to_http(URLContext *h, const char *uri, int flags, AVD
+                    "3. Define an $IPFS_PATH environment variable "
+                    "and point it to the IPFS data path "
+                    "- this is typically ~/.ipfs\n");
++            ret = AVERROR(EINVAL);
++            goto err;
+         }
+     }
+ 


### PR DESCRIPTION
###### Description of changes

ffmpeg 5.1 introduced ipfs:// and ipns:// streaming support as part of
libavformat. This new implementation falls back to fetching from an
untrusted 3rd party internet service in the (likely) case where a user
doesn't have a local IPFS gateway running on their computer. This puts
an unaudited 3rd party provider in a position where they can log and
alter any IPFS content being streamed by the ffmpeg library. No user
consent is collected at any point by the library.

ffmpeg developers are currently discussing [1] how to better implement
this feature. In the meantime, cherry-pick the proposed patch to disable
the default gateway until a better alternative is released.

[1] https://ffmpeg.org/pipermail/ffmpeg-devel/2022-August/299924.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
