### PR TITLE
gcl_2_6_13_pre: 2.6.13pre50 -> 2.6.13pre124 (fix build)

### DIFF
--- a/pkgs/development/compilers/gcl/2.6.13-pre.nix
+++ b/pkgs/development/compilers/gcl/2.6.13-pre.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchgit, mpfr, m4, binutils, emacs, zlib, which
-, texinfo, libX11, xorgproto, libXi, gmp, readline, strace
+, texinfo, libX11, xorgproto, libXi, gmp, readline
 , libXext, libXt, libXaw, libXmu } :
 
 assert stdenv ? cc ;
@@ -7,26 +7,24 @@ assert stdenv.cc.isGNU ;
 assert stdenv.cc ? libc ;
 assert stdenv.cc.libc != null ;
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "gcl";
-  version = "2.6.13pre50";
+  version = "2.6.13pre124";
 
   src = fetchgit {
-    sha256 = "0vpxb6z5g9fjavrgx8gz8fsjvskfz64f63qibh5s00fvvndlwi88";
+    sha256 = "sha256-e4cUQlNSfdz+B3urlZ82pf7fTc6aoloUyDDorAUi5kc=";
     url = "https://git.savannah.gnu.org/r/gcl.git";
-    rev = "refs/tags/Version_2_6_13pre50";
+    rev = "refs/tags/Version_${builtins.replaceStrings ["."] ["_"] version}";
   };
 
   postPatch = ''
     sed -e 's/<= obj-date/<= (if (= 0 obj-date) 1 obj-date)/' -i lsp/make.lisp
-  ''
-  # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=902475
-  + ''
-    substituteInPlace h/elf64_i386_reloc.h \
-      --replace 'case R_X86_64_PC32:' 'case R_X86_64_PC32: case R_X86_64_PLT32:'
   '';
 
   sourceRoot = "gcl/gcl";
+
+  # breaks when compiling in parallel
+  enableParallelBuilding = false;
 
   patches = [];
 
@@ -34,7 +32,7 @@ stdenv.mkDerivation {
     mpfr m4 binutils emacs gmp
     libX11 xorgproto libXi
     libXext libXt libXaw libXmu
-    zlib which texinfo readline strace
+    zlib which texinfo readline
   ];
 
   configureFlags = [


### PR DESCRIPTION
###### Description of changes

noticed while reviewing: https://github.com/NixOS/nixpkgs/pull/186637

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
