### PR TITLE
bioextalign: init 1.5.1

### DIFF
--- a/pkgs/development/perl-modules/Bio-Ext-Align/default.nix
+++ b/pkgs/development/perl-modules/Bio-Ext-Align/default.nix
@@ -1,0 +1,36 @@
+{ lib, buildPerlPackage, fetchFromGitHub }:
+
+buildPerlPackage rec {
+  pname = "BioExtAlign";
+  version = "1.5.1";
+
+  outputs = [ "out" "dev" ];
+
+  src = fetchFromGitHub {
+    owner = "bioperl";
+    repo = "bioperl-ext";
+    rev = "bioperl-ext-release-${lib.replaceStrings ["."] ["-"] version}";
+    sha256 = "sha256-+0tZ6q3PFem8DWa2vq+njOLmjDvMB0JhD0FGk00lVMA=";
+  };
+
+  patches = [ ./fprintf.patch ];
+
+  # Do not install other Bio-ext packages
+  preConfigure = ''
+    cd Bio/Ext/Align
+  '';
+
+  # Disable tests as it requires Bio::Tools::Align which is in a different directory
+  buildPhase = ''
+    make
+  '';
+
+  meta = {
+    homepage = "https://github.com/bioperl/bioperl-ext";
+    description = "Write Perl Subroutines in Other Programming Languages";
+    longDescription = ''
+      Part of BioPerl Extensions (BioPerl-Ext) distribution, a collection of Bioperl C-compiled extensions.
+    '';
+    license = with lib.licenses; [ artistic1 ];
+  };
+}

--- a/pkgs/development/perl-modules/Bio-Ext-Align/fprintf.patch
+++ b/pkgs/development/perl-modules/Bio-Ext-Align/fprintf.patch
@@ -1,0 +1,13 @@
+diff --git a/libs/dpalign.c b/libs/dpalign.c
+index 0e07b67..0eab932 100644
+--- a/Bio/Ext/Align/libs/dpalign.c
++++ b/Bio/Ext/Align/libs/dpalign.c
+@@ -40,7 +40,7 @@ int blosum62[24][24] = {
+ void
+ dpAlign_fatal(char * s)
+ {
+-    fprintf(stderr, s);
++    fputs(stderr, s);
+     exit(-1);
+ }
+ 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -1594,6 +1594,8 @@ let
     };
   };
 
+  BioExtAlign = callPackage ../development/perl-modules/Bio-Ext-Align { };
+
   BioPerl = buildPerlPackage {
     pname = "BioPerl";
     version = "1.7.8";


### PR DESCRIPTION
Part of BioPerl Extensions (BioPerl-Ext) distribution, a collection of Bioperl C-compiled extensions.
These are no longer maintained but needed for Ensembl-VEP (annotation
for genomics).

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
