### PR TITLE
python310Packages.webdav4: init at 0.9.7

### DIFF
--- a/pkgs/development/python-modules/webdav4/default.nix
+++ b/pkgs/development/python-modules/webdav4/default.nix
@@ -1,0 +1,89 @@
+{ lib
+, buildPythonPackage
+, cheroot
+, colorama
+, fetchFromGitHub
+, fsspec
+, httpx
+, pytestCheckHook
+, python-dateutil
+, pythonOlder
+, setuptools-scm
+, wsgidav
+}:
+
+buildPythonPackage rec {
+  pname = "webdav4";
+  version = "0.9.7";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "skshetry";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-7v4dcwbTCGiEMkAQHtH9+zQj745dI0QqoEqdxRYRuO4=";
+  };
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    httpx
+    python-dateutil
+  ];
+
+  checkInputs = [
+    cheroot
+    colorama
+    pytestCheckHook
+    wsgidav
+  ] ++ passthru.optional-dependencies.fsspec;
+
+  passthru.optional-dependencies = {
+    fsspec = [
+      fsspec
+    ];
+    http2 = [
+      httpx.optional-dependencies.http2
+    ];
+    all = [
+      fsspec
+      httpx.optional-dependencies.http2
+    ];
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace " --cov" ""
+  '';
+
+  pythonImportsCheck = [
+    "webdav4"
+  ];
+
+  disabledTests = [
+    # ValueError: Invalid dir_browser htdocs_path
+    "test_retry_reconnect_on_failure"
+    "test_open"
+    "test_open_binary"
+    "test_close_connection_if_nothing_is_read"
+  ];
+
+  disabledTestPaths = [
+    # Tests requires network access
+    "tests/test_client.py"
+    "tests/test_fsspec.py"
+  ];
+
+  meta = with lib; {
+    description = "Library for interacting with WebDAV";
+    homepage = "https://skshetry.github.io/webdav4/";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/wsgidav/default.nix
+++ b/pkgs/development/python-modules/wsgidav/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, buildPythonPackage
+, cheroot
+, fetchFromGitHub
+, pytestCheckHook
+, pythonOlder
+, defusedxml
+, jinja2
+, json5
+, python-pam
+, pyyaml
+, requests
+, webtest
+}:
+
+buildPythonPackage rec {
+  pname = "wsgidav";
+  version = "4.0.2";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "mar10";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-LQdS9d2DB4PXqRSzmtZCSyCQI47ncLCG+RSB+goZYoA=";
+  };
+
+  propagatedBuildInputs = [
+    defusedxml
+    jinja2
+    json5
+    python-pam
+    pyyaml
+  ];
+
+  checkInputs = [
+    cheroot
+    pytestCheckHook
+    requests
+    webtest
+  ];
+
+  pythonImportsCheck = [
+    "wsgidav"
+  ];
+
+  meta = with lib; {
+    description = "Generic and extendable WebDAV server based on WSGI";
+    homepage = "https://wsgidav.readthedocs.io/";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11530,6 +11530,8 @@ in {
 
   wsgi-intercept = callPackage ../development/python-modules/wsgi-intercept { };
 
+  wsgidav = callPackage ../development/python-modules/wsgidav { };
+
   wsgiprox = callPackage ../development/python-modules/wsgiprox { };
 
   wsgiproxy2 = callPackage ../development/python-modules/wsgiproxy2 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11424,6 +11424,8 @@ in {
 
   webcolors = callPackage ../development/python-modules/webcolors { };
 
+  webdav4 = callPackage ../development/python-modules/webdav4 { };
+
   webdavclient3 = callPackage ../development/python-modules/webdavclient3 { };
 
   webencodings = callPackage ../development/python-modules/webencodings { };


### PR DESCRIPTION
###### Description of changes
Library for interacting with WebDAV

https://skshetry.github.io/webdav4/
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
