### PR TITLE
gnome.mutter: Fix stride calculation when using dmabufs

### DIFF
--- a/pkgs/desktops/gnome/core/mutter/default.nix
+++ b/pkgs/desktops/gnome/core/mutter/default.nix
@@ -64,6 +64,10 @@ let self = stdenv.mkDerivation rec {
       src = ./fix-paths.patch;
       inherit zenity;
     })
+
+    # Fix stride calculation, see https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/2513
+    # The patch was merged into the main mutter repository and should be included from GNOME 43.0.
+    ./fix-stream-stride-2513.patch
   ];
 
   mesonFlags = [

--- a/pkgs/desktops/gnome/core/mutter/fix-stream-stride-2513.patch
+++ b/pkgs/desktops/gnome/core/mutter/fix-stream-stride-2513.patch
@@ -1,0 +1,46 @@
+diff --git a/src/backends/meta-screen-cast-stream-src.c b/src/backends/meta-screen-cast-stream-src.c
+index 0d8bc175142f5da2b350ed5a6d81c2773f3ed832..806fa806c1e005b0f1f52f75376a8c7a79e7da9a 100644
+--- a/src/backends/meta-screen-cast-stream-src.c
++++ b/src/backends/meta-screen-cast-stream-src.c
+@@ -569,6 +569,26 @@ maybe_schedule_follow_up_frame (MetaScreenCastStreamSrc *src,
+                                                    src);
+ }
+ 
++static int32_t
++meta_screen_cast_stream_src_calculate_stride (MetaScreenCastStreamSrc *src,
++                                              struct spa_data         *spa_data)
++{
++  MetaScreenCastStreamSrcPrivate *priv =
++    meta_screen_cast_stream_src_get_instance_private (src);
++  CoglDmaBufHandle *dmabuf_handle = NULL;
++
++  if (spa_data->type == SPA_DATA_DmaBuf)
++    {
++      dmabuf_handle = g_hash_table_lookup (priv->dmabuf_handles,
++                                           GINT_TO_POINTER (spa_data->fd));
++    }
++
++  if (dmabuf_handle)
++    return cogl_dma_buf_handle_get_stride (dmabuf_handle);
++  else
++    return priv->video_stride;
++}
++
+ void
+ meta_screen_cast_stream_src_maybe_record_frame (MetaScreenCastStreamSrc  *src,
+                                                 MetaScreenCastRecordFlag  flags)
+@@ -631,10 +651,12 @@ meta_screen_cast_stream_src_maybe_record_frame (MetaScreenCastStreamSrc  *src,
+       g_clear_handle_id (&priv->follow_up_frame_source_id, g_source_remove);
+       if (do_record_frame (src, flags, spa_buffer, data, &error))
+         {
++          struct spa_data *spa_data = &spa_buffer->datas[0];
+           struct spa_meta_region *spa_meta_video_crop;
+ 
+-          spa_buffer->datas[0].chunk->size = spa_buffer->datas[0].maxsize;
+-          spa_buffer->datas[0].chunk->stride = priv->video_stride;
++          spa_data->chunk->size = spa_data->maxsize;
++          spa_data->chunk->stride =
++            meta_screen_cast_stream_src_calculate_stride (src, spa_data);
+ 
+           /* Update VideoCrop if needed */
+           spa_meta_video_crop =


### PR DESCRIPTION
Sharing screen with applications using DMA-BUF at some screen
resolutions results in a corrupted image.  The added patch
'fix-stream-stride-2513.patch' fixes the problem by correcting the
stride calculation. The patch has been merged into the main repository
and should be included in GNOME 43.0, see
https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/2513.

###### Description of changes

Added patch 'fix-stream-stride-2513.patch' .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I've tested the patch on my NixOS system using the override below in 'configuration.nix' and checked that sharing my screen at 3440x1440 with 'obs-studio' produces the expected result.

```
  nixpkgs.overlays = [
    (self: super: {
      gnome = super.gnome.overrideScope' (gself: gsuper: {
        mutter = gsuper.mutter.overrideAttrs (oldAttrs: {
          patches = oldAttrs.patches ++ [
            # Fix mutter stride size
            /path-to-patch/fix-stream-stride-2513.patch
          ];
        });
      });
    })
  ];
```

I propose this patch to be back-ported to 'nixos-22.05'.