### PR TITLE
treewide: don't set phases

### DIFF
--- a/maintainers/scripts/nix-generate-from-cpan.nix
+++ b/maintainers/scripts/nix-generate-from-cpan.nix
@@ -7,9 +7,7 @@ stdenv.mkDerivation {
     makeWrapper perl GetoptLongDescriptive CPANPLUS Readonly LogLog4perl
   ];
 
-  phases = [ "installPhase" ];
-
-  installPhase =
+  buildCommand =
     ''
       mkdir -p $out/bin
       cp ${./nix-generate-from-cpan.pl} $out/bin/nix-generate-from-cpan

--- a/nixos/modules/services/amqp/activemq/default.nix
+++ b/nixos/modules/services/amqp/activemq/default.nix
@@ -9,9 +9,8 @@ let
 
   activemqBroker = stdenv.mkDerivation {
     name = "activemq-broker";
-    phases = [ "installPhase" ];
     buildInputs = [ jdk ];
-    installPhase = ''
+    buildCommand = ''
       mkdir -p $out/lib
       source ${activemq}/lib/classpath.env
       export CLASSPATH

--- a/nixos/tests/common/acme/server/generate-certs.nix
+++ b/nixos/tests/common/acme/server/generate-certs.nix
@@ -11,16 +11,13 @@ let
 in mkDerivation {
   name = "test-certs";
   buildInputs = [ minica ];
-  phases = [ "buildPhase" "installPhase" ];
 
-  buildPhase = ''
+  buildCommand = ''
     minica \
       --ca-key ca.key.pem \
       --ca-cert ca.cert.pem \
       --domains ${domain}
-  '';
 
-  installPhase = ''
     mkdir -p $out
     mv ca.*.pem $out/
     mv ${domain}/key.pem $out/${domain}.key.pem

--- a/pkgs/applications/misc/kdbplus/default.nix
+++ b/pkgs/applications/misc/kdbplus/default.nix
@@ -24,7 +24,6 @@ stdenv.mkDerivation rec {
   dontStrip = true;
   nativeBuildInputs = [ unzip ];
 
-  phases = "unpackPhase installPhase";
   unpackPhase = "mkdir ${pname}-${version} && cd ${pname}-${version} && unzip -qq ${src}";
   installPhase = ''
     mkdir -p $out/bin $out/libexec

--- a/pkgs/applications/networking/misc/zammad/update.nix
+++ b/pkgs/applications/networking/misc/zammad/update.nix
@@ -11,13 +11,12 @@
 
 stdenv.mkDerivation rec {
   name = "zammad-update-script";
-  installPhase = ''
+  buildCommand = ''
     mkdir -p $out/bin
     cp ${./update.sh} $out/bin/update.sh
     patchShebangs $out/bin/update.sh
     wrapProgram $out/bin/update.sh --prefix PATH : ${lib.makeBinPath buildInputs}
   '';
-  phases = [ "installPhase" ];
 
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [

--- a/pkgs/applications/office/ib/tws/default.nix
+++ b/pkgs/applications/office/ib/tws/default.nix
@@ -16,8 +16,6 @@ stdenv.mkDerivation rec {
     sha256 = "1a2jiwwnr5g3xfba1a89c257bdbnq4zglri8hz021vk7f6s4rlrf";
   };
 
-  phases = [ "unpackPhase" "buildPhase" "installPhase" ];
-
   buildInputs = [ jdk ];
 
   buildPhase = ''

--- a/pkgs/applications/office/moneyplex/default.nix
+++ b/pkgs/applications/office/moneyplex/default.nix
@@ -27,8 +27,6 @@ stdenv.mkDerivation {
                   else throw "moneyplex requires i686-linux or x86_64-linux");
 
 
-  phases = [ "unpackPhase" "installPhase" "postInstall" ];
-
   buildInputs = [ ];
 
   installPhase =

--- a/pkgs/applications/science/math/mathematica/10.nix
+++ b/pkgs/applications/science/math/mathematica/10.nix
@@ -74,23 +74,29 @@ stdenv.mkDerivation rec {
     + lib.optionalString (stdenv.hostPlatform.system == "x86_64-linux")
       (":" + lib.makeSearchPathOutput "lib" "lib64" buildInputs);
 
-  phases = "unpackPhase installPhase fixupPhase";
-
   unpackPhase = ''
+    runHook preUnpack
+
     echo "=== Extracting makeself archive ==="
     # find offset from file
     offset=$(${stdenv.shell} -c "$(grep -axm1 -e 'offset=.*' $src); echo \$offset" $src)
     dd if="$src" ibs=$offset skip=1 | tar -xf -
     cd Unix
+
+    runHook postUnpack
   '';
 
   installPhase = ''
+    runHook preInstall
+
     cd Installer
     # don't restrict PATH, that has already been done
     sed -i -e 's/^PATH=/# PATH=/' MathInstaller
 
     echo "=== Running MathInstaller ==="
     ./MathInstaller -auto -createdir=y -execdir=$out/bin -targetdir=$out/libexec/Mathematica -platforms=${platform} -silent
+
+    runHook postInstall
   '';
 
   preFixup = ''

--- a/pkgs/applications/science/math/mathematica/11.nix
+++ b/pkgs/applications/science/math/mathematica/11.nix
@@ -75,17 +75,21 @@ stdenv.mkDerivation rec {
     + lib.optionalString (stdenv.hostPlatform.system == "x86_64-linux")
       (":" + lib.makeSearchPathOutput "lib" "lib64" buildInputs);
 
-  phases = "unpackPhase installPhase fixupPhase";
-
   unpackPhase = ''
+    runHook preUnpack
+
     echo "=== Extracting makeself archive ==="
     # find offset from file
     offset=$(${stdenv.shell} -c "$(grep -axm1 -e 'offset=.*' $src); echo \$offset" $src)
     dd if="$src" ibs=$offset skip=1 | tar -xf -
     cd Unix
+
+    runHook postUnpack
   '';
 
   installPhase = ''
+    runHook preInstall
+
     cd Installer
     # don't restrict PATH, that has already been done
     sed -i -e 's/^PATH=/# PATH=/' MathInstaller
@@ -105,6 +109,8 @@ stdenv.mkDerivation rec {
       line=$(grep -n QT_PLUGIN_PATH $path | sed 's/:.*//')
       sed -i -e "$line iexport QT_XKB_CONFIG_ROOT=\"${xkeyboard_config}/share/X11/xkb\"" $path
     done
+
+    runHook postInstall
   '';
 
   preFixup = ''

--- a/pkgs/applications/science/math/mathematica/9.nix
+++ b/pkgs/applications/science/math/mathematica/9.nix
@@ -64,23 +64,29 @@ stdenv.mkDerivation rec {
     + lib.optionalString (stdenv.hostPlatform.system == "x86_64-linux")
     (":" + lib.makeSearchPathOutput "lib" "lib64" buildInputs);
 
-  phases = "unpackPhase installPhase fixupPhase";
-
   unpackPhase = ''
+    runHook preUnpack
+
     echo "=== Extracting makeself archive ==="
     # find offset from file
     offset=$(${stdenv.shell} -c "$(grep -axm1 -e 'offset=.*' $src); echo \$offset" $src)
     dd if="$src" ibs=$offset skip=1 | tar -xf -
     cd Unix
+
+    runHook postUnpack
   '';
 
   installPhase = ''
+    runHook preInstall
+
     cd Installer
     # don't restrict PATH, that has already been done
     sed -i -e 's/^PATH=/# PATH=/' MathInstaller
 
     echo "=== Running MathInstaller ==="
     ./MathInstaller -auto -createdir=y -execdir=$out/bin -targetdir=$out/libexec/Mathematica -platforms=${platform} -silent
+
+    runHook postInstall
   '';
 
   preFixup = ''

--- a/pkgs/build-support/fetchmavenartifact/default.nix
+++ b/pkgs/build-support/fetchmavenartifact/default.nix
@@ -63,12 +63,15 @@ let
 in
   stdenv.mkDerivation {
     name = name_;
-    phases = "installPhase fixupPhase";
     # By moving the jar to $out/share/java we make it discoverable by java
     # packages packages that mention this derivation in their buildInputs.
     installPhase = ''
+      runHook preInstall
+
       mkdir -p $out/share/java
       ln -s ${jar} $out/share/java/${artifactId}-${version}.jar
+
+      runHook postInstall
     '';
     # We also add a `jar` attribute that can be used to easily obtain the path
     # to the downloaded jar file.

--- a/pkgs/data/misc/colemak-dh/default.nix
+++ b/pkgs/data/misc/colemak-dh/default.nix
@@ -15,8 +15,6 @@ stdenvNoCC.mkDerivation rec {
     sparseCheckout = "console";
   };
 
-  phases = [ "unpackPhase" "installPhase" ];
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/development/tools/neoload/default.nix
+++ b/pkgs/development/tools/neoload/default.nix
@@ -43,7 +43,6 @@ in stdenv.mkDerivation rec {
         sha256 = "1z66jiwcxixsqqwa0f4q8m2p5kna4knq6lic8y8l74dgv25mw912"; } );
 
   nativeBuildInputs = [ makeWrapper ];
-  phases = [ "installPhase" ];
 
   # TODO: load generator / monitoring agent only builds
 

--- a/pkgs/games/vessel/default.nix
+++ b/pkgs/games/vessel/default.nix
@@ -18,7 +18,6 @@ stdenv.mkDerivation rec {
       sha256 = "1vpwcrjiln2mx43h7ib3jnccyr3chk7a5x2bw9kb4lw8ycygvg96";
     } else throw "unsupported platform ${stdenv.hostPlatform.system} only i686-linux supported for now.";
 
-  phases = "installPhase";
   ld_preload = ./isatty.c;
 
   libPath = lib.makeLibraryPath [ stdenv.cc.cc stdenv.cc.libc ]

--- a/pkgs/games/worldofgoo/default.nix
+++ b/pkgs/games/worldofgoo/default.nix
@@ -35,7 +35,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ unzip ];
   sourceRoot = pname;
-  phases = [ "unpackPhase installPhase" ];
 
   libPath = lib.makeLibraryPath [ stdenv.cc.cc.lib stdenv.cc.libc SDL2 SDL2_mixer
     libogg libvorbis ];


### PR DESCRIPTION
###### Description of changes

This is an attempt at discouraging setting `phases` explicitly in derivations, beyond what is already present in the documentation.

This is done in two parts:
1. Removing usages of `phases` treewide, when it's clear that it's not required
2. Renaming `phases` to `_phases`, to further discourage its usage and reliability

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
