### PR TITLE
tessen: init at 2.1.2

### DIFF
--- a/pkgs/applications/misc/tessen/default.nix
+++ b/pkgs/applications/misc/tessen/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, libnotify
+, makeWrapper
+, pass
+, wl-clipboard
+, wtype
+, rofi
+, backend ? rofi
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tessen";
+  version = "2.1.2";
+
+  src = fetchFromGitHub {
+    owner = "ayushnix";
+    repo = "tessen";
+    rev = "v${version}";
+    sha256 = "sha256-MkZM/Au0nC2DPkgGDH5XuSJcGfwOtcjFHvMQhKfqSgY=";
+  };
+
+  dontBuild = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -a tessen $out/bin/tessen
+  '';
+
+  fixupPhase = let
+    wrapperPath = lib.makeBinPath [
+      backend
+      libnotify
+      pass
+      wl-clipboard
+      wtype
+    ];
+  in ''
+    patchShebangs $out/bin
+    wrapProgram $out/bin/tessen --prefix PATH : ${wrapperPath}
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/ayushnix/tessen";
+    description = "An interactive menu to autotype and copy pass and gopass data";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ magnouvean ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36269,6 +36269,8 @@ with pkgs;
 
   teseq = callPackage ../applications/misc/teseq {  };
 
+  tessen = callPackage ../applications/misc/tessen { };
+
   ape = callPackage ../applications/misc/ape { };
   attemptoClex = callPackage ../applications/misc/ape/clex.nix { };
   apeClex = callPackage ../applications/misc/ape/apeclex.nix { };


### PR DESCRIPTION
###### Description of changes
Added tessen package. Tessen is a wayland-equivelant to rofi-pass with some added features and more maintained. It also support other backends than rofi, for example bemenu. For more information see: https://github.com/ayushnix/tessen

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
