### PR TITLE
firecracker: 1.0.0 -> 1.1.1

### DIFF
--- a/pkgs/applications/virtualization/firecracker/default.nix
+++ b/pkgs/applications/virtualization/firecracker/default.nix
@@ -1,7 +1,7 @@
 { fetchurl, lib, stdenv }:
 
 let
-  version = "1.0.0";
+  version = "1.1.1";
 
   suffix = {
     x86_64-linux = "x86_64";
@@ -22,8 +22,8 @@ stdenv.mkDerivation {
 
   sourceRoot = ".";
   src = dlbin {
-    x86_64-linux = "sha256-yeWVsrvH3yYlS2uH/TkSleHjXvIDnHWcZSvLgV+CGF0=";
-    aarch64-linux = "sha256-9ggRmijwXE9adVFv5XommgvdpeeWnWUFES+Ep2GrBVo=";
+    x86_64-linux = "sha256-KRlOE4iDWMYzKZUZnuKIwIGooj5o8ARpROS7f2VIr1c=";
+    aarch64-linux = "sha256-AqVFqUbMtjPmOsSgAaJ2AFNc0McC708fAD36qLz0VAc=";
   };
 
   dontConfigure = true;

--- a/pkgs/applications/virtualization/firectl/default.nix
+++ b/pkgs/applications/virtualization/firectl/default.nix
@@ -4,16 +4,16 @@ buildGoModule rec {
   pname = "firectl";
   # The latest upstream 0.1.0 is incompatible with firecracker
   # v0.1.0. See issue: https://github.com/firecracker-microvm/firectl/issues/82
-  version = "unstable-2022-03-01";
+  version = "unstable-2022-07-12";
 
   src = fetchFromGitHub {
     owner = "firecracker-microvm";
     repo = pname;
-    rev = "9f1b639a446e8d75f31787a00b9f273c1e68f12c";
-    sha256 = "TjzzHY9VYPpWoPt6nHYUerKX94O03sm524wGM9lGzno=";
+    rev = "ec72798240c0561dea8341d828e8c72bb0cc36c5";
+    sha256 = "sha256-RAl1DaeMR7eYYwqVAvm6nib5gEGaM/t7TR8u1IpqOIM=";
   };
 
-  vendorSha256 = "3SVEvvGNx6ienyJZg0EOofHNHCPSpJUGXwHxokdRG1c=";
+  vendorSha256 = "sha256-dXAJOifRtzcTyGzUTFu9+daGAlL/5dQSwcjerkZDuKA=";
 
   doCheck = false;
 


### PR DESCRIPTION
###### Description of changes

Update

Test with:
```bash
nix run github:astro/microvm.nix#firecracker-example \
  --override-input nixpkgs github:astro/nixpkgs/firecracker
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
