### PR TITLE
pythonPackages.django_4: fix sandboxed test failure

### DIFF
--- a/pkgs/development/python-modules/django/4.nix
+++ b/pkgs/development/python-modules/django/4.nix
@@ -2,6 +2,7 @@
 , stdenv
 , buildPythonPackage
 , fetchPypi
+, pythonAtLeast
 , pythonOlder
 , substituteAll
 
@@ -65,6 +66,8 @@ buildPythonPackage rec {
       gdal = gdal;
       extension = stdenv.hostPlatform.extensions.sharedLibrary;
     })
+  ] ++ lib.optionals (pythonAtLeast "3.9") [
+    ./django_4_ignore_zoneinfo_exception.patch
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/django/django_4_ignore_zoneinfo_exception.patch
+++ b/pkgs/development/python-modules/django/django_4_ignore_zoneinfo_exception.patch
@@ -1,0 +1,16 @@
+--- a/django/conf/__init__.py	2022-08-19 00:21:44.000000000 -0400
++++ b/django/conf/__init__.py	2022-08-19 00:23:04.000000000 -0400
+@@ -229,8 +229,11 @@
+             # this file, no check happens and it's harmless.
+             zoneinfo_root = Path("/usr/share/zoneinfo")
+             zone_info_file = zoneinfo_root.joinpath(*self.TIME_ZONE.split("/"))
+-            if zoneinfo_root.exists() and not zone_info_file.exists():
+-                raise ValueError("Incorrect timezone setting: %s" % self.TIME_ZONE)
++            try:
++                if zoneinfo_root.exists() and not zone_info_file.exists():
++                    raise ValueError("Incorrect timezone setting: %s" % self.TIME_ZONE)
++            except PermissionError:
++                pass
+             # Move the time zone info into os.environ. See ticket #2315 for why
+             # we don't do this unconditionally (breaks Windows).
+             os.environ["TZ"] = self.TIME_ZONE


### PR DESCRIPTION
###### Description of changes

A test failure is encountered when installing Django 4 plugins in a sandboxed environment on Darwin:

```
nix-repl> pkgs = import ./. { system = "x86_64-darwin"; overlays = [ (final: prev: { python310 = prev.python310.override (old: { packageOverrides = (pfinal: pprev: { django = pprev.django_4; }); }); })];}

nix-repl> :b pkgs.python310.pkgs.django-guardian
error: builder for '/nix/store/p2klj56jhzpd42vhv7xav0p45w5qi6c3-python3.10-django-guardian-2.4.0.drv' failed with exit code 1;
       last 10 log lines:
       >     self._setup(name)
       >   File "/nix/store/hk0w4m0lpm2wcvrw6b8rllnaw73hcqws-python3.10-Django-4.1/lib/python3.10/site-packages/django/conf/__init__.py", line 79, in _setup
       >     self._wrapped = Settings(settings_module)
       >   File "/nix/store/hk0w4m0lpm2wcvrw6b8rllnaw73hcqws-python3.10-Django-4.1/lib/python3.10/site-packages/django/conf/__init__.py", line 232, in __init__
       >     if zoneinfo_root.exists() and not zone_info_file.exists():
       >   File "/nix/store/8b68yhhj335ajv25iqc2cdmp78csdlcv-python3-3.10.6/lib/python3.10/pathlib.py", line 1290, in exists
       >     self.stat()
       >   File "/nix/store/8b68yhhj335ajv25iqc2cdmp78csdlcv-python3-3.10.6/lib/python3.10/pathlib.py", line 1097, in stat
       >     return self._accessor.stat(self, follow_symlinks=follow_symlinks)
       > PermissionError: [Errno 1] Operation not permitted: '/usr/share/zoneinfo'
       For full logs, run 'nix log /nix/store/p2klj56jhzpd42vhv7xav0p45w5qi6c3-python3.10-django-guardian-2.4.0.drv'.
```

This PR is meant to address the issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
