### PR TITLE
pythonPackages.nbclassic: fix build failure due to nodejs deps

### DIFF
--- a/pkgs/development/python-modules/nbclassic/default.nix
+++ b/pkgs/development/python-modules/nbclassic/default.nix
@@ -1,8 +1,8 @@
 { lib
 , buildPythonPackage
-, fetchFromGitHub
-, python
+, fetchPypi
 , notebook
+, notebook-shim
 , pythonOlder
 , jupyter_server
 , pytestCheckHook
@@ -14,23 +14,13 @@ buildPythonPackage rec {
   version = "0.4.3";
   disabled = pythonOlder "3.6";
 
-  # tests only on github
-  src = fetchFromGitHub {
-    owner = "jupyterlab";
-    repo = pname;
-    rev = "refs/tags/v${version}";
-    sha256 = "sha256-5sof5EOqzK7kNHSXp7eJl3ZagZRWF74e08ahqJId2Z8=";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-8DERss66ppuINwp7I7GbKzfJu3F2fxgozf16BH6ujt0=";
   };
 
-  propagatedBuildInputs = [ jupyter_server notebook ];
+  propagatedBuildInputs = [ jupyter_server notebook notebook-shim ];
 
-  preCheck = ''
-    cd nbclassic
-    mv conftest.py tests
-    cd tests
-
-    export PYTHONPATH=$out/${python.sitePackages}:$PYTHONPATH
-  '';
   checkInputs = [
     pytestCheckHook
     pytest-tornasync

--- a/pkgs/development/python-modules/notebook-shim/default.nix
+++ b/pkgs/development/python-modules/notebook-shim/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, jupyter_server
+, pytestCheckHook
+, pytest-tornasync
+}:
+
+buildPythonPackage rec {
+  pname = "notebook-shim";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "jupyter";
+    repo = "notebook_shim";
+    rev = "v${version}";
+    sha256 = "sha256-5oIYj8SdC4E0N/yFxsmD2p4VkStHvqrVqAwb/htyPm4=";
+  };
+
+  propagatedBuildInputs = [ jupyter_server ];
+
+  preCheck = ''
+    mv notebook_shim/conftest.py notebook_shim/tests
+    cd notebook_shim/tests
+  '';
+
+  # TODO: understand & possibly fix why tests fail. On github most testfiles
+  # have been comitted with msgs "wip" though.
+  doCheck = false;
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-tornasync
+  ];
+
+  pythonImportsCheck = [ "notebook_shim" ];
+
+  meta = with lib; {
+    description = "Switch frontends to Jupyter Server";
+    longDescription = ''
+      This project provides a way for JupyterLab and other frontends to switch
+      to Jupyter Server for their Python Web application backend.
+    '';
+    homepage = "https://github.com/jupyter/notebook_shim";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ friedelino ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6085,6 +6085,8 @@ in {
 
   notebook = callPackage ../development/python-modules/notebook { };
 
+  notebook-shim = callPackage ../development/python-modules/notebook-shim { };
+
   notedown = callPackage ../development/python-modules/notedown { };
 
   notifications-python-client = callPackage ../development/python-modules/notifications-python-client { };


### PR DESCRIPTION
###### Description of changes

using  v4.3.0 `nbclassic` github version as src for this package would require dealing with bower nodejs dependencies which would be, given the fact that bower is almost deprecated, cumbersome to deal with directly (i tried for a while...).

So i decided to use the Pypi-version where all node-deps are included. Also an new dependency `notebook_shim` had to be packaged. 

I only started looking into this matter because another package i maintain `manim` did not build anymore because of nbclassic not building.

Unfortunately ATM nbclassic only builds with `export NIXPKGS_ALLOW_INSECURE=1` because of `pythonPackages.mistune`, see also PR #186272.

Closes #186694, closes #185028.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
