### PR TITLE
python39Packages.cairo-lang: init at 0.9.1

### DIFF
--- a/pkgs/development/python-modules/cairo-lang/default.nix
+++ b/pkgs/development/python-modules/cairo-lang/default.nix
@@ -1,0 +1,96 @@
+{ lib
+, fetchzip
+, buildPythonPackage
+, setuptools
+, ecdsa
+, fastecdsa
+, sympy
+, frozendict
+, marshmallow
+, marshmallow-enum
+, marshmallow-dataclass
+, marshmallow-oneofschema
+, pipdeptree
+, eth-hash
+, web3
+, aiohttp
+, cachetools
+, mpmath
+, numpy
+, prometheus-client
+, typeguard
+, lark
+, pyyaml
+, pytest-asyncio
+, pytest
+, pytestCheckHook
+, gmp
+}:
+
+buildPythonPackage rec {
+  pname = "cairo-lang";
+  version = "0.9.1";
+
+  src = fetchzip {
+    url = "https://github.com/starkware-libs/cairo-lang/releases/download/v${version}/cairo-lang-${version}.zip";
+    sha256 = "sha256-i4030QLG6PssfKD5FO4VrZxap19obMZ3Aa77p5MXlNY=";
+  };
+
+  # TODO: remove a substantial part when https://github.com/starkware-libs/cairo-lang/pull/88/files is merged.
+  # TODO: pytest and pytest-asyncio must be removed as they are check inputs in fact.
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace 'frozendict==1.2' 'frozendict>=1.2' \
+      --replace 'lark-parser' 'lark' \
+      --replace 'pytest-asyncio' ''' \
+      --replace "pytest" '''
+
+    substituteInPlace starkware/cairo/lang/compiler/parser_transformer.py \
+      --replace 'value, meta' 'meta, value' \
+      --replace 'value: Tuple[CommaSeparatedWithNotes], meta' 'meta, value: Tuple[CommaSeparatedWithNotes]'
+    substituteInPlace starkware/cairo/lang/compiler/parser.py \
+      --replace 'standard' 'basic'
+  '';
+
+  buildInputs = [ gmp ];
+
+  propagatedBuildInputs = [
+    aiohttp
+    cachetools
+    setuptools
+    ecdsa
+    fastecdsa
+    sympy
+    mpmath
+    numpy
+    typeguard
+    frozendict
+    prometheus-client
+    marshmallow
+    marshmallow-enum
+    marshmallow-dataclass
+    marshmallow-oneofschema
+    pipdeptree
+    lark
+    web3
+    eth-hash
+    eth-hash.optional-dependencies.pycryptodome
+    pyyaml
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  # There seems to be no test included in the ZIP release…
+  # Cloning from GitHub is harder because they use a custom CMake setup
+  # TODO(raitobezarius): upstream was pinged out of band about it.
+  doCheck = false;
+
+  meta = {
+    homepage = "https://github.com/starkware/cairo-lang";
+    description = "Tooling for Cairo language";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ raitobezarius ];
+  };
+}

--- a/pkgs/development/python-modules/ipfshttpclient/default.nix
+++ b/pkgs/development/python-modules/ipfshttpclient/default.nix
@@ -80,6 +80,8 @@ buildPythonPackage rec {
     runHook postCheck
   '';
 
+  doCheck = false;
+
   pythonImportsCheck = [ "ipfshttpclient" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/web3/default.nix
+++ b/pkgs/development/python-modules/web3/default.nix
@@ -1,0 +1,83 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, aiohttp
+, eth-abi
+, eth-account
+, eth-hash
+, eth-typing
+, eth-utils
+, eth-rlp
+, hexbytes
+, ipfshttpclient
+, jsonschema
+, lru-dict
+, protobuf
+, requests
+, typing-extensions
+, websockets
+# , eth-tester
+# , py-geth
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "web3";
+  version = "5.30.0";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "ethereum";
+    repo = "web3.py";
+    rev = "v${version}";
+    sha256 = "sha256-HajumvOG18r7TslkmCfI0iiLsEddevGrRZQFWICGeYE=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "eth-account>=0.5.7,<0.6.0" "eth-account>=0.5.7,<0.7" \
+      --replace "eth-utils>=1.9.5,<2.0.0" "eth-utils>=1.9.5,<3" \
+      --replace "eth-rlp<0.3" "eth-rlp<0.4" \
+      --replace "websockets>=9.1,<10" "websockets>=9.1,<11" \
+      --replace "eth-abi>=2.0.0b6,<3.0.0" "eth-abi>=2.0.0b6,<4" \
+      --replace "eth-typing>=2.0.0,<3.0.0" "eth-typing>=2.0.0,<4"
+  '';
+
+  propagatedBuildInputs = [
+    aiohttp
+    eth-abi
+    eth-account
+    eth-hash
+    eth-hash.optional-dependencies.pycryptodome
+    eth-rlp
+    eth-typing
+    eth-utils
+    hexbytes
+    ipfshttpclient
+    jsonschema
+    lru-dict
+    protobuf
+    requests
+    websockets
+  ] ++ lib.optional (pythonOlder "3.8") [ typing-extensions ];
+
+  # TODO: package eth-tester
+  #checkInputs = [
+  #  eth-tester
+  #  eth-tester.optional-dependencies.py-evm
+  #  py-geth
+  #  pytestCheckHook
+  #];
+
+  doCheck = false;
+
+  pythonImportsCheck = [ "web3" ];
+
+  meta = with lib; {
+    description = "Web3 library for interactions";
+    homepage = "https://github.com/ethereum/web3";
+    license = licenses.mit;
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1522,6 +1522,8 @@ in {
     inherit (self) python numpy boost;
   });
 
+  cairo-lang = callPackage ../development/python-modules/cairo-lang { };
+
   cairocffi = callPackage ../development/python-modules/cairocffi { };
 
   cairosvg = callPackage ../development/python-modules/cairosvg { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11351,6 +11351,8 @@ in {
 
   weasyprint = callPackage ../development/python-modules/weasyprint { };
 
+  web3 = callPackage ../development/python-modules/web3 { };
+
   webargs = callPackage ../development/python-modules/webargs { };
 
   webassets = callPackage ../development/python-modules/webassets { };


### PR DESCRIPTION
###### Description of changes

This introduces `cairo-lang`, a language to prove stuff using [PCPs](https://en.wikipedia.org/wiki/Probabilistically_checkable_proof) used as a machinery for layers 2 smart contracts in the Ethereum ecosystem.

It also adds `web3.py` library and applies https://github.com/NixOS/nixpkgs/issues/185294 suggestion to disable ipfshttpclient tests for now.

**TODO**:

- `cairo-lang` has a lot of hacks because upstream has not updated it in a while.
- testing is not enabled on web3.py because it requires `eth-tester` and `pyevm` (which I am working on in another PR).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [  Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
