### PR TITLE
python3Packages.bucketstore: init at 0.2.2

### DIFF
--- a/pkgs/development/python-modules/bucketstore/default.nix
+++ b/pkgs/development/python-modules/bucketstore/default.nix
@@ -19,11 +19,12 @@ buildPythonPackage rec {
     sha256 = "sha256-BtoyGqFbeBhGQeXnmeSfiuJLZtXFrK26WO0SDlAtKG4=";
   };
 
+  propagatedBuildInputs = [ boto3 ];
+
   checkInputs = [
     pytestCheckHook
     moto
   ];
-  propagatedBuildInputs = [ boto3 ];
 
   pythonImportsCheck = [
     "bucketstore"

--- a/pkgs/development/python-modules/bucketstore/default.nix
+++ b/pkgs/development/python-modules/bucketstore/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+, boto3
+, moto
+}:
+
+buildPythonPackage rec {
+  pname = "bucketstore";
+  version = "0.2.2";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "jpetrucciani";
+    repo = "bucketstore";
+    rev = version;
+    sha256 = "sha256-BtoyGqFbeBhGQeXnmeSfiuJLZtXFrK26WO0SDlAtKG4=";
+  };
+
+  checkInputs = [
+    pytestCheckHook
+    moto
+  ];
+  propagatedBuildInputs = [ boto3 ];
+
+  pythonImportsCheck = [
+    "bucketstore"
+  ];
+
+  meta = with lib; {
+    description = "Library for interacting with Amazon S3";
+    homepage = "https://github.com/jpetrucciani/bucketstore";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jpetrucciani ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1502,6 +1502,8 @@ in {
 
   btrfsutil = toPythonModule (pkgs.btrfs-progs.override { python3 = self.python; });
 
+  bucketstore = callPackage ../development/python-modules/bucketstore { };
+
   bugsnag = callPackage ../development/python-modules/bugsnag { };
 
   bugwarrior = callPackage ../development/python-modules/bugwarrior { };


### PR DESCRIPTION
###### Description of changes

I would like to be able to use `bucketstore` from nixpkgs proper instead of adding overlays to include it in my various python repos!

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
