### PR TITLE
python310Packages.mne-python: 1.0.3 -> 1.1.0

### DIFF
--- a/pkgs/development/python-modules/mne-python/default.nix
+++ b/pkgs/development/python-modules/mne-python/default.nix
@@ -1,52 +1,62 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, isPy27
 , numpy
 , scipy
 , pytestCheckHook
-, pytest-cov
 , pytest-timeout
 , h5py
 , matplotlib
 , nibabel
 , pandas
 , scikit-learn
+, decorator
+, jinja2
+, pooch
+, tqdm
+, setuptools
 }:
 
 buildPythonPackage rec {
   pname = "mne-python";
-  version = "1.0.3";
-
-  disabled = isPy27;
+  version = "1.1.0";
 
   # PyPI dist insufficient to run tests
   src = fetchFromGitHub {
     owner = "mne-tools";
     repo = pname;
     rev = "refs/tags/v${version}";
-    sha256 = "sha256-6eDS/hKqEQqUxJtnfsPhxw9b4p5CC1ifnxVCRBmVVA8=";
+    sha256 = "sha256-p4brwO6uERM2vJdkJ34GdeAKk07QeVEmQrZMPcDjI2I=";
   };
 
-  propagatedBuildInputs = [ numpy scipy ];
-
-  # all tests pass, but Pytest hangs afterwards - probably some thread hasn't terminated
-  doCheck = false;
-  checkInputs = [
-    pytestCheckHook
-    pytest-cov
-    pytest-timeout
-    h5py
+  propagatedBuildInputs = [
+    decorator
+    jinja2
     matplotlib
+    numpy
+    pooch
+    scipy
+    setuptools
+    tqdm
+  ];
+
+  checkInputs = [
+    h5py
     nibabel
     pandas
+    pytestCheckHook
     scikit-learn
+    pytest-timeout
   ];
+
   preCheck = ''
     export HOME=$TMP
     export MNE_SKIP_TESTING_DATASET_TESTS=true
     export MNE_SKIP_NETWORK_TESTS=1
   '';
+
+  # all tests pass, but Pytest hangs afterwards - probably some thread hasn't terminated
+  doCheck = false;
 
   pythonImportsCheck = [ "mne" ];
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
