### PR TITLE
abseil-cpp: lock in provided vocabulary types

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/default.nix
@@ -72,7 +72,6 @@ let
     abseil-cpp = (abseil-cpp.override {
       # abseil-cpp should use the same compiler
       inherit stdenv;
-      cxxStandard = "20";
     }).overrideAttrs (_: {
       # https://github.com/NixOS/nixpkgs/issues/130963
       NIX_LDFLAGS = optionalString stdenv.isDarwin "-lc++abi";

--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
@@ -64,9 +64,7 @@
 
 let
   tg_owt = callPackage ./tg_owt.nix {
-    abseil-cpp = abseil-cpp.override {
-      cxxStandard = "17";
-    };
+    inherit abseil-cpp;
   };
   # Aarch64 default gcc9 will cause ICE. For reference #108305
   env = if stdenv.isAarch64 then gcc10Stdenv else stdenv;

--- a/pkgs/development/libraries/abseil-cpp/202103.nix
+++ b/pkgs/development/libraries/abseil-cpp/202103.nix
@@ -4,7 +4,6 @@
 , fetchpatch
 , cmake
 , static ? stdenv.hostPlatform.isStatic
-, cxxStandard ? null
 }:
 
 stdenv.mkDerivation rec {
@@ -15,7 +14,19 @@ stdenv.mkDerivation rec {
     owner = "abseil";
     repo = "abseil-cpp";
     rev = version;
-    sha256 = "sha256-fcxPhuI2eL/fnd6nT11p8DpUNwGNaXZmd03yOiZcOT0=";
+    sha256 = "sha256-rLEd0HYWfPIDIhZbsBDqG8lads6kKaTMVJEEegPOz+o=";
+    # Make sure to use the provided implementations of C++17 types.
+    # Without this setting libraries compiled with different C++ standards
+    # will not be ABI compatible.
+    # Done here because the src attribute is reused in tensorflow-lite and
+    # dragonflydb.
+    postFetch = ''
+      substituteInPlace $out/absl/base/options.h \
+        --replace "ABSL_OPTION_USE_STD_ANY 2" "ABSL_OPTION_USE_STD_ANY 0" \
+        --replace "ABSL_OPTION_USE_STD_OPTIONAL 2" "ABSL_OPTION_USE_STD_OPTIONAL 0" \
+        --replace "ABSL_OPTION_USE_STD_STRING_VIEW 2" "ABSL_OPTION_USE_STD_STRING_VIEW 0" \
+        --replace "ABSL_OPTION_USE_STD_VARIANT 2" "ABSL_OPTION_USE_STD_VARIANT 0"
+    '';
   };
 
   patches = [
@@ -29,8 +40,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=${if static then "OFF" else "ON"}"
-  ] ++ lib.optionals (cxxStandard != null) [
-    "-DCMAKE_CXX_STANDARD=${cxxStandard}"
+    "-DABSL_PROPAGATE_CXX_STD=ON"
   ];
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/abseil-cpp/202111.nix
+++ b/pkgs/development/libraries/abseil-cpp/202111.nix
@@ -4,7 +4,6 @@
 , fetchpatch
 , cmake
 , static ? stdenv.hostPlatform.isStatic
-, cxxStandard ? null
 }:
 
 stdenv.mkDerivation rec {
@@ -15,13 +14,24 @@ stdenv.mkDerivation rec {
     owner = "abseil";
     repo = "abseil-cpp";
     rev = version;
-    sha256 = "sha256-sSXT6D4JSrk3dA7kVaxfKkzOMBpqXQb0WbMYWG+nGwk=";
+    sha256 = "sha256-jKaCo000Ah6IsYSepHyuPOZLDt6FXtXlX1tmOtzhv3Q=";
+    # Make sure to use the provided implementations of C++17 types.
+    # Without this setting libraries compiled with different C++ standards
+    # will not be ABI compatible.
+    # Done here because the src attribute is reused in tensorflow-lite and
+    # dragonflydb.
+    postFetch = ''
+      substituteInPlace $out/absl/base/options.h \
+        --replace "ABSL_OPTION_USE_STD_ANY 2" "ABSL_OPTION_USE_STD_ANY 0" \
+        --replace "ABSL_OPTION_USE_STD_OPTIONAL 2" "ABSL_OPTION_USE_STD_OPTIONAL 0" \
+        --replace "ABSL_OPTION_USE_STD_STRING_VIEW 2" "ABSL_OPTION_USE_STD_STRING_VIEW 0" \
+        --replace "ABSL_OPTION_USE_STD_VARIANT 2" "ABSL_OPTION_USE_STD_VARIANT 0"
+    '';
   };
 
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=${if static then "OFF" else "ON"}"
-  ] ++ lib.optionals (cxxStandard != null) [
-    "-DCMAKE_CXX_STANDARD=${cxxStandard}"
+    "-DABSL_PROPAGATE_CXX_STD=ON"
   ];
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/science/math/or-tools/absl-string_view.patch
+++ b/pkgs/development/libraries/science/math/or-tools/absl-string_view.patch
@@ -1,0 +1,19 @@
+commit 32513329e4d024afaf0f62831587fa89c7990ea7
+Author: Tobias Mayer <tobim@fastmail.fm>
+Date:   Sun Aug 14 23:17:35 2022 +0200
+
+    Fix build with absl::string_view
+
+diff --git a/examples/cpp/network_routing_sat.cc b/examples/cpp/network_routing_sat.cc
+index b64fe87932..68bb84eb0a 100644
+--- a/examples/cpp/network_routing_sat.cc
++++ b/examples/cpp/network_routing_sat.cc
+@@ -131,7 +131,7 @@ class NetworkRoutingData {
+   void AddDemand(int source, int destination, int traffic) {
+     all_demands_[std::make_pair(source, destination)] = traffic;
+   }
+-  void set_name(absl::string_view name) { name_ = name; }
++  void set_name(absl::string_view name) { name_ = std::string{name}; }
+   void set_max_capacity(int max_capacity) { max_capacity_ = max_capacity; }
+   void set_fixed_charge_cost(int cost) { fixed_charge_cost_ = cost; }
+ 

--- a/pkgs/development/libraries/science/math/or-tools/default.nix
+++ b/pkgs/development/libraries/science/math/or-tools/default.nix
@@ -26,6 +26,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-dEYMPWpa3J9EqtCq3kubdUYJivNRTOKUpNDx3UC1IcQ=";
   };
 
+  patches = [
+    ./absl-string_view.patch
+  ];
+
   # The original build system uses cmake which does things like pull
   # in dependencies through git and Makefile creation time. We
   # obviously don't want to do this so instead we provide the

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6457,9 +6457,7 @@ with pkgs;
   fcitx5-chinese-addons = libsForQt5.callPackage ../tools/inputmethods/fcitx5/fcitx5-chinese-addons.nix { };
 
   fcitx5-mozc = libsForQt5.callPackage ../tools/inputmethods/fcitx5/fcitx5-mozc.nix {
-    abseil-cpp = abseil-cpp.override {
-      cxxStandard = "17";
-    };
+    abseil-cpp = abseil-cpp;
   };
 
   fcitx5-unikey = libsForQt5.callPackage ../tools/inputmethods/fcitx5/fcitx5-unikey.nix { };
@@ -7290,9 +7288,7 @@ with pkgs;
 
   google-cloud-cpp = callPackage ../development/libraries/google-cloud-cpp {
     openssl = openssl_1_1;
-    abseil-cpp = abseil-cpp.override {
-      cxxStandard = "14";
-    };
+    abseil-cpp = abseil-cpp_202111;
   };
 
   google-java-format = callPackage ../development/tools/google-java-format { };
@@ -18953,10 +18949,7 @@ with pkgs;
   grilo-plugins = callPackage ../development/libraries/grilo-plugins { };
 
   grpc = callPackage ../development/libraries/grpc {
-    # grpc builds with c++14 so abseil must also be built that way
-    abseil-cpp = abseil-cpp_202111.override {
-      cxxStandard = "14";
-    };
+    abseil-cpp = abseil-cpp_202111;
   };
 
   gsettings-qt = libsForQt5.callPackage ../development/libraries/gsettings-qt { };
@@ -35235,7 +35228,6 @@ with pkgs;
     # also be built that way
     abseil-cpp = abseil-cpp.override {
       static = true;
-      cxxStandard = "17";
     };
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6456,9 +6456,7 @@ with pkgs;
 
   fcitx5-chinese-addons = libsForQt5.callPackage ../tools/inputmethods/fcitx5/fcitx5-chinese-addons.nix { };
 
-  fcitx5-mozc = libsForQt5.callPackage ../tools/inputmethods/fcitx5/fcitx5-mozc.nix {
-    abseil-cpp = abseil-cpp;
-  };
+  fcitx5-mozc = libsForQt5.callPackage ../tools/inputmethods/fcitx5/fcitx5-mozc.nix { };
 
   fcitx5-unikey = libsForQt5.callPackage ../tools/inputmethods/fcitx5/fcitx5-unikey.nix { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2759,11 +2759,7 @@ in {
 
   dm-sonnet = callPackage ../development/python-modules/dm-sonnet { };
 
-  dm-tree = callPackage ../development/python-modules/dm-tree {
-    abseil-cpp = pkgs.abseil-cpp.override {
-      cxxStandard = "14";
-    };
-  };
+  dm-tree = callPackage ../development/python-modules/dm-tree { };
 
   dnachisel = callPackage ../development/python-modules/dnachisel { };
 


### PR DESCRIPTION
###### Description of changes

Abseil provides a special header that allows software distributions
to override compile option dependent features. If this file is left
as-is downstream packages will usually fail to link due to undefined
references.

See the upstream documentation for a more comprehensive explanation:
https://github.com/abseil/abseil-cpp/blob/lts_2021_11_02/absl/base/options.h

Up till now we allowed to bulid abseil itself with different C++
Standards to overcome this problem, but that approach didn't fully
solve it:

 * The override is an optional argument, so its easy to overlook.
 * Processes that see multiple variants of the library (becausse
   they get pulled into the closure by different dependencies) are
   subject to undefined behavior.

###### Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


I built up to `libtensorflow` without problem, but `nixpkgs-review` is too much for my hardware.
resolves #185865