### PR TITLE
nixos: fix nscd for plugins which depends on dbus

### DIFF
--- a/nixos/tests/systemd-machinectl.nix
+++ b/nixos/tests/systemd-machinectl.nix
@@ -62,16 +62,11 @@ import ./make-test-python.nix (
       # Test nss_mymachines without nscd
       machine.succeed('LD_LIBRARY_PATH="/run/current-system/sw/lib" getent -s hosts:mymachines hosts ${containerName}');
 
-      # Test failing nss_mymachines via nscd
-      # nscd has not enough rights to connect to systemd bus
-      # via sd_bus_open_system() in
-      # https://github.com/systemd/systemd/blob/main/src/nss-mymachines/nss-mymachines.c#L287
-      machine.fail("getent hosts ${containerName}");
+      # Test nss_mymachines via nscd
+      machine.succeed("getent hosts ${containerName}");
 
       # Test systemd-nspawn network configuration
-      machine.succeed("systemctl stop nscd");
-      machine.succeed('LD_LIBRARY_PATH="/run/current-system/sw/lib" ping -n -c 1 ${containerName}');
-      machine.succeed("systemctl start nscd");
+      machine.succeed("ping -n -c 1 ${containerName}");
 
       # Test systemd-nspawn uses a user namespace
       machine.succeed("test $(machinectl status ${containerName} | grep 'UID Shift: ' | wc -l) = 1")


### PR DESCRIPTION
###### Description of changes

The service nsdc runs as dynamic user and nss plugins like nss_mymachines use dbus. Since dbus is broken for dynamic users, we have to make the user static.

The incompatibility between dynamic user and dbus is documented here:
- https://github.com/systemd/systemd/issues/9503
- https://github.com/systemd/systemd/issues/22737

I faced the problem for PR:
- https://github.com/NixOS/nixpkgs/pull/186310

A possible alternative is to run nscd as root, which seems to be the default for most distributions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
