### PR TITLE
chromium: fix screencast

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -160,6 +160,22 @@ let
       ./patches/no-build-timestamps.patch
       # For bundling Widevine (DRM), might be replaceable via bundle_widevine_cdm=true in gnFlags:
       ./patches/widevine-79.patch
+    ] ++ optionals (lib.versionOlder version "105") [
+      # Fix WebRTP affecting screen sharing. These fixes were integrated into chromium 105
+      # See https://webrtc-review.googlesource.com/c/src/+/267002
+      # and https://webrtc-review.googlesource.com/c/src/+/267002
+      (fetchpatch {
+        extraPrefix = "third_party/webrtc/";
+        stripLen = 1;
+        url = "https://github.com/maitrungduc1410/webrtc/commit/a6ed749b12c63d252c6d893d5b5b62fcf35773d9.patch";
+        sha256 = "sha256-pFVM9a6os8/cy0L8gc7iPfVYbWVtQpMN+2c0bPee5bw=";
+      })
+      (fetchpatch {
+        extraPrefix = "third_party/webrtc/";
+        stripLen = 1;
+        url = "https://github.com/maitrungduc1410/webrtc/commit/450da27933f9fc623f4f697e2e724b9e68fd2a99.patch";
+        sha256 = "sha256-0zRlsO1BCXrxfNS+b/ezMAGO/M2+0ZRz2Iw05j0gzUg=";
+      })
     ];
 
     postPatch = ''


### PR DESCRIPTION
Add patches './patches/chromium-webrtc-fix.patch' and
'./patches/fix-wayland-screencast.patch' fixing bugs in WebRTP
affecting screen sharing. These fixes were integrated into chromium
105 See https://webrtc-review.googlesource.com/c/src/+/267002 and
https://webrtc-review.googlesource.com/c/src/+/267002.

###### Description of changes

Add the two patches './patches/chromium-webrtc-fix.patch' and './patches/fix-wayland-screencast.patch' .

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

This commit is intended to be back-ported to 'nixos-22.05' so as to fix screencast in 'chromium'. Systems using some resolutions also need #186435.

With these patches I can finally sharing my screen in, e.g., teams calls.