### PR TITLE
pythonPackages.uamqp: fix build on Darwin

### DIFF
--- a/pkgs/development/python-modules/uamqp/default.nix
+++ b/pkgs/development/python-modules/uamqp/default.nix
@@ -9,6 +9,7 @@
 , fetchpatch
 , fetchPypi
 , isPy3k
+, libcxxabi
 , openssl
 , Security
 , six
@@ -56,6 +57,10 @@ buildPythonPackage rec {
     six
   ] ++ lib.optionals (!isPy3k) [
     enum34
+  ];
+
+  LDFLAGS = lib.optionals stdenv.isDarwin [
+    "-L${lib.getLib libcxxabi}/lib"
   ];
 
   dontUseCmakeConfigure = true;


### PR DESCRIPTION
###### Description of changes

This PR fixes the following build error on Darwin:

```
-- Check for working CXX compiler: /nix/store/6kbh4b2pyq8d20cs8avq40fc7m68jw33-clang-wrapper-11.1.0/bin/clang++
-- Check for working CXX compiler: /nix/store/6kbh4b2pyq8d20cs8avq40fc7m68jw33-clang-wrapper-11.1.0/bin/clang++ - broken
CMake Error at /nix/store/2vapcv5rjzf41nkfylg1inlpkhi738r7-cmake-3.24.0/share/cmake-3.24/Modules/CMakeTestCXXCompiler.cmake:62 (message):
  The C++ compiler

    "/nix/store/6kbh4b2pyq8d20cs8avq40fc7m68jw33-clang-wrapper-11.1.0/bin/clang++"

  is not able to compile a simple test program.

  It fails with the following output:

    Change Dir: /tmp/nix-build-python3.10-uamqp-1.5.3.drv-0/uamqp-1.5.3/build/temp.macosx-10.12-x86_64-cpython-310/cmake/CMakeFiles/CMakeTmp

    Run Build Command(s):/nix/store/blfda540ckpisxpzvkdh5aaiddyr80ap-gnumake-4.3/bin/make -f Makefile cmTC_4313f/fast && /nix/store/blfda540ckpisxpzvkdh5aaiddyr80ap-gnumake
-4.3/bin/make  -f CMakeFiles/cmTC_4313f.dir/build.make CMakeFiles/cmTC_4313f.dir/build
    make[1]: Entering directory '/private/tmp/nix-build-python3.10-uamqp-1.5.3.drv-0/uamqp-1.5.3/build/temp.macosx-10.12-x86_64-cpython-310/cmake/CMakeFiles/CMakeTmp'
    Building CXX object CMakeFiles/cmTC_4313f.dir/testCXXCompiler.cxx.o
    /nix/store/6kbh4b2pyq8d20cs8avq40fc7m68jw33-clang-wrapper-11.1.0/bin/clang++   -fPIE -MD -MT CMakeFiles/cmTC_4313f.dir/testCXXCompiler.cxx.o -MF CMakeFiles/cmTC_4313f.d
ir/testCXXCompiler.cxx.o.d -o CMakeFiles/cmTC_4313f.dir/testCXXCompiler.cxx.o -c /tmp/nix-build-python3.10-uamqp-1.5.3.drv-0/uamqp-1.5.3/build/temp.macosx-10.12-x86_64-cpyt
hon-310/cmake/CMakeFiles/CMakeTmp/testCXXCompiler.cxx
    Linking CXX executable cmTC_4313f
    /nix/store/2vapcv5rjzf41nkfylg1inlpkhi738r7-cmake-3.24.0/bin/cmake -E cmake_link_script CMakeFiles/cmTC_4313f.dir/link.txt --verbose=1
    /nix/store/6kbh4b2pyq8d20cs8avq40fc7m68jw33-clang-wrapper-11.1.0/bin/clang++ -Wl,-search_paths_first -Wl,-headerpad_max_install_names CMakeFiles/cmTC_4313f.dir/testCXXC
ompiler.cxx.o -o cmTC_4313f
    ld: library not found for -lc++abi
    clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
    make[1]: *** [CMakeFiles/cmTC_4313f.dir/build.make:100: cmTC_4313f] Error 1
    make[1]: Leaving directory '/private/tmp/nix-build-python3.10-uamqp-1.5.3.drv-0/uamqp-1.5.3/build/temp.macosx-10.12-x86_64-cpython-310/cmake/CMakeFiles/CMakeTmp'
    make: *** [Makefile:127: cmTC_4313f/fast] Error 2
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).