### PR TITLE
libbluray: fix various java related issues

### DIFF
--- a/pkgs/development/libraries/libbluray/BDJ-JARFILE-path.patch
+++ b/pkgs/development/libraries/libbluray/BDJ-JARFILE-path.patch
@@ -1,27 +1,24 @@
 diff --git a/configure.ac b/configure.ac
-index 5fd3c8de..7ae343e0 100644
+index 5007bbd..335f3f5 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -228,6 +228,10 @@ if test "x$use_bdjava_jar" = "xyes" && test "x$HAVE_ANT" = "xno"; then
-     AC_MSG_ERROR([BD-J requires ANT, but ant was not found. Please install it.])
- fi
+@@ -253,6 +253,7 @@ AS_IF([test "x${JDK_HOME}" != "x"], [
+ ])
  
-+if test "x$use_bdjava_jar" = "xyes"; then
-+  CPPFLAGS="${CPPFLAGS} -DJARDIR='\"\$(datadir)/java\"'"
-+fi
-+
- AC_DEFINE_UNQUOTED([JAVA_ARCH], ["$java_arch"], ["Defines the architecture of the java vm."])
- AC_DEFINE_UNQUOTED([JDK_HOME], ["$JDK_HOME"], [""])
- AM_CONDITIONAL([USING_BDJAVA_BUILD_JAR], [ test $use_bdjava_jar = "yes" ])
+ AS_IF([test "x$use_bdjava_jar" = "xyes"], [
++    CPPFLAGS="${CPPFLAGS} -DJARDIR='\"\$(datadir)/java\"'"
+ 
+     dnl check for ant
+     AC_CHECK_PROG(HAVE_ANT, [ant], yes, no)
 diff --git a/src/libbluray/bdj/bdj.c b/src/libbluray/bdj/bdj.c
-index 511ad533..e273b9e0 100644
+index 1cb1bfe..94a175c 100644
 --- a/src/libbluray/bdj/bdj.c
 +++ b/src/libbluray/bdj/bdj.c
-@@ -478,6 +478,7 @@ static const char *_find_libbluray_jar(BDJ_STORAGE *storage)
-     // pre-defined search paths for libbluray.jar
-     static const char * const jar_paths[] = {
- #ifndef _WIN32
+@@ -533,6 +533,7 @@ static char *_find_libbluray_jar0()
+ #  ifdef __FreeBSD__
+         "/usr/local/share/java/" BDJ_JARFILE,
+ #  else
 +        JARDIR "/" BDJ_JARFILE,
          "/usr/share/java/" BDJ_JARFILE,
          "/usr/share/libbluray/lib/" BDJ_JARFILE,
- #endif
+ #  endif

--- a/pkgs/development/libraries/libbluray/BDJ-JARFILE-path.patch
+++ b/pkgs/development/libraries/libbluray/BDJ-JARFILE-path.patch
@@ -1,24 +1,27 @@
 diff --git a/configure.ac b/configure.ac
-index 5007bbd..335f3f5 100644
+index 5007bbd..f46de1a 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -253,6 +253,7 @@ AS_IF([test "x${JDK_HOME}" != "x"], [
+@@ -253,7 +253,7 @@ AS_IF([test "x${JDK_HOME}" != "x"], [
  ])
  
  AS_IF([test "x$use_bdjava_jar" = "xyes"], [
+-
 +    CPPFLAGS="${CPPFLAGS} -DJARDIR='\"\$(datadir)/java\"'"
- 
      dnl check for ant
      AC_CHECK_PROG(HAVE_ANT, [ant], yes, no)
+     AS_IF([test "x$HAVE_ANT" = "xno"], [
 diff --git a/src/libbluray/bdj/bdj.c b/src/libbluray/bdj/bdj.c
-index 1cb1bfe..94a175c 100644
+index 1cb1bfe..f3711c2 100644
 --- a/src/libbluray/bdj/bdj.c
 +++ b/src/libbluray/bdj/bdj.c
-@@ -533,6 +533,7 @@ static char *_find_libbluray_jar0()
+@@ -533,6 +533,9 @@ static char *_find_libbluray_jar0()
  #  ifdef __FreeBSD__
          "/usr/local/share/java/" BDJ_JARFILE,
  #  else
++#    ifdef JARDIR
 +        JARDIR "/" BDJ_JARFILE,
++#    endif
          "/usr/share/java/" BDJ_JARFILE,
          "/usr/share/libbluray/lib/" BDJ_JARFILE,
  #  endif

--- a/pkgs/development/libraries/libbluray/default.nix
+++ b/pkgs/development/libraries/libbluray/default.nix
@@ -20,11 +20,13 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-wksPQcW3N7u2XFRP5jSVY3p3HBClGd/IAudp8RK0O3U=";
   };
 
-  patches = optional withJava ./BDJ-JARFILE-path.patch;
+  patches = [
+    ./BDJ-JARFILE-path.patch
+    ./libbluray-1.3.1-Fix-build-failure-after-Oracle-Java-CPU-for-April-2022.patch
+  ];
 
   nativeBuildInputs = [ pkg-config autoreconfHook ]
-                      ++ optionals withJava [ ant ]
-                      ;
+    ++ optionals withJava [ ant ];
 
   buildInputs = [ fontconfig ]
                 ++ optional withJava jdk

--- a/pkgs/development/libraries/libbluray/libbluray-1.3.1-Fix-build-failure-after-Oracle-Java-CPU-for-April-2022.patch
+++ b/pkgs/development/libraries/libbluray/libbluray-1.3.1-Fix-build-failure-after-Oracle-Java-CPU-for-April-2022.patch
@@ -1,0 +1,25 @@
+From 8f26777b1ce124ff761f80ef52d6be10bcea323e Mon Sep 17 00:00:00 2001
+From: Fridrich Strba <fstrba@suse.com>
+Date: Mon, 25 Apr 2022 14:28:58 +0300
+Subject: [PATCH] Fix build failure after Oracle Java CPU for April 2022
+
+--- a/src/libbluray/bdj/java/java/io/BDFileSystem.java
++++ b/src/libbluray/bdj/java/java/io/BDFileSystem.java
+@@ -227,6 +227,17 @@ public abstract class BDFileSystem extends FileSystem {
+         return fs.isAbsolute(f);
+     }
+ 
++    public boolean isInvalid(File f) {
++        try {
++            Method m = fs.getClass().getDeclaredMethod("isInvalid", new Class[] { File.class });
++            Object[] args = new Object[] {(Object)f};
++            Boolean result = (Boolean)m.invoke(fs, args);
++            return result.booleanValue();
++        } finally {
++            return false;
++        }
++    }
++
+     public String resolve(File f) {
+         if (!booted)
+             return fs.resolve(f);


### PR DESCRIPTION
###### Description of changes

The current master's build of libbluray wouldn't apply our patches correctly:
```
applying patch /nix/store/iygrcikrrvd467fcbwjb86qlpksxbq9s-BDJ-JARFILE-path.patch
patching file configure.ac
Hunk #1 succeeded at 279 with fuzz 2 (offset 51 lines).
patching file src/libbluray/bdj/bdj.c
Hunk #1 FAILED at 478.
1 out of 1 hunk FAILED -- saving rejects to file src/libbluray/bdj/bdj.c.rej
```

I went on and updated the patch, but then the java build failed. 
This is a known bug that was corrected upstream, so I went ahead and backported the patch. This version now compiles correctly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

