### PR TITLE
obs-studio: Fix wrapOBS double-including the built-in plugins

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8481,6 +8481,15 @@
     githubId = 9980864;
     name = "Max Hofer";
   };
+  miangraham = {
+    email = "miangraham@users.noreply.github.com";
+    github = "miangraham";
+    githubId = 704580;
+    name = "M. Ian Graham";
+    keys = [{
+      fingerprint = "8CE3 2906 516F C4D8 D373  308A E189 648A 55F5 9A9F";
+    }];
+  };
   mic92 = {
     email = "joerg@thalheim.io";
     matrix = "@mic92:nixos.dev";

--- a/pkgs/applications/video/obs-studio/default.nix
+++ b/pkgs/applications/video/obs-studio/default.nix
@@ -140,7 +140,7 @@ mkDerivation rec {
       video content, efficiently
     '';
     homepage = "https://obsproject.com";
-    maintainers = with maintainers; [ jb55 MP2E V ];
+    maintainers = with maintainers; [ jb55 MP2E V miangraham ];
     license = licenses.gpl2Plus;
     platforms = [ "x86_64-linux" "i686-linux" "aarch64-linux" ];
     mainProgram = "obs";

--- a/pkgs/applications/video/obs-studio/wrapper.nix
+++ b/pkgs/applications/video/obs-studio/wrapper.nix
@@ -6,7 +6,7 @@ symlinkJoin {
   name = "wrapped-${obs-studio.name}";
 
   nativeBuildInputs = [ makeWrapper ];
-  paths = [ obs-studio ] ++ plugins;
+  paths = [ obs-studio ];
 
   postBuild = with lib;
     let
@@ -14,11 +14,21 @@ symlinkJoin {
       pluginArguments =
         lists.concatMap (plugin: plugin.obsWrapperArguments or []) plugins;
 
+      pluginsJoined = symlinkJoin {
+        name = "obs-studio-plugins";
+        paths = lists.map (plugin: "${plugin}/lib/obs-plugins") plugins;
+      };
+
+      pluginsDataJoined = symlinkJoin {
+        name = "obs-studio-plugins-data";
+        paths = lists.map (plugin: "${plugin}/share/obs/obs-plugins") plugins;
+      };
+
       wrapCommand = [
           "wrapProgram"
           "$out/bin/obs"
-          ''--set OBS_PLUGINS_PATH "$out/lib/obs-plugins"''
-          ''--set OBS_PLUGINS_DATA_PATH "$out/share/obs/obs-plugins"''
+          ''--set OBS_PLUGINS_PATH "${pluginsJoined}"''
+          ''--set OBS_PLUGINS_DATA_PATH "${pluginsDataJoined}"''
         ] ++ pluginArguments;
     in concatStringsSep " " wrapCommand;
 


### PR DESCRIPTION
###### Description of changes

## Bug 
wrapOBS includes new plugins by symlinkJoining them with obs-studio, then adding the new path to the OBS_PLUGINS_* environment variables. These path settings are additive, not overriding, causing all plugins included with the default obs-studio package to be loaded twice after wrapping. This results in a double free and crash on exit when running on sway/pipewire.

## Fix

In wrapOBS: Rather than linking new plugins into the default obs-plugins directory, symlinkJoin them into their own separate location which is then used to set OBS_PLUGINS_*. This results in (1) built-in plugins being loaded once by the default import behavior and (2) added plugins being loaded once by the envvar settings.

wrapOBS itself probably doesn't need to be a symlinkJoin after this fix, but I kept the diff minimal for legibility. 

## How to reproduce

Here's a quick test script:

```nix
{ pkgs ? (import (
  fetchTarball {
    # Master
    url = "https://github.com/NixOS/nixpkgs/archive/dc98fc6bb6671b51f67af41b60ffa335c5d3b0e7.tar.gz";
    sha256 = "0s7xzbvsbz387l35vwmnwqhz9p7yd39ga3cibp35cj6scka1sqav"; }
    # Patched
    # url = "https://github.com/miangraham/nixpkgs/archive/6ec68643c24049c8d073bd2dd7c7e3b0fa6f1c12.tar.gz";
    # sha256 = "0g7phcc9z8hl363hq7f2a8515az0sg3pffykz6171sn7dnnvf3v1"; }
) {}) }:
let
  obs-unwrapped = pkgs.obs-studio;
  obs-wrapped = pkgs.wrapOBS {};
in
pkgs.mkShell {
  buildInputs = [
    (pkgs.writeShellScriptBin "run_test" ''
      echo "-- Testing --"

      UNWRAPPED_CNT=$(grep -E '^info:     .*\.so$'  <(timeout 2s ${obs-unwrapped}/bin/obs) | wc -l)
      WRAPPED_CNT=$(grep -E '^info:     .*\.so$'  <(timeout 2s ${obs-wrapped}/bin/obs) | wc -l)

      echo "-- Test results --"
      echo "Unwrapped modules loaded: $UNWRAPPED_CNT"
      echo "Wrapped modules loaded: $WRAPPED_CNT"
    '')
  ];
}
```

Result on master (bug):
```console
$ nix-shell ./test.nix --command run_test
...
-- Test results --
Unwrapped modules loaded: 21
Wrapped modules loaded: 42
```

Result with patch (correct):
```console
$ nix-shell ./test.nix --command run_test
...
-- Test results --
Unwrapped modules loaded: 21
Wrapped modules loaded: 21
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### Pings for feedback

@jb55 @MP2E @deviant

Thoughts appreciated!