### PR TITLE
wasmtime: disable tests on x86_64-darwin

### DIFF
--- a/pkgs/development/interpreters/wasmtime/default.nix
+++ b/pkgs/development/interpreters/wasmtime/default.nix
@@ -1,4 +1,4 @@
-{ rustPlatform, fetchFromGitHub, lib }:
+{ rustPlatform, fetchFromGitHub, lib, stdenv }:
 
 rustPlatform.buildRustPackage rec {
   pname = "wasmtime";
@@ -14,7 +14,13 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "sha256-DnThste0SbBdpGAUYhmwbdQFNEB3LozyDf0X8r2A90Q=";
 
-  doCheck = true;
+  # We disable tests on x86_64-darwin because Hydra runners do not
+  # support SSE3, SSSE3, SSE4.1 and SSE4.2 at this time. This is
+  # required by wasmtime. Given this is very specific to Hydra
+  # runners, just disable tests on this platform, so we don't get
+  # false positives of this package being broken due to failed runs on
+  # Hydra (e.g. https://hydra.nixos.org/build/187667794/)
+  doCheck = (stdenv.system != "x86_64-darwin");
   checkFlags = [
     "--skip=cli_tests::run_cwasm"
     "--skip=commands::compile::test::test_unsupported_flags_compile"


### PR DESCRIPTION
###### Description of changes

Remove tests on x86_64-darwin to avoid specific false errors due to
the way Hydra runners are set up for this architecture.

On this platform, on Hydra runners we see: `SIMD support requires
SSE3, SSSE3, SSE4.1, and SSE4.2 on x86_64.` present in all failing
tests.

Thus, do not run tests on this platform to avoid false reports of this
derivation being broken, because Hydra runners are set up in a way
that this CPU features are not available.

An example of automation marking this derivation as broken because the
Hydra runs were reporting failures: 03bc5717445bbccda21d10eeecb6ded4c12d08fe.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).