### PR TITLE
python310Packages.cloudflare-dyndns: relax attrs constraint

### DIFF
--- a/pkgs/applications/networking/cloudflare-dyndns/default.nix
+++ b/pkgs/applications/networking/cloudflare-dyndns/default.nix
@@ -1,10 +1,11 @@
-{ buildPythonApplication
+{ lib
+, buildPythonApplication
 , attrs
 , click
 , cloudflare
 , fetchFromGitHub
-, lib
-, poetry
+, fetchpatch
+, poetry-core
 , pydantic
 , pytestCheckHook
 , requests
@@ -13,6 +14,7 @@
 buildPythonApplication rec {
   pname = "cloudflare-dyndns";
   version = "4.1";
+  format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "kissgyorgy";
@@ -21,9 +23,9 @@ buildPythonApplication rec {
     hash = "sha256-6Q5fpJ+HuQ+hc3xTtB5tR43pn9WZ0nZZR723iLAkpis=";
   };
 
-  format = "pyproject";
-
-  nativeBuildInputs = [ poetry ];
+  nativeBuildInputs = [
+    poetry-core
+  ];
 
   propagatedBuildInputs = [
     attrs
@@ -33,12 +35,24 @@ buildPythonApplication rec {
     requests
   ];
 
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  patches = [
+    # Switch to poetry-core, https://github.com/kissgyorgy/cloudflare-dyndns/pull/22
+    (fetchpatch {
+      name = "switch-to-poetry-core.patch";
+      url = "https://github.com/kissgyorgy/cloudflare-dyndns/commit/741ed1ccb3373071ce15683a3b8ddc78d64866f8.patch";
+      sha256 = "sha256-mjSah0DWptZB6cjhP6dJg10BpJylPSQ2K4TKda7VmHw=";
+    })
+  ];
+
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace 'click = "^7.0"' 'click = "*"'
+      --replace 'click = "^7.0"' 'click = "*"' \
+      --replace 'attrs = "^21.1.0"' 'attrs = "*"'
   '';
-
-  checkInputs = [ pytestCheckHook ];
 
   disabledTests = [
     "test_get_ipv4"

--- a/pkgs/applications/networking/cloudflare-dyndns/default.nix
+++ b/pkgs/applications/networking/cloudflare-dyndns/default.nix
@@ -59,7 +59,7 @@ buildPythonApplication rec {
   ];
 
   meta = with lib; {
-    description = " CloudFlare Dynamic DNS client ";
+    description = "CloudFlare Dynamic DNS client";
     homepage = "https://github.com/kissgyorgy/cloudflare-dyndns";
     license = licenses.mit;
     maintainers = with maintainers; [ lovesegfault ];


### PR DESCRIPTION
###### Description of changes
Fix build (https://hydra.nixos.org/build/187990046)

- switch to poetry-core
- relax attrs constraint
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
