### PR TITLE
python3Packages.coinmetrics-api-client: init at 2022.8.29.6

### DIFF
--- a/pkgs/development/python-modules/coinmetrics-api-client/default.nix
+++ b/pkgs/development/python-modules/coinmetrics-api-client/default.nix
@@ -1,0 +1,42 @@
+{ buildPythonPackage, fetchPypi, lib, orjson, pandas, poetry-core
+, pytestCheckHook, pytest-mock, pythonOlder, python-dateutil, requests, typer
+, websocket-client }:
+
+buildPythonPackage rec {
+  pname = "coinmetrics-api-client";
+  version = "2022.8.29.6";
+  format = "pyproject";
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-EPPRKOdFbLLYw0K5C4nojR8GueekoFW7xIlwKeSV1EY=";
+  };
+
+  nativeBuildInputs = [ poetry-core ];
+
+  propagatedBuildInputs = [
+    orjson python-dateutil requests typer websocket-client
+  ];
+
+  checkInputs = [
+    pandas
+    pytestCheckHook
+    pytest-mock
+  ];
+
+  pythonImportsCheck = [ "coinmetrics.api_client" ];
+
+  passthru = {
+    optional-dependencies = {
+      pandas = [ pandas ];
+    };
+  };
+
+  meta = with lib; {
+    homepage = "https://coinmetrics.github.io/api-client-python/site/index.html";
+    description = "Coin Metrics API v4 client library (Python)";
+    license = licenses.mit;
+    maintainers = with maintainers; [ centromere ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1947,6 +1947,8 @@ in {
 
   cogapp = callPackage ../development/python-modules/cogapp { };
 
+  coinmetrics-api-client = callPackage ../development/python-modules/coinmetrics-api-client { };
+
   ColanderAlchemy = callPackage ../development/python-modules/colanderalchemy { };
 
   colander = callPackage ../development/python-modules/colander { };


### PR DESCRIPTION
###### Description of changes

This package provides a Python interface to the Coin Metrics API.

[Documentation](https://coinmetrics.github.io/api-client-python/site/index.html)[
Home page](https://coinmetrics.io)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).