### PR TITLE
ppsspp: add SDL and headless

### DIFF
--- a/pkgs/applications/emulators/ppsspp/default.nix
+++ b/pkgs/applications/emulators/ppsspp/default.nix
@@ -3,76 +3,119 @@
 , fetchFromGitHub
 , SDL2
 , cmake
+, copyDesktopItems
 , ffmpeg
 , glew
+, libffi
 , libzip
+, makeDesktopItem
+, makeWrapper
 , pkg-config
 , python3
-, qtbase
-, qtmultimedia
+, qtbase ? null
+, qtmultimedia ? null
 , snappy
-, wrapQtAppsHook
+, vulkan-loader
+, wayland
+, wrapQtAppsHook ? null
 , zlib
+, enableVulkan ? true
+, forceWayland ? false
 }:
 
-stdenv.mkDerivation (finalAttrs: {
-  pname = "ppsspp";
-  version = "1.13.1";
+let
+  enableQt = (qtbase != null);
+  frontend = if enableQt then "Qt" else "SDL and headless";
+  vulkanPath = lib.makeLibraryPath [ vulkan-loader ];
 
-  src = fetchFromGitHub {
-    owner = "hrydgard";
-    repo = "ppsspp";
-    rev = "v${finalAttrs.version}";
-    fetchSubmodules = true;
-    sha256 = "sha256-WsFy2aSOmkII2Lte5et4W6qj0AXUKWWkYe88T0OQP08=";
-  };
+  # experimental, see https://github.com/hrydgard/ppsspp/issues/13845
+  vulkanWayland = enableVulkan && forceWayland;
+in
+  # Only SDL front end needs to specify whether to use Wayland
+  assert forceWayland -> !enableQt;
+  stdenv.mkDerivation (finalAttrs: {
+    pname = "ppsspp"
+      + lib.optionalString enableQt "-qt"
+      + lib.optionalString (!enableQt) "-sdl"
+      + lib.optionalString forceWayland "-wayland";
+    version = "1.13.1";
 
-  postPatch = ''
-    substituteInPlace git-version.cmake --replace unknown ${finalAttrs.src.rev}
-    substituteInPlace UI/NativeApp.cpp --replace /usr/share $out/share
-  '';
+    src = fetchFromGitHub {
+      owner = "hrydgard";
+      repo = "ppsspp";
+      rev = "v${finalAttrs.version}";
+      fetchSubmodules = true;
+      sha256 = "sha256-WsFy2aSOmkII2Lte5et4W6qj0AXUKWWkYe88T0OQP08=";
+    };
 
-  nativeBuildInputs = [
-    cmake
-    pkg-config
-    python3
-    wrapQtAppsHook
-  ];
+    postPatch = ''
+      substituteInPlace git-version.cmake --replace unknown ${finalAttrs.src.rev}
+      substituteInPlace UI/NativeApp.cpp --replace /usr/share $out/share
+    '';
 
-  buildInputs = [
-    SDL2
-    ffmpeg
-    glew
-    libzip
-    qtbase
-    qtmultimedia
-    snappy
-    zlib
-  ];
+    nativeBuildInputs = [
+      cmake
+      copyDesktopItems
+      makeWrapper
+      pkg-config
+      python3
+      wrapQtAppsHook
+    ];
 
-  cmakeFlags = [
-    "-DHEADLESS=OFF"
-    "-DOpenGL_GL_PREFERENCE=GLVND"
-    "-DUSE_SYSTEM_FFMPEG=ON"
-    "-DUSE_SYSTEM_LIBZIP=ON"
-    "-DUSE_SYSTEM_SNAPPY=ON"
-    "-DUSING_QT_UI=ON"
-  ];
+    buildInputs = [
+      SDL2
+      ffmpeg
+      (glew.override { enableEGL = forceWayland; })
+      libzip
+      qtbase
+      qtmultimedia
+      snappy
+      zlib
+    ] ++ lib.optional enableVulkan vulkan-loader
+      ++ lib.optionals vulkanWayland [ wayland libffi ];
 
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $out/share/ppsspp
-    install -Dm555 PPSSPPQt $out/bin/ppsspp
-    mv assets $out/share/ppsspp
-    runHook postInstall
-  '';
+    cmakeFlags = [
+      "-DHEADLESS=${if enableQt then "OFF" else "ON"}"
+      "-DOpenGL_GL_PREFERENCE=GLVND"
+      "-DUSE_SYSTEM_FFMPEG=ON"
+      "-DUSE_SYSTEM_LIBZIP=ON"
+      "-DUSE_SYSTEM_SNAPPY=ON"
+      "-DUSE_WAYLAND_WSI=${if vulkanWayland then "ON" else "OFF"}"
+      "-DUSING_QT_UI=${if enableQt then "ON" else "OFF"}"
+    ];
 
-  meta = with lib; {
-    homepage = "https://www.ppsspp.org/";
-    description = "A HLE Playstation Portable emulator, written in C++";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ AndersonTorres ];
-    platforms = platforms.linux;
-  };
-})
-# TODO: add SDL headless port
+    desktopItems = [(makeDesktopItem {
+      desktopName = "PPSSPP";
+      name = "ppsspp";
+      exec = "ppsspp";
+      icon = "ppsspp";
+      comment = "Play PSP games on your computer";
+      categories = [ "Game" "Emulator" ];
+    })];
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/share/{applications,ppsspp}
+    '' + (if enableQt then ''
+      install -Dm555 PPSSPPQt $out/bin/ppsspp
+      wrapProgram $out/bin/ppsspp \
+    '' else ''
+      install -Dm555 PPSSPPHeadless $out/bin/ppsspp-headless
+      install -Dm555 PPSSPPSDL $out/share/ppsspp/
+      makeWrapper $out/share/ppsspp/PPSSPPSDL $out/bin/ppsspp \
+        --set SDL_VIDEODRIVER ${if forceWayland then "wayland" else "x11"} \
+    '') + lib.optionalString enableVulkan ''
+        --prefix LD_LIBRARY_PATH : ${vulkanPath} \
+    '' + "\n" + ''
+      mv assets $out/share/ppsspp
+      runHook postInstall
+    '';
+
+    meta = with lib; {
+      homepage = "https://www.ppsspp.org/";
+      description = "A HLE Playstation Portable emulator, written in C++ (${frontend})";
+      license = licenses.gpl2Plus;
+      maintainers = with maintainers; [ AndersonTorres ];
+      platforms = platforms.linux;
+    };
+  })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1493,8 +1493,18 @@ with pkgs;
 
   pcsxr = callPackage ../applications/emulators/pcsxr { };
 
-  ppsspp = callPackage ../applications/emulators/ppsspp {
+  ppsspp = callPackage ../applications/emulators/ppsspp { };
+
+  ppsspp-sdl = ppsspp;
+
+  ppsspp-sdl-wayland = ppsspp.override {
+    forceWayland = true;
+    enableVulkan = false; # https://github.com/hrydgard/ppsspp/issues/13845
+  };
+
+  ppsspp-qt = ppsspp.override {
     inherit (libsForQt5) qtbase qtmultimedia wrapQtAppsHook;
+    enableVulkan = false; # https://github.com/hrydgard/ppsspp/issues/11628
   };
 
   proton-caller = callPackage ../applications/emulators/proton-caller { };


### PR DESCRIPTION
Change the default ppsspp package to SDL front end, as it supports
Vulkan, and is allowed to build the headless binary together.

###### Description of changes

- New packages
  - `ppsspp-sdl`
  - `ppsspp-sdl-wayland`

- Packages changed
  - `ppsspp` now uses SDL front end, includes the headless binary, and supports Vulkan
  - The original `ppsspp` with Qt front end is renamed to `ppsspp-qt`
  - Add a desktop entry for the packages above
 
- Additional notes
  - Qt front end doesn't support Vulkan yet. See https://github.com/hrydgard/ppsspp/issues/11628
  - SDL front end has trouble with Vulkan on Wayland, so Vulkan support is disabled by default in `ppsspp-sdl-wayland`. See https://github.com/hrydgard/ppsspp/issues/13845

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
