### PR TITLE
opengl: use requiredKernelConfig

### DIFF
--- a/nixos/modules/hardware/opengl.nix
+++ b/nixos/modules/hardware/opengl.nix
@@ -126,7 +126,7 @@ in
   config = mkIf cfg.enable {
 
     system.requiredKernelConfig =
-      lib.optional cfg.driSupport32Bit 
+      lib.optional cfg.driSupport32Bit
       (config.lib.kernelConfig.isYes "IA32_EMULATION");
 
     systemd.tmpfiles.rules = [

--- a/nixos/modules/hardware/opengl.nix
+++ b/nixos/modules/hardware/opengl.nix
@@ -127,7 +127,7 @@ in
 
     system.requiredKernelConfig =
       lib.optional cfg.driSupport32Bit 
-      (config.lib.kernelConfig.isYes "IA32_EMULATION")
+      (config.lib.kernelConfig.isYes "IA32_EMULATION");
 
     systemd.tmpfiles.rules = [
       "L+ /run/opengl-driver - - - - ${package}"

--- a/nixos/modules/hardware/opengl.nix
+++ b/nixos/modules/hardware/opengl.nix
@@ -126,9 +126,8 @@ in
   config = mkIf cfg.enable {
 
     system.requiredKernelConfig =
-      if cfg.driSupport32Bit
-      then map config.lib.kernelConfig.isYes [ "IA32_EMULATION" ]
-      else null;
+      lib.optional cfg.driSupport32Bit 
+      (config.lib.kernelConfig.isYes "IA32_EMULATION")
 
     systemd.tmpfiles.rules = [
       "L+ /run/opengl-driver - - - - ${package}"

--- a/nixos/modules/hardware/opengl.nix
+++ b/nixos/modules/hardware/opengl.nix
@@ -125,9 +125,7 @@ in
 
   config = mkIf cfg.enable {
 
-    system.requiredKernelConfig =
-      lib.optional cfg.driSupport32Bit
-      (config.lib.kernelConfig.isYes "IA32_EMULATION");
+    system.requiredKernelConfig = lib.optional cfg.driSupport32Bit (config.lib.kernelConfig.isYes "IA32_EMULATION");
 
     systemd.tmpfiles.rules = [
       "L+ /run/opengl-driver - - - - ${package}"

--- a/nixos/modules/hardware/opengl.nix
+++ b/nixos/modules/hardware/opengl.nix
@@ -129,7 +129,7 @@ in
       { assertion = cfg.driSupport32Bit -> pkgs.stdenv.isx86_64;
         message = "Option driSupport32Bit only makes sense on a 64-bit system.";
       }
-      { assertion = cfg.driSupport32Bit -> (config.boot.kernelPackages.kernel.features.ia32Emulation or false);
+      { assertion = cfg.driSupport32Bit -> (with config.lib.kernelConfig; [(isEnabled "IA32_EMULATION")] or false);
         message = "Option driSupport32Bit requires a kernel that supports 32bit emulation";
       }
     ];

--- a/nixos/modules/hardware/opengl.nix
+++ b/nixos/modules/hardware/opengl.nix
@@ -125,14 +125,10 @@ in
 
   config = mkIf cfg.enable {
 
-    assertions = [
-      { assertion = cfg.driSupport32Bit -> pkgs.stdenv.isx86_64;
-        message = "Option driSupport32Bit only makes sense on a 64-bit system.";
-      }
-      { assertion = cfg.driSupport32Bit -> (with config.lib.kernelConfig; [(isEnabled "IA32_EMULATION")] or false);
-        message = "Option driSupport32Bit requires a kernel that supports 32bit emulation";
-      }
-    ];
+    system.requiredKernelConfig =
+      if cfg.driSupport32Bit
+      then map config.lib.kernelConfig.isYes [ "IA32_EMULATION" ]
+      else null;
 
     systemd.tmpfiles.rules = [
       "L+ /run/opengl-driver - - - - ${package}"


### PR DESCRIPTION
###### Description of changes

*Expectation*: When building a kernel using `manualConfig`, OpenGL can be built when the option [`IA32_EMULATION`](https://www.kernelconfig.io/CONFIG_IA32_EMULATION?q=IA32_EMULATION&kernelversion=5.18.18&arch=x86) is yes.

*What actually happens*: OpenGL insists that `IA32_EMULATION` is no with an error message `Option driSupport32Bit requires a kernel that supports 32bit emulation`.

*Description of the PR*: Update the OpenGL package to use `requiredKernelConfig` to check 32bit emulation support. Most packages, e.g. [`zram`](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/config/zram.nix#L122) and [`systemd`](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/system/boot/systemd.nix#L566) use this (seemingly) newer approach, and I imagine that OpenGL should be updated accordingly.

*Related links*: Discussion previously on a Russian Linux forum: [NixOS: dri 32 бит на своем ядре](https://www.linux.org.ru/forum/general/16714583)

Things I haven't checked:
* if there is any problem with other platforms than Linux
* if this conflicts with some other build process in which the kernel is not built (i.e., is `kernelConfig` always available)

Note: `pkgs.stdenv.isx86_64` check is redundant when checking for the `IA32_EMULATION` option, as the option depends on [`CONFIG_X86_64`](https://www.kernelconfig.io/CONFIG_X86_64?kernelversion=5.18.18) being true.

Also, please do squash the commits for me if you end up merging.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
