### PR TITLE
nixos/apeloader: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -126,6 +126,7 @@
   ./programs/_1password.nix
   ./programs/_1password-gui.nix
   ./programs/adb.nix
+  ./programs/apeloader.nix
   ./programs/appgate-sdp.nix
   ./programs/atop.nix
   ./programs/ausweisapp.nix

--- a/nixos/modules/programs/apeloader.nix
+++ b/nixos/modules/programs/apeloader.nix
@@ -1,0 +1,23 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.programs.apeloader;
+in
+{
+  options.programs.apeloader.enable = lib.mkEnableOption
+    "support for Actually Portable Executable binaries";
+  options.programs.apeloader.package = lib.mkOption {
+    description = "The apeloader package";
+    type = lib.types.package;
+    default = pkgs.apeloader;
+    defaultText = lib.literalExpression "pkgs.apeloader";
+  };
+
+  config = lib.mkIf cfg.enable {
+    boot.binfmt.registrations.APE = {
+      recognitionType = "magic";
+      magicOrExtension = "MZqFpD";
+      interpreter = "${cfg.package}/bin/ape";
+    };
+  };
+}

--- a/nixos/tests/apeloader-bin.nix
+++ b/nixos/tests/apeloader-bin.nix
@@ -1,0 +1,19 @@
+import ./make-test-python.nix ({ pkgs, ... }: {
+  name = "apeloader";
+  meta = with pkgs.lib; {
+    maintainers = with maintainers; [ lourkeur ];
+  };
+
+  nodes.machine = {
+    programs.apeloader.enable = true;
+    programs.apeloader.package = pkgs.apeloader-bin;
+  };
+
+  testScript = ''
+    machine.succeed("""
+      # strace does `exec` directly with no support for scripts
+      # hence it fails when apeloader is not enabled.
+      strace ${pkgs.cosmopolitan.dist}/build/bootstrap/echo.com Hello world!
+    """)
+  '';
+})

--- a/nixos/tests/apeloader.nix
+++ b/nixos/tests/apeloader.nix
@@ -1,0 +1,18 @@
+import ./make-test-python.nix ({ pkgs, ... }: {
+  name = "apeloader";
+  meta = with pkgs.lib; {
+    maintainers = with maintainers; [ lourkeur ];
+  };
+
+  nodes.machine = {
+    programs.apeloader.enable = true;
+  };
+
+  testScript = ''
+    machine.succeed("""
+      # strace does `exec` directly with no support for scripts
+      # hence it fails when apeloader is not enabled.
+      strace ${pkgs.cosmopolitan.dist}/build/bootstrap/echo.com Hello world!
+    """)
+  '';
+})

--- a/pkgs/development/interpreters/apeloader-bin/default.nix
+++ b/pkgs/development/interpreters/apeloader-bin/default.nix
@@ -1,0 +1,37 @@
+{ stdenvNoCC, lib, fetchurl, cosmopolitan }:
+
+stdenvNoCC.mkDerivation {
+  pname = "apeloader-bin";
+  version = "1.o";
+
+  src =
+    if stdenvNoCC.isDarwin
+    then
+      fetchurl {
+        url = "https://justine.lol/ape.macho";
+        hash = "sha256-YmOv6dNDZAinKaFL8Si3Upfx+NRixXAzmDfBhzlfquA=";
+      }
+    else
+      fetchurl {
+        url = "https://justine.lol/ape.elf";
+        hash = "sha256-5cVAZGX/TclfHn5UsY00x4Q99g6UP7e3K2iu6bWWNHM=";
+      };
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+    install $src -D $out/bin/ape
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://justine.lol/apeloader/";
+    description = "interpreter for Cosmopolitan C programs";
+    inherit (cosmopolitan.meta) license;
+    mainProgram = "ape";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = teams.cosmopolitan.members;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/interpreters/apeloader-bin/default.nix
+++ b/pkgs/development/interpreters/apeloader-bin/default.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, lib, fetchurl, cosmopolitan }:
+{ stdenvNoCC, lib, fetchurl, cosmopolitan, nixosTests }:
 
 stdenvNoCC.mkDerivation {
   pname = "apeloader-bin";
@@ -24,6 +24,10 @@ stdenvNoCC.mkDerivation {
     install $src -D $out/bin/ape
     runHook postInstall
   '';
+
+  passthru.tests = {
+    inherit (nixosTests) apeloader;
+  };
 
   meta = with lib; {
     homepage = "https://justine.lol/apeloader/";

--- a/pkgs/development/interpreters/apeloader/default.nix
+++ b/pkgs/development/interpreters/apeloader/default.nix
@@ -1,0 +1,34 @@
+{ lib, stdenv, cosmopolitan }:
+
+stdenv.mkDerivation {
+  pname = "apeloader";
+  version = "1.o";
+
+  src = cosmopolitan.dist;
+
+  # slashes are significant because upstream uses o/$(MODE)/foo.o
+  buildFlags = "o//ape/ape.elf";
+  enableParallelBuilding = true;
+
+  doInstallCheck = true;
+  dontConfigure = true;
+  dontFixup = true;
+
+  installPhase = ''
+    runHook preInstall
+    install o/ape/ape.elf -D $out/bin/ape
+    runHook postInstall
+  '';
+
+  installCheckPhase = ''
+    $out/bin/ape build/bootstrap/echo.com Hello world!
+  '';
+
+  meta = with lib; {
+    homepage = "https://justine.lol/apeloader/";
+    description = "interpreter for Cosmopolitan C programs";
+    inherit (cosmopolitan.meta) license;
+    mainProgram = "ape";
+    maintainers = teams.cosmopolitan.members;
+  };
+}

--- a/pkgs/development/interpreters/apeloader/default.nix
+++ b/pkgs/development/interpreters/apeloader/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, cosmopolitan }:
+{ lib, stdenv, cosmopolitan, nixosTests }:
 
 stdenv.mkDerivation {
   pname = "apeloader";
@@ -23,6 +23,10 @@ stdenv.mkDerivation {
   installCheckPhase = ''
     $out/bin/ape build/bootstrap/echo.com Hello world!
   '';
+
+  passthru.tests = {
+    inherit (nixosTests) apeloader;
+  };
 
   meta = with lib; {
     homepage = "https://justine.lol/apeloader/";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15005,6 +15005,8 @@ with pkgs;
 
   apeloader = callPackage ../development/interpreters/apeloader { };
 
+  apeloader-bin = callPackage ../development/interpreters/apeloader-bin { };
+
   angelscript = callPackage ../development/interpreters/angelscript {};
 
   angelscript_2_22 = callPackage ../development/interpreters/angelscript/2.22.nix {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15003,6 +15003,8 @@ with pkgs;
   acl2 = callPackage ../development/interpreters/acl2 { };
   acl2-minimal = callPackage ../development/interpreters/acl2 { certifyBooks = false; };
 
+  apeloader = callPackage ../development/interpreters/apeloader { };
+
   angelscript = callPackage ../development/interpreters/angelscript {};
 
   angelscript_2_22 = callPackage ../development/interpreters/angelscript/2.22.nix {};


### PR DESCRIPTION
###### Description of changes

Depends on #187412.

Cosmopolitan now has support for binfmt settings with the `apeloader` program.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
