### PR TITLE
ola: build with ftdidmx support

### DIFF
--- a/pkgs/applications/misc/ola/default.nix
+++ b/pkgs/applications/misc/ola/default.nix
@@ -4,6 +4,7 @@
 , bison
 , flex
 , pkg-config
+, libftdi1
 , libuuid
 , cppunit
 , protobuf
@@ -26,7 +27,17 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoreconfHook bison flex pkg-config perl ];
-  buildInputs = [ libuuid cppunit protobuf zlib avahi libmicrohttpd python3 ];
+  buildInputs = [
+    # required for ola-ftdidmx plugin (support for 'dumb' FTDI devices)
+    libftdi1
+    libuuid
+    cppunit
+    protobuf
+    zlib
+    avahi
+    libmicrohttpd
+    python3
+  ];
   propagatedBuildInputs = [
     python3.pkgs.protobuf
     python3.pkgs.numpy


### PR DESCRIPTION
###### Description of changes

This patch adds libftdi dependency to build OLA with FTDI USB to DMX adapters support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`): played a light show during 7 hours without any issues
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
