### PR TITLE
create mautrix-whatsapp module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -531,6 +531,7 @@
   ./services/matrix/dendrite.nix
   ./services/matrix/mautrix-facebook.nix
   ./services/matrix/mautrix-telegram.nix
+  ./services/matrix/mautrix-whatsapp.nix
   ./services/matrix/mjolnir.nix
   ./services/matrix/pantalaimon.nix
   ./services/matrix/synapse.nix

--- a/nixos/modules/services/matrix/mautrix-whatsapp.nix
+++ b/nixos/modules/services/matrix/mautrix-whatsapp.nix
@@ -1,0 +1,156 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  dataDir = "/var/lib/mautrix-whatsapp";
+  registrationFile = "${dataDir}/whatsapp-registration.yaml";
+  cfg = config.services.mautrix-whatsapp;
+  settingsFormat = pkgs.formats.yaml {};
+  settingsFile = settingsFormat.generate "mautrix-whatsapp-config.yaml" cfg.settings;
+
+  puppetRegex = concatStringsSep
+    ".*"
+    (map
+      escapeRegex
+      (splitString
+        "{userid}"
+        cfg.settings.bridge.username_template));
+in {
+  options = {
+    services.mautrix-whatsapp = {
+      enable = mkEnableOption "Mautrix-Whatsapp, a Matrix-Whatsapp hybrid puppeting/relaybot bridge";
+
+      settings = mkOption rec {
+        apply = recursiveUpdate default;
+        type = settingsFormat.type;
+        default = {
+          homeserver = {
+              address = "http://localhost:8008";
+              domain = "example.com";
+          };
+          appservice = rec {
+              address = "http://${hostname}:${toString port}";
+              hostname = "0.0.0.0";
+              port = 29318;
+              database = {
+                  type = "postgres";
+                  uri = "postgres://mautrix-whatsapp:DB_PASSWORD@localhost/mautrix-whatsapp?sslmode=disable";
+              };
+              as_token = "This value is generated when generating the registration";
+              hs_token = "This value is generated when generating the registration";
+          };
+          bridge = {
+              permissions = {
+                  "*" = "relay";
+                  "example.com" = "user";
+                  "@admin:example.com" = "admin";
+              };
+          };
+          logging = {
+              directory = "/var/log/mautrix-whatsapp";
+              print_level = "warning";
+          };
+        };
+        example = literalExpression ''
+          {
+            homeserver = {
+              address = "http://localhost:8008";
+            };
+
+            bridge.permissions = {
+              "mydomain.example" = "user";
+              "@admin:mydomain.example" = "admin";
+            };
+          };
+        '';
+        description = lib.mdDoc ''
+          {file}`config.yaml` configuration as a Nix attribute set.
+          Configuration options should match those described in
+          [example-config.yaml](https://github.com/mautrix/whatsapp/blob/master/example-config.yaml).
+
+          Secret tokens should not be specified or only in the registration file
+	  Database password should be specified only in /var/lib/mautrix-whatsapp/db-password
+        '';
+      };
+
+      environmentFile = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = lib.mdDoc ''
+          File containing environment variables to be passed to the mautrix-whatsapp service.
+          Should be useless.
+
+          Any config variable can be overridden by setting `MAUTRIX_WHATSAPP_SOME_KEY` to override the `some.key` variable.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users.users.mautrix-whatsapp = {
+      isSystemUser = true;
+      group = "mautrix-whatsapp";
+    };
+    users.groups.mautrix-whatsapp = {};
+
+    systemd.services.mautrix-whatsapp = rec {
+      wantedBy = [ "multi-user.target" ];
+      wants = [
+        "network-online.target"
+      ] ++ optional config.services.matrix-synapse.enable "matrix-synapse.service";
+      after = wants;
+
+      preStart = ''
+        # copy the config file in another location to patch it with private tokens
+        cp '${settingsFile}' config.yaml
+
+        # generate the appservice's registration file if absent
+        if [ ! -f '${registrationFile}' ]; then
+          ${pkgs.mautrix-whatsapp}/bin/mautrix-whatsapp \
+            --generate-registration \
+            --config='config.yaml' \
+            --registration='${registrationFile}'
+          chmod 0440 '${registrationFile}'
+        fi
+
+        # patch config with tokens from the registration file
+        sed -i "s/as_token.*/as_token: \"$(grep "as_token" ${registrationFile} | sed "s/as_token: //")\"/" config.yaml
+        sed -i "s/hs_token.*/hs_token: \"$(grep "hs_token" ${registrationFile} | sed "s/hs_token: //")\"/" config.yaml
+
+        # set postgres password if file dataDir/db-password exist
+        if [ -f '${dataDir}/db-password' ]; then
+          sed -i "s/DB_PASSWORD/$(cat ${dataDir}/db-password)/" config.yaml
+        fi
+      '';
+
+      serviceConfig = {
+        Type = "simple";
+
+        User = "mautrix-whatsapp";
+        Group = "matrix-synapse";
+        Restart = "on-failure";
+
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        PrivateTmp = true;
+
+        EnvironmentFile = cfg.environmentFile;
+
+        RuntimeDirectory = "mautrix-whatsapp";
+        WorkingDirectory = "/run/mautrix-whatsapp";
+        StateDirectory = baseNameOf dataDir;
+        LogsDirectory = baseNameOf cfg.settings.logging.directory;
+
+        ExecStart = ''
+          ${pkgs.mautrix-whatsapp}/bin/mautrix-whatsapp --config=config.yaml
+        '';
+      };
+    };
+  };
+
+  meta.maintainers = with maintainers; [ Jo-Blade ];
+}

--- a/nixos/modules/services/matrix/mautrix-whatsapp.nix
+++ b/nixos/modules/services/matrix/mautrix-whatsapp.nix
@@ -8,14 +8,6 @@ let
   cfg = config.services.mautrix-whatsapp;
   settingsFormat = pkgs.formats.yaml {};
   settingsFile = settingsFormat.generate "mautrix-whatsapp-config.yaml" cfg.settings;
-
-  puppetRegex = concatStringsSep
-    ".*"
-    (map
-      escapeRegex
-      (splitString
-        "{userid}"
-        cfg.settings.bridge.username_template));
 in {
   options = {
     services.mautrix-whatsapp = {
@@ -54,13 +46,18 @@ in {
         };
         example = literalExpression ''
           {
-            homeserver = {
-              address = "http://localhost:8008";
-            };
-
-            bridge.permissions = {
-              "mydomain.example" = "user";
-              "@admin:mydomain.example" = "admin";
+            homeserver.domain = "mydomain";
+      
+            bridge = {
+              permissions = {
+                "mydomain.example" = "user";
+                "@admin:mydomain.example" = "admin";
+              };
+      
+              encryption = {
+                allow = true;
+                default = true;
+              };
             };
           };
         '';

--- a/nixos/modules/services/matrix/mautrix-whatsapp.nix
+++ b/nixos/modules/services/matrix/mautrix-whatsapp.nix
@@ -69,8 +69,8 @@ in {
           Configuration options should match those described in
           [example-config.yaml](https://github.com/mautrix/whatsapp/blob/master/example-config.yaml).
 
-          Secret tokens should not be specified or only in the registration file
-	  Database password should be specified only in /var/lib/mautrix-whatsapp/db-password
+          Secret tokens should not be specified or only in the registration file.
+          Database password should be specified only in /var/lib/mautrix-whatsapp/db-password
         '';
       };
 

--- a/nixos/modules/services/matrix/mautrix-whatsapp.nix
+++ b/nixos/modules/services/matrix/mautrix-whatsapp.nix
@@ -47,13 +47,13 @@ in {
         example = literalExpression ''
           {
             homeserver.domain = "mydomain";
-      
+
             bridge = {
               permissions = {
                 "mydomain.example" = "user";
                 "@admin:mydomain.example" = "admin";
               };
-      
+
               encryption = {
                 allow = true;
                 default = true;


### PR DESCRIPTION
create a module with options for automatic configuration of mautrix-whatsapp

###### Description of changes

This file add options for the package mautrix-whatsapp (matrix<->whatsapp bridge).
You can with this module install and configure automatically the mautrix-whatsapp bridge.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
