### PR TITLE
zig: fix index out of bounds reading RPATH

### DIFF
--- a/pkgs/development/compilers/zig/default.nix
+++ b/pkgs/development/compilers/zig/default.nix
@@ -18,6 +18,9 @@ stdenv.mkDerivation rec {
     hash = "sha256-x2c4c9RSrNWGqEngio4ArW7dJjW0gg+8nqBwPcR721k=";
   };
 
+  # Fix index out of bounds reading RPATH (cherry-picked from 0.10-dev)
+  patches = [ ./rpath.patch ];
+
   nativeBuildInputs = [
     cmake
     llvmPackages.llvm.dev

--- a/pkgs/development/compilers/zig/rpath.patch
+++ b/pkgs/development/compilers/zig/rpath.patch
@@ -1,0 +1,39 @@
+commit ebcdbd9b3c9d437780aee4d6af76bbd2ab32ea06
+Author: LeRoyce Pearson <contact@leroycepearson.dev>
+Date:   2022-07-17 16:01:22 -0600
+
+    Read dynstr starting at rpath offset
+    
+    Since we know the offset, we may as well read starting there. Still expects
+    rpath to fit in 4096 bytes; that might be worth fixing in the future.
+    
+    Fixes issue #12112
+
+diff --git a/lib/std/zig/system/NativeTargetInfo.zig b/lib/std/zig/system/NativeTargetInfo.zig
+index af41fc790579..ad0b6d5ce1e1 100644
+--- a/lib/std/zig/system/NativeTargetInfo.zig
++++ b/lib/std/zig/system/NativeTargetInfo.zig
+@@ -652,14 +652,19 @@ pub fn abiAndDynamicLinkerFromFile(
+             } else null;
+ 
+             if (dynstr) |ds| {
+-                const strtab_len = std.math.min(ds.size, strtab_buf.len);
+-                const strtab_read_len = try preadMin(file, &strtab_buf, ds.offset, strtab_len);
+-                const strtab = strtab_buf[0..strtab_read_len];
+                 // TODO this pointer cast should not be necessary
+                 const rpoff_usize = std.math.cast(usize, rpoff) catch |err| switch (err) {
+                     error.Overflow => return error.InvalidElfFile,
+                 };
+-                const rpath_list = mem.sliceTo(std.meta.assumeSentinel(strtab[rpoff_usize..].ptr, 0), 0);
++                if (rpoff_usize > ds.size) return error.InvalidElfFile;
++                const rpoff_file = ds.offset + rpoff_usize;
++                const rp_max_size = ds.size - rpoff_usize;
++
++                const strtab_len = std.math.min(rp_max_size, strtab_buf.len);
++                const strtab_read_len = try preadMin(file, &strtab_buf, rpoff_file, strtab_len);
++                const strtab = strtab_buf[0..strtab_read_len];
++
++                const rpath_list = mem.sliceTo(std.meta.assumeSentinel(strtab.ptr, 0), 0);
+                 var it = mem.tokenize(u8, rpath_list, ":");
+                 while (it.next()) |rpath| {
+                     var dir = fs.cwd().openDir(rpath, .{}) catch |err| switch (err) {


### PR DESCRIPTION
###### Description of changes

Fix GH-182416 by cherry picking https://github.com/ziglang/zig/pull/12155 instead of waiting for 0.10 (which could take a few months)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).