### PR TITLE
Change clickhouse's module conf directory to permit overrides

### DIFF
--- a/nixos/modules/services/databases/clickhouse.nix
+++ b/nixos/modules/services/databases/clickhouse.nix
@@ -54,7 +54,7 @@ with lib;
         AmbientCapabilities = "CAP_SYS_NICE";
         StateDirectory = "clickhouse";
         LogsDirectory = "clickhouse";
-        ExecStart = "${cfg.package}/bin/clickhouse-server --config-file=${cfg.package}/etc/clickhouse-server/config.xml";
+        ExecStart = "${cfg.package}/bin/clickhouse-server --config-file=/etc/clickhouse-server/config.xml";
       };
     };
 


### PR DESCRIPTION
The module already creates the file `/etc/clickhouse-server/config.xml`.

If the service uses this file for config instead of the one in the package, it permits to override the conf like this:

```nix
environment.etc."clickhouse-server/config.d/logging.xml".text = ''
  <clickhouse>
    <logger>
      <level>notice</level>
    <logger>
  </clickhouse>
'';
```

###### Description of changes

`systemd.services.clickhouse.serviceConfig.ExecStart` now uses `/etc/clickhouse/` config. 
