### PR TITLE
nixos/xdg/xdg-open: init

### DIFF
--- a/nixos/modules/config/xdg/xdg-open.nix
+++ b/nixos/modules/config/xdg/xdg-open.nix
@@ -1,0 +1,44 @@
+{ config, pkgs, lib, ... }:
+let
+  cfg = config.xdg.xdg-open;
+  implementations = {
+    "xdg-utils" = pkgs: pkgs.xdg-utils;
+    "xdg-open-with-portal" = pkgs: pkgs.xdg-open-with-portal;
+    "handlr" = pkgs: pkgs.handlr;
+  };
+  xdg-utils-patched = pkgs: target: (pkgs.xdg-utils.overrideAttrs (old: {
+    postInstall = (old.postInstall or "") +
+      ''
+        sed -i '2i if ${target pkgs}/bin/xdg-open "$1"; then exit 0; fi;' $out/bin/xdg-open
+      '';
+  }));
+  impl = implementations.${cfg.implementation};
+in
+{
+  options.xdg.xdg-open = {
+    enable = lib.mkEnableOption "adding an xdg-open implementation to the path (environment.systemPackages)";
+    implementation = lib.mkOption {
+      description = "Which implementation to use";
+      type = lib.types.enum (builtins.attrNames implementations);
+      # This makes the most sense as a default for NixOS
+      # due to https://github.com/NixOS/nixpkgs/issues/160923
+      default = "xdg-open-with-portal";
+    };
+    # TODO:
+    # Consider removing this option later, if packages start using xdg-open on the path more reliably?
+    # See discussion here https://discourse.nixos.org/t/should-we-support-encoding-runtime-dependencies-without-requiring-a-specific-implementation/21031/17
+    # for potential future approaches to runtime swappable dependencies
+    useXdgUtilsOverlay = lib.mkEnableOption "replacing xdg-utils's xdg-open using an overlay. Applies more reliably but causes mass rebuilds.";
+  };
+
+  config = lib.mkIf cfg.enable {
+    # TODO: consider making a small wrapper package around impl so only /bin/xdg-open ends up on path?
+    environment.systemPackages = [ (lib.hiPrio (impl pkgs)) ];
+
+    nixpkgs.overlays = lib.mkIf (cfg.useXdgUtilsOverlay && cfg.implementation != "xdg-utils") [
+      (self: super: {
+        xdg-utils = xdg-utils-patched super impl;
+      })
+    ];
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -8,6 +8,7 @@
   ./config/xdg/icons.nix
   ./config/xdg/menus.nix
   ./config/xdg/mime.nix
+  ./config/xdg/xdg-open.nix
   ./config/xdg/portal.nix
   ./config/xdg/portals/wlr.nix
   ./config/xdg/portals/lxqt.nix

--- a/pkgs/tools/X11/xdg-open-with-portal/default.nix
+++ b/pkgs/tools/X11/xdg-open-with-portal/default.nix
@@ -1,0 +1,37 @@
+{ writeShellScriptBin
+, glib
+}:
+writeShellScriptBin "xdg-open" ''
+  # uncomment to get logs somewhere and tail -f it.
+  # exec > >(tee -i ~/dev/xdg-open-portal-log.txt)
+  # exec 2>&1
+
+  set -xeuo pipefail
+
+  targetFile=$1
+
+  # Some programs run xdg-open with no stderr available so || true is needed
+  >&2 echo "xdg-open workaround: using org.freedesktop.portal to open $targetFile" || true
+
+  if [ -e "$targetFile" ]; then
+    exec {targetFileReadFd}< "$targetFile"
+    ${glib}/bin/gdbus call --session \
+      --dest org.freedesktop.portal.Desktop \
+      --object-path /org/freedesktop/portal/desktop \
+      --method org.freedesktop.portal.OpenURI.OpenFile \
+      --timeout 5 \
+      "" "$targetFileReadFd" {}
+      exec {targetFileReadFd}>&- || true
+  else
+    if ! echo "$targetFile" | grep -q '://'; then
+      targetFile="https://$targetFile"
+    fi
+
+    ${glib}/bin/gdbus call --session \
+      --dest org.freedesktop.portal.Desktop \
+      --object-path /org/freedesktop/portal/desktop \
+      --method org.freedesktop.portal.OpenURI.OpenURI \
+      --timeout 5 \
+      "" "$targetFile" {}
+  fi
+''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31713,6 +31713,8 @@ with pkgs;
     w3m = buildPackages.w3m-batch;
   };
 
+  xdg-open-with-portal = callPackage ../tools/X11/xdg-open-with-portal { };
+
   xdgmenumaker = callPackage ../applications/misc/xdgmenumaker { };
 
   xdotool = callPackage ../tools/X11/xdotool { };


### PR DESCRIPTION
###### Description of changes

Potential fix for #160923 although is not currently enabled by default.

MERGED ~~Until https://github.com/NixOS/nixpkgs/pull/181171 gets merged, this relies on enabling an overlay for all those packages to actually use the xdg-open implementation from the path.~~

~~Many other packages rely on it implicitly without adding it in a wrapper so will work already without the overlay.~~

Some other things like the steam FHS env also require the overlay currently. Could get them to pick it up from the PATH in a subsequent PR?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
