### PR TITLE
devito: unstable-2022-04-22 -> 4.7.1

### DIFF
--- a/pkgs/development/python-modules/devito/default.nix
+++ b/pkgs/development/python-modules/devito/default.nix
@@ -22,13 +22,13 @@
 
 buildPythonPackage rec {
   pname = "devito";
-  version = "unstable-2022-04-22";
+  version = "4.7.1";
 
   src = fetchFromGitHub {
     owner = "devitocodes";
     repo = "devito";
-    rev = "7cb52eded4038c1a0ee92cfd04d3412c48f2fb7c";
-    sha256 = "sha256-75hkkufQK9Nv65DBz8cmYTfkxH/UUWDQK/rGUDULvjM=";
+    rev = "v${version}";
+    sha256 = "sha256-crKTxlueE8NGjAqu625iFvp35UK2U7+9kl8rpbzf0gs=";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Description of changes

Changes

```
compiler: Fix checkpoint size when save != None @speglich (https://github.com/devitocodes/devito/pull/1906)
compiler: Revamp generation of implicit equations @FabioLuporini (https://github.com/devitocodes/devito/pull/1908)
API
compiler: Support interpolation with user-provided implicit dims @FabioLuporini (https://github.com/devitocodes/devito/pull/1948)
api: Add op.cinterface for C-level interoperability @FabioLuporini (https://github.com/devitocodes/devito/pull/1843)
Examples
examples: Fix grammar and spelling mistakes in pml example @PershingSquare (https://github.com/devitocodes/devito/pull/1930)
examples: Update MPI tutorial notebook and scripts @georgebisbas (https://github.com/devitocodes/devito/pull/1923)
examples: Use solve instead of by hand derivation @mloubout (https://github.com/devitocodes/devito/pull/1879)
examples: Rename the viscoacoustic equations @nogueirapeterson (https://github.com/devitocodes/devito/pull/1869)
examples: Update attribute names and backend for synthetics notebook @EdCaunt (https://github.com/devitocodes/devito/pull/1895)
examples: Add colab/wsl dependencies to gempy notebook @EdCaunt (https://github.com/devitocodes/devito/pull/1866)
Fix 2D Gzz when sintheta==0 @mloubout (https://github.com/devitocodes/devito/pull/1855)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
