### PR TITLE
rtl8188fu: init at 2022-06-11

### DIFF
--- a/pkgs/os-specific/linux/rtl8188fu/default.nix
+++ b/pkgs/os-specific/linux/rtl8188fu/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, lib, fetchFromGitHub, kernel }:
+
+stdenv.mkDerivation rec {
+  name = "rtl8188fu-${kernel.version}-${version}";
+  version = "2022-06-11";
+
+  src = fetchFromGitHub ({
+    owner = "kelebek333";
+    repo = "rtl8188fu";
+  } // (if stdenv.targetPlatform.isAarch32 || stdenv.targetPlatform.isAarch64 then {
+    rev = "31448865d3a262971e571e3ee1d4d78b4438dfa8";
+    sha256 = "sha256-5k0iDGj+K2ctI2G3SmGzjDk+E8ZpONP2A3G1ScvNx9s=";
+  } else {
+    rev = "dfe0a5090a1ec593ba558b589f092cce29e6256f";
+    sha256 = "sha256-ZUoNXD1ATEHTrHwW7EBLk7I7gASGv9U/GAYSjBvrQoU=";
+  }));
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  makeFlags = kernel.makeFlags ++ [
+    "KSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
+
+  installPhase = ''
+    install -D rtl8188fu.ko -t $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/net/wireless
+    install -D firmware/rtl8188fufw.bin -t $out/lib/firmware/rtlwifi
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "Driver for Realtek rtl8188fu";
+    homepage = "https://github.com/kelebek333/rtl8188fu";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ puffnfresh ];
+  };
+}

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -377,6 +377,8 @@ in {
 
     rtl8188eus-aircrack = callPackage ../os-specific/linux/rtl8188eus-aircrack { };
 
+    rtl8188fu = callPackage ../os-specific/linux/rtl8188fu { };
+
     rtl8192eu = callPackage ../os-specific/linux/rtl8192eu { };
 
     rtl8189es = callPackage ../os-specific/linux/rtl8189es { };


### PR DESCRIPTION
###### Description of changes

Fixes #91124

The repo was archived, for some reason, last month:

https://github.com/kelebek333/rtl8188fu

But it was the only active fork with compatibility above Linux 5.10

I have been using this driver on an ARM device for almost a month. It's not great, but it does mostly work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
