### PR TITLE
qt6.qtbase: patch for loading libXcursor

### DIFF
--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -49,6 +49,7 @@ let
         withGtk3 = true;
         inherit (srcs.qtbase) src version;
         inherit bison cups harfbuzz libGL dconf gtk3 developerBuild cmake;
+        patches = [ ./patches/0007-qtbase-xcursor.patch ];
       };
 
       qt3d = callPackage ./modules/qt3d.nix { };

--- a/pkgs/development/libraries/qt-6/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtbase.nix
@@ -201,6 +201,10 @@ stdenv.mkDerivation rec {
     "-DQT_FEATURE_openssl_linked=ON"
   ];
 
+  NIX_CFLAGS_COMPILE = [
+    ''-DNIXPKGS_LIBXCURSOR="${libXcursor.out}/lib/libXcursor"''
+  ];
+
   outputs = [ "out" "dev" ];
 
   postInstall = ''

--- a/pkgs/development/libraries/qt-6/patches/0007-qtbase-xcursor.patch
+++ b/pkgs/development/libraries/qt-6/patches/0007-qtbase-xcursor.patch
@@ -1,0 +1,29 @@
+From cc953cc3f736fabef1f5c211964f30be719fb35e Mon Sep 17 00:00:00 2001
+From: Thomas Tuegel <ttuegel@mailbox.org>
+Date: Tue, 17 Sep 2019 05:35:58 -0500
+Subject: [PATCH 07/10] qtbase-xcursor
+
+---
+ src/plugins/platforms/xcb/qxcbcursor.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/plugins/platforms/xcb/qxcbcursor.cpp b/src/plugins/platforms/xcb/qxcbcursor.cpp
+index fbadab4d50..c83ce0af5b 100644
+--- a/src/plugins/platforms/xcb/qxcbcursor.cpp
++++ b/src/plugins/platforms/xcb/qxcbcursor.cpp
+@@ -317,10 +317,10 @@ QXcbCursor::QXcbCursor(QXcbConnection *conn, QXcbScreen *screen)
+ #if QT_CONFIG(xcb_xlib) && QT_CONFIG(library)
+     static bool function_ptrs_not_initialized = true;
+     if (function_ptrs_not_initialized) {
+-        QLibrary xcursorLib(QLatin1String("Xcursor"), 1);
++        QLibrary xcursorLib(QLatin1String(NIXPKGS_LIBXCURSOR), 1);
+         bool xcursorFound = xcursorLib.load();
+         if (!xcursorFound) { // try without the version number
+-            xcursorLib.setFileName(QLatin1String("Xcursor"));
++            xcursorLib.setFileName(QLatin1String(NIXPKGS_LIBXCURSOR));
+             xcursorFound = xcursorLib.load();
+         }
+         if (xcursorFound) {
+-- 
+2.25.1
+


### PR DESCRIPTION
###### Description of changes
Fixes https://github.com/NixOS/nixpkgs/issues/181176 on xorg, (maybe also on wayland, I cannot reproduce this)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
