### PR TITLE
quartus-prime-lite: cleanup

### DIFF
--- a/pkgs/applications/editors/quartus-prime/quartus.nix
+++ b/pkgs/applications/editors/quartus-prime/quartus.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, unstick, requireFile
+{ stdenv, lib, unstick, fetchurl
 , supportedDevices ? [ "Arria II" "Cyclone V" "Cyclone IV" "Cyclone 10 LP" "MAX II/V" "MAX 10 FPGA" ]
 }:
 
@@ -34,18 +34,18 @@ let
   };
 
   version = "20.1.1.720";
-  homepage = "https://fpgasoftware.intel.com";
 
-  require = {name, sha256}: requireFile {
+  download = {name, sha256}: fetchurl {
     inherit name sha256;
-    url = "${homepage}/${lib.versions.majorMinor version}/?edition=lite&platform=linux";
+    # e.g. "20.1.1.720" -> "20.1std.1/720"
+    url = "https://downloads.intel.com/akdlm/software/acdsinst/${lib.versions.majorMinor version}std.${lib.versions.patch version}/${lib.elemAt (lib.splitVersion version) 3}/ib_installers/${name}";
   };
 
 in stdenv.mkDerivation rec {
   inherit version;
   pname = "quartus-prime-lite-unwrapped";
 
-  src = map require ([{
+  src = map download ([{
     name = "QuartusLiteSetup-${version}-linux.run";
     sha256 = "0mjp1rg312dipr7q95pb4nf4b8fwvxgflnd1vafi3g9cshbb1c3k";
   } {
@@ -87,12 +87,11 @@ in stdenv.mkDerivation rec {
     '';
 
   meta = with lib; {
-    inherit homepage;
+    homepage = "https://fpgasoftware.intel.com";
     description = "FPGA design and simulation software";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
-    platforms = platforms.linux;
-    hydraPlatforms = [ ]; # requireFile srcs cannot be fetched by hydra, ignore
+    platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ kwohlfahrt ];
   };
 }


### PR DESCRIPTION
Fixes a few issues, listed below.

Intel's website redesign broke the requireFile link, but fortunately
files can now be downloaded without a user account. The derivation
is modified to remove requireFile and download directly instead.

Issues with quoting command line arguments are corrected.

An issue causing crashes when running in containers is worked around
with LD_PRELOAD.

The meta.platforms attribute is corrected to the supported processors.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
