### PR TITLE
qtbase: remove mkspecs/features/mac/sdk.mk

### DIFF
--- a/pkgs/development/libraries/qt-5/5.15/qtbase.patch.d/0001-qtbase-mkspecs-mac.patch
+++ b/pkgs/development/libraries/qt-5/5.15/qtbase.patch.d/0001-qtbase-mkspecs-mac.patch
@@ -355,6 +355,37 @@ index e3534561a5..3b01424e67 100644
 -xcode_copy_phase_strip_setting.name = COPY_PHASE_STRIP
 -xcode_copy_phase_strip_setting.value = NO
 -QMAKE_MAC_XCODE_SETTINGS += xcode_copy_phase_strip_setting
+diff --git a/mkspecs/features/mac/sdk.mk b/mkspecs/features/mac/sdk.mk
+--- a/mkspecs/features/mac/sdk.mk
++++ b/mkspecs/features/mac/sdk.mk
+@@ -1,27 +0,0 @@
+-
+-ifeq ($(QT_MAC_SDK_NO_VERSION_CHECK),)
+-    CHECK_SDK_COMMAND = /usr/bin/xcrun --sdk $(EXPORT_QMAKE_MAC_SDK) -show-sdk-version 2>/dev/null
+-    CURRENT_MAC_SDK_VERSION := $(shell DEVELOPER_DIR=$(EXPORT_QMAKE_XCODE_DEVELOPER_PATH) $(CHECK_SDK_COMMAND))
+-    ifneq ($(CURRENT_MAC_SDK_VERSION),$(EXPORT_QMAKE_MAC_SDK_VERSION))
+-        # We don't want to complain about out of date SDK unless the target needs to be remade.
+-        # This covers use-cases such as running 'make check' after moving the build to a
+-        # computer without Xcode or with a different Xcode version.
+-        TARGET_UP_TO_DATE := $(shell QT_MAC_SDK_NO_VERSION_CHECK=1 $(MAKE) --question $(QMAKE_TARGET) && echo 1 || echo 0)
+-        ifeq ($(TARGET_UP_TO_DATE),0)
+-            ifneq ($(findstring missing DEVELOPER_DIR path,$(CURRENT_MAC_SDK_VERSION)),)
+-                $(info The developer dir $(EXPORT_QMAKE_XCODE_DEVELOPER_PATH) is no longer valid.)
+-            else ifneq ($(findstring SDK "$(EXPORT_QMAKE_MAC_SDK)" cannot be located,$(CURRENT_MAC_SDK_VERSION)),)
+-                $(info The developer dir $(EXPORT_QMAKE_XCODE_DEVELOPER_PATH) no longer contains the $(EXPORT_QMAKE_MAC_SDK_VERSION) platform SDK.)
+-            else ifneq ($(CURRENT_MAC_SDK_VERSION),)
+-                $(info The $(EXPORT_QMAKE_MAC_SDK) platform SDK has been changed from version $(EXPORT_QMAKE_MAC_SDK_VERSION) to version $(CURRENT_MAC_SDK_VERSION).)
+-            else
+-                $(info Unknown error resolving current platform SDK version.)
+-            endif
+-            $(info This requires a fresh build of your project. Please wipe the build directory)
+-            ifneq ($(EXPORT__QMAKE_STASH_),)
+-                $(info including the qmake cache in $(EXPORT__QMAKE_STASH_))
+-            endif
+-            $(error ^)
+-        endif
+-    endif
+-endif
 diff --git a/mkspecs/features/mac/sdk.prf b/mkspecs/features/mac/sdk.prf
 deleted file mode 100644
 index 3a9c2778bb..0000000000


### PR DESCRIPTION
###### Description of changes

Partially reverting changes in https://github.com/NixOS/nixpkgs/commit/9cc292055888b2f8eb75f99b70cf17c3334b33a6 since after this commit qtbase stopped to build on my aarch64-darwin system. Issue discussed here https://github.com/NixOS/nixpkgs/issues/185521.

Unfortunately I didn't know much about qt building process and I don't understand why we have to remove `mkspecs/features/mac/sdk.mk` from sources, I've only find this commit https://github.com/NixOS/nixpkgs/commit/70c1c856d4c96fb37b6e507db4acb125656f992d as first place where we deleted this file on qt 5.12. After that this patch copied to all other qt versions upto 5.15.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`). _I've tested that resulting qmake builds simple hello world project using qtwidgets._
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).