### PR TITLE
python310Packages.cffi: patch closures to work on M1 machines

### DIFF
--- a/pkgs/development/python-modules/cffi/darwin-use-libffi-closures.diff
+++ b/pkgs/development/python-modules/cffi/darwin-use-libffi-closures.diff
@@ -1,0 +1,21 @@
+diff -r bac92fcfe4d7 c/_cffi_backend.c
+--- a/c/_cffi_backend.c	Mon Jul 18 15:58:34 2022 +0200
++++ b/c/_cffi_backend.c	Sat Aug 20 12:38:31 2022 -0700
+@@ -96,7 +96,7 @@
+ # define CFFI_CHECK_FFI_PREP_CIF_VAR 0
+ # define CFFI_CHECK_FFI_PREP_CIF_VAR_MAYBE 0
+ 
+-#elif defined(__APPLE__) && defined(FFI_AVAILABLE_APPLE)
++#elif defined(__APPLE__)
+ 
+ # define CFFI_CHECK_FFI_CLOSURE_ALLOC __builtin_available(macos 10.15, ios 13, watchos 6, tvos 13, *)
+ # define CFFI_CHECK_FFI_CLOSURE_ALLOC_MAYBE 1
+@@ -6413,7 +6413,7 @@
+     else
+ #endif
+     {
+-#if defined(__APPLE__) && defined(FFI_AVAILABLE_APPLE) && !FFI_LEGACY_CLOSURE_API
++#if defined(__APPLE__) && !FFI_LEGACY_CLOSURE_API
+         PyErr_Format(PyExc_SystemError, "ffi_prep_closure_loc() is missing");
+         goto error;
+ #else

--- a/pkgs/development/python2-modules/cffi/default.nix
+++ b/pkgs/development/python2-modules/cffi/default.nix
@@ -1,0 +1,45 @@
+{ lib, stdenv, cffi }:
+
+if cffi == null then null else cffi.overridePythonAttrs {
+  disabledTests = lib.optionals stdenv.isDarwin [
+    # cannot load library 'c'
+    "test_FILE"
+    "test_FILE_object"
+    "test_FILE_only_for_FILE_arg"
+    "test_load_and_call_function"
+    "test_load_library"
+
+    # cannot load library 'dl'
+    "test_dlopen_handle"
+
+    # cannot load library 'm'
+    "test_dir_on_dlopen_lib"
+    "test_dlclose"
+    "test_dlopen"
+    "test_dlopen_constant"
+    "test_dlopen_flags"
+    "test_function_typedef"
+    "test_line_continuation_in_defines"
+    "test_missing_function"
+    "test_remove_comments"
+    "test_remove_line_continuation_comments"
+    "test_simple"
+    "test_sin"
+    "test_sinf"
+    "test_stdcall_only_on_windows"
+    "test_wraps_from_stdlib"
+
+    # MemoryError
+    "test_callback_as_function_argument"
+    "test_callback_crash"
+    "test_callback_decorator"
+    "test_callback_large_struct"
+    "test_callback_returning_void"
+    "test_cast_functionptr_and_int"
+    "test_function_pointer"
+    "test_functionptr_intptr_return"
+    "test_functionptr_simple"
+    "test_functionptr_void_return"
+    "test_functionptr_voidptr_return"
+  ];
+}

--- a/pkgs/top-level/python2-packages.nix
+++ b/pkgs/top-level/python2-packages.nix
@@ -15,6 +15,8 @@ with self; with super; {
 
   certifi = callPackage ../development/python2-modules/certifi { };
 
+  cffi = callPackage ../development/python2-modules/cffi { inherit cffi; };
+
   chardet = callPackage ../development/python2-modules/chardet { };
 
   cheetah = callPackage ../development/python2-modules/cheetah { };


### PR DESCRIPTION
Closes #153783

**Summary**

Currently, a feature in cffi called closures (i.e. callbacks) is broken on M1 machines. A notable consequence is that pyOpenSSL is broken on M1 machines as well, and that is depended upon by many packages. I believe that, even though closures are broken still on M1 machines in certain cases (seems to be cases where apps are signed), it can be unbroken for other cases.

The patch is simple and mergeable but will leave to maintainers to determine whether they feel the benefit is worth the risk now, or if it is better to wait for more developments.

**Details**

Trusts the libffi library inside of nixpkgs on Apple devices.

When Apple's fork of libffi is not detected, cffi assumes that libffi uses a strategy for creating closures (i.e. callbacks) that is in certain cases susceptible to a security exploit.

Based on some analysis I did:

  https://groups.google.com/g/python-cffi/c/xU0Usa8dvhk

I believe that libffi already contains the code from Apple's fork that is deemed safe to trust in cffi.

It uses a more sophisticated strategy for creating trampolines to support closures that works on Apple Silicon, while the simple approach that cffi falls back on does not, so this patch enables code that uses closures on M1 Macs again.

Notably, pyOpenSSL is impacted and will be fixed by this, reported in https://github.com/pyca/pyopenssl/issues/873

Note that libffi closures still will not work on signed apps without the com.apple.security.cs.allow-unsigned-executable-memory entitlement while https://github.com/libffi/libffi/pull/621 is still open (which I haven't tested but is my best guess from reading).

I am hopeful that all of these changes will be upstreamed back into cffi and libffi

**Note for pyOpenSSL**

Many tests that used to fail now pass, but there are still three or four (I can't remember exactly) failures that use a callback. I looked into one and do not have a root cause, but I don't believe it's because callbacks do not work. In that test, printing something during SSL handshake led to the callback working, so it feels more like something related to buffers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
