### PR TITLE
[DRAFT] python310Packages.blis: 0.9.0 -> 0.9.1

### DIFF
--- a/pkgs/development/python-modules/blis/default.nix
+++ b/pkgs/development/python-modules/blis/default.nix
@@ -4,16 +4,16 @@
 , cython
 , hypothesis
 , numpy
-, pytest
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "blis";
-  version = "0.9.0";
+  version = "0.9.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-aZ4coUlnFjcLS5tSfFjYQr+JKGPY2UTNoy+HIO08tCk=";
+    sha256 = "sha256-fOrEZoAfnZfss04Q3e2MJM9eCSfqfoNNocydLtP8Nm8=";
   };
 
   nativeBuildInputs = [
@@ -27,13 +27,16 @@ buildPythonPackage rec {
 
   checkInputs = [
     hypothesis
-    pytest
+    pytestCheckHook
   ];
+
+  pythonImportsCheck = [ "blis" ];
 
   meta = with lib; {
     description = "BLAS-like linear algebra library";
     homepage = "https://github.com/explosion/cython-blis";
     license = licenses.bsd3;
     platforms = platforms.x86_64;
+    maintainers = with maintainers; [ onny ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Currently tests fail with
```
___________________ ERROR collecting blis/tests/test_dotv.py ___________________
ImportError while importing test module '/build/blis-0.9.1/blis/tests/test_dotv.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/nix/store/rc9cz7z4qlgmsbwvpw2acig5g2rdws46-python3-3.10.5/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
blis/__init__.py:3: in <module>
    from .cy import init
E   ModuleNotFoundError: No module named 'blis.cy'
___________________ ERROR collecting blis/tests/test_gemm.py ___________________
ImportError while importing test module '/build/blis-0.9.1/blis/tests/test_gemm.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/nix/store/rc9cz7z4qlgmsbwvpw2acig5g2rdws46-python3-3.10.5/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
blis/__init__.py:3: in <module>
    from .cy import init
E   ModuleNotFoundError: No module named 'blis.cy'
```
Even tough compiling the cython module seems to work and it is copied to the output :( 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
