### PR TITLE
catppuccin-gtk: unstable-2022-08-01 -> 0.2.7

### DIFF
--- a/pkgs/data/themes/catppuccin-gtk/default.nix
+++ b/pkgs/data/themes/catppuccin-gtk/default.nix
@@ -5,7 +5,6 @@
 , gnome-themes-extra
 , gtk-engine-murrine
 , sassc
-, which
 , tweaks ? [ ]
 , size ? "standard"
 }:
@@ -14,9 +13,9 @@ let
   validTweaks = [ "nord" "dracula" "black" "rimless" "normal" ];
 
   unknownTweaks = lib.subtractLists validTweaks tweaks;
-  illegalMix = !(lib.elem "nord" tweaks) && !(lib.elem "dracula" tweaks);
+  illegalMix = (lib.elem "nord" tweaks) && (lib.elem "dracula" tweaks);
 
-  assertIllegal = lib.assertMsg illegalMix ''
+  assertIllegal = lib.assertMsg (!illegalMix) ''
     Tweaks "nord" and "dracula" cannot be mixed. Tweaks: ${toString tweaks}
   '';
 
@@ -37,16 +36,16 @@ assert assertUnknown;
 
 stdenvNoCC.mkDerivation rec {
   pname = "catppuccin-gtk";
-  version = "unstable-2022-08-01";
+  version = "0.2.7";
 
   src = fetchFromGitHub {
     repo = "gtk";
     owner = "catppuccin";
-    rev = "87a79fd2bf07accc694455df30a32a82b1b31f4f";
-    sha256 = "sha256-dKHTQva0BYkO6VPNfY/pzRn/V1ghX+tYqbnM9hTAMeE=";
+    rev = "v-${version}";
+    sha256 = "sha256-oTAfURHMWqlKHk4CNz5cn6vO/7GmQJM2rXXGDz2e+0w=";
   };
 
-  nativeBuildInputs = [ gtk3 sassc which ];
+  nativeBuildInputs = [ gtk3 sassc ];
 
   buildInputs = [ gnome-themes-extra ];
 
@@ -61,7 +60,6 @@ stdenvNoCC.mkDerivation rec {
 
     export HOME=$(mktemp -d)
 
-    mkdir -p $out/share/themes
     bash install.sh -d $out/share/themes -t all \
       ${lib.optionalString (size != "") "-s ${size}"} \
       ${lib.optionalString (tweaks != []) "--tweaks " + builtins.toString tweaks}


### PR DESCRIPTION
###### Description of changes
https://github.com/catppuccin/gtk/releases/tag/v-0.2.7

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).