### PR TITLE
swaynotificationcenter: compile schema

### DIFF
--- a/pkgs/applications/misc/swaynotificationcenter/default.nix
+++ b/pkgs/applications/misc/swaynotificationcenter/default.nix
@@ -1,25 +1,29 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, testers
+, wrapGAppsHook
+, bash-completion
+, dbus
+, dbus-glib
+, fish
+, gdk-pixbuf
+, glib
+, gobject-introspection
+, gtk-layer-shell
+, gtk3
+, json-glib
+, libhandy
+, librsvg
 , meson
 , ninja
 , pkg-config
 , scdoc
 , vala
-, gtk3
-, glib
-, gtk-layer-shell
-, dbus
-, dbus-glib
-, json-glib
-, librsvg
-, libhandy
-, gobject-introspection
-, gdk-pixbuf
-, wrapGAppsHook
+, xvfb-run
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: rec {
   pname = "SwayNotificationCenter";
   version = "0.6.3";
 
@@ -30,15 +34,54 @@ stdenv.mkDerivation rec {
     hash = "sha256-79Kda2Mi2r38f0J12bRm9wbHiZCy9+ojPDxwlFG8EYw=";
   };
 
-  nativeBuildInputs = [ gobject-introspection meson ninja pkg-config scdoc vala wrapGAppsHook ];
+  nativeBuildInputs = [
+    bash-completion
+    # cmake # currently conflicts with meson
+    fish
+    glib
+    gobject-introspection
+    meson
+    ninja
+    pkg-config
+    scdoc
+    vala
+    wrapGAppsHook
+  ];
 
-  buildInputs = [ dbus dbus-glib gdk-pixbuf glib gtk-layer-shell gtk3 json-glib libhandy librsvg ];
+  buildInputs = [
+    dbus
+    dbus-glib
+    gdk-pixbuf
+    glib
+    gtk-layer-shell
+    gtk3
+    json-glib
+    libhandy
+    librsvg
+    # systemd # ends with broken permission
+  ];
+
+  # Fix-Me: Broken in 0.6.3, but fixed on master. Enable on next release. Requires python3 in nativeBuildInputs.
+  # postPatch = ''
+  #   chmod +x build-aux/meson/postinstall.py
+  #   patchShebangs build-aux/meson/postinstall.py
+  # '';
+
+  # Remove past 0.6.3
+  postInstall = ''
+    glib-compile-schemas "$out"/share/glib-2.0/schemas
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    command = "${xvfb-run}/bin/xvfb-run swaync --version";
+  };
 
   meta = with lib; {
     description = "Simple notification daemon with a GUI built for Sway";
     homepage = "https://github.com/ErikReider/SwayNotificationCenter";
     license = licenses.gpl3;
     platforms = platforms.linux;
-    maintainers = [ maintainers.berbiche ];
+    maintainers = with maintainers; [ berbiche pedrohlc ];
   };
-}
+})


### PR DESCRIPTION
###### Description of changes

1 - Adds `glib` (native build input) and `glib-compile-schemas` (post fixup) that solves a regression added by https://github.com/NixOS/nixpkgs/pull/186550
2 - Adds `bash-completion` and `fish`, so that the installer generates their completion files;
3 - Documents why some dependencies mentioned during build are skipped;
4 - Adds myself as co-maintainer;
5 - Documents that you should use `postinstall.py` in 0.6.4.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
