### PR TITLE
minetest, irrlichtmt: cleanup

### DIFF
--- a/pkgs/development/libraries/irrlichtmt/default.nix
+++ b/pkgs/development/libraries/irrlichtmt/default.nix
@@ -7,7 +7,6 @@
 , libjpeg
 , libGL
 , libX11
-, libXxf86vm
 , withTouchSupport ? false
 , libXi
 , libXext
@@ -43,7 +42,6 @@ stdenv.mkDerivation rec {
     libjpeg
     libGL
     libX11
-    libXxf86vm
   ] ++ lib.optionals withTouchSupport [
     libXi
     libXext

--- a/pkgs/games/minetest/default.nix
+++ b/pkgs/games/minetest/default.nix
@@ -10,9 +10,7 @@
 , libogg
 , jsoncpp
 , libjpeg
-, libXxf86vm
 , libGLU
-, libGL
 , openal
 , libvorbis
 , sqlite
@@ -75,7 +73,6 @@ let
       "-DENABLE_GETTEXT=1"
       "-DENABLE_SPATIAL=1"
       "-DENABLE_SYSTEM_JSONCPP=1"
-      "-DIRRLICHT_INCLUDE_DIR=${irrlichtmtInput.dev}/include/irrlichtmt"
 
       # Remove when https://github.com/NixOS/nixpkgs/issues/144170 is fixed
       "-DCMAKE_INSTALL_BINDIR=bin"
@@ -85,8 +82,6 @@ let
       "-DCMAKE_INSTALL_MANDIR=share/man"
       "-DCMAKE_INSTALL_LOCALEDIR=share/locale"
 
-    ] ++ optionals buildClient [
-      "-DOpenGL_GL_PREFERENCE=GLVND"
     ] ++ optionals buildServer [
       "-DENABLE_PROMETHEUS=1"
     ] ++ optionals withTouchSupport [
@@ -103,7 +98,7 @@ let
     ] ++ optionals stdenv.isDarwin [
       libiconv OpenGL OpenAL Carbon Cocoa
     ] ++ optionals buildClient [
-      libpng libjpeg libGLU libGL openal libogg libvorbis xorg.libX11 libXxf86vm
+      libpng libjpeg libGLU openal libogg libvorbis xorg.libX11
     ] ++ optionals buildServer [
       leveldb postgresql hiredis prometheus-cpp
     ];


### PR DESCRIPTION
###### Description of changes

cleanup
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
