### PR TITLE
solo5: fix paths detection in compiler and linker wrappers.

### DIFF
--- a/pkgs/os-specific/solo5/default.nix
+++ b/pkgs/os-specific/solo5/default.nix
@@ -24,7 +24,7 @@ in stdenv.mkDerivation {
     sha256 = "sha256-8LftT22XzmmWxgYez+BAHDX4HOyl5DrwrpuO2+bqqcY=";
   };
 
-  patches = [ ./test_sleep.patch ];
+  patches = [ ./fix_paths.patch ./test_sleep.patch ];
 
   hardeningEnable = [ "pie" ];
 

--- a/pkgs/os-specific/solo5/fix_paths.patch
+++ b/pkgs/os-specific/solo5/fix_paths.patch
@@ -1,0 +1,29 @@
+diff --git a/toolchain/cc.in b/toolchain/cc.in
+index 337562a..0ec9315 100644
+--- a/toolchain/cc.in
++++ b/toolchain/cc.in
+@@ -30,9 +30,9 @@
+ # symbols.
+ 
+ prog="$(basename $0)"
+-I="$(dirname $0)/../include"
++I="$(realpath $0 | xargs dirname)/../include"
+ [ ! -d "${I}" ] && echo "$prog: Could not determine include path" 1>&2 && exit 1
+-L="$(dirname $0)/../lib/@@CONFIG_TARGET_TRIPLE@@"
++L="$(realpath $0 | xargs dirname)/../lib/@@CONFIG_TARGET_TRIPLE@@"
+ [ ! -d "${L}" ] && echo "$prog: Could not determine library path" 1>&2 && exit 1
+ # we can't really tell if 'cc' is called with no input, but work around the
+ # most obvious cases and stop them from "succeeding" and producing an "a.out"
+diff --git a/toolchain/ld.in b/toolchain/ld.in
+index 01dffa8..13dca2c 100644
+--- a/toolchain/ld.in
++++ b/toolchain/ld.in
+@@ -28,7 +28,7 @@
+ # linking a unikernel. No default for ABI is provided, as it is expected that a
+ # caller directly using 'ld' knows what they are doing.
+ 
+-L="$(dirname $0)/../lib/@@CONFIG_TARGET_TRIPLE@@"
++L="$(realpath $0 | xargs dirname)/../lib/@@CONFIG_TARGET_TRIPLE@@"
+ [ ! -d "${L}" ] && echo "$0: Could not determine library path" 1>&2 && exit 1
+ # ld accepts -z solo5-abi=ABI, but does not provide a default ABI
+ # this is intentional


### PR DESCRIPTION
###### Description of changes

Solo5 cc and ld wrappers have a bug that prevents their use in NixOS. Sorry for not spotting this in the previous PR.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done
Add a patch to fix that here. See also https://github.com/Solo5/solo5/pull/526.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
