### PR TITLE
ripe-atlas-tools: init at 2.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9719,6 +9719,13 @@
     githubId = 1016742;
     name = "Rafael García";
   };
+  raitobezarius = {
+    email = "ryan@lahfa.xyz";
+    matrix = "@raitobezarius:matrix.org";
+    github = "RaitoBezarius";
+    githubId = 314564;
+    name = "Ryan Lahfa";
+  };
   raquelgb = {
     email = "raquel.garcia.bautista@gmail.com";
     github = "raquelgb";

--- a/pkgs/development/python-modules/ripe-atlas-cousteau/default.nix
+++ b/pkgs/development/python-modules/ripe-atlas-cousteau/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, python-dateutil
+, socketio-client
+, requests
+, websocket-client
+, funcsigs
+, setuptools
+, nose
+, coverage
+, mock
+, jsonschema
+, buildPythonPackage
+, fetchFromGitHub }:
+buildPythonPackage rec {
+  pname = "ripe-atlas-cousteau";
+  version = "1.4.2";
+
+  src = fetchFromGitHub {
+    owner = "RIPE-NCC";
+    repo = "ripe-atlas-cousteau";
+    # 1.4.2 tag is not here...
+    rev = if version == "1.4.2" then "${version}" else "v${version}";
+    sha256 = "sha256-hEuqun39NLocFIi2lCftRvkEBbLTeST1wcnGg+l2Oc0=";
+  };
+
+
+  postPatch = ''
+    # websocket-client is a transitive dependency of socketio-client.
+    # <0.99 is not necessary.
+    substituteInPlace setup.py \
+      --replace "websocket-client<0.99" "websocket-client"
+  '';
+
+
+  propagatedBuildInputs = [
+    python-dateutil
+    requests
+    websocket-client
+    socketio-client
+  ];
+
+  checkInputs = [
+    funcsigs # For Python 3.3, which is supposed to be EOL.
+    setuptools
+    nose
+    coverage
+    mock
+    jsonschema
+  ];
+
+  passthru.updateScript = ./update.sh;
+
+  meta = with lib; {
+    description = "A Python client library for RIPE ATLAS API";
+    homepage = "https://github.com/RIPE-NCC/ripe-atlas-cousteau";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}

--- a/pkgs/development/python-modules/ripe-atlas-cousteau/update.sh
+++ b/pkgs/development/python-modules/ripe-atlas-cousteau/update.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix-update
+set -eu -o pipefail
+
+nix-update python3Packages.ripe-atlas-cousteau

--- a/pkgs/development/python-modules/ripe-atlas-sagan/default.nix
+++ b/pkgs/development/python-modules/ripe-atlas-sagan/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, python-dateutil
+, pytz
+, cryptography
+, nose
+, fetchFromGitHub }:
+buildPythonPackage rec {
+  pname = "ripe-atlas-sagan";
+  version = "1.3.1";
+
+  src = fetchFromGitHub {
+    owner = "RIPE-NCC";
+    repo = "ripe-atlas-sagan";
+    rev = "v${version}";
+    sha256 = "sha256-xIBIKsQvDmVBa/C8/7Wr3WKeepHaGhoXlgatXSUtWLA=";
+  };
+
+  propagatedBuildInputs = [
+    python-dateutil
+    pytz
+    cryptography
+  ];
+
+  checkInputs = [
+    nose
+  ];
+
+  passthru.updateScript = ./update.sh;
+
+  meta = with lib; {
+    description = "A parsing library for RIPE Atlas measurements results.";
+    homepage = "https://github.com/RIPE-NCC/ripe-atlas-sagan";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}

--- a/pkgs/development/python-modules/ripe-atlas-sagan/update.sh
+++ b/pkgs/development/python-modules/ripe-atlas-sagan/update.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix-update
+set -eu -o pipefail
+
+nix-update python3Packages.ripe-atlas-sagan

--- a/pkgs/development/python-modules/socketio-client/default.nix
+++ b/pkgs/development/python-modules/socketio-client/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, requests
+, six
+, websocket-client
+, coverage
+, nose
+, fetchFromGitHub }:
+buildPythonPackage rec {
+  pname = "socketio-client";
+  version = "0.7.2";
+
+  src = fetchFromGitHub {
+    owner = "invisibleroads";
+    repo = "socketio-client";
+    rev = version;
+    sha256 = "sha256-71sjiGJDDYElPGUNCH1HaVdvgMt8KeD/kXVDpF615ho=";
+  };
+
+  propagatedBuildInputs = [
+    six
+    websocket-client
+    requests
+  ];
+
+  checkInputs = [
+    coverage
+    nose
+  ];
+
+  # Perform networking tests.
+  doCheck = false;
+
+  passthru.updateScript = ./update.sh;
+
+  meta = with lib; {
+    description = "A socket.io client library for protocol 1.x";
+    homepage = "https://github.com/invisibleroads/socketIO-client";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}

--- a/pkgs/development/python-modules/socketio-client/update.sh
+++ b/pkgs/development/python-modules/socketio-client/update.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix-update
+set -eu -o pipefail
+
+nix-update python3Packages.socketio-client

--- a/pkgs/tools/networking/ripe-atlas-tools/default.nix
+++ b/pkgs/tools/networking/ripe-atlas-tools/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, python3
+, fetchFromGitHub
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "ripe-atlas-tools";
+  version = "2.3.0";
+
+  src = fetchFromGitHub {
+    owner = "RIPE-NCC";
+    repo = "ripe-atlas-tools";
+    rev = "v${version}";
+    sha256 = "sha256-VndPqzBG25KrybcmrJAG/9GLUT8nZNiGSEF+Amr+pP8=";
+  };
+
+  checkInputs = with python3.pkgs; [
+    nose
+    coverage
+    mock
+  ];
+
+  # TODO(raitobezarius): cannot import during tests ripe.atlas.cousteau/ripe.atlas.sagan, I do not know why.
+  doCheck = false;
+
+  propagatedBuildInputs = with python3.pkgs; [
+    ripe-atlas-cousteau
+    ripe-atlas-sagan
+
+    ujson
+
+    sphinx
+    sphinx_rtd_theme
+
+    ipy
+    python-dateutil
+    requests
+    tzlocal
+    pyyaml
+    pyopenssl
+  ];
+
+  passthru.updateScript = ./update.sh;
+
+  meta = with lib; {
+    description = "RIPE ATLAS project tools";
+    homepage = "https://github.com/RIPE-NCC/ripe-atlas-tools";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}

--- a/pkgs/tools/networking/ripe-atlas-tools/update.sh
+++ b/pkgs/tools/networking/ripe-atlas-tools/update.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix-update
+set -eu -o pipefail
+
+nix-update ripe-atlas-tools

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3720,6 +3720,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) AppKit Security;
   };
 
+  ripe-atlas-tools = callPackage ../tools/networking/ripe-atlas-tools { };
+
   roundcube = callPackage ../servers/roundcube { };
 
   roundcubePlugins = dontRecurseIntoAttrs (callPackage ../servers/roundcube/plugins { });

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8478,6 +8478,8 @@ in {
 
   ripe-atlas-cousteau = callPackage ../development/python-modules/ripe-atlas-cousteau { };
 
+  ripe-atlas-sagan = callPackage ../development/python-modules/ripe-atlas-sagan { };
+
   riprova = callPackage ../development/python-modules/riprova { };
 
   ripser = callPackage ../development/python-modules/ripser { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9013,6 +9013,8 @@ in {
     usePython = true;
   });
 
+  socketio-client = callPackage ../development/python-modules/socketio-client { };
+
   socialscan = callPackage ../development/python-modules/socialscan { };
 
   socid-extractor =  callPackage ../development/python-modules/socid-extractor { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8476,6 +8476,8 @@ in {
 
   ring-doorbell = callPackage ../development/python-modules/ring-doorbell { };
 
+  ripe-atlas-cousteau = callPackage ../development/python-modules/ripe-atlas-cousteau { };
+
   riprova = callPackage ../development/python-modules/riprova { };
 
   ripser = callPackage ../development/python-modules/ripser { };


### PR DESCRIPTION
Depends on https://github.com/NixOS/nixpkgs/pull/155267 and https://github.com/NixOS/nixpkgs/pull/155270

##### Motivation for this change
RIPE Atlas tools are command line tooling for the RIPE Atlas measurements project: https://atlas.ripe.net/measurements/ which is very useful to measure state of services across multiple point of presence.

I am unable to properly run the unit tests as it is complaining about ripe.atlas.sagan/cousteau failing imports but I am able to use the binaries nevertheless, if anyone has an idea, I'd be glad to implement it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
