### PR TITLE
vtk: unvendor some of the dependencies, fix on darwin

### DIFF
--- a/pkgs/development/libraries/vtk/generic.nix
+++ b/pkgs/development/libraries/vtk/generic.nix
@@ -1,11 +1,12 @@
 { majorVersion, minorVersion, sourceSha256, patchesToFetch ? [] }:
-{ stdenv, lib, fetchurl, cmake, libGLU, libGL, libX11, xorgproto, libXt, libpng, libtiff
+{ stdenv, lib, fetchurl, cmake
+, double-conversion, eigen, expat, gl2ps, glew, fmt_8, freetype, jsoncpp, hdf5, libpng, libtheora, libtiff, libxml2, lz4, libogg, netcdf, proj_7, pugixml, sqlite, utf8cpp
+, libGLU, libGL, libX11, xorgproto, libXt
 , fetchpatch
-, enableQt ? false, qtbase, qtx11extras, qttools, qtdeclarative, qtEnv
+, enableQt ? false, qtbase, qtx11extras, qttools
 , enablePython ? false, pythonInterpreter ? throw "vtk: Python support requested, but no python interpreter was given."
 # Darwin support
-, Cocoa, CoreServices, DiskArbitration, IOKit, CFNetwork, Security, GLUT, OpenGL
-, ApplicationServices, CoreText, IOSurface, ImageIO, xpc, libobjc
+, Cocoa, OpenGL
 }:
 
 let
@@ -24,10 +25,28 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [ libpng libtiff ]
-    ++ optionals enableQt (if lib.versionOlder majorVersion "9"
-                           then [ qtbase qtx11extras qttools ]
-                           else  [ (qtEnv "qvtk-qt-env" [ qtx11extras qttools qtdeclarative ]) ])
+  buildInputs = [
+    double-conversion
+    eigen
+    expat
+    gl2ps
+    glew
+    fmt_8
+    freetype
+    jsoncpp
+    hdf5
+    libpng
+    libtheora
+    libtiff
+    libxml2
+    lz4
+    libogg
+    netcdf
+    proj_7
+    pugixml
+    sqlite
+    utf8cpp
+  ] ++ optionals enableQt [ qtbase qtx11extras qttools ]
     ++ optionals stdenv.isLinux [
       libGLU
       libGL
@@ -35,23 +54,10 @@ in stdenv.mkDerivation rec {
       xorgproto
       libXt
     ] ++ optionals stdenv.isDarwin [
-      xpc
       Cocoa
-      CoreServices
-      DiskArbitration
-      IOKit
-      CFNetwork
-      Security
-      ApplicationServices
-      CoreText
-      IOSurface
-      ImageIO
-      OpenGL
-      GLUT
     ] ++ optional enablePython [
       pythonInterpreter
     ];
-  propagatedBuildInputs = optionals stdenv.isDarwin [ libobjc ];
 
   patches = map fetchpatch patchesToFetch;
 
@@ -65,13 +71,28 @@ in stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DCMAKE_C_FLAGS=-fPIC"
     "-DCMAKE_CXX_FLAGS=-fPIC"
-    "-D${if lib.versionOlder version "9.0" then "VTK_USE_SYSTEM_PNG" else "VTK_MODULE_USE_EXTERNAL_vtkpng"}=ON"
-    "-D${if lib.versionOlder version "9.0" then "VTK_USE_SYSTEM_TIFF" else "VTK_MODULE_USE_EXTERNAL_vtktiff"}=1"
+    "-D${if lib.versionOlder version "9.0" then "VTK_USE_SYSTEM_LIBRARIES" else "VTK_USE_EXTERNAL"}=ON"
+    "-D${if lib.versionOlder version "9.0" then "VTK_USE_SYSTEM_PEGTL" else "VTK_MODULE_USE_EXTERNAL_VTK_pegtl"}=OFF" # not packaged in nixpkgs
+    "-D${if lib.versionOlder version "9.0" then "VTK_USE_SYSTEM_LIBHARU" else "VTK_MODULE_USE_EXTERNAL_VTK_libharu"}=OFF" # requires patches
     "-DOPENGL_INCLUDE_DIR=${libGL}/include"
     "-DCMAKE_INSTALL_LIBDIR=lib"
     "-DCMAKE_INSTALL_INCLUDEDIR=include"
     "-DCMAKE_INSTALL_BINDIR=bin"
     "-DVTK_VERSIONED_INSTALL=OFF"
+    "-DVTK_MODULE_USE_EXTERNAL_VTK_exprtk=OFF"
+    "-DVTK_MODULE_USE_EXTERNAL_VTK_cgns=OFF"
+    "-DVTK_MODULE_USE_EXTERNAL_VTK_ioss=OFF"
+  ] ++ optionals (lib.versionOlder version "8.0") [
+    "-DVTK_USE_SYSTEM_LIBPROJ4=OFF" # an older version
+    "-DVTK_USE_SYSTEM_NETCDF=OFF" # fails to detect
+    "-DVTK_USE_SYSTEM_HDF5=OFF" # needs a different version
+    "-DVTK_USE_SYSTEM_GL2PS=OFF" # needs an older version
+  ] ++ optionals (lib.versionOlder version "9.0") [
+    "-DVTK_USE_SYSTEM_LIBPROJ=OFF" # buggy include paths
+    "-DVTK_USE_SYSTEM_PUGIXML=OFF" # fails to detect
+    "-DVTK_USE_SYSTEM_OGG=OFF" # undefined symbols during linking
+    "-DVTK_USE_SYSTEM_THEORA=OFF" # undefined symbols during linking
+    "-DVTK_USE_SYSTEM_JSONCPP=OFF" # undefined symbols during linking
   ] ++ optionals enableQt [
     "-D${if lib.versionOlder version "9.0" then "VTK_Group_Qt:BOOL=ON" else "VTK_GROUP_ENABLE_Qt:STRING=YES"}"
   ] ++ optionals (enableQt && lib.versionOlder version "8.0") [
@@ -83,11 +104,23 @@ in stdenv.mkDerivation rec {
       "-DVTK_PYTHON_VERSION:STRING=${pythonMajor}"
     ];
 
-  postPatch = optionalString stdenv.isDarwin ''
+  postPatch = lib.optionalString (lib.versionOlder version "9.0")
+  # https://gitlab.kitware.com/vtk/vtk/-/issues/18033
+  ''
+    sed -i Rendering/FreeType/vtkFreeTypeTools.cxx -e '1i#define FT_CALLBACK_DEF( x )  static  x'
+    sed -i Rendering/FreeTypeFontConfig/vtkFontConfigFreeTypeTools.cxx -e '1i#define FT_CALLBACK_DEF( x )  static  x'
+  '' + optionalString stdenv.isDarwin ''
     sed -i 's|COMMAND vtkHashSource|COMMAND "DYLD_LIBRARY_PATH=''${VTK_BINARY_DIR}/lib" ''${VTK_BINARY_DIR}/bin/vtkHashSource-${majorVersion}|' ./Parallel/Core/CMakeLists.txt
     sed -i 's/fprintf(output, shift)/fprintf(output, "%s", shift)/' ./ThirdParty/libxml2/vtklibxml2/xmlschemas.c
     sed -i 's/fprintf(output, shift)/fprintf(output, "%s", shift)/g' ./ThirdParty/libxml2/vtklibxml2/xpath.c
   '';
+
+  NIX_CFLAGS_COMPILE = lib.optionals (stdenv.isDarwin && lib.versionOlder version "9.0") [
+    # duplicate symbol '_exodus_unused_symbol_dummy_1' in:
+    #     CMakeFiles/vtkexodusII.dir/src/ex_create_par.c.o
+    #     CMakeFiles/vtkexodusII.dir/src/ex_open_par.c.o
+    "-fcommon"
+  ];
 
   meta = with lib; {
     description = "Open source libraries for 3D computer graphics, image processing and visualization";
@@ -95,7 +128,5 @@ in stdenv.mkDerivation rec {
     license = licenses.bsd3;
     maintainers = with maintainers; [ knedlsepp tfmoraes lheckemann ];
     platforms = with platforms; unix;
-    # /nix/store/xxxxxxx-apple-framework-Security/Library/Frameworks/Security.framework/Headers/Authorization.h:192:7: error: variably modified 'bytes' at file scope
-    broken = stdenv.isDarwin && (lib.versions.major majorVersion == "7" || lib.versions.major majorVersion == "8");
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21667,30 +21667,18 @@ with pkgs;
   vte_290 = callPackage ../development/libraries/vte/2.90.nix { };
 
   vtk_7 = libsForQt515.callPackage ../development/libraries/vtk/7.x.nix {
-    stdenv = gcc9Stdenv;
-    inherit (darwin) libobjc;
-    inherit (darwin.apple_sdk.libs) xpc;
-    inherit (darwin.apple_sdk.frameworks) Cocoa CoreServices DiskArbitration
-                                          IOKit CFNetwork Security ApplicationServices
-                                          CoreText IOSurface ImageIO OpenGL GLUT;
+    stdenv = if stdenv.cc.isGNU then gcc9Stdenv else stdenv;
+    inherit (darwin.apple_sdk.frameworks) Cocoa OpenGL;
   };
   vtk_8 = libsForQt515.callPackage ../development/libraries/vtk/8.x.nix {
-    stdenv = gcc9Stdenv;
-    inherit (darwin) libobjc;
-    inherit (darwin.apple_sdk.libs) xpc;
-    inherit (darwin.apple_sdk.frameworks) Cocoa CoreServices DiskArbitration
-                                          IOKit CFNetwork Security ApplicationServices
-                                          CoreText IOSurface ImageIO OpenGL GLUT;
+    stdenv = if stdenv.cc.isGNU then gcc9Stdenv else stdenv;
+    inherit (darwin.apple_sdk.frameworks) Cocoa OpenGL;
   };
 
   vtk_8_withQt5 = vtk_8.override { enableQt = true; };
 
   vtk_9 = libsForQt515.callPackage ../development/libraries/vtk/9.x.nix {
-    inherit (darwin) libobjc;
-    inherit (darwin.apple_sdk.libs) xpc;
-    inherit (darwin.apple_sdk.frameworks) Cocoa CoreServices DiskArbitration
-                                          IOKit CFNetwork Security ApplicationServices
-                                          CoreText IOSurface ImageIO OpenGL GLUT;
+    inherit (darwin.apple_sdk.frameworks) Cocoa OpenGL;
   };
 
   vtk_9_withQt5 = vtk_9.override { enableQt = true; };


### PR DESCRIPTION
###### Description of changes

This prevents vtk from building its own dependencies from scratch, which allows to fix it on darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
