### PR TITLE
guile-hall: init at 0.4.1

### DIFF
--- a/pkgs/development/guile-modules/guile-config/default.nix
+++ b/pkgs/development/guile-modules/guile-config/default.nix
@@ -1,0 +1,29 @@
+{ lib, stdenv, fetchFromGitLab, autoreconfHook, pkg-config, texinfo, guile }:
+
+stdenv.mkDerivation rec {
+  pname = "guile-config";
+  version = "0.5.1";
+
+  src = fetchFromGitLab {
+    owner = "a-sassmannshausen";
+    repo = "guile-config";
+    rev = version;
+    hash = "sha256-n4ukGCyIx5G1ITfKSqS6FGJ6dnDBsyxXKSFNi81E4Gg=";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkg-config texinfo ];
+
+  buildInputs = [ guile ];
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Configuration management library for GNU Guile";
+    homepage = "https://gitlab.com/a-sassmannshausen/guile-config";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = guile.meta.platforms;
+  };
+}

--- a/pkgs/development/tools/guile/guile-hall/default.nix
+++ b/pkgs/development/tools/guile/guile-hall/default.nix
@@ -1,0 +1,48 @@
+{ lib, stdenv, fetchFromGitLab, autoreconfHook, pkg-config
+, texinfo, makeWrapper, guile, guile-config }:
+
+stdenv.mkDerivation rec {
+  pname = "guile-hall";
+  version = "0.4.1";
+
+  src = fetchFromGitLab {
+    owner = "a-sassmannshausen";
+    repo = "guile-hall";
+    rev = version;
+    hash = "sha256-TUCN8kW44X6iGbSJURurcz/Tc2eCH1xgmXH1sMOMOXs=";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkg-config texinfo makeWrapper ];
+
+  buildInputs = [ guile guile-config ];
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+
+  postInstall =
+    let
+      guileVersion = lib.versions.majorMinor guile.version;
+    in
+    ''
+      wrapProgram $out/bin/hall \
+        --prefix GUILE_LOAD_PATH : "$out/share/guile/site/${guileVersion}:$GUILE_LOAD_PATH" \
+        --prefix GUILE_LOAD_COMPILED_PATH : "$out/lib/guile/${guileVersion}/site-ccache:$GUILE_LOAD_COMPILED_PATH"
+    '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    export HOME=$TMPDIR
+    $out/bin/hall --version | grep ${version} > /dev/null
+    runHook postInstallCheck
+  '';
+
+  meta = with lib; {
+    description = "Project manager and build tool for GNU guile";
+    homepage = "https://gitlab.com/a-sassmannshausen/guile-hall";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = guile.meta.platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15271,6 +15271,8 @@ with pkgs;
 
   guile-commonmark = callPackage ../development/guile-modules/guile-commonmark { };
 
+  guile-config = callPackage ../development/guile-modules/guile-config { };
+
   guile-fibers = callPackage ../development/guile-modules/guile-fibers { };
 
   guile-gcrypt = callPackage ../development/guile-modules/guile-gcrypt { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16222,6 +16222,8 @@ with pkgs;
 
   guff = callPackage ../tools/graphics/guff { };
 
+  guile-hall = callPackage ../development/tools/guile/guile-hall { };
+
   guile-lint = callPackage ../development/tools/guile/guile-lint {
     guile = guile_1_8;
   };


### PR DESCRIPTION
###### Description of changes
**[Hall](https://gitlab.com/a-sassmannshausen/guile-hall)** is a project manager and build tool for GNU guile.
See [Guile Reference Manual / 4.8 Distributing Guile Code](https://www.gnu.org/software/guile/manual/guile.html#Distributing-Guile-Code).

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
