### PR TITLE
dodo: init at 2022-08-13

### DIFF
--- a/pkgs/applications/networking/mailreaders/dodo/default.nix
+++ b/pkgs/applications/networking/mailreaders/dodo/default.nix
@@ -1,0 +1,42 @@
+{ pkgs
+, lib
+, python3
+, makeWrapper
+, notmuch
+, w3m
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "dodo";
+  version = "unstable-2022-06-09";
+  format = "pyproject";
+
+  src = pkgs.fetchFromGitHub {
+    repo = pname;
+    owner = "akissinger";
+    rev = "b377e05ab507c7bec427e3bac0c35b68bd67d9fc";
+    sha256 = "sha256-GcOcCB93/q84zPdiY8CgZN9MQtG2BG0miGsasonmofs=";
+  };
+
+  nativeBuildInputs = with python3.pkgs; [ setuptools-scm makeWrapper ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    bleach
+    pyqt5
+    pyqt5_sip
+    pyqtwebengine
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/dodo --prefix PATH ":" \
+      ${lib.makeBinPath [ notmuch w3m ]}
+  '';
+
+  meta = with lib; {
+    description = "A graphical, hackable email client based on notmuch";
+    homepage = "https://github.com/akissinger/dodo";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ matthiasbeyer ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22988,6 +22988,9 @@ with pkgs;
   dovecot = callPackage ../servers/mail/dovecot {
     openssl = openssl_1_1;
   };
+
+  dodo = callPackage ../applications/networking/mailreaders/dodo {};
+
   dovecot_pigeonhole = callPackage ../servers/mail/dovecot/plugins/pigeonhole { };
   dovecot_fts_xapian = callPackage ../servers/mail/dovecot/plugins/fts_xapian { };
 


### PR DESCRIPTION
Maybe someone can help here. The app does not start because incompatible qt versions. I am not a python nor a qt packager, so I don't know what is happening or how to investigate...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
