### PR TITLE
cvise: drop tests broken by pytest-flake8 update

### DIFF
--- a/pkgs/development/tools/misc/cvise/default.nix
+++ b/pkgs/development/tools/misc/cvise/default.nix
@@ -1,6 +1,6 @@
 { lib, buildPythonApplication, fetchFromGitHub, bash, cmake, flex
 , libclang, llvm, unifdef
-, chardet, pebble, psutil, pytestCheckHook, pytest-flake8
+, chardet, pebble, psutil
 }:
 
 buildPythonApplication rec {
@@ -22,7 +22,6 @@ buildPythonApplication rec {
   nativeBuildInputs = [ cmake flex llvm.dev ];
   buildInputs = [ bash libclang llvm llvm.dev unifdef ];
   propagatedBuildInputs = [ chardet pebble psutil ];
-  checkInputs = [ pytestCheckHook pytest-flake8 unifdef ];
 
   # 'cvise --command=...' generates a script with hardcoded shebang.
   postPatch = ''
@@ -30,14 +29,8 @@ buildPythonApplication rec {
       --replace "#!/bin/bash" "#!${bash}/bin/bash"
   '';
 
-  preCheck = ''
-    patchShebangs cvise.py
-  '';
-  disabledTests = [
-    # Needs gcc, fails when run noninteractively (without tty).
-    "test_simple_reduction"
-  ];
-
+  # pytest-flake8 is broken in nixpkgs: https://github.com/tholo/pytest-flake8/issues/87
+  doCheck = false;
   dontUsePipInstall = true;
   dontUseSetuptoolsBuild = true;
   dontUseSetuptoolsCheck = true;


### PR DESCRIPTION
Commit https://github.com/NixOS/nixpkgs/commit/47e7f78fcb4eb96aedeee430a0c4922bdf61d751
marked pytest-flake8 as broken. Let's demove cvise tests to restore
cvise package until upstream sorts it out.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
