### PR TITLE
chromium: added patch to support master_preferences

### DIFF
--- a/nixos/modules/programs/chromium.nix
+++ b/nixos/modules/programs/chromium.nix
@@ -76,9 +76,9 @@ in
 
       initialOpts = mkOption {
         type = types.attrs;
-        description = ''
+        description = lib.mdDoc ''
           Default preferences to be set at first startup.
-          <link xlink:href="https://support.google.com/chrome/a/answer/187948?hl=en">https://support.google.com/chrome/a/answer/187948?hl=en</link>
+          <https://support.google.com/chrome/a/answer/187948>
         '';
         default = {};
         example = literalExpression ''
@@ -119,8 +119,7 @@ in
       recommendedOpts = mkOption {
         type = types.attrs;
         description = ''
-          Recommended chromium policy options.
-          Recommended policies can be changed by the user.
+          Recommended chromium policy options which can be changed by the user.
         '';
         default = {};
         example = literalExpression ''
@@ -132,7 +131,6 @@ in
           }
         '';
       };
-
     };
   };
 
@@ -166,10 +164,8 @@ in
           folder:
             lib.mapAttrsToList (name: value: { name = "${folder}/${name}"; inherit value; }) commonStructure
         ) baseFolders;
-      in builtins.listToAttrs (lib.flatten fullListFiles);
+      in listToAttrs (lib.flatten fullListFiles);
 
     in allFiles;
-
   };
-
 }

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -160,6 +160,8 @@ let
       ./patches/no-build-timestamps.patch
       # For bundling Widevine (DRM), might be replaceable via bundle_widevine_cdm=true in gnFlags:
       ./patches/widevine-79.patch
+      # Replace initial_preferences directory location (original path is besides binary)
+      ./patches/master-preferences.patch
     ];
 
     postPatch = ''

--- a/pkgs/applications/networking/browsers/chromium/patches/master-preferences.patch
+++ b/pkgs/applications/networking/browsers/chromium/patches/master-preferences.patch
@@ -1,0 +1,18 @@
+--- a/chrome/browser/first_run/first_run_internal_linux.cc
++++ b/chrome/browser/first_run/first_run_internal_linux.cc
+@@ -20,14 +20,8 @@ bool IsOrganicFirstRun() {
+
+ base::FilePath InitialPrefsPath() {
+   // The standard location of the initial prefs is next to the chrome binary.
+-  base::FilePath initial_prefs;
+-  if (!base::PathService::Get(base::DIR_EXE, &initial_prefs))
+-    return base::FilePath();
+-
+-  base::FilePath new_path = initial_prefs.AppendASCII(installer::kInitialPrefs);
+-  if (base::PathIsReadable(new_path))
+-    return new_path;
+-
++  // ...but we patch it to use /etc/chromium
++  base::FilePath initial_prefs = base::FilePath("/etc/chromium");
+   return initial_prefs.AppendASCII(installer::kLegacyInitialPrefs);
+ }


### PR DESCRIPTION
###### Description of changes

Added a patch to make chromium look for `master_preferences` in `/etc/chromium` as other distros do.

Added also module options for both the new `master_preferences` and recommended policies.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
