### PR TITLE
netbird: init at 0.8.9

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -207,6 +207,13 @@
       </listitem>
       <listitem>
         <para>
+          <link xlink:href="https://netbird.io">netbird</link>, a zero
+          configuration VPN. Available as
+          <link xlink:href="options.html#opt-services.netbird.enable">services.netbird</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <link xlink:href="https://github.com/aiberia/persistent-evdev">persistent-evdev</link>,
           a daemon to add virtual proxy devices that mirror a physical
           input device but persist even if the underlying hardware is

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -76,6 +76,9 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [Outline](https://www.getoutline.com/), a wiki and knowledge base similar to Notion. Available as [services.outline](#opt-services.outline.enable).
 
+- [netbird](https://netbird.io), a zero configuration VPN.
+  Available as [services.netbird](options.html#opt-services.netbird.enable).
+
 - [persistent-evdev](https://github.com/aiberia/persistent-evdev), a daemon to add virtual proxy devices that mirror a physical input device but persist even if the underlying hardware is hot-plugged. Available as [services.persistent-evdev](#opt-services.persistent-evdev.enable).
 
 - [schleuder](https://schleuder.org/), a mailing list manager with PGP support. Enable using [services.schleuder](#opt-services.schleuder.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -861,6 +861,7 @@
   ./services/networking/nbd.nix
   ./services/networking/ndppd.nix
   ./services/networking/nebula.nix
+  ./services/networking/netbird.nix
   ./services/networking/networkmanager.nix
   ./services/networking/nextdns.nix
   ./services/networking/nftables.nix

--- a/nixos/modules/services/networking/netbird.nix
+++ b/nixos/modules/services/networking/netbird.nix
@@ -1,0 +1,64 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.netbird;
+  kernel = config.boot.kernelPackages;
+  interfaceName = "wt0";
+in {
+  meta.maintainers = with maintainers; [ misuzu ];
+
+  options.services.netbird = {
+    enable = mkEnableOption "Netbird daemon";
+    package = mkOption {
+      type = types.package;
+      default = pkgs.netbird;
+      defaultText = literalExpression "pkgs.netbird";
+      description = "The package to use for netbird";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    boot.extraModulePackages = optional (versionOlder kernel.kernel.version "5.6") kernel.wireguard;
+
+    environment.systemPackages = [ cfg.package ];
+
+    networking.dhcpcd.denyInterfaces = [ interfaceName ];
+
+    systemd.network.networks."50-netbird" = mkIf config.networking.useNetworkd {
+      matchConfig = {
+        Name = interfaceName;
+      };
+      linkConfig = {
+        Unmanaged = true;
+        ActivationPolicy = "manual";
+      };
+    };
+
+    systemd.services.netbird = {
+      description = "A WireGuard-based mesh network that connects your devices into a single private network";
+      documentation = [ "https://netbird.io/docs/" ];
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        AmbientCapabilities = [ "CAP_NET_ADMIN" ];
+        DynamicUser = true;
+        Environment = [
+          "NB_CONFIG=/var/lib/netbird/config.json"
+          "NB_LOG_FILE=console"
+        ];
+        ExecStart = "${cfg.package}/bin/netbird service run";
+        Restart = "always";
+        RuntimeDirectory = "netbird";
+        StateDirectory = "netbird";
+        WorkingDirectory = "/var/lib/netbird";
+      };
+      unitConfig = {
+        StartLimitInterval = 5;
+        StartLimitBurst = 10;
+      };
+      stopIfChanged = false;
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -357,6 +357,7 @@ in {
   ncdns = handleTest ./ncdns.nix {};
   ndppd = handleTest ./ndppd.nix {};
   nebula = handleTest ./nebula.nix {};
+  netbird = handleTest ./netbird.nix {};
   neo4j = handleTest ./neo4j.nix {};
   netdata = handleTest ./netdata.nix {};
   networking.networkd = handleTest ./networking.nix { networkd = true; };

--- a/nixos/tests/netbird.nix
+++ b/nixos/tests/netbird.nix
@@ -1,0 +1,21 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }:
+{
+  name = "netbird";
+
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ misuzu ];
+  };
+
+  nodes = {
+    node = { ... }: {
+      services.netbird.enable = true;
+    };
+  };
+
+  testScript = ''
+    start_all()
+    node.wait_for_unit("netbird.service")
+    node.wait_for_file("/var/run/netbird/sock")
+    node.succeed("netbird status | grep -q 'Daemon status: NeedsLogin'")
+  '';
+})

--- a/pkgs/tools/networking/netbird/default.nix
+++ b/pkgs/tools/networking/netbird/default.nix
@@ -80,6 +80,8 @@ buildGoModule rec {
         --replace "Exec=/usr/bin/netbird-ui" "Exec=$out/bin/netbird-ui"
     '';
 
+  passthru.tests.netbird = nixosTests.netbird;
+
   meta = with lib; {
     homepage = "https://netbird.io";
     description = "Connect your devices into a single secure private WireGuard®-based mesh network with SSO/MFA and simple access controls";

--- a/pkgs/tools/networking/netbird/default.nix
+++ b/pkgs/tools/networking/netbird/default.nix
@@ -1,0 +1,89 @@
+{ stdenv, lib, nixosTests, buildGoModule, fetchFromGitHub, installShellFiles
+, pkg-config
+, libayatana-appindicator, libX11, libXcursor, libXxf86vm
+, Cocoa, IOKit, Kernel, UserNotifications, WebKit
+, ui ? false }:
+let
+  modules = if ui then {
+    "client/ui" = "netbird-ui";
+  } else {
+    client = "netbird";
+    management = "netbird-mgmt";
+    signal = "netbird-signal";
+  };
+in
+buildGoModule rec {
+  pname = "netbird";
+  version = "0.8.9";
+
+  src = fetchFromGitHub {
+    owner = "netbirdio";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-bQrfYbzYd6T9PD2lLuldp1pGoZKpU71bO1D1SXcoZ7M=";
+  };
+
+  vendorSha256 = "sha256-KtRQwrCBsOX7Jk9mKdDNOD7zfssADfBXCO1RPZbp5Aw=";
+
+  nativeBuildInputs = [ installShellFiles ] ++ lib.optional ui pkg-config;
+
+  buildInputs = lib.optionals (stdenv.isLinux && ui) [
+    libayatana-appindicator
+    libX11
+    libXcursor
+    libXxf86vm
+  ] ++ lib.optionals (stdenv.isDarwin && ui) [
+    Cocoa
+    IOKit
+    Kernel
+    UserNotifications
+    WebKit
+  ];
+
+  subPackages = lib.attrNames modules;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/netbirdio/netbird/client/system.version=${version}"
+    "-X main.builtBy=nix"
+  ];
+
+  # needs network access
+  doCheck = false;
+
+  postPatch = ''
+    # make it compatible with systemd's RuntimeDirectory
+    substituteInPlace client/cmd/root.go \
+      --replace 'unix:///var/run/netbird.sock' 'unix:///var/run/netbird/sock'
+    substituteInPlace client/ui/client_ui.go \
+      --replace 'unix:///var/run/netbird.sock' 'unix:///var/run/netbird/sock'
+  '';
+
+  postInstall = lib.concatStringsSep "\n" (lib.mapAttrsToList
+    (module: binary: ''
+      mv $out/bin/${lib.last (lib.splitString "/" module)} $out/bin/${binary}
+    '' + lib.optionalString (!ui) ''
+      installShellCompletion --cmd ${binary} \
+        --bash <($out/bin/${binary} completion bash) \
+        --fish <($out/bin/${binary} completion fish) \
+        --zsh <($out/bin/${binary} completion zsh)
+    '')
+    modules) + lib.optionalString (stdenv.isLinux && ui) ''
+      mkdir -p $out/share/pixmaps
+      cp $src/client/ui/disconnected.png $out/share/pixmaps/netbird.png
+
+      mkdir -p $out/share/applications
+      cp $src/client/ui/netbird.desktop $out/share/applications/netbird.desktop
+
+      substituteInPlace $out/share/applications/netbird.desktop \
+        --replace "Exec=/usr/bin/netbird-ui" "Exec=$out/bin/netbird-ui"
+    '';
+
+  meta = with lib; {
+    homepage = "https://netbird.io";
+    description = "Connect your devices into a single secure private WireGuard®-based mesh network with SSO/MFA and simple access controls";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ misuzu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5137,6 +5137,14 @@ with pkgs;
     inherit (xorg) libXaw;
   };
 
+  netbird = callPackage ../tools/networking/netbird {
+    inherit (darwin.apple_sdk_11_0.frameworks) Cocoa IOKit Kernel UserNotifications WebKit;
+  };
+
+  netbird-ui = netbird.override {
+    ui = true;
+  };
+
   netevent = callPackage ../tools/inputmethods/netevent { };
 
   netplan = callPackage ../tools/admin/netplan { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/netbirdio/netbird
https://netbird.io

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
