### PR TITLE
vdrPlugins: update plugins

### DIFF
--- a/pkgs/applications/video/vdr/plugins.nix
+++ b/pkgs/applications/video/vdr/plugins.nix
@@ -14,6 +14,8 @@ in {
 
   softhddevice = callPackage ./softhddevice {};
 
+  streamdev = callPackage ./streamdev {};
+
   xineliboutput = callPackage ./xineliboutput {};
 
   skincurses = (mkPlugin "skincurses").overrideAttrs(oldAttr: {

--- a/pkgs/applications/video/vdr/plugins.nix
+++ b/pkgs/applications/video/vdr/plugins.nix
@@ -1,5 +1,5 @@
-{ lib, stdenv, fetchurl, fetchgit, vdr, alsa-lib, fetchFromGitHub
-, libvdpau, libxcb, xcbutilwm, graphicsmagick, libav, pcre, xorgserver, ffmpeg
+{ lib, stdenv, fetchurl, fetchgit, vdr, fetchFromGitHub
+, graphicsmagick, libav, pcre, xorgserver, ffmpeg
 , libiconv, boost, libgcrypt, perl, util-linux, groff, libva, xorg, ncurses
 , callPackage
 }: let
@@ -46,43 +46,6 @@ in {
     };
 
   };
-
-  vaapidevice = stdenv.mkDerivation {
-    pname = "vdr-vaapidevice";
-    version = "20190525";
-
-    buildInputs = [
-      vdr libxcb xcbutilwm ffmpeg
-      alsa-lib
-      libvdpau # vdpau
-      libva # va-api
-    ] ++ (with xorg; [ libxcb libX11 ]);
-
-    makeFlags = [ "DESTDIR=$(out)" ];
-
-    postPatch = ''
-      substituteInPlace vaapidev.c --replace /usr/bin/X ${xorgserver}/bin/X
-      # https://github.com/rofafor/vdr-plugin-vaapidevice/issues/5
-      substituteInPlace Makefile --replace libva libva-x11
-    '';
-
-    src = fetchFromGitHub {
-      owner = "pesintta";
-      repo = "vdr-plugin-vaapidevice";
-      sha256 = "1gwjp15kjki9x5742fhaqk3yc2bbma74yp2vpn6wk6kj46nbnwp6";
-      rev = "d19657bae399e79df107e316ca40922d21393f80";
-    };
-
-    meta = with lib; {
-      homepage = "https://github.com/pesintta/vdr-plugin-vaapidevice";
-      description = "VDR SoftHDDevice Plug-in (with VA-API VPP additions)";
-      maintainers = [ maintainers.ck3d ];
-      license = licenses.gpl2;
-      platforms = [ "i686-linux" "x86_64-linux" ];
-    };
-
-  };
-
 
   markad = stdenv.mkDerivation rec {
     pname = "vdr-markad";

--- a/pkgs/applications/video/vdr/plugins.nix
+++ b/pkgs/applications/video/vdr/plugins.nix
@@ -49,18 +49,19 @@ in {
 
   markad = stdenv.mkDerivation rec {
     pname = "vdr-markad";
-    version = "unstable-2017-03-13";
+    version = "2.0.4";
 
-    src = fetchgit {
-      url = "git://projects.vdr-developer.org/vdr-plugin-markad.git";
-      sha256 = "0jvy70r8bcmbs7zdqilfz019z5xkz5c6rs57h1dsgv8v6x86c2i4";
-      rev = "ea2e182ec798375f3830f8b794e7408576f139ad";
+    src = fetchFromGitHub {
+      repo = "vdr-plugin-markad";
+      owner = "jbrundiers";
+      sha256 = "sha256-Y4KsEtUq+KoUooXiw9O9RokBxNwWBkiGB31GncmHkYM=";
+      rev = "288e3dae93421b0176f4f62b68ea4b39d98e8793";
     };
 
     buildInputs = [ vdr libav ];
 
     postPatch = ''
-      substituteInPlace command/Makefile --replace '$(DESTDIR)/usr' '$(DESTDIR)'
+      substituteInPlace command/Makefile --replace '/usr' ""
 
       substituteInPlace plugin/markad.cpp \
         --replace "/usr/bin" "$out/bin" \
@@ -70,22 +71,19 @@ in {
         --replace "/var/lib/markad" "$out/var/lib/markad"
     '';
 
-    preBuild = ''
-      mkdir -p $out/lib/vdr
-    '';
-
     buildFlags = [
       "DESTDIR=$(out)"
-      "LIBDIR=$(out)/lib/vdr"
+      "LIBDIR=/lib/vdr"
+      "APIVERSION=${vdr.version}"
       "VDRDIR=${vdr.dev}/include/vdr"
-      "LOCALEDIR=$(DESTDIR)/share/locale"
+      "LOCDIR=/share/locale"
     ];
 
     installFlags = buildFlags;
 
     meta = with lib; {
-      homepage = "https://projects.vdr-developer.org/projects/plg-markad";
-      description = "Ein Programm zum automatischen Setzen von Schnittmarken bei Werbeeinblendungen während einer Sendung.";
+      homepage = "https://github.com/jbrundiers/vdr-plugin-markad";
+      description = "MarkAd marks advertisements in VDR recordings.";
       maintainers = [ maintainers.ck3d ];
       license = licenses.gpl2;
       platforms = [ "i686-linux" "x86_64-linux" ];

--- a/pkgs/applications/video/vdr/plugins.nix
+++ b/pkgs/applications/video/vdr/plugins.nix
@@ -12,6 +12,8 @@
   };
 in {
 
+  softhddevice = callPackage ./softhddevice {};
+
   xineliboutput = callPackage ./xineliboutput {};
 
   skincurses = (mkPlugin "skincurses").overrideAttrs(oldAttr: {

--- a/pkgs/applications/video/vdr/softhddevice/default.nix
+++ b/pkgs/applications/video/vdr/softhddevice/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, stdenv
+, vdr
+, alsa-lib
+, fetchFromGitHub
+, xcbutilwm
+, xorgserver
+, ffmpeg
+, libva
+, libvdpau
+, xorg
+}:
+stdenv.mkDerivation rec {
+  pname = "vdr-softhddevice";
+  version = "1.9.0";
+
+  src = fetchFromGitHub {
+    owner = "ua0lnj";
+    repo = "vdr-plugin-softhddevice";
+    sha256 = "sha256-IqG1Jr+fV4MMyTTOUGY34HNqS8qvAH+CSi2IEyVGVFo=";
+    rev = "v${version}";
+  };
+
+  buildInputs = [
+    vdr
+    xcbutilwm
+    ffmpeg
+    alsa-lib
+    libva
+    libvdpau
+    xorg.libxcb
+    xorg.libX11
+  ];
+
+  makeFlags = [ "DESTDIR=$(out)" ];
+
+  postPatch = ''
+    substituteInPlace softhddev.c \
+      --replace "LOCALBASE \"/bin/X\"" "\"${xorgserver}/bin/X\""
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/ua0lnj/vdr-plugin-softhddevice";
+    description = "VDR SoftHDDevice Plug-in";
+    maintainers = [ maintainers.ck3d ];
+    license = licenses.gpl2;
+    platforms = [ "i686-linux" "x86_64-linux" ];
+  };
+
+}

--- a/pkgs/applications/video/vdr/streamdev/default.nix
+++ b/pkgs/applications/video/vdr/streamdev/default.nix
@@ -1,0 +1,39 @@
+{ stdenv
+, fetchFromGitHub
+, lib
+, vdr
+}:
+stdenv.mkDerivation rec {
+  pname = "vdr-streamdev";
+  version = "0.6.3";
+
+  src = fetchFromGitHub {
+    owner = "vdr-projects";
+    repo = "vdr-plugin-streamdev";
+    rev = version;
+    sha256 = "sha256-12sASyFAnSuP2xQzr1KL/Am52ez6hiOUH/0zFH2bxhc=";
+  };
+
+  # configure don't accept argument --prefix
+  dontAddPrefix = true;
+
+  makeFlags = [
+    "DESTDIR=$(out)"
+    "LIBDIR=/lib/vdr"
+    "LOCDIR=/share/locale"
+  ];
+
+  enableParallelBuilding = true;
+
+  buildInputs = [
+    vdr
+  ];
+
+  meta = with lib;{
+    homepage = "https://github.com/vdr-projects/vdr-plugin-streamdev";
+    description = "This PlugIn is a VDR implementation of the VTP (Video Transfer Protocol) Version 0.0.3 (see file PROTOCOL) and a basic HTTP Streaming Protocol.";
+    maintainers = [ maintainers.ck3d ];
+    license = licenses.gpl2;
+    inherit (vdr.meta) platforms;
+  };
+}


### PR DESCRIPTION
###### Description of changes

Following VDR plugins are changed:

- vaapidevice: Remove broken plugin
- markad: unstable -> 2.0.4
- softhddevice: init at 1.9.0
- streamdev: init at 0.6.3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
