### PR TITLE
nixos/https-dns-proxy: bump version and add support for OpenDNS

### DIFF
--- a/pkgs/servers/dns/https-dns-proxy/default.nix
+++ b/pkgs/servers/dns/https-dns-proxy/default.nix
@@ -1,24 +1,40 @@
 { lib, stdenv, fetchFromGitHub, cmake, gtest, c-ares, curl, libev }:
 
+let
+  # https-dns-proxy supports HTTP3 if curl has support, but as of 2022-08 curl doesn't work with that enabled
+  # curl' = (curl.override { http3Support = true; });
+  curl' = curl;
+
+in
 stdenv.mkDerivation rec {
   pname = "https-dns-proxy";
   # there are no stable releases (yet?)
-  version = "unstable-2021-03-29";
+  version = "unstable-2022-05-05";
 
   src = fetchFromGitHub {
     owner = "aarond10";
     repo = "https_dns_proxy";
-    rev = "bbd9ef272dcda3ead515871f594768af13192af7";
-    sha256 = "sha256-r+IpDklI3vITK8ZlZvIFm3JdDe2r8DK2ND3n1a/ThrM=";
+    rev = "d310a378795790350703673388821558163944de";
+    hash = "sha256-On4SKUeltPhzM/x+K9aKciKBw5lmVySxnmLi2tnKr3Y=";
   };
+
+  postPatch = ''
+    substituteInPlace https_dns_proxy.service.in \
+      --replace "\''${CMAKE_INSTALL_PREFIX}/" ""
+    substituteInPlace munin/https_dns_proxy.plugin \
+      --replace '--unit https_dns_proxy.service' '--unit https-dns-proxy.service'
+  '';
 
   nativeBuildInputs = [ cmake gtest ];
 
-  buildInputs = [ c-ares curl libev ];
+  buildInputs = [ c-ares curl' libev ];
 
-  installPhase = ''
-    install -Dm555 -t $out/bin https_dns_proxy
-    install -Dm444 -t $out/share/doc/${pname} ../{LICENSE,README}.*
+  postInstall = ''
+    install -Dm444 -t $out/share/doc/${pname} ../{LICENSE,*.md}
+    install -Dm444 -t $out/share/${pname}/munin ../munin/*
+    # the systemd service definition is garbage, and we use our own with NixOS
+    mv $out/lib/systemd $out/share/${pname}
+    rmdir $out/lib
   '';
 
   # upstream wants to add tests and the gtest framework is in place, so be ready
@@ -30,5 +46,6 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     maintainers = with maintainers; [ peterhoeg ];
     platforms = platforms.linux;
+    mainProgram = "https_dns_proxy";
   };
 }


### PR DESCRIPTION

###### Description of changes

- https-dns-proxy: 2021-03-29 -> 2022-05-05
- nixos/https-dns-proxy: add OpenDNS support

Plus a few minor touch-ups in the NixOS module.

This PR was opened over a connection with DNS provided by this module.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
