### PR TITLE
python310Packages.sphinx-argparse: Fix tests

### DIFF
--- a/pkgs/development/python-modules/sphinx-argparse/default.nix
+++ b/pkgs/development/python-modules/sphinx-argparse/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   };
 
   postPatch = ''
-    # Fix tests for python-3.10 and add 3.10 to CI matrix 
+    # Fix tests for python-3.10 and add 3.10 to CI matrix
     # Should be fixed in versions > 0.3.1
     # https://github.com/ashb/sphinx-argparse/pull/3
     substituteInPlace sphinxarg/parser.py \

--- a/pkgs/development/python-modules/sphinx-argparse/default.nix
+++ b/pkgs/development/python-modules/sphinx-argparse/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, pytest
+, pytestCheckHook
 , sphinx
 }:
 
@@ -14,19 +14,27 @@ buildPythonPackage rec {
     sha256 = "82151cbd43ccec94a1530155f4ad34f251aaca6a0ffd5516d7fadf952d32dc1e";
   };
 
-  checkInputs = [
-    pytest
-  ];
-
-  checkPhase = "py.test";
+  postPatch = ''
+    # Fix tests for python-3.10 and add 3.10 to CI matrix 
+    # Should be fixed in versions > 0.3.1
+    # https://github.com/ashb/sphinx-argparse/pull/3
+    substituteInPlace sphinxarg/parser.py \
+      --replace "if action_group.title == 'optional arguments':" "if action_group.title == 'optional arguments' or action_group.title == 'options':"
+  '';
 
   propagatedBuildInputs = [
     sphinx
   ];
 
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "sphinxarg" ];
+
   meta = {
     description = "A sphinx extension that automatically documents argparse commands and options";
-    homepage = "https://github.com/ribozz/sphinx-argparse";
+    homepage = "https://github.com/ashb/sphinx-argparse";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ clacke ];
   };


### PR DESCRIPTION
###### Description of changes

Instead of using `fetchpatch` I patched setup.py using substituteInPlace since the upstream patch is not compatible with the latest stable version of sphinx-argparse

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
