### PR TITLE
linuxPackages.rtl8188eus-aircrack: unstable-2021-05-04 -> unstable-2022-03-19

### DIFF
--- a/pkgs/os-specific/linux/rtl8188eus-aircrack/default.nix
+++ b/pkgs/os-specific/linux/rtl8188eus-aircrack/default.nix
@@ -1,21 +1,15 @@
-{ lib, stdenv, fetchFromGitHub, kernel, bc }:
+{ lib, stdenv, fetchFromGitHub, kernel, bc, fetchpatch }:
 
 stdenv.mkDerivation {
   pname = "rtl8188eus-aircrack";
-  version = "${kernel.version}-unstable-2021-05-04";
+  version = "${kernel.version}-unstable-2022-03-19";
 
   src = fetchFromGitHub {
     owner = "aircrack-ng";
     repo = "rtl8188eus";
-    rev = "6146193406b62e942d13d4d43580ed94ac70c218";
-    sha256 = "sha256-85STELbFB7QmTaM8GvJNlWvAg6KPAXeYRiMb4cGA6RY=";
+    rev = "0958f294f90b49d6bad4972b14f90676e5d858d3";
+    sha256 = "sha256-dkCcwvOLxqU1IZ/OXTp67akjWgsaH1Cq4N8d9slMRI8=";
   };
-
-  nativeBuildInputs = [ bc ];
-
-  buildInputs = kernel.moduleBuildDependencies;
-
-  hardeningDisable = [ "pic" ];
 
   prePatch = ''
     substituteInPlace ./Makefile \
@@ -25,17 +19,30 @@ stdenv.mkDerivation {
       --replace '$(MODDESTDIR)' "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
   '';
 
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/aircrack-ng/rtl8188eus/commit/daa3a2e12290050be3af956915939a55aed50d5f.patch";
+      hash = "sha256-VsvaAhO74LzqUxbmdDT9qwVl6Y9lXfGfrHHK3SbnOVA=";
+    })
+  ];
+
+  hardeningDisable = [ "pic" ];
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ bc ];
+
+  buildInputs = kernel.moduleBuildDependencies;
+
   preInstall = ''
     mkdir -p "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
   '';
-
-  enableParallelBuilding = true;
 
   meta = with lib; {
     description = "RealTek RTL8188eus WiFi driver with monitor mode & frame injection support";
     homepage = "https://github.com/aircrack-ng/rtl8188eus";
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ fortuneteller2k ];
-    broken = kernel.kernelAtLeast "5.15" || kernel.isHardened;
+    broken = (lib.versionAtLeast kernel.version "5.17") || ((lib.versions.majorMinor kernel.version) == "5.4" && kernel.isHardened);
   };
 }


### PR DESCRIPTION
###### Description of changes

Not exactly sure what changed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
