### PR TITLE
treewide: use outputDoc = "devdoc" instead of moveToOutput

### DIFF
--- a/pkgs/applications/editors/gnome-builder/default.nix
+++ b/pkgs/applications/editors/gnome-builder/default.nix
@@ -150,11 +150,6 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput share/doc/libide "$devdoc"
-  '';
-
   passthru.updateScript = gnome.updateScript {
     packageName = pname;
   };

--- a/pkgs/build-support/setup-hooks/multiple-outputs.sh
+++ b/pkgs/build-support/setup-hooks/multiple-outputs.sh
@@ -154,6 +154,17 @@ _multioutDocs() {
 
     moveToOutput share/info "${!outputInfo}"
     moveToOutput share/doc "${!outputDoc}"
+
+    # Move gi-docgen-generated Devhelp docs to devdoc.
+    for output in $(getAllOutputNames); do
+        if [ -d "${!output}/share/doc" ]; then
+            while IFS= read -r -d $'\0' path; do
+                local dirpath="$(dirname "$path")"
+                moveToOutput "${dirpath#"${!output}/"}" "''${!outputDevdoc}"
+            done <  <(find "${!output}/share/doc" -type f -name "*devhelp*" -print0)
+        fi
+    done
+
     moveToOutput share/gtk-doc "${!outputDevdoc}"
     moveToOutput share/devhelp/books "${!outputDevdoc}"
 

--- a/pkgs/desktops/gnome/apps/ghex/default.nix
+++ b/pkgs/desktops/gnome/apps/ghex/default.nix
@@ -64,11 +64,6 @@ stdenv.mkDerivation rec {
     "-Dmmap-buffer-backend=false"
   ];
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = "ghex";

--- a/pkgs/desktops/gnome/core/eog/default.nix
+++ b/pkgs/desktops/gnome/core/eog/default.nix
@@ -101,11 +101,6 @@ stdenv.mkDerivation rec {
     )
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = pname;

--- a/pkgs/desktops/gnome/core/evince/default.nix
+++ b/pkgs/desktops/gnome/core/evince/default.nix
@@ -118,11 +118,6 @@ stdenv.mkDerivation rec {
     gappsWrapperArgs+=(--prefix XDG_DATA_DIRS : "${shared-mime-info}/share")
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = pname;

--- a/pkgs/desktops/gnome/core/nautilus/default.nix
+++ b/pkgs/desktops/gnome/core/nautilus/default.nix
@@ -112,11 +112,6 @@ stdenv.mkDerivation rec {
     )
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = pname;

--- a/pkgs/desktops/gnome/devtools/devhelp/default.nix
+++ b/pkgs/desktops/gnome/devtools/devhelp/default.nix
@@ -64,11 +64,6 @@ stdenv.mkDerivation rec {
     )
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput share/doc/devhelp-3 "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = "devhelp";

--- a/pkgs/development/libraries/gcr/4.nix
+++ b/pkgs/development/libraries/gcr/4.nix
@@ -82,11 +82,6 @@ stdenv.mkDerivation rec {
     patchShebangs gcr/fixtures/
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       attrPath = "gcr_4";

--- a/pkgs/development/libraries/gcr/default.nix
+++ b/pkgs/development/libraries/gcr/default.nix
@@ -90,11 +90,6 @@ stdenv.mkDerivation rec {
     substituteInPlace meson_post_install.py --replace ".so" "${stdenv.hostPlatform.extensions.sharedLibrary}"
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = pname;

--- a/pkgs/development/libraries/gdk-pixbuf/default.nix
+++ b/pkgs/development/libraries/gdk-pixbuf/default.nix
@@ -120,11 +120,6 @@ stdenv.mkDerivation (finalAttrs: {
     done
   '';
 
-  postFixup = lib.optionalString withIntrospection ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   # The tests take an excessive amount of time (> 1.5 hours) and memory (> 6 GB).
   inherit doCheck;
 

--- a/pkgs/development/libraries/gssdp/1.6.nix
+++ b/pkgs/development/libraries/gssdp/1.6.nix
@@ -66,15 +66,6 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  postFixup = ''
-    # Move developer documentation to devdoc output.
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    find -L "$out/share/doc" -type f -regex '.*\.devhelp2?' -print0 \
-      | while IFS= read -r -d ''' file; do
-        moveToOutput "$(dirname "''${file/"$out/"/}")" "$devdoc"
-    done
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       attrPath = "gssdp_1_6";

--- a/pkgs/development/libraries/gssdp/default.nix
+++ b/pkgs/development/libraries/gssdp/default.nix
@@ -52,15 +52,6 @@ stdenv.mkDerivation rec {
   # Bail out! GLib-GIO-FATAL-CRITICAL: g_inet_address_to_string: assertion 'G_IS_INET_ADDRESS (address)' failed
   doCheck = !stdenv.isDarwin;
 
-  postFixup = lib.optionalString (stdenv.buildPlatform == stdenv.hostPlatform) ''
-    # Move developer documentation to devdoc output.
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    find -L "$out/share/doc" -type f -regex '.*\.devhelp2?' -print0 \
-      | while IFS= read -r -d ''' file; do
-        moveToOutput "$(dirname "''${file/"$out/"/}")" "$devdoc"
-    done
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = pname;

--- a/pkgs/development/libraries/gtk/4.x.nix
+++ b/pkgs/development/libraries/gtk/4.x.nix
@@ -243,9 +243,6 @@ stdenv.mkDerivation rec {
       wrapProgram $dev/bin/$program \
         --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH:$out/share/gsettings-schemas/${pname}-${version}"
     done
-  '' + lib.optionalString x11Support ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
   '';
 
   passthru = {

--- a/pkgs/development/libraries/gtksourceview/5.x.nix
+++ b/pkgs/development/libraries/gtksourceview/5.x.nix
@@ -93,11 +93,6 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postCheck
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = "gtksourceview";

--- a/pkgs/development/libraries/gupnp/1.6.nix
+++ b/pkgs/development/libraries/gupnp/1.6.nix
@@ -51,11 +51,6 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       attrPath = "gupnp_1_6";

--- a/pkgs/development/libraries/json-glib/default.nix
+++ b/pkgs/development/libraries/json-glib/default.nix
@@ -74,17 +74,6 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  postFixup = ''
-    # Move developer documentation to devdoc output.
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    if [[ -d "$out/share/doc" ]]; then
-        find -L "$out/share/doc" -type f -regex '.*\.devhelp2?' -print0 \
-          | while IFS= read -r -d ''' file; do
-            moveToOutput "$(dirname "''${file/"$out/"/}")" "$devdoc"
-        done
-    fi
-  '';
-
   passthru = {
     tests = {
       installedTests = nixosTests.installed-tests.json-glib;

--- a/pkgs/development/libraries/jsonrpc-glib/default.nix
+++ b/pkgs/development/libraries/jsonrpc-glib/default.nix
@@ -45,11 +45,6 @@ stdenv.mkDerivation rec {
   # https://gitlab.gnome.org/GNOME/jsonrpc-glib/issues/2
   doCheck = false;
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = pname;

--- a/pkgs/development/libraries/libadwaita/default.nix
+++ b/pkgs/development/libraries/libadwaita/default.nix
@@ -97,11 +97,6 @@ stdenv.mkDerivation rec {
     runHook postCheck
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = pname;

--- a/pkgs/development/libraries/libgflow/default.nix
+++ b/pkgs/development/libraries/libgflow/default.nix
@@ -28,11 +28,6 @@ stdenv.mkDerivation rec {
     glib
   ];
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   mesonFlags = [
     "-Denable_valadoc=true"
     "-Denable_gtk3=false"

--- a/pkgs/development/libraries/libgtkflow4/default.nix
+++ b/pkgs/development/libraries/libgtkflow4/default.nix
@@ -29,11 +29,6 @@ stdenv.mkDerivation rec {
     libgflow
   ];
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   mesonFlags = [
     "-Denable_valadoc=true"
     "-Denable_gtk3=false"

--- a/pkgs/development/libraries/libgweather/default.nix
+++ b/pkgs/development/libraries/libgweather/default.nix
@@ -83,11 +83,6 @@ stdenv.mkDerivation rec {
       --replace "g_ir_scanner.found() and not meson.is_cross_build()" "g_ir_scanner.found()"
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = pname;

--- a/pkgs/development/libraries/libhandy/default.nix
+++ b/pkgs/development/libraries/libhandy/default.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation rec {
     "devdoc"
   ] ++ lib.optionals enableGlade [
     "glade"
+
   ];
   outputBin = "dev";
 
@@ -104,11 +105,6 @@ stdenv.mkDerivation rec {
       meson test --print-errorlogs
 
     runHook postCheck
-  '';
-
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
   '';
 
   passthru = {

--- a/pkgs/development/libraries/libpanel/default.nix
+++ b/pkgs/development/libraries/libpanel/default.nix
@@ -44,11 +44,6 @@ stdenv.mkDerivation rec {
     "-Dinstall-examples=true"
   ];
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = pname;

--- a/pkgs/development/libraries/libpeas/default.nix
+++ b/pkgs/development/libraries/libpeas/default.nix
@@ -55,11 +55,6 @@ stdenv.mkDerivation rec {
     "-Dgtk_doc=true"
   ];
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = pname;

--- a/pkgs/development/libraries/libportal/default.nix
+++ b/pkgs/development/libraries/libportal/default.nix
@@ -73,11 +73,6 @@ stdenv.mkDerivation rec {
     "-Ddocs=${if variant != "qt5" then "true" else "false"}" # requires introspection=true
   ];
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   # we don't have any binaries
   dontWrapQtApps = true;
 

--- a/pkgs/development/libraries/librest/1.0.nix
+++ b/pkgs/development/libraries/librest/1.0.nix
@@ -74,11 +74,6 @@ stdenv.mkDerivation rec {
       --replace "'gi-docgen', ver" "'gi-docgen', native:true, ver"
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   separateDebugInfo = true;
 
   passthru = {

--- a/pkgs/development/libraries/librsvg/default.nix
+++ b/pkgs/development/libraries/librsvg/default.nix
@@ -163,11 +163,6 @@ stdenv.mkDerivation (finalAttrs: {
         --zsh <(${emulator} $out/bin/rsvg-convert --completion zsh)
     '';
 
-  postFixup = lib.optionalString withIntrospection ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript =
       let

--- a/pkgs/development/libraries/libsecret/default.nix
+++ b/pkgs/development/libraries/libsecret/default.nix
@@ -106,11 +106,6 @@ stdenv.mkDerivation rec {
     rm "$out/lib/libmock-service.so"
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = pname;

--- a/pkgs/development/libraries/libshumate/default.nix
+++ b/pkgs/development/libraries/libshumate/default.nix
@@ -69,11 +69,6 @@ stdenv.mkDerivation rec {
     runHook postCheck
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput share/doc/libshumate-1.0 "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = pname;

--- a/pkgs/development/libraries/libsoup/3.x.nix
+++ b/pkgs/development/libraries/libsoup/3.x.nix
@@ -87,11 +87,6 @@ stdenv.mkDerivation rec {
     patchShebangs libsoup/
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     propagatedUserEnvPackages = [
       glib-networking.out

--- a/pkgs/development/libraries/pango/default.nix
+++ b/pkgs/development/libraries/pango/default.nix
@@ -89,11 +89,6 @@ stdenv.mkDerivation rec {
 
   doCheck = false; # test-font: FAIL
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = pname;

--- a/pkgs/development/libraries/vte/default.nix
+++ b/pkgs/development/libraries/vte/default.nix
@@ -102,11 +102,6 @@ stdenv.mkDerivation rec {
     patchShebangs src/modes.py
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = pname;

--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -224,11 +224,6 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs .
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   requiredSystemFeatures = [ "big-parallel" ];
 
   passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;

--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -328,9 +328,6 @@ stdenv.mkDerivation (finalAttrs: {
         wrapGApp "$file"
       fi
     done
-
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
   '';
 
   separateDebugInfo = true;


### PR DESCRIPTION
this achieves the same effect but in less lines

we cannot control the output location of gi-docgen

example of how the output location is set
https://github.com/frida/json-glib/blob/a8d3ac569bfaf509e2a20b55ee4fd6b89851b8b1/doc/meson.build#L8

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
