### PR TITLE
Fix pyspnego

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3146,6 +3146,12 @@
     githubId = 6297001;
     name = "Jona Stubbe";
   };
+  csernazs = {
+    email = "cserna.zsolt@gmail.com";
+    github = "csernazs";
+    githubId = 1304175;
+    name = "Zsolt Cserna";
+  };
   csingley = {
     email = "csingley@gmail.com";
     github = "csingley";

--- a/pkgs/development/python-modules/k5test/fix-paths.patch
+++ b/pkgs/development/python-modules/k5test/fix-paths.patch
@@ -1,122 +1,115 @@
 diff --git a/k5test/_utils.py b/k5test/_utils.py
-index e289fac..e2f486a 100644
+index 906e978..a8baac3 100644
 --- a/k5test/_utils.py
 +++ b/k5test/_utils.py
-@@ -65,12 +65,12 @@ def find_plugin_dir():
- 
+@@ -63,12 +63,12 @@ def find_plugin_dir():
+
      # if there was no LD_LIBRARY_PATH, or the above failed
      if _PLUGIN_DIR is None:
--        lib_dir = os.path.join(get_output('krb5-config --prefix'), 'lib64')
-+        lib_dir = os.path.join(get_output('@krb5Dev@/bin/krb5-config --prefix'), 'lib64')
+-        lib_dir = os.path.join(get_output("krb5-config --prefix"), "lib64")
++        lib_dir = os.path.join(get_output("@krb5Dev@/bin/krb5-config --prefix"), "lib64")
          _PLUGIN_DIR = _decide_plugin_dir(_find_plugin_dirs_installed(lib_dir))
- 
+
      # /usr/lib64 seems only to be distinct on Fedora/RHEL/Centos family
      if _PLUGIN_DIR is None:
--        lib_dir = os.path.join(get_output('krb5-config --prefix'), 'lib')
-+        lib_dir = os.path.join(get_output('@krb5Dev@/bin/krb5-config --prefix'), 'lib')
+-        lib_dir = os.path.join(get_output("krb5-config --prefix"), "lib")
++        lib_dir = os.path.join(get_output("@krb5Dev@/bin/krb5-config --prefix"), "lib")
          _PLUGIN_DIR = _decide_plugin_dir(_find_plugin_dirs_installed(lib_dir))
- 
+
      if _PLUGIN_DIR is not None:
-@@ -89,7 +89,7 @@ def _decide_plugin_dir(dirs):
- 
+@@ -87,7 +87,7 @@ def _decide_plugin_dir(dirs):
+
      for path in shortest_first:
          # check to see if it actually contains .so files
 -        if get_output('find %s -name "*.so"' % path):
 +        if get_output('@findutils@/bin/find %s -name "*.so"' % path):
              return path
- 
+
      return None
-@@ -97,7 +97,7 @@ def _decide_plugin_dir(dirs):
- 
+@@ -96,7 +96,7 @@ def _decide_plugin_dir(dirs):
  def _find_plugin_dirs_installed(search_path):
      try:
--        options_raw = get_output('find %s/ -type d \( ! -executable -o ! -readable \) '
-+        options_raw = get_output('@findutils@/bin/find %s/ -type d \( ! -executable -o ! -readable \) '
-                                  '-prune -o '
-                                  '-type d -path "*/krb5/plugins" -print' % search_path,
-                                  stderr=subprocess.STDOUT)
+         options_raw = get_output(
+-            "find %s/ -type d \( ! -executable -o ! -readable \) "
++            "@findutils@/bin/find %s/ -type d \( ! -executable -o ! -readable \) "
+             "-prune -o "
+             '-type d -path "*/krb5/plugins" -print' % search_path,
+             stderr=subprocess.STDOUT,
 @@ -111,7 +111,7 @@ def _find_plugin_dirs_installed(search_path):
- 
- 
+
+
  def _find_plugin_dirs_src(search_path):
--    options_raw = get_output('find %s/../ -type d -name plugins' % search_path)
-+    options_raw = get_output('@findutils@/bin/find %s/../ -type d -name plugins' % search_path)
- 
+-    options_raw = get_output("find %s/../ -type d -name plugins" % search_path)
++    options_raw = get_output("@findutils@/bin/find %s/../ -type d -name plugins" % search_path)
+
      if options_raw:
-         return options_raw.split('\n')
+         return options_raw.split("\n")
 diff --git a/k5test/realm.py b/k5test/realm.py
-index 161e5ad..9f50049 100644
+index 8b24141..50c2273 100644
 --- a/k5test/realm.py
 +++ b/k5test/realm.py
-@@ -90,7 +90,7 @@ class K5Realm(metaclass=abc.ABCMeta):
- 
+@@ -87,7 +87,7 @@ class K5Realm(metaclass=abc.ABCMeta):
+         provider_cls = cls
+
          if provider_cls == K5Realm:
-             krb5_config = _discover_path('krb5-config',
--                                         '/usr/bin/krb5-config', kwargs)
-+                                         '@krb5@/bin/krb5-config', kwargs)
- 
+-            krb5_config = _discover_path("krb5-config", "/usr/bin/krb5-config", kwargs)
++            krb5_config = _discover_path("krb5-config", "@krb5Dev@/bin/krb5-config", kwargs)
+
              try:
                  krb5_version = subprocess.check_output(
-@@ -101,7 +101,7 @@ class K5Realm(metaclass=abc.ABCMeta):
+@@ -99,7 +99,7 @@ class K5Realm(metaclass=abc.ABCMeta):
+
                  # macOS output doesn't contain Heimdal
-                 if 'heimdal' in krb5_version.lower() or (
-                         sys.platform == 'darwin' and
--                        krb5_config == '/usr/bin/krb5-config'):
-+                        krb5_config == '@krb5@/bin/krb5-config'):
+                 if "heimdal" in krb5_version.lower() or (
+-                    sys.platform == "darwin" and krb5_config == "/usr/bin/krb5-config"
++                    sys.platform == "darwin" and krb5_config == "@krb5Dev@/bin/krb5-config"
+                 ):
                      provider_cls = HeimdalRealm
                  else:
-                     provider_cls = MITRealm
-@@ -434,14 +434,14 @@ class MITRealm(K5Realm):
-     @property
-     def _default_paths(self):
+@@ -462,12 +462,12 @@ class MITRealm(K5Realm):
          return [
--            ('kdb5_util', 'kdb5_util', '/usr/sbin/kdb5_util'),
--            ('krb5kdc', 'krb5kdc', '/usr/sbin/kdb5kdc'),
--            ('kadmin', 'kadmin', '/usr/bin/admin'),
--            ('kadmin_local', 'kadmin.local', '/usr/sbin/kadmin.local'),
--            ('kadmind', 'kadmind', '/usr/sbin/kadmind'),
--            ('kprop', 'kprop', '/usr/sbin/kprop'),
--            ('_kinit', 'kinit', '/usr/bin/kinit'),
--            ('_klist', 'klist', '/usr/bin/klist'),
-+            ('kdb5_util', 'kdb5_util', '@krb5@/bin/kdb5_util'),
-+            ('krb5kdc', 'krb5kdc', '@krb5@/bin/kdb5kdc'),
-+            ('kadmin', 'kadmin', '@krb5@/bin/admin'),
-+            ('kadmin_local', 'kadmin.local', '@krb5@/bin/kadmin.local'),
-+            ('kadmind', 'kadmind', '@krb5@/bin/kadmind'),
-+            ('kprop', 'kprop', '@krb5@/bin/kprop'),
-+            ('_kinit', 'kinit', '@krb5@/bin/kinit'),
-+            ('_klist', 'klist', '@krb5@/bin/klist'),
+             ("kdb5_util", "kdb5_util", "/usr/sbin/kdb5_util"),
+             ("krb5kdc", "krb5kdc", "/usr/sbin/krb5kdc"),
+-            ("kadmin", "kadmin", "/usr/bin/kadmin"),
++            ("kadmin", "kadmin", "@krb5Dev@/bin/kadmin"),
+             ("kadmin_local", "kadmin.local", "/usr/sbin/kadmin.local"),
+             ("kadmind", "kadmind", "/usr/sbin/kadmind"),
+             ("kprop", "kprop", "/usr/sbin/kprop"),
+-            ("_kinit", "kinit", "/usr/bin/kinit"),
+-            ("_klist", "klist", "/usr/bin/klist"),
++            ("_kinit", "kinit", "@krb5Dev@/bin/kinit"),
++            ("_klist", "klist", "@krb5Dev@/bin/klist"),
          ]
- 
+
      @property
-@@ -585,12 +585,12 @@ class HeimdalRealm(K5Realm):
- 
+@@ -628,12 +628,12 @@ class HeimdalRealm(K5Realm):
+
          return [
-             ('krb5kdc', 'kdc', os.path.join(base, 'kdc')),
--            ('kadmin', 'kadmin', '/usr/bin/kadmin'),
--            ('kadmin_local', 'kadmin', '/usr/bin/kadmin'),
-+            ('kadmin', 'kadmin', '@krb5@/bin/kadmin'),
-+            ('kadmin_local', 'kadmin', '@krb5@/bin/kadmin'),
-             ('kadmind', 'kadmind', os.path.join(base, 'kadmind')),
--            ('_kinit', 'kinit', '/usr/bin/kinit'),
--            ('_klist', 'klist', '/usr/bin/klist'),
--            ('_ktutil', 'ktutil', '/usr/bin/ktutil'),
-+            ('_kinit', 'kinit', '@krb5@/bin/kinit'),
-+            ('_klist', 'klist', '@krb5@/bin/klist'),
-+            ('_ktutil', 'ktutil', '@krb5@/bin/ktutil'),
+             ("krb5kdc", "kdc", os.path.join(base, "kdc")),
+-            ("kadmin", "kadmin", "/usr/bin/kadmin"),
+-            ("kadmin_local", "kadmin", "/usr/bin/kadmin"),
++            ("kadmin", "kadmin", "@krb5Dev@/bin/kadmin"),
++            ("kadmin_local", "kadmin", "@krb5Dev@/bin/kadmin"),
+             ("kadmind", "kadmind", os.path.join(base, "kadmind")),
+-            ("_kinit", "kinit", "/usr/bin/kinit"),
+-            ("_klist", "klist", "/usr/bin/klist"),
+-            ("_ktutil", "ktutil", "/usr/bin/ktutil"),
++            ("_kinit", "kinit", "@krb5Dev@/bin/kinit"),
++            ("_klist", "klist", "@krb5Dev@/bin/klist"),
++            ("_ktutil", "ktutil", "@krb5Dev@/bin/ktutil"),
          ]
- 
+
      @property
 diff --git a/k5test/unit.py b/k5test/unit.py
-index 3c64b9e..59da1ab 100644
+index caa8315..5bcf0bf 100644
 --- a/k5test/unit.py
 +++ b/k5test/unit.py
-@@ -38,7 +38,7 @@ _KRB_VERSION = None
+@@ -39,7 +39,7 @@ _KRB_VERSION = None
  def krb_minversion_test(target_version, problem, provider=None):
      global _KRB_VERSION
      if _KRB_VERSION is None:
 -        _KRB_VERSION = _utils.get_output("krb5-config --version")
 +        _KRB_VERSION = _utils.get_output("@krb5Dev@/bin/krb5-config --version")
-         _KRB_VERSION = _KRB_VERSION.split(' ')[-1].split('.')
- 
+         _KRB_VERSION = _KRB_VERSION.split(" ")[-1].split(".")
+
      def make_ext_test(func):

--- a/pkgs/development/python-modules/pykrb5/default.nix
+++ b/pkgs/development/python-modules/pykrb5/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchPypi, buildPythonPackage, krb5, cython, pytestCheckHook, k5test, which }:
+
+buildPythonPackage rec {
+  pname = "krb5";
+  version = "0.4.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-brDpHgRNN8s0yEuDExD0pIlR8pAtTrtluXy6xf8bImQ=";
+  };
+
+  nativeBuildInputs = [
+    krb5.dev # for krb5-config
+  ];
+
+  buildInputs = [ cython ];
+  checkInputs = [ pytestCheckHook k5test which ];
+
+  meta = with lib; {
+    description = "Kerberos API bindings for Python";
+    license     = licenses.mit;
+    homepage    = "https://github.com/jborean93/pykrb5";
+    maintainers = with maintainers; [ csernazs ];
+  };
+}

--- a/pkgs/development/python-modules/pyspnego/default.nix
+++ b/pkgs/development/python-modules/pyspnego/default.nix
@@ -3,7 +3,7 @@
 , cryptography
 , fetchFromGitHub
 , gssapi
-, krb5
+, pykrb5
 , ruamel-yaml
 , pytest-mock
 , pytestCheckHook
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     cryptography
     gssapi
-    krb5
+    pykrb5
     ruamel-yaml
   ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7279,6 +7279,8 @@ self: super: with self; {
 
   pykrakenapi = callPackage ../development/python-modules/pykrakenapi { };
 
+  pykrb5  = callPackage ../development/python-modules/pykrb5 { };
+
   pylddwrap = callPackage ../development/python-modules/pylddwrap { };
 
   pyngrok = callPackage ../development/python-modules/pyngrok { };


### PR DESCRIPTION
###### Description of changes

pyspnego is broken as its `krb5` dependency in the nix expression is specified incorrectly. For example, when it is used by `requests-kerberos` python library, it raises `ImportError` exception.

Example test which shows the issue:
```python
import requests
from pytest_httpserver import HTTPServer
from requests_kerberos import HTTPKerberosAuth


def test_spnego(httpserver: HTTPServer):
    httpserver.expect_request("/auth").respond_with_data(status=401, headers={"WWW-Authenticate": "Negotiate"})
    resp = requests.get(httpserver.url_for("/auth"), auth=HTTPKerberosAuth())

    assert resp.status_code == 401
```

With current nixpkgs master it produces:
```
[...]
        if not HAS_GSSAPI:
>           raise ImportError("GSSAPIProxy requires the Python gssapi library: %s" % GSSAPI_IMP_ERR)
E           ImportError: GSSAPIProxy requires the Python gssapi library: No module named 'krb5'
```

The problem is that `pyspnego` depends on the `pykrb5` python library and not on the `krb5` derivation as specified (which contains the C library, and the related toolchain).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


CC: @fabaff (pyspnego) @catern (requests-kerberos)
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
