### PR TITLE
python3Packages.betterproto: init at 2.0.0b5

### DIFF
--- a/pkgs/development/python-modules/betterproto/default.nix
+++ b/pkgs/development/python-modules/betterproto/default.nix
@@ -1,0 +1,75 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, pythonOlder
+, poetry-core
+, grpclib
+, python-dateutil
+, dataclasses
+, black
+, jinja2
+, isort
+, python3
+, pytestCheckHook
+, pytest-asyncio
+, pytest-mock
+, tomlkit
+, grpcio-tools
+}:
+buildPythonPackage rec {
+  pname = "betterproto";
+  version = "2.0.0b5";
+  format = "pyproject";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "danielgtaylor";
+    repo = "python-betterproto";
+    rev = "v${version}";
+    sha256 = "sha256-XyXdpo3Yo4aO1favMWC7i9utz4fNDbKbsnYXJW0b7Gc=";
+  };
+
+  nativeBuildInputs = [ poetry-core ];
+
+  propagatedBuildInputs = [
+    grpclib
+    python-dateutil
+  ] ++ lib.optional (pythonOlder "3.7") [
+    dataclasses
+  ];
+
+  passthru.optional-dependencies.compiler = [
+    black
+    jinja2
+    isort
+  ];
+
+  pythonImportsCheck = [ "betterproto" ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-asyncio
+    pytest-mock
+    tomlkit
+    grpcio-tools
+  ] ++ passthru.optional-dependencies.compiler;
+
+  # The tests require the generation of code before execution. This requires
+  # the protoc-gen-python_betterproto script from the packge to be on PATH.
+  preCheck = ''
+    export PATH=$PATH:$out/bin
+    ${python3.interpreter} -m tests.generate
+  '';
+
+  meta = with lib; {
+    description = "Clean, modern, Python 3.6+ code generator & library for Protobuf 3 and async gRPC";
+    longDescription = ''
+      This project aims to provide an improved experience when using Protobuf /
+      gRPC in a modern Python environment by making use of modern language
+      features and generating readable, understandable, idiomatic Python code.
+    '';
+    homepage = "https://github.com/danielgtaylor/python-betterproto";
+    license = licenses.mit;
+    maintainers = with maintainers; [ nikstur ];
+  };
+}

--- a/pkgs/development/python-modules/betterproto/default.nix
+++ b/pkgs/development/python-modules/betterproto/default.nix
@@ -9,13 +9,14 @@
 , black
 , jinja2
 , isort
-, python3
+, python
 , pytestCheckHook
 , pytest-asyncio
 , pytest-mock
 , tomlkit
 , grpcio-tools
 }:
+
 buildPythonPackage rec {
   pname = "betterproto";
   version = "2.0.0b5";
@@ -58,7 +59,7 @@ buildPythonPackage rec {
   # the protoc-gen-python_betterproto script from the packge to be on PATH.
   preCheck = ''
     export PATH=$PATH:$out/bin
-    ${python3.interpreter} -m tests.generate
+    ${python.interpreter} -m tests.generate
   '';
 
   meta = with lib; {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1301,6 +1301,8 @@ in {
 
   betamax-serializers = callPackage ../development/python-modules/betamax-serializers { };
 
+  betterproto = callPackage ../development/python-modules/betterproto { };
+
   bibtexparser = callPackage ../development/python-modules/bibtexparser { };
 
   bidict = callPackage ../development/python-modules/bidict { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

betterproto is a clean, modern, Python 3.6+ code generator & library for Protobuf 3 and async gRPC
https://github.com/danielgtaylor/python-betterproto

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
