### PR TITLE
nixos/minio: fix startup issue

### DIFF
--- a/nixos/modules/services/web-servers/minio.nix
+++ b/nixos/modules/services/web-servers/minio.nix
@@ -102,7 +102,7 @@ in
 
     systemd.services.minio = {
       description = "Minio Object Storage";
-      after = [ "network.target" ];
+      after = [ "network-online.target" ];
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
         ExecStart = "${cfg.package}/bin/minio server --json --address ${cfg.listenAddress} --console-address ${cfg.consoleAddress} --config-dir=${cfg.configDir} ${toString cfg.dataDir}";


### PR DESCRIPTION
Fixes this problem with minio service on boot:

> {"level":"FATAL","errKind":"","time":"2022-08-18T14:59:08.027689427Z","message":"host in server address should be this server","error":{"message":"host in server address should be this server","source":["cmd/server-main.go:439:cmd.serverMain()"]}}
