### PR TITLE
libgccjit: don't try to enter into non-existent $lib output

### DIFF
--- a/pkgs/development/compilers/gcc/10/default.nix
+++ b/pkgs/development/compilers/gcc/10/default.nix
@@ -229,7 +229,7 @@ stdenv.mkDerivation ({
     (if profiledCompiler then "profiledbootstrap" else "bootstrap");
 
   inherit
-    (import ../common/strip-attributes.nix { inherit stdenv; })
+    (import ../common/strip-attributes.nix { inherit lib stdenv langJit; })
     stripDebugList
     stripDebugListTarget
     preFixup;

--- a/pkgs/development/compilers/gcc/11/default.nix
+++ b/pkgs/development/compilers/gcc/11/default.nix
@@ -237,7 +237,7 @@ stdenv.mkDerivation ({
     (if profiledCompiler then "profiledbootstrap" else "bootstrap");
 
   inherit
-    (import ../common/strip-attributes.nix { inherit stdenv; })
+    (import ../common/strip-attributes.nix { inherit lib stdenv langJit; })
     stripDebugList
     stripDebugListTarget
     preFixup;

--- a/pkgs/development/compilers/gcc/12/default.nix
+++ b/pkgs/development/compilers/gcc/12/default.nix
@@ -232,7 +232,7 @@ stdenv.mkDerivation ({
     (if profiledCompiler then "profiledbootstrap" else "bootstrap");
 
   inherit
-    (import ../common/strip-attributes.nix { inherit stdenv; })
+    (import ../common/strip-attributes.nix { inherit lib stdenv langJit; })
     stripDebugList
     stripDebugListTarget
     preFixup;

--- a/pkgs/development/compilers/gcc/4.8/default.nix
+++ b/pkgs/development/compilers/gcc/4.8/default.nix
@@ -236,7 +236,7 @@ stdenv.mkDerivation ({
     (if profiledCompiler then "profiledbootstrap" else "bootstrap");
 
   inherit
-    (import ../common/strip-attributes.nix { inherit stdenv; })
+    (import ../common/strip-attributes.nix { inherit lib stdenv langJit; })
     stripDebugList
     stripDebugListTarget
     preFixup;

--- a/pkgs/development/compilers/gcc/4.9/default.nix
+++ b/pkgs/development/compilers/gcc/4.9/default.nix
@@ -256,7 +256,7 @@ stdenv.mkDerivation ({
     (if profiledCompiler then "profiledbootstrap" else "bootstrap");
 
   inherit
-    (import ../common/strip-attributes.nix { inherit stdenv; })
+    (import ../common/strip-attributes.nix { inherit lib stdenv langJit; })
     stripDebugList
     stripDebugListTarget
     preFixup;

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -268,7 +268,7 @@ stdenv.mkDerivation ({
     (if profiledCompiler then "profiledbootstrap" else "bootstrap");
 
   inherit
-    (import ../common/strip-attributes.nix { inherit stdenv; })
+    (import ../common/strip-attributes.nix { inherit lib stdenv langJit; })
     stripDebugList
     stripDebugListTarget
     preFixup;

--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -235,7 +235,7 @@ stdenv.mkDerivation ({
     (if profiledCompiler then "profiledbootstrap" else "bootstrap");
 
   inherit
-    (import ../common/strip-attributes.nix { inherit stdenv; })
+    (import ../common/strip-attributes.nix { inherit lib stdenv langJit; })
     stripDebugList
     stripDebugListTarget
     preFixup;

--- a/pkgs/development/compilers/gcc/8/default.nix
+++ b/pkgs/development/compilers/gcc/8/default.nix
@@ -216,7 +216,7 @@ stdenv.mkDerivation ({
     (if profiledCompiler then "profiledbootstrap" else "bootstrap");
 
   inherit
-    (import ../common/strip-attributes.nix { inherit stdenv; })
+    (import ../common/strip-attributes.nix { inherit lib stdenv langJit; })
     stripDebugList
     stripDebugListTarget
     preFixup;

--- a/pkgs/development/compilers/gcc/9/default.nix
+++ b/pkgs/development/compilers/gcc/9/default.nix
@@ -231,7 +231,7 @@ stdenv.mkDerivation ({
     (if profiledCompiler then "profiledbootstrap" else "bootstrap");
 
   inherit
-    (import ../common/strip-attributes.nix { inherit stdenv; })
+    (import ../common/strip-attributes.nix { inherit lib stdenv langJit; })
     stripDebugList
     stripDebugListTarget
     preFixup;

--- a/pkgs/development/compilers/gcc/common/strip-attributes.nix
+++ b/pkgs/development/compilers/gcc/common/strip-attributes.nix
@@ -1,4 +1,4 @@
-{ stdenv }:
+{ lib, stdenv, langJit }:
 
 {
   # Note [Cross-compiler stripping]
@@ -48,7 +48,8 @@
         lib{,32,64}/gcc/${stdenv.targetPlatform.config}/*/*.{a,o,so*}
       )
       popd
-
+  '' + lib.optionalString (!langJit) ''
+    ${/*keep indentation*/ ""}
       pushd $lib
       local -ar libHostFiles=(
         lib{,32,64}/*.{a,o,so*}
@@ -58,6 +59,7 @@
       )
       popd
 
+  '' + ''
       eval "$oldOpts"
 
       stripDebugList="$stripDebugList ''${outHostFiles[*]} ''${libHostFiles[*]}"


### PR DESCRIPTION
Fixed reported `staging-next` failure: https://github.com/NixOS/nixpkgs/pull/186941#issuecomment-1219523356

Fixes build failure on `staging-next` introduced by commit c817efe6
("gcc: extend stripping of .a libraries and .o objects"):

    ...-bootstrap-stage3-stdenv-linux/setup: line 106: pushd: no other directory

Build failure happens because `libgccjit` has different `outputs` layout
compared to the rest of `gcc` derivations:

     outputs = [ "out" "man" "info" ] ++ lib.optional (!langJit) "lib";

The change carves out `$lib` lib handling part to avoid `gcc` rebuild
in `staging-next`.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
