### PR TITLE
nixos/switch-to-configuration: fix units starting with dash not being able to reload

### DIFF
--- a/nixos/modules/system/activation/switch-to-configuration.pl
+++ b/nixos/modules/system/activation/switch-to-configuration.pl
@@ -167,7 +167,7 @@ sub get_active_units {
 # Takes the name of the unit as an argument and returns a bool whether the unit is active or not.
 sub unit_is_active {
     my ($unit_name) = @_;
-    my $units = busctl_call_systemd1_mgr("ListUnitsByNames", "as", 1, $unit_name)->{data}->[0];
+    my $units = busctl_call_systemd1_mgr("ListUnitsByNames", "as", 1, , "--", $unit_name)->{data}->[0];
     if (scalar(@{$units}) == 0) {
         return 0;
     }


### PR DESCRIPTION
Fix units starting with `-` being recognized as options, preventing them from reloading:
```console
sudo nixos-rebuild switch                                                                                                                         ~
building Nix...
building the system configuration...
activating the configuration...
setting up /etc...
reloading user units for weathercold...
setting up tmpfiles
'/nix/store/75zlhlgv7bsdgivn2i6xb5la1qdr5rpf-system-path/bin/busctl --json=short call org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager ListUnitsByNames as 1 -.mount' exited with value 1 at /nix/store/zaxzsq8aprz2qr3ph6ksd9rsjzhm1vm4-nixos-system-nixos-22.11pre399062.3a11db5f408/bin/switch-to-configuration line 140.
warning: error(s) occurred while switching to the new configuration
```
```console
/nix/store/75zlhlgv7bsdgivn2i6xb5la1qdr5rpf-system-path/bin/busctl --json=short call org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager ListUnitsByNames as 1 -.mount
/nix/store/75zlhlgv7bsdgivn2i6xb5la1qdr5rpf-system-path/bin/busctl: invalid option -- '.'
```

This is a regression introduced by #185067.

###### Description of changes
Add `--` before `$unit_name` so it is always treated as an argument.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Unfortunately I don't have time to test.