### PR TITLE
stratis-cli: init at 3.2.0

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1266,6 +1266,7 @@
   ./tasks/network-interfaces-scripted.nix
   ./tasks/scsi-link-power-management.nix
   ./tasks/snapraid.nix
+  ./tasks/stratis.nix
   ./tasks/swraid.nix
   ./tasks/trackpoint.nix
   ./tasks/powertop.nix

--- a/nixos/modules/tasks/stratis.nix
+++ b/nixos/modules/tasks/stratis.nix
@@ -1,0 +1,18 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.stratis;
+in
+{
+  options.services.stratis = {
+    enable = lib.mkEnableOption (lib.mdDoc "Stratis Storage - Easy to use local storage management for Linux");
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.stratis-cli ];
+    systemd.packages = [ pkgs.stratisd ];
+    services.dbus.packages = [ pkgs.stratisd ];
+    services.udev.packages = [ pkgs.stratisd ];
+    systemd.services.stratisd.wantedBy = [ "sysinit.target" ];
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -533,6 +533,7 @@ in {
   sssd-ldap = handleTestOn ["x86_64-linux"] ./sssd-ldap.nix {};
   starship = handleTest ./starship.nix {};
   step-ca = handleTestOn ["x86_64-linux"] ./step-ca.nix {};
+  stratis = handleTest ./stratis {};
   strongswan-swanctl = handleTest ./strongswan-swanctl.nix {};
   stunnel = handleTest ./stunnel.nix {};
   sudo = handleTest ./sudo.nix {};

--- a/nixos/tests/stratis/default.nix
+++ b/nixos/tests/stratis/default.nix
@@ -1,0 +1,7 @@
+{ system ? builtins.currentSystem
+, pkgs ? import ../../.. { inherit system; }
+}:
+
+{
+  simple = import ./simple.nix { inherit system pkgs; };
+}

--- a/nixos/tests/stratis/simple.nix
+++ b/nixos/tests/stratis/simple.nix
@@ -1,0 +1,37 @@
+import ../make-test-python.nix ({ pkgs, ... }:
+  {
+    name = "stratis";
+
+    meta = with pkgs.lib.maintainers; {
+      maintainers = [ nickcao ];
+    };
+
+    nodes.machine = { pkgs, ... }: {
+      services.stratis.enable = true;
+      virtualisation.emptyDiskImages = [ 1024 1024 1024 1024 ];
+    };
+
+    testScript = ''
+      machine.wait_for_unit("stratisd")
+      # test pool creation
+      machine.succeed("stratis pool create     testpool /dev/vdb")
+      machine.succeed("stratis pool add-data   testpool /dev/vdc")
+      machine.succeed("stratis pool init-cache testpool /dev/vdd")
+      machine.succeed("stratis pool add-cache  testpool /dev/vde")
+      # test filesystem creation and rename
+      machine.succeed("stratis filesystem create testpool testfs0")
+      machine.succeed("stratis filesystem rename testpool testfs0 testfs1")
+      # test snapshot
+      machine.succeed("mkdir -p /mnt/testfs1 /mnt/testfs2")
+      machine.succeed("mount /dev/stratis/testpool/testfs1 /mnt/testfs1")
+      machine.succeed("echo test0 > /mnt/testfs1/test0")
+      machine.succeed("echo test1 > /mnt/testfs1/test1")
+      machine.succeed("stratis filesystem snapshot testpool testfs1 testfs2")
+      machine.succeed("echo test2 > /mnt/testfs1/test1")
+      machine.succeed("mount /dev/stratis/testpool/testfs2 /mnt/testfs2")
+      assert "test0" in machine.succeed("cat /mnt/testfs1/test0")
+      assert "test0" in machine.succeed("cat /mnt/testfs2/test0")
+      assert "test2" in machine.succeed("cat /mnt/testfs1/test1")
+      assert "test1" in machine.succeed("cat /mnt/testfs2/test1")
+    '';
+  })

--- a/nixos/tests/stratis/simple.nix
+++ b/nixos/tests/stratis/simple.nix
@@ -23,11 +23,13 @@ import ../make-test-python.nix ({ pkgs, ... }:
       machine.succeed("stratis filesystem rename testpool testfs0 testfs1")
       # test snapshot
       machine.succeed("mkdir -p /mnt/testfs1 /mnt/testfs2")
+      machine.wait_for_file("/dev/stratis/testpool/testfs1")
       machine.succeed("mount /dev/stratis/testpool/testfs1 /mnt/testfs1")
       machine.succeed("echo test0 > /mnt/testfs1/test0")
       machine.succeed("echo test1 > /mnt/testfs1/test1")
       machine.succeed("stratis filesystem snapshot testpool testfs1 testfs2")
       machine.succeed("echo test2 > /mnt/testfs1/test1")
+      machine.wait_for_file("/dev/stratis/testpool/testfs2")
       machine.succeed("mount /dev/stratis/testpool/testfs2 /mnt/testfs2")
       assert "test0" in machine.succeed("cat /mnt/testfs1/test0")
       assert "test0" in machine.succeed("cat /mnt/testfs2/test0")

--- a/pkgs/development/python-modules/dbus-python-client-gen/default.nix
+++ b/pkgs/development/python-modules/dbus-python-client-gen/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, into-dbus-python
+, dbus-python
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "dbus-python-client-gen";
+  version = "0.8";
+
+  src = fetchFromGitHub {
+    owner = "stratis-storage";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-nSzxT65WHBVct5pGHmIAHJXftd0tKZeK/argN+V9xcs=";
+  };
+
+  propagatedBuildInputs = [
+    into-dbus-python
+    dbus-python
+  ];
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "A Python library for generating dbus-python client code";
+    homepage = "https://github.com/stratis-storage/dbus-python-client-gen";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ nickcao ];
+  };
+}

--- a/pkgs/development/python-modules/dbus-signature-pyparsing/default.nix
+++ b/pkgs/development/python-modules/dbus-signature-pyparsing/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pyparsing
+, pytestCheckHook
+, hypothesis
+, hs-dbus-signature
+}:
+
+buildPythonPackage rec {
+  pname = "dbus-signature-pyparsing";
+  version = "0.04";
+
+  src = fetchFromGitHub {
+    owner = "stratis-storage";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-IXyepfq7pLTRkTolKWsKGrYDoxukVC9JTrxS9xV7s2I=";
+  };
+
+  propagatedBuildInputs = [ pyparsing ];
+  checkInputs = [
+    pytestCheckHook
+    hypothesis
+    hs-dbus-signature
+  ];
+
+  meta = with lib; {
+    description = "A Parser for a D-Bus Signature";
+    homepage = "https://github.com/stratis-storage/dbus-signature-pyparsing";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ nickcao ];
+  };
+}

--- a/pkgs/development/python-modules/hs-dbus-signature/default.nix
+++ b/pkgs/development/python-modules/hs-dbus-signature/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+, hypothesis
+}:
+
+buildPythonPackage rec {
+  pname = "hs-dbus-signature";
+  version = "0.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-NNnTcSX+K8zU+sj1QBd13h7aEXN9VqltJMNWCuhgZ6I=";
+  };
+
+  checkInputs = [
+    pytestCheckHook
+    hypothesis
+  ];
+
+  meta = with lib; {
+    description = "A Hypothesis Strategy for Generating Arbitrary DBus Signatures";
+    homepage = "https://github.com/stratis-storage/hs-dbus-signature";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ nickcao ];
+  };
+}

--- a/pkgs/development/python-modules/into-dbus-python/default.nix
+++ b/pkgs/development/python-modules/into-dbus-python/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, dbus-signature-pyparsing
+, dbus-python
+, pytestCheckHook
+, hypothesis
+, hs-dbus-signature
+}:
+
+buildPythonPackage rec {
+  pname = "into-dbus-python";
+  version = "0.08";
+
+  src = fetchFromGitHub {
+    owner = "stratis-storage";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-Z8e6oAvRMIisMjG4HcS5jSH1znGVc7pGpMITo5fXYVs=";
+  };
+
+  propagatedBuildInputs = [
+    dbus-signature-pyparsing
+    dbus-python
+  ];
+  checkInputs = [
+    pytestCheckHook
+    hypothesis
+    hs-dbus-signature
+  ];
+
+  meta = with lib; {
+    description = "A transformer to dbus-python types";
+    homepage = "https://github.com/stratis-storage/into-dbus-python";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ nickcao ];
+  };
+}

--- a/pkgs/tools/filesystems/stratis-cli/default.nix
+++ b/pkgs/tools/filesystems/stratis-cli/default.nix
@@ -1,6 +1,7 @@
 { lib
 , python3Packages
 , fetchFromGitHub
+, nixosTests
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -23,6 +24,8 @@ python3Packages.buildPythonApplication rec {
     dbus-python-client-gen
     packaging
   ];
+
+  passthru.tests = nixosTests.stratis;
 
   meta = with lib; {
     description = "CLI for the Stratis project";

--- a/pkgs/tools/filesystems/stratis-cli/default.nix
+++ b/pkgs/tools/filesystems/stratis-cli/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, python3Packages
+, fetchFromGitHub
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "stratis-cli";
+  version = "3.2.0";
+
+  src = fetchFromGitHub {
+    owner = "stratis-storage";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-JQXTzvm4l/pl2T4djZ3HEdDQJdFE+I9doe8Iv5q34kw=";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    psutil
+    python-dateutil
+    wcwidth
+    justbytes
+    dbus-client-gen
+    dbus-python-client-gen
+    packaging
+  ];
+
+  meta = with lib; {
+    description = "CLI for the Stratis project";
+    homepage = "https://stratis-storage.github.io";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ nickcao ];
+  };
+}

--- a/pkgs/tools/filesystems/stratisd/default.nix
+++ b/pkgs/tools/filesystems/stratisd/default.nix
@@ -18,6 +18,7 @@
 , tpm2-tools
 , coreutils
 , clevisSupport ? false
+, nixosTests
 }:
 
 stdenv.mkDerivation rec {
@@ -94,6 +95,8 @@ stdenv.mkDerivation rec {
     rm -r "$out/lib/dracut"
     rm -r "$out/lib/systemd/system-generators"
   '';
+
+  passthru.tests = nixosTests.stratis;
 
   meta = with lib; {
     description = "Easy to use local storage management for Linux";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5918,6 +5918,8 @@ with pkgs;
 
   stratisd = callPackage ../tools/filesystems/stratisd { };
 
+  stratis-cli = callPackage ../tools/filesystems/stratis-cli { };
+
   strawberry = libsForQt5.callPackage ../applications/audio/strawberry { };
 
   schildichat-desktop = callPackage ../applications/networking/instant-messengers/schildichat/schildichat-desktop.nix {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2299,6 +2299,8 @@ in {
     inherit (pkgs) dbus;
   };
 
+  dbus-python-client-gen = callPackage ../development/python-modules/dbus-python-client-gen { };
+
   dbus-signature-pyparsing = callPackage ../development/python-modules/dbus-signature-pyparsing { };
 
   dbutils = callPackage ../development/python-modules/dbutils { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4232,6 +4232,8 @@ in {
 
   hpccm = callPackage ../development/python-modules/hpccm { };
 
+  hs-dbus-signature = callPackage ../development/python-modules/hs-dbus-signature { };
+
   hsaudiotag3k = callPackage ../development/python-modules/hsaudiotag3k { };
 
   hsluv = callPackage ../development/python-modules/hsluv { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4524,6 +4524,8 @@ in {
 
   intervaltree = callPackage ../development/python-modules/intervaltree { };
 
+  into-dbus-python = callPackage ../development/python-modules/into-dbus-python { };
+
   intreehooks = callPackage ../development/python-modules/intreehooks { };
 
   invocations = callPackage ../development/python-modules/invocations { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2299,6 +2299,8 @@ in {
     inherit (pkgs) dbus;
   };
 
+  dbus-signature-pyparsing = callPackage ../development/python-modules/dbus-signature-pyparsing { };
+
   dbutils = callPackage ../development/python-modules/dbutils { };
 
   db-dtypes = callPackage ../development/python-modules/db-dtypes { };


### PR DESCRIPTION
###### Description of changes
To be used with https://github.com/NixOS/nixpkgs/pull/184675
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
