### PR TITLE
llvmPackages*.libunwind: Don't redo install phase from scratch

### DIFF
--- a/pkgs/development/compilers/llvm/10/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/10/libcxxabi/default.nix
@@ -40,28 +40,20 @@ stdenv.mkDerivation {
     "-DLIBCXXABI_ENABLE_SHARED=OFF"
   ];
 
-  installPhase = if stdenv.isDarwin
-    then ''
-      for file in lib/*.dylib; do
-        # this should be done in CMake, but having trouble figuring out
-        # the magic combination of necessary CMake variables
-        # if you fancy a try, take a look at
-        # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
-        install_name_tool -id $out/$file $file
-      done
-      make install
-      install -d 755 $out/include
-      install -m 644 ../include/*.h $out/include
-    ''
-    else ''
-      install -d -m 755 $out/include $out/lib
-      install -m 644 lib/libc++abi.a $out/lib
-      install -m 644 ../include/cxxabi.h $out/include
-    '' + lib.optionalString enableShared ''
-      install -m 644 lib/libc++abi.so.1.0 $out/lib
-      ln -s libc++abi.so.1.0 $out/lib/libc++abi.so
-      ln -s libc++abi.so.1.0 $out/lib/libc++abi.so.1
-    '';
+  preInstall = lib.optionalString stdenv.isDarwin ''
+    for file in lib/*.dylib; do
+      # this should be done in CMake, but having trouble figuring out
+      # the magic combination of necessary CMake variables
+      # if you fancy a try, take a look at
+      # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
+      install_name_tool -id $out/$file $file
+    done
+  '';
+
+  postInstall = ''
+    mkdir -p "$dev/include"
+    install -m 644 ../include/${if stdenv.isDarwin then "*" else "cxxabi.h"} "$dev/include"
+  '';
 
   meta = llvm_meta // {
     homepage = "https://libcxxabi.llvm.org/";

--- a/pkgs/development/compilers/llvm/11/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/11/libcxxabi/default.nix
@@ -44,28 +44,20 @@ stdenv.mkDerivation {
     "-DLIBCXXABI_ENABLE_SHARED=OFF"
   ];
 
-  installPhase = if stdenv.isDarwin
-    then ''
-      for file in lib/*.dylib; do
-        # this should be done in CMake, but having trouble figuring out
-        # the magic combination of necessary CMake variables
-        # if you fancy a try, take a look at
-        # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
-        ${stdenv.cc.targetPrefix}install_name_tool -id $out/$file $file
-      done
-      make install
-      install -d 755 $out/include
-      install -m 644 ../include/*.h $out/include
-    ''
-    else ''
-      install -d -m 755 $out/include $out/lib
-      install -m 644 lib/libc++abi.a $out/lib
-      install -m 644 ../include/cxxabi.h $out/include
-    '' + lib.optionalString enableShared ''
-      install -m 644 lib/libc++abi.so.1.0 $out/lib
-      ln -s libc++abi.so.1.0 $out/lib/libc++abi.so
-      ln -s libc++abi.so.1.0 $out/lib/libc++abi.so.1
-    '';
+  preInstall = lib.optionalString stdenv.isDarwin ''
+    for file in lib/*.dylib; do
+      # this should be done in CMake, but having trouble figuring out
+      # the magic combination of necessary CMake variables
+      # if you fancy a try, take a look at
+      # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
+      install_name_tool -id $out/$file $file
+    done
+  '';
+
+  postInstall = ''
+    mkdir -p "$dev/include"
+    install -m 644 ../include/${if stdenv.isDarwin then "*" else "cxxabi.h"} "$dev/include"
+  '';
 
   meta = llvm_meta // {
     homepage = "https://libcxxabi.llvm.org/";

--- a/pkgs/development/compilers/llvm/12/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/12/libcxxabi/default.nix
@@ -42,28 +42,20 @@ stdenv.mkDerivation {
     "-DLIBCXXABI_ENABLE_SHARED=OFF"
   ];
 
-  installPhase = if stdenv.isDarwin
-    then ''
-      for file in lib/*.dylib; do
-        # this should be done in CMake, but having trouble figuring out
-        # the magic combination of necessary CMake variables
-        # if you fancy a try, take a look at
-        # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
-        ${stdenv.cc.targetPrefix}install_name_tool -id $out/$file $file
-      done
-      make install
-      install -d 755 $out/include
-      install -m 644 ../include/*.h $out/include
-    ''
-    else ''
-      install -d -m 755 $out/include $out/lib
-      install -m 644 lib/libc++abi.a $out/lib
-      install -m 644 ../include/cxxabi.h $out/include
-    '' + lib.optionalString enableShared ''
-      install -m 644 lib/libc++abi.so.1.0 $out/lib
-      ln -s libc++abi.so.1.0 $out/lib/libc++abi.so
-      ln -s libc++abi.so.1.0 $out/lib/libc++abi.so.1
-    '';
+  preInstall = lib.optionalString stdenv.isDarwin ''
+    for file in lib/*.dylib; do
+      # this should be done in CMake, but having trouble figuring out
+      # the magic combination of necessary CMake variables
+      # if you fancy a try, take a look at
+      # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
+      install_name_tool -id $out/$file $file
+    done
+  '';
+
+  postInstall = ''
+    mkdir -p "$dev/include"
+    install -m 644 ../include/${if stdenv.isDarwin then "*" else "cxxabi.h"} "$dev/include"
+  '';
 
   meta = llvm_meta // {
     homepage = "https://libcxxabi.llvm.org/";

--- a/pkgs/development/compilers/llvm/13/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/13/libcxxabi/default.nix
@@ -39,28 +39,20 @@ stdenv.mkDerivation rec {
     "-DLIBCXXABI_ENABLE_SHARED=OFF"
   ];
 
-  installPhase = if stdenv.isDarwin
-    then ''
-      for file in lib/*.dylib; do
-        # this should be done in CMake, but having trouble figuring out
-        # the magic combination of necessary CMake variables
-        # if you fancy a try, take a look at
-        # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
-        install_name_tool -id $out/$file $file
-      done
-      make install
-      install -d 755 $out/include
-      install -m 644 ../include/*.h $out/include
-    ''
-    else ''
-      install -d -m 755 $out/include $out/lib
-      install -m 644 lib/libc++abi.a $out/lib
-      install -m 644 ../include/cxxabi.h $out/include
-    '' + lib.optionalString enableShared ''
-      install -m 644 lib/libc++abi.so.1.0 $out/lib
-      ln -s libc++abi.so.1.0 $out/lib/libc++abi.so
-      ln -s libc++abi.so.1.0 $out/lib/libc++abi.so.1
-    '';
+  preInstall = lib.optionalString stdenv.isDarwin ''
+    for file in lib/*.dylib; do
+      # this should be done in CMake, but having trouble figuring out
+      # the magic combination of necessary CMake variables
+      # if you fancy a try, take a look at
+      # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
+      install_name_tool -id $out/$file $file
+    done
+  '';
+
+  postInstall = ''
+    mkdir -p "$dev/include"
+    install -m 644 ../include/${if stdenv.isDarwin then "*" else "cxxabi.h"} "$dev/include"
+  '';
 
   meta = llvm_meta // {
     homepage = "https://libcxxabi.llvm.org/";

--- a/pkgs/development/compilers/llvm/5/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/5/libcxxabi/default.nix
@@ -25,27 +25,20 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ cmake ];
   buildInputs = lib.optional (!stdenv.isDarwin && !stdenv.isFreeBSD) libunwind;
 
-  installPhase = if stdenv.isDarwin
-    then ''
-      for file in lib/*.dylib; do
-        # this should be done in CMake, but having trouble figuring out
-        # the magic combination of necessary CMake variables
-        # if you fancy a try, take a look at
-        # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
-        install_name_tool -id $out/$file $file
-      done
-      make install
-      install -d 755 $out/include
-      install -m 644 ../include/*.h $out/include
-    ''
-    else ''
-      install -d -m 755 $out/include $out/lib
-      install -m 644 lib/libc++abi.a $out/lib
-      install -m 644 lib/libc++abi.so.1.0 $out/lib
-      install -m 644 ../include/cxxabi.h $out/include
-      ln -s libc++abi.so.1.0 $out/lib/libc++abi.so
-      ln -s libc++abi.so.1.0 $out/lib/libc++abi.so.1
-    '';
+  preInstall = lib.optionalString stdenv.isDarwin ''
+    for file in lib/*.dylib; do
+      # this should be done in CMake, but having trouble figuring out
+      # the magic combination of necessary CMake variables
+      # if you fancy a try, take a look at
+      # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
+      install_name_tool -id $out/$file $file
+    done
+  '';
+
+  postInstall = ''
+    mkdir -p "$dev/include"
+    install -m 644 ../include/${if stdenv.isDarwin then "*" else "cxxabi.h"} "$dev/include"
+  '';
 
   meta = llvm_meta // {
     homepage = "https://libcxxabi.llvm.org/";

--- a/pkgs/development/compilers/llvm/6/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/6/libcxxabi/default.nix
@@ -25,27 +25,20 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ cmake ];
   buildInputs = lib.optional (!stdenv.isDarwin && !stdenv.isFreeBSD) libunwind;
 
-  installPhase = if stdenv.isDarwin
-    then ''
-      for file in lib/*.dylib; do
-        # this should be done in CMake, but having trouble figuring out
-        # the magic combination of necessary CMake variables
-        # if you fancy a try, take a look at
-        # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
-        install_name_tool -id $out/$file $file
-      done
-      make install
-      install -d 755 $out/include
-      install -m 644 ../include/*.h $out/include
-    ''
-    else ''
-      install -d -m 755 $out/include $out/lib
-      install -m 644 lib/libc++abi.a $out/lib
-      install -m 644 lib/libc++abi.so.1.0 $out/lib
-      install -m 644 ../include/cxxabi.h $out/include
-      ln -s libc++abi.so.1.0 $out/lib/libc++abi.so
-      ln -s libc++abi.so.1.0 $out/lib/libc++abi.so.1
-    '';
+  preInstall = lib.optionalString stdenv.isDarwin ''
+    for file in lib/*.dylib; do
+      # this should be done in CMake, but having trouble figuring out
+      # the magic combination of necessary CMake variables
+      # if you fancy a try, take a look at
+      # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
+      install_name_tool -id $out/$file $file
+    done
+  '';
+
+  postInstall = ''
+    mkdir -p "$dev/include"
+    install -m 644 ../include/${if stdenv.isDarwin then "*" else "cxxabi.h"} "$dev/include"
+  '';
 
   meta = llvm_meta // {
     homepage = "https://libcxxabi.llvm.org/";

--- a/pkgs/development/compilers/llvm/7/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/7/libcxxabi/default.nix
@@ -44,27 +44,20 @@ stdenv.mkDerivation {
     "-DLIBCXXABI_USE_LLVM_UNWINDER=ON"
   ] ++ lib.optional (!enableShared) "-DLIBCXXABI_ENABLE_SHARED=OFF";
 
-  installPhase = if stdenv.isDarwin
-    then ''
-      for file in lib/*.dylib; do
-        # this should be done in CMake, but having trouble figuring out
-        # the magic combination of necessary CMake variables
-        # if you fancy a try, take a look at
-        # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
-        install_name_tool -id $out/$file $file
-      done
-      make install
-      install -d 755 $out/include
-      install -m 644 ../include/*.h $out/include
-    ''
-    else ''
-      install -d -m 755 $out/include $out/lib
-      install -m 644 lib/libc++abi.a $out/lib
-      ${lib.optionalString enableShared "install -m 644 lib/libc++abi.so.1.0 $out/lib"}
-      install -m 644 ../include/cxxabi.h $out/include
-      ${lib.optionalString enableShared "ln -s libc++abi.so.1.0 $out/lib/libc++abi.so"}
-      ${lib.optionalString enableShared "ln -s libc++abi.so.1.0 $out/lib/libc++abi.so.1"}
-    '';
+  preInstall = lib.optionalString stdenv.isDarwin ''
+    for file in lib/*.dylib; do
+      # this should be done in CMake, but having trouble figuring out
+      # the magic combination of necessary CMake variables
+      # if you fancy a try, take a look at
+      # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
+      install_name_tool -id $out/$file $file
+    done
+  '';
+
+  postInstall = ''
+    mkdir -p "$dev/include"
+    install -m 644 ../include/${if stdenv.isDarwin then "*" else "cxxabi.h"} "$dev/include"
+  '';
 
   meta = llvm_meta // {
     homepage = "https://libcxxabi.llvm.org/";

--- a/pkgs/development/compilers/llvm/8/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/8/libcxxabi/default.nix
@@ -40,28 +40,20 @@ stdenv.mkDerivation {
     "-DLIBCXXABI_ENABLE_SHARED=OFF"
   ];
 
-  installPhase = if stdenv.isDarwin
-    then ''
-      for file in lib/*.dylib; do
-        # this should be done in CMake, but having trouble figuring out
-        # the magic combination of necessary CMake variables
-        # if you fancy a try, take a look at
-        # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
-        install_name_tool -id $out/$file $file
-      done
-      make install
-      install -d 755 $out/include
-      install -m 644 ../include/*.h $out/include
-    ''
-    else ''
-      install -d -m 755 $out/include $out/lib
-      install -m 644 lib/libc++abi.a $out/lib
-      install -m 644 ../include/cxxabi.h $out/include
-    '' + lib.optionalString enableShared ''
-      install -m 644 lib/libc++abi.so.1.0 $out/lib
-      ln -s libc++abi.so.1.0 $out/lib/libc++abi.so
-      ln -s libc++abi.so.1.0 $out/lib/libc++abi.so.1
-    '';
+  preInstall = lib.optionalString stdenv.isDarwin ''
+    for file in lib/*.dylib; do
+      # this should be done in CMake, but having trouble figuring out
+      # the magic combination of necessary CMake variables
+      # if you fancy a try, take a look at
+      # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
+      install_name_tool -id $out/$file $file
+    done
+  '';
+
+  postInstall = ''
+    mkdir -p "$dev/include"
+    install -m 644 ../include/${if stdenv.isDarwin then "*" else "cxxabi.h"} "$dev/include"
+  '';
 
   meta = llvm_meta // {
     homepage = "https://libcxxabi.llvm.org/";

--- a/pkgs/development/compilers/llvm/9/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/9/libcxxabi/default.nix
@@ -40,28 +40,20 @@ stdenv.mkDerivation {
     "-DLIBCXXABI_ENABLE_SHARED=OFF"
   ];
 
-  installPhase = if stdenv.isDarwin
-    then ''
-      for file in lib/*.dylib; do
-        # this should be done in CMake, but having trouble figuring out
-        # the magic combination of necessary CMake variables
-        # if you fancy a try, take a look at
-        # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
-        install_name_tool -id $out/$file $file
-      done
-      make install
-      install -d 755 $out/include
-      install -m 644 ../include/*.h $out/include
-    ''
-    else ''
-      install -d -m 755 $out/include $out/lib
-      install -m 644 lib/libc++abi.a $out/lib
-      install -m 644 ../include/cxxabi.h $out/include
-    '' + lib.optionalString enableShared ''
-      install -m 644 lib/libc++abi.so.1.0 $out/lib
-      ln -s libc++abi.so.1.0 $out/lib/libc++abi.so
-      ln -s libc++abi.so.1.0 $out/lib/libc++abi.so.1
-    '';
+  preInstall = lib.optionalString stdenv.isDarwin ''
+    for file in lib/*.dylib; do
+      # this should be done in CMake, but having trouble figuring out
+      # the magic combination of necessary CMake variables
+      # if you fancy a try, take a look at
+      # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
+      install_name_tool -id $out/$file $file
+    done
+  '';
+
+  postInstall = ''
+    mkdir -p "$dev/include"
+    install -m 644 ../include/${if stdenv.isDarwin then "*" else "cxxabi.h"} "$dev/include"
+  '';
 
   meta = llvm_meta // {
     homepage = "https://libcxxabi.llvm.org/";

--- a/pkgs/development/compilers/llvm/git/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/git/libcxxabi/default.nix
@@ -49,28 +49,20 @@ stdenv.mkDerivation rec {
     "-DLIBCXXABI_ENABLE_SHARED=OFF"
   ];
 
-  installPhase = if stdenv.isDarwin
-    then ''
-      for file in lib/*.dylib; do
-        # this should be done in CMake, but having trouble figuring out
-        # the magic combination of necessary CMake variables
-        # if you fancy a try, take a look at
-        # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
-        install_name_tool -id $out/$file $file
-      done
-      make install
-      install -d 755 $out/include
-      install -m 644 ../include/*.h $out/include
-    ''
-    else ''
-      install -d -m 755 $out/include $out/lib
-      install -m 644 lib/libc++abi.a $out/lib
-      install -m 644 ../include/cxxabi.h $out/include
-    '' + lib.optionalString enableShared ''
-      install -m 644 lib/libc++abi.so.1.0 $out/lib
-      ln -s libc++abi.so.1.0 $out/lib/libc++abi.so
-      ln -s libc++abi.so.1.0 $out/lib/libc++abi.so.1
-    '';
+  preInstall = lib.optionalString stdenv.isDarwin ''
+    for file in lib/*.dylib; do
+      # this should be done in CMake, but having trouble figuring out
+      # the magic combination of necessary CMake variables
+      # if you fancy a try, take a look at
+      # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
+      install_name_tool -id $out/$file $file
+    done
+  '';
+
+  postInstall = ''
+    mkdir -p "$dev/include"
+    install -m 644 ../include/${if stdenv.isDarwin then "*" else "cxxabi.h"} "$dev/include"
+  '';
 
   meta = llvm_meta // {
     homepage = "https://libcxxabi.llvm.org/";


### PR DESCRIPTION
###### Description of changes

I can't think of any good reason it was the way it was before. I think
CMake can be made to install the headers too, but this is a fine first
step.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
