### PR TITLE
python310Packages.ocifs: init at 1.1.2, oci-cli: 3.7.2 -> 3.14.0

### DIFF
--- a/pkgs/development/python-modules/oci/default.nix
+++ b/pkgs/development/python-modules/oci/default.nix
@@ -2,7 +2,6 @@
 , buildPythonPackage
 , certifi
 , circuitbreaker
-, configparser
 , cryptography
 , fetchFromGitHub
 , pyopenssl
@@ -13,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "oci";
-  version = "2.75.0";
+  version = "2.78.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.6";
@@ -22,13 +21,12 @@ buildPythonPackage rec {
     owner = "oracle";
     repo = "oci-python-sdk";
     rev = "refs/tags/v${version}";
-    hash = "sha256-dr95RHM8h2JIqkaey7E9DzbTLfLlCCUL1ZmTIH4mBRw=";
+    hash = "sha256-24V9vfuNMxvC5iqluW4xz7WICXbQA89xmiAH6tIDRw0=";
   };
 
   propagatedBuildInputs = [
     certifi
     circuitbreaker
-    configparser
     cryptography
     pyopenssl
     python-dateutil
@@ -37,9 +35,9 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "configparser==4.0.2 ; python_version < '3'" "configparser" \
-      --replace "cryptography>=3.2.1,<=3.4.7" "cryptography" \
-      --replace "pyOpenSSL>=17.5.0,<=19.1.0" "pyOpenSSL"
+      --replace "configparser==4.0.2 ; python_version < '3'" "" \
+      --replace "cryptography>=3.2.1,<=37.0.2" "cryptography" \
+      --replace "pyOpenSSL>=17.5.0,<=22.0.0" "pyOpenSSL"
   '';
 
   # Tests fail: https://github.com/oracle/oci-python-sdk/issues/164

--- a/pkgs/development/python-modules/ocifs/default.nix
+++ b/pkgs/development/python-modules/ocifs/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fsspec
+, oci
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "ocifs";
+  version = "1.1.2";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "oracle";
+    repo = pname;
+    rev = "refs/tags/${version}";
+    hash = "sha256-4Yf6f89btzLij0OxGYRrnRpYCs8edDcwJPFbPZUfx9w=";
+  };
+
+  propagatedBuildInputs = [
+    fsspec
+    oci
+  ];
+
+  # Module has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "ocifs"
+  ];
+
+  meta = with lib; {
+    description = "Oracle Cloud Infrastructure Object Storage fsspec implementation";
+    homepage = "https://ocifs.readthedocs.io";
+    license = with licenses; [ upl ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/tools/admin/oci-cli/default.nix
+++ b/pkgs/tools/admin/oci-cli/default.nix
@@ -22,6 +22,7 @@ let
           inherit version;
           sha256 = "b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9";
         };
+        doCheck = false;
       });
 
     };
@@ -31,24 +32,24 @@ with py.pkgs;
 
 buildPythonApplication rec {
   pname = "oci-cli";
-  version = "3.7.2";
+  version = "3.14.0";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "oracle";
-    repo = "oci-cli";
+    repo = pname;
     rev = "v${version}";
-    hash = "sha256-20Tnn0s+sfLEsAG9S6f61OVGpRf53wFPtt4a2/TJbCg=";
+    hash = "sha256-yooEZuSIw2EMJVyT/Z/x4hJi8a1F674CtsMMGkMAYLg=";
   };
 
   propagatedBuildInputs = [
     arrow
     certifi
     click
-    configparser
     cryptography
     jmespath
     oci
+    prompt-toolkit
     pyopenssl
     python-dateutil
     pytz
@@ -60,9 +61,10 @@ buildPythonApplication rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "cryptography>=3.2.1,<=3.4.7" "cryptography" \
-      --replace "pyOpenSSL==19.1.0" "pyOpenSSL" \
+      --replace "cryptography>=3.2.1,<=37.0.2" "cryptography" \
+      --replace "pyOpenSSL>=17.5.0,<=22.0.0" "pyOpenSSL" \
       --replace "PyYAML>=5.4,<6" "PyYAML" \
+      --replace "prompt-toolkit==3.0.29" "prompt-toolkit" \
       --replace "terminaltables==3.1.0" "terminaltables"
   '';
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6166,6 +6166,8 @@ in {
 
   oci = callPackage ../development/python-modules/oci { };
 
+  ocifs = callPackage ../development/python-modules/ocifs { };
+
   ocrmypdf = callPackage ../development/python-modules/ocrmypdf { };
 
   od = callPackage ../development/python-modules/od { };


### PR DESCRIPTION
###### Description of changes
Oracle Cloud Infrastructure Object Storage fsspec implementation

https://ocifs.readthedocs.io

https://github.com/oracle/oci-cli/releases/tag/v3.14.0

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
