### PR TITLE
Revert "mullvad-vpn: 2022.2 -> 2022.3"

### DIFF
--- a/pkgs/applications/networking/mullvad-vpn/default.nix
+++ b/pkgs/applications/networking/mullvad-vpn/default.nix
@@ -43,11 +43,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "mullvad-vpn";
-  version = "2022.3";
+  version = "2022.2";
 
   src = fetchurl {
     url = "https://github.com/mullvad/mullvadvpn-app/releases/download/${version}/MullvadVPN-${version}_amd64.deb";
-    sha256 = "sha256-AxBVH5dHp1IBgeAMEUm+6xgHNuDChNs1+kOinbsUJu0=";
+    sha256 = "sha256-h/c4aPH6E2TzbXGROpLJgF9uHYcjvKiW5upIobpJM9o=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Reverts NixOS/nixpkgs#185983

https://github.com/NixOS/nixpkgs/pull/185983#issuecomment-1214323193