### PR TITLE
pokemon-colorscripts-mac: init at stable=2021-08-10

### DIFF
--- a/pkgs/applications/misc/pokemon-colorscripts-mac/default.nix
+++ b/pkgs/applications/misc/pokemon-colorscripts-mac/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, stdenv
+, coreutils
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pokemon-colorscripts-mac";
+  version = "stable=2021-08-10";
+
+  src = fetchFromGitHub {
+    owner = "nuke-dash";
+    repo = "${pname}";
+    rev = "6aa0cd93b255bee35c5716652b8b7dfecb5fcfa2";
+    sha256 = "06b86qy2fpzdd81n2mscc2njkrxx0dyzxpgnm1xk6ldn17c853lc";
+  };
+
+  buildInputs = [ coreutils ];
+
+  preBuild = ''
+    patchShebangs ./install.sh
+
+    # Fix hardcoded prefixed coreutils
+    substituteInPlace pokemon-colorscripts.sh --replace greadlink readlink
+    substituteInPlace pokemon-colorscripts.sh --replace gshuf shuf
+
+    substituteInPlace install.sh --replace /usr/local $out
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/opt
+    mkdir -p $out/bin
+    ./install.sh
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Pokémon colorscripts for the terminal, compatible for mac";
+    longDescription = ''
+      Show colored sprites of pokémons in your terminal.
+      Contains almost 900 pokemon from gen 1 to gen 8.
+      Inspired by DT's colorscripts.
+    '';
+    homepage = "https://github.com/nuke-dash/pokemon-colorscripts-mac";
+    license = licenses.mit;
+    maintainers = [ maintainers.wesleyjrz ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28127,6 +28127,8 @@ with pkgs;
 
   cmatrix = callPackage ../applications/misc/cmatrix { };
 
+  pokemon-colorscripts-mac = callPackage ../applications/misc/pokemon-colorscripts-mac { };
+
   cmctl = callPackage ../applications/networking/cluster/cmctl { };
 
   cmus = callPackage ../applications/audio/cmus {


### PR DESCRIPTION
###### Description of changes

Show pokémon sprites in a terminal, based on [DT's colorscripts compilation](https://gitlab.com/dwt1/shell-color-scripts).

![screenshot-20221231-205644](https://user-images.githubusercontent.com/60184588/210157894-de84cc36-cbef-4b47-a760-9f4f6f9f7833.png)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
