### PR TITLE
mpv: add libXpresent compile-time X11 dependency

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -32,6 +32,7 @@
   , libXext
   , libXxf86vm
   , libXrandr
+  , libXpresent
 
 , cddaSupport ? false
   , libcdio
@@ -160,7 +161,7 @@ in stdenv.mkDerivation rec {
     ++ lib.optionals vdpauSupport       [ libvdpau ]
     ++ lib.optionals vulkanSupport      [ libplacebo shaderc vulkan-headers vulkan-loader ]
     ++ lib.optionals waylandSupport     [ wayland wayland-protocols libxkbcommon ]
-    ++ lib.optionals x11Support         [ libX11 libXext libGLU libGL libXxf86vm libXrandr ]
+    ++ lib.optionals x11Support         [ libX11 libXext libGLU libGL libXxf86vm libXrandr libXpresent ]
     ++ lib.optionals xineramaSupport    [ libXinerama ]
     ++ lib.optionals xvSupport          [ libXv ]
     ++ lib.optionals zimgSupport        [ zimg ]


### PR DESCRIPTION
###### Description of changes

mpv has apparently added libXpresent as a compile-time dependency: https://github.com/mpv-player/mpv/issues/10506

Without it, hardware decoding doesn't function. Before this patch:

```
$ mpv example.mp4                
 (+) Video --vid=1 (*) (h264 1920x1080 25.000fps)
 (+) Audio --aid=1 (*) (aac 1ch 8000Hz)
[vo/gpu] VT_GETMODE failed: Inappropriate ioctl for device
[vo/gpu/opengl] Failed to set up VT switcher. Terminal switching will be unavailable.
MESA-LOADER: failed to open i965: /run/opengl-driver/lib/dri/i965_dri.so: cannot open shared object file: No such file or directory (search paths /run/opengl-driver/lib/dri, suffix _dri)
failed to load driver: i965
MESA-LOADER: failed to open kms_swrast: /nix/store/jvlq57vcmkdng66f0wr4npxsnrp72ysf-gcc-10.3.0-lib/lib/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by /run/opengl-driver/lib/dri/kms_swrast_dri.so) (search paths /run/opengl-driver/lib/dri, suffix _dri)
failed to load driver: kms_swrast
MESA-LOADER: failed to open swrast: /nix/store/jvlq57vcmkdng66f0wr4npxsnrp72ysf-gcc-10.3.0-lib/lib/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by /run/opengl-driver/lib/dri/swrast_dri.so) (search paths /run/opengl-driver/lib/dri, suffix _dri)
failed to load swrast driver
[vo/gpu] Failed to create GBM device.
[vo/gpu] Failed to setup GBM.
Failed to open VDPAU backend libvdpau_va_gl.so: cannot open shared object file: No such file or directory
[vo/vdpau] Error when calling vdp_device_create_x11: 1
[vo/xv] Warning: this legacy VO has bad quality and performance, and will in particular result in blurry OSD and subtitles. You should fix your graphics drivers, or not force the xv VO.
AO: [pulse] 8000Hz mono 1ch float
VO: [xv] 1920x1080 yuv420p
AV: 00:00:00 / 00:00:56 (1%) A-V:  0.000

Exiting... (Quit)
$            
```

After:

```
$ mpv example.mp4                
 (+) Video --vid=1 (*) (h264 1920x1080 25.000fps)
 (+) Audio --aid=1 (*) (aac 1ch 8000Hz)
AO: [pulse] 8000Hz mono 1ch float
VO: [gpu] 1920x1080 yuv420p
AV: 00:00:00 / 00:00:56 (1%) A-V:  0.000

Exiting... (Quit)
$    
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).