### PR TITLE
Add Vosk offline speech recognition service

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -258,6 +258,13 @@
       </listitem>
       <listitem>
         <para>
+          <link xlink:href="https://alphacephei.com/vosk/">vosk</link>,
+          an offline speech recognition service. Available as
+          <link linkend="opt-services.vosk.enable">services.vosk</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <link xlink:href="https://www.expressvpn.com">expressvpn</link>,
           the CLI client for ExpressVPN. Available as
           <link linkend="opt-services.expressvpn.enable">services.expressvpn</link>.

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -92,6 +92,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [Dolibarr](https://www.dolibarr.org/), an enterprise resource planning and customer relationship manager. Enable using [services.dolibarr](#opt-services.dolibarr.enable).
 
+- [vosk](https://alphacephei.com/vosk/), an offline speech recognition service. Available as [services.vosk](#opt-services.vosk.enable).
+
 - [expressvpn](https://www.expressvpn.com), the CLI client for ExpressVPN. Available as [services.expressvpn](#opt-services.expressvpn.enable).
 
 - [go-autoconfig](https://github.com/L11R/go-autoconfig), IMAP/SMTP autodiscover server. Available as [services.go-autoconfig](#opt-services.go-autoconfig.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -296,6 +296,7 @@
   ./services/audio/snapserver.nix
   ./services/audio/squeezelite.nix
   ./services/audio/spotifyd.nix
+  ./services/audio/vosk.nix
   ./services/audio/ympd.nix
   ./services/backup/automysqlbackup.nix
   ./services/backup/bacula.nix

--- a/nixos/modules/services/audio/vosk.nix
+++ b/nixos/modules/services/audio/vosk.nix
@@ -1,0 +1,89 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.services.vosk;
+in
+{
+  options.services.vosk = with lib; {
+    enable = mkEnableOption (lib.mdDoc "the Vosk WebSocket speech recognition server");
+    package = mkOption {
+      type = types.package;
+      default = pkgs.vosk-server;
+      defaultText = literalExpression "pkgs.vosk-server";
+      description = lib.mdDoc "The package to use for the Vosk server.";
+    };
+    interface = mkOption {
+      type = types.str;
+      default = "0.0.0.0";
+      description = lib.mdDoc "Interface the Vosk server should bind to.";
+    };
+    port = mkOption {
+      type = types.port;
+      default = 2700;
+      description = lib.mdDoc "Port the Vosk server should listen on.";
+    };
+    model = mkOption {
+      type = types.path;
+      default = pkgs.vosk.models.en-us;
+      defaultText = literalExpression "pkgs.vosk.models.en-us";
+      example = literalExpression "pkgs.vosk.models.de";
+      description = lib.mdDoc "Model the Vosk server should use.";
+    };
+    spkModel = mkOption {
+      type = types.nullOr types.path;
+      default = pkgs.vosk.models.spk;
+      defaultText = literalExpression "pkgs.vosk.models.spk";
+      description = lib.mdDoc "Speaker identification model the Vosk server should use.";
+    };
+    sampleRate = mkOption {
+      type = types.int;
+      default = 8000;
+      description = lib.mdDoc "Sample rate the Vosk server should use.";
+    };
+    maxAlternatives = mkOption {
+      type = types.int;
+      default = 0;
+      description = lib.mdDoc "The number of alternative guesses the Vosk server should return.";
+    };
+    showWords = mkOption {
+      type = types.bool;
+      default = true;
+      description = lib.mdDoc "Whether the Vosk server should return timestamps for recognised words.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.vosk = {
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      environment = {
+        HOME = "/var/empty"; # vosk-server fails if it can’t resolve HOME
+
+        VOSK_SERVER_INTERFACE = cfg.interface;
+        VOSK_SERVER_PORT = toString cfg.port;
+        VOSK_MODEL_PATH = cfg.model;
+        VOSK_SAMPLE_RATE = toString cfg.sampleRate;
+        VOSK_ALTERNATIVES = toString cfg.maxAlternatives;
+        VOSK_SHOW_WORDS = toString cfg.showWords;
+      } // (lib.optionalAttrs (!(isNull cfg.spkModel)) {
+        VOSK_SPK_MODEL_PATH = cfg.spkModel;
+      });
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/vosk-server";
+
+        # from systemd-analyze --no-pager security vosk.service
+        CapabilityBoundingSet = null;
+        DynamicUser = true;
+        MemoryDenyWriteExecute = true;
+        PrivateDevices = true;
+        PrivateUsers = true;
+        ProtectHome = true;
+        ProtectKernelLogs = true;
+        RestrictAddressFamilies = [ "AF_INET" "AF_INET6" ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = "@system-service";
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -617,6 +617,7 @@ in {
   victoriametrics = handleTest ./victoriametrics.nix {};
   vikunja = handleTest ./vikunja.nix {};
   virtualbox = handleTestOn ["x86_64-linux"] ./virtualbox.nix {};
+  vosk = handleTest ./vosk.nix { };
   vscodium = discoverTests (import ./vscodium.nix);
   vsftpd = handleTest ./vsftpd.nix {};
   wasabibackend = handleTest ./wasabibackend.nix {};

--- a/nixos/tests/vosk.nix
+++ b/nixos/tests/vosk.nix
@@ -1,0 +1,26 @@
+import ./make-test-python.nix ({ lib, pkgs, ... }: {
+  name = "vosk";
+
+  nodes.machine = {
+    services.vosk = {
+      enable = true;
+      # The test does not use one of the packaged models for two reasons:
+      #  - The large models require 8GiB+ RAM and ideally multiple CPU cores
+      #  - An update to the model could make the test assertion fail
+      model = pkgs.fetchzip {
+        url = "https://alphacephei.com/vosk/models/vosk-model-small-en-us-0.15.zip";
+        sha256 = "sha256-CIoPZ/krX+UW2w7c84W3oc1n4zc9BBS/fc8rVYUthuY=";
+        meta.license = lib.licenses.asl20;
+      };
+    };
+  };
+
+  testScript = { nodes, ... }: ''
+    machine.wait_for_open_port(2700)
+
+    machine.succeed("${pkgs.python3.withPackages (ps: [ ps.websockets ])}/bin/python ${pkgs.vosk-server.src}/websocket/test.py ${pkgs.vosk-server.src}/websocket/test16k.wav | ${pkgs.jq}/bin/jq -r 'select(.text).text' > /tmp/result")
+    machine.succeed("grep 'one zero zero zero one' /tmp/result")
+    machine.succeed("grep 'nah no to i know' /tmp/result")
+    machine.succeed("grep 'zero one eight zero three' /tmp/result")
+  '';
+})

--- a/pkgs/development/python-modules/vosk/default.nix
+++ b/pkgs/development/python-modules/vosk/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonPackage, vosk, cffi, requests, srt, tqdm, websockets }:
+
+buildPythonPackage rec {
+  pname = "vosk";
+  inherit (vosk) version src meta;
+
+  sourceRoot = "source/python";
+
+  postPatch = ''
+    substituteInPlace vosk/__init__.py \
+      --replace "dlldir = os.path.abspath(os.path.dirname(__file__))" 'dlldir = "${vosk}/lib"'
+  '';
+
+  propagatedBuildInputs = [
+    cffi
+    requests
+    srt
+    tqdm
+    websockets
+  ];
+
+  doCheck = false; # no tests
+
+  pythonImportsCheck = [ "vosk" ];
+}

--- a/pkgs/tools/audio/vosk-server/default.nix
+++ b/pkgs/tools/audio/vosk-server/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonApplication, fetchFromGitHub, vosk }:
+{ lib, buildPythonApplication, fetchFromGitHub, vosk, nixosTests }:
 
 buildPythonApplication rec {
   pname = "vosk-server";
@@ -22,6 +22,10 @@ buildPythonApplication rec {
     install -D asr_server.py $out/bin/vosk-server
     runHook postInstall
   '';
+
+  passthru.tests = {
+    inherit (nixosTests) vosk;
+  };
 
   meta = with lib; {
     homepage = "https://alphacephei.com/vosk/server";

--- a/pkgs/tools/audio/vosk-server/default.nix
+++ b/pkgs/tools/audio/vosk-server/default.nix
@@ -1,0 +1,32 @@
+{ lib, buildPythonApplication, fetchFromGitHub, vosk }:
+
+buildPythonApplication rec {
+  pname = "vosk-server";
+  version = "unstable-2022-04-01";
+
+  src = fetchFromGitHub {
+    owner = "alphacep";
+    repo = pname;
+    rev = "1ef2052573fb75a0ebca3458279a89c613383d99";
+    sha256 = "sha256-0hHHJLQfCWetfB+ab6O6B700sTjs9nsLeldcTWUfvrY=";
+  };
+
+  sourceRoot = "source/websocket";
+
+  format = "custom";
+
+  propagatedBuildInputs = [ vosk ];
+
+  installPhase = ''
+    runHook preInstall
+    install -D asr_server.py $out/bin/vosk-server
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://alphacephei.com/vosk/server";
+    description = "Server for highly accurate offline speech recognition using Kaldi and Vosk";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ sbruder ];
+  };
+}

--- a/pkgs/tools/audio/vosk/default.nix
+++ b/pkgs/tools/audio/vosk/default.nix
@@ -35,7 +35,11 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     install -D libvosk${stdenv.hostPlatform.extensions.sharedLibrary} $out/lib/libvosk${stdenv.hostPlatform.extensions.sharedLibrary}
-  '';
+    '';
+
+  passthru = {
+    models = callPackage ./models.nix { };
+  };
 
   meta = with lib; {
     homepage = "https://alphacephei.com/vosk/";

--- a/pkgs/tools/audio/vosk/default.nix
+++ b/pkgs/tools/audio/vosk/default.nix
@@ -1,0 +1,47 @@
+{ lib, callPackage, stdenv, fetchFromGitHub, openblas, libf2c }:
+let
+  # It requires a special fork that needs to be built differently than how kaldi gets built in nixpkgs.
+  kaldi = callPackage ./kaldi.nix { };
+in
+stdenv.mkDerivation rec {
+  pname = "vosk-api";
+  version = "0.3.43";
+
+  src = fetchFromGitHub {
+    owner = "alphacep";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-SbCZx+G5q/W7CBVbmGZYf2ubhUJXtSTzaFAwQEJEt3Y=";
+  };
+
+  sourceRoot = "source/src";
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace '-I$(KALDI_ROOT)/src' '-I${kaldi.src}/src' \
+      --replace '-I$(OPENFST_ROOT)/include' '-I${kaldi.openfst.src}/src/include'
+  '';
+
+  buildInputs = [ openblas kaldi kaldi.openfst libf2c ];
+
+  makeFlags = [
+    "KALDI_ROOT=${kaldi}"
+    "OPENBLAS_ROOT=${openblas}"
+    "USE_SHARED=1"
+    "EXT=${let ext = stdenv.hostPlatform.extensions.sharedLibrary; in lib.substring 1 (lib.stringLength ext - 1) ext}"
+  ];
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    install -D libvosk${stdenv.hostPlatform.extensions.sharedLibrary} $out/lib/libvosk${stdenv.hostPlatform.extensions.sharedLibrary}
+  '';
+
+  meta = with lib; {
+    homepage = "https://alphacephei.com/vosk/";
+    description = "Offline speech recognition API";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ sbruder ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/tools/audio/vosk/kaldi.nix
+++ b/pkgs/tools/audio/vosk/kaldi.nix
@@ -1,0 +1,125 @@
+{ lib
+, openfst
+, fetchFromGitHub
+, stdenv
+, writeText
+, autoconf
+, automake
+, libtool
+, gfortran
+, openblas
+}:
+let
+  openfst' = openfst.overrideAttrs (oldAttrs: {
+    version = "1.8.0"; # this needs to match the version from kaldi/tools/Makefile
+
+    # not pinned, so it should be updated to the latest version when updating kaldi
+    src = fetchFromGitHub {
+      owner = "alphacep";
+      repo = "openfst";
+      rev = "7dfd808194105162f20084bb4d8e4ee4b65266d5";
+      sha256 = "sha256-XiPR4AaSa/7OqYoYZOwlW3UhAsYmscBE36xffI2gPPg=";
+    };
+
+    # from OPENFST_CONFIGURE in kaldi/tools/Makefile
+    configureFlags = [
+      "--enable-shared"
+      "--enable-far"
+      "--enable-ngram-fsts"
+      "--enable-lookahead-fsts"
+      "--with-pic"
+    ];
+  });
+
+  # pinned in kaldi/tools/Makefile
+  cub = fetchFromGitHub {
+    owner = "nvidia";
+    repo = "cub";
+    rev = "1.8.0";
+    sha256 = "sha256-j52BSkTItExznQApZbv868ipU4SCAu0EOqljzzKnIdk=";
+    meta.license = lib.licenses.bsd3;
+  };
+
+  # When updating, always update the git revision (rev) and the version base.
+  # The version base can be obtained by running src/base/get_version.sh in the kaldi source.
+  # Only the first three components (major.minor.patch) should be put in here,
+  # the last one (short git commit hash) will automatically be appended
+  version_base = "5.5.1046";
+  rev = "76cd51d44c0a61e3905c35cadb2ec5f54f3e42d1";
+in
+stdenv.mkDerivation rec {
+  pname = "kaldi";
+  version = "${version_base}-${lib.substring 0 5 rev}";
+
+  src = fetchFromGitHub {
+    owner = "alphacep";
+    repo = "kaldi";
+    inherit rev;
+    sha256 = "sha256-utsHBkkjQzUcsPeEuag7BMf9wSdZxEO98aGEP4iFx30=";
+  };
+
+  sourceRoot = "source/src";
+
+  postPatch = ''
+    # disable script (requires .git) and hardcode version
+    echo > base/get_version.sh
+    ln -s ${writeText "version.h" ''
+      #define KALDI_VERSION "${version}"
+      #define KALDI_GIT_HEAD "${rev}"
+    ''} base/version.h
+
+    # otherwise /build/source/src/lib gets added to RPATH
+    substituteInPlace makefiles/default_rules.mk \
+      --replace '-Wl,-rpath -Wl,$(KALDILIBDIR)' "-Wl,-rpath, -Wl,$out/lib" \
+      --replace '-Wl,-rpath=$(shell readlink -f $(KALDILIBDIR))' "-Wl,-rpath=$out/lib"
+  '';
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    libtool
+  ];
+
+  buildInputs = [
+    gfortran.cc.lib
+    # Vosk’s guide states that their Kaldi fork requires OpenBLAS with CLAPACK.
+    # However, it works just as well with regular OpenBLAS,
+    # which also avoids introducing a different OpenBLAS derivation.
+    openblas
+  ];
+
+  enableParallelBuilding = true;
+
+  preConfigure = ''
+    patchShebangs configure
+  '';
+
+  dontAddPrefix = true;
+  configureFlags = [
+    "--shared"
+    "--fst-root=${openfst'}"
+    "--fst-version=${openfst'.version}"
+    "--cub-root=${cub}"
+    "--openblas-root=${openblas}"
+  ];
+
+  makeFlags = [ "online2" "lm" "rnnlm" ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir $out
+    cp -rL lib $out/lib
+    runHook postInstall
+  '';
+
+  passthru = {
+    openfst = openfst';
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/alphacep/kaldi/tree/vosk";
+    description = "Kaldi fork for the Vosk offline speech recognition API";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/tools/audio/vosk/models.nix
+++ b/pkgs/tools/audio/vosk/models.nix
@@ -1,0 +1,155 @@
+{ lib, fetchzip }:
+lib.mapAttrs
+  (model: config: fetchzip rec {
+    name = "vosk-model-${model}-${config.version}";
+    url = "https://alphacephei.com/vosk/models/${name}.zip";
+    inherit (config) sha256;
+    meta = {
+      inherit (config) license;
+    };
+  })
+{
+  # Regular models
+  ar-mgb2 = {
+    version = "0.4";
+    sha256 = "sha256-o4DuSLWf0sBj1qUf0wT1AUzT4nqFp4UdVn5a6pgIB0A=";
+    license = lib.licenses.asl20;
+  };
+  small-ca = {
+    version = "0.4";
+    sha256 = "sha256-3pN+xE09nUHUSsCIK6iNsvjlNYvsz8XeWxHowmawJgU=";
+    license = lib.licenses.asl20;
+  };
+  cn = {
+    version = "0.22";
+    sha256 = "sha256-dmc9MpjAQgCC/IyiBm/sAYwgzzsbGcJPJ0ZoJAbj740=";
+    license = lib.licenses.asl20;
+  };
+  small-cs = {
+    version = "0.4-rhasspy";
+    sha256 = "sha256-z58e1gKT4vb0yhkhNVznY9iIn42p7i3rldZd8QVAd7A=";
+    license = lib.licenses.mit;
+  };
+  de = {
+    version = "0.21";
+    sha256 = "sha256-Pqf6Eo15aIfI3NYN1kYakUVyA6JD0hR2rW+R/2hDug4=";
+    license = lib.licenses.asl20;
+  };
+  el-gr = {
+    version = "0.7";
+    sha256 = "sha256-XKavK46sX6r4GiXiYbs/+XbN+H8fAu/TC7tQE8d8NRQ=";
+    license = lib.licenses.asl20;
+  };
+  en-in = {
+    version = "0.5";
+    sha256 = "sha256-sE7NkBHP7sHRyyqPIkLxNuf2aZqNeNZVpSrBVYafWSU=";
+    license = lib.licenses.asl20;
+  };
+  en-us = {
+    version = "0.22";
+    sha256 = "sha256-kakOhA7hEtDM6WY3oAnb8xKZil9WTA3xePpLIxr2+yM=";
+    license = lib.licenses.asl20;
+  };
+  small-eo = {
+    version = "0.42";
+    sha256 = "sha256-ZRbggC2TM9ynUPqzof/aPTVN3vlbcuZ2+trqBVsXKdQ=";
+    license = lib.licenses.asl20;
+  };
+  small-es = {
+    version = "0.22";
+    sha256 = "sha256-JRe3KTikkIq7kBV+YmxW6uc0dMRRclZAhhHOI3g9HBQ=";
+    license = lib.licenses.asl20;
+  };
+  fa = {
+    version = "0.5";
+    sha256 = "sha256-yUTpPFtFdfZxm+Xh8KvyyCvjtl256nc8H2zQ0WCIFrc=";
+    license = lib.licenses.asl20;
+  };
+  fr = {
+    version = "0.22";
+    sha256 = "sha256-PQYByIbw1pwGJnGODkpvlzy/7cLCQK3v+zAswj53jvA=";
+    license = lib.licenses.asl20;
+  };
+  hi = {
+    version = "0.22";
+    sha256 = "sha256-KSH85TYuGBHAR4fU4KDXr44YHdP7lZV11iJ+fEiti6M=";
+    license = lib.licenses.asl20;
+  };
+  it = {
+    version = "0.22";
+    sha256 = "sha256-W8rg16lLQeAz6St8n3/kPdO7pbXQ1QSombF1Aq7tgIM=";
+    license = lib.licenses.asl20;
+  };
+  ja = {
+    version = "0.22";
+    sha256 = "sha256-CjifemsTm6T2MnPgUOLhd7EsTqAc18N6MfhrhwBk06s=";
+    license = lib.licenses.asl20;
+  };
+  kz = {
+    version = "0.15";
+    sha256 = "sha256-AcDUGa/o9709nC12Cv6+aKBDo4b9RU8oFJEwgoEyuzY=";
+    license = lib.licenses.asl20;
+  };
+  small-nl = {
+    version = "0.22";
+    sha256 = "sha256-K71Zi75J7r3V6Q/uipWFywMbWIRElCbk5Nu8QN6zilE=";
+    license = lib.licenses.asl20;
+  };
+  nl-spraakherkenning ={
+    version = "0.6";
+    sha256 = "sha256-BtyErVwrcUCbsGZmClWqYRytIfal05AjITzOcAIKLok=";
+    license = lib.licenses.cc-by-nc-sa-40;
+  };
+  small-pl = {
+    version = "0.22";
+    sha256 = "sha256-ZiZZtbv5kbwqcIDEzaYwtJbRgmIA9Hjx86tBUk+CpPI=";
+    license = lib.licenses.asl20;
+  };
+  small-pt = {
+    version = "0.3";
+    sha256 = "sha256-HG7tAQPkfMGGaGaCACIWapGHGsDAPBll5dtl7xi/AJc=";
+    license = lib.licenses.asl20;
+  };
+  pt-fb = {
+    version = "v0.1.1-20220516_2113";
+    sha256 = "sha256-35z/Df34SXl/a8LwfG4/sHiDXASCRuHcks3mJ0Zn8Yo=";
+    license = lib.licenses.gpl3Only;
+  };
+  ru = {
+    version = "0.22";
+    sha256 = "sha256-vxe1YJpA5hI5L3ZhpGE3vFh1kTbRkcOrletaGWLnL5M=";
+    license = lib.licenses.asl20;
+  };
+  small-sv-rhasspy = {
+    version = "0.15";
+    sha256 = "sha256-JVAGCkCOHbcDsfJDJqHaWEq3If9pI1gehWhLcLmdHN4=";
+    license = lib.licenses.mit;
+  };
+  tl-ph-generic = {
+    version = "0.6";
+    sha256 = "sha256-c5k/dB+Kq9iAmz6UKY/cTqIwWK6uQ6qEjz7qAvvD4oo=";
+    license = lib.licenses.cc-by-nc-sa-40;
+  };
+  small-tr = {
+    version = "0.3";
+    sha256 = "sha256-IOpQTgUbH5sFP9BQg9TbzJpeRrWPNy3UAQkSloVsKig=";
+    license = lib.licenses.asl20;
+  };
+  uk = {
+    version = "v3";
+    sha256 = "sha256-uxocuXspb0ec7X6Ig3yUkJ4tDX2ytn10WKS78BYeoUE=";
+    license = lib.licenses.asl20;
+  };
+  small-vn = {
+    version = "0.3";
+    sha256 = "sha256-6pX1B+BhhFDQ/hPtuIdKnujSWc0BNXJnEgohe7hpaUE=";
+    license = lib.licenses.asl20;
+  };
+
+  # Speaker identification models
+  spk = {
+    version = "0.4";
+    sha256 = "sha256-wpTfZnEL1sCfpLhp+l62d8GcOinR15XnSHaLVASH4RA=";
+    license = lib.licenses.asl20;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12092,6 +12092,8 @@ with pkgs;
 
   vosk = callPackage ../tools/audio/vosk { };
 
+  vosk-server = python3Packages.callPackage ../tools/audio/vosk-server { };
+
   vpnc = callPackage ../tools/networking/vpnc { };
 
   vpnc-scripts = callPackage ../tools/networking/vpnc-scripts { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12090,6 +12090,8 @@ with pkgs;
 
   vorbisgain = callPackage ../tools/misc/vorbisgain { };
 
+  vosk = callPackage ../tools/audio/vosk { };
+
   vpnc = callPackage ../tools/networking/vpnc { };
 
   vpnc-scripts = callPackage ../tools/networking/vpnc-scripts { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11562,6 +11562,10 @@ in {
 
   volvooncall = callPackage ../development/python-modules/volvooncall { };
 
+  vosk = callPackage ../development/python-modules/vosk {
+    inherit (pkgs) vosk;
+  };
+
   vowpalwabbit = callPackage ../development/python-modules/vowpalwabbit { };
 
   vpk = callPackage ../development/python-modules/vpk { };


### PR DESCRIPTION
###### Description of changes

This adds [Vosk](https://alphacephei.com/vosk/), an offline speech recognition service. It is part of [Summer of Nix](https://summer.nixos.org/) to allow live transcriptions with Jitsi Meet, for which Vosk is required.

It consists of several parts:

 * The main vosk library, including alpha cephei’s fork of kaldi, which is incompatible with the current kaldi derivation in nixpkgs
 * The python bindings/library to vosk (includes `vosk-transcriber` command line tool)
   + There are also other bindings available, but the python ones are required for vosk-server, so I only packaged them
   + I’m not sure if this is the correct way to handle a library that also includes (multiple) language bindings. I wanted to separate them and not put the library itself in python-modules, because it provides bindings for a lot of languages.
 * The language models for vosk. I packaged the main model directly provided by Vosk, when this is not available the small model and/or a third-party one
 * The vosk-server WebSocket server
 * A NixOS module for vosk-server
 * A NixOS integration test for vosk-server
   + It does not use any of the pre-packaged models because their memory consumption is too high and updates to them could make the test fail

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [X] (Module addition) Added a release notes entry if adding a new NixOS module
  - [X] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
