### PR TITLE
python3Packages.stim: init at 1.9.0

### DIFF
--- a/pkgs/development/python-modules/stim/default.nix
+++ b/pkgs/development/python-modules/stim/default.nix
@@ -1,0 +1,67 @@
+{ lib
+, pkgs
+, buildPythonPackage
+, pythonOlder
+, pytestCheckHook
+, pytest-xdist
+, fetchFromGitHub
+, numpy
+, pybind11
+, cirq-core
+, matplotlib
+, networkx
+, scipy
+, pandas
+}:
+
+buildPythonPackage rec {
+  pname = "stim";
+  version = "1.9.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.6";
+
+  src = pkgs.fetchFromGitHub {
+    owner = "quantumlib";
+    repo = "Stim";
+    rev = "refs/tags/v${version}";
+    sha256 = "sha256-zXWdJjFkf74FCWxyVMF8dx0P8GmUkuHFxUo5wYNU2o0=";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+    pybind11
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-xdist
+
+    cirq-core
+    matplotlib
+    networkx
+    scipy
+    pandas
+  ];
+
+  meta = {
+    description = "A tool for high performance simulation and analysis of quantum stabilizer circuits, especially quantum error correction (QEC) circuits.";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ chrispattison ];
+    homepage = "https://github.com/quantumlib/stim";
+  };
+
+  pythonImportsCheck = [ "stim" ];
+
+  enableParallelBuilding = true;
+
+  disabledTestPaths = [
+    # No pymatching
+    "glue/sample/src/sinter/main_test.py"
+    "glue/sample/src/sinter/decoding_test.py"
+    "glue/sample/src/sinter/predict_test.py"
+    "glue/sample/src/sinter/collection_test.py"
+    "glue/sample/src/sinter/collection_work_manager.py"
+    "glue/sample/src/sinter/worker_test.py"
+  ];
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10339,6 +10339,8 @@ in {
 
   stickytape = callPackage ../development/python-modules/stickytape { };
 
+  stim = callPackage ../development/python-modules/stim { };
+
   stm32loader = callPackage ../development/python-modules/stm32loader { };
 
   stone = callPackage ../development/python-modules/stone { };


### PR DESCRIPTION
###### Description of changes

- Add Python package stim (https://github.com/quantumlib/stim)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
