### PR TITLE
communi: fix Qt wrapping

### DIFF
--- a/pkgs/applications/networking/irc/communi/default.nix
+++ b/pkgs/applications/networking/irc/communi/default.nix
@@ -32,6 +32,11 @@ stdenv.mkDerivation rec {
     qtbase
   ];
 
+  # libCommuni.dylib is installed in $out/Applications/Communi.app/Contents/Frameworks/ on Darwin
+  # Wrapper hook thinks it's a binary because it's in $out/Applications, wraps it with a shell script
+  # So we manually call the wrapper script on just the binary
+  dontWrapQtApps = stdenv.isDarwin;
+
   preConfigure = ''
     export QMAKEFEATURES=${libcommuni}/features
   '';
@@ -51,6 +56,9 @@ stdenv.mkDerivation rec {
       install_name_tool \
         -add_rpath @executable_path/../Frameworks \
         $out/Applications/Communi.app/Contents/MacOS/Communi
+
+      # Do not remove until wrapQtAppsHook doesn't wrap dylibs in app bundles anymore
+      wrapQtApp $out/Applications/Communi.app/Contents/MacOS/Communi
     '' else ''
       substituteInPlace "$out/share/applications/communi.desktop" \
         --replace "/usr/bin" "$out/bin"
@@ -66,6 +74,5 @@ stdenv.mkDerivation rec {
     license = licenses.bsd3;
     maintainers = with maintainers; [ hrdinka ];
     platforms = platforms.all;
-    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/applications/networking/irc/communi/default.nix
+++ b/pkgs/applications/networking/irc/communi/default.nix
@@ -1,4 +1,11 @@
-{ fetchFromGitHub, libcommuni, qtbase, qmake, lib, stdenv, wrapQtAppsHook }:
+{ stdenv
+, lib
+, fetchFromGitHub
+, libcommuni
+, qmake
+, qtbase
+, wrapQtAppsHook
+}:
 
 stdenv.mkDerivation rec {
   pname = "communi";
@@ -15,12 +22,15 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  nativeBuildInputs = [ qmake ]
-    ++ lib.optional stdenv.isDarwin wrapQtAppsHook;
+  nativeBuildInputs = [
+    qmake
+    wrapQtAppsHook
+  ];
 
-  buildInputs = [ libcommuni qtbase ];
-
-  dontWrapQtApps = true;
+  buildInputs = [
+    libcommuni
+    qtbase
+  ];
 
   preConfigure = ''
     export QMAKEFEATURES=${libcommuni}/features
@@ -32,20 +42,19 @@ stdenv.mkDerivation rec {
     "COMMUNI_INSTALL_ICONS=${placeholder "out"}/share/icons/hicolor"
     "COMMUNI_INSTALL_DESKTOP=${placeholder "out"}/share/applications"
     "COMMUNI_INSTALL_THEMES=${placeholder "out"}/share/communi/themes"
-    (if stdenv.isDarwin
-      then [ "COMMUNI_INSTALL_BINS=${placeholder "out"}/Applications" ]
-      else [ "COMMUNI_INSTALL_BINS=${placeholder "out"}/bin" ])
+    "COMMUNI_INSTALL_BINS=${placeholder "out"}/${if stdenv.isDarwin then "Applications" else "bin"}"
   ];
 
-  postInstall = if stdenv.isDarwin then ''
-    # Nix qmake does not add the bundle rpath by default.
-    install_name_tool \
-      -add_rpath @executable_path/../Frameworks \
-      $out/Applications/Communi.app/Contents/MacOS/Communi
-  '' else ''
-    substituteInPlace "$out/share/applications/communi.desktop" \
-      --replace "/usr/bin" "$out/bin"
-  '';
+  postInstall =
+    if stdenv.isDarwin then ''
+      # Nix qmake does not add the bundle rpath by default.
+      install_name_tool \
+        -add_rpath @executable_path/../Frameworks \
+        $out/Applications/Communi.app/Contents/MacOS/Communi
+    '' else ''
+      substituteInPlace "$out/share/applications/communi.desktop" \
+        --replace "/usr/bin" "$out/bin"
+    '';
 
   preFixup = ''
     rm -rf lib
@@ -56,6 +65,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/communi/communi-desktop";
     license = licenses.bsd3;
     maintainers = with maintainers; [ hrdinka ];
-    platforms = platforms.linux;
+    platforms = platforms.all;
+    broken = stdenv.isDarwin;
   };
 }


### PR DESCRIPTION
###### Description of changes

Without:

```
[nix-shell:~/devel/nixpkgs]$ communi
qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Aborted (core dumped)
```

Also some small refactoring. `communi` should be cross-platform, it's just broken on Darwin with our build rn. (Looking into & fixing that in a separate PR when I have access to a Darwin machine again)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
