### PR TITLE
pocketbase: init at 0.4.2

### DIFF
--- a/pkgs/development/web/pocketbase/default.nix
+++ b/pkgs/development/web/pocketbase/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+buildGoModule rec {
+  pname = "pocketbase";
+  version = "0.4.2";
+
+  src = fetchFromGitHub {
+    owner = "pocketbase";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-uDseJmuK6SI3e2ICqr8SJ0iKOVCXONueZUJ6J8MKwYE=";
+  };
+
+  vendorSha256 = "sha256-8IiY/gjK8m2ntOXyG84HMiyT4GK3CgDTRG1DB+v0jAs=";
+
+  # This is the released subpackage from upstream repo
+  subPackages = [ "examples/base" ];
+
+  CGO_ENABLED = 0;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/pocketbase/pocketbase.Version=${version}"
+  ];
+
+  postInstall = ''
+    mv $out/bin/base $out/bin/pocketbase
+  '';
+
+  meta = with lib; {
+    description = "Open Source realtime backend in 1 file";
+    homepage = "https://github.com/pocketbase/pocketbase";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dit7ya ];
+  };
+}

--- a/pkgs/servers/pocketbase/default.nix
+++ b/pkgs/servers/pocketbase/default.nix
@@ -2,6 +2,7 @@
 , buildGoModule
 , fetchFromGitHub
 }:
+
 buildGoModule rec {
   pname = "pocketbase";
   version = "0.4.2";
@@ -20,6 +21,7 @@ buildGoModule rec {
 
   CGO_ENABLED = 0;
 
+  # Upstream build instructions
   ldflags = [
     "-s"
     "-w"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9828,6 +9828,8 @@ with pkgs;
 
   podiff = callPackage ../tools/text/podiff { };
 
+  pocketbase = callPackage ../servers/pocketbase { };
+
   podman = callPackage ../applications/virtualization/podman/wrapper.nix { };
   podman-unwrapped = callPackage ../applications/virtualization/podman { };
 


### PR DESCRIPTION
###### Description of changes

PocketBase is an open source Go backend, consisting of:

    embedded database (SQLite) with realtime subscriptions
    built-in files and users management
    convenient Admin dashboard UI
    and simple REST-ish API

https://github.com/pocketbase/pocketbase

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
