### PR TITLE
openvpn3: 17_beta -> 18_beta

### DIFF
--- a/pkgs/tools/networking/openvpn3/default.nix
+++ b/pkgs/tools/networking/openvpn3/default.nix
@@ -4,7 +4,6 @@
 , asio
 , autoconf-archive
 , autoreconfHook
-, fetchpatch
 , glib
 , gtest
 , jsoncpp
@@ -24,30 +23,21 @@ let
   openvpn3-core = fetchFromGitHub {
     owner = "OpenVPN";
     repo = "openvpn3";
-    rev = "7765540e581c48721752bcad0b3d74b8397b1f73";
-    sha256 = "sha256-v/suF/tWfuukQO1wFiHRzC7ZW+3Gh1tav6qj0uYUP4E=";
+    rev = "c4fa5a69c5d2e4ba4a86e79da8de0fc95f95edc3";
+    sha256 = "sha256-VhQkx35JKNqXKgg4i+/aJYIg3iXPGlC57wDrjDpvTyE=";
   };
 in
 stdenv.mkDerivation rec {
   pname = "openvpn3";
   # also update openvpn3-core
-  version = "17_beta";
+  version = "18_beta";
 
   src = fetchFromGitHub {
     owner = "OpenVPN";
     repo = "openvpn3-linux";
     rev = "v${version}";
-    sha256 = "sha256-ITSnC105YNYFW1M2bOASFemPZAh+HETIzX2ofABWTho=";
+    sha256 = "sha256-4TKRnHjEm6QRE2artAa0t1VC+0XPgz3VpCfQS8tnrFQ=";
   };
-
-  patches = [
-    # remove when v18_beta hits
-    (fetchpatch {
-      name = "dont-hardcode-gio.patch";
-      url = "https://github.com/OpenVPN/openvpn3-linux/commit/f7d6d3ae1d52b18b398d3d3b6e21c720c98d0e89.patch";
-      sha256 = "sha256-Bo5uaHadMTDROpwM7Y5aXhCoGUrsAAkSxeXLLhvOeEg=";
-    })
-  ];
 
   postPatch = ''
     rm -r ./vendor/googletest


### PR DESCRIPTION
###### Description of changes
Bump openvpn3 version. Changelog: https://github.com/OpenVPN/openvpn3-linux/releases/tag/v18_beta
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
