### PR TITLE
nvidia_x11: reorganize latest versions

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/generic.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/generic.nix
@@ -103,7 +103,10 @@ let
     disallowedReferences = optional (!libsOnly) [ kernel.dev ];
 
     passthru = {
-      open = mapNullable (hash: callPackage (import ./open.nix self hash) { }) openSha256;
+      open = mapNullable (hash: callPackage ./open.nix {
+        inherit hash broken;
+        nvidia_x11 = self;
+      }) openSha256;
       settings = (if settings32Bit then pkgsi686Linux.callPackage else callPackage) (import ./settings.nix self settingsSha256) {
         withGtk2 = preferGtk2;
         withGtk3 = !preferGtk2;

--- a/pkgs/os-specific/linux/nvidia-x11/open.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/open.nix
@@ -1,8 +1,10 @@
-nvidia_x11: hash:
 { stdenv
 , lib
 , fetchFromGitHub
 , kernel
+, nvidia_x11
+, hash
+, broken ? false
 }:
 
 stdenv.mkDerivation {
@@ -32,7 +34,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/NVIDIA/open-gpu-kernel-modules";
     license = with licenses; [ gpl2Plus mit ];
     platforms = platforms.linux;
-    broken = kernel.kernelAtLeast "5.19";
     maintainers = with maintainers; [ nickcao ];
+    inherit broken;
   };
 }

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -356,12 +356,13 @@ in {
 
     nvidiaPackages = dontRecurseIntoAttrs (lib.makeExtensible (_: callPackage ../os-specific/linux/nvidia-x11 { }));
 
+    nvidia_x11             = nvidiaPackages.stable;
+    nvidia_x11_beta        = nvidiaPackages.beta;
     nvidia_x11_legacy340   = nvidiaPackages.legacy_340;
     nvidia_x11_legacy390   = nvidiaPackages.legacy_390;
     nvidia_x11_legacy470   = nvidiaPackages.legacy_470;
-    nvidia_x11_beta        = nvidiaPackages.beta;
+    nvidia_x11_production  = nvidiaPackages.production;
     nvidia_x11_vulkan_beta = nvidiaPackages.vulkan_beta;
-    nvidia_x11             = nvidiaPackages.stable;
 
     # this is not a replacement for nvidia_x11
     # only the opensource kernel driver exposed for hydra to build


### PR DESCRIPTION
###### Description of changes

Based on https://github.com/NixOS/nixpkgs/pull/186321#issuecomment-1214140110

* nvidia appears to not update packages if there is a package with a higher maturity (`long-lived-branch-release` > `official` > `beta`) and a higher version. At the moment the "beta" and "new feature branch" branches aren't actively in use, so only the "production" is getting updates, superceding the other branches.
  * Add `nvidia_x11_production` `kernelPackages` alias so all 3 versions are represented
  * Unbreak the `open-kernel` builds for linux 5.19 and linked its `broken` flag to the proprietary build, since they share kernel glue code.
* Add a warning on the `nvidia_x11` -> `nvidia_x11_legacy390` alias for x86 and change the `nvidia.package` default to use `nvidia_x11_legacy390` on `i686-linux`. Handling the alternatives in the nixos configuration seems a lot cleaner and by just adding a warning we avoid breaking configurations that explicitly select `nvidia_x11`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
