### PR TITLE
Imlib2: Add JPEGXL and Postscript support, make webp support optional

### DIFF
--- a/pkgs/development/libraries/imlib2/default.nix
+++ b/pkgs/development/libraries/imlib2/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl
 # Image file formats
-, libjpeg, libtiff, giflib, libpng, libwebp
+, libjpeg, libtiff, giflib, libpng, libwebp, libjxl
 # imlib2 can load images from ID3 tags.
 , libid3tag, librsvg, libheif
 , freetype , bzip2, pkg-config
@@ -9,6 +9,7 @@
 # https://github.com/NixOS/nixpkgs/pull/166452#issuecomment-1090725613
 , svgSupport ? !stdenv.isDarwin
 , heifSupport ? !stdenv.isDarwin
+, jxlSupport ? true
 
 # for passthru.tests
 , libcaca
@@ -37,7 +38,8 @@ stdenv.mkDerivation rec {
     bzip2 freetype libid3tag
   ] ++ optional x11Support xlibsWrapper
     ++ optional heifSupport libheif
-    ++ optional svgSupport librsvg;
+    ++ optional svgSupport librsvg
+    ++ optional jxlSupport libjxl;
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/development/libraries/imlib2/default.nix
+++ b/pkgs/development/libraries/imlib2/default.nix
@@ -10,6 +10,7 @@
 # https://github.com/NixOS/nixpkgs/pull/166452#issuecomment-1090725613
 , svgSupport ? !stdenv.isDarwin
 , heifSupport ? !stdenv.isDarwin
+, webpSupport ? true
 , jxlSupport ? true
 , psSupport ? true
 
@@ -36,11 +37,12 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    libjpeg libtiff giflib libpng libwebp
+    libjpeg libtiff giflib libpng
     bzip2 freetype libid3tag
   ] ++ optional x11Support xlibsWrapper
     ++ optional heifSupport libheif
     ++ optional svgSupport librsvg
+    ++ optional webpSupport libwebp
     ++ optional jxlSupport libjxl
     ++ optional psSupport libspectre;
 

--- a/pkgs/development/libraries/imlib2/default.nix
+++ b/pkgs/development/libraries/imlib2/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv, fetchurl
 # Image file formats
 , libjpeg, libtiff, giflib, libpng, libwebp, libjxl
+, libspectre
 # imlib2 can load images from ID3 tags.
 , libid3tag, librsvg, libheif
 , freetype , bzip2, pkg-config
@@ -10,6 +11,7 @@
 , svgSupport ? !stdenv.isDarwin
 , heifSupport ? !stdenv.isDarwin
 , jxlSupport ? true
+, psSupport ? true
 
 # for passthru.tests
 , libcaca
@@ -39,7 +41,8 @@ stdenv.mkDerivation rec {
   ] ++ optional x11Support xlibsWrapper
     ++ optional heifSupport libheif
     ++ optional svgSupport librsvg
-    ++ optional jxlSupport libjxl;
+    ++ optional jxlSupport libjxl
+    ++ optional psSupport libspectre;
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/development/libraries/imlib2/default.nix
+++ b/pkgs/development/libraries/imlib2/default.nix
@@ -6,13 +6,11 @@
 , libid3tag, librsvg, libheif
 , freetype , bzip2, pkg-config
 , x11Support ? true, xlibsWrapper ? null
-# Compilation error on Darwin with librsvg. For more information see:
-# https://github.com/NixOS/nixpkgs/pull/166452#issuecomment-1090725613
-, svgSupport ? !stdenv.isDarwin
-, heifSupport ? !stdenv.isDarwin
-, webpSupport ? true
-, jxlSupport ? true
-, psSupport ? true
+, svgSupport ? false
+, heifSupport ? false
+, webpSupport ? false
+, jxlSupport ? false
+, psSupport ? false
 
 # for passthru.tests
 , libcaca

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18635,6 +18635,15 @@ with pkgs;
   iml = callPackage ../development/libraries/iml { };
 
   imlib2 = callPackage ../development/libraries/imlib2 { };
+  imlib2Full = imlib2.override {
+    # Compilation error on Darwin with librsvg. For more information see:
+    # https://github.com/NixOS/nixpkgs/pull/166452#issuecomment-1090725613
+    svgSupport = !stdenv.isDarwin;
+    heifSupport = !stdenv.isDarwin;
+    webpSupport = true;
+    jxlSupport = true;
+    psSupport = true;
+  };
   imlib2-nox = imlib2.override {
     x11Support = false;
   };


### PR DESCRIPTION
###### Description of changes

This adds support for two new image formats to imlib2.

@risicle This is similar to last time.

###### Things done



- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
