### PR TITLE
mc: stop retaining configure arguments in the final binary

### DIFF
--- a/pkgs/applications/file-managers/mc/default.nix
+++ b/pkgs/applications/file-managers/mc/default.nix
@@ -67,6 +67,10 @@ stdenv.mkDerivation rec {
     "PERL=${perl}/bin/perl"
     # used for .hlp generation at build time:
     "PERL_FOR_BUILD=${buildPackages.perl}/bin/perl"
+
+    # configure arguments have a bunch of build-only dependencies.
+    # Avoid their retention in final closure.
+    "--disable-configure-args"
   ];
 
   postPatch = ''
@@ -75,11 +79,6 @@ stdenv.mkDerivation rec {
 
     substituteInPlace misc/ext.d/misc.sh.in \
       --replace /bin/cat ${coreutils}/bin/cat
-  '';
-
-  preFixup = ''
-    # remove unwanted build-dependency references
-    sed -i -e "s!PKG_CONFIG_PATH=''${PKG_CONFIG_PATH}!PKG_CONFIG_PATH=$(echo "$PKG_CONFIG_PATH" | sed -e 's/./0/g')!" $out/bin/mc
   '';
 
   postFixup = lib.optionalString (!stdenv.isDarwin) ''


### PR DESCRIPTION
Reduces closure size of cross-compiled binary a bit by not retaining
build-time perl and friends.

Before:

    $ nix path-info -Sh $(nix-build -A pkgsCross.ppc64.mc) | unnix
    /<<NIX>>/mc-powerpc64-unknown-linux-gnu-4.8.28   273.7M

After:

    $ nix path-info -Sh $(nix-build -A pkgsCross.ppc64.mc) | unnix
    /<<NIX>>/mc-powerpc64-unknown-linux-gnu-4.8.28   198.6M

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
