### PR TITLE
mullvad{,-vpn}: 2022.2 -> 2022.4

### DIFF
--- a/pkgs/applications/networking/mullvad-vpn/default.nix
+++ b/pkgs/applications/networking/mullvad-vpn/default.nix
@@ -43,11 +43,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "mullvad-vpn";
-  version = "2022.2";
+  version = "2022.4";
 
   src = fetchurl {
     url = "https://github.com/mullvad/mullvadvpn-app/releases/download/${version}/MullvadVPN-${version}_amd64.deb";
-    sha256 = "sha256-h/c4aPH6E2TzbXGROpLJgF9uHYcjvKiW5upIobpJM9o=";
+    sha256 = "sha256-OwTtWzlZjHNFSN5/UjFJbcrPCv9+ucWYEL2idYjeozU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/networking/mullvad/mullvad.nix
+++ b/pkgs/applications/networking/mullvad/mullvad.nix
@@ -15,16 +15,16 @@
 }:
 rustPlatform.buildRustPackage rec {
   pname = "mullvad";
-  version = "2022.2";
+  version = "2022.4";
 
   src = fetchFromGitHub {
     owner = "mullvad";
     repo = "mullvadvpn-app";
     rev = version;
-    hash = "sha256-ZtQKzbFrkacrfPIkMz/UOfIwQBXQUoVVlFla//jmMwY=";
+    hash = "sha256-s0Cmeh10lQUB5BK4i1qxkDy/ylx/3c6V66dxH+kcnLs=";
   };
 
-  cargoHash = "sha256-J6h3KY1RDCnAc/tQHNGEyOlVQoQNhRqjWbmimPitydQ=";
+  cargoHash = "sha256-HPURL+CFUVLWRq8nzLiZxDhckgH76b6JBUObLGtoEEw=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
###### Description of changes
Update Mullvad packages to 2022.4.
Closes #187152.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
