### PR TITLE
python3Packages.psycopg: package pool and c variants

### DIFF
--- a/pkgs/development/python-modules/psycopg/default.nix
+++ b/pkgs/development/python-modules/psycopg/default.nix
@@ -6,12 +6,16 @@
 , pythonOlder
 , substituteAll
 
-# links (libpq)
+# build
 , postgresql
+, setuptools
 
 # propagates
 , backports-zoneinfo
 , typing-extensions
+
+# psycopg-c
+, cython_3
 
 # docs
 , furo
@@ -29,13 +33,6 @@
 let
   pname = "psycopg";
   version = "3.0.16";
-in
-
-buildPythonPackage {
-  inherit pname version;
-  format = "pyproject";
-
-  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "psycopg";
@@ -43,6 +40,80 @@ buildPythonPackage {
     rev = version;
     hash = "sha256-jKhpmCcDi7FyMSpn51eSukFvmu3yacNovmRYG9jnu3g=";
   };
+
+  patches = [
+    (substituteAll {
+      src = ./libpq.patch;
+      libpq = "${postgresql.lib}/lib/libpq${stdenv.hostPlatform.extensions.sharedLibrary}";
+    })
+  ];
+
+  baseMeta = {
+    changelog = "https://github.com/psycopg/psycopg/blob/master/docs/news.rst";
+    homepage = "https://github.com/psycopg/psycopg";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ hexa ];
+  };
+
+  psycopg-c = buildPythonPackage {
+    pname = "${pname}-c";
+    inherit version src;
+    format = "pyproject";
+
+    # apply patches to base repo
+    inherit patches;
+
+    # move into source root after patching
+    postPatch = ''
+      cd psycopg_c
+    '';
+
+    nativeBuildInputs = [
+      setuptools
+      cython_3
+      postgresql
+    ];
+
+    # tested in psycopg
+    doCheck = false;
+
+    meta = baseMeta // {
+      description = "C optimisation distribution for Psycopg";
+    };
+  };
+
+  psycopg-pool = buildPythonPackage {
+    pname = "${pname}-pool";
+    inherit version src;
+    format = "setuptools";
+
+    # apply patches to base repo
+    inherit patches;
+
+    # move into source root after patching
+    postPatch = ''
+      cd psycopg_pool
+    '';
+
+    propagatedBuildInputs = lib.optionals (pythonOlder "3.10") [
+      typing-extensions
+    ];
+
+    # tested in psycopg
+    doCheck = false;
+
+    meta = baseMeta // {
+      description = "Connection Pool for Psycopg";
+    };
+  };
+
+in
+
+buildPythonPackage rec {
+  inherit pname version src;
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
 
   outputs = [
     "out"
@@ -57,26 +128,24 @@ buildPythonPackage {
     hash = "sha256-yn09fR9+7zQni8SvTG7BUmYRD7MK7u2arVAznWz2oAw=";
   };
 
-  patches = [
-    (substituteAll {
-      src = ./libpq.patch;
-      libpq = "${postgresql.lib}/lib/libpq${stdenv.hostPlatform.extensions.sharedLibrary}";
-    })
-  ];
+  inherit patches;
 
   # only move to sourceRoot after patching, makes patching easier
   postPatch = ''
-    cd ${pname}
+    cd psycopg
   '';
 
   nativeBuildInputs = [
     furo
+    setuptools
     shapely
-    sphinxHook
     sphinx-autodoc-typehints
+    sphinxHook
   ];
 
-  propagatedBuildInputs = lib.optionals (pythonOlder "3.11") [
+  propagatedBuildInputs = [
+    psycopg-c
+  ] ++ lib.optionals (pythonOlder "3.11") [
     typing-extensions
   ] ++ lib.optionals (pythonOlder "3.9") [
     backports-zoneinfo
@@ -84,12 +153,13 @@ buildPythonPackage {
 
   pythonImportsCheck = [
     "psycopg"
+    "psycopg_c"
+    "psycopg_pool"
   ];
 
   passthru.optional-dependencies = {
-    # TODO: package remaining variants
-    #c = [ psycopg-c ];
-    #pool = [ psycopg-pool ];
+    c = [ psycopg-c ];
+    pool = [ psycopg-pool ];
   };
 
   preCheck = ''
@@ -102,16 +172,17 @@ buildPythonPackage {
     pytest-randomly
     pytestCheckHook
     postgresql
-  ];
+  ]
+  ++ passthru.optional-dependencies.c
+  ++ passthru.optional-dependencies.pool;
 
   disabledTests = [
-    # linters shouldn't be run in checks
+    # don't depend on mypy for tests
     "test_version"
+    "test_package_version"
   ];
 
   disabledTestPaths = [
-    # TODO: requires the pooled variant
-    "tests/pool/"
     # Network access
     "tests/test_dns.py"
     "tests/test_dns_srv.py"
@@ -127,11 +198,12 @@ buildPythonPackage {
     cd ${pname}
   '';
 
-  meta = with lib; {
-    changelog = "https://github.com/psycopg/psycopg/blob/master/docs/news.rst";
+  passthru = {
+    c = psycopg-c;
+    pool = psycopg-pool;
+  };
+
+  meta = baseMeta // {
     description = "PostgreSQL database adapter for Python";
-    homepage = "https://github.com/psycopg/psycopg";
-    license = licenses.lgpl3Plus;
-    maintainers = with maintainers; [ hexa ];
   };
 }

--- a/pkgs/development/python-modules/psycopg/default.nix
+++ b/pkgs/development/python-modules/psycopg/default.nix
@@ -180,6 +180,10 @@ buildPythonPackage rec {
     # don't depend on mypy for tests
     "test_version"
     "test_package_version"
+  ] ++ lib.optionals (stdenv.isDarwin) [
+    # racy test
+    "test_sched"
+    "test_sched_error"
   ];
 
   disabledTestPaths = [


### PR DESCRIPTION
Both implementations require the basic psycopg package and cannot exist
without it. Therefore they have no global name within the python package
set and are only accessible via psycopg's optional-dependencies.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
