### PR TITLE
nss: backport upstream gcc-13 fix

### DIFF
--- a/pkgs/development/libraries/nss/gcc-13.patch
+++ b/pkgs/development/libraries/nss/gcc-13.patch
@@ -1,0 +1,22 @@
+https://hg.mozilla.org/projects/nss/raw-rev/21e7aaa1f7d94bca15d997e5b4c2329b32fad21a
+--- nss/cpputil/databuffer.h
++++ nss/cpputil/databuffer.h
+@@ -6,16 +6,17 @@
+ 
+ #ifndef databuffer_h__
+ #define databuffer_h__
+ 
+ #include <algorithm>
+ #include <cstring>
+ #include <iomanip>
+ #include <iostream>
++#include <cstdint>
+ 
+ namespace nss_test {
+ 
+ class DataBuffer {
+  public:
+   DataBuffer() : data_(nullptr), len_(0) {}
+   DataBuffer(const uint8_t* d, size_t l) : data_(nullptr), len_(0) {
+     Assign(d, l);
+

--- a/pkgs/development/libraries/nss/generic.nix
+++ b/pkgs/development/libraries/nss/generic.nix
@@ -47,6 +47,8 @@ stdenv.mkDerivation rec {
       ./85_security_load_3.77+.patch
     )
     ./fix-cross-compilation.patch
+  ] ++ lib.optionals (lib.versionOlder version "3.82") [
+    ./gcc-13.patch
   ];
 
   patchFlags = [ "-p0" ];


### PR DESCRIPTION
Without the change nss build fails on upcoming gcc-13 as:

    FAILED: obj/cpputil/cpputil.databuffer.o
    g++ -MMD -MF obj/cpputil/cpputil.databuffer.o.d -DNSS_FIPS_DISABLED -DNSS_NO_INIT_SUPPORT -DNSS_X86_OR_X64 -DNSS_X86 -DUSE_UTIL_DIRECTLY -DNO_NSPR_10_SUPPORT -DSSL_DISABLE_DEPRECATED_CIPHER_SUITE_NAMES -DLINUX2_1 -DLINUX -Dlinux -D_DEFAULT_SOURCE -D_BSD_SOURCE -D_POSIX_SOURCE -DSQL_MEASURE_USE_TEMP_DIR -DHAVE_STRERROR -DXP_UNIX -D_REENTRANT -DNDEBUG -I/nix/store/bn4yr99gbgd27h6akdx1ilbif0f9d5nv-nspr-4.34.1-dev/include -I/nix/store/5wy6l06sllan2c2wbhldq3ck868y2k8p-nss-3.68.4/private -I/nix/store/5wy6l06sllan2c2wbhldq3ck868y2k8p-nss-3.68.4/public/nss -fPIC -pipe -ffunction-sections -fdata-sections -m32 -Werror -Wall -Wshadow -O2 -std=c++11  -c ../../cpputil/databuffer.cc -o obj/cpputil/cpputil.databuffer.o
    In file included from ../../cpputil/databuffer.cc:7:
    ../../cpputil/databuffer.h:20:20: error: 'uint8_t' does not name a type
       20 |   DataBuffer(const uint8_t* d, size_t l) : data_(nullptr), len_(0) {
          |                    ^~~~~~~

It's a backport of upstream fix at https://bugzilla.mozilla.org/show_bug.cgi?id=1771273

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
