### PR TITLE
aitrack: init at 0.6.5

### DIFF
--- a/pkgs/applications/misc/aitrack/default.nix
+++ b/pkgs/applications/misc/aitrack/default.nix
@@ -1,0 +1,51 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, pkg-config
+, qmake
+, wrapQtAppsHook
+, opencv
+, spdlog
+, onnxruntime
+, qtx11extras
+}: stdenv.mkDerivation {
+  pname = "aitrack";
+  version = "0.6.5";
+
+  src = fetchFromGitHub {
+    owner = "mdk97";
+    repo = "aitrack-linux";
+    rev = "00bcca9b685abf3a19e4eab653198ca2b1895ae4";
+    sha256 = "sha256-pPvYVLUPYdjtJKdxqZI+JN7OZ4xw9gZ3baYTnJUSTGE=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    qmake
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    opencv
+    spdlog
+    qtx11extras
+    onnxruntime
+  ];
+
+  postPatch = ''
+    substituteInPlace Client/src/Main.cpp \
+      --replace "/usr/share/" "$out/share/"
+  '';
+
+  postInstall = ''
+    install -Dt $out/bin aitrack
+    install -Dt $out/share/aitrack/models models/*
+  '';
+
+  meta = with lib; {
+    description = "6DoF Head tracking software";
+    maintainers = with maintainers; [ ck3d ];
+    platforms = platforms.linux;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36512,4 +36512,6 @@ with pkgs;
   swift-corelibs-libdispatch = callPackage ../development/libraries/swift-corelibs-libdispatch { };
 
   swaysettings = callPackage ../applications/misc/swaysettings { };
+
+  aitrack = libsForQt5.callPackage ../applications/misc/aitrack { };
 }


### PR DESCRIPTION
###### Description of changes

I like to share my the Nix expression for package aitrack.
Since aitrack is the first user of onnxruntime, it can be seen as test for it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
