### PR TITLE
compiler-rt: build builtins on darwin

### DIFF
--- a/pkgs/development/compilers/llvm/13/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/13/compiler-rt/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, llvm_meta, version, src, cmake, python3, libllvm, libcxxabi }:
+{ lib, stdenv, llvm_meta, version, src, cmake, python3, xcbuild, libllvm, libcxxabi }:
 
 let
 
@@ -16,7 +16,8 @@ stdenv.mkDerivation {
   inherit src;
   sourceRoot = "source/compiler-rt";
 
-  nativeBuildInputs = [ cmake python3 libllvm.dev ];
+  nativeBuildInputs = [ cmake python3 libllvm.dev ]
+    ++ lib.optional stdenv.isDarwin xcbuild.xcrun;
   buildInputs = lib.optional stdenv.hostPlatform.isDarwin libcxxabi;
 
   NIX_CFLAGS_COMPILE = [
@@ -62,9 +63,11 @@ stdenv.mkDerivation {
     # ld-wrapper dislikes `-rpath-link //nix/store`, so we normalize away the
     # extra `/`.
     ./normalize-var.patch
-  ] # Prevent a compilation error on darwin
-    ++ lib.optional stdenv.hostPlatform.isDarwin ./darwin-targetconditionals.patch
-    ++ lib.optional stdenv.hostPlatform.isAarch32 ./armv7l.patch;
+    # Prevent a compilation error on darwin
+    ./darwin-targetconditionals.patch
+    ../../common/compiler-rt/darwin-plistbuddy-workaround.patch
+    ./armv7l.patch
+  ];
 
   # TSAN requires XPC on Darwin, which we have no public/free source files for. We can depend on the Apple frameworks
   # to get it, but they're unfree. Since LLVM is rather central to the stdenv, we patch out TSAN support so that Hydra
@@ -75,8 +78,6 @@ stdenv.mkDerivation {
     substituteInPlace cmake/builtin-config-ix.cmake \
       --replace 'set(X86 i386)' 'set(X86 i386 i486 i586 i686)'
   '' + lib.optionalString stdenv.isDarwin ''
-    substituteInPlace cmake/builtin-config-ix.cmake \
-      --replace 'set(ARM64 arm64 arm64e)' 'set(ARM64)'
     substituteInPlace cmake/config-ix.cmake \
       --replace 'set(COMPILER_RT_HAS_TSAN TRUE)' 'set(COMPILER_RT_HAS_TSAN FALSE)'
   '' + lib.optionalString (useLLVM) ''

--- a/pkgs/development/compilers/llvm/common/compiler-rt/darwin-plistbuddy-workaround.patch
+++ b/pkgs/development/compilers/llvm/common/compiler-rt/darwin-plistbuddy-workaround.patch
@@ -1,0 +1,25 @@
+CMake tries to read a list field from SDKSettings.plist, but the output of
+xcbuild PlistBuddy is incompatible with Apple's. (Plus we don't want it in our
+dependencies.)
+
+Simply assume ARM64 is supported by the SDK. We already limit the actual archs
+we build for by setting DARWIN_osx_BUILTIN_ARCHS explicitely.
+
+--- a/cmake/builtin-config-ix.cmake
++++ b/cmake/builtin-config-ix.cmake
+@@ -97,14 +97,7 @@ if(APPLE)
+   set(DARWIN_osx_BUILTIN_MIN_VER 10.5)
+   set(DARWIN_osx_BUILTIN_MIN_VER_FLAG
+       -mmacosx-version-min=${DARWIN_osx_BUILTIN_MIN_VER})
+-  set(DARWIN_osx_BUILTIN_ALL_POSSIBLE_ARCHS ${X86} ${X86_64})
+-  # Add support for arm64 macOS if available in SDK.
+-  foreach(arch ${ARM64})
+-    sdk_has_arch_support(${DARWIN_osx_SYSROOT} macosx ${arch} MACOS_ARM_SUPPORT)
+-    if (MACOS_ARM_SUPPORT)
+-     list(APPEND DARWIN_osx_BUILTIN_ALL_POSSIBLE_ARCHS ${arch})
+-    endif()
+-  endforeach(arch)
++  set(DARWIN_osx_BUILTIN_ALL_POSSIBLE_ARCHS ${X86} ${X86_64} ${ARM64})
+ 
+   if(COMPILER_RT_ENABLE_IOS)
+     list(APPEND DARWIN_EMBEDDED_PLATFORMS ios)


### PR DESCRIPTION
###### Description of changes

On Darwin, compiler-rt is missing builtins. There is supposed to be a `libclang_rt.osx.a`, but it is missing completely. I'm a little surprised this wasn't an issue before, but I'm trying to build some code that uses `if (@available(...))` which is breaking, because it uses `__isPlatformVersionAtLeast` from compiler-rt.

I believe this is down to the CMake configuration using `xcrun` to determine what to build for the target SDK, and we simply didn't provide it and ignored the errors. In #185969, I added the necessary functionality to our shell-based `xcrun`, and more importantly made it available separately from `xcbuild` as `xcbuild.xcrun`. This hopefully means it's not an objection to make it part of Darwin stdenv, as it's just a bunch of Nix-generated scripts and files.

I'm also patching out a check that uses `PlistBuddy`. We could add the field to our `SDKSettings.plist`, but the output of querying an array with `PlistBuddy` from facebook/xcbuild is different from Apple's `PlistBuddy`. I felt it was easier to patch the CMake check.

Finally, I removed the subtitute rule that disabled ARM64, because it is obviously essential. I believe this was just a workaround for the other issues.

I tested buils of compiler-rt itself on `x86_64-darwin`, versions 12, 13 & 14. On `aarch64-darwin`, I did a full rebuild of stdenv including version 11, and also tested version 13 (part of my intended build).

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).