### PR TITLE
[22.05] monero-{cli,gui}: 0.17.3.2 -> 0.18.1.0

### DIFF
--- a/pkgs/applications/blockchains/monero-cli/default.nix
+++ b/pkgs/applications/blockchains/monero-cli/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "monero-cli";
-  version = "0.17.3.2";
+  version = "0.18.1.0";
 
   src = fetchFromGitHub {
     owner = "monero-project";
     repo = "monero";
     rev = "v${version}";
-    sha256 = "19sgcbli7fc1l6ms7ma6hcz1mmpbnd296lc8a19rl410acpv45zy";
+    sha256 = "sha256-xniGiGqZpL1b6alnCxa2MNzuDQxPgMdNjqifOC8h0qM=";
     fetchSubmodules = true;
   };
 
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     # remove vendored libraries
-    rm -r external/{miniupnp,randomx,rapidjson,unbound}
+    rm -r external/{miniupnp,randomx,rapidjson}
     # export patched source for monero-gui
     cp -r . $source
   '';

--- a/pkgs/applications/blockchains/monero-gui/default.nix
+++ b/pkgs/applications/blockchains/monero-gui/default.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation rec {
   pname = "monero-gui";
-  version = "0.17.3.2";
+  version = "0.18.1.0";
 
   src = fetchFromGitHub {
-    owner  = "monero-project";
-    repo   = "monero-gui";
-    rev    = "v${version}";
-    sha256 = "10gincmgc0qpsgm94m1fqfy9j8jn9g1gjk12lcqnf77kvcnz37hq";
+    owner = "monero-project";
+    repo = "monero-gui";
+    rev = "v${version}";
+    sha256 = "sha256-XL7DV4YD/U6RiqgdYJf6zFfvJWlOx//4YVmnc51riiE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/hidapi/default.nix
+++ b/pkgs/development/libraries/hidapi/default.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation rec {
   pname = "hidapi";
-  version = "0.11.2";
+  version = "0.12.0";
 
   src = fetchFromGitHub {
     owner = "libusb";
     repo = "hidapi";
     rev = "${pname}-${version}";
-    sha256 = "sha256-zSAhnvnDI3+q8VwZ8fIx/YmvwTpL87PBJ2C1mTmD7Ko=";
+    sha256 = "sha256-SMhlcB7LcViC6UFVYACjunxsGkvSOKC3mbLBH4XQSzM=";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];

--- a/pkgs/development/libraries/randomx/default.nix
+++ b/pkgs/development/libraries/randomx/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "randomX";
-  version = "1.1.9";
+  version = "1.1.10";
 
   nativeBuildInputs = [ cmake ];
 
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner = "tevador";
     repo = pname;
     rev = "v${version}";
-    sha256 = "188fh4l8wda1y9vxa9asbk8nw35gyapw7gyn4w2p2qspdjhi5mnq";
+    sha256 = "sha256-ZPphhZFzQL72xcEp9kNfZITY4oqK930ve/bbljTYNBs=";
   };
 
   meta = with lib; {

--- a/pkgs/os-specific/darwin/apple-sdk-11.0/apple_sdk.nix
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/apple_sdk.nix
@@ -168,8 +168,8 @@ in rec {
   bareFrameworks = (
     lib.mapAttrs framework (import ./frameworks.nix {
       inherit frameworks libs;
-      inherit (pkgs.darwin) libobjc Libsystem;
-      inherit (pkgs.darwin.apple_sdk) libnetwork;
+      inherit (pkgs.darwin.apple_sdk_11_0) libnetwork Libsystem;
+      libobjc = pkgs.darwin.apple_sdk_11_0.objc4;
     })
   ) // (
     lib.mapAttrs privateFramework (import ./private-frameworks.nix {

--- a/pkgs/os-specific/darwin/apple-sdk-11.0/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/default.nix
@@ -1,4 +1,5 @@
 { stdenvNoCC, fetchurl, newScope, pkgs
+, stdenv, overrideCC
 , xar, cpio, python3, pbzx }:
 
 let
@@ -54,5 +55,21 @@ let
     # questionable aliases
     configd = pkgs.darwin.apple_sdk.frameworks.SystemConfiguration;
     IOKit = pkgs.darwin.apple_sdk.frameworks.IOKit;
+
+    stdenv =
+      let
+        clang = stdenv.cc.override {
+          bintools = stdenv.cc.bintools.override { libc = packages.Libsystem; };
+          libc = packages.Libsystem;
+        };
+      in
+      if stdenv.isAarch64 then stdenv
+      else
+        (overrideCC stdenv clang).override {
+          targetPlatform = stdenv.targetPlatform // {
+            darwinMinVersion = "10.12";
+            darwinSdkVersion = "11.0";
+          };
+        };
   };
 in packages

--- a/pkgs/os-specific/darwin/apple-sdk-11.0/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/default.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, fetchurl, newScope, pkgs
+{ stdenvNoCC, fetchurl, newScope, lib, pkgs
 , stdenv, overrideCC
 , xar, cpio, python3, pbzx }:
 
@@ -55,6 +55,20 @@ let
     # questionable aliases
     configd = pkgs.darwin.apple_sdk.frameworks.SystemConfiguration;
     IOKit = pkgs.darwin.apple_sdk.frameworks.IOKit;
+
+    callPackage = newScope (lib.optionalAttrs stdenv.isDarwin rec {
+      inherit (pkgs.darwin.apple_sdk_11_0) stdenv;
+      darwin = pkgs.darwin.overrideScope (_: prev: {
+        inherit (prev.darwin.apple_sdk_11_0) Libsystem LibsystemCross libcharset libunwind objc4 configd IOKit Security;
+        apple_sdk = prev.darwin.apple_sdk_11_0;
+        CF = prev.darwin.apple_sdk_11_0.CoreFoundation;
+      });
+      xcodebuild = pkgs.xcbuild.override {
+        inherit (pkgs.darwin.apple_sdk_11_0.frameworks) CoreServices CoreGraphics ImageIO;
+        inherit stdenv;
+      };
+      xcbuild = xcodebuild;
+    });
 
     stdenv =
       let

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20450,7 +20450,7 @@ with pkgs;
 
   qgnomeplatform = libsForQt5.callPackage ../development/libraries/qgnomeplatform { };
 
-  randomx = callPackage ../development/libraries/randomx { };
+  randomx = darwin.apple_sdk_11_0.callPackage ../development/libraries/randomx { };
 
   retro-gtk = callPackage ../development/libraries/retro-gtk { };
 

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -70,7 +70,7 @@ in
 
 impure-cmds // appleSourcePackages // chooseLibs // {
 
-  inherit apple_sdk;
+  inherit apple_sdk apple_sdk_10_12 apple_sdk_11_0;
 
   stdenvNoCF = stdenv.override {
     extraBuildInputs = [];


### PR DESCRIPTION
###### Description of changes

Backport monero updates

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change (in progress...)
- [ ] Tested basic functionality of all binary files 
  - [x] Tested monero-cli, monero-gui
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
