### PR TITLE
[22.05] thunderbird*-102: 102.0.3 -> 102.1.2

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,665 +1,665 @@
 {
-  version = "102.0";
+  version = "102.1.2";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/af/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/af/thunderbird-102.1.2.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "f69e2070fe8412b3c0cfeb195806cd9154664e52141320f89fae759f520f9a7f";
+      sha256 = "045a2ae8a4da72b4ebe18800b03a5a5f722fcf2a26a3fb382b4412f5be1958bf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/ar/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/ar/thunderbird-102.1.2.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "7cf14a50702de7e13d8d819ca8fde40bc44d7bd6857292f5f8f0801d9279377d";
+      sha256 = "5d3b5ef861ef742025be92e49233b6f1ed91ae5bbc19e4819cfc68ad139663a7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/ast/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/ast/thunderbird-102.1.2.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "c96d5e3eaaaf97b89771f969da3c0a6efc2404eb1ea5a88cf82a2cfa82dd94b1";
+      sha256 = "8a9255162105f0148aa12a5833a5a27294dcc5dd48841d871808031bf08d0e64";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/be/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/be/thunderbird-102.1.2.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "29ef1905e0a9020647ddf2b3c77d74c26c6e78a312162e7a951e9dae1774f0a1";
+      sha256 = "b46b07e20417ea588645893d3aa256acabf1689bb226e439983c55d99049dbab";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/bg/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/bg/thunderbird-102.1.2.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "4d09f8f22d97e8527c7161c7b98f75c94acbd2a6eb8ab3e2f46a936f4430b143";
+      sha256 = "090e8d450209b3584cf77bbe304c914d903be40491113d8667126cc7607d0ae2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/br/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/br/thunderbird-102.1.2.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "e383b9a21c6e6a3cab0da875d079a9c304e2a8e5a9d6bfe1956c4fad8d635a9c";
+      sha256 = "b5aebf8f6210a2234041cc8774ff94459c38da193abfc222ae2994bba1f9b5b5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/ca/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/ca/thunderbird-102.1.2.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "439efb2053a5e41c2bae8ef8c3e02f085736763837d8f95738e1fbb63c01bbc0";
+      sha256 = "67e6fc3cd2a4ba0ba9b4a45cf4acc7a3cded9dea42a4e2826f06a750739a61ab";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/cak/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/cak/thunderbird-102.1.2.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "d7d2817be7f68577cc338e34ee2e56c7a89fd06537880e93c804ff435dc64854";
+      sha256 = "bba56f6fbeb8441df134eb4a3179a6e95494e55feda1f8e697e7d1d8c45cbfc5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/cs/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/cs/thunderbird-102.1.2.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "e49042d9738857a2849a3f3e9c3238c92fb692a082242d280ed60d1d3a0129ef";
+      sha256 = "d6d586b4c28f189006928605537e73d33d4e6f3cb2cac7762961d300f180d7b7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/cy/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/cy/thunderbird-102.1.2.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "ec89d4d5fb0ad334c8dd368fb595c19370777d94016fc057270cb441382c4c3f";
+      sha256 = "80bedee4129f6ad3cbe452ffd744ae1273d230bff6b5ea1a149f7884f6c3a856";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/da/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/da/thunderbird-102.1.2.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "01389e135d567d32fb4bd76f073892a21c61f34df384135619458e3902e8817f";
+      sha256 = "fe828dcd369eecce999dcada43703e7ae64f40d65e1a527aa1c8b5a12872da4b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/de/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/de/thunderbird-102.1.2.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "61b65e10d1372547a792f81345460c814e7733b1a89d079e6b4317b0a16f70b3";
+      sha256 = "c1caf3070b417ef809203a4da6bf93cdc328a9b240304ea609b52f707627bb69";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/dsb/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/dsb/thunderbird-102.1.2.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "d3364f68190e427b0b5a12a638633a2bfd23810d6e59c27aa6736881ecfb237e";
+      sha256 = "8c3c81ad3b6067d51261aed574a6fd9df2188e6533540794763d6d58cf323849";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/el/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/el/thunderbird-102.1.2.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "67b289cb548a48e272d82b66097f2041c0063a9cddfce54c37d74a45acf25b77";
+      sha256 = "81ad4bc8a3d1fc7da97bb8655b12363c2a4033f39ece73ba37097315b6df0c70";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/en-CA/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/en-CA/thunderbird-102.1.2.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "23c42a361b0bd493490bdb5393f06c3eaa4a07f928b9e79bb26b4410ea8c42f0";
+      sha256 = "3487c91dc802bb0c284bd87dfaddd2aac907aca7ed9bcdde8d8d74d79a51eea9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/en-GB/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/en-GB/thunderbird-102.1.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "b75c8c65c18e0fbc79035fbb305c7f5478321bf0ea2ac56e59b0105c59d398ec";
+      sha256 = "631f9c56e3b9dd3d606cf031a432c05f84c333c47067649264fd35e295d00910";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/en-US/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/en-US/thunderbird-102.1.2.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "98d872089fc7957f359ffb2711023c6613803da3ab773dcaed3bd20b906c2754";
+      sha256 = "5227881c30d9723386a9296c44c5253fe930c2f32b094c63972e4ba3a6c316eb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/es-AR/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/es-AR/thunderbird-102.1.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "88358fb4fd33d59b349dcabcb02237ac9cd7c5153eb549cc09f452913bff79b0";
+      sha256 = "094652b5b87bfe24389ef15acdb8a62b2bdee5b16d0ea3fa8b10b47ea8371391";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/es-ES/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/es-ES/thunderbird-102.1.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "b1722ddb52e96a4d93a31687d349f343441f6f3e34d2d2e92bd8368dd1c4e709";
+      sha256 = "63fa635cfc4e0d1c1365589090a1d01025f4b03d826f09530876329d23ab3f8f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/es-MX/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/es-MX/thunderbird-102.1.2.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "a5a51e2059127fedeab3c6c137c206b0d538bf39cb9962e07f16887bcdec1b7d";
+      sha256 = "efa60acc622b904efbf99f8708f236221f474da529741da7ae411300c0a839ac";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/et/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/et/thunderbird-102.1.2.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "39a360d73c2f21790cd4c87e7ea9a158b7d9c7f4c9b32256c8104a2d2dacb238";
+      sha256 = "c9eb969de36dddd32eca24c9845093caa9afffaba2e22e1c84ca8b1a1c39850f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/eu/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/eu/thunderbird-102.1.2.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "72f8ad94b03bfc8aebc849afbd7c0d3ac92a33f756ca00887acaf25b88431451";
+      sha256 = "65348b4703f68daa83f2964593c38fda497fe2426472138bdbc5c7a7eb48f348";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/fi/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/fi/thunderbird-102.1.2.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "fbb7630f8e514e2e5d744e4772d8d4ecfdecad036eeffaea19a63c8e79076195";
+      sha256 = "a229d9e9d7ea87e940d2aff60b0ee8e0288d3e584b0c73a45d1bb34d16d57117";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/fr/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/fr/thunderbird-102.1.2.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "e0abffb51251d9d631a4b4862ab4d01e9009efd06a6f01b633f3dc5d254c12af";
+      sha256 = "714f5aefaab686cf6daa699f4e00455e2a4abf2414b5bbf3436e9020694ed27d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/fy-NL/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/fy-NL/thunderbird-102.1.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "e8abc599e7776a4fad0d2f4434d21b1faa9842e23ada032060ac7bd9d451fa5a";
+      sha256 = "89198e512ee6a8384a95739f718b89b3309b51c2afbe3f86841724e829990d05";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/ga-IE/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/ga-IE/thunderbird-102.1.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "5f2799f139076e3949e65e8ce21baa4b8b0a24c89ff07afc1f96c59504badd76";
+      sha256 = "4b68b313a633aab863abad1ebf80385a8a2bc95915ce74b7277e9bd6ec95fba0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/gd/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/gd/thunderbird-102.1.2.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "c19cfd9cee3f2aa3ba90a16317bc7b5e746eac86f5a5ef99e403e6dcfc960cc1";
+      sha256 = "8703b7388f1f183707682dc9f29d847a56a3e61b8018361e583bdb2081d0a92e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/gl/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/gl/thunderbird-102.1.2.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "a432c504156ca531802cf3fb59eec04c5d985a90c3f3d05128af8d9826fbc107";
+      sha256 = "f46a7c1a5e6d6b413220b2edcd8d0e9c3d0ebb7fe55599b3f151e8b82d0d0d6f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/he/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/he/thunderbird-102.1.2.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "c9f87690c37ac80d53a3aeb6fc6b0256648600021212aff94d64ccdb2ece4d4a";
+      sha256 = "cb79bc77109b9e36874755f497ff55e7df29dd45a411df134e342efae4df91a0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/hr/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/hr/thunderbird-102.1.2.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "d608740702e368fae7ea29101816399297a0e570dfd00bdf46f50e220a39c1dd";
+      sha256 = "f7f83473148269479dfa94211c3465e2dfb1e746a61c749d8a4648e37790832f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/hsb/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/hsb/thunderbird-102.1.2.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "036937820bd2e5526669eaf47c90c530c380683101ab17d5c3605be35dd3d3c1";
+      sha256 = "f26ebf4f971502b6a5681b6888a65b4dbbd49bc7e44d99b2580bdad1e656be44";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/hu/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/hu/thunderbird-102.1.2.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "5b0cab788a5cfe5f7aa4df7edbd7dccb9343db3a2d53d719d95f63871e0b9083";
+      sha256 = "d05150adc28458e01b52a45d633ce895713bc4fbbc1a867bf61efa4459682fc2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/hy-AM/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/hy-AM/thunderbird-102.1.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "e8b9388741f0623a1d4272b6fe5c3385d2c517e44889ff3d412e7fa9c9650b9b";
+      sha256 = "bb2d7f8167dc30c1a927701022b927f6cd21aab4e60e02cee8274badb196c77c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/id/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/id/thunderbird-102.1.2.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "e00711cd79850ccff35b8ff95f491e10b504cc49ec024daa408dabb4b39430be";
+      sha256 = "06342277629f9f42fb6a2ccaeed5421047cf2dec9dd912b0825ee9ffee2d1aba";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/is/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/is/thunderbird-102.1.2.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "ceb0aa9e639735c5a409d0e2bc57a0ef97ee5f0c65e9151824d4aef8c2e6e4ac";
+      sha256 = "ffa8a785f1a7c5c670782e87d492c9d2831ede93c178b1038f8735484036f8be";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/it/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/it/thunderbird-102.1.2.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "cd24a1154a4b6fb3c417a19213e2980b25326fadfd09987854bd3d9eaf87e903";
+      sha256 = "97d0433d6c49d445006738fe43cccca9c76216e065b0d6f126eb50084f5ab265";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/ja/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/ja/thunderbird-102.1.2.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "f64fe4150b19e2575699dbcb5ac09f47773cd3c0079d53f1864985dca2448ee0";
+      sha256 = "d8f885cb04693fc9a079ac541350b03805ab053b5aa60e49b037ebdfd5532019";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/ka/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/ka/thunderbird-102.1.2.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "ed485c31ee0eedd34c6be9aa4cde98f608e25a6d2eaa68086a9bd13f65d66399";
+      sha256 = "e07636d63fc6b22ea1534022a7e1433da1a3ddc5a22dd0e9e2245f2a18d4bdd6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/kab/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/kab/thunderbird-102.1.2.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "3b8a00228c9f62f55e13710df17e5a9cff57840a98935c5ba7a08ada4ee0e3e1";
+      sha256 = "a0a087c5bbdc1acf2ab45ba164ce3a390cb40496b5c82a8821fff9e23641a193";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/kk/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/kk/thunderbird-102.1.2.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "910735678c009b59ccb82b43c740c2ee23a0960472386fc68e22fa108acaa84c";
+      sha256 = "97548dde66cc92df20e2f807e70d57a4a72b4a6f5ff18caecf26e218ac218ca5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/ko/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/ko/thunderbird-102.1.2.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "7a5b3a71a8b88113e8c7b15070bfa567e4b458b73a06c24ac44602879cf833d4";
+      sha256 = "bc51227d4f7bfd5c45b0234da669d8b6998c2cf109fe298e6edac65a34df5b02";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/lt/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/lt/thunderbird-102.1.2.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "391f60f21310ccad85ff47ce1cf30f9ff4884868c5cb4ba663293d576fe2c8fe";
+      sha256 = "438017e6f6f6dd71553a0248282dfe25922121af6c4b14fce45dd95defd3a519";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/lv/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/lv/thunderbird-102.1.2.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "ab97757d9cdc310e0e604420a1dfb75a6105100dcdafc29daff67a581bcb098b";
+      sha256 = "4e631147ed90b5eaf92f9c324f85620e59b22d96d4dba225567d13123393713e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/ms/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/ms/thunderbird-102.1.2.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "dfd79cf270836ba6bd0bdaac17648d49b180c6beb0547745c3c5e7b55649c4ab";
+      sha256 = "26046b38c260068dadb29d779a0a7a4a15fda0c5aba9ace9e078554d01f337e4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/nb-NO/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/nb-NO/thunderbird-102.1.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "176f52c21e9f7e538b3bfca7d00ae1cce4e06e5ea10e042b2ca5d33473dba574";
+      sha256 = "933a7042a64c0f730aeef00449f4b05ef1f72bf031c31f3f4348c57f75243ff1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/nl/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/nl/thunderbird-102.1.2.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "6624128d7119e8dc3e0c52b0a4f1961c12b404cf3409c335e34e0297d19de5ad";
+      sha256 = "8a221cb6c2f308c8b1761e436ac69b3e4367afc5d0b0bafe8463a19605d23307";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/nn-NO/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/nn-NO/thunderbird-102.1.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "4637047fa46220e3af16c8a3e65246ddd31be49ecdcc76f3ad483048620c5dff";
+      sha256 = "ab4182c6d11c0c4deb3ce09608e2c8ef771400562f3dceaa1c41e6592d376bf5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/pa-IN/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/pa-IN/thunderbird-102.1.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "5df91362352f2e847cc0cbc8a5736f9ab4eca89da0a1a6c029aa343bfc69c062";
+      sha256 = "bb9a7c35ee2b73217a80c6a9fc05c9ddf41cedf04b4fe872c11959ee5e80e95c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/pl/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/pl/thunderbird-102.1.2.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "8a45ef1a268da00b8712d59bbd2fd92464ac0526eb948cf9e17e28cd9166e247";
+      sha256 = "aa705ada7e847104cfffc8e67cf2261b0c546a0fb6522aae8288cb0332ef480b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/pt-BR/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/pt-BR/thunderbird-102.1.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "f9065d7b788d17b922be39081ca168fc443942aa1ce49fdfb8c7f42e9c5d4cd7";
+      sha256 = "1871803eb0df4341aca0a5e49956fdaa5b8a180b1a9b5d4891a6b5145141f0fa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/pt-PT/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/pt-PT/thunderbird-102.1.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "26629b8d1c3b85f1d8e8266ea724347f331c7fb2d3a3cf74aee5940f28e11bb7";
+      sha256 = "dde614c584721d3d0ac34f022000691d9138777f5bf016b1f73b50eaec5297e6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/rm/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/rm/thunderbird-102.1.2.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "62c6b0f824901ee4c053d9a36da71fc75249dc0f0b9199f69ea55f5a0bec4348";
+      sha256 = "748b3db1b3984cfaa6deb55ab14bae5001a43a44013a9f0533b20dfb0914a171";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/ro/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/ro/thunderbird-102.1.2.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "7315cf49e824cac56b21330e72cc3d2115252356b461e95140517d1419800d12";
+      sha256 = "9ac16bcebfb28ab3f0eeec7504c62b8965d25d0d199b4e2f371feed0daf71298";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/ru/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/ru/thunderbird-102.1.2.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "ec4e44b4938dc6028a2916e0ef0fbb080e54d0e86a91bee028bdcbb81c99631d";
+      sha256 = "32db96e0aafba6a886e90c2adb89363aaf06b0a03abadca558cbd8c97051d41c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/sk/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/sk/thunderbird-102.1.2.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "bc1615bb7b638e84da76af24f6c491945b097e20a69bbcac0871410e2185ff3c";
+      sha256 = "7a16cbfa0944c6592285d26a9a88ddd4f7d3100af139bfc079aced2252e6564d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/sl/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/sl/thunderbird-102.1.2.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "7f1c542984ec16f02010d1c681af07805614cde200ed640776f47c260399cde3";
+      sha256 = "165468dc4a5a012e7d84d7cb5a83d0ebc907fe95581dc9faf838bfcdf7958f49";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/sq/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/sq/thunderbird-102.1.2.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "5e55e7394315cc6dcf69c0bf7e260240e8c09943df9b3ca9f9592b07aa84db09";
+      sha256 = "7ada316a5bad8752666d7497365863589a5693a6f9579a7978aafea69ab95be8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/sr/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/sr/thunderbird-102.1.2.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "fc325dc18fcb2e7e00b7bc3657728cde92e90dee38162e5b2b5f86b746d0fc96";
+      sha256 = "b7a3a141050b189051010a977bf85f27135f8ee10af0c70dcbe04780c7f05489";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/sv-SE/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/sv-SE/thunderbird-102.1.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "736b18f75b5c9183a8a0831f002f880142387a839f8ce8f97d0b1f8509cddadc";
+      sha256 = "35b058a42ca3627f9695eb22d1c8d71ee72aa4bc3be2e072aa9561cded1d6686";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/th/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/th/thunderbird-102.1.2.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "d15e8fc2d381465ce280857fe7e1ffab22e7b90c922c59b06245fb189b97b4b2";
+      sha256 = "39cc0214918f882ed19b0986f500d7b24a29026b2651f35b798571460f3cf022";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/tr/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/tr/thunderbird-102.1.2.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "588f8fd019fb8a907fb06fc77a6fb7e292265fc2b66ecf29b23301df478a0fda";
+      sha256 = "b8f2d411457ce94ee48f98725f996098f3868406ba82ecd4a9305a17e42aaccf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/uk/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/uk/thunderbird-102.1.2.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "2d01f335696fcf137f4125e585350400224283e449c5ce9dbd6f6b1b0ae41c9e";
+      sha256 = "e41fb8cbe8da3f632992f4fd15e812b2e10e5ade070f3970446a213724b3736d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/uz/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/uz/thunderbird-102.1.2.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "8f2205b79e96cf946392ed30e10cd0b375ef4ab7a6cf9882bd3a268abac2d47f";
+      sha256 = "26fdadcb748baf1c699a23fc90caa9cb342cf93bc18b110c6efcce89b3eb555a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/vi/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/vi/thunderbird-102.1.2.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "1bd1939f20964e202328a686d5a5da53d477b0da3a1e6a46db21ba6013bf5a95";
+      sha256 = "a91cf22c3592346599ede9495f51b0aac22823194f4ceb4d34b785dfd494d47d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/zh-CN/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/zh-CN/thunderbird-102.1.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "27773d8544cf40991215d94dfe8752fb304e83742ab71e223b3f3fa0a2349d96";
+      sha256 = "db5c8a102bd3038105f032339a055c7f859ba64ed5f013aeaabae66a5f9b7c97";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-x86_64/zh-TW/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-x86_64/zh-TW/thunderbird-102.1.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "c5e9a289305eaa08c1479b711bc2f8a96f420198e26a09ef1bcd7dd66d19ac16";
+      sha256 = "6eb7070f15f25eed3a4af81ac4d10444e9bf8fc16dcc20d1d0b2877ca508c3ad";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/af/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/af/thunderbird-102.1.2.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "afa495817ab077e447ca52522516c1872c829d5a3947870b120f656a016366c7";
+      sha256 = "0389d59440492dba14c4600618da93b1d6164c2942b160398ef48d2d33ff6afe";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/ar/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/ar/thunderbird-102.1.2.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "f9d940d674838dd116eccb794f7643d44236c593b043b99243650de46e1ebec9";
+      sha256 = "b1aa3d6f9bd3b124ebc81e4b7bd244e07267aa9fdb433a15cc55259678b65d59";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/ast/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/ast/thunderbird-102.1.2.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "88d9f54c1685f74981ea8be205f4acdaa80f2fc5845a9135d6b307ccf5873380";
+      sha256 = "39557a3ff8b1b9f334fb60ba0f21f652eb052e2ce52ca69132c256ab18f36484";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/be/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/be/thunderbird-102.1.2.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "2d355c0834c68e1fd8a9205b41f88afc1547886e5f3d2bc37b5bdb245fdff390";
+      sha256 = "c8ad677a9c20d462cca53030ef21708668fad7f6ca2432e48159cdc35b283416";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/bg/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/bg/thunderbird-102.1.2.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "5f2350b80cdbc3fb2afbc64ce35542f3848ac397561f0bd63b2b4541a5b26226";
+      sha256 = "248fb0b4259c9936d0ab7246d49749d79cac136843393cfb42fb8fb1e60a3c4d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/br/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/br/thunderbird-102.1.2.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "7972d7e086b52cbfbb7134b54945a265151fb1e9e8057754d45321449583f704";
+      sha256 = "4f7b9cb23ce763d4c80bbbfa55f37dc950c768620891a1540a4cd2c2add61120";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/ca/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/ca/thunderbird-102.1.2.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "75c7002c3f5b96ff7b4175a62b9e77bf52bbdd33c9b9a5d62041f3fc78a96aad";
+      sha256 = "95335a5eca928b64cfd3b66bc3fd04c013300122ebd6120d53fffa5450544532";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/cak/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/cak/thunderbird-102.1.2.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "a653c97a2e6f1c9631b2845350c8a370f19fab363dea97e23b4bb0c31ac33a57";
+      sha256 = "f70d912d44e5d86dc565ac1ea517178e1c02a054805a1fe2f46c0749bbc94327";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/cs/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/cs/thunderbird-102.1.2.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "183350cd3a58c6e9826297e17bfc6fcdf35a49474e22b1f6a154b3601d445f2d";
+      sha256 = "27ca0c7c25ea1eddda5416a8e79e21f5c56d11c58d25f7716f8aa5e7628dc3fd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/cy/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/cy/thunderbird-102.1.2.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "c6fc5ac93f7e9324ae021890870edc1ba71779319f22bbc9be05d2cc68e8cff0";
+      sha256 = "24927b8410cef3c9ed234fe1ae4d264333e4d14577715580817117479d4039b5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/da/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/da/thunderbird-102.1.2.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "68492bfadbf6f1c13375a9f26ddb47c7eb7bdcd2d4c16057a7bd3ffd49577758";
+      sha256 = "bf34f47b5397ba7abaf8df61deea65a28f61d66dc91502d41fec5f8593fecc75";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/de/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/de/thunderbird-102.1.2.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "35151be19918dfe7241207d80c6c0fae11f503b4ca62729a49e19e3e30695a66";
+      sha256 = "372606ca06a8e86ec7d39f9da0d6943b1dac6389aa5223ceab572d7b17aef4e1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/dsb/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/dsb/thunderbird-102.1.2.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "e17871f7471371910f63ae43b241f10c26918f4784f280034b8685741c0219a3";
+      sha256 = "b771a808ed13d2e21b4411e3e1b22e0a4159593cdf2e5eb7aad37a19b58892dc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/el/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/el/thunderbird-102.1.2.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "2404a1c9649563fba40700e22f9298c0eebc2c87b82da4cfb41b6d86464fabd1";
+      sha256 = "da57fe1f356d9b26bf49289e4755e3faefa31f0719ff00f8af7e3b832bf59e4a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/en-CA/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/en-CA/thunderbird-102.1.2.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "2cf311e32cfff88d859036d092cae9fd559755a0df006f9ec702353ed343a93c";
+      sha256 = "a4abeea1e5477fcdbb2a5606610eefeb40fdd65e6e418042058e684b86b2c30e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/en-GB/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/en-GB/thunderbird-102.1.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "76b0899214e47317fc222aadd02f330f90e181b3bb71846f624a25f3939c6b00";
+      sha256 = "8ff8ca611dfdbd03b63eff740fa70c4fceeb292157af3718a79499b77d6954f7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/en-US/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/en-US/thunderbird-102.1.2.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "ea4abcf1bea79b2e5a20ea605a46c5b5a028a2707d6ea4071d784845581aa850";
+      sha256 = "5eb0b8c567be77cd8231ebab5269acbac310c2d01cf6f810c5e321496884b94c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/es-AR/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/es-AR/thunderbird-102.1.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "f82541bfd35e4c497f133f60801bc2d880673e59947c18a30effaeed6f691e6c";
+      sha256 = "6e19e0ba0a54e175b5810a42a2f086a07be421dd6f6c227c60b870324042b2ca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/es-ES/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/es-ES/thunderbird-102.1.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "0da6aa24d52b4fdd71ccef9cbef96685d7db47d98ca324e3a92cdca8d94f47cf";
+      sha256 = "a626601734b040c32a1e54309799a6d953719a38eec731c6ef23b09d544c282c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/es-MX/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/es-MX/thunderbird-102.1.2.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "21a9445e0393d524c052e6e6013f514c62e3584ebc34b662b19e57fa698a1c87";
+      sha256 = "209a1a0b6d86301740846943ea62acd1781456210f3b5c3b9191017730a2dc72";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/et/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/et/thunderbird-102.1.2.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "c1884317fea7da7b9fd20fb44c7eb220cd8d48fa6eaece33cded9a561af34410";
+      sha256 = "9e4bb92b59ab36e317e38986c42a3231c18761a9fe6c3cc3aba7e672fc8c4334";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/eu/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/eu/thunderbird-102.1.2.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "bdd0a86395f8dfa7eaeee41b692c165288c344099ee718720c3757b1fba3cfb0";
+      sha256 = "68ed1a1137601c4f2f57e6afc146dc8700041b5c39931f1eb80b3c3807ab515e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/fi/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/fi/thunderbird-102.1.2.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "7dc7fe5d742af4329a7e33c4171266e54fd17a6169ad35f605bb199f2c4301af";
+      sha256 = "71fbf151a51727cd43f56dda7039442246bd6faa98a45ccef5c8b8c040315064";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/fr/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/fr/thunderbird-102.1.2.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "11ead902c94e420786133b7d86aa25489d88d8256bcf0c41d07ba812ca855cc7";
+      sha256 = "a2119c1e7e652d1f2423e62be999c70303fafe1498df31c74e9254f8f6b7a63d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/fy-NL/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/fy-NL/thunderbird-102.1.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "405191d135b2b13fcfd4340d5935df8b3dcac9c400c6906a4ea5a1feeba7eac5";
+      sha256 = "6dc49239f5e7abfbd460e35d79872edf264911ebede3bbaed30f36af9ba16400";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/ga-IE/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/ga-IE/thunderbird-102.1.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "d46a6a7cc2e372ce90057e4da5caba14b138415584036ede71d1a20fb65d0fdc";
+      sha256 = "e5faa22d057228ca0a982601469e2bb41a1782e61fac694b5ae458e74f84fe37";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/gd/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/gd/thunderbird-102.1.2.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "ef5f929513187003e1ca655fa1cc8680abc88d84331637035da8cf5d3e34e2fd";
+      sha256 = "ea99f37e3310978ae95bd04b2dbfa8f7e7f4f2f7dc41c72df662c3778c9941a5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/gl/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/gl/thunderbird-102.1.2.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "bb53c116baa60f56d58751dd14ae6d500b05956c521d3d6eccd2da254acbf574";
+      sha256 = "6bafaa93902648eb3964e0e1bbf6743fb4b4415e98e29b6f678ccfaf99a7120d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/he/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/he/thunderbird-102.1.2.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "2e04a433ffca23eff89dde4dd688b4c3353768db5eceeba5decf796891f4d3ef";
+      sha256 = "3f7abb2eadbb725b5e2e3a71863b0ac5a2f5b2747d4f207c1cf712ba36d1d9ed";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/hr/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/hr/thunderbird-102.1.2.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "a01fc8fbfcec7d30da99453a5bc8dad86af62a4d5ca347cc31e68ea3e4815004";
+      sha256 = "2dea47835e6b7b1c40148b449dceb993368558f9c8c40a9c5b4506a8409c9bb8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/hsb/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/hsb/thunderbird-102.1.2.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "415a00ff235c8800dba2bac4829eabbdadb8aeed128c5a9ab5cafbbdd012f9e4";
+      sha256 = "d58fab220f516fbf1a4e219b9d1e64882a7b1fbd905bc07b9930815857eab991";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/hu/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/hu/thunderbird-102.1.2.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "b541712df9b68013b8efab7e2535c6d8e338d9501db3221081e8b3959a2ff054";
+      sha256 = "40fd326287e681413b5631ffdfbbb07bae2aedd15d35f73c4dd0058fe622a315";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/hy-AM/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/hy-AM/thunderbird-102.1.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "9e91e643b5a3e96098b5c4a42845b907ec0fc3875a131a7aded6467ead53afde";
+      sha256 = "2e3976460f2e49805fef9e455eb24647bb0a9c77f4302b8e1f9e7caf0a4f69dd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/id/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/id/thunderbird-102.1.2.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "4e6ad5de0dbe913f6bc76661295267dd4b0d1312f0d0492c7f3c585f2d5ff826";
+      sha256 = "4d1782b347f631547902c4896eb809927e459e031cbadd69e561cec0d67f0be9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/is/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/is/thunderbird-102.1.2.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "650d8cd703d04ba54f41e003ac2f872a7a602d8a6cc6a10e3aaba015972ed5c2";
+      sha256 = "948dbf54d7a325500ad93fcb2664fe2a198defda12cc46ed9df60658c1dee3ef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/it/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/it/thunderbird-102.1.2.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "8502e7cba349e4e0e8baf3858698ee82e281f4382d2d0ed01a7a7834efeac8cd";
+      sha256 = "b8b56dbdeb2649473971d9b0dbfb759c615f300dda0484536083be1b9bfa0f9e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/ja/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/ja/thunderbird-102.1.2.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "a6c372b2501c0fe0a7005386ba24c9a878e5eb85551494be1772f27718a0d116";
+      sha256 = "156f2aada12af105f8751ebd15c9fe0e55e7c590e899eec1c45560d6ae36af80";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/ka/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/ka/thunderbird-102.1.2.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "57b0712bca1a9814ac57083e2f06d2c5430df8ab77112e1ab130f36607fa041a";
+      sha256 = "2ef2f49658a117de9de1ac194b83efa3a3b2a30c64ddd6c9296f14c2618bc1ee";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/kab/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/kab/thunderbird-102.1.2.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "dc4fbc557007e0c6547a7b70fa9f0e1347e3528defb4cef87acb9182f109dbf2";
+      sha256 = "95b14e777593530ba764cfcc8c60726b41637b49801fdd22e9fb3c07e2abd84f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/kk/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/kk/thunderbird-102.1.2.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "62b8bc8a331cb90f73933508a36a7b44a670c464f8f1401ad6415e65c897aa17";
+      sha256 = "f032b6a3295b85512b68ab436b8b83dca63a3867a56a3623555720d2905bbfe8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/ko/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/ko/thunderbird-102.1.2.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "f20ca476e69fca6d160d28bc6c0d3289f43605f224b8455f6dae2b886109ec68";
+      sha256 = "3b75a679e817c1c4eee93e91c71ee329b0b8fc35dc4695bbeb1b6fa3f4cd71b2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/lt/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/lt/thunderbird-102.1.2.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "e4101bcc9654892c2b9d3af21482dceeaa5edfbd81a8f1b0edb3d3489364839d";
+      sha256 = "00c5a79529e8daf343eb0334d1e9e5a7506c2ef6b2005a715e5305a3403b4b23";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/lv/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/lv/thunderbird-102.1.2.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "f40e2b87e2274abf51a479c9c768d05bce3e408ee0649424a2c8cc4763dc4963";
+      sha256 = "84fd3ae0a1acf4af8dd00edbf612bd1186130f757a6523f8f8da124eef2d47a5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/ms/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/ms/thunderbird-102.1.2.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "6c59ec75380f5eb73a4fbd6362c197f2b3ba24b65b7d1152df4fdbb1e3a6e194";
+      sha256 = "3ca1fe79a9f8d9ae49ad2815c74133126d4b1b6e982903a6d2d4612f8e40c2e6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/nb-NO/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/nb-NO/thunderbird-102.1.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "93b7cb3947d9b411847ce7919854d28f260d026ea9c833c4bb1e4a9193dbacc9";
+      sha256 = "1f26868424c8ee51d45254b8fd6e9695de1223d2574e7e4de2037b2f4c34af62";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/nl/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/nl/thunderbird-102.1.2.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "688aecb96ecd57c9ecdab92090c528cdd8e490c8a69c7171ca6e68ec0cad5de8";
+      sha256 = "953cf766dcc14ca591ae5633f8dfa07abe757e0dfdd5dc3ba8e2caba506b6cf8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/nn-NO/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/nn-NO/thunderbird-102.1.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "61927c3ded1cafc12f87db61fd344881474584cc37d8fb40f8a70c2a32ba7ce7";
+      sha256 = "1098dbaf39d678db1a8267f23f4e3dcffcf56cf29a3626db54d2d99f4323a14b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/pa-IN/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/pa-IN/thunderbird-102.1.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "1746d3f779dec7d1fa488d0eb3f6c61e492ebe5d3e022644a4af3eb8cd85edfe";
+      sha256 = "8932202b4c411b5be0cfd13cab442998ca1799d2912ac65c5ba758bc5fab3b77";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/pl/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/pl/thunderbird-102.1.2.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "5081d6396b7d00f573e8d2ea2beec165a80eb2eb84d59163d8f65f218c606d08";
+      sha256 = "9bcacb8f37e8470f0550c11fab8b4a45ae3086856ba7fcb64a4065f9d3af3a84";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/pt-BR/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/pt-BR/thunderbird-102.1.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "c618ca6a2869df9411be0cf6473db8d68f0f41e12b971bc699a1edfa4f8ea9ff";
+      sha256 = "7d2614cd3210ff0d352143105c08ffe4d5f3763a22683ab0710fa836fa1a12ca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/pt-PT/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/pt-PT/thunderbird-102.1.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "17f5d2cfe49e016b092ada8f8c883769a07a0941729d9bfceabc645dc716c363";
+      sha256 = "39f0165269f56e70d61b07d993b1d9ea06cfc08275fbee1d44a95b809cd8e701";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/rm/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/rm/thunderbird-102.1.2.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "93814f0b10edc82a246eed29b3b77ac843c6b22506b131c512ddee698ed70361";
+      sha256 = "649efb2f33afa27db7a9b330b903b7804b640bb5bd63133590354b832439c83b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/ro/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/ro/thunderbird-102.1.2.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "8937f068b76accf7d4f160147c2a6cbeacccd69a124b4d7c5262792c77588474";
+      sha256 = "2634b9c82e303be352fda72c386517216da92a6e39928221c681f80afee11c5a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/ru/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/ru/thunderbird-102.1.2.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "c874130c501182c58eaf83f2890404e4fa3f94e936240d728254f3833b45bb20";
+      sha256 = "3f223227cca70e3142fdd2f537dbf9a7511ddc47ee821cf4e90c8238333a41b3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/sk/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/sk/thunderbird-102.1.2.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "5477d79beb77587532a5631a92d9da63d75d5481a73372a6451f562d8cd1dff5";
+      sha256 = "63209953a283c2dd5a41d647eebfecb5b5da51bcb380cfe8c57fbb58228829be";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/sl/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/sl/thunderbird-102.1.2.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "7179ced1b60a437b39fbf22991469f496027abe8680e9a0d713b317775d481d0";
+      sha256 = "ecfb2460e9c35f52f2dfe159791f576ad25611cfe028c492e30a3b385b998c68";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/sq/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/sq/thunderbird-102.1.2.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "f81a55eaf802f28e44d182454fec18c4fcad196eed0a1f24e01e52a829a8bdb3";
+      sha256 = "6d087ac410aeda35b9b595904e28c5300226bef19a9a36b522504ae8ea3cd6a7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/sr/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/sr/thunderbird-102.1.2.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "35367de9ce01c2a04302b6d01e0dafa2173c7353ac72b05cbe77380b6423db51";
+      sha256 = "6bb2e8a43ab378432afc917a0d211867b9bb25965d257675e0f935a08c5381c7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/sv-SE/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/sv-SE/thunderbird-102.1.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "bc82694f82eacfe44f80f40af42ade13a5e26a56982175dadd49ecd178cfcffe";
+      sha256 = "fcf9245e837e0c2514358410a074e19023ba7158668eef857daa67f5059e8411";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/th/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/th/thunderbird-102.1.2.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "c9f7348c38a29c9931339ca09542ce4e48b25d63554101774e149d160f86db3c";
+      sha256 = "5c33365f0b774dafec6ab8d86e865ffc99144bb36b176ca4f2b0659913c76880";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/tr/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/tr/thunderbird-102.1.2.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "409dad6dd457af20e3b19da6e39b5831ebe78d425613072392409de8e8ff40c8";
+      sha256 = "7071b53d00d2c16140c3de4867ddc0f58f27ceb8bb68f7d6c3f942a4e072db45";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/uk/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/uk/thunderbird-102.1.2.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "a9a108789dc812b9c5c5d839d441c1ec8182f3d730eddb46abcc0f995acf766d";
+      sha256 = "dc85e271eafa9bb26d266c3c6019177b68444b4705757c961895f130e222ddb3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/uz/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/uz/thunderbird-102.1.2.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "f1ad87679d2680c409cbfd415c19e73862cb27ef769d181cb5571ef292ad2a1c";
+      sha256 = "a1ffa39b4a480560949ca42efed831f87c03e63b6532193f288298277efd6b46";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/vi/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/vi/thunderbird-102.1.2.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "5da2a53f1c2649bc809082369dbfeadb91830f3275f36414b64c7468a86483e5";
+      sha256 = "10414a1ad61baf1da9319826e8deb20ba79644ffb4e8de5d038d931f54b23f7a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/zh-CN/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/zh-CN/thunderbird-102.1.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "df5501c1fa7308a69d3c6a31fa3667e3013a792a0abf9530309b998a331c4976";
+      sha256 = "379f4b36b6ceb7b357e8d140c062b9855cd3471573e867e4173947bf087df948";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.0/linux-i686/zh-TW/thunderbird-102.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.1.2/linux-i686/zh-TW/thunderbird-102.1.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "a2cf33f94ca9bfbd63c23ebc86c5ad20bd6475c52442db2efde8238bd2355326";
+      sha256 = "edd3c26c9e5e76d388c1a4f2b20f23902d81c530fdfc2b183a0714bee53a6921";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
@@ -38,13 +38,13 @@ rec {
   };
   thunderbird-102 = (buildMozillaMach rec {
     pname = "thunderbird";
-    version = "102.0.3";
+    version = "102.1.2";
     application = "comm/mail";
     applicationName = "Mozilla Thunderbird";
     binaryName = pname;
     src = fetchurl {
       url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
-      sha512 = "ac9f22935ef558890c95cf7fbbbe32a5bb1b7140acb10088ed0d037d1ca5c6e11695c131eb40844807003b77e83b1dd2d9008df420ec394fed5008d5c4c6c3cb";
+      sha512 = "f5c6c77e932b30b43eaa6384b1dd1ab511d0ae8262cb51a5789f7c633235d5f8f343000d1cc1cae12e00a1d73571a814f98b0bf78681e00d7a51a34cfefdfdf1";
     };
     extraPatches = [
       # The file to be patched is different from firefox's `no-buildconfig-ffx90.patch`.
@@ -62,7 +62,7 @@ rec {
       license = licenses.mpl20;
     };
     updateScript = callPackage ./update.nix {
-      attrPath = "thunderbird-unwrapped";
+      attrPath = "thunderbird-102-unwrapped";
     };
   }).override {
     geolocationSupport = false;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30088,7 +30088,7 @@ with pkgs;
   thunderbird-bin = thunderbird-bin-91;
   thunderbird-bin-unwrapped = thunderbird-bin-91-unwrapped;
 
-  thunderbird-bin-102 = wrapThunderbird thunderbird-bin-unwrapped {
+  thunderbird-bin-102 = wrapThunderbird thunderbird-bin-102-unwrapped {
     applicationName = "thunderbird";
     pname = "thunderbird-bin";
     desktopName = "Thunderbird";


### PR DESCRIPTION
https://www.thunderbird.net/en-US/thunderbird/102.1.0/releasenotes/
https://www.thunderbird.net/en-US/thunderbird/102.1.1/releasenotes/
https://www.thunderbird.net/en-US/thunderbird/102.1.2/releasenotes/

On nixpkgs master this is in commit https://github.com/NixOS/nixpkgs/commit/f4e93a3ded837ea8b49e7dec899bc8e19ff2690f / PR https://github.com/NixOS/nixpkgs/pull/187428

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] N/A Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] N/A Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
