### PR TITLE
python310Packages.scikits-odes: Mark as broken

### DIFF
--- a/pkgs/development/python-modules/scikits-odes/default.nix
+++ b/pkgs/development/python-modules/scikits-odes/default.nix
@@ -2,10 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , cython
-, enum34
 , gfortran
-, isPy27
-, isPy3k
 , numpy
 , pytest
 , python
@@ -16,8 +13,6 @@
 buildPythonPackage rec {
   pname = "scikits.odes";
   version = "2.6.4";
-
-  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
@@ -33,10 +28,11 @@ buildPythonPackage rec {
     numpy
     sundials
     scipy
-  ] ++ lib.optionals (!isPy3k) [ enum34 ];
+  ];
+
+  checkInputs = [ pytestCheckHook ];
 
   doCheck = true;
-  checkInputs = [ pytest ];
 
   checkPhase = ''
     cd $out/${python.sitePackages}/scikits/odes/tests
@@ -49,5 +45,8 @@ buildPythonPackage rec {
     license = licenses.bsd3;
     maintainers = with maintainers; [ idontgetoutmuch ];
     platforms = [ "aarch64-linux" "x86_64-linux" "x86_64-darwin" ];
+    # Build fails with sundials 6.3.0
+    # https://github.com/bmcage/odes/issues/138
+    broken = true;
   };
 }


### PR DESCRIPTION
###### Description of changes

Fails to build with sundials 6.3.0 https://github.com/bmcage/odes/issues/138

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
