### PR TITLE
torchdata-bin: init at 0.4.1

### DIFF
--- a/pkgs/development/python-modules/torchdata/bin.nix
+++ b/pkgs/development/python-modules/torchdata/bin.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
   ];
 
   postFixup = let
-    rpath = lib.makeLibraryPath [ zlib ];
+    rpath = lib.makeLibraryPath [ stdenv.cc.cc.lib zlib ];
   in ''
     find $out/${python.sitePackages}/torchdata -type f \( -name '*.so' -or -name '*.so.*' \) | while read lib; do
       echo "setting rpath for $lib..."

--- a/pkgs/development/python-modules/torchdata/bin.nix
+++ b/pkgs/development/python-modules/torchdata/bin.nix
@@ -5,8 +5,11 @@
 , stdenv
 
 # Propagated build inputs
+, portalocker
 , pytorch
 , requests
+, urllib3
+, zlib
 
 # Python version
 , pythonOlder
@@ -31,6 +34,8 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     pytorch
     requests
+    portalocker
+    urllib3
   ];
 
   pythonImportsCheck = [ "torchdata" ];

--- a/pkgs/development/python-modules/torchdata/bin.nix
+++ b/pkgs/development/python-modules/torchdata/bin.nix
@@ -1,0 +1,69 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, python
+, stdenv
+
+# Propagated build inputs
+, pytorch
+, requests
+
+# Python version
+, pythonOlder
+, pythonAtLeast
+}:
+
+let
+  srcs = {
+    "0.4.0" = {
+      "x86_64-linux-310" = {
+        platform = "manylinux2014_x86_64.whl";
+        sha256 = "sha256-6zBYHZ/06t0/m4MMKfzMMqnhse1zJ3aRWXL7SM37VHE=";
+      };
+    };
+    "0.4.1" = {
+      "x86_64-linux-310" = {
+        platform = "manylinux_2_17_x86_64.manylinux2014_x86_64";
+        sha256 = "sha256-HclqlVhvmab8cki6LqEIqfbKVVqoDMWDC8NKcgHpLyY=";
+      };
+    };
+  };
+  pyVerNoDot = lib.replaceStrings [ "." ] [ "" ] python.pythonVersion;
+  unsupported = throw "Unsupported system";
+in
+buildPythonPackage rec {
+  pname = "torchdata";
+  version = "0.3.0";
+  format = "wheel";
+
+  src =
+    if version == "0.3.0" then
+      fetchPypi {
+        inherit pname version format;
+        python = "py3";
+        dist = "py3";
+        sha256 = "sha256-vRb+N82aPcGWBQNVe11VYlHh8yuQeO2Ron3OUY6zKNY=";
+      }
+    else fetchPypi ({
+      inherit pname version format;
+      python = "cp${pyVerNoDot}";
+      abi = if pyVerNoDot == "37" then "cp${pyVerNoDot}m" else "cp${pyVerNoDot}";
+      dist = "cp${pyVerNoDot}";
+    } // srcs.${version}."${stdenv.system}-${pyVerNoDot}" or unsupported);
+
+  disabled = pythonOlder "3.7" || pythonAtLeast "3.11";
+
+  propagatedBuildInputs = [
+    pytorch
+    requests
+  ];
+
+  pythonImportsCheck = [ "torchdata" ];
+
+  meta = with lib; {
+    description = "A PyTorch repo for data loading and utilities to be shared by the PyTorch domain libraries.";
+    homepage = "github.com/pytorch/data";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [  ];
+  };
+}

--- a/pkgs/development/python-modules/torchdata/bin.nix
+++ b/pkgs/development/python-modules/torchdata/bin.nix
@@ -33,7 +33,7 @@ let
 in
 buildPythonPackage rec {
   pname = "torchdata";
-  version = "0.3.0";
+  version = "0.4.1";
   format = "wheel";
 
   src =

--- a/pkgs/development/python-modules/torchdata/binary-hashes.nix
+++ b/pkgs/development/python-modules/torchdata/binary-hashes.nix
@@ -1,0 +1,66 @@
+# Warning: Need to update at the same time as pytorch-bin
+#
+# Precompiled wheels can be found at:
+# https://pypi.org/project/torchdata/#files
+
+# To add a new version, run "prefetch.sh 'new-version'" to paste the generated file as follows.
+
+version : builtins.getAttr version {
+  "0.4.1" = {
+    x86_64-linux-37 = {
+      name = "torchdata-0.4.1-cp37-cp37m-linux_x86_64.whl";
+      url = "https://files.pythonhosted.org/packages/cp37/t/torchdata/torchdata-0.4.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
+      hash = "sha256-RCuu0lDggkX/9JLTYtefjbZ5bvzbbrXsXzFnqGDwqGs=";
+    };
+    x86_64-linux-38 = {
+      name = "torchdata-0.4.1-cp38-cp38-linux_x86_64.whl";
+      url = "https://files.pythonhosted.org/packages/cp38/t/torchdata/torchdata-0.4.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
+      hash = "sha256-+rqP6uZo2fK9klNIAkqui3n3TBhcmQCPX0xN5a587mc=";
+    };
+    x86_64-linux-39 = {
+      name = "torchdata-0.4.1-cp39-cp39-linux_x86_64.whl";
+      url = "https://files.pythonhosted.org/packages/cp39/t/torchdata/torchdata-0.4.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
+      hash = "sha256-QEhKqs1+rz56bwRkSyMjjKVgu0mf4ta2x20UguY00DM=";
+    };
+    x86_64-linux-310 = {
+      name = "torchdata-0.4.1-cp310-cp310-linux_x86_64.whl";
+      url = "https://files.pythonhosted.org/packages/cp310/t/torchdata/torchdata-0.4.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
+      hash = "sha256-HclqlVhvmab8cki6LqEIqfbKVVqoDMWDC8NKcgHpLyY=";
+    };
+    x86_64-darwin-37 = {
+      name = "torchdata-0.4.1-cp37-cp37m-macosx_10_13_x86_64.whl";
+      url = "https://files.pythonhosted.org/packages/cp37/t/torchdata/torchdata-0.4.1-cp37-cp37m-macosx_10_13_x86_64.whl";
+      hash = "sha256-y0Aa8c0nAi5//goXOy9Fpvv4Ff+mHYKkthd4T6I3Ep4=";
+    };
+    x86_64-darwin-38 = {
+      name = "torchdata-0.4.1-cp38-cp38-macosx_10_13_x86_64.whl";
+      url = "https://files.pythonhosted.org/packages/cp38/t/torchdata/torchdata-0.4.1-cp38-cp38-macosx_10_13_x86_64.whl";
+      hash = "sha256-wJLjKzYg/FpjOcTkx43wdASo3RpSrl8kiboSANgYfrM=";
+    };
+    x86_64-darwin-39 = {
+      name = "torchdata-0.4.1-cp39-cp39-macosx_10_13_x86_64.whl";
+      url = "https://files.pythonhosted.org/packages/cp39/t/torchdata/torchdata-0.4.1-cp39-cp39-macosx_10_13_x86_64.whl";
+      hash = "sha256-RFzqXYoiHaXFlZ27GtftA08h0iOlggovhnYZGjnd6ZY=";
+    };
+    x86_64-darwin-310 = {
+      name = "torchdata-0.4.1-cp310-cp310-macosx_10_13_x86_64.whl";
+      url = "https://files.pythonhosted.org/packages/cp310/t/torchdata/torchdata-0.4.1-cp310-cp310-macosx_10_13_x86_64.whl";
+      hash = "sha256-zwmN/906LWrgxIxP7Fg3IemxwgviWrQB4AeFJqd9mVo=";
+    };
+    aarch64-darwin-38 = {
+      name = "torchdata-0.4.1-cp38-cp38-macosx_11_0_arm64.whl";
+      url = "https://files.pythonhosted.org/packages/cp38/t/torchdata/torchdata-0.4.1-cp38-cp38-macosx_11_0_arm64.whl";
+      hash = "sha256-9V6TU3qVE+D1oj/kvRQmL80w4+3XUaOO+GuuQ1rmtHk=";
+    };
+    aarch64-darwin-39 = {
+      name = "torchdata-0.4.1-cp39-cp39-macosx_11_0_arm64.whl";
+      url = "https://files.pythonhosted.org/packages/cp39/t/torchdata/torchdata-0.4.1-cp39-cp39-macosx_11_0_arm64.whl";
+      hash = "sha256-Mqy1eKfQGj07ou2upiG/NTT2pFGKOfyYKoXYLiW2n/c=";
+    };
+    aarch64-darwin-310 = {
+      name = "torchdata-0.4.1-cp310-cp310-macosx_11_0_arm64.whl";
+      url = "https://files.pythonhosted.org/packages/cp310/t/torchdata/torchdata-0.4.1-cp310-cp310-macosx_11_0_arm64.whl";
+      hash = "sha256-mVcnqbWHF54mHkUUR7sdVvlbtahdP7AR24895+GHRmw=";
+    };
+  };
+}

--- a/pkgs/development/python-modules/torchdata/prefetch.sh
+++ b/pkgs/development/python-modules/torchdata/prefetch.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix-prefetch-scripts
+
+set -eou pipefail
+
+version=$1
+
+bucket="https://files.pythonhosted.org/packages"
+
+url_and_key_list=(
+  "x86_64-linux-37 $bucket/cp37/t/torchdata/torchdata-${version}-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl torchdata-${version}-cp37-cp37m-linux_x86_64.whl"
+  "x86_64-linux-38 $bucket/cp38/t/torchdata/torchdata-${version}-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl torchdata-${version}-cp38-cp38-linux_x86_64.whl"
+  "x86_64-linux-39 $bucket/cp39/t/torchdata/torchdata-${version}-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl torchdata-${version}-cp39-cp39-linux_x86_64.whl"
+  "x86_64-linux-310 $bucket/cp310/t/torchdata/torchdata-${version}-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl torchdata-${version}-cp310-cp310-linux_x86_64.whl"
+
+  "x86_64-darwin-37 $bucket/cp37/t/torchdata/torchdata-${version}-cp37-cp37m-macosx_10_13_x86_64.whl torchdata-${version}-cp37-cp37m-macosx_10_13_x86_64.whl"
+  "x86_64-darwin-38 $bucket/cp38/t/torchdata/torchdata-${version}-cp38-cp38-macosx_10_13_x86_64.whl torchdata-${version}-cp38-cp38-macosx_10_13_x86_64.whl"
+  "x86_64-darwin-39 $bucket/cp39/t/torchdata/torchdata-${version}-cp39-cp39-macosx_10_13_x86_64.whl torchdata-${version}-cp39-cp39-macosx_10_13_x86_64.whl"
+  "x86_64-darwin-310 $bucket/cp310/t/torchdata/torchdata-${version}-cp310-cp310-macosx_10_13_x86_64.whl torchdata-${version}-cp310-cp310-macosx_10_13_x86_64.whl"
+
+  "aarch64-darwin-38 $bucket/cp38/t/torchdata/torchdata-${version}-cp38-cp38-macosx_11_0_arm64.whl torchdata-${version}-cp38-cp38-macosx_11_0_arm64.whl"
+  "aarch64-darwin-39 $bucket/cp39/t/torchdata/torchdata-${version}-cp39-cp39-macosx_11_0_arm64.whl torchdata-${version}-cp39-cp39-macosx_11_0_arm64.whl"
+  "aarch64-darwin-310 $bucket/cp310/t/torchdata/torchdata-${version}-cp310-cp310-macosx_11_0_arm64.whl torchdata-${version}-cp310-cp310-macosx_11_0_arm64.whl"
+)
+
+hashfile=binary-hashes-"$version".nix
+echo "  \"$version\" = {" >> $hashfile
+
+for url_and_key in "${url_and_key_list[@]}"; do
+  key=$(echo "$url_and_key" | cut -d' ' -f1)
+  url=$(echo "$url_and_key" | cut -d' ' -f2)
+  name=$(echo "$url_and_key" | cut -d' ' -f3)
+
+  echo "prefetching ${url}..."
+  hash=$(nix hash to-sri --type sha256 `nix-prefetch-url "$url" --name "$name"`)
+
+  echo "    $key = {" >> $hashfile
+  echo "      name = \"$name\";" >> $hashfile
+  echo "      url = \"$url\";" >> $hashfile
+  echo "      hash = \"$hash\";" >> $hashfile
+  echo "    };" >> $hashfile
+
+  echo
+done
+
+echo "  };" >> $hashfile
+echo "done."

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10826,6 +10826,8 @@ in {
 
   torchaudio-bin = callPackage ../development/python-modules/torchaudio/bin.nix { };
 
+  torchdata-bin = callPackage ../development/python-modules/torchdata/bin.nix { };
+
   torchgpipe = callPackage ../development/python-modules/torchgpipe { };
 
   torchmetrics = callPackage ../development/python-modules/torchmetrics { };


### PR DESCRIPTION
###### Description of changes

Initialize torchdata-bin at 0.4.1. 

This is similar to other torch binary packages like `torchvision-bin` and `torchaudio-bin`.

###### Current status:

- [x] ~This requires pytorch 1.12 which is currently unmerged in #187110~ Now merged as of #189013
- [ ] This doesn't include a source based package but it shouldn't be too tricky if someone is interested in modifying #160213

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
