### PR TITLE
cmake: fix crash on CC without libc support

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/001-search-path.diff
+++ b/pkgs/development/tools/build-managers/cmake/001-search-path.diff
@@ -12,7 +12,7 @@ index b9381c3d7d..5e944640b5 100644
    # CMake install location
    "${_CMAKE_INSTALL_DIR}"
    )
-@@ -47,48 +44,46 @@ endif()
+@@ -47,48 +44,48 @@ endif()
  
  # Non "standard" but common install prefixes
  list(APPEND CMAKE_SYSTEM_PREFIX_PATH
@@ -22,7 +22,9 @@ index b9381c3d7d..5e944640b5 100644
    )
  
  # List common include file locations not under the common prefixes.
-+if(IS_DIRECTORY $ENV{NIX_CC})
++if(IS_DIRECTORY $ENV{NIX_CC}
++  AND EXISTS $ENV{NIX_CC}/nix-support/orig-libc
++  AND EXISTS $ENV{NIX_CC}/nix-support/orig-libc-dev)
 +  file(STRINGS "$ENV{NIX_CC}/nix-support/orig-libc" _nix_cmake_libc)
 +  file(STRINGS "$ENV{NIX_CC}/nix-support/orig-libc-dev" _nix_cmake_libc_dev)
 +else()


### PR DESCRIPTION
Without this change pkgsLLVM fails to build any packages
as compiler-rt fails early in cmake:

    CMake Error at ...-cmake-3.24.0/share/cmake-3.24/Modules/Platform/UnixPaths.cmake:53 (file):
      file STRINGS file
      "...-x86_64-unknown-linux-gnu-clang-wrapper-11.1.0/nix-support/orig-libc-dev"
      cannot be read.

It's a regression caused by 871cf9f7b3e5a "cmake: detect libc location
at runtime #181431" where we started using `orig-libc-dev` as a libc pointer.

During pkgsLLVM pootstrap first compiler has no libc support yet.

The change skips runtime detection if there are no libc signs.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
