### PR TITLE
dotnetCorePackages.combinePackages: refactor

### DIFF
--- a/pkgs/development/compilers/dotnet/combine-packages.nix
+++ b/pkgs/development/compilers/dotnet/combine-packages.nix
@@ -1,8 +1,13 @@
 packages:
-{ buildEnv, lib }:
+{ buildEnv, makeWrapper, lib }:
+# TODO: Rethink how we determine and/or get the CLI.
+#       Possible options raised in #187118:
+#         1. A separate argument for the CLI (as suggested by IvarWithoutBones
+#         2. Use the highest version SDK for the CLI (as suggested by GGG)
+#         3. Something else?
 let cli = builtins.head packages;
 in
-assert lib.assertMsg ((builtins.length packages) != 0)
+assert lib.assertMsg ((builtins.length packages) < 1)
     ''You must include at least one package, e.g
       `with dotnetCorePackages; combinePackages [
           sdk_3_1 aspnetcore_5_0
@@ -10,11 +15,20 @@ assert lib.assertMsg ((builtins.length packages) != 0)
   buildEnv {
     name = "dotnet-core-combined";
     paths = packages;
-    pathsToLink = [ "/host" "/packs" "/sdk" "/shared" "/templates" ];
+    pathsToLink = [ "/host" "/packs" "/sdk" "/sdk-manifests" "/shared" "/templates" ];
     ignoreCollisions = true;
+    nativeBuildInputs = [
+      makeWrapper
+    ];
     postBuild = ''
-      cp ${cli}/dotnet $out/dotnet
+      cp -R ${cli}/{dotnet,LICENSE.txt,nix-support,ThirdPartyNotices.txt} $out/
+
       mkdir $out/bin
-      ln -s $out/dotnet $out/bin/
+      ln -s $out/dotnet $out/bin/dotnet
+      wrapProgram $out/bin/dotnet \
+        --prefix LD_LIBRARY_PATH : ${cli.icu}/lib
     '';
+    passthru = {
+      inherit (cli) icu packages;
+    };
   }


### PR DESCRIPTION
###### Description of changes

This refactors the combinePackages function to properly combine the different .NET versions as the previous version was copying already wrapped binary which wasn't pointing to the combined directories' binary and it also wasn't linking the `/sdk-manifests` directory.

A few other miscellaneous files like `LICENSE.txt`, `ThirdPartyNotices.txt` and the `nix-support` directory weren't being copied either which resulted in an incomplete .NET installation in the combined directory (although nothing that really affected the user, in my experience).

The `passthrough.icu` property was also not being set which resulted in us being unable to use the result of this function in `buildDotnetModule` for projects that combine different versions of .NET.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).