### PR TITLE
krunvm: add support for darwin

### DIFF
--- a/pkgs/applications/virtualization/krunvm/default.nix
+++ b/pkgs/applications/virtualization/krunvm/default.nix
@@ -3,7 +3,12 @@
 , rustPlatform
 , fetchFromGitHub
 , asciidoctor
+, buildah
+, buildah-unwrapped
+, libiconv
 , libkrun
+, makeWrapper
+, sigtool
 }:
 
 stdenv.mkDerivation rec {
@@ -22,16 +27,40 @@ stdenv.mkDerivation rec {
     hash = "sha256-3WiXm90XiQHpCbhlkigg/ZATQeDdUKTstN7hwcsKm4o=";
   };
 
-  nativeBuildInputs = with rustPlatform;[
+  nativeBuildInputs = with rustPlatform; [
     cargoSetupHook
     rust.cargo
     rust.rustc
     asciidoctor
+    makeWrapper
+  ] ++ lib.optionals stdenv.isDarwin [ sigtool ];
+
+  buildInputs = [ libkrun ] ++ lib.optionals stdenv.isDarwin [
+    libiconv
   ];
 
-  buildInputs = [ libkrun ];
-
   makeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  postPatch = ''
+    # do not pollute etc
+    substituteInPlace src/utils.rs \
+      --replace "etc/containers" "share/krunvm/containers"
+  '';
+
+  postInstall = ''
+    mkdir -p $out/share/krunvm/containers
+    install -D -m755 ${buildah-unwrapped.src}/docs/samples/registries.conf $out/share/krunvm/containers/registries.conf
+    install -D -m755 ${buildah-unwrapped.src}/tests/policy.json $out/share/krunvm/containers/policy.json
+  '';
+
+  # It attaches entitlements with codesign and strip removes those,
+  # voiding the entitlements and making it non-operational.
+  dontStrip = stdenv.isDarwin;
+
+  postFixup = ''
+    wrapProgram $out/bin/krunvm \
+      --prefix PATH : ${lib.makeBinPath [ buildah ]} \
+  '';
 
   meta = with lib; {
     description = "A CLI-based utility for creating microVMs from OCI images";

--- a/pkgs/development/compilers/dtc/default.nix
+++ b/pkgs/development/compilers/dtc/default.nix
@@ -44,6 +44,10 @@ stdenv.mkDerivation rec {
   makeFlags = [ "PYTHON=python" "STATIC_BUILD=${toString stdenv.hostPlatform.isStatic}" ];
   installFlags = [ "INSTALL=install" "PREFIX=$(out)" "SETUP_PREFIX=$(out)" ];
 
+  postFixup = lib.optionalString stdenv.isDarwin ''
+    install_name_tool -id $out/lib/libfdt.dylib $out/lib/libfdt-${version}.dylib
+  '';
+
   # Checks are broken on aarch64 darwin
   # https://github.com/NixOS/nixpkgs/pull/118700#issuecomment-885892436
   doCheck = !stdenv.isDarwin;

--- a/pkgs/development/libraries/libkrun/default.nix
+++ b/pkgs/development/libraries/libkrun/default.nix
@@ -1,11 +1,15 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchurl
 , rustPlatform
 , pkg-config
+, dtc
 , glibc
 , openssl
+, libiconv
 , libkrunfw
+, Hypervisor
 , sevVariant ? false
 }:
 
@@ -13,11 +17,14 @@ stdenv.mkDerivation rec {
   pname = "libkrun";
   version = "1.3.0";
 
-  src = fetchFromGitHub {
+  src = if stdenv.isLinux then fetchFromGitHub {
     owner = "containers";
     repo = pname;
     rev = "v${version}";
     hash = "sha256-qVyEqiqaQ8wfZhL5u+Bsaa1yXlgHUitSj5bo7FJ5Y8c=";
+  } else fetchurl {
+    url = "https://github.com/containers/libkrun/releases/download/v${version}/v${version}-with_macos_prebuilts.tar.gz";
+    hash = "sha256-RBqeGUhB6Sdt+JujyQBW/76mZwnT0LNs9AMYr8+OCVU=";
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
@@ -25,20 +32,29 @@ stdenv.mkDerivation rec {
     hash = "sha256-jxSzhj1iU8qY+sZEVCYTaUqpaA4egjJi9qxrapASQF0=";
   };
 
-  nativeBuildInputs = with rustPlatform;[
+  nativeBuildInputs = with rustPlatform; [
     cargoSetupHook
     rust.cargo
     rust.rustc
   ] ++ lib.optional sevVariant pkg-config;
 
   buildInputs = [
+    (libkrunfw.override { inherit sevVariant; })
+  ] ++ lib.optionals stdenv.isLinux [
     glibc
     glibc.static
-    (libkrunfw.override { inherit sevVariant; })
+  ] ++ lib.optionals stdenv.isDarwin [
+    libiconv
+    Hypervisor
+    dtc
   ] ++ lib.optional sevVariant openssl;
 
   makeFlags = [ "PREFIX=${placeholder "out"}" ]
     ++ lib.optional sevVariant "SEV=1";
+
+  postFixup = lib.optionalString stdenv.isDarwin ''
+    install_name_tool -id $out/lib/libkrun.dylib $out/lib/libkrun.${version}.dylib
+  '';
 
   meta = with lib; {
     description = "A dynamic library providing Virtualization-based process isolation capabilities";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23933,7 +23933,9 @@ with pkgs;
 
   libcgroup = callPackage ../os-specific/linux/libcgroup { };
 
-  libkrun = callPackage ../development/libraries/libkrun { };
+  libkrun = callPackage ../development/libraries/libkrun {
+    inherit (darwin.apple_sdk.frameworks) Hypervisor;
+  };
 
   libkrun-sev = callPackage ../development/libraries/libkrun { sevVariant = true; };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7882,7 +7882,9 @@ with pkgs;
 
   krunner-pass = libsForQt5.callPackage ../tools/security/krunner-pass { };
 
-  krunvm = callPackage ../applications/virtualization/krunvm { };
+  krunvm = callPackage ../applications/virtualization/krunvm {
+    inherit (darwin) sigtool;
+  };
 
   kronometer = libsForQt5.callPackage ../tools/misc/kronometer { };
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This pr allows krunvm to build and run on darwin:

```shell
macbookair@macbookair /V/D/nixpkgs (krunvm-darwin)> ./result/bin/krunvm create debian --name debian
Resolving "debian" using unqualified-search registries (/nix/store/cmjp18dcg117hkf0qlv0sxlkbmjbgi01-krunvm-0.2.1/etc/containers/registries.conf)
Trying to pull quay.io/debian:latest...
Trying to pull docker.io/library/debian:latest...
Getting image source signatures
Copying blob 114ba63dd73a done  
Copying config 585393df05 done  
Writing manifest to image destination
Storing signatures
microVM created with name: debian
macbookair@macbookair /V/D/nixpkgs (krunvm-darwin)> ./result/bin/krunvm start debian
root@debian:/# cat /etc/issue
Debian GNU/Linux 11 \n \l

root@debian:/# 
```

Some commands are learned from krunvm homebrew formulae:

- https://github.com/slp/homebrew-krun/blob/master/Formula/buildah.rb
- https://github.com/slp/homebrew-krun/blob/master/Formula/krunvm.rb
- https://github.com/slp/homebrew-krun/blob/master/Formula/libkrun.rb
- https://github.com/slp/homebrew-krun/blob/master/Formula/libkrunfw.rb

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
