### PR TITLE
python310Packages.nats-py: 2.1.4 -> 2.1.7 

### DIFF
--- a/pkgs/development/python-modules/nats-py/default.nix
+++ b/pkgs/development/python-modules/nats-py/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , buildPythonPackage
 , ed25519
 , fetchFromGitHub
@@ -42,6 +43,9 @@ buildPythonPackage rec {
     "test_pull_subscribe_limits"
     "test_fetch_n"
     "test_subscribe_no_echo"
+  ] ++ lib.optionals stdenv.isDarwin [
+    "test_subscribe_iterate_next_msg"
+    "test_buf_size_force_flush_timeout"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/nats-py/default.nix
+++ b/pkgs/development/python-modules/nats-py/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "nats-py";
-  version = "2.1.6";
+  version = "2.1.7";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "nats-io";
     repo = "nats.py";
     rev = "refs/tags/v${version}";
-    hash = "sha256-ILYZofQf9xnD294GL8rB07bg/Su7TD3KzpDTxrqERak=";
+    hash = "sha256-K2ugTwfeYrdBnXFV9SHNQP+fNvUmc1yuy53gpGmmvS0=";
   };
 
   propagatedBuildInputs = [
@@ -38,21 +38,10 @@ buildPythonPackage rec {
   '';
 
   disabledTests = [
-    # RuntimeError: Event loop is closed
-    "test_subscribe_no_echo"
-    "test_publish"
-    "test_publish_verbose"
-    "test_fetch_max_waiting_fetch_one"
+    # AssertionError: assert 5 == 0
+    "test_pull_subscribe_limits"
     "test_fetch_n"
-    "test_consumer_management"
-    "test_ephemeral_subscribe"
-    "test_queue_subscribe_deliver_group"
-    "test_subscribe_push_bound"
-    "test_double_acking_subscribe"
-    "test_flow_control"
-    "test_ordered_consumer"
-    "test_ordered_consumer_single_loss"
-    "test_kv_simple"
+    "test_subscribe_no_echo"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/nats-py/default.nix
+++ b/pkgs/development/python-modules/nats-py/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "nats-py";
-  version = "2.1.5";
+  version = "2.1.6";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "nats-io";
     repo = "nats.py";
     rev = "refs/tags/v${version}";
-    hash = "sha256-Tl5qzw8q+6Pt8mWFjCc7gKZ+mFlp+9klO0ETkibcnFA=";
+    hash = "sha256-ILYZofQf9xnD294GL8rB07bg/Su7TD3KzpDTxrqERak=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/nats-py/default.nix
+++ b/pkgs/development/python-modules/nats-py/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "nats-py";
-  version = "2.1.4";
+  version = "2.1.5";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "nats-io";
     repo = "nats.py";
     rev = "refs/tags/v${version}";
-    hash = "sha256-gLNMKLkufy/+zS5quH/UYXBIBfkZUyHtB0TiPNEBw6I=";
+    hash = "sha256-Tl5qzw8q+6Pt8mWFjCc7gKZ+mFlp+9klO0ETkibcnFA=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Description of changes
https://github.com/nats-io/nats.py/releases/tag/v2.1.7
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
