### PR TITLE
hyperrogue: 11.3o -> 12.0u

### DIFF
--- a/pkgs/games/hyperrogue/default.nix
+++ b/pkgs/games/hyperrogue/default.nix
@@ -1,20 +1,27 @@
-{ lib, stdenv, fetchFromGitHub, SDL, SDL_ttf, SDL_gfx, SDL_mixer, autoreconfHook,
-  libpng, glew, makeDesktopItem }:
+{ lib, stdenv, fetchFromGitHub, SDL, SDL_ttf, SDL_gfx, SDL_mixer, libpng
+, glew, dejavu_fonts, makeDesktopItem }:
 
 stdenv.mkDerivation rec {
   pname = "hyperrogue";
-  version = "11.3o";
+  version = "12.0u";
 
   src = fetchFromGitHub {
     owner = "zenorogue";
     repo = "hyperrogue";
     rev = "v${version}";
-    sha256 = "0bijgbqpc867pq8lbwwvcnc713gm51mmz625xb5br0q2qw09nkyh";
+    sha256 = "sha256-zG8Z+wpwr5z2r2CcjNxKOdiqXUN0AFChZcihUWel68A=";
   };
 
-  CPPFLAGS = "-I${lib.getDev SDL}/include/SDL";
+  CXXFLAGS = [
+    "-I${lib.getDev SDL}/include/SDL"
+    "-DHYPERPATH='\"${placeholder "out"}/share/hyperrogue/\"'"
+    "-DRESOURCEDESTDIR=HYPERPATH"
+    "-DHYPERFONTPATH='\"${dejavu_fonts}/share/fonts/truetype/\"'"
+  ];
+  HYPERROGUE_USE_GLEW = 1;
+  HYPERROGUE_USE_PNG = 1;
 
-  buildInputs = [ autoreconfHook SDL SDL_ttf SDL_gfx SDL_mixer libpng glew ];
+  buildInputs = [ SDL SDL_ttf SDL_gfx SDL_mixer libpng glew ];
 
   desktopItem = makeDesktopItem {
     name = "hyperrogue";
@@ -26,7 +33,14 @@ stdenv.mkDerivation rec {
     categories = [ "Game" "AdventureGame" ];
   };
 
-  postInstall = ''
+  installPhase = ''
+    install -d $out/share/hyperrogue/{sounds,music}
+
+    install -m 555 -D hyperrogue $out/bin/hyperrogue
+    install -m 444 -D hyperrogue-music.txt *.dat $out/share/hyperrogue
+    install -m 444 -D music/* $out/share/hyperrogue/music
+    install -m 444 -D sounds/* $out/share/hyperrogue/sounds
+
     install -m 444 -D ${desktopItem}/share/applications/hyperrogue.desktop \
       $out/share/applications/hyperrogue.desktop
     install -m 444 -D hyperroid/app/src/main/res/drawable-ldpi/icon.png \


### PR DESCRIPTION
###### Description of changes

[12.0 release notes](https://github.com/zenorogue/hyperrogue/releases/tag/v12.0)

All the release notes from 12.0a to 12.0u are available [here](https://github.com/zenorogue/hyperrogue/releases), though most of them are ‘mostly bugfixes’.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
