### PR TITLE
heroic-unwrapped: init at 2.4.0

### DIFF
--- a/pkgs/games/heroic/default.nix
+++ b/pkgs/games/heroic/default.nix
@@ -1,32 +1,35 @@
-{ lib, fetchurl, appimageTools }:
+{ lib
+, stdenv
+, fetchurl
+, makeWrapper
+, electron
+}:
 
-let
-  pname = "heroic";
-  version = "2.2.6";
-  name = "${pname}-${version}";
+stdenv.mkDerivation rec {
+  pname = "heroic-unwrapped";
+  version = "2.4.0";
+
   src = fetchurl {
-    url = "https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/releases/download/v${version}/Heroic-${version}.AppImage";
-    sha256 = "sha256-kL30/G4DpDPwGN7PvbWest7TcgL4Rd1c2OM4nRCT3bg=";
+    url = "https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/releases/download/v${version}/heroic-${version}.tar.xz";
+    sha256 = "sha256-KX1NyqpCX0hQfdEBF334I0yhH47He7KFIZSKeyak+ZU=";
   };
-  appimageContents = appimageTools.extractType2 { inherit name src; };
 
-in
-appimageTools.wrapType2 {
-  inherit name src;
+  nativeBuildInputs = [
+    makeWrapper
+  ];
 
-  extraInstallCommands = ''
-    mv $out/bin/${name} $out/bin/${pname}
+  installPhase = ''
+    runHook preInstall
 
-    mkdir -p $out/share/${pname}
-    cp -a ${appimageContents}/locales $out/share/${pname}
-    cp -a ${appimageContents}/resources $out/share/${pname}
+    mkdir -p $out/share/Heroic
 
-    install -m 444 -D ${appimageContents}/heroic.desktop -t $out/share/applications
+    cp -r locales $out/share/Heroic
+    cp -r resources $out/share/Heroic
 
-    cp -a ${appimageContents}/usr/share/icons $out/share/
+    makeWrapper ${electron}/bin/electron $out/bin/heroic \
+      --add-flags $out/share/Heroic/resources/app.asar
 
-    substituteInPlace $out/share/applications/heroic.desktop \
-      --replace 'Exec=AppRun' 'Exec=heroic'
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32399,7 +32399,7 @@ with pkgs;
 
   gotypist = callPackage ../games/gotypist { };
 
-  heroic = callPackage ../games/heroic { };
+  heroic-unwrapped = callPackage ../games/heroic { };
 
   julius = callPackage ../games/julius { };
 


### PR DESCRIPTION
###### Description of changes

Based on [aidalgol's branch](https://nur.nix-community.org/repos/wolfangaukang/), I'm setting the current `heroic` package as unwrapped as it is only able to log into the Epic account and handle the game library (needs `legendary-gl` and `gogdl`, the latter available on [NUR](https://nur.nix-community.org/repos/wolfangaukang/)). For gaming, it will require some extra dependencies through a wrapper (I currently do not have the time or interest in creating it).

Another detail is that it is now using the tarball from the releases page, instead of the AppImage, to allow a little more flexibility with the changes on the package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
