### PR TITLE
auto-cpufreq: 1.7.1 -> 1.9.6

### DIFF
--- a/pkgs/tools/system/auto-cpufreq/default.nix
+++ b/pkgs/tools/system/auto-cpufreq/default.nix
@@ -2,16 +2,21 @@
 
 python3Packages.buildPythonPackage rec {
   pname = "auto-cpufreq";
-  version = "1.7.1";
+  version = "1.9.5";
 
   src = fetchFromGitHub {
     owner = "AdnanHodzic";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1r27ydv258c6pc82za0wq8q8fj0j3r50c8wxc6r7dwr6wx8q3asx";
+    sha256 = "sha256-+8M7PJiJvfFAKYgN93R4NML9GQR989DRnJnv+j0sjUI=";
   };
 
-  propagatedBuildInputs = with python3Packages; [ click distro psutil ];
+  propagatedBuildInputs = with python3Packages; [
+    click
+    distro
+    psutil
+    setuptools
+  ];
 
   doCheck = false;
   pythonImportsCheck = [ "auto_cpufreq" ];
@@ -25,15 +30,18 @@ python3Packages.buildPythonPackage rec {
 
     # patch to prevent script copying and to disable install
     ./prevent-install-and-copy.patch
+
+    # patch to remove venvs from the service file
+    ./remove-service-venv.patch
   ];
 
   postInstall = ''
     # copy script manually
-    cp ${src}/scripts/cpufreqctl.sh $out/bin/cpufreqctl.auto-cpufreq
+    cp scripts/cpufreqctl.sh $out/bin/cpufreqctl.auto-cpufreq
 
     # systemd service
     mkdir -p $out/lib/systemd/system
-    cp ${src}/scripts/auto-cpufreq.service $out/lib/systemd/system
+    cp scripts/auto-cpufreq.service $out/lib/systemd/system
     substituteInPlace $out/lib/systemd/system/auto-cpufreq.service --replace "/usr/local" $out
   '';
 

--- a/pkgs/tools/system/auto-cpufreq/default.nix
+++ b/pkgs/tools/system/auto-cpufreq/default.nix
@@ -2,13 +2,13 @@
 
 python3Packages.buildPythonPackage rec {
   pname = "auto-cpufreq";
-  version = "1.9.5";
+  version = "1.9.6";
 
   src = fetchFromGitHub {
     owner = "AdnanHodzic";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-+8M7PJiJvfFAKYgN93R4NML9GQR989DRnJnv+j0sjUI=";
+    sha256 = "sha256-rT6OFM9hc9cx62xDV5aPebYgrZdWRkofL27l2HRSqTU=";
   };
 
   propagatedBuildInputs = with python3Packages; [

--- a/pkgs/tools/system/auto-cpufreq/fix-version-output.patch
+++ b/pkgs/tools/system/auto-cpufreq/fix-version-output.patch
@@ -1,37 +1,45 @@
+diff --git a/auto_cpufreq/core.py b/auto_cpufreq/core.py
+index faf86c6..e0e0f42 100644
 --- a/auto_cpufreq/core.py
 +++ b/auto_cpufreq/core.py
-@@ -68,32 +68,8 @@ dist_name = distro.id()
+@@ -114,26 +114,8 @@ except PermissionError:
  
  # display running version of auto-cpufreq
  def app_version():
 -
--    print("auto-cpufreq version:")
+-    print("auto-cpufreq version: ", end="")
 -
 -    # snap package
 -    if os.getenv("PKG_MARKER") == "SNAP":
--        print(getoutput("echo Snap: $SNAP_VERSION"))
+-        print(getoutput("echo \(Snap\) $SNAP_VERSION"))
 -    # aur package
 -    elif dist_name in ["arch", "manjaro", "garuda"]:
 -        aur_pkg_check = call("pacman -Qs auto-cpufreq > /dev/null", shell=True)
 -        if aur_pkg_check == 1:
--            print(
--                "Git commit:",
--                check_output(["git", "describe", "--always"]).strip().decode(),
--            )
+-            print(get_formatted_version())
 -        else:
 -            print(getoutput("pacman -Qi auto-cpufreq | grep Version"))
 -    else:
 -        # source code (auto-cpufreq-installer)
 -        try:
--            print(
--                "Git commit:",
--                check_output(["git", "describe", "--always"]).strip().decode(),
--            )
+-            print(get_formatted_version())
 -        except Exception as e:
 -            print(repr(e))
 -            pass
 +    print("auto-cpufreq version: @version@")
 +    print("Git commit: v@version@")
  
- 
- def app_res_use():
+ # return formatted version for a better readability
+ def get_formatted_version():
+diff --git a/setup.py b/setup.py
+index e0c97e7..f95c014 100644
+--- a/setup.py
++++ b/setup.py
+@@ -23,7 +23,6 @@ setup(
+         "dev_template": "{tag}+{sha}",
+         "dirty_template": "{tag}+{sha}.post{ccount}.dirty"
+     },
+-    setup_requires=["setuptools-git-versioning"],
+     description="Automatic CPU speed & power optimizer for Linux",
+     long_description=readme,
+     author="Adnan Hodzic",

--- a/pkgs/tools/system/auto-cpufreq/prevent-install-and-copy.patch
+++ b/pkgs/tools/system/auto-cpufreq/prevent-install-and-copy.patch
@@ -1,8 +1,8 @@
 diff --git a/auto_cpufreq/core.py b/auto_cpufreq/core.py
-index e0e0f42..51ba6f6 100644
+index 815fc88..ba0b4e8 100644
 --- a/auto_cpufreq/core.py
 +++ b/auto_cpufreq/core.py
-@@ -269,31 +269,13 @@ def get_current_gov():
+@@ -278,29 +278,13 @@ def get_current_gov():
  
  
  def cpufreqctl():
@@ -15,9 +15,7 @@ index e0e0f42..51ba6f6 100644
 -        pass
 -    else:
 -        # deploy cpufreqctl.auto-cpufreq script
--        if os.path.isfile("/usr/bin/cpufreqctl"):
--            shutil.copy(SCRIPTS_DIR / "cpufreqctl.sh", "/usr/bin/cpufreqctl.auto-cpufreq")
--        else:
+-        if not os.path.isfile("/usr/bin/cpufreqctl.auto-cpufreq"):
 -            shutil.copy(SCRIPTS_DIR / "cpufreqctl.sh", "/usr/bin/cpufreqctl.auto-cpufreq")
 +    # scripts are already in the correct place
 +    pass
@@ -38,7 +36,7 @@ index e0e0f42..51ba6f6 100644
  
  
  def footer(l=79):
-@@ -329,99 +311,13 @@ def remove_complete_msg():
+@@ -336,99 +320,13 @@ def remove_complete_msg():
  
  
  def deploy_daemon():

--- a/pkgs/tools/system/auto-cpufreq/prevent-install-and-copy.patch
+++ b/pkgs/tools/system/auto-cpufreq/prevent-install-and-copy.patch
@@ -1,8 +1,8 @@
 diff --git a/auto_cpufreq/core.py b/auto_cpufreq/core.py
-index 83d0d64..04b5035 100644
+index e0e0f42..51ba6f6 100644
 --- a/auto_cpufreq/core.py
 +++ b/auto_cpufreq/core.py
-@@ -204,35 +204,13 @@ def get_current_gov():
+@@ -269,31 +269,13 @@ def get_current_gov():
  
  
  def cpufreqctl():
@@ -16,13 +16,9 @@ index 83d0d64..04b5035 100644
 -    else:
 -        # deploy cpufreqctl.auto-cpufreq script
 -        if os.path.isfile("/usr/bin/cpufreqctl"):
--            shutil.copy(
--                SCRIPTS_DIR / "cpufreqctl.sh", "/usr/bin/cpufreqctl.auto-cpufreq"
--            )
+-            shutil.copy(SCRIPTS_DIR / "cpufreqctl.sh", "/usr/bin/cpufreqctl.auto-cpufreq")
 -        else:
--            shutil.copy(
--                SCRIPTS_DIR / "cpufreqctl.sh", "/usr/bin/cpufreqctl.auto-cpufreq"
--            )
+-            shutil.copy(SCRIPTS_DIR / "cpufreqctl.sh", "/usr/bin/cpufreqctl.auto-cpufreq")
 +    # scripts are already in the correct place
 +    pass
  
@@ -42,7 +38,7 @@ index 83d0d64..04b5035 100644
  
  
  def footer(l=79):
-@@ -276,76 +254,13 @@ def remove_complete_msg():
+@@ -329,99 +311,13 @@ def remove_complete_msg():
  
  
  def deploy_daemon():
@@ -51,28 +47,57 @@ index 83d0d64..04b5035 100644
 -    # deploy cpufreqctl script func call
 -    cpufreqctl()
 -
--    print("* Turn off bluetooth on boot")
--    btconf = Path("/etc/bluetooth/main.conf")
--    try:
--        orig_set = "AutoEnable=true"
--        change_set = "AutoEnable=false"
--        with btconf.open(mode="r+") as f:
--            content = f.read()
--            f.seek(0)
--            f.truncate()
--            f.write(content.replace(orig_set, change_set))
--    except Exception as e:
--        print(f"\nERROR:\nWas unable to turn off bluetooth on boot\n{repr(e)}")
+-    # turn off bluetooth on boot
+-    bluetooth_disable()
 -
 -    auto_cpufreq_stats_path.touch(exist_ok=True)
 -
 -    print("\n* Deploy auto-cpufreq install script")
--    shutil.copy(
--        SCRIPTS_DIR / "auto-cpufreq-install.sh", "/usr/bin/auto-cpufreq-install"
--    )
+-    shutil.copy(SCRIPTS_DIR / "auto-cpufreq-install.sh", "/usr/bin/auto-cpufreq-install")
 -
 -    print("\n* Deploy auto-cpufreq remove script")
 -    shutil.copy(SCRIPTS_DIR / "auto-cpufreq-remove.sh", "/usr/bin/auto-cpufreq-remove")
+-
+-    # output warning if gnome power profile is running
+-    gnome_power_detect_install()
+-    gnome_power_svc_disable()
+-
+-    # output warning if TLP service is detected
+-    tlp_service_detect()
+-
+-    call("/usr/bin/auto-cpufreq-install", shell=True)
+-
+-
+-def deploy_daemon_performance():
+-    print("\n" + "-" * 21 + " Deploying auto-cpufreq as a daemon (performance) " + "-" * 22 + "\n")
+-
+-    # check that performance is in scaling_available_governors
+-    with open("/sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors") as available_governors:
+-        if "performance" not in available_governors.read():
+-            print("\"performance\" governor is unavailable on this system, run:\n"
+-                    "sudo sudo auto-cpufreq --install\n\n"
+-                    "to install auto-cpufreq using default \"balanced\" governor.\n")
+-
+-    # deploy cpufreqctl script func call
+-    cpufreqctl()
+-
+-    # turn off bluetooth on boot
+-    bluetooth_disable()
+-
+-    auto_cpufreq_stats_path.touch(exist_ok=True)
+-
+-    print("\n* Deploy auto-cpufreq install script")
+-    shutil.copy(SCRIPTS_DIR / "auto-cpufreq-install.sh", "/usr/bin/auto-cpufreq-install")
+-
+-    print("\n* Deploy auto-cpufreq remove script")
+-    shutil.copy(SCRIPTS_DIR / "auto-cpufreq-remove.sh", "/usr/bin/auto-cpufreq-remove")
+-
+-    # output warning if gnome power profile is running
+-    gnome_power_detect_install()
+-    gnome_power_svc_disable_performance()
+-
+-    # output warning if TLP service is detected
+-    tlp_service_detect()
 -
 -    call("/usr/bin/auto-cpufreq-install", shell=True)
 +    # prevent needless copying and system changes
@@ -89,20 +114,14 @@ index 83d0d64..04b5035 100644
 -
 -    print("\n" + "-" * 21 + " Removing auto-cpufreq daemon " + "-" * 22 + "\n")
 -
--    print("* Turn on bluetooth on boot")
--    btconf = "/etc/bluetooth/main.conf"
--    try:
--        orig_set = "AutoEnable=true"
--        change_set = "AutoEnable=false"
--        with open(btconf, "r+") as f:
--            content = f.read()
--            f.seek(0)
--            f.truncate()
--            f.write(content.replace(change_set, orig_set))
--    except Exception as e:
--        print(f"\nERROR:\nWas unable to turn on bluetooth on boot\n{repr(e)}")
+-    # turn on bluetooth on boot
+-    bluetooth_enable()
 -
--    # run auto-cpufreq daemon install script
+-    # output warning if gnome power profile is stopped
+-    gnome_power_rm_reminder()
+-    gnome_power_svc_enable()
+-
+-    # run auto-cpufreq daemon remove script
 -    call("/usr/bin/auto-cpufreq-remove", shell=True)
 -
 -    # remove auto-cpufreq-remove
@@ -122,47 +141,3 @@ index 83d0d64..04b5035 100644
  
  def gov_check():
      for gov in get_avail_gov():
-diff --git a/scripts/cpufreqctl.sh b/scripts/cpufreqctl.sh
-index 63a2b5b..e157efe 100755
---- a/scripts/cpufreqctl.sh
-+++ b/scripts/cpufreqctl.sh
-@@ -467,35 +467,21 @@ fi
- 
- if [ $OPTION = "--install" ]
- then
--  echo 'installing helpers...'
--  cp $0 /usr/bin/
--  echo 'installing policy...'
--  cp $(dirname "$(readlink -f "$0")")/konkor.cpufreq.policy /usr/share/polkit-1/actions/
--  echo 'installing fonts...'
--  mkdir -p /usr/share/fonts/truetype/cpufreq
--  cp $(dirname "$(readlink -f "$0")")/fonts/cpufreq.ttf /usr/share/fonts/truetype/cpufreq/
--  echo "done"
-+  echo "install is disabled in the nix package"
-   exit
- fi
- if [ $OPTION = "--update-fonts" ]
- then
--  fc-cache -f
-+  echo "update-fonts is disabled in the nix package"
-   exit
- fi
- if [ $OPTION = "--uninstall" ]
- then
--  echo 'uninstalling cpufreqctl helper...'
--  rm /usr/bin/cpufreqctl
--  echo 'uninstalling policy...'
--  rm /usr/share/polkit-1/actions/konkor.cpufreq.policy
--  echo 'uninstalling fonts...'
--  rm -rf /usr/share/fonts/truetype/cpufreq
--  echo "done"
-+  echo "uninstall is disabled in the nix package"
-   exit
- fi
- if [ $OPTION = "--reset" ]
- then
--  echo 'reset to default values...'
--  dconf reset -f "/org/gnome/shell/extensions/cpufreq/"
-+  echo "reset is disabled in the nix package"
-   exit
- fi

--- a/pkgs/tools/system/auto-cpufreq/remove-service-venv.patch
+++ b/pkgs/tools/system/auto-cpufreq/remove-service-venv.patch
@@ -1,0 +1,15 @@
+diff --git a/scripts/auto-cpufreq.service b/scripts/auto-cpufreq.service
+index 3362723..aa95fba 100644
+--- a/scripts/auto-cpufreq.service
++++ b/scripts/auto-cpufreq.service
+@@ -5,9 +5,7 @@ After=network.target network-online.target
+ [Service]
+ Type=simple
+ User=root
+-WorkingDirectory=/opt/auto-cpufreq/venv
+-Environment=PYTHONPATH=/opt/auto-cpufreq
+-ExecStart=/opt/auto-cpufreq/venv/bin/python /opt/auto-cpufreq/venv/bin/auto-cpufreq --daemon
++ExecStart=/usr/local/bin/auto-cpufreq --daemon
+ Restart=on-failure
+ 
+ [Install]


### PR DESCRIPTION
###### Description of changes

Release summaries: https://github.com/AdnanHodzic/auto-cpufreq/releases

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
