### PR TITLE
haskell-language-server: fix with ghc-lib >= 9.0 and ghc <= 8.10.7

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
@@ -92,13 +92,15 @@ self: super: {
   mime-string = disableOptimization super.mime-string;
 
   # Older compilers need the latest ghc-lib to build this package.
-  hls-hlint-plugin = addBuildDepend self.ghc-lib (overrideCabal (drv: {
-      # Workaround for https://github.com/haskell/haskell-language-server/issues/2728
-      postPatch = ''
-        sed -i 's/(GHC.RealSrcSpan x,/(GHC.RealSrcSpan x Nothing,/' src/Ide/Plugin/Hlint.hs
-      '';
-    })
-     super.hls-hlint-plugin);
+  # Fix build with ghc-lib >= 9.0 and ghc <= 8.10.7
+  # https://github.com/haskell/haskell-language-server/issues/2728
+  hls-hlint-plugin = addBuildDepend self.ghc-lib (appendPatch (pkgs.fetchpatch {
+    name = "hls-hlint-plugin-workaround.patch";
+    url = "https://github.com/haskell/haskell-language-server/pull/2854.patch";
+    hash = "sha256-bLGu0OQtXsmMF3rZM+R6k7bsZm4Vgf2r0ert5Wunong=";
+    stripLen = 2;
+    includes = ["src/Ide/Plugin/Hlint.hs"];
+  }) super.hls-hlint-plugin);
 
   haskell-language-server = appendConfigureFlags [
       "-f-stylishhaskell"


### PR DESCRIPTION
This cherry-picks the relevant changes from
https://github.com/haskell/haskell-language-server/pull/2854 into the
8.10.x version of hls-hlint-plugin, as suggested in
https://github.com/NixOS/nixpkgs/issues/168064#issuecomment-1146691884

I built `haskell-language-server.override { supportedGhcVersions = [ "8107" ]; }` with that.

Fixes https://github.com/NixOS/nixpkgs/issues/168064.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
