### PR TITLE
zf: init at 0.7.0

### DIFF
--- a/pkgs/tools/misc/zf/default.nix
+++ b/pkgs/tools/misc/zf/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, zig
+}:
+stdenv.mkDerivation rec {
+  pname = "zf";
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "natecraddock";
+    repo = pname;
+    rev = version;
+    fetchSubmodules = true;
+    hash = "sha256-XxNMm4NKQOJ4U4xspoonnruXRSGz3rSEdZJclfub/f0=";
+  };
+
+  nativeBuildInputs = [ zig ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    export HOME="$(mktemp -d)"
+    zig build -Drelease-fast=true
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp zig-out/bin/zf $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/natecraddock/zf";
+    description = "A commandline fuzzy finder that prioritizes matches on filenames";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ dit7ya ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5677,6 +5677,8 @@ with pkgs;
 
   squawk = callPackage ../development/tools/squawk { };
 
+  zf = callPackage ../tools/misc/zf { };
+
   antibody = callPackage ../shells/zsh/antibody { };
 
   antigen = callPackage ../shells/zsh/antigen { };


### PR DESCRIPTION
###### Description of changes

zf is a commandline fuzzy finder that prioritizes matches on filenames. 
https://github.com/natecraddock/zf

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
