### PR TITLE
obs-studio: resolve failed wrapping if a plugin has no data path

### DIFF
--- a/pkgs/applications/video/obs-studio/wrapper.nix
+++ b/pkgs/applications/video/obs-studio/wrapper.nix
@@ -16,19 +16,14 @@ symlinkJoin {
 
       pluginsJoined = symlinkJoin {
         name = "obs-studio-plugins";
-        paths = lists.map (plugin: "${plugin}/lib/obs-plugins") plugins;
-      };
-
-      pluginsDataJoined = symlinkJoin {
-        name = "obs-studio-plugins-data";
-        paths = lists.map (plugin: "${plugin}/share/obs/obs-plugins") plugins;
+        paths = plugins;
       };
 
       wrapCommand = [
           "wrapProgram"
           "$out/bin/obs"
-          ''--set OBS_PLUGINS_PATH "${pluginsJoined}"''
-          ''--set OBS_PLUGINS_DATA_PATH "${pluginsDataJoined}"''
+          ''--set OBS_PLUGINS_PATH "${pluginsJoined}/lib/obs-plugins"''
+          ''--set OBS_PLUGINS_DATA_PATH "${pluginsJoined}/share/obs/obs-plugins"''
         ] ++ pluginArguments;
     in concatStringsSep " " wrapCommand;
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

fixes a regression due to #186548 where the symlinkJoin fails when a
package does not have that path such as `obs-studio-plugins.wlrobs`

Only one `symlinkJoin` is necessary


Try the following before and after this PR

```nix
{ pkgs ? import ./. {} }:
pkgs.wrapOBS {
  plugins = with pkgs.obs-studio-plugins; [ wlrobs obs-multi-rtmp ];
}
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
