### PR TITLE
{sublime4,sublime-merge}: fix updateScript and update dev packages

### DIFF
--- a/pkgs/applications/editors/sublime/4/common.nix
+++ b/pkgs/applications/editors/sublime/4/common.nix
@@ -6,33 +6,22 @@
 }:
 
 let
-  pname = "sublimetext4";
+  pnameBase = "sublimetext4";
   packageAttribute = "sublime4${lib.optionalString dev "-dev"}";
   binaries = [ "sublime_text" "plugin_host-3.3" "plugin_host-3.8" "crash_reporter" ];
   primaryBinary = "sublime_text";
   primaryBinaryAliases = [ "subl" "sublime" "sublime4" ];
-  downloadUrl = "https://download.sublimetext.com/sublime_text_build_${buildVersion}_${arch}.tar.xz";
+  downloadUrl = arch: "https://download.sublimetext.com/sublime_text_build_${buildVersion}_${arch}.tar.xz";
   versionUrl = "https://download.sublimetext.com/latest/${if dev then "dev" else "stable"}";
   versionFile = builtins.toString ./packages.nix;
-  archSha256 = {
-    "aarch64-linux" = aarch64sha256;
-    "x86_64-linux" = x64sha256;
-  }.${stdenv.hostPlatform.system};
-  arch = {
-    "aarch64-linux" = "arm64";
-    "x86_64-linux" = "x64";
-  }.${stdenv.hostPlatform.system};
 
   libPath = lib.makeLibraryPath [ xorg.libX11 xorg.libXtst glib libglvnd openssl gtk3 cairo pango curl ];
 in let
-  binaryPackage = stdenv.mkDerivation {
-    pname = "${pname}-bin";
+  binaryPackage = stdenv.mkDerivation rec {
+    pname = "${pnameBase}-bin";
     version = buildVersion;
 
-    src = fetchurl {
-      url = downloadUrl;
-      sha256 = archSha256;
-    };
+    src = passthru.sources.${stdenv.hostPlatform.system};
 
     dontStrip = true;
     dontPatchELF = true;
@@ -95,9 +84,22 @@ in let
         --set LOCALE_ARCHIVE "${glibcLocales.out}/lib/locale/locale-archive" \
         "''${gappsWrapperArgs[@]}"
     '';
+
+    passthru = {
+      sources = {
+        "aarch64-linux" = fetchurl {
+          url = downloadUrl "arm64";
+          sha256 = aarch64sha256;
+        };
+        "x86_64-linux" = fetchurl {
+          url = downloadUrl "x64";
+          sha256 = x64sha256;
+        };
+      };
+    };
   };
 in stdenv.mkDerivation (rec {
-  inherit pname;
+  pname = pnameBase;
   version = buildVersion;
 
   dontUnpack = true;
@@ -119,24 +121,26 @@ in stdenv.mkDerivation (rec {
     done
   '';
 
-  passthru.updateScript = writeShellScript "${pname}-update-script" ''
-    set -o errexit
-    PATH=${lib.makeBinPath [ common-updater-scripts curl ]}
+  passthru = {
+    updateScript = writeShellScript "${packageAttribute}-update-script" ''
+      set -o errexit
+      PATH=${lib.makeBinPath [ common-updater-scripts curl ]}
 
-    latestVersion=$(curl -s ${versionUrl})
+      latestVersion=$(curl -s "${versionUrl}")
 
-    if [[ "${buildVersion}" = "$latestVersion" ]]; then
-        echo "The new version same as the old version."
-        exit 0
-    fi
+      if [[ "${buildVersion}" = "$latestVersion" ]]; then
+          echo "The new version same as the old version."
+          exit 0
+      fi
 
-    for platform in ${lib.concatStringsSep " " meta.platforms}; do
-        # The script will not perform an update when the version attribute is up to date from previous platform run
-        # We need to clear it before each run
-        update-source-version ${packageAttribute}.${primaryBinary} 0 0000000000000000000000000000000000000000000000000000000000000000 --file=${versionFile} --version-key=buildVersion --system=$platform
-        update-source-version ${packageAttribute}.${primaryBinary} $latestVersion --file=${versionFile} --version-key=buildVersion --system=$platform
-    done
-  '';
+      for platform in ${lib.escapeShellArgs meta.platforms}; do
+          # The script will not perform an update when the version attribute is up to date from previous platform run
+          # We need to clear it before each run
+          update-source-version "${packageAttribute}.${primaryBinary}" 0 "${lib.fakeSha256}" --file=${versionFile} --version-key=buildVersion --source-key="sources.$platform"
+          update-source-version "${packageAttribute}.${primaryBinary}" "$latestVersion" --file=${versionFile} --version-key=buildVersion --source-key="sources.$platform"
+      done
+    '';
+  };
 
   meta = with lib; {
     description = "Sophisticated text editor for code, markup and prose";

--- a/pkgs/applications/editors/sublime/4/common.nix
+++ b/pkgs/applications/editors/sublime/4/common.nix
@@ -122,24 +122,28 @@ in stdenv.mkDerivation (rec {
   '';
 
   passthru = {
-    updateScript = writeShellScript "${packageAttribute}-update-script" ''
-      set -o errexit
-      PATH=${lib.makeBinPath [ common-updater-scripts curl ]}
+    updateScript =
+      let
+        script = writeShellScript "${packageAttribute}-update-script" ''
+          set -o errexit
+          PATH=${lib.makeBinPath [ common-updater-scripts curl ]}
 
-      latestVersion=$(curl -s "${versionUrl}")
+          versionFile=$1
+          latestVersion=$(curl -s "${versionUrl}")
 
-      if [[ "${buildVersion}" = "$latestVersion" ]]; then
-          echo "The new version same as the old version."
-          exit 0
-      fi
+          if [[ "${buildVersion}" = "$latestVersion" ]]; then
+              echo "The new version same as the old version."
+              exit 0
+          fi
 
-      for platform in ${lib.escapeShellArgs meta.platforms}; do
-          # The script will not perform an update when the version attribute is up to date from previous platform run
-          # We need to clear it before each run
-          update-source-version "${packageAttribute}.${primaryBinary}" 0 "${lib.fakeSha256}" --file=${versionFile} --version-key=buildVersion --source-key="sources.$platform"
-          update-source-version "${packageAttribute}.${primaryBinary}" "$latestVersion" --file=${versionFile} --version-key=buildVersion --source-key="sources.$platform"
-      done
-    '';
+          for platform in ${lib.escapeShellArgs meta.platforms}; do
+              # The script will not perform an update when the version attribute is up to date from previous platform run
+              # We need to clear it before each run
+              update-source-version "${packageAttribute}.${primaryBinary}" 0 "${lib.fakeSha256}" --file="$versionFile" --version-key=buildVersion --source-key="sources.$platform"
+              update-source-version "${packageAttribute}.${primaryBinary}" "$latestVersion" --file="$versionFile" --version-key=buildVersion --source-key="sources.$platform"
+          done
+        '';
+      in [ script versionFile ];
   };
 
   meta = with lib; {

--- a/pkgs/applications/editors/sublime/4/packages.nix
+++ b/pkgs/applications/editors/sublime/4/packages.nix
@@ -11,9 +11,9 @@ in
     } {};
 
     sublime4-dev = common {
-      buildVersion = "4125";
+      buildVersion = "4134";
       dev = true;
-      x64sha256 = "sha256-+WvLkA7sltJadfm704rOECU4LNoVsv8rDmoAlO/M6Jo=";
-      aarch64sha256 = "11rbdy9rsn5b39qykbws4dqss89snrik7c2vdiw9cj0kibglsc3f";
+      x64sha256 = "rd3EG8e13FsPKihSM9qjUMRsEA6joMwVqhj1NZlwIaE=";
+      aarch64sha256 = "gdfEDd2E1sew08sVmcmw21zyil8JuJJMpG2T/9Pi81E=";
     } {};
   }

--- a/pkgs/applications/version-management/sublime-merge/default.nix
+++ b/pkgs/applications/version-management/sublime-merge/default.nix
@@ -9,8 +9,8 @@ in {
   } {};
 
   sublime-merge-dev = common {
-    buildVersion = "2073";
-    x64sha256 = "AQ0ESdi45LHndRNJnkYS+o9L+dlRJkw3nzBfJo8FYPc=";
+    buildVersion = "2076";
+    x64sha256 = "k43D+TqS1DImpJKzYuf3LqmsxF3XF9Fwqn2txL13xAA=";
     dev = true;
   } {};
 }

--- a/pkgs/applications/version-management/sublime-merge/default.nix
+++ b/pkgs/applications/version-management/sublime-merge/default.nix
@@ -5,12 +5,12 @@ let
 in {
   sublime-merge = common {
     buildVersion = "2074";
-    sha256 = "REo59Lpi0fmAOp0XJa4Iln3VKxR5kRiMpz2zfqz1MQs=";
+    x64sha256 = "REo59Lpi0fmAOp0XJa4Iln3VKxR5kRiMpz2zfqz1MQs=";
   } {};
 
   sublime-merge-dev = common {
     buildVersion = "2073";
-    sha256 = "AQ0ESdi45LHndRNJnkYS+o9L+dlRJkw3nzBfJo8FYPc=";
+    x64sha256 = "AQ0ESdi45LHndRNJnkYS+o9L+dlRJkw3nzBfJo8FYPc=";
     dev = true;
   } {};
 }


### PR DESCRIPTION
###### Description of changes

Running `update-source-version` with `--system` flag passes it to `nix-build -A $attr.src`, which requires that an appropriate builders are set on the system.

It works for me because I have aarch64-linux builder configured but it is broken for other users and r-ryantm.

cc @demin-dmitriy 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
