### PR TITLE
mpvScripts.thumbnail: switch to maintained fork, unstable-2020-01-16 -> 0.4.9

### DIFF
--- a/pkgs/applications/video/mpv/scripts/thumbnail.nix
+++ b/pkgs/applications/video/mpv/scripts/thumbnail.nix
@@ -1,13 +1,13 @@
-{ fetchFromGitHub, lib, python3, stdenvNoCC }:
+{ lib, stdenvNoCC, fetchFromGitHub, python3 }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "mpv_thumbnail_script";
-  version = "unstable-2020-01-16";
+  version = "0.4.9";
 
   src = fetchFromGitHub {
-    owner = "theamm";
+    owner = "marzzzello";
     repo = pname;
-    rev = "682becf5b5115c2a206b4f0bdee413d4be8b5bef";
+    rev = version;
     sha256 = "0dgfrb8ypc5vlq35kzn423fm6l6348ivl85vb6j3ccc9a51xprw3";
   };
 
@@ -28,7 +28,7 @@ stdenvNoCC.mkDerivation rec {
 
   meta = with lib; {
     description = "A lua script to show preview thumbnails in mpv's OSC seekbar";
-    homepage = "https://github.com/theamm/mpv_thumbnail_script";
+    homepage = "https://github.com/marzzzello/mpv_thumbnail_script";
     license = licenses.gpl3Plus;
     platforms = platforms.all;
     maintainers = with maintainers; [ figsoda ];


### PR DESCRIPTION
###### Description of changes

https://github.com/marzzzello/mpv_thumbnail_script/releases
https://github.com/theamm/mpv_thumbnail_script/compare/682becf5b5115c2a206b4f0bdee413d4be8b5bef...marzzzello:mpv_thumbnail_script:0.4.9

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
