### PR TITLE
hebbot: init at 2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1359,6 +1359,12 @@
     githubId = 9315;
     name = "Zhong Jianxin";
   };
+  a-kenji = {
+    email = "aks.kenji@protonmail.com";
+    github = "a-kenji";
+    githubId = 65275785;
+    name = "Alexander Kenji Berthold";
+  };
   b4dm4n = {
     email = "fabianm88@gmail.com";
     github = "B4dM4n";

--- a/pkgs/servers/matrix-hebbot/default.nix
+++ b/pkgs/servers/matrix-hebbot/default.nix
@@ -8,8 +8,7 @@
 , openssl
 , autoconf
 , automake
-, withSecurity ? true
-, Security # darwin Security.framework
+, Security
 }:
 
 rustPlatform.buildRustPackage rec {

--- a/pkgs/servers/matrix-hebbot/default.nix
+++ b/pkgs/servers/matrix-hebbot/default.nix
@@ -1,10 +1,15 @@
 { lib
 , fetchFromGitHub
 , pkgs
+, stdenv
 , rustPlatform
 , pkg-config
 , cmake
 , openssl
+, autoconf
+, automake
+, withSecurity ? true
+, darwin # darwin Security.framework
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -20,9 +25,11 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "sha256-ZNETA2JUZCS8/a2oeF+JCGVKbzeyhp51D0BmBTPToOw=";
 
-  nativeBuildInputs = [ pkg-config cmake ];
+  nativeBuildInputs = [ pkg-config cmake ] ++
+    lib.optionals (stdenv.isDarwin && !withSecurity) [ autoconf automake ];
 
-  buildInputs = [ openssl ];
+  buildInputs = [ openssl ] ++ lib.optional (stdenv.isDarwin && withSecurity) darwin.apple_sdk.frameworks.Security
+  ;
 
   meta = with lib; {
     description = "A Matrix bot which can generate \"This Week in X\" like blog posts ";

--- a/pkgs/servers/matrix-hebbot/default.nix
+++ b/pkgs/servers/matrix-hebbot/default.nix
@@ -9,7 +9,7 @@
 , autoconf
 , automake
 , withSecurity ? true
-, darwin # darwin Security.framework
+, Security # darwin Security.framework
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -28,8 +28,7 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [ pkg-config cmake ] ++
     lib.optionals (stdenv.isDarwin && !withSecurity) [ autoconf automake ];
 
-  buildInputs = [ openssl ] ++ lib.optional (stdenv.isDarwin && withSecurity) darwin.apple_sdk.frameworks.Security
-  ;
+  buildInputs = [ openssl ] ++ lib.optional (stdenv.isDarwin && withSecurity) Security;
 
   meta = with lib; {
     description = "A Matrix bot which can generate \"This Week in X\" like blog posts ";

--- a/pkgs/servers/matrix-hebbot/default.nix
+++ b/pkgs/servers/matrix-hebbot/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, fetchFromGitHub
+, pkgs
+, rustPlatform
+, pkg-config
+, cmake
+, openssl
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "hebbot";
+  version = "2.1";
+
+  src = fetchFromGitHub {
+    owner = "haecker-felix";
+    repo = "hebbot";
+    rev = "v${version}";
+    sha256 = "sha256-zcsoTWpNonkgJLTC8S9Nubnzdhj5ROL/UGNWUsLxLgs=";
+  };
+
+  cargoSha256 = "sha256-ZNETA2JUZCS8/a2oeF+JCGVKbzeyhp51D0BmBTPToOw=";
+
+  nativeBuildInputs = [ pkg-config cmake ];
+
+  buildInputs = [ openssl ];
+
+  meta = with lib; {
+    description = "A Matrix bot which can generate \"This Week in X\" like blog posts ";
+    homepage = "https://github.com/haecker-felix/hebbot";
+    changelog = "https://github.com/haecker-felix/hebbot/releases/tag/v${version}";
+    license = with licenses; [ agpl3 ];
+    maintainers = with maintainers; [ a-kenji ];
+  };
+
+}
+

--- a/pkgs/servers/matrix-hebbot/default.nix
+++ b/pkgs/servers/matrix-hebbot/default.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage rec {
   cargoSha256 = "sha256-ZNETA2JUZCS8/a2oeF+JCGVKbzeyhp51D0BmBTPToOw=";
 
   nativeBuildInputs = [ pkg-config cmake ] ++
-    lib.optionals (stdenv.isDarwin && !withSecurity) [ autoconf automake ];
+    lib.optionals stdenv.isDarwin [ autoconf automake ];
 
   buildInputs = [ openssl ] ++ lib.optional (stdenv.isDarwin && withSecurity) Security;
 

--- a/pkgs/servers/matrix-hebbot/default.nix
+++ b/pkgs/servers/matrix-hebbot/default.nix
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [ pkg-config cmake ] ++
     lib.optionals stdenv.isDarwin [ autoconf automake ];
 
-  buildInputs = [ openssl ] ++ lib.optional (stdenv.isDarwin && withSecurity) Security;
+  buildInputs = [ openssl ] ++ lib.optional stdenv.isDarwin Security;
 
   meta = with lib; {
     description = "A Matrix bot which can generate \"This Week in X\" like blog posts ";

--- a/pkgs/servers/matrix-hebbot/default.nix
+++ b/pkgs/servers/matrix-hebbot/default.nix
@@ -36,6 +36,4 @@ rustPlatform.buildRustPackage rec {
     license = with licenses; [ agpl3 ];
     maintainers = with maintainers; [ a-kenji ];
   };
-
 }
-

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3986,6 +3986,8 @@ with pkgs;
 
   hebcal = callPackage ../tools/misc/hebcal {};
 
+  hebbot = callPackage ../servers/matrix-hebbot {};
+
   hexio = callPackage ../development/tools/hexio { };
 
   hexyl = callPackage ../tools/misc/hexyl { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3986,7 +3986,9 @@ with pkgs;
 
   hebcal = callPackage ../tools/misc/hebcal {};
 
-  hebbot = callPackage ../servers/matrix-hebbot {};
+  hebbot = callPackage ../servers/matrix-hebbot {
+     inherit (darwin.apple_sdk.frameworks) Security;
+  };
 
   hexio = callPackage ../development/tools/hexio { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3987,7 +3987,7 @@ with pkgs;
   hebcal = callPackage ../tools/misc/hebcal {};
 
   hebbot = callPackage ../servers/matrix-hebbot {
-     inherit (darwin.apple_sdk.frameworks) Security;
+    inherit (darwin.apple_sdk.frameworks) Security;
   };
 
   hexio = callPackage ../development/tools/hexio { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


