### PR TITLE
python3Packages.radon: init at 5.1.0

### DIFF
--- a/pkgs/development/python-modules/mando/default.nix
+++ b/pkgs/development/python-modules/mando/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+, six
+}:
+
+buildPythonPackage {
+  pname = "mando";
+  version = "0.6.4";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "rubik";
+    repo = "mando";
+
+    # this rev contains a fix for newer versions of python (3.8+), but is still tagged 0.6.4
+    rev = "460c2ed296f04530a84d39c1e547b143f11b7580";
+    sha256 = "sha256-Ge73kNrE5PeiFKy1lxOC3OS/0b5HWfGz95ZuLcMJCkI=";
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  # these tests are disabled since they are only docstring tests and appear to be broken upstream
+  disabledTests = [
+    "test_google_docstring_help"
+    "test_numpy_docstring_help"
+  ];
+
+  propagatedBuildInputs = [ six ];
+
+  pythonImportsCheck = [
+    "mando"
+  ];
+
+  meta = with lib; {
+    description = "Create Python CLI apps with little to no effort at all";
+    homepage = "https://mando.readthedocs.org/";
+    changelog = "https://github.com/rubik/mando/blob/master/CHANGELOG";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jpetrucciani ];
+  };
+}
+

--- a/pkgs/development/python-modules/radon/default.nix
+++ b/pkgs/development/python-modules/radon/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+, mando
+, colorama
+, future
+, pytest-mock
+}:
+
+buildPythonPackage rec {
+  pname = "radon";
+  version = "5.1.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "rubik";
+    repo = "radon";
+    rev = "v${version}";
+    sha256 = "sha256-5gO3Wciqecv6uXC8cwDk/DQIM7fQ9muw/u+z73fV6aY=";
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-mock
+  ];
+
+  propagatedBuildInputs = [
+    mando
+    colorama
+    future
+  ];
+
+  pythonImportsCheck = [
+    "radon"
+  ];
+
+  meta = with lib; {
+    description = "Code Metrics in Python";
+    homepage = "https://radon.readthedocs.org/";
+    changelog = "https://github.com/rubik/radon/blob/master/CHANGELOG";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jpetrucciani ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5623,6 +5623,8 @@ self: super: with self; {
 
   managesieve = callPackage ../development/python-modules/managesieve { };
 
+  mando = callPackage ../development/python-modules/mando { };
+
   manhole = callPackage ../development/python-modules/manhole { };
 
   manimpango = callPackage ../development/python-modules/manimpango {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9754,6 +9754,8 @@ self: super: with self; {
 
   radish-bdd = callPackage ../development/python-modules/radish-bdd { };
 
+  radon = callPackage ../development/python-modules/radon { };
+
   railroad-diagrams = callPackage ../development/python-modules/railroad-diagrams { };
 
   rainbowstream = callPackage ../development/python-modules/rainbowstream { };


### PR DESCRIPTION
###### Description of changes

I would like to be able to use the `radon` ([link here](https://github.com/rubik/radon)) code metrics tool inside of nixpkgs!

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
