### PR TITLE
perl: `verify_SSL=>1` by default in HTTP::Tiny

### DIFF
--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -39,6 +39,9 @@ let
       [
         # Do not look in /usr etc. for dependencies.
         ./no-sys-dirs-5.31.patch
+
+        # Enable TLS/SSL verification in HTTP::Tiny by default
+        ./http-tiny-verify-ssl-by-default.patch
       ]
       ++ optional stdenv.isSunOS ./ld-shared.patch
       ++ optionals stdenv.isDarwin [ ./cpp-precomp.patch ./sw_vers.patch ]

--- a/pkgs/development/interpreters/perl/http-tiny-verify-ssl-by-default.patch
+++ b/pkgs/development/interpreters/perl/http-tiny-verify-ssl-by-default.patch
@@ -1,0 +1,79 @@
+Patch for HTTP::Tiny that defaults verify_SSL to 1
+
+Based on proposed Debian patch by Dominic Hargreaves:
+https://salsa.debian.org/perl-team/interpreter/perl/-/commit/1490431e40e22052f75a0b3449f1f53cbd27ba92
+
+
+diff --git a/cpan/HTTP-Tiny/lib/HTTP/Tiny.pm b/cpan/HTTP-Tiny/lib/HTTP/Tiny.pm
+index 5803e4599..88ba51461 100644
+--- a/cpan/HTTP-Tiny/lib/HTTP/Tiny.pm
++++ b/cpan/HTTP-Tiny/lib/HTTP/Tiny.pm
+@@ -40,7 +40,7 @@ sub _croak { require Carp; Carp::croak(@_) }
+ #pod * C<timeout> — Request timeout in seconds (default is 60) If a socket open,
+ #pod   read or write takes longer than the timeout, an exception is thrown.
+ #pod * C<verify_SSL> — A boolean that indicates whether to validate the SSL
+-#pod   certificate of an C<https> — connection (default is false)
++#pod   certificate of an C<https> — connection (default is true)
+ #pod * C<SSL_options> — A hashref of C<SSL_*> — options to pass through to
+ #pod   L<IO::Socket::SSL>
+ #pod
+@@ -112,7 +112,7 @@ sub new {
+         max_redirect => 5,
+         timeout      => defined $args{timeout} ? $args{timeout} : 60,
+         keep_alive   => 1,
+-        verify_SSL   => $args{verify_SSL} || $args{verify_ssl} || 0, # no verification by default
++        verify_SSL   => $args{verify_SSL} // $args{verify_ssl} // 1, # verification by default
+         no_proxy     => $ENV{no_proxy},
+     };
+ 
+@@ -1038,7 +1038,7 @@ sub new {
+         timeout          => 60,
+         max_line_size    => 16384,
+         max_header_lines => 64,
+-        verify_SSL       => 0,
++        verify_SSL       => 1,
+         SSL_options      => {},
+         %args
+     }, $class;
+@@ -1765,7 +1765,7 @@ C<timeout> — Request timeout in seconds (default is 60) If a socket open, read
+ 
+ =item *
+ 
+-C<verify_SSL> — A boolean that indicates whether to validate the SSL certificate of an C<https> — connection (default is false)
++C<verify_SSL> — A boolean that indicates whether to validate the SSL certificate of an C<https> — connection (default is true)
+ 
+ =item *
+ 
+@@ -2035,7 +2035,7 @@ Verification of server identity
+ 
+ =back
+ 
+-B<By default, HTTP::Tiny does not verify server identity>.
++B<By default, HTTP::Tiny in NixOS verifies server identity>.
+ 
+ Server identity verification is controversial and potentially tricky because it
+ depends on a (usually paid) third-party Certificate Authority (CA) trust model
+@@ -2043,16 +2043,14 @@ to validate a certificate as legitimate.  This discriminates against servers
+ with self-signed certificates or certificates signed by free, community-driven
+ CA's such as L<CAcert.org|http://cacert.org>.
+ 
+-By default, HTTP::Tiny does not make any assumptions about your trust model,
+-threat level or risk tolerance.  It just aims to give you an encrypted channel
+-when you need one.
+-
+ Setting the C<verify_SSL> attribute to a true value will make HTTP::Tiny verify
+ that an SSL connection has a valid SSL certificate corresponding to the host
+ name of the connection and that the SSL certificate has been verified by a CA.
+ Assuming you trust the CA, this will protect against a L<man-in-the-middle
+-attack|http://en.wikipedia.org/wiki/Man-in-the-middle_attack>.  If you are
+-concerned about security, you should enable this option.
++attack|http://en.wikipedia.org/wiki/Man-in-the-middle_attack>.
++
++If you are not concerned about security, and this default in NixOS causes
++problems, you should disable this option.
+ 
+ Certificate verification requires a file containing trusted CA certificates.
+ 
+-- 
+
+


### PR DESCRIPTION
###### Description of changes

Perl's core `HTTP::Tiny` module does not verify TLS/SSL connections by default. This PR applies a proposed patch from Debian by @jmdh to fix that.

- Patch: https://salsa.debian.org/perl-team/interpreter/perl/-/commit/1490431e40e22052f75a0b3449f1f53cbd27ba92
- Discussion: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=954089

Upstream has decided against changing the default due to backwards compatibility concerns.

- https://github.com/chansen/p5-http-tiny/issues/134
- https://github.com/chansen/p5-http-tiny/issues/68

So this is an opinionated patch which would break for users of `HTTP::Tiny` that rely on the insecure default.

Example:
```
$ perl -MIO::Socket::SSL -MHTTP::Tiny -E 'my $res = HTTP::Tiny->new->get(q(https://wrong.host.badssl.com/)); say qq($res->{status} $res->{reason})'
200 OK
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
