### PR TITLE
python310Packages.distutils_extra: 2.45 -> 2.48

### DIFF
--- a/pkgs/development/python-modules/distutils_extra/default.nix
+++ b/pkgs/development/python-modules/distutils_extra/default.nix
@@ -1,4 +1,3 @@
-
 { lib
 , buildPythonPackage
 , fetchurl

--- a/pkgs/development/python-modules/distutils_extra/default.nix
+++ b/pkgs/development/python-modules/distutils_extra/default.nix
@@ -1,3 +1,4 @@
+
 { lib
 , buildPythonPackage
 , fetchurl
@@ -5,17 +6,20 @@
 
 buildPythonPackage rec {
   pname = "distutils-extra";
-  version = "2.45";
+  version = "2.47";
+  format = "setuptools";
 
   src = fetchurl {
     url = "https://salsa.debian.org/python-team/modules/python-distutils-extra/-/archive/${version}/python-${pname}-${version}.tar.bz2";
-    sha256 = "1aifizd4nkvdnkwdna7i6xgjcqi1cf228bg8kmnwz67f5rflk3z8";
+    hash = "sha256-vIl50yDVt5AW5lteWYqhAPlu8ErroOOJ1N/sfE2fbBU=";
   };
 
   # Tests are out-dated as the last upstream release is from 2016
   doCheck = false;
 
-  pythonImportsCheck = [ "DistUtilsExtra" ];
+  pythonImportsCheck = [
+    "DistUtilsExtra"
+  ];
 
   meta = with lib; {
     description = "Enhancements to Python's distutils";


### PR DESCRIPTION
###### Description of changes
Update to latest upstream release 2.47
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
