### PR TITLE
make plausible service start after clickhouse service

### DIFF
--- a/nixos/modules/services/web-apps/plausible.nix
+++ b/nixos/modules/services/web-apps/plausible.nix
@@ -188,7 +188,11 @@ in {
           inherit (pkgs.plausible.meta) description;
           documentation = [ "https://plausible.io/docs/self-hosting" ];
           wantedBy = [ "multi-user.target" ];
-          after = optionals cfg.database.postgres.setup [ "postgresql.service" "plausible-postgres.service" ];
+          after = optional cfg.database.clickhouse.setup "clickhouse.service"
+          ++ optionals cfg.database.postgres.setup [
+              "postgresql.service"
+              "plausible-postgres.service"
+            ];
           requires = optional cfg.database.clickhouse.setup "clickhouse.service"
             ++ optionals cfg.database.postgres.setup [
               "postgresql.service"


### PR DESCRIPTION
Plausible fails on start because clickhouse is not ready,
when clickhouse has low CPU available, eg.
```nix
{systemd.services.clickhouse.serviceConfig.CPUWeight = 20;}
```

Fixed with
```nix
{systemd.services.plausible.after = [ "clickhouse.service" ];}
```