### PR TITLE
python3Packages.gradio: init at 3.20.1

### DIFF
--- a/pkgs/development/python-modules/ffmpy/default.nix
+++ b/pkgs/development/python-modules/ffmpy/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, ffmpeg
+}:
+
+buildPythonPackage rec {
+  pname = "ffmpy";
+  version = "0.3.0";
+
+  disabled = pythonOlder "3.6";
+
+  # The github repo has no release tags, the pypi distribution has no tests.
+  # This package is quite trivial anyway, and the tests mainly play around with the ffmpeg cli interface.
+  # https://github.com/Ch00k/ffmpy/issues/60
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "dXWRWB7uJbSlCsn/ubWANaJ5RTPbR+BRL1P7LXtvmtw=";
+  };
+
+  propagatedBuildInputs = [
+    ffmpeg
+  ];
+
+  pythonImportsCheck = [ "ffmpy" ];
+
+  meta = with lib; {
+    description = "A simple python interface for FFmpeg/FFprobe";
+    homepage = "https://github.com/Ch00k/ffmpy";
+    license = licenses.mit;
+    maintainers = with maintainers; [ pbsds ];
+  };
+}

--- a/pkgs/development/python-modules/gradio/default.nix
+++ b/pkgs/development/python-modules/gradio/default.nix
@@ -1,0 +1,204 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, writeText
+
+# pyproject
+, hatchling
+, hatch-requirements-txt
+, hatch-fancy-pypi-readme
+
+# runtime
+, aiofiles
+, aiohttp
+, altair
+, fastapi
+, ffmpy
+, markdown-it-py
+, mdit-py-plugins
+, markupsafe
+, matplotlib
+, numpy
+, orjson
+, pandas
+, pillow
+, pycryptodome
+, python-multipart
+, pydub
+, pyyaml
+, requests
+, uvicorn
+, jinja2
+, fsspec
+, httpx
+, pydantic
+, websockets
+, typing-extensions
+
+# check
+, pytestCheckHook
+, pytest-asyncio
+, mlflow
+, huggingface-hub
+, transformers
+, wandb
+, respx
+, scikit-image
+, shap
+, ipython
+, ffmpeg
+, vega_datasets
+, boto3
+}:
+
+let
+  # breaks way too frquently
+  shapWorks = (builtins.tryEval shap.outPath).success;
+in
+
+buildPythonPackage rec {
+  pname = "gradio";
+  version = "3.20.1";
+  format = "pyproject";
+  disabled = pythonOlder "3.7";
+
+  # We use the Pypi release, as it provides prebuild webui assets,
+  # and its releases are also more frequent than github tags
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-oG97GwehyBWjWXzDqyfj+x2mAfM6OQhYKdA3j0Rv8Vs=";
+  };
+
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace \
+        "mdit-py-plugins<=0.3.3" \
+        "mdit-py-plugins"
+  '';
+
+  propagatedBuildInputs = [
+    aiofiles
+    aiohttp
+    altair
+    fastapi
+    ffmpy
+    markdown-it-py
+    mdit-py-plugins
+    markupsafe
+    matplotlib
+    numpy
+    orjson
+    pandas
+    pillow
+    pycryptodome
+    python-multipart
+    pydub
+    pyyaml
+    requests
+    uvicorn
+    jinja2
+    fsspec
+    httpx
+    pydantic
+    websockets
+    typing-extensions
+  ] ++ markdown-it-py.optional-dependencies.linkify;
+
+  nativeBuildInputs = [
+    hatchling
+    hatch-requirements-txt
+    hatch-fancy-pypi-readme
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-asyncio
+    mlflow
+    #cometml # FIXME: enable once comet-ml is packaged
+    huggingface-hub
+    transformers
+    wandb
+    respx
+    scikit-image
+    ipython
+    ffmpeg
+    vega_datasets
+    boto3
+   ] ++ lib.optional shapWorks shap;
+
+  # Add pytest hook skipping tests that access network, marking them as "Expected fail" (xfail)
+  # We additionally xfail FileNotFoundError, as gradio often fail to upload test files to pypi.
+  preCheck = let
+    conftestSkipNetworkErrors = writeText "conftest-network-xfail.py" ''
+      from _pytest.runner import pytest_runtest_makereport as orig_pytest_runtest_makereport
+      import urllib, urllib3, httpx, requests, websockets
+
+      class NixNetworkAccessDeniedError(BaseException): pass
+      def deny_network_access(*a, **kw):
+        raise NixNetworkAccessDeniedError
+
+      def iterate_exc_chain(exc: Exception):
+        yield exc
+        if getattr(exc, "__context__", None) is not None:
+          yield from iterate_exc_chain(exc.__context__)
+        if getattr(exc, "__cause__", None) is not None:
+          yield from iterate_exc_chain(exc.__cause__)
+
+      httpx.Request = \
+      httpx.AsyncClient.get = \
+      httpx.AsyncClient.head = \
+      requests.head = \
+      requests.get = \
+      requests.post = \
+      urllib.request.urlopen = \
+      urllib.request.Request = \
+      urllib3.connection.HTTPSConnection._new_conn = \
+      websockets.connect = \
+        deny_network_access
+
+      def pytest_runtest_makereport(item, call):
+        tr = orig_pytest_runtest_makereport(item, call)
+        if call.excinfo is not None:
+          for exc in iterate_exc_chain(call.excinfo.value):
+            if isinstance(exc, NixNetworkAccessDeniedError):
+              tr.outcome, tr.wasxfail = 'skipped', "reason: Requires network access."
+            if isinstance(exc, FileNotFoundError):
+              tr.outcome, tr.wasxfail = 'skipped', "reason: Pypi dist bad."
+        return tr
+    '';
+  in ''
+    export HOME=$TMPDIR
+    cat ${conftestSkipNetworkErrors} >> test/conftest.py
+  '';
+
+  disabledTests = [
+    # Actually broken
+    "test_mount_gradio_app"
+
+    # FIXME: enable once comet-ml is packaged
+    "test_inline_display"
+    "test_integration_comet"
+
+    # Flaky (very sensitive to dep version)
+    "test_in_interface_as_output"
+    "test_should_warn_url_not_having_version"
+  ]
+  ++ lib.optionals (!shapWorks) [
+    "test_shapley_text"
+  ];
+  disabledTestPaths = [
+    # makes pytest freeze 50% of the time
+    "test/test_interfaces.py"
+  ];
+  #pytestFlagsArray = [ "-x" "-W" "ignore" ]; # uncomment for debugging help
+
+  pythonImportsCheck = [ "gradio" ];
+
+  meta = with lib; {
+    homepage = "https://www.gradio.app/";
+    description = "Python library for easily interacting with trained machine learning models";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ pbsds ];
+  };
+}

--- a/pkgs/development/python-modules/markdown-it-py/default.nix
+++ b/pkgs/development/python-modules/markdown-it-py/default.nix
@@ -3,7 +3,6 @@
 , buildPythonPackage
 , commonmark
 , fetchFromGitHub
-, flit-core
 , linkify-it-py
 , markdown
 , mdurl
@@ -25,7 +24,7 @@
 buildPythonPackage rec {
   pname = "markdown-it-py";
   version = "2.2.0";
-  format = "pyproject";
+  format = "flit";
 
   disabled = pythonOlder "3.6";
 
@@ -36,9 +35,13 @@ buildPythonPackage rec {
     hash = "sha256-qdRU1BxczFDGoIEtl0ZMkKNn4p5tec8YuPt5ZwX5fYM=";
   };
 
-  nativeBuildInputs = [
-    flit-core
-  ];
+  # fix downstrem usage of markdown-it-py[linkify]
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace \
+        'linkify = ["linkify-it-py~=1.0"]' \
+        'linkify = ["linkify-it-py"]'
+  '';
 
   propagatedBuildInputs = [
     mdurl

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4338,6 +4338,8 @@ self: super: with self; {
 
   gradient_statsd = callPackage ../development/python-modules/gradient_statsd { };
 
+  gradio = callPackage ../development/python-modules/gradio { };
+
   grammalecte = callPackage ../development/python-modules/grammalecte { };
 
   grandalf = callPackage ../development/python-modules/grandalf { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3556,6 +3556,10 @@ self: super: with self; {
 
   ffmpeg-progress-yield = callPackage ../development/python-modules/ffmpeg-progress-yield { };
 
+  ffmpy = callPackage ../development/python-modules/ffmpy {
+    inherit (pkgs) ffmpeg;
+  };
+
   fiblary3-fork = callPackage ../development/python-modules/fiblary3-fork { };
 
   fido2 = callPackage ../development/python-modules/fido2 { };


### PR DESCRIPTION
###### Description of changes

This PR add gradio by @gradio-app, a web server framework for making AI (anything really) demos.

I made this PR some time ago, made upstream fix some issues, then rebased it on master. The shap and markdown-it-py commits were initially update commits, but they were reduced to fixup commits during the rebase, as someone else upgraded them before me.

Depends on #187008

Close #235184

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


_Fun fact:_ the shap module has been updated three times while marked broken. 