### PR TITLE
ladybird: unstable-2022-07-20 -> unstable-2022-08-14, add nixos test

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -279,6 +279,7 @@ in {
   ksm = handleTest ./ksm.nix {};
   kthxbye = handleTest ./kthxbye.nix {};
   kubernetes = handleTestOn ["x86_64-linux"] ./kubernetes {};
+  ladybird = handleTest ./ladybird.nix {};
   languagetool = handleTest ./languagetool.nix {};
   latestKernel.login = handleTest ./login.nix { latestKernel = true; };
   leaps = handleTest ./leaps.nix {};

--- a/nixos/tests/ladybird.nix
+++ b/nixos/tests/ladybird.nix
@@ -1,0 +1,30 @@
+import ./make-test-python.nix ({ pkgs, ... }: {
+  name = "ladybird";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ fgaz ];
+  };
+
+  nodes.machine = { config, pkgs, ... }: {
+    imports = [
+      ./common/x11.nix
+    ];
+
+    services.xserver.enable = true;
+    environment.systemPackages = [
+      pkgs.ladybird
+    ];
+  };
+
+  enableOCR = true;
+
+  testScript =
+    ''
+      machine.wait_for_x()
+      machine.succeed("echo '<!DOCTYPE html><html><body><h1>Hello world</h1></body></html>' > page.html")
+      machine.execute("ladybird file://$(pwd)/page.html >&2 &")
+      machine.wait_for_window("Ladybird")
+      machine.sleep(5)
+      machine.wait_for_text("Hello world")
+      machine.screenshot("screen")
+    '';
+})

--- a/pkgs/applications/networking/browsers/ladybird/default.nix
+++ b/pkgs/applications/networking/browsers/ladybird/default.nix
@@ -5,7 +5,6 @@
 , ninja
 , unzip
 , wrapQtAppsHook
-, makeWrapper
 , qtbase
 , qttools
 , nixosTests
@@ -14,20 +13,20 @@
 let serenity = fetchFromGitHub {
   owner = "SerenityOS";
   repo = "serenity";
-  rev = "ae8f1c7dc88e5bd79fb3e232e540ddc3dd2f1c11";
-  hash = "sha256-1OcSBwEs/SGocTlOoVEv+2bTg4kqtUT2TUBOWG7BqkE=";
+  rev = "a0f3e2c9a2b82117aa7c1a3444ad0d31baa070d5";
+  hash = "sha256-8Xde59ZfdkTD39mYSv0lfFjBHFDWTUwfozE+Q9Yq6C8=";
 };
 
 in gcc11Stdenv.mkDerivation {
   pname = "ladybird";
-  version = "unstable-2022-08-14";
+  version = "unstable-2022-09-29";
 
   # Remember to update `serenity` too!
   src = fetchFromGitHub {
-    owner = "awesomekling";
+    owner = "SerenityOS";
     repo = "ladybird";
-    rev = "35a6f69d65fcdb17fb9f84247fe8caf2b49f7c7d";
-    hash = "sha256-W46GXK2vxDgeUtCR3OwUs00WiAAu0aAERmtxrt2ICYI=";
+    rev = "d69ad7332477de33bfd1963026e057d55c6f222d";
+    hash = "sha256-XQj2Bohk8F6dGCAManOmmDP5b/SqEeZXZbLDYPfvi2E=";
   };
 
   nativeBuildInputs = [
@@ -35,7 +34,6 @@ in gcc11Stdenv.mkDerivation {
     ninja
     unzip
     wrapQtAppsHook
-    makeWrapper
   ];
 
   buildInputs = [
@@ -49,40 +47,6 @@ in gcc11Stdenv.mkDerivation {
     "-DENABLE_UNICODE_DATABASE_DOWNLOAD=false"
   ];
 
-  NIX_CFLAGS_COMPILE = [ "-Wno-error" ];
-
-  # Upstream install rules are missing
-  # https://github.com/awesomekling/ladybird/issues/36
-  installPhase = ''
-    runHook preInstall
-    install -Dm755 ladybird $out/bin/ladybird
-    mkdir -p $out/lib/ladybird
-    cp -d _deps/lagom-build/*.so* $out/lib/ladybird/
-    runHook postInstall
-  '';
-
-  # Patch rpaths
-  # https://github.com/awesomekling/ladybird/issues/36
-  preFixup = ''
-    for f in $out/bin/ladybird $out/lib/ladybird/*.so; do
-      old_rpath=$(patchelf --print-rpath "$f")
-      # Remove reference to libraries from build directory
-      rpath_without_build=$(sed -e 's@[^:]*/_deps/lagom-build:@@g' <<< $old_rpath)
-      # Add directory where we install those libraries
-      new_rpath=$out/lib/ladybird:$rpath_without_build
-      patchelf --set-rpath "$new_rpath" "$f"
-    done
-  '';
-
-  # According to the readme, the program needs access to the serenity sources
-  # at runtime
-  postFixup = ''
-    wrapProgram $out/bin/ladybird --set SERENITY_SOURCE_DIR "${serenity}"
-  '';
-
-  # Stripping results in a symbol lookup error
-  dontStrip = true;
-
   passthru.tests = {
     nixosTest = nixosTests.ladybird;
   };
@@ -93,7 +57,6 @@ in gcc11Stdenv.mkDerivation {
     license = licenses.bsd2;
     maintainers = with maintainers; [ fgaz ];
     # SerenityOS only works on x86, and can only be built on unix systems.
-    # We also use patchelf in preFixup, so we restrict that to linux only.
-    platforms = [ "x86_64-linux" "i686-linux" ];
+    platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" ];
   };
 }

--- a/pkgs/applications/networking/browsers/ladybird/default.nix
+++ b/pkgs/applications/networking/browsers/ladybird/default.nix
@@ -8,6 +8,7 @@
 , makeWrapper
 , qtbase
 , qttools
+, nixosTests
 }:
 
 let serenity = fetchFromGitHub {
@@ -81,6 +82,10 @@ in gcc11Stdenv.mkDerivation {
 
   # Stripping results in a symbol lookup error
   dontStrip = true;
+
+  passthru.tests = {
+    nixosTest = nixosTests.ladybird;
+  };
 
   meta = with lib; {
     description = "A browser using the SerenityOS LibWeb engine with a Qt GUI";

--- a/pkgs/applications/networking/browsers/ladybird/default.nix
+++ b/pkgs/applications/networking/browsers/ladybird/default.nix
@@ -13,20 +13,20 @@
 let serenity = fetchFromGitHub {
   owner = "SerenityOS";
   repo = "serenity";
-  rev = "094ba6525f0217f3b8d5e467cef326caeb659e8a";
-  hash = "sha256-IHXe2Td9iRSL1oQVwL2gZHxEM2ID4SghZwK6ewjFV1Y=";
+  rev = "ae8f1c7dc88e5bd79fb3e232e540ddc3dd2f1c11";
+  hash = "sha256-1OcSBwEs/SGocTlOoVEv+2bTg4kqtUT2TUBOWG7BqkE=";
 };
 
 in gcc11Stdenv.mkDerivation {
   pname = "ladybird";
-  version = "unstable-2022-07-20";
+  version = "unstable-2022-08-14";
 
   # Remember to update `serenity` too!
   src = fetchFromGitHub {
     owner = "awesomekling";
     repo = "ladybird";
-    rev = "9e3a1f47d484cee6f23c4dae6c51750af155a8fc";
-    hash = "sha256-1cPWpPvjM/VcVUEf2k+MvGvTgZ3Fc4LFHZCLh1wU78Y=";
+    rev = "35a6f69d65fcdb17fb9f84247fe8caf2b49f7c7d";
+    hash = "sha256-W46GXK2vxDgeUtCR3OwUs00WiAAu0aAERmtxrt2ICYI=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
