### PR TITLE
python3Packages.pydmd: fixed missing dependency

### DIFF
--- a/pkgs/development/python-modules/ezyrb/default.nix
+++ b/pkgs/development/python-modules/ezyrb/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, future
+, numpy
+, scipy
+, matplotlib
+, scikit-learn
+, pytorch
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "ezyrb";
+  version = "1.3.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "mathLab";
+    repo = "EZyRB";
+    rev = "v${version}";
+    sha256 = "sha256-tFkz+j97m+Bgk/87snQMXtgZnykiWYyWJJLaqwRKiaY=";
+  };
+
+  propagatedBuildInputs = [
+    future
+    numpy
+    scipy
+    matplotlib
+    scikit-learn
+    pytorch
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "ezyrb"
+  ];
+
+  disabledTestPaths = [
+    # Exclude long tests
+    "tests/test_podae.py"
+  ];
+
+  meta = with lib; {
+    description = "Easy Reduced Basis method";
+    homepage = "https://mathlab.github.io/EZyRB/";
+    downloadPage = "https://github.com/mathLab/EZyRB/releases";
+    license = licenses.mit;
+    maintainers = with maintainers; [ yl3dy ];
+  };
+}

--- a/pkgs/development/python-modules/pydmd/default.nix
+++ b/pkgs/development/python-modules/pydmd/default.nix
@@ -8,6 +8,7 @@
 , pytestCheckHook
 , pythonOlder
 , scipy
+, ezyrb
 }:
 
 buildPythonPackage rec {
@@ -29,6 +30,7 @@ buildPythonPackage rec {
     matplotlib
     numpy
     scipy
+    ezyrb
   ];
 
   checkInputs = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3042,6 +3042,8 @@ in {
 
   ezdxf = callPackage ../development/python-modules/ezdxf { };
 
+  ezyrb = callPackage ../development/python-modules/ezyrb { };
+
   f90nml = callPackage ../development/python-modules/f90nml { };
 
   Fabric = callPackage ../development/python-modules/Fabric { };


### PR DESCRIPTION
###### Description of changes

Fixed `pydmd` by adding a missing dependency `ezyrb`.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
