### PR TITLE
itk: enable additional cmake modules

### DIFF
--- a/pkgs/development/libraries/itk/default.nix
+++ b/pkgs/development/libraries/itk/default.nix
@@ -5,6 +5,20 @@ stdenv.mkDerivation rec {
   pname = "itk";
   version = "5.2.1";
 
+  itkGenericLabelInterpolatorSrc = fetchFromGitHub {
+    owner = "InsightSoftwareConsortium";
+    repo = "ITKGenericLabelInterpolator";
+    rev = "2f3768110ffe160c00c533a1450a49a16f4452d9";
+    hash = "sha256-Cm3jg14MMnbr/sP+gqR2Rh25xJjoRvpmY/jP/DKH978=";
+  };
+
+  itkAdaptiveDenoisingSrc = fetchFromGitHub {
+    owner = "ntustison";
+    repo = "ITKAdaptiveDenoising";
+    rev = "24825c8d246e941334f47968553f0ae388851f0c";
+    hash = "sha256-deJbza36c0Ohf9oKpO2T4po37pkyI+2wCSeGL4r17Go=";
+  };
+
   src = fetchFromGitHub {
     owner = "InsightSoftwareConsortium";
     repo = "ITK";
@@ -16,16 +30,22 @@ stdenv.mkDerivation rec {
     substituteInPlace CMake/ITKSetStandardCompilerFlags.cmake  \
       --replace "-march=corei7" ""  \
       --replace "-mtune=native" ""
+    ln -sr ${itkGenericLabelInterpolatorSrc} Modules/External/ITKGenericLabelInterpolator
+    ln -sr ${itkAdaptiveDenoisingSrc} Modules/External/ITKAdaptiveDenoising
   '';
 
   cmakeFlags = [
     "-DBUILD_EXAMPLES=OFF"
     "-DBUILD_SHARED_LIBS=ON"
+    "-DITK_FORBID_DOWNLOADS=ON"
     "-DModule_ITKMINC=ON"
     "-DModule_ITKIOMINC=ON"
     "-DModule_ITKIOTransformMINC=ON"
     "-DModule_ITKVtkGlue=ON"
     "-DModule_ITKReview=ON"
+    "-DModule_MGHIO=ON"
+    "-DModule_AdaptiveDenoising=ON"
+    "-DModule_GenericLabelInterpolator=ON"
   ];
 
   nativeBuildInputs = [ cmake xz makeWrapper ];


### PR DESCRIPTION
Enable MGHIO, GenericLabelInterpolator, and AdaptiveDenoising ITK modules,
which are required by current versions of ANTs (e.g. 2.3.5 and 2.4.0);
see, e.g., https://github.com/ANTsX/ANTs/issues/1353#issuecomment-1117462739,
the Gentoo ANTs package, or the ANTs SuperBuild itself.
Updating ANTs will, in particular, allow removal of itk4 and vtk_7 from Nixpkgs.
Unfortunately, these ANTs releases do not build against the version of ITK (5.2.1)
currently in tree, so we need to either add another ITK 5.x version or wait until ITK
is bumped to 5.3.x (currently still in beta) in Nixpkgs.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [NA] (Package updates) Added a release notes entry if the change is major or breaking
  - [NA] (Module updates) Added a release notes entry if the change is significant
  - [NA] (Module addition) Added a release notes entry if adding a new NixOS module
  - [NA] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
