### PR TITLE
xgboost: add headers from dmlc-core and rabit

### DIFF
--- a/pkgs/development/libraries/xgboost/default.nix
+++ b/pkgs/development/libraries/xgboost/default.nix
@@ -55,6 +55,8 @@ stdenv.mkDerivation rec {
     runHook preInstall
     mkdir -p $out
     cp -r ../include $out
+    cp -r ../dmlc-core/include/dmlc $out/include
+    cp -r ../rabit/include/rabit $out/include
     install -Dm755 ../lib/${libname} $out/lib/${libname}
     install -Dm755 ../xgboost $out/bin/xgboost
     runHook postInstall


### PR DESCRIPTION
Adding headers from dmlc-core and rabit.