### PR TITLE
defaultCrateOverrides: add more case

### DIFF
--- a/pkgs/build-support/rust/default-crate-overrides.nix
+++ b/pkgs/build-support/rust/default-crate-overrides.nix
@@ -28,6 +28,9 @@
 , rdkafka
 , udev
 , libevdev
+, alsaLib
+, libxkbcommon
+, shaderc
 , ...
 }:
 
@@ -35,6 +38,11 @@ let
   inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
 in
 {
+  alsa-sys = attrs: {
+    buildInputs = [ alsaLib ];
+    nativeBuildInputs = [ pkg-config ];
+  };
+
   cairo-rs = attrs: {
     buildInputs = [ cairo ];
   };
@@ -119,7 +127,7 @@ in
   libgit2-sys = attrs: {
     LIBGIT2_SYS_USE_PKG_CONFIG = true;
     nativeBuildInputs = [ pkg-config ];
-    buildInputs = [ openssl zlib libgit2 ];
+    buildInputs = [ openssl zlib libgit2 libssh2 ];
   };
 
   libsqlite3-sys = attrs: {
@@ -219,6 +227,10 @@ in
     buildInputs = [ freetype ];
   };
 
+  shaderc-sys = attrs: {
+    SHADERC_LIB_DIR = "${shaderc.lib}/lib";
+  };
+
   thrussh-libsodium = attrs: {
     nativeBuildInputs = [ pkg-config ];
     buildInputs = [ libsodium ];
@@ -226,5 +238,10 @@ in
 
   xcb = attrs: {
     buildInputs = [ python3 ];
+  };
+
+  xkbcommon-sys = attrs: {
+    nativeBuildInputs = [ pkg-config ];
+    buildInputs = [ libxkbcommon ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Added a few dependancies and crates, required to compile recent version of cargo-release and veloren (I didn’t put veloren-specific crates here)

*(via crate2nix. https://github.com/NixOS/nixpkgs/pull/187563 may also be relevant, as it helped me figure where the issue was for libgit2-sys)*

(cargo-release is used in the tests of crate2nix, and wasn’t updated in a while)
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage) (there are none)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
