### PR TITLE
wofi-emoji: 2021-05-24 -> 2022-08-19

### DIFF
--- a/pkgs/applications/misc/wofi-emoji/default.nix
+++ b/pkgs/applications/misc/wofi-emoji/default.nix
@@ -16,13 +16,13 @@ stdenv.mkDerivation rec {
     sha256 = "1wq276bhf9x24ds13b2dwa69cjnr207p6977hr4bsnczryg609rh";
   };
 
-  buildInputs = [ wofi wtype wl-clipboard ];
   nativeBuildInputs = [ jq ];
+  buildInputs = [ wofi wtype wl-clipboard ];
 
   postPatch = ''
     substituteInPlace build.sh \
-      --replace 'curl https://raw.githubusercontent.com/muan/emojilib/v3.0.6/dist/emoji-en-US.json' 'cat emoji-en-US.json'
-  '';
+      --replace 'curl ${emojiJSON.url}' 'cat emoji-en-US.json'
+      '';
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/applications/misc/wofi-emoji/default.nix
+++ b/pkgs/applications/misc/wofi-emoji/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   postPatch = ''
     substituteInPlace build.sh \
       --replace 'curl ${emojiJSON.url}' 'cat emoji-en-US.json'
-      '';
+  '';
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/applications/misc/wofi-emoji/default.nix
+++ b/pkgs/applications/misc/wofi-emoji/default.nix
@@ -1,30 +1,27 @@
-{ stdenv, lib, fetchFromGitHub, jq }:
+{ stdenv, lib, fetchurl, fetchFromGitHub, jq, wofi, wtype, wl-clipboard }:
 
-let
-  emojiJSON = fetchFromGitHub {
-    owner = "github";
-    repo = "gemoji";
-    sha256 = "sha256-Tn0vba129LPlX+MRcCBA9qp2MU1ek1jYzVCqoNxCL/w=";
-    rev = "v4.0.0.rc2";
-  };
-
-in stdenv.mkDerivation rec {
+let emojiJSON = fetchurl {
+  url = "https://raw.githubusercontent.com/muan/emojilib/v3.0.6/dist/emoji-en-US.json";
+  sha256 = "sha256-wf7zsIEbX/diLwmVvnN2Goxh2V5D3Z6nbEMSb5pSGt0=";
+};
+in
+stdenv.mkDerivation rec {
   pname = "wofi-emoji";
-  version = "unstable-2021-05-24";
+  version = "unstable-2022-08-19";
 
   src = fetchFromGitHub {
     owner = "dln";
     repo = pname;
-    rev = "bfe35c1198667489023109f6843217b968a35183";
-    sha256 = "sha256-wMIjTUCVn4uF0cpBkPfs76NRvwS0WhGGJRy9vvtmVWQ=";
+    rev = "c5ecb4f0f164aedb046f52b5eacac889609c8522";
+    sha256 = "1wq276bhf9x24ds13b2dwa69cjnr207p6977hr4bsnczryg609rh";
   };
 
+  buildInputs = [ wofi wtype wl-clipboard ];
   nativeBuildInputs = [ jq ];
 
   postPatch = ''
-    cp "${emojiJSON}/db/emoji.json" .
     substituteInPlace build.sh \
-      --replace 'curl https://raw.githubusercontent.com/github/gemoji/master/db/emoji.json' 'cat emoji.json'
+      --replace 'curl https://raw.githubusercontent.com/muan/emojilib/v3.0.6/dist/emoji-en-US.json' 'cat emoji-en-US.json'
   '';
 
   buildPhase = ''


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

No upstream changelog, GitHub diff of the previous and this commit: https://github.com/dln/wofi-emoji/compare/bfe35c1..HEAD
Added missing dependencies; without those the program would fail at runtime (it did previously)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
I couldn't get these to run, my low-end hardware ran out of memory :( (or something related to the CPU, not sure)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).