### PR TITLE
pythonPackage.django-encrypted-model-fields: init at 0.6.5

### DIFF
--- a/pkgs/development/python-modules/django-encrypted-model-fields/default.nix
+++ b/pkgs/development/python-modules/django-encrypted-model-fields/default.nix
@@ -1,0 +1,36 @@
+{ buildPythonPackage
+, cryptography
+, django
+, fetchPypi
+, lib
+, poetry-core
+, pythonOlder }:
+buildPythonPackage rec {
+  pname = "django-encrypted-model-fields";
+  version = "0.6.5";
+  disabled = pythonOlder "3.6";
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-i9IcVWXA1k7E29N1rTT+potNotuHHew/px/nteQiHJk=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    cryptography
+    django
+  ];
+
+  pythonImportsCheck = [ "encrypted_model_fields" ];
+
+  meta = with lib; {
+    description = "A set of fields that wrap standard Django fields with encryption provided by the python cryptography library";
+    homepage = "https://gitlab.com/lansharkconsulting/django/django-encrypted-model-fields";
+    license = licenses.mit;
+    maintainers = with maintainers; [ centromere ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2466,6 +2466,8 @@ in {
 
   django-dynamic-preferences = callPackage ../development/python-modules/django-dynamic-preferences { };
 
+  django-encrypted-model-fields = callPackage ../development/python-modules/django-encrypted-model-fields { };
+
   django-environ = callPackage ../development/python-modules/django_environ { };
 
   django-extensions = callPackage ../development/python-modules/django-extensions { };


### PR DESCRIPTION
###### Description of changes

A set of fields that wrap standard Django fields with
encryption provided by the python cryptography library.

https://gitlab.com/lansharkconsulting/django/django-encrypted-model-fields

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).