### PR TITLE
dataexplorer: init at 3.6.2

### DIFF
--- a/pkgs/applications/science/electronics/dataexplorer/default.nix
+++ b/pkgs/applications/science/electronics/dataexplorer/default.nix
@@ -1,0 +1,67 @@
+{ lib
+, stdenv
+, fetchurl
+, jdk
+, jre
+, ant
+, makeWrapper
+}:
+
+stdenv.mkDerivation rec {
+  pname = "dataexplorer";
+  version = "3.6.2";
+
+  src = fetchurl {
+    url = "mirror://savannah/dataexplorer/dataexplorer-${version}-src.tar.gz";
+    sha256 = "sha256-2e8qeoJh7z/RIowMtAd8PGcMPck5H8iHqel6bW7EQ0E=";
+  };
+
+  nativeBuildInputs = [ ant makeWrapper ];
+
+  buildInputs = [ jdk ];
+
+  buildPhase = ''
+    ant -f build/build.xml dist
+  '';
+
+  doCheck = false;
+  # Missing dependencies (e.g. junit). Does not work.
+  #checkPhase = ''
+  #  ant -f build/build.xml check
+  #'';
+
+  installPhase = ''
+    ant -Dprefix=$out/share/ -f build/build.xml install
+
+    # The sources contain a wrapper script in $out/share/DataExplorer/DataExplorer
+    # but it hardcodes bash shebang and does not pin the java path.
+    # So we create our own wrapper, using similar cmdline args as upstream.
+    mkdir -p $out/bin
+    makeWrapper ${jre}/bin/java $out/bin/DataExplorer \
+      --add-flags "-Dfile.encoding=UTF-8 -Xms64m -Xmx3092m -jar $out/share/DataExplorer/DataExplorer.jar" \
+      --set SWT_GTK3 0
+
+    makeWrapper ${jre}/bin/java $out/bin/DevicePropertiesEditor \
+      --add-flags "-Dfile.encoding=UTF-8 -Xms32m -Xmx512m -classpath $out/share/DataExplorer/DataExplorer.jar gde.ui.dialog.edit.DevicePropertiesEditor" \
+      --set SWT_GTK3 0 \
+      --set LIBOVERLAY_SCROLLBAR 0
+
+    install -Dvm644 build/misc/GNU_LINUX_JUNSI_ICHARER_DUO_UDEV_RULE/50-Junsi-iCharger-DUO.rules \
+      $out/etc/udev/rules.d/50-Junsi-iCharger-DUO.rules
+    install -Dvm644 build/misc/GNU_LINUX_SKYRC_UDEV_RULE/50-SkyRC-Charger.rules \
+      $out/etc/udev/rules.d/50-SkyRC-Charger.rules
+  '';
+
+  meta = with lib; {
+    description = "Graphical tool to analyze data, gathered from various hardware devices";
+    homepage = "https://www.nongnu.org/dataexplorer/index.html";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ panicgh ];
+    platforms = jdk.meta.platforms;
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryNativeCode  # contains RXTXcomm (JNI library with *.so files)
+      binaryBytecode    # contains thirdparty jar files, e.g. javax.json, org.glassfish.json
+    ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34541,6 +34541,8 @@ with pkgs;
 
   csxcad = callPackage ../applications/science/electronics/csxcad { };
 
+  dataexplorer = callPackage ../applications/science/electronics/dataexplorer { };
+
   diylc = callPackage ../applications/science/electronics/diylc { };
 
   flatcam = callPackage ../applications/science/electronics/flatcam { };


### PR DESCRIPTION
###### Description of changes

New package. The [DataExplorer](https://www.nongnu.org/dataexplorer/index.html) gathers data from connected devices and displays this data for further analysis. It provides device plugins for communicating with various battery chargers, GPS trackers, variometers etc.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).