### PR TITLE
podman, etc: cleanup and format

### DIFF
--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -8,20 +8,20 @@ let
 in
 {
   meta = {
-    maintainers = [] ++ lib.teams.podman.members;
+    maintainers = [ ] ++ lib.teams.podman.members;
   };
 
 
   imports = [
     (
       lib.mkRemovedOptionModule
-      [ "virtualisation" "containers" "users" ]
-      "All users with `isNormalUser = true` set now get appropriate subuid/subgid mappings."
+        [ "virtualisation" "containers" "users" ]
+        "All users with `isNormalUser = true` set now get appropriate subuid/subgid mappings."
     )
     (
       lib.mkRemovedOptionModule
-      [ "virtualisation" "containers" "containersConf" "extraConfig" ]
-      "Use virtualisation.containers.containersConf.settings instead."
+        [ "virtualisation" "containers" "containersConf" "extraConfig" ]
+        "Use virtualisation.containers.containersConf.settings instead."
     )
   ];
 
@@ -87,7 +87,7 @@ in
       };
 
       insecure = mkOption {
-        default = [];
+        default = [ ];
         type = types.listOf types.str;
         description = lib.mdDoc ''
           List of insecure repositories.
@@ -95,7 +95,7 @@ in
       };
 
       block = mkOption {
-        default = [];
+        default = [ ];
         type = types.listOf types.str;
         description = lib.mdDoc ''
           List of blocked repositories.
@@ -104,7 +104,7 @@ in
     };
 
     policy = mkOption {
-      default = {};
+      default = { };
       type = types.attrs;
       example = literalExpression ''
         {
@@ -149,7 +149,7 @@ in
     };
 
     environment.etc."containers/policy.json".source =
-      if cfg.policy != {} then pkgs.writeText "policy.json" (builtins.toJSON cfg.policy)
+      if cfg.policy != { } then pkgs.writeText "policy.json" (builtins.toJSON cfg.policy)
       else utils.copyFile "${pkgs.skopeo.src}/default-policy.json";
   };
 

--- a/nixos/modules/virtualisation/podman/default.nix
+++ b/nixos/modules/virtualisation/podman/default.nix
@@ -12,10 +12,11 @@ let
   });
 
   # Provides a fake "docker" binary mapping to podman
-  dockerCompat = pkgs.runCommand "${podmanPackage.pname}-docker-compat-${podmanPackage.version}" {
-    outputs = [ "out" "man" ];
-    inherit (podmanPackage) meta;
-  } ''
+  dockerCompat = pkgs.runCommand "${podmanPackage.pname}-docker-compat-${podmanPackage.version}"
+    {
+      outputs = [ "out" "man" ];
+      inherit (podmanPackage) meta;
+    } ''
     mkdir -p $out/bin
     ln -s ${podmanPackage}/bin/podman $out/bin/docker
 
@@ -26,13 +27,14 @@ let
     done
   '';
 
-  net-conflist = pkgs.runCommand "87-podman-bridge.conflist" {
-    nativeBuildInputs = [ pkgs.jq ];
-    extraPlugins = builtins.toJSON cfg.defaultNetwork.extraPlugins;
-    jqScript = ''
-      . + { "plugins": (.plugins + $extraPlugins) }
-    '';
-  } ''
+  net-conflist = pkgs.runCommand "87-podman-bridge.conflist"
+    {
+      nativeBuildInputs = [ pkgs.jq ];
+      extraPlugins = builtins.toJSON cfg.defaultNetwork.extraPlugins;
+      jqScript = ''
+        . + { "plugins": (.plugins + $extraPlugins) }
+      '';
+    } ''
     jq <${cfg.package}/etc/cni/net.d/87-podman-bridge.conflist \
       --argjson extraPlugins "$extraPlugins" \
       "$jqScript" \
@@ -119,7 +121,7 @@ in
 
     defaultNetwork.extraPlugins = lib.mkOption {
       type = types.listOf json.type;
-      default = [];
+      default = [ ];
       description = lib.mdDoc ''
         Extra CNI plugin configurations to add to podman's default network.
       '';
@@ -167,14 +169,15 @@ in
           grep -v 'D! /run/podman 0700 root root' \
             <$package/lib/tmpfiles.d/podman.conf \
             >$out/lib/tmpfiles.d/podman.conf
-        '') ];
+        '')
+      ];
 
       systemd.tmpfiles.rules =
         lib.optionals cfg.dockerSocket.enable [
           "L! /run/docker.sock - - - - /run/podman/podman.sock"
         ];
 
-      users.groups.podman = {};
+      users.groups.podman = { };
 
       assertions = [
         {

--- a/nixos/modules/virtualisation/podman/network-socket-ghostunnel.nix
+++ b/nixos/modules/virtualisation/podman/network-socket-ghostunnel.nix
@@ -26,7 +26,7 @@ in
         allowAll = lib.mkDefault true;
       };
     };
-    systemd.services.ghostunnel-server-podman-socket.serviceConfig.SupplementaryGroups = ["podman"];
+    systemd.services.ghostunnel-server-podman-socket.serviceConfig.SupplementaryGroups = [ "podman" ];
 
   };
 

--- a/nixos/modules/virtualisation/podman/network-socket.nix
+++ b/nixos/modules/virtualisation/podman/network-socket.nix
@@ -31,7 +31,7 @@ in
     };
 
     server = mkOption {
-      type = types.enum [];
+      type = types.enum [ ];
       description = lib.mdDoc ''
         Choice of TLS proxy server.
       '';

--- a/pkgs/applications/virtualization/cri-o/wrapper.nix
+++ b/pkgs/applications/virtualization/cri-o/wrapper.nix
@@ -8,7 +8,6 @@
 , crun # Container runtime (default with cgroups v2 for podman/buildah)
 , conmon # Container runtime monitor
 , util-linux # nsenter
-, cni-plugins # not added to path
 , iptables
 }:
 

--- a/pkgs/applications/virtualization/podman/wrapper.nix
+++ b/pkgs/applications/virtualization/podman/wrapper.nix
@@ -12,7 +12,6 @@
 , slirp4netns # User-mode networking for unprivileged namespaces
 , fuse-overlayfs # CoW for images, much faster than default vfs
 , util-linux # nsenter
-, cni-plugins # not added to path
 , iptables
 , iproute2
 , catatonit

--- a/pkgs/development/tools/buildah/wrapper.nix
+++ b/pkgs/development/tools/buildah/wrapper.nix
@@ -11,7 +11,6 @@
 , slirp4netns # User-mode networking for unprivileged namespaces
 , fuse-overlayfs # CoW for images, much faster than default vfs
 , util-linux # nsenter
-, cni-plugins # not added to path
 , iptables
 }:
 


### PR DESCRIPTION
###### Description of changes

minor cleanup and formatting to make the `netavark` changes easier / smaller diff / etc.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
