### PR TITLE
zim: 0.74.2 -> 0.74.3

### DIFF
--- a/pkgs/applications/office/zim/default.nix
+++ b/pkgs/applications/office/zim/default.nix
@@ -7,18 +7,24 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "zim";
-  version = "0.74.2";
+  version = "0.74.3";
 
   src = fetchurl {
     url = "https://zim-wiki.org/downloads/zim-${version}.tar.gz";
-    sha256 = "sha256-tZxBlpps2nLThSOq3WJ42iUQ4NG1Lb463bvDQ+djZJA=";
+    sha256 = "sha256-3ehPIkhsf1JnC9Qx3kQ6ilvRaBB7auBm2C1HOuNGzRU=";
   };
 
-  buildInputs = [ gtk3 gobject-introspection wrapGAppsHook gnome.adwaita-icon-theme ];
+  buildInputs = [ gtk3 gobject-introspection gnome.adwaita-icon-theme ];
   propagatedBuildInputs = with python3Packages; [ pyxdg pygobject3 ];
+  # see https://github.com/NixOS/nixpkgs/issues/56943#issuecomment-1131643663
+  nativeBuildInputs = [ gobject-introspection wrapGAppsHook ];
+
+  dontWrapGApps = true;
 
   preFixup = ''
-    export makeWrapperArgs="--prefix XDG_DATA_DIRS : $out/share --argv0 $out/bin/.zim-wrapped"
+    makeWrapperArgs+=(--prefix XDG_DATA_DIRS : $out/share)
+    makeWrapperArgs+=(--argv0 $out/bin/.zim-wrapped)
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
   '';
 
   # RuntimeError: could not create GtkClipboard object
@@ -31,6 +37,7 @@ python3Packages.buildPythonApplication rec {
   meta = with lib; {
     description = "A desktop wiki";
     homepage = "https://zim-wiki.org/";
+    changelog = "https://github.com/zim-desktop-wiki/zim-desktop-wiki/blob/${version}/CHANGELOG.md";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ pSub ];
     broken = stdenv.isDarwin; # https://github.com/NixOS/nixpkgs/pull/52658#issuecomment-449565790


### PR DESCRIPTION
###### Description of changes
Changelog: https://github.com/zim-desktop-wiki/zim-desktop-wiki/blob/0.74.3/CHANGELOG.md#0743---tue-07-dec-2021

This also fixes problems with the build failing due to missing gobject-interospection. See https://github.com/NixOS/nixpkgs/issues/56943#issuecomment-1131643663 for issue and other packages affected by this. Resolves #186451.

Also, stop double-wrapping `bin/zim`.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).