### PR TITLE
archivebox: relax django3 constraint

### DIFF
--- a/pkgs/applications/misc/archivebox/default.nix
+++ b/pkgs/applications/misc/archivebox/default.nix
@@ -2,41 +2,21 @@
 , python3
 }:
 
-let
-  python = python3.override {
-    packageOverrides = self: super: {
-      django = super.django_3.overridePythonAttrs (old: rec {
-        version = "3.1.14";
-        src = old.src.override {
-          inherit version;
-          sha256 = "72a4a5a136a214c39cf016ccdd6b69e2aa08c7479c66d93f3a9b5e4bb9d8a347";
-        };
-        meta = old.meta // {
-          knownVulnerabilities = [
-            "CVE-2021-45115"
-            "CVE-2021-45116"
-            "CVE-2021-45452"
-            "CVE-2022-23833"
-            "CVE-2022-22818"
-            "CVE-2022-28347"
-            "CVE-2022-28346"
-          ];
-        };
-      });
-    };
-  };
-in
-
-python.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "archivebox";
   version = "0.6.2";
 
-  src = python.pkgs.fetchPypi {
+  src = python3.pkgs.fetchPypi {
     inherit pname version;
     sha256 = "sha256-zHty7lTra6yab9d0q3EqsPG3F+lrnZL6PjQAbL1A2NY=";
   };
 
-  propagatedBuildInputs = with python.pkgs; [
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "django>=3.1.3,<3.2" "django<4"
+  '';
+
+  propagatedBuildInputs = with python3.pkgs; [
     requests
     mypy-extensions
     django
@@ -48,6 +28,9 @@ python.pkgs.buildPythonApplication rec {
     w3lib
     ipython
   ];
+
+  # TODO: implement tests
+  doCheck = false;
 
   meta = with lib; {
     description = "Open source self-hosted web archiving";


### PR DESCRIPTION
Doing overrides like that prevents us from shipping django security
updates, which is how these CVEs accumulated here.

Also django should be largely compatible inside a major version.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
