### PR TITLE
renpy: 8.0.0 -> 8.0.1

### DIFF
--- a/pkgs/development/interpreters/renpy/default.nix
+++ b/pkgs/development/interpreters/renpy/default.nix
@@ -10,15 +10,15 @@ stdenv.mkDerivation rec {
   # base_version is of the form major.minor.patch
   # vc_version is of the form YYMMDDCC
   # version corresponds to the tag on GitHub
-  base_version = "8.0.0";
-  vc_version = "22062402";
+  base_version = "8.0.1";
+  vc_version = "22070801";
   version = "${base_version}.${vc_version}";
 
   src = fetchFromGitHub {
     owner = "renpy";
     repo = "renpy";
     rev = version;
-    sha256 = "sha256-37Hbs0i5eXMjVaETX7ImJCak0y8XtEHUaRFceA9J39A=";
+    sha256 = "sha256-rwRykovY8vv+boQiaSjCBoGxGpT1dF3qdEyxkykrKyk=";
   };
 
   nativeBuildInputs = [
@@ -41,6 +41,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./renpy-system-fribidi.diff
+    ./shutup-erofs-errors.patch
   ];
 
   postPatch = ''
@@ -71,7 +72,7 @@ stdenv.mkDerivation rec {
 
     makeWrapper ${python.interpreter} $out/bin/renpy \
       --set PYTHONPATH "$PYTHONPATH:$out/${python.sitePackages}" \
-      --add-flags "-O $out/share/renpy/renpy.py"
+      --add-flags "$out/share/renpy/renpy.py"
 
     runHook postInstall
   '';

--- a/pkgs/development/interpreters/renpy/shutup-erofs-errors.patch
+++ b/pkgs/development/interpreters/renpy/shutup-erofs-errors.patch
@@ -1,0 +1,29 @@
+From 1660c8f20ac807fcd0ce65a8b9dc31e646a40711 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=E5=A4=9C=E5=9D=82=E9=9B=85?=
+ <23130178+ShadowRZ@users.noreply.github.com>
+Date: Sat, 13 Aug 2022 19:26:42 +0800
+Subject: [PATCH] Don't print a backtrace on EROFS
+
+This can shut up EROFS errors caused by writing to read-only /nix/store.
+---
+ renpy/script.py | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/renpy/script.py b/renpy/script.py
+index 3e5dae8..8f103c1 100644
+--- a/renpy/script.py
++++ b/renpy/script.py
+@@ -656,6 +656,10 @@ class Script(object):
+                             rpydigest = hashlib.md5(fullf.read()).digest()
+ 
+                         self.write_rpyc_md5(f, rpydigest)
++                except OSError as e:
++                    if e.errno != 30:
++                        import traceback
++                        traceback.print_exc()
+                 except Exception:
+                     import traceback
+                     traceback.print_exc()
+-- 
+2.37.1
+

--- a/pkgs/development/python-modules/pygame_sdl2/default.nix
+++ b/pkgs/development/python-modules/pygame_sdl2/default.nix
@@ -9,7 +9,7 @@ buildPythonPackage rec {
 
   src = fetchurl {
     url = "https://www.renpy.org/dl/${renpy_version}/pygame_sdl2-${version}-for-renpy-${renpy_version}.tar.gz";
-    sha256 = "sha256-iKsnmuSBzfHlIOHUwWECfvPa9LuBbCr9Kmq5dolxUlU=";
+    sha256 = "sha256-/PCw2sF3CxiBXV7WZcTl6NAs+v++od4Fs6uYFUhJMH8=";
   };
 
   # force rebuild of headers needed for install


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://renpy.org/doc/html/changelog.html#renpy-8-0-1

I also added a patch to shut up Ren'Py complaining unwritable files when it compiles .rpyc files for launcher, tutorial and bundled game sample.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
