### PR TITLE
python310Packages.dynd: Fix broken build

### DIFF
--- a/pkgs/development/python-modules/dynd/default.nix
+++ b/pkgs/development/python-modules/dynd/default.nix
@@ -1,23 +1,33 @@
 { lib
 , buildPythonPackage
-, isPyPy
-, isPy3k
 , cython
 , numpy
-, pkgs
+, libdynd
+, fetchpatch
+, cmake
+, fetchFromGitHub
 }:
 
 buildPythonPackage rec {
   version = "0.7.2";
   pname = "dynd";
-  disabled = isPyPy || !isPy3k; # tests fail on python2, 2018-04-11
 
-  src = pkgs.fetchFromGitHub {
+  src = fetchFromGitHub {
     owner = "libdynd";
     repo = "dynd-python";
     rev = "v${version}";
     sha256 = "19igd6ibf9araqhq9bxmzbzdz05vp089zxvddkiik3b5gb7l17nh";
   };
+
+  patches = [
+    # Fix numpy compatibility
+    # https://github.com/libdynd/dynd-python/issues/746
+    (fetchpatch {
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/numpy-compatibility.patch?h=python-dynd&id=e626acabd041069861311f314ac3dbe9e6fd24b7";
+      sha256 = "sha256-oA/3G8CGeDhiYXbNX+G6o3QSb7rkKItuCDCbnK3Rt10=";
+      name = "numpy-compatibility.patch";
+    })
+  ];
 
   # setup.py invokes git on build but we're fetching a tarball, so
   # can't retrieve git version. We hardcode:
@@ -28,12 +38,22 @@ buildPythonPackage rec {
 
   dontUseCmakeConfigure = true;
 
-  # Python 3 works but has a broken import test that I couldn't
-  # figure out.
-  doCheck = !isPy3k;
-  nativeBuildInputs = [ pkgs.cmake ];
-  buildInputs = [ pkgs.libdynd.dev cython ];
-  propagatedBuildInputs = [ numpy pkgs.libdynd ];
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [
+    cython
+    libdynd.dev
+  ];
+
+  propagatedBuildInputs = [
+    libdynd
+    numpy
+  ];
+
+  #  ModuleNotFoundError: No module named 'dynd.config'
+  doCheck = false;
+
+  pythonImportsCheck = [ "dynd" ];
 
   meta = with lib; {
     homepage = "http://libdynd.org";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
