### PR TITLE
hostapd-mana: init at 2.6.5

### DIFF
--- a/pkgs/tools/networking/hostapd-mana/default.nix
+++ b/pkgs/tools/networking/hostapd-mana/default.nix
@@ -1,0 +1,87 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, pkg-config
+, libnl
+, openssl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "hostapd-mana";
+  version = "2.6.5";
+
+  src = fetchFromGitHub {
+    owner = "sensepost";
+    repo = pname;
+    rev = version;
+    hash = "sha256-co5LMJAUYSdcvhLv1gfjDvdVqdSXgjtFoiQ7+KxR07M=";
+  };
+
+  patches = [
+    # Fix compile errors with GCC 10 on newer Kali
+    (fetchpatch {
+      url = "https://github.com/sensepost/hostapd-mana/commit/8581994d8d19646da63e1e37cde27dd4c966e526.patch";
+      hash = "sha256-UBkhuqvX1nFiceECAIC9B13ReKbrAAUtPKjqD17mQgg=";
+    })
+  ];
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ libnl openssl ];
+
+  extraConfig = ''
+    CONFIG_DRIVER_WIRED=y
+    CONFIG_LIBNL32=y
+    CONFIG_EAP_SIM=y
+    CONFIG_EAP_AKA=y
+    CONFIG_EAP_AKA_PRIME=y
+    CONFIG_EAP_PAX=y
+    CONFIG_EAP_PWD=y
+    CONFIG_EAP_SAKE=y
+    CONFIG_EAP_GPSK=y
+    CONFIG_EAP_GPSK_SHA256=y
+    CONFIG_EAP_FAST=y
+    CONFIG_EAP_IKEV2=y
+    CONFIG_EAP_TNC=y
+    CONFIG_EAP_EKE=y
+    CONFIG_RADIUS_SERVER=y
+    CONFIG_IEEE80211R=y
+    CONFIG_IEEE80211N=y
+    CONFIG_IEEE80211AC=y
+    CONFIG_FULL_DYNAMIC_VLAN=y
+    CONFIG_VLAN_NETLINK=y
+    CONFIG_TLS=openssl
+    CONFIG_TLSV11=y
+    CONFIG_TLSV12=y
+    CONFIG_INTERNETWORKING=y
+    CONFIG_HS20=y
+    CONFIG_ACS=y
+    CONFIG_GETRANDOM=y
+    CONFIG_SAE=y
+  '';
+
+  postPatch = ''
+    substituteInPlace hostapd/Makefile --replace /usr/local $out
+  '';
+
+  configurePhase = ''
+    runHook preConfigure
+    cd hostapd
+    cp -v defconfig .config
+    echo "$extraConfig" >> .config
+    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE $(pkg-config --cflags libnl-${lib.versions.major libnl.version}.0)"
+    runHook postConfigure
+  '';
+
+  preInstall = ''
+    mkdir -p $out/bin
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/sensepost/hostapd-mana";
+    description = "A featureful rogue wifi access point tool";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ lourkeur ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1447,6 +1447,8 @@ with pkgs;
 
   hercules = callPackage ../applications/emulators/hercules { };
 
+  hostapd-mana = callPackage ../tools/networking/hostapd-mana { };
+
   image-analyzer = callPackage ../applications/emulators/cdemu/analyzer.nix { };
 
   kega-fusion = pkgsi686Linux.callPackage ../applications/emulators/kega-fusion { };


### PR DESCRIPTION
###### Description of changes

Useful WiFi pentesting business

#81418

https://www.kali.org/tools/hostapd-mana/

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
