### PR TITLE
obs-backgroundremoval: init at 0.4.0

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/default.nix
@@ -11,4 +11,5 @@
   obs-nvfbc = callPackage ./obs-nvfbc.nix {};
   obs-pipewire-audio-capture = callPackage ./obs-pipewire-audio-capture.nix {};
   obs-vkcapture = callPackage ./obs-vkcapture.nix {};
+  obs-backgroundremoval = callPackage ./obs-backgroundremoval.nix {};
 }

--- a/pkgs/applications/video/obs-studio/plugins/obs-backgroundremoval-includes.patch
+++ b/pkgs/applications/video/obs-studio/plugins/obs-backgroundremoval-includes.patch
@@ -1,0 +1,36 @@
+diff --git a/src/Model.h b/src/Model.h
+index 5c21eae..74b8078 100644
+--- a/src/Model.h
++++ b/src/Model.h
+@@ -1,13 +1,8 @@
+ #ifndef MODEL_H
+ #define MODEL_H
+ 
+-#if defined(__APPLE__)
+ #include <onnxruntime/core/session/onnxruntime_cxx_api.h>
+ #include <onnxruntime/core/providers/cpu/cpu_provider_factory.h>
+-#else
+-#include <onnxruntime_cxx_api.h>
+-#include <cpu_provider_factory.h>
+-#endif
+ #ifdef _WIN32
+ #ifdef WITH_CUDA
+ #include <cuda_provider_factory.h>
+diff --git a/src/background-filter.cpp b/src/background-filter.cpp
+index 9fa5794..5d66aee 100644
+--- a/src/background-filter.cpp
++++ b/src/background-filter.cpp
+@@ -1,13 +1,8 @@
+ #include <obs-module.h>
+ #include <media-io/video-scaler.h>
+ 
+-#if defined(__APPLE__)
+ #include <onnxruntime/core/session/onnxruntime_cxx_api.h>
+ #include <onnxruntime/core/providers/cpu/cpu_provider_factory.h>
+-#else
+-#include <onnxruntime_cxx_api.h>
+-#include <cpu_provider_factory.h>
+-#endif
+ #ifdef _WIN32
+ #ifdef WITH_CUDA
+ #include <cuda_provider_factory.h>

--- a/pkgs/applications/video/obs-studio/plugins/obs-backgroundremoval.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-backgroundremoval.nix
@@ -1,0 +1,45 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, obs-studio
+, onnxruntime
+, opencv
+}:
+
+stdenv.mkDerivation rec {
+  pname = "obs-backgroundremoval";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "royshil";
+    repo = "obs-backgroundremoval";
+    rev = "v${version}";
+    sha256 = "sha256-TI1FlhE0+JL50gAZCSsI+g8savX8GRQkH3jYli/66hQ=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ obs-studio onnxruntime opencv ];
+
+  dontWrapQtApps = true;
+
+  cmakeFlags = [
+    "-DLIBOBS_INCLUDE_DIR=${obs-studio.src}/libobs"
+    "-DOnnxruntime_INCLUDE_DIRS=${onnxruntime.dev}/include/onnxruntime/core/session"
+  ];
+
+  patches = [ ./obs-backgroundremoval-includes.patch ];
+
+  prePatch = ''
+    sed -i 's/version_from_git()/set(VERSION "${version}")/' CMakeLists.txt
+  '';
+
+  meta = with lib; {
+    description = "OBS plugin to replace the background in portrait images and video";
+    homepage = "https://github.com/royshil/obs-backgroundremoval";
+    maintainers = with maintainers; [ puffnfresh ];
+    license = licenses.mit;
+    platforms = [ "x86_64-linux" "i686-linux" ];
+  };
+}


### PR DESCRIPTION
###### Description of changes

Does not include CUDA support, so is pretty slow. I will submit a PR adding CUDA to both obs-backgroundremoval and onnxruntime together.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
