### PR TITLE
llvmPackages_14.compiler-rt: fix aarch32 patch

### DIFF
--- a/pkgs/development/compilers/llvm/14/compiler-rt/armv7l.patch
+++ b/pkgs/development/compilers/llvm/14/compiler-rt/armv7l.patch
@@ -1,0 +1,32 @@
+diff -ur compiler-rt-10.0.0.src/cmake/builtin-config-ix.cmake compiler-rt-10.0.0.src-patched/cmake/builtin-config-ix.cmake
+--- compiler-rt-10.0.0.src/cmake/builtin-config-ix.cmake	2020-03-24 00:01:02.000000000 +0900
++++ compiler-rt-10.0.0.src-patched/cmake/builtin-config-ix.cmake	2020-05-10 03:42:00.883450706 +0900
+@@ -24,7 +24,7 @@
+ 
+ 
+ set(ARM64 aarch64)
+-set(ARM32 arm armhf armv6m armv7m armv7em armv7 armv7s armv7k)
++set(ARM32 arm armhf armv6m armv7m armv7em armv7 armv7s armv7k armv7l)
+ set(HEXAGON hexagon)
+ set(X86 i386)
+ set(X86_64 x86_64)
+diff -ur compiler-rt-10.0.0.src/lib/builtins/CMakeLists.txt compiler-rt-10.0.0.src-patched/lib/builtins/CMakeLists.txt
+--- compiler-rt-10.0.0.src/lib/builtins/CMakeLists.txt	2020-03-24 00:01:02.000000000 +0900
++++ compiler-rt-10.0.0.src-patched/lib/builtins/CMakeLists.txt	2020-05-10 03:44:49.468579650 +0900
+@@ -474,6 +474,7 @@
+ set(armv7_SOURCES ${arm_SOURCES})
+ set(armv7s_SOURCES ${arm_SOURCES})
+ set(armv7k_SOURCES ${arm_SOURCES})
++set(armv7l_SOURCES ${arm_SOURCES})
+ set(arm64_SOURCES ${aarch64_SOURCES})
+ 
+ # macho_embedded archs
+@@ -595,7 +596,7 @@
+   foreach (arch ${BUILTIN_SUPPORTED_ARCH})
+     if (CAN_TARGET_${arch})
+       # For ARM archs, exclude any VFP builtins if VFP is not supported
+-      if (${arch} MATCHES "^(arm|armhf|armv7|armv7s|armv7k|armv7m|armv7em)$")
++      if (${arch} MATCHES "^(arm|armhf|armv7|armv7s|armv7k|armv7l|armv7m|armv7em)$")
+         string(REPLACE ";" " " _TARGET_${arch}_CFLAGS "${TARGET_${arch}_CFLAGS}")
+         check_compile_definition(__VFP_FP__ "${CMAKE_C_FLAGS} ${_TARGET_${arch}_CFLAGS}" COMPILER_RT_HAS_${arch}_VFP)
+         if(NOT COMPILER_RT_HAS_${arch}_VFP)

--- a/pkgs/development/compilers/llvm/14/compiler-rt/armv7l.patch
+++ b/pkgs/development/compilers/llvm/14/compiler-rt/armv7l.patch
@@ -1,19 +1,18 @@
 diff -ur compiler-rt-10.0.0.src/cmake/builtin-config-ix.cmake compiler-rt-10.0.0.src-patched/cmake/builtin-config-ix.cmake
 --- compiler-rt-10.0.0.src/cmake/builtin-config-ix.cmake	2020-03-24 00:01:02.000000000 +0900
 +++ compiler-rt-10.0.0.src-patched/cmake/builtin-config-ix.cmake	2020-05-10 03:42:00.883450706 +0900
-@@ -24,7 +24,7 @@
- 
+@@ -37,6 +37,6 @@
  
  set(ARM64 aarch64)
--set(ARM32 arm armhf armv6m armv7m armv7em armv7 armv7s armv7k)
-+set(ARM32 arm armhf armv6m armv7m armv7em armv7 armv7s armv7k armv7l)
+-set(ARM32 arm armhf armv6m armv7m armv7em armv7 armv7s armv7k armv8m.main armv8.1m.main)
++set(ARM32 arm armhf armv6m armv7m armv7em armv7 armv7s armv7k armv7l armv8m.main armv8.1m.main)
  set(HEXAGON hexagon)
  set(X86 i386)
  set(X86_64 x86_64)
 diff -ur compiler-rt-10.0.0.src/lib/builtins/CMakeLists.txt compiler-rt-10.0.0.src-patched/lib/builtins/CMakeLists.txt
 --- compiler-rt-10.0.0.src/lib/builtins/CMakeLists.txt	2020-03-24 00:01:02.000000000 +0900
 +++ compiler-rt-10.0.0.src-patched/lib/builtins/CMakeLists.txt	2020-05-10 03:44:49.468579650 +0900
-@@ -474,6 +474,7 @@
+@@ -555,6 +555,7 @@
  set(armv7_SOURCES ${arm_SOURCES})
  set(armv7s_SOURCES ${arm_SOURCES})
  set(armv7k_SOURCES ${arm_SOURCES})
@@ -21,12 +20,12 @@ diff -ur compiler-rt-10.0.0.src/lib/builtins/CMakeLists.txt compiler-rt-10.0.0.s
  set(arm64_SOURCES ${aarch64_SOURCES})
  
  # macho_embedded archs
-@@ -595,7 +596,7 @@
+@@ -705,7 +705,7 @@
    foreach (arch ${BUILTIN_SUPPORTED_ARCH})
      if (CAN_TARGET_${arch})
        # For ARM archs, exclude any VFP builtins if VFP is not supported
--      if (${arch} MATCHES "^(arm|armhf|armv7|armv7s|armv7k|armv7m|armv7em)$")
-+      if (${arch} MATCHES "^(arm|armhf|armv7|armv7s|armv7k|armv7l|armv7m|armv7em)$")
+-      if (${arch} MATCHES "^(arm|armhf|armv7|armv7s|armv7k|armv7m|armv7em|armv8m.main|armv8.1m.main)$")
++      if (${arch} MATCHES "^(arm|armhf|armv7|armv7s|armv7k|armv7l|armv7m|armv7em|armv8m.main|armv8.1m.main)$")
          string(REPLACE ";" " " _TARGET_${arch}_CFLAGS "${TARGET_${arch}_CFLAGS}")
          check_compile_definition(__VFP_FP__ "${CMAKE_C_FLAGS} ${_TARGET_${arch}_CFLAGS}" COMPILER_RT_HAS_${arch}_VFP)
          if(NOT COMPILER_RT_HAS_${arch}_VFP)

--- a/pkgs/development/compilers/llvm/14/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/14/compiler-rt/default.nix
@@ -73,7 +73,8 @@ stdenv.mkDerivation {
     # extra `/`.
     ./normalize-var.patch
   ] # Prevent a compilation error on darwin
-    ++ lib.optional stdenv.hostPlatform.isDarwin ./darwin-targetconditionals.patch;
+    ++ lib.optional stdenv.hostPlatform.isDarwin ./darwin-targetconditionals.patch
+    ++ lib.optional stdenv.hostPlatform.isAarch32 ./armv7l.patch;
 
   # TSAN requires XPC on Darwin, which we have no public/free source files for. We can depend on the Apple frameworks
   # to get it, but they're unfree. Since LLVM is rather central to the stdenv, we patch out TSAN support so that Hydra


### PR DESCRIPTION
###### Description of changes

This is just the same fix we did for LLVM 13 in 265ba73a782aab3049177ccf67e2612cb51b831f applied to LLVM 14.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
