### PR TITLE
video-trimmer: init at 0.7.1

### DIFF
--- a/pkgs/applications/video/video-trimmer/default.nix
+++ b/pkgs/applications/video/video-trimmer/default.nix
@@ -1,0 +1,93 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, rustPlatform
+, gnome
+, pkg-config
+, meson
+, wrapGAppsHook4
+, appstream-glib
+, desktop-file-utils
+, blueprint-compiler
+, ninja
+, python3
+, gtk3-x11
+, glib
+, gobject-introspection
+, gtk4
+, libadwaita
+, gst_all_1
+}:
+
+stdenv.mkDerivation rec {
+  pname = "video-trimmer";
+  version = "0.7.1";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "YaLTeR";
+    repo = "video-trimmer";
+    rev = "v${version}";
+    sha256 = "sha256-D7wjJkdqqjjwwYEUZnNr7hFQK59wfTnaCLXCy+SK8Jo=";
+  };
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "${pname}-${version}";
+    hash = "sha256-cB5dVrEbISvHrOb87uVZSkT694VKtPtyk+c1tYNCTp0=";
+  };
+
+  patches = [
+    # The metainfo.xml file has a URL to a screenshot of the application,
+    # unaccessible in the build's sandbox. We don't need the screenshot, so
+    # it's best to remove it.
+    ./remove-screenshot-metainfo.diff
+  ];
+
+  postPatch = ''
+    patchShebangs \
+      build-aux/meson/postinstall.py \
+      build-aux/cargo.sh \
+      build-aux/dist-vendor.sh
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+    meson
+    wrapGAppsHook4
+    appstream-glib
+    desktop-file-utils
+    blueprint-compiler
+    ninja
+    # For post-install.py
+    python3
+    gtk3-x11 # For gtk-update-icon-cache
+    glib # For glib-compile-schemas
+  ] ++ (with rustPlatform; [
+    cargoSetupHook
+    rust.cargo
+    rust.rustc
+  ]);
+
+  buildInputs = [
+    gobject-introspection
+    gtk4
+    libadwaita
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-bad
+  ];
+
+  doCheck = true;
+
+  passthru.updateScript = gnome.updateScript {
+    packageName = pname;
+  };
+
+  meta = with lib; {
+    homepage = "https://gitlab.gnome.org/YaLTeR/video-trimmer";
+    description = "Trim videos quickly";
+    maintainers = with maintainers; [ doronbehar ];
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/video/video-trimmer/remove-screenshot-metainfo.diff
+++ b/pkgs/applications/video/video-trimmer/remove-screenshot-metainfo.diff
@@ -1,0 +1,17 @@
+diff --git i/data/org.gnome.gitlab.YaLTeR.VideoTrimmer.metainfo.xml.in.in w/data/org.gnome.gitlab.YaLTeR.VideoTrimmer.metainfo.xml.in.in
+index 9bd25b6..c627369 100644
+--- i/data/org.gnome.gitlab.YaLTeR.VideoTrimmer.metainfo.xml.in.in
++++ w/data/org.gnome.gitlab.YaLTeR.VideoTrimmer.metainfo.xml.in.in
+@@ -19,12 +19,6 @@
+ 			Video Trimmer cuts out a fragment of a video given the start and end timestamps. The video is never re-encoded, so the process is very fast and does not reduce the video quality.
+ 		</p>
+ 	</description>
+-	<screenshots>
+-		<screenshot type="default">
+-			<image>https://gitlab.gnome.org/YaLTeR/video-trimmer/uploads/e840fa093439348448007197d07c8033/image.png</image>
+-			<caption>Main Window</caption>
+-		</screenshot>
+-	</screenshots>
+ 	<releases>
+ 		<release version="0.7.1" date="2022-03-23">
+ 			<description>

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11742,6 +11742,8 @@ with pkgs;
     pythonPackages = python3Packages;
   };
 
+  video-trimmer = callPackage ../applications/video/video-trimmer { };
+
   via = callPackage ../tools/misc/via {};
 
   vial = callPackage ../tools/misc/vial {};


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
