### PR TITLE
sbctl: init at 0.9

### DIFF
--- a/pkgs/tools/security/sbctl/default.nix
+++ b/pkgs/tools/security/sbctl/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, installShellFiles
+, asciidoc
+, databasePath ? "/etc/secureboot"
+}:
+
+buildGoModule rec {
+  pname = "sbctl";
+  version = "0.9";
+
+  src = fetchFromGitHub {
+    owner = "Foxboron";
+    repo = pname;
+    rev = version;
+    hash = "sha256-mntb3EMB+QTnFU476Dq6T6rAAv0JeYbvWJ/pbL3a4RE=";
+  };
+
+  vendorSha256 = "sha256-k6AIYigjxbitH0hH+vwRt2urhNYTToIF0eSsIWbzslI=";
+
+  ldflags = [ "-s" "-w" "-X github.com/foxboron/sbctl.DatabasePath=${databasePath}" ];
+
+  nativeBuildInputs = [ installShellFiles asciidoc ];
+
+  postBuild = ''
+    make docs/sbctl.8
+  '';
+
+  postInstall = ''
+    installManPage docs/sbctl.8
+
+    installShellCompletion --cmd sbctl \
+    --bash <($out/bin/sbctl completion bash) \
+    --fish <($out/bin/sbctl completion fish) \
+    --zsh <($out/bin/sbctl completion zsh)
+  '';
+
+  meta = with lib; {
+    description = "Secure Boot key manager";
+    homepage = "https://github.com/Foxboron/sbctl";
+    license = licenses.mit;
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7138,6 +7138,8 @@ with pkgs;
 
   efitools = callPackage ../tools/security/efitools { };
 
+  sbctl = callPackage ../tools/security/sbctl { };
+
   sbsigntool = callPackage ../tools/security/sbsigntool { };
 
   gsmartcontrol = callPackage ../tools/misc/gsmartcontrol { };


### PR DESCRIPTION
###### Description of changes

This is a secure boot management tool.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).