### PR TITLE
doggo: init at 0.5.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4682,6 +4682,15 @@
       fingerprint = "386E D1BF 848A BB4A 6B4A  3C45 FC83 907C 125B C2BC";
     }];
   };
+  georgesalkhouri = {
+    name = "Georges Alkhouri";
+    email = "incense.stitch_0w@icloud.com";
+    github = "GeorgesAlkhouri";
+    githubId = 6077574;
+    keys = [{
+      fingerprint = "1608 9E8D 7C59 54F2 6A7A 7BD0 8BD2 09DC C54F D339";
+    }];
+  };
   georgewhewell = {
     email = "georgerw@gmail.com";
     github = "georgewhewell";

--- a/pkgs/tools/networking/doggo/default.nix
+++ b/pkgs/tools/networking/doggo/default.nix
@@ -1,48 +1,44 @@
-{
-  lib,
-  buildGoModule,
-  fetchFromGitHub,
-  runCommand,
-  installShellFiles,
-}: let
-  buildDate = "2022-08-15T21:36:49";
-  buildCommit = "2cf9e7b";
-in
-  with lib;
-    buildGoModule rec {
-      pname = "doggo";
-      version = "0.5.4";
-      vendorSha256 = "sha256-pyzu89HDFrMQqYJZC2vdqzOc6PiAbqhaTgYakmN0qj8=";
-      src = fetchFromGitHub {
-        owner = "mr-karan";
-        repo = "doggo";
-        rev = "v0.5.4";
-        sha256 = "sha256-6jNs8vigrwKk47Voe42J9QYMTP7KnNAtJ5vFZTUW680=";
-      };
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, installShellFiles
+}:
 
-      nativeBuildInputs = [installShellFiles];
-      subPackages = ["cmd/doggo"];
+buildGoModule rec {
+  pname = "doggo";
+  version = "0.5.4";
 
-      ldflags = [
-        "-w -s"
-        "-X main.buildVersion=${buildCommit}"
-        "-X main.buildDate=${buildDate}"
-      ];
+  src = fetchFromGitHub {
+    owner = "mr-karan";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-6jNs8vigrwKk47Voe42J9QYMTP7KnNAtJ5vFZTUW680=";
+  };
 
-      postInstall = ''
-        installShellCompletion --cmd doggo --fish --name doggo.fish completions/doggo.fish
-        installShellCompletion --cmd doggo --zsh --name _doggo completions/doggo.zsh
-      '';
+  vendorSha256 = "sha256-pyzu89HDFrMQqYJZC2vdqzOc6PiAbqhaTgYakmN0qj8=";
+  nativeBuildInputs = [ installShellFiles ];
+  subPackages = [ "cmd/doggo" ];
 
-      meta = {
-        homepage = "https://github.com/mr-karan/doggo";
-        description = "Command-line DNS Client for Humans. Written in Golang";
-        longDescription = ''
-          doggo is a modern command-line DNS client (like dig) written in Golang.
-          It outputs information in a neat concise manner and supports protocols like DoH, DoT, DoQ, and DNSCrypt as well
-        '';
-        license = licenses.gpl3Only;
-        platforms = platforms.linux;
-        maintainers = with maintainers; [georgesalkhouri];
-      };
-    }
+  ldflags = [
+    "-w -s"
+    "-X main.buildVersion=v${version}"
+  ];
+
+  postInstall = ''
+    installShellCompletion --cmd doggo \
+      --fish --name doggo.fish completions/doggo.fish \
+      --zsh --name _doggo completions/doggo.zsh
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/mr-karan/doggo";
+    description = "Command-line DNS Client for Humans. Written in Golang";
+    longDescription = ''
+      doggo is a modern command-line DNS client (like dig) written in Golang.
+      It outputs information in a neat concise manner and supports protocols like DoH, DoT, DoQ, and DNSCrypt as well
+    '';
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ georgesalkhouri ];
+  };
+}

--- a/pkgs/tools/networking/doggo/default.nix
+++ b/pkgs/tools/networking/doggo/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  runCommand,
+  installShellFiles,
+}: let
+  buildDate = "2022-08-15T21:36:49";
+  buildCommit = "2cf9e7b";
+in
+  with lib;
+    buildGoModule rec {
+      pname = "doggo";
+      version = "0.5.4";
+      vendorSha256 = "sha256-pyzu89HDFrMQqYJZC2vdqzOc6PiAbqhaTgYakmN0qj8=";
+      src = fetchFromGitHub {
+        owner = "mr-karan";
+        repo = "doggo";
+        rev = "v0.5.4";
+        sha256 = "sha256-6jNs8vigrwKk47Voe42J9QYMTP7KnNAtJ5vFZTUW680=";
+      };
+
+      nativeBuildInputs = [installShellFiles];
+      subPackages = ["cmd/doggo"];
+
+      ldflags = [
+        "-w -s"
+        "-X main.buildVersion=${buildCommit}"
+        "-X main.buildDate=${buildDate}"
+      ];
+
+      postInstall = ''
+        installShellCompletion --cmd doggo --fish --name doggo.fish completions/doggo.fish
+        installShellCompletion --cmd doggo --zsh --name _doggo completions/doggo.zsh
+      '';
+
+      meta = {
+        homepage = "https://github.com/mr-karan/doggo";
+        description = "Command-line DNS Client for Humans. Written in Golang";
+        longDescription = ''
+          doggo is a modern command-line DNS client (like dig) written in Golang.
+          It outputs information in a neat concise manner and supports protocols like DoH, DoT, DoQ, and DNSCrypt as well
+        '';
+        license = licenses.gpl3Only;
+        platforms = platforms.linux;
+        maintainers = with maintainers; [georgesalkhouri];
+      };
+    }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5602,6 +5602,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  doggo = callPackage ../tools/networking/doggo { };
+
   dosfstools = callPackage ../tools/filesystems/dosfstools { };
 
   dotnetfx35 = callPackage ../development/libraries/dotnetfx35 { };


### PR DESCRIPTION
###### Description of changes

Added a new package for doggo.

> doggo is a modern command-line DNS client (like dig) written in Golang. It outputs information in a neat concise manner and supports protocols like DoH, DoT, DoQ, and DNSCrypt as well.
https://github.com/mr-karan/doggo

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
