### PR TITLE
cataclysm-dda: update locale path patch

### DIFF
--- a/pkgs/games/cataclysm-dda/common.nix
+++ b/pkgs/games/cataclysm-dda/common.nix
@@ -40,12 +40,7 @@ stdenv.mkDerivation {
   buildInputs = cursesDeps ++ optionals tiles tilesDeps;
 
   postPatch = ''
-    patchShebangs .
-
-    # Locale patch required for Darwin builds, see:
-    # https://github.com/NixOS/nixpkgs/pull/74064#issuecomment-560083970
-    sed -i src/translations.cpp \
-        -e 's@#elif (defined(__linux__) || (defined(MACOSX) && !defined(TILES)))@#elif 1@'
+    patchShebangs lang/compile_mo.sh
   '';
 
   makeFlags = [

--- a/pkgs/games/cataclysm-dda/locale-path-stable.patch
+++ b/pkgs/games/cataclysm-dda/locale-path-stable.patch
@@ -1,0 +1,20 @@
+diff --git a/src/translations.cpp b/src/translations.cpp
+index fa0ee479b2..0e470098dc 100644
+--- a/src/translations.cpp
++++ b/src/translations.cpp
+@@ -141,15 +141,11 @@ void select_language()
+ std::string locale_dir()
+ {
+     std::string loc_dir;
+-#if !defined(__ANDROID__) && ((defined(__linux__) || defined(BSD) || (defined(MACOSX) && !defined(TILES))))
+     if( !PATH_INFO::base_path().empty() ) {
+         loc_dir = PATH_INFO::base_path() + "share/locale";
+     } else {
+         loc_dir = PATH_INFO::langdir();
+     }
+-#else
+-    loc_dir = PATH_INFO::langdir();
+-#endif
+     return loc_dir;
+ }
+ 

--- a/pkgs/games/cataclysm-dda/stable.nix
+++ b/pkgs/games/cataclysm-dda/stable.nix
@@ -19,6 +19,11 @@ let
       sha256 = "sha256-2su1uQaWl9WG41207dRvOTdVKcQsEz/y0uTi9JX52uI=";
     };
 
+    patches = [
+      # Unconditionally look for translation files in $out/share/locale
+      ./locale-path-stable.patch
+    ];
+
     makeFlags = common.makeFlags ++ [
       # Makefile declares version as 0.F, with no minor release number
       "VERSION=${version}"


### PR DESCRIPTION
###### Description of changes
The previous `sed` patch no longer applies; this replaces it with a patch file.

Both of these are solutions for the fact that Nixpkgs Darwin build of CDDA outputs locale files to `$out/share/locale`, but the game assumes that the locale files are elsewhere on OSX.

This patch applies only to stable, since the patch does not apply on cataclysm-dda's master, and cataclysm-dda-git is broken on Darwin right now.

This is intended as a fix to #186304, but I have no Darwin machine to test it on, so would appreciate someone checking that.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

