### PR TITLE
osm2pgsql: 1.6.0 → 1.7.0

### DIFF
--- a/pkgs/tools/misc/osm2pgsql/default.nix
+++ b/pkgs/tools/misc/osm2pgsql/default.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , cmake
 , expat
+, fmt
 , proj
 , bzip2
 , zlib
@@ -12,33 +13,43 @@
 , luajit
 , libosmium
 , protozero
+, rapidjson
 }:
 
 stdenv.mkDerivation rec {
   pname = "osm2pgsql";
-  version = "1.6.0";
+  version = "1.7.0";
 
   src = fetchFromGitHub {
     owner = "openstreetmap";
     repo = pname;
     rev = version;
-    sha256 = "sha256-6FVMv+DowMYdRdsQFL2iwG/V9D2cLWkHUVkmR3/TuUI=";
+    hash = "sha256-MWJzCZdqvy/nH1Doj0fmGuzTubaHDnPOED7qgzvJ3ZU=";
   };
+
+  postPatch = ''
+    # Remove bundled libraries
+    rm -r contrib
+  '';
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [ expat proj bzip2 zlib boost postgresql libosmium protozero ]
+  buildInputs = [ expat fmt proj bzip2 zlib boost postgresql libosmium protozero rapidjson ]
     ++ lib.optional withLuaJIT luajit
     ++ lib.optional (!withLuaJIT) lua;
 
-  cmakeFlags = [ "-DEXTERNAL_LIBOSMIUM=ON" "-DEXTERNAL_PROTOZERO=ON" ]
-    ++ lib.optional withLuaJIT "-DWITH_LUAJIT:BOOL=ON";
+  cmakeFlags = [
+    "-DEXTERNAL_LIBOSMIUM=ON"
+    "-DEXTERNAL_PROTOZERO=ON"
+    "-DEXTERNAL_RAPIDJSON=ON"
+    "-DEXTERNAL_FMT=ON"
+  ] ++ lib.optional withLuaJIT "-DWITH_LUAJIT:BOOL=ON";
 
   meta = with lib; {
     description = "OpenStreetMap data to PostgreSQL converter";
     homepage = "https://osm2pgsql.org";
     license = licenses.gpl2Plus;
-    platforms = with platforms; linux ++ darwin;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ jglukasik das-g ];
   };
 }


### PR DESCRIPTION
###### Description of changes
[Changelog](https://github.com/openstreetmap/osm2pgsql/releases/tag/1.7.0)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
