### PR TITLE
maigret: ignore DeprecationWarning

### DIFF
--- a/pkgs/tools/security/maigret/default.nix
+++ b/pkgs/tools/security/maigret/default.nix
@@ -63,11 +63,16 @@ python3.pkgs.buildPythonApplication rec {
   postPatch = ''
     # Remove all version pinning
     sed -i -e "s/==[0-9.]*//" requirements.txt
+
     # We are not build for Python < 3.7
-    sed -i -e '/future-annotations/d' requirements.txt
-    # We can't work with dummy packages
-    sed -i -e 's/bs4/beautifulsoup4/g' requirements.txt
+    substituteInPlace requirements.txt \
+      --replace "future-annotations" ""
   '';
+
+  pytestFlagsArray = [
+    # DeprecationWarning: There is no current event loop
+    "-W ignore::DeprecationWarning"
+  ];
 
   disabledTests = [
     # Tests require network access


### PR DESCRIPTION
###### Description of changes

Fix build:

```console
_____________________ test_self_check_db_positive_disable ______________________

test_db = <maigret.sites.MaigretDatabase object at 0x7ffff40836d0>

    @pytest.mark.slow
    def test_self_check_db_positive_disable(test_db):
        logger = Mock()
        assert test_db.sites[0].disabled is False
    
>       loop = asyncio.get_event_loop()
E       DeprecationWarning: There is no current event loop

tests/test_maigret.py:42: DeprecationWarning
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
