### PR TITLE
tesseract5: fix darwin compilation

### DIFF
--- a/pkgs/applications/graphics/tesseract/default.nix
+++ b/pkgs/applications/graphics/tesseract/default.nix
@@ -1,9 +1,11 @@
-{ callPackage, lowPrio }:
+{ callPackage, lowPrio, Accelerate, CoreGraphics, CoreVideo}:
 
 let
   base3 = callPackage ./tesseract3.nix {};
   base4 = callPackage ./tesseract4.nix {};
-  base5 = callPackage ./tesseract5.nix {};
+  base5 = callPackage ./tesseract5.nix {
+    inherit Accelerate CoreGraphics CoreVideo;
+  };
   languages = callPackage ./languages.nix {};
 in
 {

--- a/pkgs/applications/graphics/tesseract/tesseract5.nix
+++ b/pkgs/applications/graphics/tesseract/tesseract5.nix
@@ -1,5 +1,7 @@
 { lib, stdenv, fetchFromGitHub, autoreconfHook, autoconf-archive, pkg-config
-, leptonica, libpng, libtiff, icu, pango, opencl-headers, fetchpatch }:
+, leptonica, libpng, libtiff, icu, pango, opencl-headers, fetchpatch
+, Accelerate, CoreGraphics, CoreVideo
+}:
 
 stdenv.mkDerivation rec {
   pname = "tesseract";
@@ -27,6 +29,10 @@ stdenv.mkDerivation rec {
     icu
     pango
     opencl-headers
+  ] ++ lib.optionals stdenv.isDarwin [
+    Accelerate
+    CoreGraphics
+    CoreVideo
   ];
 
   meta = {
@@ -34,6 +40,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/tesseract-ocr/tesseract";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ anselmschueler ];
-    platforms = with lib.platforms; linux ++ darwin;
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30829,7 +30829,9 @@ with pkgs;
 
   termtosvg = callPackage ../tools/misc/termtosvg { };
 
-  inherit (callPackage ../applications/graphics/tesseract {})
+  inherit (callPackage ../applications/graphics/tesseract {
+    inherit (darwin.apple_sdk.frameworks) Accelerate CoreGraphics CoreVideo;
+  })
     tesseract3
     tesseract4
     tesseract5;


### PR DESCRIPTION
###### Description of changes

Update tesseract5 to include the required darwin frameworks.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
