### PR TITLE
nixos/hardware/device-tree: make overlays more reliable

### DIFF
--- a/nixos/modules/hardware/device-tree.nix
+++ b/nixos/modules/hardware/device-tree.nix
@@ -14,6 +14,15 @@ let
         '';
       };
 
+      filter = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "*rpi*.dtb";
+        description = lib.mdDoc ''
+          Only apply to .dtb files matching glob expression.
+        '';
+      };
+
       dtsFile = mkOption {
         type = types.nullOr types.path;
         description = lib.mdDoc ''
@@ -165,6 +174,7 @@ in
           '';
           type = types.listOf (types.coercedTo types.path (path: {
             name = baseNameOf path;
+            filter = null;
             dtboFile = path;
           }) overlayType);
           description = lib.mdDoc ''

--- a/pkgs/os-specific/linux/device-tree/default.nix
+++ b/pkgs/os-specific/linux/device-tree/default.nix
@@ -8,22 +8,35 @@ with lib; {
       overlays = toList overlays';
     in ''
       mkdir -p $out
-      cd ${base}
+      cd "${base}"
       find . -type f -name '*.dtb' -print0 \
-        | xargs -0 cp -v --no-preserve=mode --target-directory $out --parents
+        | xargs -0 cp -v --no-preserve=mode --target-directory "$out" --parents
 
-      for dtb in $(find $out -type f -name '*.dtb'); do
-        dtbCompat="$( fdtget -t s $dtb / compatible )"
+      for dtb in $(find "$out" -type f -name '*.dtb'); do
+        dtbCompat=$(fdtget -t s "$dtb" / compatible 2>/dev/null || true)
+        # skip files without `compatible` string
+        test -z "$dtbCompat" && continue
 
         ${flip (concatMapStringsSep "\n") overlays (o: ''
-        overlayCompat="$( fdtget -t s ${o.dtboFile} / compatible )"
-        # overlayCompat in dtbCompat
-        if [[ "$dtbCompat" =~ "$overlayCompat" ]]; then
-          echo "Applying overlay ${o.name} to $( basename $dtb )"
-          mv $dtb{,.in}
-          fdtoverlay -o "$dtb" -i "$dtb.in" ${o.dtboFile};
-          rm $dtb.in
+        overlayCompat="$(fdtget -t s "${o.dtboFile}" / compatible)"
+
+        # skip incompatible and non-matching overlays
+        if [[ ! "$dtbCompat" =~ "$overlayCompat" ]]; then
+          echo -n "Skipping overlay ${o.name}: incompatible with $(basename "$dtb")"
+          continue
         fi
+        ${optionalString (o.filter != null) ''
+        if [[ "''${dtb//${o.filter}/}" ==  "$dtb" ]]; then
+          echo -n "Skipping overlay ${o.name}: filter does not match $(basename "$dtb")"
+          continue
+        fi
+        ''}
+
+        echo -n "Applying overlay ${o.name} to $(basename "$dtb")... "
+        mv "$dtb"{,.in}
+        fdtoverlay -o "$dtb" -i "$dtb.in" "${o.dtboFile}"
+        echo "ok"
+        rm "$dtb.in"
         '')}
 
       done


### PR DESCRIPTION
###### Description of changes

This make the process of applying overlays more reliable by:

1. Ignoring dtb files that are not really device trees. [^1]

2. Adding a `filter` option (per-overlay, there already is a global one)
   to limit the files to which the overlay applies. This is useful
   in cases where the `compatible` string is ambiguous and multiple
   unrelated files match.

Previously the script would fail in both cases.

[^1]: For example, there is dtbs/overlays/overlay_map.dtb in the
      Raspberry Pi 1 kernel.


###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] armv6l-linux (Raspberry Pi 1)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - `filter` option with zero, one, two globs
  - `overlay_map.dtb` is ignored
  - success/failure messages
- [x] Tested compilation of all packages that depend on this change
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @K900
