### PR TITLE
brev-cli: init at 0.6.95

### DIFF
--- a/pkgs/development/misc/brev-cli/default.nix
+++ b/pkgs/development/misc/brev-cli/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "brev-cli";
+  version = "0.6.95";
+
+  src = fetchFromGitHub {
+    owner = "brevdev";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "09qhc38ycqs6vdyy1rxaxbihq0q59g2ffkmmlk6ipdlv2b3ywz0f";
+  };
+
+  vendorSha256 = "sha256-5P9oodntXn7RMpjKLoCXlnEZeW4/W0hfYPt7I3hjvGw=";
+
+  CGO_ENABLED = 0;
+  subPackages = [ "." ];
+
+  ldflags = [
+    "-X github.com/brevdev/brev-cli/pkg/cmd/version.Version=${src.rev}"
+  ];
+
+  postInstall = ''
+    mv $out/bin/brev-cli $out/bin/brev
+  '';
+
+  meta = with lib; {
+    description = "Connect your laptop to cloud computers";
+    homepage = "https://github.com/brevdev/brev-cli";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dit7ya ];
+  };
+}

--- a/pkgs/development/misc/brev-cli/default.nix
+++ b/pkgs/development/misc/brev-cli/default.nix
@@ -20,6 +20,8 @@ buildGoModule rec {
   subPackages = [ "." ];
 
   ldflags = [
+    "-s"
+    "-w"
     "-X github.com/brevdev/brev-cli/pkg/cmd/version.Version=${src.rev}"
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -294,6 +294,8 @@ with pkgs;
 
   breakpad = callPackage ../development/misc/breakpad { };
 
+  brev-cli = callPackage ../development/misc/brev-cli { };
+
   buf = callPackage ../development/tools/buf { };
 
   cbfmt = callPackage ../development/tools/cbfmt { };


### PR DESCRIPTION
###### Description of changes


Brev.dev makes it easy to develop on remote machines. 

https://github.com/brevdev/brev-cli

This is the CLI client package.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
