### PR TITLE
piper: 0.5.1 -> 0.7

### DIFF
--- a/pkgs/os-specific/linux/piper/default.nix
+++ b/pkgs/os-specific/linux/piper/default.nix
@@ -4,7 +4,7 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "piper";
-  version = "0.5.1";
+  version = "0.7";
 
   format = "other";
 
@@ -12,7 +12,7 @@ python3.pkgs.buildPythonApplication rec {
     owner  = "libratbag";
     repo   = "piper";
     rev    =  version;
-    sha256 = "1nfjnsiwg2rs6gkjsxzhr2708i6di149dgwq3cf6l12rxqpb8arj";
+    sha256 = "0jsvfy0ihdcgnqljfgs41lys1nlz18qvsa0a8ndx3pyr41f8w8wf";
   };
 
   nativeBuildInputs = [ meson ninja gettext pkg-config wrapGAppsHook desktop-file-utils appstream-glib gobject-introspection ];
@@ -23,9 +23,14 @@ python3.pkgs.buildPythonApplication rec {
     gobject-introspection # fixes https://github.com/NixOS/nixpkgs/issues/56943 for now
   ];
 
+  mesonFlags = [
+    "-Druntime-dependency-checks=false"
+    "-Dtests=false"
+  ];
+
   postPatch = ''
     chmod +x meson_install.sh # patchShebangs requires executable file
-    patchShebangs meson_install.sh
+    patchShebangs meson_install.sh data/generate-piper-gresource.xml.py
   '';
 
   meta = with lib; {

--- a/pkgs/os-specific/linux/piper/default.nix
+++ b/pkgs/os-specific/linux/piper/default.nix
@@ -1,6 +1,6 @@
 { lib, meson, ninja, pkg-config, gettext, fetchFromGitHub, python3
 , wrapGAppsHook, gtk3, glib, desktop-file-utils, appstream-glib, gnome
-, gobject-introspection }:
+, gobject-introspection, librsvg }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "piper";
@@ -17,7 +17,7 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = [ meson ninja gettext pkg-config wrapGAppsHook desktop-file-utils appstream-glib gobject-introspection ];
   buildInputs = [
-    gtk3 glib gnome.adwaita-icon-theme python3
+    gtk3 glib gnome.adwaita-icon-theme python3 librsvg
   ];
   propagatedBuildInputs = with python3.pkgs; [ lxml evdev pygobject3 ] ++ [
     gobject-introspection # fixes https://github.com/NixOS/nixpkgs/issues/56943 for now


### PR DESCRIPTION
Closes #187508.

###### Description of changes

Adds a missing dependency to `buildInputs`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Additionally, for another PR, the following diff upgrades to 0.6, but I wasn't sure about the two new dependencies:

```diff
diff --git a/pkgs/os-specific/linux/piper/default.nix b/pkgs/os-specific/linux/piper/default.nix
index 9ec4b331d82..3a8133b3c4e 100644
--- a/pkgs/os-specific/linux/piper/default.nix
+++ b/pkgs/os-specific/linux/piper/default.nix
@@ -1,10 +1,10 @@
 { lib, meson, ninja, pkg-config, gettext, fetchFromGitHub, python3
 , wrapGAppsHook, gtk3, glib, desktop-file-utils, appstream-glib, gnome
-, gobject-introspection, librsvg }:
+, gobject-introspection, librsvg, libratbag }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "piper";
-  version = "0.5.1";
+  version = "0.6";
 
   format = "other";
 
@@ -12,10 +12,12 @@ python3.pkgs.buildPythonApplication rec {
     owner  = "libratbag";
     repo   = "piper";
     rev    =  version;
-    sha256 = "1nfjnsiwg2rs6gkjsxzhr2708i6di149dgwq3cf6l12rxqpb8arj";
+    sha256 = "02x4d4n0078slj2pl0rvgayrrxvna6y6vj8fxfamvazsh5xyfzwk";
   };
 
-  nativeBuildInputs = [ meson ninja gettext pkg-config wrapGAppsHook desktop-file-utils appstream-glib gobject-introspection ];
+  nativeBuildInputs = [
+    meson ninja gettext pkg-config wrapGAppsHook desktop-file-utils appstream-glib gobject-introspection libratbag python3.pkgs.flake8
+  ];
   buildInputs = [
     gtk3 glib gnome.adwaita-icon-theme python3 librsvg
   ];

```

I was unable to get 0.7 to run as there are further dependency changes I don't understand.