### PR TITLE
rubygems: 3.2.26 -> 3.3.20

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -224,8 +224,8 @@ let
           ++ op useBaseRuby baseRuby;
 
         meta = with lib; {
-          description = "The Ruby language";
-          homepage    = "http://www.ruby-lang.org/en/";
+          description = "An object-oriented language for quick and easy programming";
+          homepage    = "https://www.ruby-lang.org/";
           license     = licenses.ruby;
           maintainers = with maintainers; [ vrthra manveru marsam ];
           platforms   = platforms.all;

--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -19,7 +19,6 @@ let
 
   generic = { version, sha256 }: let
     ver = version;
-    tag = ver.gitTag;
     atLeast30 = lib.versionAtLeast ver.majMin "3.0";
     self = lib.makeOverridable (
       { stdenv, buildPackages, lib
@@ -248,11 +247,6 @@ let
             ruby = self;
           }) withPackages gems;
 
-          # deprecated 2016-09-21
-          majorVersion = ver.major;
-          minorVersion = ver.minor;
-          teenyVersion = ver.tiny;
-          patchLevel = ver.patchLevel;
         } // lib.optionalAttrs useBaseRuby {
           inherit baseRuby;
         };

--- a/pkgs/development/interpreters/ruby/patchsets.nix
+++ b/pkgs/development/interpreters/ruby/patchsets.nix
@@ -2,14 +2,19 @@
 
 {
   "2.7.6" = ops useRailsExpress [
-    "${patchSet}/patches/ruby/2.7/head/railsexpress/01-fix-broken-tests-caused-by-ad.patch"
-    "${patchSet}/patches/ruby/2.7/head/railsexpress/02-improve-gc-stats.patch"
-    "${patchSet}/patches/ruby/2.7/head/railsexpress/03-more-detailed-stacktrace.patch"
+    "${patchSet}/patches/ruby/2.7/head/railsexpress/01-fix-with-openssl-dir-option.patch"
+    "${patchSet}/patches/ruby/2.7/head/railsexpress/02-fix-broken-tests-caused-by-ad.patch"
+    "${patchSet}/patches/ruby/2.7/head/railsexpress/03-improve-gc-stats.patch"
+    "${patchSet}/patches/ruby/2.7/head/railsexpress/04-more-detailed-stacktrace.patch"
+    "${patchSet}/patches/ruby/2.7/head/railsexpress/05-malloc-trim.patch"
   ];
   "3.0.4" = ops useRailsExpress [
-    "${patchSet}/patches/ruby/3.0/head/railsexpress/01-improve-gc-stats.patch"
-    "${patchSet}/patches/ruby/3.0/head/railsexpress/02-malloc-trim.patch"
+    "${patchSet}/patches/ruby/3.0/head/railsexpress/01-fix-with-openssl-dir-option.patch"
+    "${patchSet}/patches/ruby/3.0/head/railsexpress/02-improve-gc-stats.patch"
+    "${patchSet}/patches/ruby/3.0/head/railsexpress/03-malloc-trim.patch"
   ];
-  "3.1.2" = ops useRailsExpress [ # no patches yet (2021-12-25)
+  "3.1.2" = ops useRailsExpress [
+    "${patchSet}/patches/ruby/3.1/head/railsexpress/01-improve-gc-stats.patch"
+    "${patchSet}/patches/ruby/3.1/head/railsexpress/02-malloc-trim.patch"
   ];
 }

--- a/pkgs/development/interpreters/ruby/rubygems/default.nix
+++ b/pkgs/development/interpreters/ruby/rubygems/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "rubygems";
-  version = "3.2.26";
+  version = "3.3.20";
 
   src = fetchurl {
     url = "https://rubygems.org/rubygems/rubygems-${version}.tgz";
-    sha256 = "sha256-9wa6lOWnua8zBblQKRgjjiTVPYp2TW0n7XOvgW7u1e8=";
+    sha256 = "sha256-VTUMZ2mqbszM7uXOYV6Grg7dkeGAGVXYjBX0hA/vOTg=";
   };
 
   patches = [

--- a/pkgs/development/interpreters/ruby/rvm-patchsets.nix
+++ b/pkgs/development/interpreters/ruby/rvm-patchsets.nix
@@ -3,6 +3,6 @@
 fetchFromGitHub {
   owner  = "skaes";
   repo   = "rvm-patchsets";
-  rev    = "0251817e2b9d5f73370bbbb12fdf7f7089bd1ac3";
-  sha256 = "1biiq5xzzdfb4hr1sgmx14i2nr05xa9w21pc7dl8c5n4f2ilg8ss";
+  rev    = "a6429bb1a7fb9b5798c22f43338739a6c192b42d";
+  sha256 = "sha256-NpSa+uGQA1rfHNcLzPNTK65J+Wk9ZlzhHFePDA4uuo0=";
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
