### PR TITLE
dillo: 3.0.5 -> 2021-02-09

### DIFF
--- a/pkgs/applications/networking/browsers/dillo/default.nix
+++ b/pkgs/applications/networking/browsers/dillo/default.nix
@@ -1,37 +1,63 @@
-{ lib, stdenv, fetchurl
+{ lib
+, stdenv
+, fetchhg
+, autoreconfHook
 , fltk
+, libXcursor
+, libXi
+, libXinerama
+, libjpeg
+, libpng
+, mbedtls
 , openssl
-, libjpeg, libpng
 , perl
-, libXcursor, libXi, libXinerama }:
+, pkg-config
+, which
+}:
 
-stdenv.mkDerivation rec {
-  version = "3.0.5";
+stdenv.mkDerivation {
   pname = "dillo";
+  version = "unstable-2021-02-09";
 
-  src = fetchurl {
-    url = "https://www.dillo.org/download/${pname}-${version}.tar.bz2";
-    sha256 = "12ql8n1lypv3k5zqgwjxlw1md90ixz3ag6j1gghfnhjq3inf26yv";
+  src = fetchhg {
+    url = "https://hg.sr.ht/~seirdy/dillo-mirror";
+    rev = "67b70f024568b505633524be61fcfbde5337849f";
+    sha256 = "sha256-lbn5u9oEL0zt9yBhznBS9Dz9/6kSwRDJeNXKEojty1g=";
   };
 
-  buildInputs = with lib;
-  [ perl fltk openssl libjpeg libpng libXcursor libXi libXinerama ];
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    which
+  ];
+
+  buildInputs = [
+    fltk
+    libXcursor
+    libXi
+    libXinerama
+    libjpeg
+    libpng
+    mbedtls
+    openssl
+    perl
+  ];
 
   # Workaround build failure on -fno-common toolchains:
   #   ld: main.o:/build/dillo-3.0.5/dpid/dpid.h:64: multiple definition of `sock_set';
   #     dpid.o:/build/dillo-3.0.5/dpid/dpid.h:64: first defined here
   NIX_CFLAGS_COMPILE = "-fcommon";
 
-  configureFlags = [ "--enable-ssl" ];
+  configureFlags = [ "--enable-ssl=yes" ];
 
   meta = with lib; {
-    homepage = "https://www.dillo.org/";
+    homepage = "https://hg.sr.ht/~seirdy/dillo-mirror";
     description = "A fast graphical web browser with a small footprint";
     longDescription = ''
       Dillo is a small, fast web browser, tailored for older machines.
     '';
     maintainers = [ maintainers.AndersonTorres ];
     platforms = platforms.linux;
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
   };
 }


### PR DESCRIPTION
Mirrored, because the original site died.

Incidentally, closes https://github.com/NixOS/nixpkgs/issues/75906

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
