### PR TITLE
discord: remove nss from LD_LIBRARY_PATH

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/linux.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/linux.nix
@@ -77,7 +77,6 @@ stdenv.mkDerivation rec {
     libXrender
     libXtst
     nspr
-    nss
     libxcb
     pango
     libXScrnSaver


### PR DESCRIPTION
Avoids contaminating Firefox launched from Discord with the wrong version of nss, fixes https://github.com/NixOS/nixpkgs/issues/78961

`libnss3.so` is already in the binary's DT_NEEDED, and removing it from LD_LIBRARY_PATH doesn't seem to make Discord complain.

Note that **I have no idea what I am doing** and have many questions:

1. how are we even supposed to know what runtime libraries Discord requires? I can't find this information anywhere.
2. why are some of those libraries in DT_NEEDED and some aren't? Does this has to do with some of them being `dlopen`ed and some not?
3. why do we need to put all those libraries in LD_LIBRARY_PATH? From the original PR https://github.com/NixOS/nixpkgs/pull/33666 (cc @dtzWill) it seems like this is because DT_RUNPATH is scoped and thus not inherited by plugins, so I tried playing around with `patchelf --force-rpath --set-rpath ${libPath}` instead to put everything in DT_RPATH, but then Discord complains about a corrupt installation (but still seems to work fine).