### PR TITLE
geographiclib: init at 2.1.1

### DIFF
--- a/pkgs/development/libraries/geographiclib/default.nix
+++ b/pkgs/development/libraries/geographiclib/default.nix
@@ -1,0 +1,34 @@
+{ lib, stdenv, fetchFromGitHub, cmake, doxygen }:
+
+stdenv.mkDerivation rec {
+  pname = "geographiclib";
+  version = "2.1.1";
+
+  src = fetchFromGitHub {
+    owner = "geographiclib";
+    repo = "geographiclib";
+    rev = "v${version}";
+    hash = "sha256-7K4vI5vNSGPo2d9QNmasjJa4oMDfE8WTW6Guk2604Yg=";
+  };
+
+  nativeBuildInputs = [ cmake doxygen ];
+
+  cmakeFlags = [
+    "-DBUILD_DOCUMENTATION=ON"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+  ];
+
+  meta = with lib; {
+    description = "C++ geographic library";
+    longDescription = ''
+      GeographicLib is a small C++ library for:
+      * geodesic and rhumb line calculations
+      * conversions between geographic, UTM, UPS, MGRS, geocentric, and local cartesian coordinates
+      * gravity (e.g., EGM2008) and geomagnetic field (e.g., WMM2020) calculations
+    '';
+    homepage = "https://geographiclib.sourceforge.io/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18496,6 +18496,8 @@ with pkgs;
     geoipDatabase = geolite-legacy;
   };
 
+  geographiclib = callPackage ../development/libraries/geographiclib { };
+
   geoip = callPackage ../development/libraries/geoip { };
 
   geoipjava = callPackage ../development/libraries/java/geoipjava { };


### PR DESCRIPTION
###### Description of changes
**[GeographicLib](https://github.com/geographiclib/geographiclib)** is a C++ geographic library.

[![Packaging status](https://repology.org/badge/tiny-repos/geographiclib.svg)](https://repology.org/project/geographiclib/versions)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
