### PR TITLE
ocaml-vdom: init at 0.2

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-vdom/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-vdom/default.nix
@@ -14,6 +14,9 @@ buildDunePackage rec {
   buildInputs = [
     js_of_ocaml-compiler
     gen_js_api
+  ];
+
+  propagatedBuildInputs = [
     ojs
   ];
 

--- a/pkgs/development/ocaml-modules/ocaml-vdom/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-vdom/default.nix
@@ -3,7 +3,7 @@
 buildDunePackage rec {
   pname = "ocaml-vdom";
   version = "0.2";
-  minimumOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.08";
   duneVersion = "3";
 
   src = fetchurl {

--- a/pkgs/development/ocaml-modules/ocaml-vdom/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-vdom/default.nix
@@ -12,11 +12,11 @@ buildDunePackage rec {
   };
 
   buildInputs = [
-    js_of_ocaml-compiler
     gen_js_api
   ];
 
   propagatedBuildInputs = [
+    js_of_ocaml-compiler
     ojs
   ];
 

--- a/pkgs/development/ocaml-modules/ocaml-vdom/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-vdom/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, buildDunePackage, js_of_ocaml-compiler , gen_js_api }:
+{ lib, fetchurl, buildDunePackage, js_of_ocaml-compiler , gen_js_api, ojs }:
 
 buildDunePackage rec {
   pname = "ocaml-vdom";
@@ -14,6 +14,7 @@ buildDunePackage rec {
   buildInputs = [
     js_of_ocaml-compiler
     gen_js_api
+    ojs
   ];
 
   meta = {

--- a/pkgs/development/ocaml-modules/ocaml-vdom/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-vdom/default.nix
@@ -1,0 +1,27 @@
+{ lib, fetchurl, buildDunePackage, js_of_ocaml-compiler , gen_js_api }:
+
+buildDunePackage rec {
+  pname = "ocaml-vdom";
+  version = "0.2";
+  minimumOCamlVersion = "4.08";
+  duneVersion = "3";
+
+  src = fetchurl {
+    url = "https://github.com/LexiFi/ocaml-vdom/archive/refs/tags/v${version}.tar.gz";
+    sha256 = "sha256-FVR0WubW9VJBGVtVaXdJ+O/ghq0w5+BuItFWXkuVYL8=";
+  };
+
+  buildInputs = [
+    js_of_ocaml-compiler
+    gen_js_api
+  ];
+
+  meta = {
+    homepage = "https://github.com/LexiFi/ocaml-vdom";
+    description = "Elm architecture and (V)DOM for OCaml";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jayesh-bhoot ];
+  };
+}
+
+

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1013,6 +1013,8 @@ let
 
     ocaml-syntax-shims = callPackage ../development/ocaml-modules/ocaml-syntax-shims { };
 
+    ocaml-vdom = callPackage ../development/ocaml-modules/ocaml-vdom { };
+
     syslog = callPackage ../development/ocaml-modules/syslog { };
 
     syslog-message = callPackage ../development/ocaml-modules/syslog-message { };


### PR DESCRIPTION
###### Description of changes

Elm architecture and (V)DOM for OCaml 

This package contains:

- OCaml bindings to DOM and other client-side Javascript APIs (using [gen_js_api](https://github.com/LexiFi/gen_js_api)).
- An implementation of the [Elm architecture](https://guide.elm-lang.org/architecture/), where the UI is specified as a functional "view" on the current state.

https://github.com/LexiFi/ocaml-vdom

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
