### PR TITLE
tuptime: 5.1.0 -> 5.2.0

### DIFF
--- a/nixos/modules/services/monitoring/tuptime.nix
+++ b/nixos/modules/services/monitoring/tuptime.nix
@@ -45,7 +45,7 @@ in {
       services = {
 
         tuptime = {
-          description = "the total uptime service";
+          description = "The total uptime service";
           documentation = [ "man:tuptime(1)" ];
           after = [ "time-sync.target" ];
           wantedBy = [ "multi-user.target" ];
@@ -59,10 +59,9 @@ in {
           };
         };
 
-        tuptime-oneshot = mkIf cfg.timer.enable {
-          description = "the tuptime scheduled execution unit";
+        tuptime-sync = mkIf cfg.timer.enable {
+          description = "Tuptime scheduled sync service";
           serviceConfig = {
-            StateDirectory = "tuptime";
             Type = "oneshot";
             User = "_tuptime";
             ExecStart = "${pkgs.tuptime}/bin/tuptime -x";
@@ -70,8 +69,8 @@ in {
         };
       };
 
-      timers.tuptime = mkIf cfg.timer.enable {
-        description = "the tuptime scheduled execution timer";
+      timers.tuptime-sync = mkIf cfg.timer.enable {
+        description = "Tuptime scheduled sync timer";
         # this timer should be started if the service is started
         # even if the timer was previously stopped
         wantedBy = [ "tuptime.service" "timers.target" ];
@@ -80,7 +79,7 @@ in {
         timerConfig = {
           OnBootSec = "1min";
           OnCalendar = cfg.timer.period;
-          Unit = "tuptime-oneshot.service";
+          Unit = "tuptime-sync.service";
         };
       };
     };

--- a/pkgs/tools/system/tuptime/default.nix
+++ b/pkgs/tools/system/tuptime/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "tuptime";
-  version = "5.1.0";
+  version = "5.2.0";
 
   src = fetchFromGitHub {
     owner = "rfrail3";
     repo = "tuptime";
     rev = version;
-    sha256 = "sha256-6N4dqgLOhWqVR8GqlBUxHWy10AHBZ4aZbdkw5SOxxBQ=";
+    sha256 = "sha256-s0VtKOaSPQlF58/2m/DwYDuHHPGnHVAJMA/p3hISTNE=";
   };
 
   nativeBuildInputs = [ makeWrapper installShellFiles ];
@@ -41,6 +41,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Total uptime & downtime statistics utility";
     homepage = "https://github.com/rfrail3/tuptime";
+    changelog = "https://github.com/rfrail3/tuptime/blob/master/CHANGELOG";
     license = licenses.gpl2Plus;
     platforms = platforms.all;
     maintainers = [ maintainers.evils ];


### PR DESCRIPTION
add meta.changelog

and update module to upstream wording


closes #186906 as this includes that change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).