### PR TITLE
quarto: init at 1.1.189

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8920,6 +8920,12 @@
     githubId = 15896005;
     name = "Vladyslav Burzakovskyy";
   };
+  mrtarantoga = {
+    email = "goetz-dev@web.de";
+    name = "Götz Grimmer";
+    github = "MrTarantoga";
+    githubId = 53876219;
+  };
   mrVanDalo = {
     email = "contact@ingolf-wagner.de";
     github = "mrVanDalo";

--- a/pkgs/development/libraries/quarto/default.nix
+++ b/pkgs/development/libraries/quarto/default.nix
@@ -1,0 +1,68 @@
+{ stdenv
+, lib
+, pandoc
+, esbuild
+, deno
+, fetchurl
+, nodePackages
+, rWrapper
+, rPackages
+, makeWrapper
+, python3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "quarto";
+  version = "1.1.189";
+  src = fetchurl {
+    url = "https://github.com/quarto-dev/quarto-cli/releases/download/v${version}/quarto-${version}-linux-amd64.tar.gz";
+    sha256 = "1a3xsgqdccm4ky1xjnin1idpp8gsansskq37c00mrxz1raxn1mi7";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  patches = [
+      ./fix-deno-path.patch
+  ];
+
+  dontStrip = true;
+
+  preFixup = ''
+    wrapProgram $out/bin/quarto \
+      --prefix PATH : ${lib.makeBinPath [ deno ]} \
+      --prefix QUARTO_PANDOC : ${pandoc}/bin/pandoc \
+      --prefix QUARTO_ESBUILD : ${esbuild}/bin/esbuild \
+      --prefix QUARTO_DART_SASS : ${nodePackages.sass}/bin/sass \
+      --prefix QUARTO_R : ${rWrapper.override { packages = [ rPackages.rmarkdown]; }}/bin/R \
+      --prefix QUARTO_PYTHON : ${python3.withPackages (ps: with ps; [ jupyter ipython ])}/bin/python3
+  '';
+
+  installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/bin $out/share
+
+      rm -r bin/tools
+
+      mv bin/* $out/bin
+      mv share/* $out/share
+
+      runHook preInstall
+  '';
+
+  meta = with lib; {
+    description = "Open-source scientific and technical publishing system built on Pandoc";
+    longDescription = ''
+        Quarto is an open-source scientific and technical publishing system built on Pandoc.
+        Quarto documents are authored using markdown, an easy to write plain text format.
+    '';
+    homepage = "https://quarto.org/";
+    changelog = "https://github.com/quarto-dev/quarto-cli/releases/tag/v${version}";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ mrtarantoga ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode binaryBytecode ];
+  };
+}

--- a/pkgs/development/libraries/quarto/default.nix
+++ b/pkgs/development/libraries/quarto/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   ];
 
   patches = [
-      ./fix-deno-path.patch
+    ./fix-deno-path.patch
   ];
 
   dontStrip = true;

--- a/pkgs/development/libraries/quarto/fix-deno-path.patch
+++ b/pkgs/development/libraries/quarto/fix-deno-path.patch
@@ -1,0 +1,8 @@
+--- a/bin/quarto
++++ b/bin/quarto
+@@ -125,4 +125,4 @@ fi
+ # Be sure to include any already defined QUARTO_DENO_OPTIONS
+ QUARTO_DENO_OPTIONS="--unstable --no-config --cached-only --allow-read --allow-write --allow-run --allow-env --allow-net --allow-ffi ${QUARTO_DENO_OPTIONS}"
+ 
+-"${QUARTO_DENO}" ${QUARTO_ACTION} ${QUARTO_DENO_OPTIONS} ${QUARTO_DENO_EXTRA_OPTIONS} "${QUARTO_IMPORT_ARGMAP}" "${QUARTO_TARGET}" "$@"
++deno ${QUARTO_ACTION} ${QUARTO_DENO_OPTIONS} ${QUARTO_DENO_EXTRA_OPTIONS} "${QUARTO_IMPORT_ARGMAP}" "${QUARTO_TARGET}" "$@"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20790,6 +20790,8 @@ with pkgs;
 
   qolibri = libsForQt5.callPackage ../applications/misc/qolibri { };
 
+  quarto = callPackage ../development/libraries/quarto { };
+
   qt4 = qt48;
 
   qt48 = callPackage ../development/libraries/qt-4.x/4.8 {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[Quarto®](https://quarto.org/) is an open-source scientific and technical publishing system built on [Pandoc](https://pandoc.org/)

The idea is, to add quarto support to RStudio.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
