### PR TITLE
kanata: 1.06 -> 1.07

### DIFF
--- a/nixos/modules/services/hardware/kanata.nix
+++ b/nixos/modules/services/hardware/kanata.nix
@@ -180,8 +180,8 @@ in
     package = mkOption {
       type = types.package;
       default = pkgs.kanata;
-      defaultText = lib.literalExpression "pkgs.kanata";
-      example = lib.literalExpression "pkgs.kanata-with-cmd";
+      defaultText = literalExpression "pkgs.kanata";
+      example = literalExpression "pkgs.kanata-with-cmd";
       description = mdDoc ''
         The kanata package to use.
 
@@ -198,7 +198,7 @@ in
     };
   };
 
-  config = lib.mkIf cfg.enable {
+  config = mkIf cfg.enable {
     hardware.uinput.enable = true;
 
     systemd = {
@@ -211,5 +211,5 @@ in
     };
   };
 
-  meta.maintainers = with lib.maintainers; [ linj ];
+  meta.maintainers = with maintainers; [ linj ];
 }

--- a/pkgs/tools/system/kanata/default.nix
+++ b/pkgs/tools/system/kanata/default.nix
@@ -1,41 +1,26 @@
 { fetchFromGitHub
-, fetchpatch
 , lib
-, libevdev
-, pkg-config
 , rustPlatform
 , withCmd ? false
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "kanata";
-  version = "1.0.6";
+  version = "1.0.7";
 
   src = fetchFromGitHub {
     owner = "jtroo";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-0S27dOwtHxQi5ERno040RWZNo5+ao0ULFwHKJz27wWw=";
+    sha256 = "sha256-2gGFAz0zXea+27T4ayDj6KdoI0ThwXV7U0CspHduTiQ=";
   };
 
-  cargoHash = "sha256-Ge9CiYIl6R8cjfUAY4B9ggjNZv5vpjmQKMPv93wGJwc=";
-
-  cargoPatches = [
-    (fetchpatch {
-      name = "update-cargo.lock-for-1.0.6.patch";
-      url = "https://github.com/jtroo/kanata/commit/29a7669ac230571c30c9113e5c82e8440c8b89af.patch";
-      sha256 = "sha256-s4R7vUFlrL1XTNpgXRyIpIq4rDuM5A85ECzbMUX4MAw=";
-    })
-  ];
+  cargoHash = "sha256-0NvZATdPABIboL5xvmBmDbqPPWvO4mM6wVB3FrOVHIQ=";
 
   buildFeatures = lib.optional withCmd "cmd";
 
-  nativeBuildInputs = [ pkg-config ];
-
-  buildInputs = [ libevdev ];
-
   meta = with lib; {
-    description = "A cross-platform advanced keyboard customization tool";
+    description = "A tool to improve keyboard comfort and usability with advanced customization";
     homepage = "https://github.com/jtroo/kanata";
     license = licenses.lgpl3Only;
     maintainers = with maintainers; [ linj ];


### PR DESCRIPTION
###### Description of changes
https://github.com/jtroo/kanata/releases/tag/v1.0.7
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
