### PR TITLE
rsync: 3.2.4 -> 3.2.5

### DIFF
--- a/pkgs/applications/networking/sync/rsync/default.nix
+++ b/pkgs/applications/networking/sync/rsync/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchurl
-, fetchpatch
 , perl
 , libiconv
 , zlib
@@ -16,27 +15,18 @@
 , xxHash
 , enableZstd ? true
 , zstd
-, enableCopyDevicesPatch ? false
 , nixosTests
 }:
 
 stdenv.mkDerivation rec {
   pname = "rsync";
-  version = "3.2.4";
+  version = "3.2.5";
 
-  srcs = [
-    (fetchurl {
-      # signed with key 0048 C8B0 26D4 C96F 0E58  9C2F 6C85 9FB1 4B96 A8C5
-      url = "mirror://samba/rsync/src/rsync-${version}.tar.gz";
-      sha256 = "sha256-b3YYONCAUrC2V5z39nN9k+R/AfTaBMXSTTRHt/Kl+tE=";
-    })
-  ] ++ lib.optional enableCopyDevicesPatch (fetchurl {
+  src = fetchurl {
     # signed with key 0048 C8B0 26D4 C96F 0E58  9C2F 6C85 9FB1 4B96 A8C5
-    url = "mirror://samba/rsync/rsync-patches-${version}.tar.gz";
-    sha256 = "1wj21v57v135n6fnm2m2dxmb9lhrrg62jgkggldp1gb7d6s4arny";
-  });
-
-  patches = lib.optional enableCopyDevicesPatch "./patches/copy-devices.diff";
+    url = "mirror://samba/rsync/src/rsync-${version}.tar.gz";
+    sha256 = "sha256-KsTSFjXN95GGe8N3w1ym3af1DZGaWL5FBX/VFgDGmro=";
+  };
 
   nativeBuildInputs = [ perl ];
 
@@ -64,6 +54,6 @@ stdenv.mkDerivation rec {
     homepage = "https://rsync.samba.org/";
     license = licenses.gpl3Plus;
     platforms = platforms.unix;
-    maintainers = with lib.maintainers; [ ehmry kampfschlaefer ];
+    maintainers = with lib.maintainers; [ ehmry kampfschlaefer ivan ];
   };
 }

--- a/pkgs/applications/networking/sync/rsync/rrsync.nix
+++ b/pkgs/applications/networking/sync/rsync/rrsync.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation {
   pname = "rrsync";
-  inherit (rsync) version srcs;
+  inherit (rsync) version src;
 
   buildInputs = [
     rsync


### PR DESCRIPTION
###### Description of changes

This release fixes CVE-2022-29154:
https://download.samba.org/pub/rsync/NEWS#3.2.5

Remove enableCopyDevicesPatch because `--copy-devices` was included in rsync 3.2.4:
https://download.samba.org/pub/rsync/NEWS#3.2.4:~:text=Added%20the%20%2D%2Dcopy%2Ddevices%20option

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc maintainers @ehmry @kampfschlaefer 