### PR TITLE
aiolifx-connection: init at 1.0.0

### DIFF
--- a/pkgs/development/python-modules/aiolifx-connection/default.nix
+++ b/pkgs/development/python-modules/aiolifx-connection/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, pythonOlder
+, aiolifx
+}:
+
+buildPythonPackage rec {
+  pname = "aiolifx-connection";
+  version = "1.0.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    pname = "aiolifx_connection";
+    inherit version;
+    hash = "sha256:09fydp5fqqh1s0vav39mw98i1la6qcgk17gch0m5ihyl9q50ks13";
+  };
+
+  propagatedBuildInputs = [
+    aiolifx
+  ];
+
+  # tests are not implemented
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "aiolifx_connection"
+  ];
+
+  meta = with lib; {
+    description = "Wrapper for aiolifx to connect to a single LIFX device";
+    homepage = "https://github.com/bdraco/aiolifx_connection";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ lukegb ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -1448,10 +1448,11 @@
     ];
     "lifx" = ps: with ps; [
       aiohttp-cors
+      aiolifx-connection
       aiolifx
       aiolifx-effects
       ifaddr
-    ]; # missing inputs: aiolifx-connection
+    ];
     "lifx_cloud" = ps: with ps; [
     ];
     "light" = ps: with ps; [
@@ -3557,6 +3558,7 @@
     "lcn"
     "lg_soundbar"
     "life360"
+    "lifx"
     "light"
     "litterrobot"
     "local_file"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -361,6 +361,8 @@ in {
 
   aiolifx = callPackage ../development/python-modules/aiolifx { };
 
+  aiolifx-connection = callPackage ../development/python-modules/aiolifx-connection { };
+
   aiolifx-effects = callPackage ../development/python-modules/aiolifx-effects { };
 
   aiolimiter = callPackage ../development/python-modules/aiolimiter { };


### PR DESCRIPTION
###### Description of changes

Add https://pypi.org/project/aiolifx-connection/ (deprecated package) at 1.0.0 to fix missing dependency for Home Assistant. This package is a very very thin shim around the base aiolifx package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
