### PR TITLE
am2r: init at 29

### DIFF
--- a/pkgs/games/am2r/default.nix
+++ b/pkgs/games/am2r/default.nix
@@ -1,0 +1,137 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, requireFile
+, autoPatchelfHook
+, unzip
+, xdelta
+, jre
+, androidenv
+
+# 32 bit packages inherited from `all-packages.nix`.
+, stdenv32Bit
+, libX11
+, libXext
+, libXrandr
+, libXxf86vm
+, openal
+, libGLU
+, libglvnd
+, libzip
+, curl
+
+# Include higher quality music with the cost of a bigger file size.
+, highQualityMusic ? true
+# Build an Android APK instead of a Linux binary.
+, androidApk ? false
+# Mods for AM2R are distributed as custom clients, to be patched in place. This should refer to a directory containing the patches.
+, customClient ? null
+
+, am2r_zip ? requireFile {
+    name = "AM2R_11.zip";
+    message = ''
+      This nix expression requires that 'AM2R_11.zip' is already part of the store.
+      You can then add it the nix store with 'nix-store --add-fixed sha256 AM2R_11.zip'.
+    '';
+    sha256 = "sha256-+j0JMbr4shi2qLTOnrjhjKEeFCw08LQE1AXYMA7w+kw=";
+  }
+}:
+
+let
+  # A 32-bit stdenv is required on Linux for autoPatchelfHook, as the target binary is 32-bit.
+  # For the android build we never need to patch any binaries, so we can use the regular stdenv.
+  stdenv' = if androidApk then stdenvNoCC else stdenv32Bit;
+in
+stdenv'.mkDerivation rec {
+  pname = "am2r";
+  version = "29";
+
+  src = fetchFromGitHub {
+    owner = "AM2R-Community-Developers";
+    repo = "AM2R-Autopatcher-Linux";
+    rev = "Patchdata-v${version}";
+    sha256 = "sha256-WMYm/J1AGUA+VzVS7PW2GSMT71YQLLAzJNiRJkt4yPk=";
+  };
+
+  nativeBuildInputs = [
+    unzip
+    xdelta
+  ] ++ lib.optional (!androidApk) autoPatchelfHook
+    ++ lib.optional androidApk jre;
+
+  buildInputs = lib.optionals (!androidApk) [
+    stdenv32Bit.cc.cc.lib
+    libX11
+    libXext
+    libXrandr
+    libXxf86vm
+    openal
+    libGLU
+    libglvnd
+    libzip
+    curl
+  ];
+
+  # The patcher script executes a java application to sign Android APKs, which in turn attempts to
+  # execute a native binary. Manually specify the path to it instead to avoid dynamic linker issues.
+  postPatch = let
+    build-tools = builtins.head androidenv.androidPkgs_9_0.build-tools;
+    zipalign = "${build-tools}/libexec/android-sdk/build-tools/${build-tools.version}/zipalign";
+  in lib.optionalString androidApk ''
+    substituteInPlace ./patcher.sh \
+      --replace 'java -jar "$uberPath"' 'java -jar "$uberPath" --zipAlignPath ${zipalign}'
+  '';
+
+  configurePhase = ''
+    runHook preConfigure
+
+    patchShebangs ./patcher.sh
+  '' + lib.optionalString (customClient != null) ''
+    cp -r ${customClient}/* ./data
+    chmod -R u+w ./data
+  '' + ''
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    mkdir -p ./output
+    ./patcher.sh \
+      --prefix ./output \
+      --am2rzip ${am2r_zip} \
+      ${lib.optionalString highQualityMusic "--hqmusic"} \
+      --os ${if androidApk then "android" else "linux --systemwide"}
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -r ./output/* $out
+    ln -sf $out/opt/am2r/runner $out/bin/am2r
+    ln -s $out/opt/am2r/.runner-unwrapped $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/AM2R-Community-Developers/AM2R-Autopatcher-Linux";
+    description = "A fan-made remake of Metroid II: Return of Samus in the style of Metroid: Zero Mission";
+    longDescription = ''
+      Unofficial AM2R Community Updates, a fan-made remake of Metroid II: Return of Samus in the style of Metroid: Zero Mission.
+      A reconstruction of the original AM2R release, bringing more features such as widescreen and a built-in randomizer.
+      You must provide your own AM2R_1.1 zip file for patching. It can be added to the store with 'nix-store --add-fixed sha256 AM2R_11.zip'.
+    '' + lib.optionalString androidApk ''
+      This will build an Android APK of AM2R, to be installed on your mobile device.
+    '';
+    license = with licenses; [
+      gpl3Only # The patching utility.
+      unfree # The game itself, provided through `requireFile`.
+    ] ++ lib.optional androidApk asl20; # From a dependency needed to build the APK.
+    platforms = if androidApk then platforms.unix else [ "i686-linux" ];
+    maintainers = with maintainers; [ ivar ];
+  };
+}

--- a/pkgs/games/am2r/multitroid.nix
+++ b/pkgs/games/am2r/multitroid.nix
@@ -1,0 +1,100 @@
+{ lib
+, fetchzip
+, autoPatchelfHook
+, makeWrapper
+
+# 32 bit packages inherited from `all-packages.nix`.
+, stdenv32Bit
+, libX11
+, libXext
+, libXrandr
+, libXxf86vm
+, openal
+, libGLU
+, libglvnd
+, libzip
+, curl
+}:
+
+stdenv32Bit.mkDerivation rec {
+  pname = "am2r-multitroid-server";
+  version = "1.4.2";
+
+  # Building GameMaker games from source is unfortunately a bit involved, so we use the pre-built binaries instead.
+  src = fetchzip {
+    url = "https://github.com/milesthenerd/AM2R-Server/releases/download/v${version}/AM2R_Server_${version}_lin.zip";
+    sha256 = "sha256-7UaoFcpWxM3DKoTvqGK6DMpCyXVp0pSsOrYDpM5SUkI=";
+    stripRoot = false;
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    libX11
+    libXext
+    libXrandr
+    libXxf86vm
+    openal
+    libGLU
+    libglvnd
+    libzip
+    curl
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,opt}
+    cp -r ./* $out/opt
+
+    runHook postInstall
+  '';
+
+
+  preFixup = ''
+    # GameMaker games (like this server) link to OpenSSL 1.0.0, which is outdated and insecure.
+    # When attempting to link to newer versions, an error is raised at runtime claiming it cannot find
+    # the outdated version of OpenSSL, even though it has been patched to link to the newer version.
+    # After replacing it with libcurl, versioning is ignored, and the binary starts just fine.
+    patchelf $out/opt/AM2R_Server \
+      --replace-needed libcrypto.so.1.0.0 libcurl.so \
+      --replace-needed libssl.so.1.0.0 libcurl.so
+
+    # An environment variable needs to be set on Mesa to avoid a race related to multithreaded shader compilation.
+    # See https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/4181 for more information.
+    makeWrapper $out/opt/AM2R_Server $out/bin/AM2R_Server \
+       --set "radeonsi_sync_compile" "true"
+
+    ln -s $out/bin/AM2R_Server $out/bin/am2r-server
+  '';
+
+  # This contains patches usable from the 'am2r' derivation.
+  passthru.client = fetchzip {
+    name = "am2r-multitroid-mod.zip";
+    url = "https://github.com/milesthenerd/AM2R-Multitroid/releases/download/v${version}/Multitroid${builtins.replaceStrings ["."] ["_"] version}VM_Linux.zip";
+    sha256 = "sha256-3rYjwMPmQrfLlyDxoHii1u158fwNnn7S6dX+bkzcyF4=";
+    stripRoot = false;
+
+    meta = with lib; {
+      description = "A multiplayer client mod for AM2R";
+      homepage = "https://github.com/milesthenerd/AM2R-Multitroid";
+      # A custom unfree license is used: https://github.com/milesthenerd/AM2R-Multitroid/blob/v1.4.2/LICENSE
+      license = licenses.unfreeRedistributable;
+    };
+  };
+
+  meta = with lib; {
+    description = "A multiplayer server for AM2R Multitroid clients";
+    homepage = "https://github.com/milesthenerd/AM2R-Server";
+    license = licenses.mit;
+    platforms = [ "i686-linux" ];
+    mainProgram = "AM2R_Server";
+    maintainers = with maintainers; [ ivar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1097,6 +1097,22 @@ with pkgs;
 
   adriconf = callPackage ../tools/graphics/adriconf { };
 
+  am2r = callPackage ../games/am2r {
+    stdenv32Bit = pkgsi686Linux.stdenv;
+
+    inherit (pkgsi686Linux)
+      openal
+      libGLU
+      libglvnd
+      libzip
+      curl;
+    inherit (pkgsi686Linux.xorg)
+      libX11
+      libXext
+      libXrandr
+      libXxf86vm;
+  };
+
   amass = callPackage ../tools/networking/amass { };
 
   afew = callPackage ../applications/networking/mailreaders/afew { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1113,6 +1113,26 @@ with pkgs;
       libXxf86vm;
   };
 
+  am2r-multitroid-server = callPackage ../games/am2r/multitroid.nix {
+    stdenv32Bit = pkgsi686Linux.stdenv;
+
+    inherit (pkgsi686Linux)
+      openal
+      libGLU
+      libglvnd
+      libzip
+      curl;
+    inherit (pkgsi686Linux.xorg)
+      libX11
+      libXext
+      libXrandr
+      libXxf86vm;
+  };
+
+  am2r-multitroid = am2r.override {
+    customClient = am2r-multitroid-server.client;
+  };
+
   amass = callPackage ../tools/networking/amass { };
 
   afew = callPackage ../applications/networking/mailreaders/afew { };


### PR DESCRIPTION
###### Description of changes
This adds AM2R, a fan-made remake of Metroid II: Return of Samus in the style of Metroid: Zero Mission. I've also added a multiplayer mod and a server for it. See https://github.com/AM2R-Community-Developers/AM2R-Autopatcher-Linux for the utility patching it with Linux support, and https://github.com/AM2R-Community-Developers/AM2R-Community-Updates for the community updates.

A multiplayer mod and a server for it are added as well. Tested it locally and everything seems to work flawlessly :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
