### PR TITLE
sparrow: 1.6.5 -> 1.7.0

### DIFF
--- a/pkgs/applications/blockchains/sparrow/default.nix
+++ b/pkgs/applications/blockchains/sparrow/default.nix
@@ -223,6 +223,8 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
+  passthru.updateScript = ./update.sh;
+
   meta = with lib; {
     description = "A modern desktop Bitcoin wallet application supporting most hardware wallets and built on common standards such as PSBT, with an emphasis on transparency and usability.";
     homepage = "https://sparrowwallet.com";

--- a/pkgs/applications/blockchains/sparrow/default.nix
+++ b/pkgs/applications/blockchains/sparrow/default.nix
@@ -5,7 +5,7 @@
 , makeDesktopItem
 , copyDesktopItems
 , autoPatchelfHook
-, openjdk17
+, openjdk18
 , gtk3
 , gsettings-desktop-schemas
 , writeScript
@@ -20,11 +20,11 @@
 
 let
   pname = "sparrow";
-  version = "1.6.5";
+  version = "1.7.0";
 
   src = fetchurl {
-    url = "https://github.com/sparrowwallet/${pname}/releases/download/${version}/${pname}-${version}.tar.gz";
-    sha256 = "0zk33w664fky3ir6cqm6walc80fjhg9s0hnrllrc2hrxrqnrn88p";
+    url = "https://github.com/sparrowwallet/${pname}/releases/download/${version}/${pname}-${version}-x86_64.tar.gz";
+    sha256 = "1rrf5xba733c2vxgd7bf164iswc66ggp64ywh79d0vf188imzmwr";
   };
 
   launcher = writeScript "sparrow" ''
@@ -60,7 +60,7 @@ let
       -m com.sparrowwallet.sparrow
     )
 
-    XDG_DATA_DIRS=${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS ${openjdk17}/bin/java ''${params[@]} $@
+    XDG_DATA_DIRS=${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS ${openjdk18}/bin/java ''${params[@]} $@
   '';
 
   torWrapper = writeScript "tor-wrapper" ''
@@ -71,14 +71,14 @@ let
 
   jdk-modules = stdenv.mkDerivation {
     name = "jdk-modules";
-    nativeBuildInputs = [ openjdk17 ];
+    nativeBuildInputs = [ openjdk18 ];
     dontUnpack = true;
 
     buildPhase = ''
       # Extract the JDK's JIMAGE and generate a list of modules.
       mkdir modules
       pushd modules
-      jimage extract ${openjdk17}/lib/openjdk/lib/modules
+      jimage extract ${openjdk18}/lib/openjdk/lib/modules
       ls | xargs -d " " -- echo > ../manifest.txt
       popd
     '';
@@ -93,7 +93,7 @@ let
   sparrow-modules = stdenv.mkDerivation {
     pname = "sparrow-modules";
     inherit version src;
-    nativeBuildInputs = [ makeWrapper gnugrep openjdk17 autoPatchelfHook stdenv.cc.cc.lib zlib ];
+    nativeBuildInputs = [ makeWrapper gnugrep openjdk18 autoPatchelfHook stdenv.cc.cc.lib zlib ];
 
     buildPhase = ''
       # Extract Sparrow's JIMAGE and generate a list of them.
@@ -187,6 +187,7 @@ stdenv.mkDerivation rec {
       desktopName = "Sparrow Bitcoin Wallet";
       genericName = "Bitcoin Wallet";
       categories = [ "Finance" ];
+      mimeTypes = [ "application/psbt" "application/bitcoin-transaction" "x-scheme-handler/bitcoin" "x-scheme-handler/auth47" "x-scheme-handler/lightning" ];
     })
   ];
 

--- a/pkgs/applications/blockchains/sparrow/update.sh
+++ b/pkgs/applications/blockchains/sparrow/update.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p coreutils curl jq gnused gnupg common-updater-scripts
+
+set -eu -o pipefail
+
+version="$(curl -s https://api.github.com/repos/sparrowwallet/sparrow/releases| jq '.[] | {name} | limit(1;.[])' | sed 's/[\"v]//g' | head -n 1)"
+depname="sparrow-$version-x86_64.tar.gz"
+src_root="https://github.com/sparrowwallet/sparrow/releases/download/$version";
+src="$src_root/$depname";
+manifest="$src_root/sparrow-$version-manifest.txt"
+signature="$src_root/sparrow-$version-manifest.txt.asc"
+key="D4D0 D320 2FC0 6849 A257 B38D E946 1833 4C67 4B40"
+
+pushd $(mktemp -d --suffix=-sparrow-updater)
+export GNUPGHOME=$PWD/gnupg
+mkdir -m 700 -p "$GNUPGHOME"
+curl -L -o "$depname" -- "$src"
+curl -L -o manifest.txt -- "$manifest"
+curl -L -o signature.asc -- "$signature"
+gpg --batch --recv-keys "$key"
+gpg --batch --verify signature.asc manifest.txt
+sha256sum -c --ignore-missing manifest.txt
+sha256=$(nix-prefetch-url --type sha256 "file://$PWD/$depname")
+popd
+
+update-source-version sparrow "$version" "$sha256"


### PR DESCRIPTION
###### Description of changes

There are two commits in this PR:

1. Version bump from 1.6.5 to 1.7.0
2. Add update.sh script

Notable changes:

1. Addition of mimetypes to the .desktop file, per upstream.
2. Update from OpenJDK 17 to OpenJDK 18, as required by upstream; The Java bytecode is incompatible with JDK 17.

Release notes:

- 1.6.6 release notes: https://github.com/sparrowwallet/sparrow/releases/tag/1.6.6
- 1.7.0 release notes: https://github.com/sparrowwallet/sparrow/releases/tag/1.7.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - ~[ ] aarch64-linux~
  - ~[ ] x86_64-darwin~
  - ~[ ] aarch64-darwin~
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
