### PR TITLE
Clickhouse reduce verbosity

### DIFF
--- a/nixos/modules/services/databases/clickhouse.nix
+++ b/nixos/modules/services/databases/clickhouse.nix
@@ -54,7 +54,7 @@ with lib;
         AmbientCapabilities = "CAP_SYS_NICE";
         StateDirectory = "clickhouse";
         LogsDirectory = "clickhouse";
-        ExecStart = "${cfg.package}/bin/clickhouse-server --config-file=${cfg.package}/etc/clickhouse-server/config.xml";
+        ExecStart = "${cfg.package}/bin/clickhouse-server --config-file=/etc/clickhouse-server/config.xml";
       };
     };
 

--- a/nixos/modules/services/databases/clickhouse.nix
+++ b/nixos/modules/services/databases/clickhouse.nix
@@ -66,6 +66,15 @@ with lib;
       "clickhouse-server/users.xml" = {
         source = "${cfg.package}/etc/clickhouse-server/users.xml";
       };
+      "clickhouse-server/config.d/logging.xml" = {
+        text = ''
+          <clickhouse>
+            <logger>
+              <level>notice</level>
+            <logger>
+          </clickhouse>
+        '';
+      };
     };
 
     environment.systemPackages = [ cfg.package ];


### PR DESCRIPTION
Clickhouse default configuration has a very verbose level.
For instance, on my home server, with a small load from plausible, it generated ~1 GB of logs per day.

I don't know if introducing this kind of breaking change needs some attention or modifications in the releases notes.

Reduce verbosity level from 8 (trace) to 5 (notice).

Needs PR #186660 (first commit od this PR)
