### PR TITLE
[Backport release-22.05] sigrok: multiple updates and minor refactoring

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9772,6 +9772,12 @@
     githubId = 1788628;
     name = "pandaman";
   };
+  panicgh = {
+    email = "nbenes.gh@xandea.de";
+    github = "panicgh";
+    githubId = 79252025;
+    name = "Nicolas Benes";
+  };
   paperdigits = {
     email = "mica@silentumbrella.com";
     github = "paperdigits";

--- a/pkgs/applications/science/electronics/pulseview/default.nix
+++ b/pkgs/applications/science/electronics/pulseview/default.nix
@@ -1,15 +1,15 @@
 { mkDerivation, lib, fetchurl, fetchpatch, pkg-config, cmake, glib, boost, libsigrok
 , libsigrokdecode, libserialport, libzip, udev, libusb1, libftdi1, glibmm
-, pcre, librevisa, python3, qtbase, qtsvg
+, pcre, librevisa, python3, qtbase, qtsvg, qttools
 }:
 
 mkDerivation rec {
   pname = "pulseview";
-  version = "0.4.1";
+  version = "0.4.2";
 
   src = fetchurl {
     url = "https://sigrok.org/download/source/pulseview/${pname}-${version}.tar.gz";
-    sha256 = "0bvgmkgz37n2bi9niskpl05hf7rsj1lj972fbrgnlz25s4ywxrwy";
+    sha256 = "1jxbpz1h3m1mgrxw74rnihj8vawgqdpf6c33cqqbyd8v7rxgfhph";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];
@@ -17,7 +17,7 @@ mkDerivation rec {
   buildInputs = [
     glib boost libsigrok libsigrokdecode libserialport libzip udev libusb1 libftdi1 glibmm
     pcre librevisa python3
-    qtbase qtsvg
+    qtbase qtsvg qttools
   ];
 
   patches = [

--- a/pkgs/development/tools/libsigrok/default.nix
+++ b/pkgs/development/tools/libsigrok/default.nix
@@ -15,6 +15,7 @@
 , hidapi
 , libieee1284
 , bluez
+, sigrok-firmware-fx2lafw
 }:
 
 stdenv.mkDerivation rec {
@@ -24,11 +25,6 @@ stdenv.mkDerivation rec {
   src = fetchurl {
     url = "https://sigrok.org/download/source/${pname}/${pname}-${version}.tar.gz";
     sha256 = "0g6fl684bpqm5p2z4j12c62m45j1dircznjina63w392ns81yd2d";
-  };
-
-  firmware = fetchurl {
-    url = "https://sigrok.org/download/binary/sigrok-firmware-fx2lafw/sigrok-firmware-fx2lafw-bin-0.1.6.tar.gz";
-    sha256 = "14sd8xqph4kb109g073daiavpadb20fcz7ch1ipn0waz7nlly4sw";
   };
 
   enableParallelBuilding = true;
@@ -45,7 +41,7 @@ stdenv.mkDerivation rec {
     cp contrib/*.rules $out/etc/udev/rules.d
 
     mkdir -p "$out/share/sigrok-firmware/"
-    tar --strip-components=1 -xvf "${firmware}" -C "$out/share/sigrok-firmware/"
+    cp ${sigrok-firmware-fx2lafw}/share/sigrok-firmware/* "$out/share/sigrok-firmware/"
   '';
 
   doInstallCheck = true;

--- a/pkgs/development/tools/sigrok-firmware-fx2lafw/default.nix
+++ b/pkgs/development/tools/sigrok-firmware-fx2lafw/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, stdenv
+, fetchurl
+, sdcc
+}:
+
+stdenv.mkDerivation rec {
+  pname = "sigrok-firmware-fx2lafw";
+  version = "0.1.7";
+
+  src = fetchurl {
+    url = "https://sigrok.org/download/source/sigrok-firmware-fx2lafw/sigrok-firmware-fx2lafw-${version}.tar.gz";
+    sha256 = "sha256-o/RA1qhSpG4sXRmfwcjk2s0Aa8BODVV2KY7lXQVqzjs=";
+  };
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ sdcc ];
+
+  meta = with lib; {
+    description = "Firmware for FX2 logic analyzers";
+    homepage = "https://sigrok.org/";
+
+    # licensing details explained in:
+    # https://sigrok.org/gitweb/?p=sigrok-firmware-fx2lafw.git;a=blob;f=README;hb=HEAD#l122
+    license = with licenses; [
+      gpl2Plus    # overall
+      lgpl21Plus  # fx2lib, Hantek 6022BE, Sainsmart DDS120 firmwares
+    ];
+
+    platforms = platforms.all;
+    maintainers = with maintainers; [ panicgh ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4680,7 +4680,6 @@ with pkgs;
   convertlit = callPackage ../tools/text/convertlit { };
 
   collectd = callPackage ../tools/system/collectd {
-    libsigrok = libsigrok_0_3; # not compatible with >= 0.4.0 yet
     jdk = jdk8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
     inherit (darwin.apple_sdk.frameworks) IOKit;
   };
@@ -15381,13 +15380,6 @@ with pkgs;
 
   libsigrok = callPackage ../development/tools/libsigrok {
     python = python3;
-  };
-  # old version:
-  libsigrok_0_3 = libsigrok.override {
-    python = python3;
-    version = "0.3.0";
-    sha256 = "0l3h7zvn3w4c1b9dgvl3hirc4aj1csfkgbk87jkpl7bgl03nk4j3";
-    doInstallCheck = false;
   };
 
   libsigrokdecode = callPackage ../development/tools/libsigrokdecode {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15390,6 +15390,8 @@ with pkgs;
   libsigrok4dsl = callPackage ../applications/science/electronics/dsview/libsigrok4dsl.nix { };
   libsigrokdecode4dsl = callPackage ../applications/science/electronics/dsview/libsigrokdecode4dsl.nix { };
 
+  sigrok-firmware-fx2lafw = callPackage ../development/tools/sigrok-firmware-fx2lafw { };
+
   cli11 = callPackage ../development/tools/misc/cli11 { };
 
   datree = callPackage ../development/tools/datree { };


### PR DESCRIPTION
###### Description of changes

Backport adding myself to the maintainers file and of #186604:

* unpin an old libsigrok-0.3.0 from collectd, use the 0.5.2 instead
* libsigrok:
  * 0.5.1 -> 0.5.2
  * add hidapi and (on Linux) ieee1284 and bluetooth support
  * add udev rules
* sigrok-firmware-fx2lafw:
  * 0.1.6 -> 0.1.7
  * manually removed `meta.sourceProvenance`, which is not yet supported in 22.05
* pulseview: 0.4.1 -> 0.4.2

Reasons for backport: non-breaking upstream updates, bugfixes, support for USB-HID devices, usable udev rules.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).