### PR TITLE
linux_5_4_hardened: don't build on x86_64-linux anymore

### DIFF
--- a/pkgs/os-specific/linux/kernel/hardened/config.nix
+++ b/pkgs/os-specific/linux/kernel/hardened/config.nix
@@ -8,13 +8,14 @@
 #
 # See also <nixos/modules/profiles/hardened.nix>
 
-{ lib, version }:
+{ stdenv, lib, version }:
 
 with lib;
 with lib.kernel;
 with (lib.kernel.whenHelpers version);
 
 assert (versionAtLeast version "4.9");
+assert (stdenv.hostPlatform.isx86_64 -> versions.majorMinor version != "5.4");
 
 {
   # Report BUG() conditions and kill the offending process.

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -36,7 +36,7 @@ let
       modDirVersion' = builtins.replaceStrings [ kernel.version ] [ version ] kernel.modDirVersion;
     in kernel.override {
       structuredExtraConfig = import ../os-specific/linux/kernel/hardened/config.nix {
-        inherit lib version;
+        inherit stdenv lib version;
       };
       argsOverride = {
         inherit version;


### PR DESCRIPTION
5.4 hasn't configured successfully on x86_64-linux for months.
People don't seem to care, but the 5.4 packages clutter failure lists
on Hydra + tools.
https://hydra.nixos.org/job/nixpkgs/trunk/linux_5_4_hardened.x86_64-linux/all

Perhaps surprisingly, it works on aarch64-linux and also on older kernels.

###### Things done
None of the usual list is applicable here, I believe.
<!--
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
