### PR TITLE
python310Packages.paperwork-backend: Fix tests

### DIFF
--- a/pkgs/applications/office/paperwork/paperwork-backend.nix
+++ b/pkgs/applications/office/paperwork/paperwork-backend.nix
@@ -1,10 +1,6 @@
 { buildPythonPackage
 , lib
 , fetchFromGitLab
-
-, isPy3k
-, isPyPy
-
 , pyenchant
 , scikit-learn
 , pypillowfight
@@ -20,8 +16,13 @@
 , openpaperwork-core
 , openpaperwork-gtk
 , psutil
-
-, pkgs
+, gtk3
+, poppler_gi
+, gettext
+, which
+, shared-mime-info
+, libreoffice
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -30,9 +31,6 @@ buildPythonPackage rec {
 
   sourceRoot = "source/paperwork-backend";
 
-  # Python 2.x is not supported.
-  disabled = !isPy3k && !isPyPy;
-
   patchPhase = ''
     echo 'version = "${version}"' > src/paperwork_backend/_version.py
     chmod a+w -R ..
@@ -40,38 +38,48 @@ buildPythonPackage rec {
   '';
 
   propagatedBuildInputs = [
-    pyenchant
-    scikit-learn
-    pypillowfight
-    pycountry
-    whoosh
-    termcolor
-    python-Levenshtein
+    distro
+    gtk3
     libinsane
+    natsort
+    openpaperwork-core
+    pyenchant
+    pycountry
     pygobject3
     pyocr
-    natsort
-    pkgs.poppler_gi
-    pkgs.gtk3
-    distro
-    openpaperwork-core
+    pypillowfight
+    python-Levenshtein
+    poppler_gi
+    scikit-learn
+    termcolor
+    whoosh
   ];
 
-  preCheck = ''
-    export HOME=$(mktemp -d)
-  '';
+  nativeBuildInputs = [
+    gettext
+    shared-mime-info
+    which
+  ];
 
-  nativeBuildInputs = [ pkgs.gettext pkgs.which pkgs.shared-mime-info ];
   preBuild = ''
     make l10n_compile
   '';
 
-  checkInputs = [ openpaperwork-gtk psutil pkgs.libreoffice ];
+  checkInputs = [
+    libreoffice
+    openpaperwork-gtk
+    psutil
+    unittestCheckHook
+  ];
 
-  meta = {
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  meta = with lib; {
     description = "Backend part of Paperwork (Python API, no UI)";
-    homepage = "https://openpaper.work/";
-    license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ aszlig symphorien ];
+    homepage = "https://openpaper.work";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ aszlig symphorien ];
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
