### PR TITLE
Cinnamon updates 2022-08-15

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/cinnamon.nix
+++ b/nixos/modules/services/x11/desktop-managers/cinnamon.nix
@@ -212,6 +212,7 @@ in
         # external apps shipped with linux-mint
         hexchat
         gnome-calculator
+        gnome-screenshot
       ] config.environment.cinnamon.excludePackages;
     })
   ];

--- a/pkgs/applications/misc/sticky/default.nix
+++ b/pkgs/applications/misc/sticky/default.nix
@@ -11,14 +11,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "sticky";
-  version = "1.11";
+  version = "1.12";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-PXJpNKzF9goQvfh3lUUfOaZFessFNrWtg8nMDxPxRMo=";
+    hash = "sha256-kAO8Qz4bTn3+YeIXAvPZ1SpKgn+g+rBgi9+TaqL1vOY=";
   };
 
   postPatch = ''

--- a/pkgs/desktops/cinnamon/cinnamon-common/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-common/default.nix
@@ -9,6 +9,7 @@
 , cjs
 , clutter
 , fetchFromGitHub
+, fetchpatch
 , gdk-pixbuf
 , libgnomekbd
 , glib
@@ -53,18 +54,31 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-common";
-  version = "5.4.9";
+  version = "5.4.10";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "cinnamon";
     rev = version;
-    hash = "sha256-nM87NO/dwOd+hN5/3zX7XUjyKvXh4uDhLcGFcKE9ccA=";
+    hash = "sha256-yNjFP32+0LXqHfJUxm1A+CTuwny5/IxxT08689f7VlE=";
   };
 
   patches = [
     ./use-sane-install-dir.patch
     ./libdir.patch
+    # Re-add libsoup 2.4 as dependency - needed by some applets.
+    # Can be removed on next update.
+    (fetchpatch {
+      url = "https://github.com/linuxmint/cinnamon/commit/76224fe409d074f8a44c70e4fd5e1289f92800b9.patch";
+      sha256 = "sha256-nDt4kkK1kVstxbij63XxTJ2L/TM9Q1P6feok3xlPQOM=";
+    })
+    # keybindings.js: Use bindings.get().
+    # Can be removed on next update.
+    # https://github.com/linuxmint/cinnamon/issues/11055
+    (fetchpatch {
+      url = "https://github.com/linuxmint/cinnamon/commit/7724e4146baf8431bc1fb55dce60984e77adef5a.patch";
+      sha256 = "sha256-idGtkBa13nmoEprtmAr6OssO16wJwBd16r2ZbbhrYDQ=";
+    })
   ];
 
   buildInputs = [
@@ -95,7 +109,7 @@ stdenv.mkDerivation rec {
     gsound
     gtk3
     json-glib
-    libsoup
+    libsoup # referenced in js/ui/environment.js
     libstartup_notification
     libXtst
     libXdamage

--- a/pkgs/desktops/cinnamon/cinnamon-common/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-common/default.nix
@@ -11,6 +11,7 @@
 , fetchFromGitHub
 , fetchpatch
 , gdk-pixbuf
+, gettext
 , libgnomekbd
 , glib
 , gobject-introspection
@@ -177,6 +178,8 @@ stdenv.mkDerivation rec {
 
     sed "s| cinnamon-session| ${cinnamon-session}/bin/cinnamon-session|g" -i ./files/usr/bin/cinnamon-session-cinnamon  -i ./files/usr/bin/cinnamon-session-cinnamon2d
     sed "s|/usr/bin|$out/bin|g" -i ./files/usr/share/xsessions/cinnamon.desktop ./files/usr/share/xsessions/cinnamon2d.desktop
+
+    sed "s|msgfmt|${gettext}/bin/msgfmt|g" -i ./files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
 
     patchShebangs src/data-to-c.pl
   '';

--- a/pkgs/desktops/cinnamon/nemo/default.nix
+++ b/pkgs/desktops/cinnamon/nemo/default.nix
@@ -23,7 +23,7 @@
 
 stdenv.mkDerivation rec {
   pname = "nemo";
-  version = "5.4.2";
+  version = "5.4.3";
 
   # TODO: add plugins support (see https://github.com/NixOS/nixpkgs/issues/78327)
 
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    sha256 = "sha256-Xn9CgGe7j2APaJRLvx58z2w+sN7ZeDScQz53ZBBnsQs=";
+    sha256 = "sha256-f3rO0lpOcwpSpIpKrslf6/6nqFbbGTwnKbHpWO+Uf+Q=";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/desktops/cinnamon/xreader/default.nix
+++ b/pkgs/desktops/cinnamon/xreader/default.nix
@@ -26,13 +26,13 @@
 
 stdenv.mkDerivation rec {
   pname = "xreader";
-  version = "3.4.3";
+  version = "3.4.4";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    sha256 = "sha256-GkJo/wc5StyeQv0pv5XK0Qy3o8EGpfPYY8gOMq0Afgs=";
+    sha256 = "sha256-uYnQE1GjkUxYlvXSJNmvr6q4OdvAWgv8HqTXk0KkRQM=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes

Previous one: https://github.com/NixOS/nixpkgs/pull/185864

Closes https://github.com/bobby285271/what-changed/issues/4

- cinnamon.cinnamon-common: 5.4.9 -> 5.4.10
- cinnamon.nemo: 5.4.2 -> 5.4.3
- cinnamon.xreader: 3.4.3 -> 3.4.4
- sticky: 1.11 -> 1.12

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
