### PR TITLE
python3Packages.pep8-naming: fix tests for flake8 => 5

### DIFF
--- a/pkgs/development/python-modules/pep8-naming/default.nix
+++ b/pkgs/development/python-modules/pep8-naming/default.nix
@@ -1,6 +1,7 @@
 { lib
-, fetchPypi
 , buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
 , flake8
 , python
 }:
@@ -9,10 +10,21 @@ buildPythonPackage rec {
   pname = "pep8-naming";
   version = "0.13.1";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-Ovd82qnHll98haVs1Xk1RVPJu9P98weKd28S21TdaUQ=";
+  src = fetchFromGitHub {
+    owner = "PyCQA";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-NG4hLZcOMKprUyMnzkHRmUCFGyYgvT6ydBQNpgWE9h0=";
   };
+
+  patches = [
+    # Fixes tests for flake8 => 5
+    # Remove on next release
+    (fetchpatch {
+      url = "https://github.com/PyCQA/pep8-naming/commit/c8808a0907f64b5d081cff8d3f9443e5ced1474e.patch";
+      sha256 = "sha256-4c+a0viS0rXuxj+TuIfgrKZjnrjiJjDoYBbNp3+6Ed0=";
+    })
+  ];
 
   propagatedBuildInputs = [
     flake8


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

pep8-naming is currently broken on the unstable channel.

This PR:
* Changes from `fetchpypi` to `fetchFromGitHub` so that the patch will apply
* Adds a patch that fixes the tests: https://github.com/PyCQA/pep8-naming/commit/c8808a0907f64b5d081cff8d3f9443e5ced1474e

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
