### PR TITLE
google-cloud-sdk: add support for components

### DIFF
--- a/pkgs/tools/admin/google-cloud-sdk/components.json
+++ b/pkgs/tools/admin/google-cloud-sdk/components.json
@@ -1,0 +1,6910 @@
+{
+  "components": [
+    {
+      "data": {
+        "checksum": "5a65179c291bc480696ca323d2f8c4874985458303eff8f233e16cdca4e88e6f",
+        "contents_checksum": "038c999c7a7d70d5133eab7dc5868c4c3d0358431dad250f9833306af63016c8",
+        "size": 800,
+        "source": "components/google-cloud-sdk-alpha-20220805142045.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "core"
+      ],
+      "details": {
+        "description": "Alpha version of gcloud commands.",
+        "display_name": "gcloud Alpha Commands"
+      },
+      "id": "alpha",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {},
+      "platform_required": false,
+      "version": {
+        "build_number": 20220805142045,
+        "version_string": "2022.08.05"
+      }
+    },
+    {
+      "dependencies": [
+        "anthos-auth-darwin-arm",
+        "anthos-auth-darwin-x86_64",
+        "anthos-auth-linux-arm",
+        "anthos-auth-linux-x86_64",
+        "anthos-auth-windows-x86_64"
+      ],
+      "details": {
+        "description": "Configure kubectl with OIDC credentials for Anthos clusters.",
+        "display_name": "anthos-auth"
+      },
+      "id": "anthos-auth",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm",
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX",
+          "MACOSX",
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": "1.4.3"
+      }
+    },
+    {
+      "data": {
+        "checksum": "9a11f7c85ffff2fd7ad4946b5c1ea97a1162e687b559244ee21228c8154d90dd",
+        "contents_checksum": "2cd31930d0f1326c8f3e0be44bb9ab3c5335ed38c170090f7105ba7accccb4a1",
+        "size": 19054806,
+        "source": "components/google-cloud-sdk-anthos-auth-darwin-arm-20220729144039.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "anthos-auth"
+      ],
+      "details": {
+        "description": "Configure kubectl with OIDC credentials for Anthos clusters.",
+        "display_name": "anthos-auth"
+      },
+      "id": "anthos-auth-darwin-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220729144039,
+        "version_string": "1.4.3"
+      }
+    },
+    {
+      "data": {
+        "checksum": "e04c7143047fd26430e26e3e67fa1768413d8ed1d6e014a0d96c6075559ce3aa",
+        "contents_checksum": "f7b242bfa64f2c78d388ce361a829f6d0bfd53e8f0fabfc6b4b14fa6e3ef4682",
+        "size": 19911349,
+        "source": "components/google-cloud-sdk-anthos-auth-darwin-x86_64-20220729144039.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "anthos-auth"
+      ],
+      "details": {
+        "description": "Configure kubectl with OIDC credentials for Anthos clusters.",
+        "display_name": "anthos-auth"
+      },
+      "id": "anthos-auth-darwin-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220729144039,
+        "version_string": "1.4.3"
+      }
+    },
+    {
+      "data": {
+        "checksum": "030fa3615f5a7833a642047bdf531936c8d8fa827f5dbc44384de1a9e85df254",
+        "contents_checksum": "5119864e84d03d45dc0c00713072a8c34ecf95f18ac4633c938b581dbad86a28",
+        "size": 18716150,
+        "source": "components/google-cloud-sdk-anthos-auth-linux-arm-20220729144039.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "anthos-auth"
+      ],
+      "details": {
+        "description": "Configure kubectl with OIDC credentials for Anthos clusters.",
+        "display_name": "anthos-auth"
+      },
+      "id": "anthos-auth-linux-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220729144039,
+        "version_string": "1.4.3"
+      }
+    },
+    {
+      "data": {
+        "checksum": "b3377c443f135a112ace343bb6ab6c20bf763e29512947f95bb239a381ee9b86",
+        "contents_checksum": "4543d98cd25e05c6bfb9e36d89b7b34a226218e5ce3feee07276377fde8f5967",
+        "size": 20095013,
+        "source": "components/google-cloud-sdk-anthos-auth-linux-x86_64-20220729144039.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "anthos-auth"
+      ],
+      "details": {
+        "description": "Configure kubectl with OIDC credentials for Anthos clusters.",
+        "display_name": "anthos-auth"
+      },
+      "id": "anthos-auth-linux-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220729144039,
+        "version_string": "1.4.3"
+      }
+    },
+    {
+      "data": {
+        "checksum": "29c9c078662d94e48a601c2916ca9030e0d81f8f442e3e11a654c90ff0816838",
+        "contents_checksum": "78662933c423257a0aaafd07a1bcbf1eed864015a5e42ffbfb0d4caa30d9b5f0",
+        "size": 20093409,
+        "source": "components/google-cloud-sdk-anthos-auth-windows-x86_64-20220729144039.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "anthos-auth"
+      ],
+      "details": {
+        "description": "Configure kubectl with OIDC credentials for Anthos clusters.",
+        "display_name": "anthos-auth"
+      },
+      "id": "anthos-auth-windows-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220729144039,
+        "version_string": "1.4.3"
+      }
+    },
+    {
+      "dependencies": [
+        "anthoscli-darwin-arm",
+        "anthoscli-darwin-x86",
+        "anthoscli-darwin-x86_64",
+        "anthoscli-linux-arm",
+        "anthoscli-linux-x86",
+        "anthoscli-linux-x86_64",
+        "anthoscli-windows-x86",
+        "anthoscli-windows-x86_64"
+      ],
+      "details": {
+        "description": "The cli for Anthos infrastructure.",
+        "display_name": "anthoscli"
+      },
+      "id": "anthoscli",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm",
+          "x86",
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX",
+          "MACOSX",
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": "0.2.28"
+      }
+    },
+    {
+      "data": {
+        "checksum": "9e6a78c4747f425c93933e61635a2caf7685ae750adc065bf1ddd70f018e3f29",
+        "contents_checksum": "bc2e1ce26d099e6b384b732e452e3c784cfc234a96292c446bd6856bce555337",
+        "size": 48898452,
+        "source": "components/google-cloud-sdk-anthoscli-darwin-arm-20220617150114.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "anthoscli"
+      ],
+      "details": {
+        "description": "The cli for Anthos infrastructure.",
+        "display_name": "anthoscli"
+      },
+      "id": "anthoscli-darwin-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220617150114,
+        "version_string": "0.2.28"
+      }
+    },
+    {
+      "data": {
+        "checksum": "1040e5510117e0759085bb099d661462b7ae8dfe48ec919a56e5261d127be25f",
+        "contents_checksum": "9be893eceb503735424483a74cf5fc9eb6f255975ceff37b9088129a2437a583",
+        "size": 53541169,
+        "source": "components/google-cloud-sdk-anthoscli-darwin-x86-20200717144158.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "anthoscli"
+      ],
+      "details": {
+        "description": "The cli for Anthos infrastructure.",
+        "display_name": "anthoscli"
+      },
+      "id": "anthoscli-darwin-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20200717144158,
+        "version_string": "0.2.4"
+      }
+    },
+    {
+      "data": {
+        "checksum": "d4c9ff15fac4fa8ad75c3dd972b0271b073999ead2ddd8f5881a6e2cf271f1a5",
+        "contents_checksum": "50a63d70cb7ee41503ee66649ab65d1a18eea756a67a674a0ea1eae54b1240dc",
+        "size": 50295536,
+        "source": "components/google-cloud-sdk-anthoscli-darwin-x86_64-20220617150114.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "anthoscli"
+      ],
+      "details": {
+        "description": "The cli for Anthos infrastructure.",
+        "display_name": "anthoscli"
+      },
+      "id": "anthoscli-darwin-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220617150114,
+        "version_string": "0.2.28"
+      }
+    },
+    {
+      "data": {
+        "checksum": "95410d27b5d587ba3388b9f38c328a358b292df154008480189a3e21a542f204",
+        "contents_checksum": "654021667b0b0be6df14e3df31f57c5374b2291670172bd9dd83c05606fce1d5",
+        "size": 46826425,
+        "source": "components/google-cloud-sdk-anthoscli-linux-arm-20220617150114.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "anthoscli"
+      ],
+      "details": {
+        "description": "The cli for Anthos infrastructure.",
+        "display_name": "anthoscli"
+      },
+      "id": "anthoscli-linux-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220617150114,
+        "version_string": "0.2.28"
+      }
+    },
+    {
+      "data": {
+        "checksum": "4aa7db2210073b098e96a550a2fd8148ca57d7ec9f9f4d6290faffee52390d5f",
+        "contents_checksum": "1dc52de4cfd28caa1218869a997759f5f7e3a41b5fab7802155cec397b914125",
+        "size": 47889870,
+        "source": "components/google-cloud-sdk-anthoscli-linux-x86-20220617150114.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "anthoscli"
+      ],
+      "details": {
+        "description": "The cli for Anthos infrastructure.",
+        "display_name": "anthoscli"
+      },
+      "id": "anthoscli-linux-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220617150114,
+        "version_string": "0.2.28"
+      }
+    },
+    {
+      "data": {
+        "checksum": "3f51ff8c11103daa5e771ca5152ac77c3243d24cbb7157807d13b4b4b07308d7",
+        "contents_checksum": "2c5e0483a0e2d2f54563b4fb37f10499c0fcd0197c62b2e62be03be2109c7874",
+        "size": 49978629,
+        "source": "components/google-cloud-sdk-anthoscli-linux-x86_64-20220617150114.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "anthoscli"
+      ],
+      "details": {
+        "description": "The cli for Anthos infrastructure.",
+        "display_name": "anthoscli"
+      },
+      "id": "anthoscli-linux-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220617150114,
+        "version_string": "0.2.28"
+      }
+    },
+    {
+      "data": {
+        "checksum": "a343d442a43feb9f9500b3cd9d4f57a7a1e7bf32e8d6505316a6cc0982d37ba3",
+        "contents_checksum": "cacbe5eb27fd9383ff8c7db63ae089f2b2cb5480102066043cf8cdcb61483dff",
+        "size": 48905650,
+        "source": "components/google-cloud-sdk-anthoscli-windows-x86-20220617150114.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "anthoscli"
+      ],
+      "details": {
+        "description": "The cli for Anthos infrastructure.",
+        "display_name": "anthoscli"
+      },
+      "id": "anthoscli-windows-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220617150114,
+        "version_string": "0.2.28"
+      }
+    },
+    {
+      "data": {
+        "checksum": "d012a903e88f92e6a1638f396d05cfb7ae592f79c388d84d2ac559fa9fd8b74c",
+        "contents_checksum": "d0d54c5ac6c2f1b6109a28b6ae29e327082d35259db4d84aed9ca90605841b81",
+        "size": 49983739,
+        "source": "components/google-cloud-sdk-anthoscli-windows-x86_64-20220617150114.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "anthoscli"
+      ],
+      "details": {
+        "description": "The cli for Anthos infrastructure.",
+        "display_name": "anthoscli"
+      },
+      "id": "anthoscli-windows-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220617150114,
+        "version_string": "0.2.28"
+      }
+    },
+    {
+      "dependencies": [
+        "app-engine-go-darwin-arm",
+        "app-engine-go-darwin-x86_64",
+        "app-engine-go-linux-arm",
+        "app-engine-go-linux-x86",
+        "app-engine-go-linux-x86_64",
+        "app-engine-go-windows-x86",
+        "app-engine-go-windows-x86_64",
+        "app-engine-python",
+        "core"
+      ],
+      "details": {
+        "description": "Provides the tools to develop Go applications on App Engine.",
+        "display_name": "App Engine Go Extensions"
+      },
+      "id": "app-engine-go",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm",
+          "x86",
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX",
+          "MACOSX",
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": "1.9.72"
+      }
+    },
+    {
+      "data": {
+        "checksum": "7eb024d38ca4287ae4b801f0406ddf96ec9a038a24b44ff47e08598043fffcb5",
+        "contents_checksum": "edf102f8324654513dbbda4c2ef08e4c326da5e07fded3812cdda40dcc6a3779",
+        "size": 4164730,
+        "source": "components/google-cloud-sdk-app-engine-go-darwin-arm-20220107150005.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "app-engine-go",
+        "app-engine-python",
+        "core"
+      ],
+      "details": {
+        "description": "Provides the tools to develop Go applications on App Engine.",
+        "display_name": "App Engine Go Extensions"
+      },
+      "id": "app-engine-go-darwin-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220107150005,
+        "version_string": "1.9.72"
+      }
+    },
+    {
+      "data": {
+        "checksum": "a6bd5fe9b82e6e48592bffe7c319c042644d2935f422653d6ca6962d1607593f",
+        "contents_checksum": "7e3ea0397ca5204f324f96bd98f4cb3c66081dc692336ab834aa51f052f3b88f",
+        "size": 4320254,
+        "source": "components/google-cloud-sdk-app-engine-go-darwin-x86_64-20211210155428.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "app-engine-go",
+        "app-engine-python",
+        "core"
+      ],
+      "details": {
+        "description": "Provides the tools to develop Go applications on App Engine.",
+        "display_name": "App Engine Go Extensions"
+      },
+      "id": "app-engine-go-darwin-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20211210155428,
+        "version_string": "1.9.72"
+      }
+    },
+    {
+      "data": {
+        "checksum": "b1db6b942bc01f490a6299a9f115f4e11249125d5d50145385bbb6cfb8df3854",
+        "contents_checksum": "cad0737a0c9c29e686b230c13324c74dd64c28add244ba8cd3cba7b2027c0444",
+        "size": 4124968,
+        "source": "components/google-cloud-sdk-app-engine-go-linux-arm-20220107150005.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "app-engine-go",
+        "app-engine-python",
+        "core"
+      ],
+      "details": {
+        "description": "Provides the tools to develop Go applications on App Engine.",
+        "display_name": "App Engine Go Extensions"
+      },
+      "id": "app-engine-go-linux-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220107150005,
+        "version_string": "1.9.72"
+      }
+    },
+    {
+      "data": {
+        "checksum": "700fc1f67d85f439e70ea74f5900d0810fd43225416f54c6712e5b5b5c6fa63c",
+        "contents_checksum": "05f6c1ca0bed61e98dd6ed38824c3fa3205e519801e39778f36ca4c043e2a866",
+        "size": 4419403,
+        "source": "components/google-cloud-sdk-app-engine-go-linux-x86-20211210155428.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "app-engine-go",
+        "app-engine-python",
+        "core"
+      ],
+      "details": {
+        "description": "Provides the tools to develop Go applications on App Engine.",
+        "display_name": "App Engine Go Extensions"
+      },
+      "id": "app-engine-go-linux-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20211210155428,
+        "version_string": "1.9.72"
+      }
+    },
+    {
+      "data": {
+        "checksum": "61d3e66633a172238431d30209e646667b5608b623ea0d31a2397704b09f47a0",
+        "contents_checksum": "9bd4b565d108db2fbe7cc8150cba9e8774380c898409c6bfd3a96b51513dc47d",
+        "size": 4407886,
+        "source": "components/google-cloud-sdk-app-engine-go-linux-x86_64-20211210155428.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "app-engine-go",
+        "app-engine-python",
+        "core"
+      ],
+      "details": {
+        "description": "Provides the tools to develop Go applications on App Engine.",
+        "display_name": "App Engine Go Extensions"
+      },
+      "id": "app-engine-go-linux-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20211210155428,
+        "version_string": "1.9.72"
+      }
+    },
+    {
+      "data": {
+        "checksum": "0a36462f03981be984ed591f7655fe0a01763b42d8cea40aaec727f2a3627f90",
+        "contents_checksum": "28164bba9a55357f09f2682e6e628e1b3860a434ceefdd697d7bb3fc04f864cf",
+        "size": 4412927,
+        "source": "components/google-cloud-sdk-app-engine-go-windows-x86-20211210155428.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "app-engine-go",
+        "app-engine-python",
+        "core"
+      ],
+      "details": {
+        "description": "Provides the tools to develop Go applications on App Engine.",
+        "display_name": "App Engine Go Extensions"
+      },
+      "id": "app-engine-go-windows-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20211210155428,
+        "version_string": "1.9.72"
+      }
+    },
+    {
+      "data": {
+        "checksum": "e96f10ecd585eb69d9a8a296e8963cb22a1613d63a94b88e54d9108d088a868b",
+        "contents_checksum": "e504a1ab5135fcfb597f22739fe3595337887603d1908b77c755616b9d923310",
+        "size": 4365713,
+        "source": "components/google-cloud-sdk-app-engine-go-windows-x86_64-20211210155428.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "app-engine-go",
+        "app-engine-python",
+        "core"
+      ],
+      "details": {
+        "description": "Provides the tools to develop Go applications on App Engine.",
+        "display_name": "App Engine Go Extensions"
+      },
+      "id": "app-engine-go-windows-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20211210155428,
+        "version_string": "1.9.72"
+      }
+    },
+    {
+      "dependencies": [
+        "app-engine-grpc-darwin-x86_64",
+        "app-engine-grpc-linux-x86",
+        "app-engine-grpc-linux-x86_64",
+        "app-engine-grpc-windows-x86",
+        "app-engine-grpc-windows-x86_64",
+        "app-engine-python",
+        "core"
+      ],
+      "details": {
+        "description": "Provides the gRPC Python library for App Engine.",
+        "display_name": "gRPC Python library"
+      },
+      "id": "app-engine-grpc",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86",
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX",
+          "MACOSX",
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": "1.20.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "ab866ccff1a9da0ea3a8e71c432c2f3c768827971192de9466938bb9e80a632e",
+        "contents_checksum": "e2eb0eec683ba513ac95ffa535cebccff326998033155cfb187eb2677f216e0c",
+        "size": 1957787,
+        "source": "components/google-cloud-sdk-app-engine-grpc-darwin-x86_64-20190426144518.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "app-engine-grpc",
+        "app-engine-python",
+        "core"
+      ],
+      "details": {
+        "description": "Provides the gRPC Python library for App Engine.",
+        "display_name": "gRPC Python library"
+      },
+      "id": "app-engine-grpc-darwin-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20190426144518,
+        "version_string": "1.20.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "7da7ca03d04b770d96efbbf55a7b0e992328e947215d00ca702aaed8f5a27161",
+        "contents_checksum": "9f1bf2b01845ba427f5c833e3995c8919b98719a89c841269f15c55482012567",
+        "size": 2104919,
+        "source": "components/google-cloud-sdk-app-engine-grpc-linux-x86-20190426144518.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "app-engine-grpc",
+        "app-engine-python",
+        "core"
+      ],
+      "details": {
+        "description": "Provides the gRPC Python library for App Engine.",
+        "display_name": "gRPC Python library"
+      },
+      "id": "app-engine-grpc-linux-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20190426144518,
+        "version_string": "1.20.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "e6f65a8ec8192f024e59a093279b2be53d36d77862d63a9173a637a4533ad3bb",
+        "contents_checksum": "1b1cfad1979caf370bd308a725e30623f6f65fea5370481b39fe9e3ebe23f6a2",
+        "size": 2153684,
+        "source": "components/google-cloud-sdk-app-engine-grpc-linux-x86_64-20190426144518.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "app-engine-grpc",
+        "app-engine-python",
+        "core"
+      ],
+      "details": {
+        "description": "Provides the gRPC Python library for App Engine.",
+        "display_name": "gRPC Python library"
+      },
+      "id": "app-engine-grpc-linux-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20190426144518,
+        "version_string": "1.20.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "c0c878b429d2ca9ee5196bb348576547062da65b144aac4bbd8cd4c5a1dde1d6",
+        "contents_checksum": "a3edadedc0287b30caaf1db8c27f85e5c9311de3b555a0dfb7c276b3348ab132",
+        "size": 1615365,
+        "source": "components/google-cloud-sdk-app-engine-grpc-windows-x86-20190426144518.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "app-engine-grpc",
+        "app-engine-python",
+        "core"
+      ],
+      "details": {
+        "description": "Provides the gRPC Python library for App Engine.",
+        "display_name": "gRPC Python library"
+      },
+      "id": "app-engine-grpc-windows-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20190426144518,
+        "version_string": "1.20.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "ff3c75c9b459610c33c2dcc4060598bd5edec06ed01d916ded1e429e8defed5d",
+        "contents_checksum": "f6f05b6c3d087ff4e98c1cf9d841319adc30255e08dfff3fa85992238cb0f6a6",
+        "size": 1616022,
+        "source": "components/google-cloud-sdk-app-engine-grpc-windows-x86_64-20190426144518.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "app-engine-grpc",
+        "app-engine-python",
+        "core"
+      ],
+      "details": {
+        "description": "Provides the gRPC Python library for App Engine.",
+        "display_name": "gRPC Python library"
+      },
+      "id": "app-engine-grpc-windows-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20190426144518,
+        "version_string": "1.20.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "975bcefab33d4e48823a743fbfd727033e47635639768354bc3151ffa962b49b",
+        "contents_checksum": "1b13d5c165be0138d5c94024129d36373442ae1f86a8f0745a43375fd3ef9ad3",
+        "size": 53824926,
+        "source": "components/google-cloud-sdk-app-engine-java-20220722145557.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "app-engine-python",
+        "core"
+      ],
+      "details": {
+        "description": "Provides the tools required to develop Java applications using gcloud.",
+        "display_name": "gcloud app Java Extensions"
+      },
+      "id": "app-engine-java",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {},
+      "platform_required": false,
+      "version": {
+        "build_number": 20220722145557,
+        "version_string": "1.9.98"
+      }
+    },
+    {
+      "dependencies": [
+        "app-engine-php-darwin",
+        "app-engine-php-windows",
+        "app-engine-python",
+        "core"
+      ],
+      "details": {
+        "description": "Provides the PHP runtimes for the dev_appserver.",
+        "display_name": "gcloud app PHP Extensions"
+      },
+      "id": "app-engine-php",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {
+        "operating_systems": [
+          "CYGWIN",
+          "MACOSX",
+          "MSYS",
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": ""
+      }
+    },
+    {
+      "data": {
+        "checksum": "9d6d9d232739c8de9dcd7b35b7f8021136138e7892697229d3c04cb4a7aab494",
+        "contents_checksum": "5682195caf966a52c95bb865a3c2b607237ed97c36952b479ef358370401aaeb",
+        "size": 22985548,
+        "source": "components/google-cloud-sdk-app-engine-php-darwin-20170915105257.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "app-engine-php",
+        "app-engine-python",
+        "core"
+      ],
+      "details": {
+        "description": "Provides the PHP runtimes for the dev_appserver.",
+        "display_name": "gcloud app PHP Extensions"
+      },
+      "id": "app-engine-php-darwin",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20170915105257,
+        "version_string": "2017.09.15"
+      }
+    },
+    {
+      "data": {
+        "checksum": "c1f560a660d36d2bca873c01ca37a0790888713b2e056dfeeff3ea03f037235c",
+        "contents_checksum": "d11e66fd28ac784e4ef57b315bf626f01974db5cdbbc5e69f8e2689d4dc4de55",
+        "size": 20074666,
+        "source": "components/google-cloud-sdk-app-engine-php-windows-20170915105257.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "app-engine-php",
+        "app-engine-python",
+        "core"
+      ],
+      "details": {
+        "description": "Provides the PHP runtimes for the dev_appserver.",
+        "display_name": "gcloud app PHP Extensions"
+      },
+      "id": "app-engine-php-windows",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "operating_systems": [
+          "CYGWIN",
+          "MSYS",
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20170915105257,
+        "version_string": "2017.09.15"
+      }
+    },
+    {
+      "data": {
+        "checksum": "bfff4dc45ced105e5010076dfea392f3d6a5e14a8c5289a8b2af77db2fe9632f",
+        "contents_checksum": "0438831ce5792c465cc5e704862dbe55d29cf2c529ca656070854d6c7f945f8c",
+        "size": 8153872,
+        "source": "components/google-cloud-sdk-app-engine-python-20220401142023.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "app-engine-grpc",
+        "cloud-datastore-emulator",
+        "core"
+      ],
+      "details": {
+        "description": "Provides the tools required to develop Python and PHP applications using gcloud.",
+        "display_name": "gcloud app Python Extensions"
+      },
+      "id": "app-engine-python",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {},
+      "platform_required": false,
+      "version": {
+        "build_number": 20220401142023,
+        "version_string": "1.9.100"
+      }
+    },
+    {
+      "data": {
+        "checksum": "83b1c2df408816a9d51d9a0301eb97e30d61d729c987ba585806a444a6785ffc",
+        "contents_checksum": "5d88b8454d9e5d39fb3f4d7a4bb16e296eb6883c325c17622050bf7b73ef8ff0",
+        "size": 27709995,
+        "source": "components/google-cloud-sdk-app-engine-python-extras-20211015142804.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "app-engine-python",
+        "core"
+      ],
+      "details": {
+        "description": "Extra libraries for the App Engine Python Extensions.",
+        "display_name": "gcloud app Python Extensions (Extra Libraries)"
+      },
+      "id": "app-engine-python-extras",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {},
+      "platform_required": false,
+      "version": {
+        "build_number": 20211015142804,
+        "version_string": "1.9.96"
+      }
+    },
+    {
+      "dependencies": [
+        "appctl-darwin-x86",
+        "appctl-darwin-x86_64",
+        "appctl-linux-x86",
+        "appctl-linux-x86_64",
+        "appctl-windows-x86",
+        "appctl-windows-x86_64"
+      ],
+      "details": {
+        "description": "Provides appctl executable.",
+        "display_name": "Appctl"
+      },
+      "id": "appctl",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86",
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX",
+          "MACOSX",
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": "0.1.12"
+      }
+    },
+    {
+      "data": {
+        "checksum": "dc1346aa497ab9856a61d4baadb999d46a025616b0fb941499930e8cd2bb08ef",
+        "contents_checksum": "dc9f7c06e11b6368358bc374d1a281896df26bc2b5d8403e27645452d551db54",
+        "size": 19669923,
+        "source": "components/google-cloud-sdk-appctl-darwin-x86-20200626165905.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "appctl"
+      ],
+      "details": {
+        "description": "Provides appctl executable.",
+        "display_name": "Appctl"
+      },
+      "id": "appctl-darwin-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20200626165905,
+        "version_string": "0.1.12"
+      }
+    },
+    {
+      "data": {
+        "checksum": "73702c9e36f3fa25d3cba2f5b747ccaf40d4439a4beca2187c775cf0b87b5ba0",
+        "contents_checksum": "8f6243a30cde23bea18034fe4b1dcd8373a2e410d92fc784d5708ffb817bb418",
+        "size": 19381598,
+        "source": "components/google-cloud-sdk-appctl-darwin-x86_64-20200626165905.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "appctl"
+      ],
+      "details": {
+        "description": "Provides appctl executable.",
+        "display_name": "Appctl"
+      },
+      "id": "appctl-darwin-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20200626165905,
+        "version_string": "0.1.12"
+      }
+    },
+    {
+      "data": {
+        "checksum": "f9e00574acdc98da65aa7167a11bb1d349e8811f4aabc7a9cad231959a578017",
+        "contents_checksum": "bec7f3d72271d31f4be1516919207d8ab9a5364546339aa6361d47a06e764d44",
+        "size": 20215575,
+        "source": "components/google-cloud-sdk-appctl-linux-x86-20200626165905.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "appctl"
+      ],
+      "details": {
+        "description": "Provides appctl executable.",
+        "display_name": "Appctl"
+      },
+      "id": "appctl-linux-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20200626165905,
+        "version_string": "0.1.12"
+      }
+    },
+    {
+      "data": {
+        "checksum": "1017488e55a6316d6fb51ebfa8306cc58b2f6f24186686f6258c46b2b39d6781",
+        "contents_checksum": "9db848fc1e8721f80b5937dea801d18912d22aeed5682671e77f6d29959be483",
+        "size": 22041660,
+        "source": "components/google-cloud-sdk-appctl-linux-x86_64-20200626165905.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "appctl"
+      ],
+      "details": {
+        "description": "Provides appctl executable.",
+        "display_name": "Appctl"
+      },
+      "id": "appctl-linux-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20200626165905,
+        "version_string": "0.1.12"
+      }
+    },
+    {
+      "data": {
+        "checksum": "1d4bffafcbc0f1a378048123fd838cfaebab55c73c286e7b5128328750268262",
+        "contents_checksum": "908ec0c86e7f779641888f42b7f3b39f98fb91de8c68f4a24d360b1d3050d646",
+        "size": 19638844,
+        "source": "components/google-cloud-sdk-appctl-windows-x86-20200626165905.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "appctl"
+      ],
+      "details": {
+        "description": "Provides appctl executable.",
+        "display_name": "Appctl"
+      },
+      "id": "appctl-windows-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20200626165905,
+        "version_string": "0.1.12"
+      }
+    },
+    {
+      "data": {
+        "checksum": "3ecd725f24eef4715946387442e06af0f9ced436f37d1c9428480fdaa2df034b",
+        "contents_checksum": "0cfec25922905ba72982b630f026045233a0f567220262b3b0aec169559b0732",
+        "size": 19657321,
+        "source": "components/google-cloud-sdk-appctl-windows-x86_64-20200626165905.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "appctl"
+      ],
+      "details": {
+        "description": "Provides appctl executable.",
+        "display_name": "Appctl"
+      },
+      "id": "appctl-windows-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20200626165905,
+        "version_string": "0.1.12"
+      }
+    },
+    {
+      "data": {
+        "checksum": "707d412854a14450b4fddee199d258e75946fe51b44eb2980c8cd7e274c15760",
+        "contents_checksum": "0b4e9d8e6394dc841aece07ca4da91920a460cbd7ec22495be4a2b4f46635b4d",
+        "size": 797,
+        "source": "components/google-cloud-sdk-beta-20220805142045.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "core"
+      ],
+      "details": {
+        "description": "Beta version of gcloud commands.",
+        "display_name": "gcloud Beta Commands"
+      },
+      "id": "beta",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {},
+      "platform_required": false,
+      "version": {
+        "build_number": 20220805142045,
+        "version_string": "2022.08.05"
+      }
+    },
+    {
+      "dependencies": [
+        "bigtable-darwin-arm",
+        "bigtable-darwin-x86",
+        "bigtable-darwin-x86_64",
+        "bigtable-linux-arm",
+        "bigtable-linux-x86",
+        "bigtable-linux-x86_64",
+        "bigtable-windows-x86",
+        "bigtable-windows-x86_64",
+        "core"
+      ],
+      "details": {
+        "description": "Provides a tool for local Cloud Bigtable emulation.",
+        "display_name": "Cloud Bigtable Emulator"
+      },
+      "id": "bigtable",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm",
+          "x86",
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX",
+          "MACOSX",
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": ""
+      }
+    },
+    {
+      "data": {
+        "checksum": "7d209506db2a83c5718976816fff6ac31de6c28edfbd4306ab40dbe356479c64",
+        "contents_checksum": "ee39a485611ad8d2455ea8c24f283e6064b98f5565423759fc1f71439689e891",
+        "size": 6002688,
+        "source": "components/google-cloud-sdk-bigtable-darwin-arm-20211210155428.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "bigtable",
+        "core"
+      ],
+      "details": {
+        "description": "Provides a tool for local Cloud Bigtable emulation.",
+        "display_name": "Cloud Bigtable Emulator"
+      },
+      "id": "bigtable-darwin-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20211210155428,
+        "version_string": ""
+      }
+    },
+    {
+      "data": {
+        "checksum": "be895d4ef5e80c918c49aabb257226192fccaf54933de967725a7a5ad31ec849",
+        "contents_checksum": "d3291c80aa740ddf5ab17943262c2af6eff226508aa0d48b1a5b5c5cbd913962",
+        "size": 6730815,
+        "source": "components/google-cloud-sdk-bigtable-darwin-x86-20190830142709.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "bigtable",
+        "core"
+      ],
+      "details": {
+        "description": "Provides a tool for local Cloud Bigtable emulation.",
+        "display_name": "Cloud Bigtable Emulator"
+      },
+      "id": "bigtable-darwin-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20190830142709,
+        "version_string": "2019.08.30"
+      }
+    },
+    {
+      "data": {
+        "checksum": "72c16c86308c3b202528d40f73af0fc15dc97d10c4456712078aea83e79039cd",
+        "contents_checksum": "98b665df4c937ac84ae9115a0da3491b62691e4e7e1fb98d4b4672078f7d185d",
+        "size": 6190366,
+        "source": "components/google-cloud-sdk-bigtable-darwin-x86_64-20211210155428.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "bigtable",
+        "core"
+      ],
+      "details": {
+        "description": "Provides a tool for local Cloud Bigtable emulation.",
+        "display_name": "Cloud Bigtable Emulator"
+      },
+      "id": "bigtable-darwin-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20211210155428,
+        "version_string": ""
+      }
+    },
+    {
+      "data": {
+        "checksum": "7d8985de0c53340c58bdedeb75d4ffd10f4a55bb94391f6cb4d2c6b1df70101e",
+        "contents_checksum": "d6178d34b99ae088658df06ab27fa990073f0b3d2e1b515ce49036822b71b615",
+        "size": 5877132,
+        "source": "components/google-cloud-sdk-bigtable-linux-arm-20211210155428.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "bigtable",
+        "core"
+      ],
+      "details": {
+        "description": "Provides a tool for local Cloud Bigtable emulation.",
+        "display_name": "Cloud Bigtable Emulator"
+      },
+      "id": "bigtable-linux-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20211210155428,
+        "version_string": ""
+      }
+    },
+    {
+      "data": {
+        "checksum": "4e487d1d370fa6ac500fa7a6a8451af5d69db83767157683c45ff763069119da",
+        "contents_checksum": "3519180cff8988049ac04f273e912613ad5ed82ef947bbbdd9ffb0917b29b39e",
+        "size": 6023473,
+        "source": "components/google-cloud-sdk-bigtable-linux-x86-20211210155428.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "bigtable",
+        "core"
+      ],
+      "details": {
+        "description": "Provides a tool for local Cloud Bigtable emulation.",
+        "display_name": "Cloud Bigtable Emulator"
+      },
+      "id": "bigtable-linux-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20211210155428,
+        "version_string": ""
+      }
+    },
+    {
+      "data": {
+        "checksum": "7500ab3fcfb74e5b9979d56678154aabf6e10e70f12d4a05daa88be92cd7bba3",
+        "contents_checksum": "4a874d418499ef66ebb3e77849017d9924f13fdc267cfb4542b7bf72e90197aa",
+        "size": 6334742,
+        "source": "components/google-cloud-sdk-bigtable-linux-x86_64-20211210155428.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "bigtable",
+        "core"
+      ],
+      "details": {
+        "description": "Provides a tool for local Cloud Bigtable emulation.",
+        "display_name": "Cloud Bigtable Emulator"
+      },
+      "id": "bigtable-linux-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20211210155428,
+        "version_string": ""
+      }
+    },
+    {
+      "data": {
+        "checksum": "050132fe1d123604b1b76754354bf9c3d159886efee74ac754cf46c835b28948",
+        "contents_checksum": "b10643a676f3046e14d75249401b8dc80b6dc32256c3406f1a9f45ced9a472e2",
+        "size": 5991791,
+        "source": "components/google-cloud-sdk-bigtable-windows-x86-20211210155428.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "bigtable",
+        "core"
+      ],
+      "details": {
+        "description": "Provides a tool for local Cloud Bigtable emulation.",
+        "display_name": "Cloud Bigtable Emulator"
+      },
+      "id": "bigtable-windows-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20211210155428,
+        "version_string": ""
+      }
+    },
+    {
+      "data": {
+        "checksum": "f10b8f3075e3defa81027e59323089ab50ddf2cb2a450cdc88696303b49686a0",
+        "contents_checksum": "c0cdf344a3699f5f4d1bef3fc2df9a143ffa0a48c448f4744cb230868ff1554c",
+        "size": 6226583,
+        "source": "components/google-cloud-sdk-bigtable-windows-x86_64-20211210155428.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "bigtable",
+        "core"
+      ],
+      "details": {
+        "description": "Provides a tool for local Cloud Bigtable emulation.",
+        "display_name": "Cloud Bigtable Emulator"
+      },
+      "id": "bigtable-windows-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20211210155428,
+        "version_string": ""
+      }
+    },
+    {
+      "data": {
+        "checksum": "00ee91abb4d06c1bd3e61b621a5139dbc0358629223010503b8513ae720f83c9",
+        "contents_checksum": "4e9be9dfb23ff2071f8a51128a4e84cad77fb0ce5befa1ffd875ea0aa2a1bea0",
+        "size": 1630286,
+        "source": "components/google-cloud-sdk-bq-20220610143733.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "bq-nix",
+        "bq-win",
+        "core"
+      ],
+      "details": {
+        "description": "Provides the bq tool for interacting with the BigQuery service.",
+        "display_name": "BigQuery Command Line Tool"
+      },
+      "id": "bq",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {},
+      "platform_required": false,
+      "version": {
+        "build_number": 20220610143733,
+        "version_string": "2.0.75"
+      }
+    },
+    {
+      "data": {
+        "checksum": "31be1877239d6dcb9113966dbeea4ff62f2526f0e39a860c34f141a150ef78c5",
+        "contents_checksum": "73f7b6b5d91c4b7ec7cd49116af97ac4e806c983850dadf9ac5b9c5364068d78",
+        "size": 1816,
+        "source": "components/google-cloud-sdk-bq-nix-20220805142045.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "bq",
+        "core"
+      ],
+      "details": {
+        "description": "Provides the bq tool for interacting with the BigQuery service.",
+        "display_name": "BigQuery Command Line Tool (Platform Specific)"
+      },
+      "id": "bq-nix",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "operating_systems": [
+          "CYGWIN",
+          "LINUX",
+          "MACOSX",
+          "MSYS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220805142045,
+        "version_string": "2.0.75"
+      }
+    },
+    {
+      "data": {
+        "checksum": "5ae0ba4bdf9b217a5f51f8787ba5cf2ee80ded38d7aa3a49d7040cb7302858de",
+        "contents_checksum": "68c4a31b0e8314777157a20aafb03af681d38b1ff7c95fd9b709a0e378203495",
+        "size": 2567,
+        "source": "components/google-cloud-sdk-bq-win-20210430141114.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "bq",
+        "core"
+      ],
+      "details": {
+        "description": "Provides the bq tool for interacting with the BigQuery service.",
+        "display_name": "BigQuery Command Line Tool (Platform Specific)"
+      },
+      "id": "bq-win",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20210430141114,
+        "version_string": "2.0.67"
+      }
+    },
+    {
+      "dependencies": [
+        "bundled-python-windows-x86",
+        "bundled-python-windows-x86_64",
+        "bundled-python3",
+        "core"
+      ],
+      "details": {
+        "description": "Provides stand-alone Python 2.7 install.",
+        "display_name": "Bundled Python 2.7"
+      },
+      "id": "bundled-python",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86",
+          "x86_64"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": "2.7.13"
+      }
+    },
+    {
+      "data": {
+        "checksum": "8b179d2ffd01bd29d3252feb638de41662ad853f4a109143c45cfbeb221d466b",
+        "contents_checksum": "649ff2cbb21688bb04ccf2c6366bff8008975f7b94848fcfd0e2200dfaca442e",
+        "size": 12763722,
+        "source": "components/google-cloud-sdk-bundled-python-windows-x86-20200605144945.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "bundled-python",
+        "bundled-python3",
+        "core"
+      ],
+      "details": {
+        "description": "Provides stand-alone Python 2.7 install.",
+        "display_name": "Bundled Python 2.7"
+      },
+      "id": "bundled-python-windows-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20200605144945,
+        "version_string": "2.7.13"
+      }
+    },
+    {
+      "data": {
+        "checksum": "6345eae40bebdbbce12f0ccf75161a32c040cd017d43aa697a1cf38a237a3a6f",
+        "contents_checksum": "29e7c3624d567ef8f63fad1f6863391b6e0577dc7f9034433ece3fc6949363bc",
+        "size": 13965732,
+        "source": "components/google-cloud-sdk-bundled-python-windows-x86_64-20200605144945.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "bundled-python",
+        "bundled-python3",
+        "core"
+      ],
+      "details": {
+        "description": "Provides stand-alone Python 2.7 install.",
+        "display_name": "Bundled Python 2.7"
+      },
+      "id": "bundled-python-windows-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20200605144945,
+        "version_string": "2.7.13"
+      }
+    },
+    {
+      "dependencies": [
+        "bundled-python3-windows-x86",
+        "bundled-python3-windows-x86_64",
+        "core"
+      ],
+      "details": {
+        "description": "Provides stand-alone Python 3.9.12 install.",
+        "display_name": "Bundled Python 3.9"
+      },
+      "id": "bundled-python3",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86",
+          "x86_64"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": "3.9.12"
+      }
+    },
+    {
+      "dependencies": [
+        "bundled-python3-unix-linux-x86_64",
+        "core"
+      ],
+      "details": {
+        "description": "Provides stand-alone Python 3.9.12 installation for UNIX.",
+        "display_name": "Bundled Python 3.9"
+      },
+      "id": "bundled-python3-unix",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": "3.9.12"
+      }
+    },
+    {
+      "data": {
+        "checksum": "34e4c2a1c15f45e6142b059f9e13813aa5a49c5a0a32ae4aa2b787fb1144f1fe",
+        "contents_checksum": "2aa3b48f270bdc5b8e2bbf512b7ff80b36f2bbadd57c61628b19b623d71ebed4",
+        "size": 65223088,
+        "source": "components/google-cloud-sdk-bundled-python3-unix-linux-x86_64-20220506143240.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "bundled-python3-unix",
+        "core"
+      ],
+      "details": {
+        "description": "Provides stand-alone Python 3.9.12 installation for UNIX.",
+        "display_name": "Bundled Python 3.9"
+      },
+      "id": "bundled-python3-unix-linux-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220506143240,
+        "version_string": "3.9.12"
+      }
+    },
+    {
+      "data": {
+        "checksum": "67eea3b181e7de3ac9133214bc03c0784aa746a55172a3935e07c26d0b27a3cf",
+        "contents_checksum": "054233368a0de21a5bdc38275418db4ed263191adc85f5e1196795169ef56c0d",
+        "size": 20496613,
+        "source": "components/google-cloud-sdk-bundled-python3-windows-x86-20220506143240.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "bundled-python3",
+        "core"
+      ],
+      "details": {
+        "description": "Provides stand-alone Python 3.9.12 install.",
+        "display_name": "Bundled Python 3.9"
+      },
+      "id": "bundled-python3-windows-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220506143240,
+        "version_string": "3.9.12"
+      }
+    },
+    {
+      "data": {
+        "checksum": "ba15e08bfb91ea0bbefbee8e1cd74fec52ecc10ae318f592dc9c78fd7658d9d7",
+        "contents_checksum": "dea9551901841c338e21f4891f6aa5c969f868fb2bb6db3670b31a9efe608aa9",
+        "size": 22319841,
+        "source": "components/google-cloud-sdk-bundled-python3-windows-x86_64-20220506143240.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "bundled-python3",
+        "core"
+      ],
+      "details": {
+        "description": "Provides stand-alone Python 3.9.12 install.",
+        "display_name": "Bundled Python 3.9"
+      },
+      "id": "bundled-python3-windows-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220506143240,
+        "version_string": "3.9.12"
+      }
+    },
+    {
+      "dependencies": [
+        "cbt-darwin-arm",
+        "cbt-darwin-x86",
+        "cbt-darwin-x86_64",
+        "cbt-linux-arm",
+        "cbt-linux-x86",
+        "cbt-linux-x86_64",
+        "cbt-windows-x86",
+        "cbt-windows-x86_64"
+      ],
+      "details": {
+        "description": "Provides the cbt tool for interacting with the Cloud Bigtable service.",
+        "display_name": "Cloud Bigtable Command Line Tool"
+      },
+      "id": "cbt",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm",
+          "x86",
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX",
+          "MACOSX",
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": "0.12.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "d1b87b622b52227749950bdac78c4fde7273e6be7d933da829909e41b1fbe162",
+        "contents_checksum": "bddf5cd1addcbd5873284a80d24003894d959447a8d5a2b8f332b9e0262d4654",
+        "size": 9711886,
+        "source": "components/google-cloud-sdk-cbt-darwin-arm-20220408151416.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "cbt"
+      ],
+      "details": {
+        "description": "Provides the cbt tool for interacting with the Cloud Bigtable service.",
+        "display_name": "Cloud Bigtable Command Line Tool"
+      },
+      "id": "cbt-darwin-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220408151416,
+        "version_string": "0.12.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "730929dfb7fb308bea5206037004409db36c098ee60e25e5a3792fdbb062899f",
+        "contents_checksum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "size": 94,
+        "source": "components/google-cloud-sdk-cbt-darwin-x86-20220527165258.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "cbt"
+      ],
+      "details": {
+        "description": "Provides the cbt tool for interacting with the Cloud Bigtable service.",
+        "display_name": "Cloud Bigtable Command Line Tool"
+      },
+      "id": "cbt-darwin-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220527165258,
+        "version_string": "0.12.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "7c9db850cffc8cf3023741fee07a29e258663171eba94c439a8293a05d5c5628",
+        "contents_checksum": "2a5f5bf0e4077f21ee492da47b78f5c84d38721e5e1f1f556970a9f9ca2f9311",
+        "size": 10005464,
+        "source": "components/google-cloud-sdk-cbt-darwin-x86_64-20220408151416.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "cbt"
+      ],
+      "details": {
+        "description": "Provides the cbt tool for interacting with the Cloud Bigtable service.",
+        "display_name": "Cloud Bigtable Command Line Tool"
+      },
+      "id": "cbt-darwin-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220408151416,
+        "version_string": "0.12.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "7cc16862e33b712ebb4d7a3e37930a6cec0621f12d06e8371f6be0b2f1d5c4fc",
+        "contents_checksum": "39020c4b1541d32e3e3a2171ef99026e1b913d4bdfff881949c32b821f451ea2",
+        "size": 9596153,
+        "source": "components/google-cloud-sdk-cbt-linux-arm-20220408151416.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "cbt"
+      ],
+      "details": {
+        "description": "Provides the cbt tool for interacting with the Cloud Bigtable service.",
+        "display_name": "Cloud Bigtable Command Line Tool"
+      },
+      "id": "cbt-linux-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220408151416,
+        "version_string": "0.12.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "a6fd809346f8a67ed3fb9721285343ab0d2bd974c80c8fc63e465d6d7a28a92f",
+        "contents_checksum": "973b6d95455dae468b2a4710613805fd20709fded4745e6c3499ef2ae9657659",
+        "size": 10080639,
+        "source": "components/google-cloud-sdk-cbt-linux-x86-20220408151416.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "cbt"
+      ],
+      "details": {
+        "description": "Provides the cbt tool for interacting with the Cloud Bigtable service.",
+        "display_name": "Cloud Bigtable Command Line Tool"
+      },
+      "id": "cbt-linux-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220408151416,
+        "version_string": "0.12.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "7fa96c548bc2ebb0caaebfb22e6a3ee5868d862e382f79b08ba4cbcb36c31607",
+        "contents_checksum": "7c99951de391710e7054252a2a488db9bdd6a1c8174447a04d06e0e7b8be9cc0",
+        "size": 10226666,
+        "source": "components/google-cloud-sdk-cbt-linux-x86_64-20220408151416.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "cbt"
+      ],
+      "details": {
+        "description": "Provides the cbt tool for interacting with the Cloud Bigtable service.",
+        "display_name": "Cloud Bigtable Command Line Tool"
+      },
+      "id": "cbt-linux-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220408151416,
+        "version_string": "0.12.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "5d3cc750386887dffd3e2037587a25c99d704c8a39a63d5bdb4515916de3d286",
+        "contents_checksum": "dacd1b1b498bbcbb4b5d27f2e30d744f43e167dffb2e162ffd1c73247de5e94a",
+        "size": 10069922,
+        "source": "components/google-cloud-sdk-cbt-windows-x86-20220408151416.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "cbt"
+      ],
+      "details": {
+        "description": "Provides the cbt tool for interacting with the Cloud Bigtable service.",
+        "display_name": "Cloud Bigtable Command Line Tool"
+      },
+      "id": "cbt-windows-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220408151416,
+        "version_string": "0.12.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "8cce87fbc5230dd7e9d6852dc9b0e1080dd43b9924ffe0b8af8fc0895d84049d",
+        "contents_checksum": "9f793cbc4bb6c5df4729836eccc40c7374e61634c5a3610a1f38fcd69915eeff",
+        "size": 10087793,
+        "source": "components/google-cloud-sdk-cbt-windows-x86_64-20220408151416.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "cbt"
+      ],
+      "details": {
+        "description": "Provides the cbt tool for interacting with the Cloud Bigtable service.",
+        "display_name": "Cloud Bigtable Command Line Tool"
+      },
+      "id": "cbt-windows-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220408151416,
+        "version_string": "0.12.0"
+      }
+    },
+    {
+      "dependencies": [
+        "cloud-build-local-darwin-x86_64",
+        "cloud-build-local-linux-x86",
+        "cloud-build-local-linux-x86_64"
+      ],
+      "details": {
+        "description": "Provides cloud-build-local executable.  See https://github.com/GoogleCloudPlatform/cloud-build-local",
+        "display_name": "Google Cloud Build Local Builder"
+      },
+      "id": "cloud-build-local",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86",
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX",
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": "0.5.2"
+      }
+    },
+    {
+      "data": {
+        "checksum": "d96d493deac9ee5e6153072a3e8cc89e752be3b00aa3d23deded8656b0a46298",
+        "contents_checksum": "1f75c89816240cd2be9a6be6485f339e855c414aa329d9c263a10eb252371718",
+        "size": 6461890,
+        "source": "components/google-cloud-sdk-cloud-build-local-darwin-x86_64-20201023143012.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "cloud-build-local"
+      ],
+      "details": {
+        "description": "Provides cloud-build-local executable.  See https://github.com/GoogleCloudPlatform/cloud-build-local",
+        "display_name": "Google Cloud Build Local Builder"
+      },
+      "id": "cloud-build-local-darwin-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20201023143012,
+        "version_string": "0.5.2"
+      }
+    },
+    {
+      "data": {
+        "checksum": "c61eb8ad5125db4f22c8eab4b76b92432e872842ca0df19ef7f38174cc964c14",
+        "contents_checksum": "e2a36220cdfb3043d711657e22228d597f8f937e7da0ab56cce168676ba9fa8f",
+        "size": 6346956,
+        "source": "components/google-cloud-sdk-cloud-build-local-linux-x86-20201023143012.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "cloud-build-local"
+      ],
+      "details": {
+        "description": "Provides cloud-build-local executable.  See https://github.com/GoogleCloudPlatform/cloud-build-local",
+        "display_name": "Google Cloud Build Local Builder"
+      },
+      "id": "cloud-build-local-linux-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20201023143012,
+        "version_string": "0.5.2"
+      }
+    },
+    {
+      "data": {
+        "checksum": "3916fed470f06ee12e123781f1e11979d35e363556e64ec601a013f0973683e1",
+        "contents_checksum": "c6a30f889ddb1c00a78a68127b9c9b9d5196f345b5558389da1ab85f019e2503",
+        "size": 6591757,
+        "source": "components/google-cloud-sdk-cloud-build-local-linux-x86_64-20201023143012.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "cloud-build-local"
+      ],
+      "details": {
+        "description": "Provides cloud-build-local executable.  See https://github.com/GoogleCloudPlatform/cloud-build-local",
+        "display_name": "Google Cloud Build Local Builder"
+      },
+      "id": "cloud-build-local-linux-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20201023143012,
+        "version_string": "0.5.2"
+      }
+    },
+    {
+      "data": {
+        "checksum": "7c98eaacbee43daec9ba3ce54133657c6e49ce089310a2fc780de549c678d1c7",
+        "contents_checksum": "7f3e86a3cf39f484009dac34ee13b66fd389927cd4b71566df227d740f67f07b",
+        "size": 36712826,
+        "source": "components/google-cloud-sdk-cloud-datastore-emulator-20220805142045.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "core"
+      ],
+      "details": {
+        "description": "Provides a local emulator of Cloud Datastore.",
+        "display_name": "Cloud Datastore Emulator"
+      },
+      "id": "cloud-datastore-emulator",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {},
+      "platform_required": false,
+      "version": {
+        "build_number": 20220805142045,
+        "version_string": "2.2.2"
+      }
+    },
+    {
+      "data": {
+        "checksum": "ca78b8ebadd0bf5ce42bde5975bbd0f8f79df4dd926ba6ab6bd68b2e12367ec2",
+        "contents_checksum": "2f8fe1680cea2e545ae13628c7d26af6e22d249b892da0243b10461b928884ce",
+        "size": 42140696,
+        "source": "components/google-cloud-sdk-cloud-firestore-emulator-20220708145531.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "core"
+      ],
+      "details": {
+        "description": "Provides a local emulator of Cloud Firestore.",
+        "display_name": "Cloud Firestore Emulator"
+      },
+      "id": "cloud-firestore-emulator",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {},
+      "platform_required": false,
+      "version": {
+        "build_number": 20220708145531,
+        "version_string": "1.14.4"
+      }
+    },
+    {
+      "dependencies": [
+        "cloud-run-proxy-darwin-arm",
+        "cloud-run-proxy-darwin-x86_64",
+        "cloud-run-proxy-linux-arm",
+        "cloud-run-proxy-linux-x86_64",
+        "cloud-run-proxy-windows-x86_64"
+      ],
+      "details": {
+        "description": "Provides cloud-run-proxy executable. See https://github.com/GoogleCloudPlatform/cloud-run-proxy",
+        "display_name": "Cloud Run Proxy"
+      },
+      "id": "cloud-run-proxy",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm",
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX",
+          "MACOSX",
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": "0.3.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "8b6f1e898426170cc9d828d56c65077a2030a2ef4cc1c3acd2faa041ddc11eab",
+        "contents_checksum": "254e6455954c6fbe7edc20e36df09b1a5430e47d3ef6ba855fa64f23558be77e",
+        "size": 7735939,
+        "source": "components/google-cloud-sdk-cloud-run-proxy-darwin-arm-20220310160002.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "cloud-run-proxy"
+      ],
+      "details": {
+        "description": "Provides cloud-run-proxy executable. See https://github.com/GoogleCloudPlatform/cloud-run-proxy",
+        "display_name": "Cloud Run Proxy"
+      },
+      "id": "cloud-run-proxy-darwin-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220310160002,
+        "version_string": "0.3.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "20ae1978957d1686c6e47eeec2eb3374304b87000a4ac9d38aaa48ed0d6a9a78",
+        "contents_checksum": "b84b90138765c10084ad1822c198d2b4e4264effdb6301c8e3cddec2f64ebfda",
+        "size": 8024792,
+        "source": "components/google-cloud-sdk-cloud-run-proxy-darwin-x86_64-20220310160002.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "cloud-run-proxy"
+      ],
+      "details": {
+        "description": "Provides cloud-run-proxy executable. See https://github.com/GoogleCloudPlatform/cloud-run-proxy",
+        "display_name": "Cloud Run Proxy"
+      },
+      "id": "cloud-run-proxy-darwin-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220310160002,
+        "version_string": "0.3.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "4605882aaef70f337c2b92ebc993396d4565edaf0f85dff31c0dc0d553c6cf85",
+        "contents_checksum": "1c8d5c6c77d0cc304ecb562aa887ccc72d8f7cf00dd3c6495fa5e5c1041a22f6",
+        "size": 7670643,
+        "source": "components/google-cloud-sdk-cloud-run-proxy-linux-arm-20220310160002.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "cloud-run-proxy"
+      ],
+      "details": {
+        "description": "Provides cloud-run-proxy executable. See https://github.com/GoogleCloudPlatform/cloud-run-proxy",
+        "display_name": "Cloud Run Proxy"
+      },
+      "id": "cloud-run-proxy-linux-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220310160002,
+        "version_string": "0.3.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "8d5d6af2bc3b912e7b5b0575ef9b5255f33be284065035728b1318c39fdbe4b2",
+        "contents_checksum": "f3fb71ce6c6082cfc4d985a39df76b3a4ba01b326ada09d9c2b68a87b92041e9",
+        "size": 9387984,
+        "source": "components/google-cloud-sdk-cloud-run-proxy-linux-x86_64-20220310160002.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "cloud-run-proxy"
+      ],
+      "details": {
+        "description": "Provides cloud-run-proxy executable. See https://github.com/GoogleCloudPlatform/cloud-run-proxy",
+        "display_name": "Cloud Run Proxy"
+      },
+      "id": "cloud-run-proxy-linux-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220310160002,
+        "version_string": "0.3.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "25fb7bb66dc08fcebc2471e9a040c4a6eab8e5e13c917674f3d108762b399562",
+        "contents_checksum": "b710b3a69fe57881ff1940a28466950d245885a064d7c0c6060fdb313f1e6cda",
+        "size": 7998283,
+        "source": "components/google-cloud-sdk-cloud-run-proxy-windows-x86_64-20220310160002.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "cloud-run-proxy"
+      ],
+      "details": {
+        "description": "Provides cloud-run-proxy executable. See https://github.com/GoogleCloudPlatform/cloud-run-proxy",
+        "display_name": "Cloud Run Proxy"
+      },
+      "id": "cloud-run-proxy-windows-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220310160002,
+        "version_string": "0.3.0"
+      }
+    },
+    {
+      "dependencies": [
+        "cloud-spanner-emulator-linux-x86_64",
+        "core"
+      ],
+      "details": {
+        "description": "Provides a local emulator of Cloud Spanner.",
+        "display_name": "Cloud Spanner Emulator"
+      },
+      "id": "cloud-spanner-emulator",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": "1.4.3"
+      }
+    },
+    {
+      "data": {
+        "checksum": "70917c386da1adc19e650b58285b73e5c0ae487748b926edb68e506f3be27c33",
+        "contents_checksum": "78a0616222d1caca2dae4ccec6f0f030af2c70b49b2369b002bfbe265b6e5399",
+        "size": 28519205,
+        "source": "components/google-cloud-sdk-cloud-spanner-emulator-linux-x86_64-20220719210002.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "cloud-spanner-emulator",
+        "core"
+      ],
+      "details": {
+        "description": "Provides a local emulator of Cloud Spanner.",
+        "display_name": "Cloud Spanner Emulator"
+      },
+      "id": "cloud-spanner-emulator-linux-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220719210002,
+        "version_string": "1.4.3"
+      }
+    },
+    {
+      "dependencies": [
+        "cloud_sql_proxy-darwin-arm",
+        "cloud_sql_proxy-darwin-x86_64",
+        "cloud_sql_proxy-linux-arm",
+        "cloud_sql_proxy-linux-x86",
+        "cloud_sql_proxy-linux-x86_64",
+        "cloud_sql_proxy-windows-x86",
+        "cloud_sql_proxy-windows-x86_64"
+      ],
+      "details": {
+        "description": "Provides cloud_sql_proxy executable. See https://github.com/GoogleCloudPlatform/cloudsql-proxy",
+        "display_name": "Cloud SQL Proxy"
+      },
+      "id": "cloud_sql_proxy",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm",
+          "x86",
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX",
+          "MACOSX",
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": "1.27.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "53f6eba831fdd16a75b290315be4753e826f6b3b2abb8458c95e5af85470279d",
+        "contents_checksum": "2be63d10873f39e791dfae2507a6010de222a142df63354e46ad03370260a040",
+        "size": 7700917,
+        "source": "components/google-cloud-sdk-cloud_sql_proxy-darwin-arm-20211210155428.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "cloud_sql_proxy"
+      ],
+      "details": {
+        "description": "Provides cloud_sql_proxy executable. See https://github.com/GoogleCloudPlatform/cloudsql-proxy",
+        "display_name": "Cloud SQL Proxy"
+      },
+      "id": "cloud_sql_proxy-darwin-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20211210155428,
+        "version_string": "1.27.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "36c550fc7cd33f22688e5859a3e4c93e7aaf503c5171b0b37f90d155baca4174",
+        "contents_checksum": "e1f2fabffeb3a93961c32a19fbe728599f9ef5f602bc9302dddf3491dbfc9f67",
+        "size": 7986647,
+        "source": "components/google-cloud-sdk-cloud_sql_proxy-darwin-x86_64-20211210155428.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "cloud_sql_proxy"
+      ],
+      "details": {
+        "description": "Provides cloud_sql_proxy executable. See https://github.com/GoogleCloudPlatform/cloudsql-proxy",
+        "display_name": "Cloud SQL Proxy"
+      },
+      "id": "cloud_sql_proxy-darwin-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20211210155428,
+        "version_string": "1.27.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "36daf7fcd3097dd871c4d7cae925a6f4dee94b9bf342ce6bc5fdc28bc39308e3",
+        "contents_checksum": "c50c0af3d040a47218548822bac4e2f8ddbfb734037ea5769614d2953d6ca232",
+        "size": 7503669,
+        "source": "components/google-cloud-sdk-cloud_sql_proxy-linux-arm-20211210155428.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "cloud_sql_proxy"
+      ],
+      "details": {
+        "description": "Provides cloud_sql_proxy executable. See https://github.com/GoogleCloudPlatform/cloudsql-proxy",
+        "display_name": "Cloud SQL Proxy"
+      },
+      "id": "cloud_sql_proxy-linux-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20211210155428,
+        "version_string": "1.27.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "0dee101a9fa6edcc449a85e7ea19ba3047f3c16c5108321df5ab7c47eb97b575",
+        "contents_checksum": "caed77ba8b8c3a2f999ef9e68dce4cf85e793460013f0e32857f3950b4b066b9",
+        "size": 7691309,
+        "source": "components/google-cloud-sdk-cloud_sql_proxy-linux-x86-20211210155428.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "cloud_sql_proxy"
+      ],
+      "details": {
+        "description": "Provides cloud_sql_proxy executable. See https://github.com/GoogleCloudPlatform/cloudsql-proxy",
+        "display_name": "Cloud SQL Proxy"
+      },
+      "id": "cloud_sql_proxy-linux-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20211210155428,
+        "version_string": "1.27.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "a43e22a2b8494ceb3b637b1abde7c3a6192eaaa602ea4b577aa129a0b36e7a2e",
+        "contents_checksum": "ed70eb92475f99513c52a40a5137c30fccf0e96e254905d1af4ff8b9ff919aa0",
+        "size": 8154678,
+        "source": "components/google-cloud-sdk-cloud_sql_proxy-linux-x86_64-20211210155428.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "cloud_sql_proxy"
+      ],
+      "details": {
+        "description": "Provides cloud_sql_proxy executable. See https://github.com/GoogleCloudPlatform/cloudsql-proxy",
+        "display_name": "Cloud SQL Proxy"
+      },
+      "id": "cloud_sql_proxy-linux-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20211210155428,
+        "version_string": "1.27.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "22746a14a7687df9a4f681c2b8df1215e89446bb16dcd390c0cb6c30a2698ae4",
+        "contents_checksum": "83569a21f534b605f9dc3a41a07a230ea3b161ff8aec1beee91a528a9235e292",
+        "size": 7381389,
+        "source": "components/google-cloud-sdk-cloud_sql_proxy-windows-x86-20211210155428.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "cloud_sql_proxy"
+      ],
+      "details": {
+        "description": "Provides cloud_sql_proxy executable. See https://github.com/GoogleCloudPlatform/cloudsql-proxy",
+        "display_name": "Cloud SQL Proxy"
+      },
+      "id": "cloud_sql_proxy-windows-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20211210155428,
+        "version_string": "1.27.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "cb47a4c839401c2755e16ee09986ae4c6bdff71e1dd8162fd70f181b7c1e3e82",
+        "contents_checksum": "1e2a0a4304009f4c066956e3fae8065ee0d3eaf5aabb7fac19726f9b8c6bf6ac",
+        "size": 7718129,
+        "source": "components/google-cloud-sdk-cloud_sql_proxy-windows-x86_64-20211210155428.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "cloud_sql_proxy"
+      ],
+      "details": {
+        "description": "Provides cloud_sql_proxy executable. See https://github.com/GoogleCloudPlatform/cloudsql-proxy",
+        "display_name": "Cloud SQL Proxy"
+      },
+      "id": "cloud_sql_proxy-windows-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20211210155428,
+        "version_string": "1.27.0"
+      }
+    },
+    {
+      "dependencies": [
+        "config-connector-darwin-arm",
+        "config-connector-darwin-x86_64",
+        "config-connector-linux-arm",
+        "config-connector-linux-x86_64",
+        "config-connector-windows-x86_64"
+      ],
+      "details": {
+        "description": "Google Cloud Config Connector. See https://cloud.google.com/config-connector/docs/overview",
+        "display_name": "config-connector"
+      },
+      "id": "config-connector",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm",
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX",
+          "MACOSX",
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": "1.91.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "8a5c84aaa997c0fce5abc3080b49d0385f20d17b72d7467d7718eb1de291e172",
+        "contents_checksum": "f5b1d75e99ddf0cd2d2700e140bb9a8725bb5353ddd57dfed46528edfa82352a",
+        "size": 58043186,
+        "source": "components/google-cloud-sdk-config-connector-darwin-arm-20220805142045.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "config-connector"
+      ],
+      "details": {
+        "description": "Google Cloud Config Connector. See https://cloud.google.com/config-connector/docs/overview",
+        "display_name": "config-connector"
+      },
+      "id": "config-connector-darwin-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220805142045,
+        "version_string": "1.91.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "26d1826db0040b76e6143a3c3a85092b64ce3634c55bac41513a16fbc75db1bb",
+        "contents_checksum": "4b4067694172d9c85f722fa75f2c449cd4d67aad192514993c3108cf4d5d8739",
+        "size": 59625932,
+        "source": "components/google-cloud-sdk-config-connector-darwin-x86_64-20220805142045.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "config-connector"
+      ],
+      "details": {
+        "description": "Google Cloud Config Connector. See https://cloud.google.com/config-connector/docs/overview",
+        "display_name": "config-connector"
+      },
+      "id": "config-connector-darwin-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220805142045,
+        "version_string": "1.91.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "974604a14f8ab9d4146cbf3c70b974a7b45eb9f3060de98a3647926ecd675359",
+        "contents_checksum": "31f6186d634e8e7541d1b9a157bb865a6fb259b83b5ada22f6cb6828b871c973",
+        "size": 54420510,
+        "source": "components/google-cloud-sdk-config-connector-linux-arm-20220805142045.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "config-connector"
+      ],
+      "details": {
+        "description": "Google Cloud Config Connector. See https://cloud.google.com/config-connector/docs/overview",
+        "display_name": "config-connector"
+      },
+      "id": "config-connector-linux-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220805142045,
+        "version_string": "1.91.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "b1a296624de7ced067375268c0796aba27c7250102526e98cf6ef7bd095d80c6",
+        "contents_checksum": "1ad0f7c85b4738ce88dc44020714da73379d45e87079e623ac47ac861f168d94",
+        "size": 59194241,
+        "source": "components/google-cloud-sdk-config-connector-linux-x86_64-20220805142045.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "config-connector"
+      ],
+      "details": {
+        "description": "Google Cloud Config Connector. See https://cloud.google.com/config-connector/docs/overview",
+        "display_name": "config-connector"
+      },
+      "id": "config-connector-linux-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220805142045,
+        "version_string": "1.91.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "2feefddab47150f6bb9a10ad6799f865bc1e1ddaa59b8585b0251e2345b199b4",
+        "contents_checksum": "9493d18fbaadd734d35116b20419e7bbb55c949d1ece5d760ff0d5924ba980d3",
+        "size": 59353671,
+        "source": "components/google-cloud-sdk-config-connector-windows-x86_64-20220805142045.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "config-connector"
+      ],
+      "details": {
+        "description": "Google Cloud Config Connector. See https://cloud.google.com/config-connector/docs/overview",
+        "display_name": "config-connector"
+      },
+      "id": "config-connector-windows-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220805142045,
+        "version_string": "1.91.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "21664b6bffac84c8239b217e70217850e33331980b62e2531e93c9e737589071",
+        "contents_checksum": "fa7efddd74122403cee90c15c0f6bf4801f3e11b16197b8c79c040a7a28a8cc7",
+        "size": 25447400,
+        "source": "components/google-cloud-sdk-core-20220805142045.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "core-nix",
+        "core-win",
+        "gcloud-deps",
+        "ssh-tools"
+      ],
+      "details": {
+        "description": "Handles all core functionality for the Google Cloud CLI.",
+        "display_name": "Google Cloud CLI Core Libraries"
+      },
+      "id": "core",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": true,
+      "platform": {},
+      "platform_required": false,
+      "version": {
+        "build_number": 20220805142045,
+        "version_string": "2022.08.05"
+      }
+    },
+    {
+      "data": {
+        "checksum": "8b588bd281f23c083d797c5144da4f856edf23c86131efbabc8ab389ce740fdc",
+        "contents_checksum": "8f1c24d273122da4020ac2106e439187e5d1d2769c75ccff72359fd4e892746f",
+        "size": 2202,
+        "source": "components/google-cloud-sdk-core-nix-20220805142045.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "core",
+        "gcloud-deps",
+        "ssh-tools"
+      ],
+      "details": {
+        "description": "Handles all core functionality for the Google Cloud CLI.",
+        "display_name": "Google Cloud CLI Core Libraries (Platform Specific)"
+      },
+      "id": "core-nix",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": true,
+      "platform": {
+        "operating_systems": [
+          "CYGWIN",
+          "LINUX",
+          "MACOSX",
+          "MSYS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220805142045,
+        "version_string": "2022.08.05"
+      }
+    },
+    {
+      "data": {
+        "checksum": "03fca068cee37d376a81d01475541c099c9e1d11c52a4c9c39f962e20f6edce5",
+        "contents_checksum": "ccd1995010434f506a75d8140fa9b54e8009de81fcbc93b6b35d083db40dc01f",
+        "size": 3087,
+        "source": "components/google-cloud-sdk-core-win-20210430141114.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "core",
+        "gcloud-deps",
+        "ssh-tools"
+      ],
+      "details": {
+        "description": "Handles all core functionality for the Google Cloud CLI.",
+        "display_name": "Google Cloud CLI Core Libraries (Platform Specific)"
+      },
+      "id": "core-win",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": true,
+      "platform": {
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20210430141114,
+        "version_string": "2021.04.30"
+      }
+    },
+    {
+      "data": {
+        "checksum": "be642bd7b9efb920807c74e98fbce1510734f6f125177e18d97e4e64bf9d97e6",
+        "contents_checksum": "a0c6cef6ae50c3f9f756a478a837497a6e33ec0ea7c7c01ee73de308263d87f9",
+        "size": 101325922,
+        "source": "components/google-cloud-sdk-dataflow-sql-20180716155816.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "alpha",
+        "core",
+        "dataflow-sql-nix",
+        "dataflow-sql-win"
+      ],
+      "details": {
+        "description": "Dataflow SQL Shell",
+        "display_name": "Dataflow SQL Shell"
+      },
+      "id": "dataflow-sql",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {},
+      "platform_required": false,
+      "version": {
+        "build_number": 20180716155816,
+        "version_string": "20180711"
+      }
+    },
+    {
+      "data": {
+        "checksum": "85315f1aa4992df190762349d735080dfa74cbb4ba3a9e0e24104df164d6482e",
+        "contents_checksum": "f75bd0240fa748e3f779b7ea4bd19fc7f35ed47fb9eb62705a244c920efd0690",
+        "size": 1839,
+        "source": "components/google-cloud-sdk-dataflow-sql-nix-20220805142045.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "alpha",
+        "core",
+        "dataflow-sql"
+      ],
+      "details": {
+        "description": "Dataflow SQL Shell",
+        "display_name": "Dataflow SQL Shell (Platform Specific)"
+      },
+      "id": "dataflow-sql-nix",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "operating_systems": [
+          "CYGWIN",
+          "LINUX",
+          "MACOSX",
+          "MSYS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220805142045,
+        "version_string": "20180711"
+      }
+    },
+    {
+      "data": {
+        "checksum": "6379500528f324f547d502fe17054f7ee11f4e34fe8cd5e11649a109dfaaf7d9",
+        "contents_checksum": "2822a81f487d4db182c830642336381ec043109ac38cf085fad6b49abeeafc52",
+        "size": 2598,
+        "source": "components/google-cloud-sdk-dataflow-sql-win-20210430141114.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "alpha",
+        "core",
+        "dataflow-sql"
+      ],
+      "details": {
+        "description": "Dataflow SQL Shell",
+        "display_name": "Dataflow SQL Shell (Platform Specific)"
+      },
+      "id": "dataflow-sql-win",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20210430141114,
+        "version_string": "20180711"
+      }
+    },
+    {
+      "data": {
+        "checksum": "14a35a0d77ace272dc527d47da52e8179d108896e0c4ae26fc53ad7823d0ce80",
+        "contents_checksum": "e20f84db8e9b863aa4eac38e273c21c79f4e1ab6afb93743b667caf79c66fedb",
+        "size": 74849,
+        "source": "components/google-cloud-sdk-datalab-20190614191715.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "alpha",
+        "beta",
+        "core",
+        "datalab-nix",
+        "datalab-win",
+        "gcloud"
+      ],
+      "details": {
+        "description": "Provides the datalab tool for managing Google Cloud Datalab instances.",
+        "display_name": "Cloud Datalab Command Line Tool"
+      },
+      "id": "datalab",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {},
+      "platform_required": false,
+      "version": {
+        "build_number": 20190614191715,
+        "version_string": "20190610"
+      }
+    },
+    {
+      "data": {
+        "checksum": "ede6475214e26c5237656f3381b267609bb1470303bea118bd4d85025105da25",
+        "contents_checksum": "e15062374974a0b422807965f10d3599cfe3caf0643d62aee2d0cc5e46bc96cf",
+        "size": 1832,
+        "source": "components/google-cloud-sdk-datalab-nix-20220805142045.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "alpha",
+        "beta",
+        "core",
+        "datalab",
+        "gcloud"
+      ],
+      "details": {
+        "description": "Provides the datalab tool for managing Google Cloud Datalab instances.",
+        "display_name": "Cloud Datalab Command Line Tool (Platform Specific)"
+      },
+      "id": "datalab-nix",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "operating_systems": [
+          "CYGWIN",
+          "LINUX",
+          "MACOSX",
+          "MSYS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220805142045,
+        "version_string": "20190610"
+      }
+    },
+    {
+      "data": {
+        "checksum": "7f5703ef6932516dc1ad1324ae6f46ead4397fe265a3cb944f25ee3dfa3ecc45",
+        "contents_checksum": "ec6a4a4955c462149dd72c50090455ea579dc6c7e3b465b7f6449700cde8ddb4",
+        "size": 1433,
+        "source": "components/google-cloud-sdk-datalab-win-20210430141114.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "alpha",
+        "beta",
+        "core",
+        "datalab",
+        "gcloud"
+      ],
+      "details": {
+        "description": "Provides the datalab tool for managing Google Cloud Datalab instances.",
+        "display_name": "Cloud Datalab Command Line Tool (Platform Specific)"
+      },
+      "id": "datalab-win",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20210430141114,
+        "version_string": "20190610"
+      }
+    },
+    {
+      "dependencies": [
+        "docker-credential-gcr-darwin-x86",
+        "docker-credential-gcr-darwin-x86_64",
+        "docker-credential-gcr-linux-arm",
+        "docker-credential-gcr-linux-x86",
+        "docker-credential-gcr-linux-x86_64",
+        "docker-credential-gcr-windows-x86",
+        "docker-credential-gcr-windows-x86_64"
+      ],
+      "details": {
+        "description": "Provides docker-credential-gcr executable. See https://github.com/GoogleCloudPlatform/docker-credential-gcr",
+        "display_name": "Google Container Registry's Docker credential helper"
+      },
+      "id": "docker-credential-gcr",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm",
+          "x86",
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX",
+          "MACOSX",
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": "1.5.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "42563a3d7d05e960b1fe05708b7923e01cc99ec2f9577041a4290e213c2c6c4c",
+        "contents_checksum": "19ab65926272397722708696135651d1f8f0b384d5f1f921b5936c8ab06da764",
+        "size": 1790467,
+        "source": "components/google-cloud-sdk-docker-credential-gcr-darwin-x86-20180618122334.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "docker-credential-gcr"
+      ],
+      "details": {
+        "description": "Provides docker-credential-gcr executable. See https://github.com/GoogleCloudPlatform/docker-credential-gcr",
+        "display_name": "Google Container Registry's Docker credential helper"
+      },
+      "id": "docker-credential-gcr-darwin-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20180618122334,
+        "version_string": "1.5.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "ac6df1b36972a1160d93c493978e7ad3e061722300808ec10104d703a2dbf66f",
+        "contents_checksum": "13f423113bb0ef0b356aa23b4b01327ec23667a710e98bc88430e2dcd2f5a7bb",
+        "size": 2266831,
+        "source": "components/google-cloud-sdk-docker-credential-gcr-darwin-x86_64-20210205155736.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "docker-credential-gcr"
+      ],
+      "details": {
+        "description": "Provides docker-credential-gcr executable. See https://github.com/GoogleCloudPlatform/docker-credential-gcr",
+        "display_name": "Google Container Registry's Docker credential helper"
+      },
+      "id": "docker-credential-gcr-darwin-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20210205155736,
+        "version_string": "1.5.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "e8218f7e508d944f8654e8c9a547f4be81ce6fa128e15bd27703e51e4ebcfe86",
+        "contents_checksum": "2ff30360e7aaf1219a493b3743979af5cdb8dadb0a2b2a4883d8835cbfaafd85",
+        "size": 2079984,
+        "source": "components/google-cloud-sdk-docker-credential-gcr-linux-arm-20210212155704.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "docker-credential-gcr"
+      ],
+      "details": {
+        "description": "Provides docker-credential-gcr executable. See https://github.com/GoogleCloudPlatform/docker-credential-gcr",
+        "display_name": "Google Container Registry's Docker credential helper"
+      },
+      "id": "docker-credential-gcr-linux-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20210212155704,
+        "version_string": "1.5.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "9fc85ad26ca64564b41cacacb0d5a5fe46d4cc6e2ef07cd6d57633a461247365",
+        "contents_checksum": "5cbd9d9e990c575e1c96ce02a5ac01e0a04d32644bb86ff50203d572103c42ad",
+        "size": 1800324,
+        "source": "components/google-cloud-sdk-docker-credential-gcr-linux-x86-20180618122334.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "docker-credential-gcr"
+      ],
+      "details": {
+        "description": "Provides docker-credential-gcr executable. See https://github.com/GoogleCloudPlatform/docker-credential-gcr",
+        "display_name": "Google Container Registry's Docker credential helper"
+      },
+      "id": "docker-credential-gcr-linux-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20180618122334,
+        "version_string": "1.5.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "f7548568d4c898128e1a76a96d0fb1081d1d762db4e489fcb93e7d6f220981fc",
+        "contents_checksum": "cae6e3cb5a89bfc5e034cf46db18212cec86db1139c9b29b150fa3317c6bd80a",
+        "size": 1900431,
+        "source": "components/google-cloud-sdk-docker-credential-gcr-linux-x86_64-20180618122334.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "docker-credential-gcr"
+      ],
+      "details": {
+        "description": "Provides docker-credential-gcr executable. See https://github.com/GoogleCloudPlatform/docker-credential-gcr",
+        "display_name": "Google Container Registry's Docker credential helper"
+      },
+      "id": "docker-credential-gcr-linux-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20180618122334,
+        "version_string": "1.5.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "234f4b1028ce46c205b6794f33542d51501645628959aef8739020ba63de913d",
+        "contents_checksum": "72c0ccc5ecd3191f0117633d15f9de18363a597d4f618d6feb1420356efeb3b0",
+        "size": 1748011,
+        "source": "components/google-cloud-sdk-docker-credential-gcr-windows-x86-20180618122334.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "docker-credential-gcr"
+      ],
+      "details": {
+        "description": "Provides docker-credential-gcr executable. See https://github.com/GoogleCloudPlatform/docker-credential-gcr",
+        "display_name": "Google Container Registry's Docker credential helper"
+      },
+      "id": "docker-credential-gcr-windows-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20180618122334,
+        "version_string": "1.5.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "ee6e6b15ff38dd6b32bb55ea7d014715bb361ea3eba4efcaa0fb9db52d6d851b",
+        "contents_checksum": "dfb8381b7d79460caa07f1cf27e1511bb56b7e04dfdabac8f6e8d76b1dc715ac",
+        "size": 1849342,
+        "source": "components/google-cloud-sdk-docker-credential-gcr-windows-x86_64-20180618122334.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "docker-credential-gcr"
+      ],
+      "details": {
+        "description": "Provides docker-credential-gcr executable. See https://github.com/GoogleCloudPlatform/docker-credential-gcr",
+        "display_name": "Google Container Registry's Docker credential helper"
+      },
+      "id": "docker-credential-gcr-windows-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20180618122334,
+        "version_string": "1.5.0"
+      }
+    },
+    {
+      "dependencies": [
+        "core"
+      ],
+      "details": {
+        "description": "Default set of gcloud commands.",
+        "display_name": "Default set of gcloud commands"
+      },
+      "id": "gcloud",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {},
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": ""
+      }
+    },
+    {
+      "dependencies": [
+        "gcloud-crc32c-darwin-arm",
+        "gcloud-crc32c-darwin-x86",
+        "gcloud-crc32c-darwin-x86_64",
+        "gcloud-crc32c-linux-arm",
+        "gcloud-crc32c-linux-x86",
+        "gcloud-crc32c-linux-x86_64",
+        "gcloud-crc32c-windows-x86",
+        "gcloud-crc32c-windows-x86_64"
+      ],
+      "details": {
+        "description": "Command line tool that calculates CRC32C hashes on local files.",
+        "display_name": "Google Cloud CRC32C Hash Tool"
+      },
+      "id": "gcloud-crc32c",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm",
+          "x86",
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX",
+          "MACOSX",
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": "1.0.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "a93bc825b66488f72ffcc76e8d2345c7f56c78bddf7d12a540b9dd87d6417703",
+        "contents_checksum": "7571adfa15a0bc8612015fd522065ba3730c5863b10f8bb117951e81a3b24979",
+        "size": 1211045,
+        "source": "components/google-cloud-sdk-gcloud-crc32c-darwin-arm-20220729144039.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "gcloud-crc32c"
+      ],
+      "details": {
+        "description": "Command line tool that calculates CRC32C hashes on local files.",
+        "display_name": "Google Cloud CRC32C Hash Tool"
+      },
+      "id": "gcloud-crc32c-darwin-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220729144039,
+        "version_string": "1.0.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "1921da0b8ce346094cf85d30c76fe8dcdc49a2c1a7024e2b92fc921f1e8f4ae6",
+        "contents_checksum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "size": 104,
+        "source": "components/google-cloud-sdk-gcloud-crc32c-darwin-x86-20220729144039.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "gcloud-crc32c"
+      ],
+      "details": {
+        "description": "Command line tool that calculates CRC32C hashes on local files.",
+        "display_name": "Google Cloud CRC32C Hash Tool"
+      },
+      "id": "gcloud-crc32c-darwin-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220729144039,
+        "version_string": "1.0.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "766f6271d8ad1de1b2b803e7aca680abc445344e30dbb448ead0b98b041ad70a",
+        "contents_checksum": "b8e4eee009bbb6e2d521353569e20f32a66a9f5decd79915baee05eb64b2ac1a",
+        "size": 1250758,
+        "source": "components/google-cloud-sdk-gcloud-crc32c-darwin-x86_64-20220729144039.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "gcloud-crc32c"
+      ],
+      "details": {
+        "description": "Command line tool that calculates CRC32C hashes on local files.",
+        "display_name": "Google Cloud CRC32C Hash Tool"
+      },
+      "id": "gcloud-crc32c-darwin-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220729144039,
+        "version_string": "1.0.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "43b90a729bd21d0e8063ad03c6c00d9436b09e970d4804cdf466e93d514a5ace",
+        "contents_checksum": "f61c2a2be9bde67f61846e8d574cd67ab944b6b164fe5d4851cef363b3221477",
+        "size": 1167442,
+        "source": "components/google-cloud-sdk-gcloud-crc32c-linux-arm-20220729144039.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "gcloud-crc32c"
+      ],
+      "details": {
+        "description": "Command line tool that calculates CRC32C hashes on local files.",
+        "display_name": "Google Cloud CRC32C Hash Tool"
+      },
+      "id": "gcloud-crc32c-linux-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220729144039,
+        "version_string": "1.0.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "eceb82509b4f08e31e21029f3689d2a08b58d27f7cb65211332292c8ea35c5f1",
+        "contents_checksum": "8b2a3c3cda6062cf9b6701f6bb538f12db7fcb8a22b9d17f7de118a949ae7bc4",
+        "size": 1232763,
+        "source": "components/google-cloud-sdk-gcloud-crc32c-linux-x86-20220729144039.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "gcloud-crc32c"
+      ],
+      "details": {
+        "description": "Command line tool that calculates CRC32C hashes on local files.",
+        "display_name": "Google Cloud CRC32C Hash Tool"
+      },
+      "id": "gcloud-crc32c-linux-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220729144039,
+        "version_string": "1.0.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "bee81c890b02fe9a29a76cd982dc06b24f3b8d05a85e26c0d0da64480cb06e02",
+        "contents_checksum": "1448cbc3797bc44b38c69697134c647a52ae4fbb66aed4789d29e2b06435b080",
+        "size": 1243294,
+        "source": "components/google-cloud-sdk-gcloud-crc32c-linux-x86_64-20220729144039.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "gcloud-crc32c"
+      ],
+      "details": {
+        "description": "Command line tool that calculates CRC32C hashes on local files.",
+        "display_name": "Google Cloud CRC32C Hash Tool"
+      },
+      "id": "gcloud-crc32c-linux-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220729144039,
+        "version_string": "1.0.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "4dd1d66aa2f129cb6366dcbd9298ea2ceb1f610e70478da9598a253b5cd7ce3f",
+        "contents_checksum": "93e3ffa333c01eb6697be5ccacc8660ded75b06d37c7e1610de853b1a64a70db",
+        "size": 1302328,
+        "source": "components/google-cloud-sdk-gcloud-crc32c-windows-x86-20220729144039.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "gcloud-crc32c"
+      ],
+      "details": {
+        "description": "Command line tool that calculates CRC32C hashes on local files.",
+        "display_name": "Google Cloud CRC32C Hash Tool"
+      },
+      "id": "gcloud-crc32c-windows-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220729144039,
+        "version_string": "1.0.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "1a4c5f17ec212e15b7c3bc4151d541c33738bb8ae51fbd287dfcc9eb1410ce95",
+        "contents_checksum": "42b91d49eecb27a445b03945dc7a51f17c70b8f0214f2b291984e15ba5f9e8d3",
+        "size": 1308403,
+        "source": "components/google-cloud-sdk-gcloud-crc32c-windows-x86_64-20220729144039.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "gcloud-crc32c"
+      ],
+      "details": {
+        "description": "Command line tool that calculates CRC32C hashes on local files.",
+        "display_name": "Google Cloud CRC32C Hash Tool"
+      },
+      "id": "gcloud-crc32c-windows-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220729144039,
+        "version_string": "1.0.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "50db9a088c2db1a16fdbe3d293a321e4e79d17c680476abc1b6946b6261ebfd2",
+        "contents_checksum": "ffdaad055d9f57c6b991133fb0bfa0e5a8c55ee937fd7cf4cffae7d8d3e833c2",
+        "size": 11787747,
+        "source": "components/google-cloud-sdk-gcloud-deps-20220729144039.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "core",
+        "gcloud-deps-darwin-x86",
+        "gcloud-deps-darwin-x86_64",
+        "gcloud-deps-linux-x86",
+        "gcloud-deps-linux-x86_64",
+        "gcloud-deps-windows-x86",
+        "gcloud-deps-windows-x86_64"
+      ],
+      "details": {
+        "description": "Set of third_party gcloud cli dependencies.",
+        "display_name": "gcloud cli dependencies"
+      },
+      "id": "gcloud-deps",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {},
+      "platform_required": false,
+      "version": {
+        "build_number": 20220729144039,
+        "version_string": "2022.07.29"
+      }
+    },
+    {
+      "data": {
+        "checksum": "b575e593cbd8489f6ecbf055288040242113895b166c0d08a19153ecdc216b69",
+        "contents_checksum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "size": 102,
+        "source": "components/google-cloud-sdk-gcloud-deps-darwin-x86-20210416153011.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "core",
+        "gcloud-deps"
+      ],
+      "details": {
+        "description": "Set of third_party gcloud cli dependencies.",
+        "display_name": "gcloud cli dependencies"
+      },
+      "id": "gcloud-deps-darwin-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20210416153011,
+        "version_string": "2021.04.16"
+      }
+    },
+    {
+      "data": {
+        "checksum": "6935f9a74112a8e4b1479d5d0016e4ab311324d3143fc03c9c5309595b22792f",
+        "contents_checksum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "size": 105,
+        "source": "components/google-cloud-sdk-gcloud-deps-darwin-x86_64-20210416153011.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "core",
+        "gcloud-deps"
+      ],
+      "details": {
+        "description": "Set of third_party gcloud cli dependencies.",
+        "display_name": "gcloud cli dependencies"
+      },
+      "id": "gcloud-deps-darwin-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20210416153011,
+        "version_string": "2021.04.16"
+      }
+    },
+    {
+      "data": {
+        "checksum": "b4f579ee674cc273abb8043ada9579976b4bc46cbbe44633d91355331f5a058c",
+        "contents_checksum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "size": 101,
+        "source": "components/google-cloud-sdk-gcloud-deps-linux-x86-20210416153011.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "core",
+        "gcloud-deps"
+      ],
+      "details": {
+        "description": "Set of third_party gcloud cli dependencies.",
+        "display_name": "gcloud cli dependencies"
+      },
+      "id": "gcloud-deps-linux-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20210416153011,
+        "version_string": "2021.04.16"
+      }
+    },
+    {
+      "data": {
+        "checksum": "685b7bb8f41d7958efc2ed4d0b7f73056150b2e201663520804a4828e2b18213",
+        "contents_checksum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "size": 104,
+        "source": "components/google-cloud-sdk-gcloud-deps-linux-x86_64-20210416153011.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "core",
+        "gcloud-deps"
+      ],
+      "details": {
+        "description": "Set of third_party gcloud cli dependencies.",
+        "display_name": "gcloud cli dependencies"
+      },
+      "id": "gcloud-deps-linux-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20210416153011,
+        "version_string": "2021.04.16"
+      }
+    },
+    {
+      "data": {
+        "checksum": "3b1bff61b17e0d3dcde7520d9fc1cf9252d21d1c67ce44f843a0cbb5c5a30439",
+        "contents_checksum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "size": 103,
+        "source": "components/google-cloud-sdk-gcloud-deps-windows-x86-20210416153011.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "core",
+        "gcloud-deps"
+      ],
+      "details": {
+        "description": "Set of third_party gcloud cli dependencies.",
+        "display_name": "gcloud cli dependencies"
+      },
+      "id": "gcloud-deps-windows-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20210416153011,
+        "version_string": "2021.04.16"
+      }
+    },
+    {
+      "data": {
+        "checksum": "b3198f563ee7e6af472b1d934db648c94e805ab7561c80ca0ac569b2a65b7cba",
+        "contents_checksum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "size": 106,
+        "source": "components/google-cloud-sdk-gcloud-deps-windows-x86_64-20210416153011.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "core",
+        "gcloud-deps"
+      ],
+      "details": {
+        "description": "Set of third_party gcloud cli dependencies.",
+        "display_name": "gcloud cli dependencies"
+      },
+      "id": "gcloud-deps-windows-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20210416153011,
+        "version_string": "2021.04.16"
+      }
+    },
+    {
+      "dependencies": [
+        "core",
+        "gcloud-man-pages-nix"
+      ],
+      "details": {
+        "description": "Man pages for gcloud commands.",
+        "display_name": "Man pages"
+      },
+      "id": "gcloud-man-pages",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "operating_systems": [
+          "CYGWIN",
+          "LINUX",
+          "MACOSX",
+          "MSYS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": ""
+      }
+    },
+    {
+      "data": {
+        "checksum": "24f72a91f2b4588cad97cfd35534021b920319360fa9f9634ef4479b64312a5f",
+        "contents_checksum": "9ea399de12fab3b13f1ce70b292e08613eb6a862a4380a4ab9f96b4763b87fc6",
+        "size": 5057361,
+        "source": "components/google-cloud-sdk-gcloud-man-pages-nix-20220805142045.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "core",
+        "gcloud-man-pages"
+      ],
+      "details": {
+        "description": "Man pages for gcloud commands.",
+        "display_name": "Man pages (Platform Specific)"
+      },
+      "id": "gcloud-man-pages-nix",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "operating_systems": [
+          "CYGWIN",
+          "LINUX",
+          "MACOSX",
+          "MSYS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220805142045,
+        "version_string": ""
+      }
+    },
+    {
+      "dependencies": [
+        "gke-gcloud-auth-plugin-darwin-arm",
+        "gke-gcloud-auth-plugin-darwin-x86_64",
+        "gke-gcloud-auth-plugin-linux-arm",
+        "gke-gcloud-auth-plugin-linux-x86",
+        "gke-gcloud-auth-plugin-linux-x86_64",
+        "gke-gcloud-auth-plugin-windows-x86",
+        "gke-gcloud-auth-plugin-windows-x86_64"
+      ],
+      "details": {
+        "description": "The auth plugin for Kubectl on GKE.",
+        "display_name": "gke-gcloud-auth-plugin"
+      },
+      "id": "gke-gcloud-auth-plugin",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm",
+          "x86",
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX",
+          "MACOSX",
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": "0.2.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "671c488a87f4901023e8d53c6a48b2e95feccf29d1205218a896a297b3c697d3",
+        "contents_checksum": "b354a76976c829c807953730cdb506e01ea591bdd5d4d515879bc0f743e7249c",
+        "size": 3926436,
+        "source": "components/google-cloud-sdk-gke-gcloud-auth-plugin-darwin-arm-20220415194303.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "gke-gcloud-auth-plugin"
+      ],
+      "details": {
+        "description": "The auth plugin for Kubectl on GKE.",
+        "display_name": "gke-gcloud-auth-plugin"
+      },
+      "id": "gke-gcloud-auth-plugin-darwin-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220415194303,
+        "version_string": "0.2.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "13246b33bc9a08cba1e351188c132fec130dbb9699b69b4867dbfde61742809a",
+        "contents_checksum": "cb1344e446dc64eb0d7cad0e8193fb46fd6724de6fabc9e782ffe4b93c9a84e3",
+        "size": 4005591,
+        "source": "components/google-cloud-sdk-gke-gcloud-auth-plugin-darwin-x86_64-20220415194303.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "gke-gcloud-auth-plugin"
+      ],
+      "details": {
+        "description": "The auth plugin for Kubectl on GKE.",
+        "display_name": "gke-gcloud-auth-plugin"
+      },
+      "id": "gke-gcloud-auth-plugin-darwin-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220415194303,
+        "version_string": "0.2.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "d11927a60ab40d5af8c2f350dbf4743234e02396e6700b32bbbfee35713b78d7",
+        "contents_checksum": "abbc8837093fa9c44ba8d8650267311a00b3c177ab008348c923093bf37eba57",
+        "size": 3680423,
+        "source": "components/google-cloud-sdk-gke-gcloud-auth-plugin-linux-arm-20220415194303.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "gke-gcloud-auth-plugin"
+      ],
+      "details": {
+        "description": "The auth plugin for Kubectl on GKE.",
+        "display_name": "gke-gcloud-auth-plugin"
+      },
+      "id": "gke-gcloud-auth-plugin-linux-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220415194303,
+        "version_string": "0.2.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "61432985d9b2fff2715b0c6b5d4322b886f5e090edc9bec9fc7e1c4524172104",
+        "contents_checksum": "8793c98cda22c6d50af6030058adabf21a5a69bd1ef309a9aaaea8f82a9cc941",
+        "size": 3760097,
+        "source": "components/google-cloud-sdk-gke-gcloud-auth-plugin-linux-x86-20220415194303.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "gke-gcloud-auth-plugin"
+      ],
+      "details": {
+        "description": "The auth plugin for Kubectl on GKE.",
+        "display_name": "gke-gcloud-auth-plugin"
+      },
+      "id": "gke-gcloud-auth-plugin-linux-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220415194303,
+        "version_string": "0.2.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "77f398eaedda9d6ae7f33a91495f3728089b2e540ea350bac78eee7c894fab69",
+        "contents_checksum": "b8695b9133a150e05b963f7859135ca8ce39d47fbc68f6524f05606e0902ae8a",
+        "size": 4030889,
+        "source": "components/google-cloud-sdk-gke-gcloud-auth-plugin-linux-x86_64-20220415194303.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "gke-gcloud-auth-plugin"
+      ],
+      "details": {
+        "description": "The auth plugin for Kubectl on GKE.",
+        "display_name": "gke-gcloud-auth-plugin"
+      },
+      "id": "gke-gcloud-auth-plugin-linux-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220415194303,
+        "version_string": "0.2.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "aefb869aa6b77a45f811ea3ae73a79df23c701e8ed2d80e65b86e438c2bc21b2",
+        "contents_checksum": "9fcb071624de3ed495b03b999df73b74a80b37d2d04ff8635d67d770285c7e3d",
+        "size": 3747135,
+        "source": "components/google-cloud-sdk-gke-gcloud-auth-plugin-windows-x86-20220415194303.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "gke-gcloud-auth-plugin"
+      ],
+      "details": {
+        "description": "The auth plugin for Kubectl on GKE.",
+        "display_name": "gke-gcloud-auth-plugin"
+      },
+      "id": "gke-gcloud-auth-plugin-windows-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220415194303,
+        "version_string": "0.2.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "e1dd018badb1e13a94fb288fea9a3c8759e72a2958d45850da12cb8c5efa2393",
+        "contents_checksum": "d750e5aa521dea77b9eb73566a8e4defcaf00f9de35c36a179941cd2c0207486",
+        "size": 4035265,
+        "source": "components/google-cloud-sdk-gke-gcloud-auth-plugin-windows-x86_64-20220415194303.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "gke-gcloud-auth-plugin"
+      ],
+      "details": {
+        "description": "The auth plugin for Kubectl on GKE.",
+        "display_name": "gke-gcloud-auth-plugin"
+      },
+      "id": "gke-gcloud-auth-plugin-windows-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220415194303,
+        "version_string": "0.2.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "75402f8c37812b0c918e2203ada4354a59dbcf7ff21a090fded513e51e6d6e62",
+        "contents_checksum": "f75df7e60be8c0325cc510393e896b1006e4adad99687d9d9d486bc1dc84030b",
+        "size": 16233224,
+        "source": "components/google-cloud-sdk-gsutil-20220719210002.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "core",
+        "gsutil-nix",
+        "gsutil-win"
+      ],
+      "details": {
+        "description": "Provides the gsutil tool for interacting with Google Cloud Storage.",
+        "display_name": "Cloud Storage Command Line Tool"
+      },
+      "id": "gsutil",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {},
+      "platform_required": false,
+      "version": {
+        "build_number": 20220719210002,
+        "version_string": "5.11"
+      }
+    },
+    {
+      "data": {
+        "checksum": "8dedc4501d4c44664dbe4bf403e7ca33d772eb92fe31622e1b0100fd7333eb06",
+        "contents_checksum": "cfed152cbb1c3bd59b818004578584d95049de6ae963f0ecfda786b7feca12f3",
+        "size": 1831,
+        "source": "components/google-cloud-sdk-gsutil-nix-20220805142045.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "core",
+        "gsutil"
+      ],
+      "details": {
+        "description": "Provides the gsutil tool for interacting with Google Cloud Storage.",
+        "display_name": "Cloud Storage Command Line Tool (Platform Specific)"
+      },
+      "id": "gsutil-nix",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "operating_systems": [
+          "CYGWIN",
+          "LINUX",
+          "MACOSX",
+          "MSYS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220805142045,
+        "version_string": "5.11"
+      }
+    },
+    {
+      "data": {
+        "checksum": "d8619ff9a346685d60cb3c9092cecc640bc3b426079454ba78d5a57f6001006c",
+        "contents_checksum": "9dce4185b8d842133a744c2582b9d1910d358cc4b9f7b2699cbd56ea65f81c94",
+        "size": 3898,
+        "source": "components/google-cloud-sdk-gsutil-win-20220805142045.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "core",
+        "gsutil"
+      ],
+      "details": {
+        "description": "Provides the gsutil tool for interacting with Google Cloud Storage.",
+        "display_name": "Cloud Storage Command Line Tool (Platform Specific)"
+      },
+      "id": "gsutil-win",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220805142045,
+        "version_string": "5.11"
+      }
+    },
+    {
+      "dependencies": [
+        "harbourbridge-linux-x86_64"
+      ],
+      "details": {
+        "description": "Performs database migrations to Cloud Spanner databases.",
+        "display_name": "Cloud Spanner Migration Tool"
+      },
+      "id": "harbourbridge",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": "1.0.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "42c9dbf6b3835f9aebc69d2c335515dc07d05ab58568335493a3d539c8108c22",
+        "contents_checksum": "97b66d6b86f066f1ff0ef51e1a15939c7014f3166ba50913d624838a3bd571a9",
+        "size": 15545662,
+        "source": "components/google-cloud-sdk-harbourbridge-linux-x86_64-20220719210002.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "harbourbridge"
+      ],
+      "details": {
+        "description": "Performs database migrations to Cloud Spanner databases.",
+        "display_name": "Cloud Spanner Migration Tool"
+      },
+      "id": "harbourbridge-linux-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220719210002,
+        "version_string": "1.0.0"
+      }
+    },
+    {
+      "dependencies": [
+        "kpt-darwin-arm",
+        "kpt-darwin-x86_64",
+        "kpt-linux-arm",
+        "kpt-linux-x86_64"
+      ],
+      "details": {
+        "description": "Kubernetes Platform Toolkit for packaging, customizing and applying Resource configuration.",
+        "display_name": "kpt"
+      },
+      "id": "kpt",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm",
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX",
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": "1.0.0-beta.15"
+      }
+    },
+    {
+      "data": {
+        "checksum": "54832faecd651a195238c6769687db952ed26ba736e29377163d31ad0be6e4d9",
+        "contents_checksum": "a321f891eac8fd81725f524d07767f67e36be8a40b480da63a184da270165926",
+        "size": 13177521,
+        "source": "components/google-cloud-sdk-kpt-darwin-arm-20220603151008.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "kpt"
+      ],
+      "details": {
+        "description": "Kubernetes Platform Toolkit for packaging, customizing and applying Resource configuration.",
+        "display_name": "kpt"
+      },
+      "id": "kpt-darwin-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220603151008,
+        "version_string": "1.0.0-beta.15"
+      }
+    },
+    {
+      "data": {
+        "checksum": "ae18833566971dee8d785446f45f57885461a2bd835d7a77e46ec88912f49d23",
+        "contents_checksum": "3558c012738e15fe73e38f32199a11f0e19de060f3ab297f0b5877afdc0cdc05",
+        "size": 13379861,
+        "source": "components/google-cloud-sdk-kpt-darwin-x86_64-20220603151008.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "kpt"
+      ],
+      "details": {
+        "description": "Kubernetes Platform Toolkit for packaging, customizing and applying Resource configuration.",
+        "display_name": "kpt"
+      },
+      "id": "kpt-darwin-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220603151008,
+        "version_string": "1.0.0-beta.15"
+      }
+    },
+    {
+      "data": {
+        "checksum": "c1bdac760bab48215aaa91e3f71be4ca05a7c0be728f837bc949ab179b4cfd07",
+        "contents_checksum": "bc5c05fcb5584a521f797f2a21178eb90dd9cd021243a50db8816f27424f7705",
+        "size": 11513185,
+        "source": "components/google-cloud-sdk-kpt-linux-arm-20220603151008.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "kpt"
+      ],
+      "details": {
+        "description": "Kubernetes Platform Toolkit for packaging, customizing and applying Resource configuration.",
+        "display_name": "kpt"
+      },
+      "id": "kpt-linux-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220603151008,
+        "version_string": "1.0.0-beta.15"
+      }
+    },
+    {
+      "data": {
+        "checksum": "0b1e44f5cdbcf03cd576965438952c01961e90da0d54a4e2c7f6cf29d77a3a04",
+        "contents_checksum": "73478069f5dfeab0b2cb1ad9be1f324b588f431ba754ecad2dacf21ebc937155",
+        "size": 12734504,
+        "source": "components/google-cloud-sdk-kpt-linux-x86_64-20220603151008.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "kpt"
+      ],
+      "details": {
+        "description": "Kubernetes Platform Toolkit for packaging, customizing and applying Resource configuration.",
+        "display_name": "kpt"
+      },
+      "id": "kpt-linux-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220603151008,
+        "version_string": "1.0.0-beta.15"
+      }
+    },
+    {
+      "data": {
+        "checksum": "53aae2e2d03d7593bd1737217c1f7ab0d4fd983fb834ec0ceb2c8a47ed4afe3e",
+        "contents_checksum": "04f1f05cc75156a6240a0e8d3e56bab4a6e1e73b80ba4449ad317f5361749a75",
+        "size": 48204,
+        "source": "components/google-cloud-sdk-kubectl-20220722145557.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "gke-gcloud-auth-plugin",
+        "kubectl-darwin-arm",
+        "kubectl-darwin-x86_64",
+        "kubectl-linux-arm",
+        "kubectl-linux-x86",
+        "kubectl-linux-x86_64",
+        "kubectl-windows-x86",
+        "kubectl-windows-x86_64"
+      ],
+      "details": {
+        "description": "Provides kubectl executables.",
+        "display_name": "kubectl"
+      },
+      "id": "kubectl",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {},
+      "platform_required": true,
+      "version": {
+        "build_number": 20220722145557,
+        "version_string": "1.22.12"
+      }
+    },
+    {
+      "data": {
+        "checksum": "183a93dc2868f125fd74ac0907d8314806af95bcdee7dfedd2a0d6693e38220a",
+        "contents_checksum": "5cc81a6770bf326c6f9dce82a620a6a6210319969e3a4de91d567eab2b21acb8",
+        "size": 68347897,
+        "source": "components/google-cloud-sdk-kubectl-darwin-arm-20220722145557.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "gke-gcloud-auth-plugin",
+        "kubectl"
+      ],
+      "details": {
+        "description": "Provides kubectl executables.",
+        "display_name": "kubectl"
+      },
+      "id": "kubectl-darwin-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": true,
+      "version": {
+        "build_number": 20220722145557,
+        "version_string": "1.22.12"
+      }
+    },
+    {
+      "data": {
+        "checksum": "f08c5e917c04dce420d4fb5fc98e4f0dbb234ed00ba81c11c7dcf6ba05da1c71",
+        "contents_checksum": "4f1cdd27d68a22e9fd4bc762f6d8d4ab6a079b2c6e52c3c2ba8f9de82b099b0d",
+        "size": 95973956,
+        "source": "components/google-cloud-sdk-kubectl-darwin-x86_64-20220722145557.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "gke-gcloud-auth-plugin",
+        "kubectl"
+      ],
+      "details": {
+        "description": "Provides kubectl executables.",
+        "display_name": "kubectl"
+      },
+      "id": "kubectl-darwin-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": true,
+      "version": {
+        "build_number": 20220722145557,
+        "version_string": "1.22.12"
+      }
+    },
+    {
+      "data": {
+        "checksum": "68a90b93bcc95518e57f627fd3db2d949ac290ba457645633c6c92f22d5a02aa",
+        "contents_checksum": "e023599a6381690ffdf61952d8183b1010d0c445b5ca3f5543650cb56b31bd43",
+        "size": 84739879,
+        "source": "components/google-cloud-sdk-kubectl-linux-arm-20220722145557.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "gke-gcloud-auth-plugin",
+        "kubectl"
+      ],
+      "details": {
+        "description": "Provides kubectl executables.",
+        "display_name": "kubectl"
+      },
+      "id": "kubectl-linux-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": true,
+      "version": {
+        "build_number": 20220722145557,
+        "version_string": "1.22.12"
+      }
+    },
+    {
+      "data": {
+        "checksum": "dbb20121a8590ae23b9b4570d9bbe1ed4ef75c0301fb5c82ba8f39d8204e3dc9",
+        "contents_checksum": "c164f5f80d3d6a6fb34faefa4a5e2f30203870fe258de483ff9da2daa636bba6",
+        "size": 85216084,
+        "source": "components/google-cloud-sdk-kubectl-linux-x86-20220722145557.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "gke-gcloud-auth-plugin",
+        "kubectl"
+      ],
+      "details": {
+        "description": "Provides kubectl executables.",
+        "display_name": "kubectl"
+      },
+      "id": "kubectl-linux-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": true,
+      "version": {
+        "build_number": 20220722145557,
+        "version_string": "1.22.12"
+      }
+    },
+    {
+      "data": {
+        "checksum": "cad7f2a1e918a582f849e2a7680a901f844b67fc13185ab81ddf0df644d73a2e",
+        "contents_checksum": "ce7711c4e5f89e79ce85cfe25e733911a67a8e20de9ac19794f4a84d083f754d",
+        "size": 91318082,
+        "source": "components/google-cloud-sdk-kubectl-linux-x86_64-20220722145557.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "gke-gcloud-auth-plugin",
+        "kubectl"
+      ],
+      "details": {
+        "description": "Provides kubectl executables.",
+        "display_name": "kubectl"
+      },
+      "id": "kubectl-linux-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": true,
+      "version": {
+        "build_number": 20220722145557,
+        "version_string": "1.22.12"
+      }
+    },
+    {
+      "dependencies": [
+        "kubectl-oidc-darwin-arm",
+        "kubectl-oidc-darwin-x86_64",
+        "kubectl-oidc-linux-arm",
+        "kubectl-oidc-linux-x86_64",
+        "kubectl-oidc-windows-x86_64"
+      ],
+      "details": {
+        "description": "Configure kubectl with OIDC credentials for GKE clusters.",
+        "display_name": "kubectl-oidc"
+      },
+      "id": "kubectl-oidc",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm",
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX",
+          "MACOSX",
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": "1.4.3"
+      }
+    },
+    {
+      "data": {
+        "checksum": "2ec95a80a5c1c165488702eecfe84a17f51c8dd0ea96e5b5b10e805bb45f61a5",
+        "contents_checksum": "2d1d1a849782dcf64e1b187387e2335277cb6801cf657e91eebd2d8582f2fe19",
+        "size": 19054821,
+        "source": "components/google-cloud-sdk-kubectl-oidc-darwin-arm-20220729144039.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "kubectl-oidc"
+      ],
+      "details": {
+        "description": "Configure kubectl with OIDC credentials for GKE clusters.",
+        "display_name": "kubectl-oidc"
+      },
+      "id": "kubectl-oidc-darwin-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220729144039,
+        "version_string": "1.4.3"
+      }
+    },
+    {
+      "data": {
+        "checksum": "f9f5fba90117efb21a256ced62d431d1c1257855052ca53066cb52dbaf76c960",
+        "contents_checksum": "72cdd4ed404e24c506ddddaaff6c5ea19a222dac673a21ac4a288bedc267a2f3",
+        "size": 19911397,
+        "source": "components/google-cloud-sdk-kubectl-oidc-darwin-x86_64-20220729144039.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "kubectl-oidc"
+      ],
+      "details": {
+        "description": "Configure kubectl with OIDC credentials for GKE clusters.",
+        "display_name": "kubectl-oidc"
+      },
+      "id": "kubectl-oidc-darwin-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220729144039,
+        "version_string": "1.4.3"
+      }
+    },
+    {
+      "data": {
+        "checksum": "b75f04ad05de495342265e6b3b65d9146cd6a0c32aa8d3c8af9cdf29ef9396a3",
+        "contents_checksum": "bd186ff699cd4a85dea551e3b2a98f9bc6b17f3c1bde5ab26de3a8013cd1b48f",
+        "size": 18716163,
+        "source": "components/google-cloud-sdk-kubectl-oidc-linux-arm-20220729144039.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "kubectl-oidc"
+      ],
+      "details": {
+        "description": "Configure kubectl with OIDC credentials for GKE clusters.",
+        "display_name": "kubectl-oidc"
+      },
+      "id": "kubectl-oidc-linux-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220729144039,
+        "version_string": "1.4.3"
+      }
+    },
+    {
+      "data": {
+        "checksum": "a961eb557b60f2b4f85efaf1178bb2b2c00dc76aad4428e52e4675ac433b39f9",
+        "contents_checksum": "02d55ba02e330737d36b164642c351579a90d96a2618b313a36b069f3dc9eb62",
+        "size": 20095032,
+        "source": "components/google-cloud-sdk-kubectl-oidc-linux-x86_64-20220729144039.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "kubectl-oidc"
+      ],
+      "details": {
+        "description": "Configure kubectl with OIDC credentials for GKE clusters.",
+        "display_name": "kubectl-oidc"
+      },
+      "id": "kubectl-oidc-linux-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220729144039,
+        "version_string": "1.4.3"
+      }
+    },
+    {
+      "data": {
+        "checksum": "58504d03cb89202ae39a199cd099d52bd370698a231dcc69636c583d58cda6f0",
+        "contents_checksum": "61fea21e4e483439b865217a3d6cffc20ece1e596415d1ed2fe5cf0157873332",
+        "size": 20093462,
+        "source": "components/google-cloud-sdk-kubectl-oidc-windows-x86_64-20220729144039.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "kubectl-oidc"
+      ],
+      "details": {
+        "description": "Configure kubectl with OIDC credentials for GKE clusters.",
+        "display_name": "kubectl-oidc"
+      },
+      "id": "kubectl-oidc-windows-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220729144039,
+        "version_string": "1.4.3"
+      }
+    },
+    {
+      "data": {
+        "checksum": "a4ab96118718d8deb17e4a6366e710016cd724e0f9aa748b12337f692f2a3560",
+        "contents_checksum": "4ef9d705ffbbe3a250f977e96144284b6eb5de741022baf9cf891b3701f3b1ae",
+        "size": 89788788,
+        "source": "components/google-cloud-sdk-kubectl-windows-x86-20220722145557.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "gke-gcloud-auth-plugin",
+        "kubectl"
+      ],
+      "details": {
+        "description": "Provides kubectl executables.",
+        "display_name": "kubectl"
+      },
+      "id": "kubectl-windows-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "CYGWIN",
+          "MSYS",
+          "WINDOWS"
+        ]
+      },
+      "platform_required": true,
+      "version": {
+        "build_number": 20220722145557,
+        "version_string": "1.22.12"
+      }
+    },
+    {
+      "data": {
+        "checksum": "a6b1959aebd022162d6fdbc83c98112a7a7fd8fc1a9d753c8c76720b94e44875",
+        "contents_checksum": "3159a9b26c49fd74a95e88235d7d0ce4c9424639121557870161d94ae4c1cc91",
+        "size": 92776963,
+        "source": "components/google-cloud-sdk-kubectl-windows-x86_64-20220722145557.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "gke-gcloud-auth-plugin",
+        "kubectl"
+      ],
+      "details": {
+        "description": "Provides kubectl executables.",
+        "display_name": "kubectl"
+      },
+      "id": "kubectl-windows-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "CYGWIN",
+          "MSYS",
+          "WINDOWS"
+        ]
+      },
+      "platform_required": true,
+      "version": {
+        "build_number": 20220722145557,
+        "version_string": "1.22.12"
+      }
+    },
+    {
+      "dependencies": [
+        "kustomize-darwin-arm",
+        "kustomize-darwin-x86_64",
+        "kustomize-linux-arm",
+        "kustomize-linux-x86_64"
+      ],
+      "details": {
+        "description": "Provides kustomize executable.",
+        "display_name": "Kustomize"
+      },
+      "id": "kustomize",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm",
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX",
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": "4.4.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "b95afa06b03f17e547147d8cdbb580d2f2aed61bcaeca54ea36c36831fe650d3",
+        "contents_checksum": "b43056bfa3c4617bda2639f6cd8ab0158d426e2e2f7efcfece1c603b525dc644",
+        "size": 7742264,
+        "source": "components/google-cloud-sdk-kustomize-darwin-arm-20211105152221.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "kustomize"
+      ],
+      "details": {
+        "description": "Provides kustomize executable.",
+        "display_name": "Kustomize"
+      },
+      "id": "kustomize-darwin-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20211105152221,
+        "version_string": "4.4.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "3249a57333c76820058bbce9e5c1092cc236d9dd92eec06c7bd96ae5daa2ffce",
+        "contents_checksum": "2240a0c0c35f660fbf17fd02f75a042fa8476898b757b6be09e6fca83ecd744b",
+        "size": 7961940,
+        "source": "components/google-cloud-sdk-kustomize-darwin-x86_64-20211105152221.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "kustomize"
+      ],
+      "details": {
+        "description": "Provides kustomize executable.",
+        "display_name": "Kustomize"
+      },
+      "id": "kustomize-darwin-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20211105152221,
+        "version_string": "4.4.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "bc7d4df4872108f616b8aa3fc73542c0659dc6497c02f47c08c89a1020d033a1",
+        "contents_checksum": "64a057772ce8a7e0ced2c8aa25137e00a4bceaf8734502ddb7933f3c9c7daf23",
+        "size": 4099867,
+        "source": "components/google-cloud-sdk-kustomize-linux-arm-20211105152221.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "kustomize"
+      ],
+      "details": {
+        "description": "Provides kustomize executable.",
+        "display_name": "Kustomize"
+      },
+      "id": "kustomize-linux-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20211105152221,
+        "version_string": "4.4.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "baa11714bcd75fef7bdf156e36b3f6fd52efef4f849bb0fd490d5287c85b3524",
+        "contents_checksum": "565e74944c349441370287bed68e8972531ba4e29f9c91aecd19ee53840a4c71",
+        "size": 4534871,
+        "source": "components/google-cloud-sdk-kustomize-linux-x86_64-20211105152221.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "kustomize"
+      ],
+      "details": {
+        "description": "Provides kustomize executable.",
+        "display_name": "Kustomize"
+      },
+      "id": "kustomize-linux-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20211105152221,
+        "version_string": "4.4.0"
+      }
+    },
+    {
+      "dependencies": [
+        "local-extract-darwin-arm",
+        "local-extract-darwin-x86_64",
+        "local-extract-linux-arm",
+        "local-extract-linux-x86_64"
+      ],
+      "details": {
+        "description": "Locally extract packages/versions from a container image.",
+        "display_name": "On-Demand Scanning API extraction helper"
+      },
+      "id": "local-extract",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm",
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX",
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": "1.5.3"
+      }
+    },
+    {
+      "data": {
+        "checksum": "a6a9d97bbd8f47f60c931b4afa61e604d1dfd55bb82192ab32d9eb2d295b36b5",
+        "contents_checksum": "8306b904f95f187528c7d1a9357ca1122aebb87f738449edd3b4f608773c3ba2",
+        "size": 11400102,
+        "source": "components/google-cloud-sdk-local-extract-darwin-arm-20220527165258.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "local-extract"
+      ],
+      "details": {
+        "description": "Locally extract packages/versions from a container image.",
+        "display_name": "On-Demand Scanning API extraction helper"
+      },
+      "id": "local-extract-darwin-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220527165258,
+        "version_string": "1.5.3"
+      }
+    },
+    {
+      "data": {
+        "checksum": "3744e613cd9c218a8ad0c713cea4c30c8bd4d34bddc2a4c1bff1208f8a6dcd2f",
+        "contents_checksum": "ae929c4c03575117c4c36d00fad3f9f417b54e03765091865ef2b449725dcc0c",
+        "size": 11814678,
+        "source": "components/google-cloud-sdk-local-extract-darwin-x86_64-20220527165258.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "local-extract"
+      ],
+      "details": {
+        "description": "Locally extract packages/versions from a container image.",
+        "display_name": "On-Demand Scanning API extraction helper"
+      },
+      "id": "local-extract-darwin-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220527165258,
+        "version_string": "1.5.3"
+      }
+    },
+    {
+      "data": {
+        "checksum": "86d0e6748dad80a1268b8e2835065e5982ebddc3a8048d55bbf301337a632e82",
+        "contents_checksum": "eff9cd2906e8c3b751b3c435e8ead1daf01aa68acb81f226a26da8404bc8fc6a",
+        "size": 11256244,
+        "source": "components/google-cloud-sdk-local-extract-linux-arm-20220527165258.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "local-extract"
+      ],
+      "details": {
+        "description": "Locally extract packages/versions from a container image.",
+        "display_name": "On-Demand Scanning API extraction helper"
+      },
+      "id": "local-extract-linux-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220527165258,
+        "version_string": "1.5.3"
+      }
+    },
+    {
+      "data": {
+        "checksum": "c6ea29aebff7fc85fe5359111e7de402fb782e0a030676f978b897d335f1025b",
+        "contents_checksum": "b6cc9c0ff16c99643373b4c98f7956008fe31fe3a8762d2809848f372846a619",
+        "size": 13350856,
+        "source": "components/google-cloud-sdk-local-extract-linux-x86_64-20220527165258.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "local-extract"
+      ],
+      "details": {
+        "description": "Locally extract packages/versions from a container image.",
+        "display_name": "On-Demand Scanning API extraction helper"
+      },
+      "id": "local-extract-linux-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220527165258,
+        "version_string": "1.5.3"
+      }
+    },
+    {
+      "dependencies": [
+        "minikube-darwin-arm",
+        "minikube-darwin-x86_64",
+        "minikube-linux-arm",
+        "minikube-linux-x86_64",
+        "minikube-windows-x86_64"
+      ],
+      "details": {
+        "description": "Provides minikube executable. See https://kubernetes.io/docs/tasks/tools/install-minikube/",
+        "display_name": "Minikube"
+      },
+      "id": "minikube",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm",
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX",
+          "MACOSX",
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": "1.26.1"
+      }
+    },
+    {
+      "data": {
+        "checksum": "27a35a1156344d63a44e376956e024a8031b1eeaf8adc0c1833b10d838bf7afe",
+        "contents_checksum": "e4101d218a7ce1f361ebffa3b2940dc45e496796e29415ad8f6913b8d2c06ab4",
+        "size": 30786798,
+        "source": "components/google-cloud-sdk-minikube-darwin-arm-20220805142045.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "minikube"
+      ],
+      "details": {
+        "description": "Provides minikube executable. See https://kubernetes.io/docs/tasks/tools/install-minikube/",
+        "display_name": "Minikube"
+      },
+      "id": "minikube-darwin-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220805142045,
+        "version_string": "1.26.1"
+      }
+    },
+    {
+      "data": {
+        "checksum": "e851e190b2a4747d32f72ba2caaf9cda7bbf6a67b1c357a221598ee9af04eb52",
+        "contents_checksum": "40b12f79e6446f3d5cbbc3133069cd7349e0ce7744959362b235345329aae84e",
+        "size": 31814476,
+        "source": "components/google-cloud-sdk-minikube-darwin-x86_64-20220805142045.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "minikube"
+      ],
+      "details": {
+        "description": "Provides minikube executable. See https://kubernetes.io/docs/tasks/tools/install-minikube/",
+        "display_name": "Minikube"
+      },
+      "id": "minikube-darwin-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220805142045,
+        "version_string": "1.26.1"
+      }
+    },
+    {
+      "data": {
+        "checksum": "793a34c028e32ed307023aed42012f89bf1677e8ef004b785b10816bd3c1347d",
+        "contents_checksum": "eeea49fc6d42b8b6aca0b5cbcc18e594042d24bdda142e530b7b4ca5b250c100",
+        "size": 30251095,
+        "source": "components/google-cloud-sdk-minikube-linux-arm-20220805142045.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "minikube"
+      ],
+      "details": {
+        "description": "Provides minikube executable. See https://kubernetes.io/docs/tasks/tools/install-minikube/",
+        "display_name": "Minikube"
+      },
+      "id": "minikube-linux-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220805142045,
+        "version_string": "1.26.1"
+      }
+    },
+    {
+      "data": {
+        "checksum": "f8018c1c90f3aaa7d6d16ebdd6fc9f9f4fe1278278257dc8baedbea8faaea055",
+        "contents_checksum": "c9a2f9ed229eab8c0bae77fd9eaa2bd1c287383db3f4395cf5131a8bb20abbe2",
+        "size": 32405345,
+        "source": "components/google-cloud-sdk-minikube-linux-x86_64-20220805142045.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "minikube"
+      ],
+      "details": {
+        "description": "Provides minikube executable. See https://kubernetes.io/docs/tasks/tools/install-minikube/",
+        "display_name": "Minikube"
+      },
+      "id": "minikube-linux-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220805142045,
+        "version_string": "1.26.1"
+      }
+    },
+    {
+      "data": {
+        "checksum": "1b3a3552de1ec3cf7b23b4add0a225272122953bc1588f24022fc68fbb331bed",
+        "contents_checksum": "1e5745e14161ac8df58286ceab2412c42ba9612b7ca689c5175b32c49384bc04",
+        "size": 32246442,
+        "source": "components/google-cloud-sdk-minikube-windows-x86_64-20220805142045.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "minikube"
+      ],
+      "details": {
+        "description": "Provides minikube executable. See https://kubernetes.io/docs/tasks/tools/install-minikube/",
+        "display_name": "Minikube"
+      },
+      "id": "minikube-windows-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220805142045,
+        "version_string": "1.26.1"
+      }
+    },
+    {
+      "dependencies": [
+        "nomos-darwin-x86_64",
+        "nomos-linux-x86_64"
+      ],
+      "details": {
+        "description": "Provides nomos executable.",
+        "display_name": "Nomos CLI"
+      },
+      "id": "nomos",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX",
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": "1.12.1-rc.3"
+      }
+    },
+    {
+      "data": {
+        "checksum": "94b193a4a7acffd284c5feb704cc32ae452bb67cf98f70cd856d05f7e7f358bf",
+        "contents_checksum": "0d7d9a897459caf53567691cf1d746a6e43501afa673bea83d4112af919527ff",
+        "size": 25577150,
+        "source": "components/google-cloud-sdk-nomos-darwin-x86_64-20220722145557.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "nomos"
+      ],
+      "details": {
+        "description": "Provides nomos executable.",
+        "display_name": "Nomos CLI"
+      },
+      "id": "nomos-darwin-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220722145557,
+        "version_string": "1.12.1-rc.3"
+      }
+    },
+    {
+      "data": {
+        "checksum": "e5195285ab44143b5953b2364d91ab09e1390780a27879b463e3956069867fc9",
+        "contents_checksum": "deef246aecb75a2157c43d2211be9c60732ffccacc0c0848a2bb521f665521af",
+        "size": 26179386,
+        "source": "components/google-cloud-sdk-nomos-linux-x86_64-20220722145557.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "nomos"
+      ],
+      "details": {
+        "description": "Provides nomos executable.",
+        "display_name": "Nomos CLI"
+      },
+      "id": "nomos-linux-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220722145557,
+        "version_string": "1.12.1-rc.3"
+      }
+    },
+    {
+      "dependencies": [
+        "package-go-module-darwin-x86_64",
+        "package-go-module-linux-x86_64",
+        "package-go-module-windows-x86_64"
+      ],
+      "details": {
+        "description": "Package a Go module zip file from Go source code.",
+        "display_name": "Artifact Registry Go Module Package Helper"
+      },
+      "id": "package-go-module",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX",
+          "MACOSX",
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": "0.2.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "9f29cc600b38245897cbcc5e3bb8d2e9519fcb7e534b476d9eb5543bab6b4ee3",
+        "contents_checksum": "88bcd25ebaece120c436e76e59bc7036d03b16269056b5f5303bd590cfbb8ec4",
+        "size": 834432,
+        "source": "components/google-cloud-sdk-package-go-module-darwin-x86_64-20220624143124.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "package-go-module"
+      ],
+      "details": {
+        "description": "Package a Go module zip file from Go source code.",
+        "display_name": "Artifact Registry Go Module Package Helper"
+      },
+      "id": "package-go-module-darwin-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220624143124,
+        "version_string": "0.2.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "b76e2ad34599a5ca779dcfde906b98ce54f84b48fb9e8341b8a0a366fe141646",
+        "contents_checksum": "f6bb7e482d6a1cd2cc8ac541a7a7d3c447ba1e35f158e98f6dc5855dd7178ccf",
+        "size": 835647,
+        "source": "components/google-cloud-sdk-package-go-module-linux-x86_64-20220624143124.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "package-go-module"
+      ],
+      "details": {
+        "description": "Package a Go module zip file from Go source code.",
+        "display_name": "Artifact Registry Go Module Package Helper"
+      },
+      "id": "package-go-module-linux-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220624143124,
+        "version_string": "0.2.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "b523eb4afbe2332941a5c983ababf1719b18137c479c27fb316b53774d12ddd3",
+        "contents_checksum": "1e9e5b4c5711a741356616939b9d82029668ba91bf14a3446d29012dce805d84",
+        "size": 841003,
+        "source": "components/google-cloud-sdk-package-go-module-windows-x86_64-20220624143124.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "package-go-module"
+      ],
+      "details": {
+        "description": "Package a Go module zip file from Go source code.",
+        "display_name": "Artifact Registry Go Module Package Helper"
+      },
+      "id": "package-go-module-windows-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220624143124,
+        "version_string": "0.2.0"
+      }
+    },
+    {
+      "dependencies": [
+        "appctl",
+        "kpt",
+        "kustomize",
+        "nomos"
+      ],
+      "details": {
+        "description": "Kubernetes Resource Model (KRM) package management tools utilites & commands.",
+        "display_name": "pkg"
+      },
+      "id": "pkg",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {},
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": ""
+      }
+    },
+    {
+      "dependencies": [
+        "core",
+        "powershell-windows"
+      ],
+      "details": {
+        "description": "PowerShell cmdlets for the Google Cloud Platform.",
+        "display_name": "Cloud Tools for PowerShell"
+      },
+      "id": "powershell",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": "1.0.1.10"
+      }
+    },
+    {
+      "data": {
+        "checksum": "b002c3d9da22c0060a14f2957b27bd72c062d1e2e63dfa0077242a7a5e152c07",
+        "contents_checksum": "287fc9400eae35d186cd1d39a74b7f8d088f12da7f40b0a041f41b9275b8aff9",
+        "size": 18745914,
+        "source": "components/google-cloud-sdk-powershell-windows-20180924183125.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "core",
+        "powershell"
+      ],
+      "details": {
+        "description": "PowerShell cmdlets for the Google Cloud Platform.",
+        "display_name": "Cloud Tools for PowerShell"
+      },
+      "id": "powershell-windows",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20180924183125,
+        "version_string": "1.0.1.10"
+      }
+    },
+    {
+      "data": {
+        "checksum": "383219987c3253d47f553cd24996c1f9ef14c2013a13b097968255a7e5d84e5b",
+        "contents_checksum": "5fd097686d48c73aae81a0446b84e0d7aa050cfb60be6ca549ba5b1c227c181a",
+        "size": 63681617,
+        "source": "components/google-cloud-sdk-pubsub-emulator-20220722145557.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "core"
+      ],
+      "details": {
+        "description": "Provides the Pub/Sub emulator.",
+        "display_name": "Cloud Pub/Sub Emulator"
+      },
+      "id": "pubsub-emulator",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {},
+      "platform_required": false,
+      "version": {
+        "build_number": 20220722145557,
+        "version_string": "0.7.0"
+      }
+    },
+    {
+      "dependencies": [
+        "kubectl",
+        "skaffold-darwin-arm",
+        "skaffold-darwin-x86_64",
+        "skaffold-linux-arm",
+        "skaffold-linux-x86_64",
+        "skaffold-windows-x86_64"
+      ],
+      "details": {
+        "description": "Provides skaffold executable.  See https://skaffold.dev/",
+        "display_name": "Skaffold"
+      },
+      "id": "skaffold",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm",
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX",
+          "MACOSX",
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": "1.39.1"
+      }
+    },
+    {
+      "data": {
+        "checksum": "c83173b24bdb4f78e7950a1593f73c49eec5dfc6ccdb332212e7932bed832245",
+        "contents_checksum": "6a4be275b2f87e0b703db49a582ae26cbd19e2fdaebb57220d826a7df00f4ad9",
+        "size": 20226684,
+        "source": "components/google-cloud-sdk-skaffold-darwin-arm-20220708145531.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "kubectl",
+        "skaffold"
+      ],
+      "details": {
+        "description": "Provides skaffold executable.  See https://skaffold.dev/",
+        "display_name": "Skaffold"
+      },
+      "id": "skaffold-darwin-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220708145531,
+        "version_string": "1.39.1"
+      }
+    },
+    {
+      "data": {
+        "checksum": "fcc5c4cd1f287eb246ee8249bff3c48e4ff4c716e7082674905a644abd4d15d1",
+        "contents_checksum": "704148fa5cf9538397a9e502f9d6ff384e1e2b0ac998da8ff41baa521947c609",
+        "size": 21900843,
+        "source": "components/google-cloud-sdk-skaffold-darwin-x86_64-20220708145531.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "kubectl",
+        "skaffold"
+      ],
+      "details": {
+        "description": "Provides skaffold executable.  See https://skaffold.dev/",
+        "display_name": "Skaffold"
+      },
+      "id": "skaffold-darwin-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220708145531,
+        "version_string": "1.39.1"
+      }
+    },
+    {
+      "data": {
+        "checksum": "f56936cce7576225d286db11fe085ae47ca6676d462306319d30b079a04f7909",
+        "contents_checksum": "90b59d90dc9af7c243e75a678bd5b7e4a2a79e3102ccf4316c57a817d0d3fcbe",
+        "size": 18444524,
+        "source": "components/google-cloud-sdk-skaffold-linux-arm-20220708145531.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "kubectl",
+        "skaffold"
+      ],
+      "details": {
+        "description": "Provides skaffold executable.  See https://skaffold.dev/",
+        "display_name": "Skaffold"
+      },
+      "id": "skaffold-linux-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220708145531,
+        "version_string": "1.39.1"
+      }
+    },
+    {
+      "data": {
+        "checksum": "0e59595854af5e6155764988534936671ec904fe512b3acaefa5616c199b27bb",
+        "contents_checksum": "4d48dbb52dc3b968043cdd39743fbf11e25e67c51cc972a147aafa49d284820e",
+        "size": 20095248,
+        "source": "components/google-cloud-sdk-skaffold-linux-x86_64-20220708145531.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "kubectl",
+        "skaffold"
+      ],
+      "details": {
+        "description": "Provides skaffold executable.  See https://skaffold.dev/",
+        "display_name": "Skaffold"
+      },
+      "id": "skaffold-linux-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220708145531,
+        "version_string": "1.39.1"
+      }
+    },
+    {
+      "data": {
+        "checksum": "88d815602c3edbc552bc31fbef5c9808b6a500ecef5d17dc094b9cb746c46ee5",
+        "contents_checksum": "956bc2c21a1bc72e0f34e83ed952e57aed02409025a706fc9762e85b11e6c736",
+        "size": 20272472,
+        "source": "components/google-cloud-sdk-skaffold-windows-x86_64-20220708145531.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "kubectl",
+        "skaffold"
+      ],
+      "details": {
+        "description": "Provides skaffold executable.  See https://skaffold.dev/",
+        "display_name": "Skaffold"
+      },
+      "id": "skaffold-windows-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220708145531,
+        "version_string": "1.39.1"
+      }
+    },
+    {
+      "dependencies": [
+        "ssh-tools-windows"
+      ],
+      "details": {
+        "description": "Provides Windows command line ssh tools.",
+        "display_name": "Windows command line ssh tools"
+      },
+      "id": "ssh-tools",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": ""
+      }
+    },
+    {
+      "data": {
+        "checksum": "d1e1fda36ce35e058bf23f8cf114acd776c2891227f23cf3b9d78fb35f89b523",
+        "contents_checksum": "8a106316d2efe6baaa483a8677c9f0f807b43189ad3cbe1cefa8055e7500a318",
+        "size": 3485676,
+        "source": "components/google-cloud-sdk-ssh-tools-windows-20211112160846.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "ssh-tools"
+      ],
+      "details": {
+        "description": "Provides Windows command line ssh tools.",
+        "display_name": "Windows command line ssh tools"
+      },
+      "id": "ssh-tools-windows",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20211112160846,
+        "version_string": ""
+      }
+    },
+    {
+      "dependencies": [
+        "terraform-tools-darwin-arm",
+        "terraform-tools-darwin-x86_64",
+        "terraform-tools-linux-arm",
+        "terraform-tools-linux-x86_64",
+        "terraform-tools-windows-x86_64"
+      ],
+      "details": {
+        "description": "Tools for working with Terraform data",
+        "display_name": "Terraform Tools"
+      },
+      "id": "terraform-tools",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm",
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX",
+          "MACOSX",
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": "0.6.2"
+      }
+    },
+    {
+      "data": {
+        "checksum": "2db0f4ccc632952976a8c675915d04e388e5288f1bded0004aa0b4548e5e2f2c",
+        "contents_checksum": "2bf5561e40bf578793db54c3bbd1ab3cccb1a530867b0dcd01fa8006f902e440",
+        "size": 52257884,
+        "source": "components/google-cloud-sdk-terraform-tools-darwin-arm-20220805142045.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "terraform-tools"
+      ],
+      "details": {
+        "description": "Tools for working with Terraform data",
+        "display_name": "Terraform Tools"
+      },
+      "id": "terraform-tools-darwin-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220805142045,
+        "version_string": "0.6.2"
+      }
+    },
+    {
+      "data": {
+        "checksum": "ff940b3f7f91e63644da8a8fda134fe13ae65ed9f7f286382005ef762c55eb8d",
+        "contents_checksum": "e9d997f7dda1a5c7dd0de150573872d096e9ec807106205bd95b95b754ac19ee",
+        "size": 54400276,
+        "source": "components/google-cloud-sdk-terraform-tools-darwin-x86_64-20220805142045.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "terraform-tools"
+      ],
+      "details": {
+        "description": "Tools for working with Terraform data",
+        "display_name": "Terraform Tools"
+      },
+      "id": "terraform-tools-darwin-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220805142045,
+        "version_string": "0.6.2"
+      }
+    },
+    {
+      "data": {
+        "checksum": "be800db8eba62f286ff49c2ad59c399a6375429bcab4d06285a0f6851b10ee01",
+        "contents_checksum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "size": 105,
+        "source": "components/google-cloud-sdk-terraform-tools-linux-arm-20220325151342.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "terraform-tools"
+      ],
+      "details": {
+        "description": "Tools for working with Terraform data",
+        "display_name": "Terraform Tools"
+      },
+      "id": "terraform-tools-linux-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220325151342,
+        "version_string": "0.2.1"
+      }
+    },
+    {
+      "data": {
+        "checksum": "c068789f390d63b85fa827c1925b873d7915668afc3f9d1a8206c6b6b033be4d",
+        "contents_checksum": "4ee8d2c3524ed33a1b182632737bdce9c4bb4388f3687dd9efb73e26ad088ed0",
+        "size": 54026742,
+        "source": "components/google-cloud-sdk-terraform-tools-linux-x86_64-20220805142045.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "terraform-tools"
+      ],
+      "details": {
+        "description": "Tools for working with Terraform data",
+        "display_name": "Terraform Tools"
+      },
+      "id": "terraform-tools-linux-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220805142045,
+        "version_string": "0.6.2"
+      }
+    },
+    {
+      "data": {
+        "checksum": "c0a861db3267e3031484f56cb57a79b788e8c6dd1ae54e7ae641ae57199c5f0a",
+        "contents_checksum": "347ce25567f86f1b4c1ddea26309960f5f16fe6b4880881f11805a5502e1c615",
+        "size": 54067583,
+        "source": "components/google-cloud-sdk-terraform-tools-windows-x86_64-20220805142045.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "terraform-tools"
+      ],
+      "details": {
+        "description": "Tools for working with Terraform data",
+        "display_name": "Terraform Tools"
+      },
+      "id": "terraform-tools-windows-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20220805142045,
+        "version_string": "0.6.2"
+      }
+    },
+    {
+      "data": {
+        "checksum": "976b46cc3e4533ddaa6f9f08960a33e49298ef59a362ad0acf6e7bd4998dc2e6",
+        "contents_checksum": "655fcf038c69bc6f661d32b9a7c59b6eb5e5a76259924dfbf127aac56311dde2",
+        "size": 36186213,
+        "source": "components/google-cloud-sdk-tests-20220805142045.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "core"
+      ],
+      "details": {
+        "description": "Collection of tests used to verity Google Cloud CLI",
+        "display_name": "Google Cloud CLI tests"
+      },
+      "id": "tests",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {},
+      "platform_required": false,
+      "version": {
+        "build_number": 20220805142045,
+        "version_string": "2022.08.05"
+      }
+    }
+  ],
+  "gcloud_rel_path": "lib/gcloud.py",
+  "notifications": [
+    {
+      "condition": {
+        "check_components": true
+      },
+      "id": "default",
+      "notification": {},
+      "trigger": {
+        "frequency": 86400
+      }
+    }
+  ],
+  "post_processing_command": "components post-process",
+  "release_notes_url": "RELEASE_NOTES",
+  "revision": 20220805142045,
+  "schema_version": {
+    "no_update": false,
+    "url": "https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz",
+    "version": 3
+  },
+  "version": "397.0.0"
+}

--- a/pkgs/tools/admin/google-cloud-sdk/components.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/components.nix
@@ -25,12 +25,10 @@ let
   # Convert an archicecture + OS to a Nix platform
   toNixPlatform = arch: os:
     let
-      arch' = builtins.getAttr arch arches;
-      os' = builtins.getAttr os oses;
+      arch' = arches.${arch} or (throw "unsupported architecture '${arch}'");
+      os' = oses.${os} or (throw "unsupported OS '${os}'");
     in
-    if (builtins.hasAttr arch arches && builtins.hasAttr os oses)
-    then "${arch'}-${os'}"
-    else throw "unsupported architecture '${arch}' and/or os '${os}'";
+    "${arch'}-${os'}";
 
   # All architectures that are supported
   allArches = builtins.attrValues arches;

--- a/pkgs/tools/admin/google-cloud-sdk/components.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/components.nix
@@ -1,0 +1,175 @@
+{ stdenv
+, lib
+, google-cloud-sdk
+, system
+, snapshotPath
+, ...
+}:
+
+let
+  # Mapping from GCS component architecture names to Nix archictecture names
+  arches = {
+    x86 = "i686";
+    x86_64 = "x86_64";
+    # TODO arm
+  };
+
+  # Mapping from GCS component operating systems to Nix operating systems
+  oses = {
+    LINUX = "linux";
+    MACOSX = "darwin";
+    WINDOWS = "windows";
+    CYGWIN = "cygwin";
+  };
+
+  # Convert an archicecture + OS to a Nix platform
+  toNixPlatform = arch: os:
+    let
+      arch' = builtins.getAttr arch arches;
+      os' = builtins.getAttr os oses;
+    in
+    if (builtins.hasAttr arch arches && builtins.hasAttr os oses)
+    then "${arch'}-${os'}"
+    else throw "unsupported architecture '${arch}' and/or os '${os}'";
+
+  # All architectures that are supported
+  allArches = builtins.attrValues arches;
+
+  # A description of all available google-cloud-sdk components.
+  # It's a JSON file with a list of components, along with some metadata
+  snapshot = builtins.fromJSON (builtins.readFile snapshotPath);
+
+  # Generate a snapshot file for a single component.  It has the same format as
+  # `snapshot`, but only contains a single component.  These files are
+  # installed with google-cloud-sdk to let it know which components are
+  # available.
+  snapshotFromComponent =
+    { component
+    , revision
+    , schema_version
+    , version
+    }:
+    builtins.toJSON {
+      components = [ component ];
+      inherit revision schema_version version;
+    };
+
+  # Generate a set of components from a JSON file describing these components
+  componentsFromSnapshot =
+    { components
+    , revision
+    , schema_version
+    , version
+    , ...
+    }:
+    lib.fix (
+      self:
+      builtins.listToAttrs (
+        builtins.map
+          (component: {
+            name = component.id;
+            value = componentFromSnapshot self { inherit component revision schema_version version; };
+          })
+          components
+      )
+    );
+
+  # Generate a single component from its snapshot, along with a set of
+  # available dependencies to choose from.
+  componentFromSnapshot =
+    # Component derivations that can be used as dependencies
+    components:
+    # This component's snapshot
+    { component
+    , revision
+    , schema_version
+    , version
+    } @ attrs:
+    let
+      baseUrl = builtins.dirOf schema_version.url;
+      # Architectures supported by this component.  Defaults to all available
+      # architectures.
+      architectures = builtins.filter
+        (arch: builtins.elem arch (builtins.attrNames arches))
+        (lib.attrByPath [ "platform" "architectures" ] allArches component);
+      # Operating systems supported by this component
+      operating_systems = builtins.filter
+        (os: builtins.elem os (builtins.attrNames oses))
+        component.platform.operating_systems;
+    in
+    mkComponent
+      {
+        name = component.id;
+        version = component.version.version_string;
+        src =
+          if lib.hasAttrByPath [ "data" "source" ] component
+          then "${baseUrl}/${component.data.source}"
+          else "";
+        sha256 = lib.attrByPath [ "data" "checksum" ] "" component;
+        dependencies = builtins.map (dep: builtins.getAttr dep components) component.dependencies;
+        platforms =
+          if component.platform == { }
+          then lib.platforms.all
+          else
+            builtins.concatMap
+              (arch: builtins.map (os: toNixPlatform arch os) operating_systems)
+              architectures;
+        snapshot = snapshotFromComponent attrs;
+      };
+
+  # Filter out dependencies not supported by current system
+  filterForSystem = builtins.filter (drv: builtins.elem system drv.meta.platforms);
+
+  # Make a google-cloud-sdk component
+  mkComponent =
+    { name
+    , version
+      # Source tarball, if any
+    , src ? ""
+      # Checksum for the source tarball, if there is a source
+    , sha256 ? ""
+      # Other components this one depends on
+    , dependencies ? [ ]
+      # Short text describing the component
+    , description ? ""
+      # Platforms supported
+    , platforms ? lib.platforms.all
+      # The snapshot corresponding to this component
+    , snapshot
+    }: stdenv.mkDerivation {
+      inherit name version snapshot;
+      src =
+        if src != "" then
+          builtins.fetchurl
+            {
+              url = src;
+              inherit sha256;
+            } else "";
+      phases = [ "installPhase" "fixupPhase" ];
+      installPhase = ''
+        mkdir -p $out/google-cloud-sdk/.install
+
+        # If there is a source, unpack it
+        if [ ! -z "$src" ]; then
+          tar -xf $src -C $out/google-cloud-sdk/
+
+          # If the source has binaries, link them to `$out/bin`
+          if [ -d "$out/google-cloud-sdk/bin" ]; then
+            mkdir $out/bin
+            find $out/google-cloud-sdk/bin/ -type f -exec ln -s {} $out/bin/ \;
+          fi
+        fi
+
+        # Write the snapshot file to the `.install` folder
+        cp $snapshotPath $out/google-cloud-sdk/.install/${name}.snapshot.json
+      '';
+      passthru = {
+        dependencies = filterForSystem dependencies;
+      };
+      passAsFile = [ "snapshot" ];
+      meta = {
+        inherit description platforms;
+      };
+    };
+in
+componentsFromSnapshot snapshot

--- a/pkgs/tools/admin/google-cloud-sdk/data.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/data.nix
@@ -28,10 +28,5 @@
         url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-397.0.0-linux-x86.tar.gz";
         sha256 = "1xw4jzl85didin26q9sg7j1pip4bmap5d0ac9ywbj0vni71mqx26";
       };
-    components =
-      {
-        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/components-v397.0.0.json";
-        sha256 = "1bm3z63lh0z8scfsvjxwvprbrbl5iciz6pbl1hkklxhbc0k9axbc";
-      };
   };
 }

--- a/pkgs/tools/admin/google-cloud-sdk/data.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/data.nix
@@ -28,5 +28,10 @@
         url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-397.0.0-linux-x86.tar.gz";
         sha256 = "1xw4jzl85didin26q9sg7j1pip4bmap5d0ac9ywbj0vni71mqx26";
       };
+    components =
+      {
+        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/components-v397.0.0.json";
+        sha256 = "1bm3z63lh0z8scfsvjxwvprbrbl5iciz6pbl1hkklxhbc0k9axbc";
+      };
   };
 }

--- a/pkgs/tools/admin/google-cloud-sdk/default.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/default.nix
@@ -7,7 +7,7 @@
 #   3) used by `google-cloud-sdk` only on GCE guests
 #
 
-{ stdenv, lib, fetchurl, makeWrapper, nixosTests, python, openssl, jq, with-gce ? false }:
+{ stdenv, lib, fetchurl, makeWrapper, nixosTests, python, openssl, jq, callPackage, with-gce ? false }:
 
 let
   pythonEnv = python.withPackages (p: with p; [
@@ -20,6 +20,12 @@ let
   data = import ./data.nix { };
   sources = system:
     data.googleCloudSdkPkgs.${system} or (throw "Unsupported system: ${system}");
+
+  components = callPackage ./components.nix {
+    snapshotPath = builtins.fetchurl data.googleCloudSdkPkgs.components;
+  };
+
+  withExtraComponents = callPackage ./withExtraComponents.nix { inherit components; };
 
 in stdenv.mkDerivation rec {
   pname = "google-cloud-sdk";
@@ -104,6 +110,10 @@ in stdenv.mkDerivation rec {
   installCheckPhase = ''
     $out/bin/gcloud version --format json | jq '."Google Cloud SDK"' | grep "${version}"
   '';
+
+  passthru = {
+    inherit components withExtraComponents;
+  };
 
   meta = with lib; {
     description = "Tools for the google cloud platform";

--- a/pkgs/tools/admin/google-cloud-sdk/default.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/default.nix
@@ -22,7 +22,7 @@ let
     data.googleCloudSdkPkgs.${system} or (throw "Unsupported system: ${system}");
 
   components = callPackage ./components.nix {
-    snapshotPath = builtins.fetchurl data.googleCloudSdkPkgs.components;
+    snapshotPath = ./components.json;
   };
 
   withExtraComponents = callPackage ./withExtraComponents.nix { inherit components; };

--- a/pkgs/tools/admin/google-cloud-sdk/update.sh
+++ b/pkgs/tools/admin/google-cloud-sdk/update.sh
@@ -18,15 +18,6 @@ function genMainSrc() {
     echo "      };"
 }
 
-function genComponentsSrc() {
-    local url="${CHANNEL_URL}/components-v${VERSION}.json"
-    local sha256
-    sha256=$(nix-prefetch-url "$url")
-    echo "      {"
-    echo "        url = \"${url}\";"
-    echo "        sha256 = \"${sha256}\";"
-    echo "      };"
-}
 {
     cat <<EOF
 # DO NOT EDIT! This file is generated automatically by update.sh
@@ -51,10 +42,9 @@ EOF
     echo "    i686-linux ="
     genMainSrc "linux" "x86"
 
-    echo "    components ="
-    genComponentsSrc
-
     echo "  };"
     echo "}"
 
 } >data.nix
+
+curl "${CHANNEL_URL}/components-v${VERSION}.json" > components.json

--- a/pkgs/tools/admin/google-cloud-sdk/update.sh
+++ b/pkgs/tools/admin/google-cloud-sdk/update.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env nix-shell
 #! nix-shell -i bash -p nix
 
-BASE_URL="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk"
+CHANNEL_URL="https://dl.google.com/dl/cloudsdk/channels/rapid"
+BASE_URL="$CHANNEL_URL/downloads/google-cloud-sdk"
 
 # Version of Google Cloud SDK from
 # https://cloud.google.com/sdk/docs/release-notes
@@ -17,6 +18,15 @@ function genMainSrc() {
     echo "      };"
 }
 
+function genComponentsSrc() {
+    local url="${CHANNEL_URL}/components-v${VERSION}.json"
+    local sha256
+    sha256=$(nix-prefetch-url "$url")
+    echo "      {"
+    echo "        url = \"${url}\";"
+    echo "        sha256 = \"${sha256}\";"
+    echo "      };"
+}
 {
     cat <<EOF
 # DO NOT EDIT! This file is generated automatically by update.sh
@@ -40,6 +50,9 @@ EOF
 
     echo "    i686-linux ="
     genMainSrc "linux" "x86"
+
+    echo "    components ="
+    genComponentsSrc
 
     echo "  };"
     echo "}"

--- a/pkgs/tools/admin/google-cloud-sdk/withExtraComponents.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/withExtraComponents.nix
@@ -1,0 +1,61 @@
+{ lib, google-cloud-sdk, callPackage, runCommand, components }:
+
+comps_:
+
+let
+  # Remove components which are already installed by default
+  filterPreInstalled =
+    let
+      preInstalledComponents = with components; [ bq bq-nix core core-nix gcloud-deps gcloud gsutil gsutil-nix ];
+    in
+    builtins.filter (drv: !(builtins.elem drv preInstalledComponents));
+
+  # Recursively build a list of components with their dependencies
+  # TODO this could be made faster, it checks the dependencies too many times
+  findDepsRecursive = lib.converge
+    (drvs: lib.unique (drvs ++ (builtins.concatMap (drv: drv.dependencies) drvs)));
+
+  # Components to install by default
+  defaultComponents = with components; [ alpha beta ];
+
+  comps = [ google-cloud-sdk ] ++ filterPreInstalled (findDepsRecursive (defaultComponents ++ comps_));
+in
+# Components are installed by copying the `google-cloud-sdk` package, along
+# with each component, over to a new location, and then patching that location
+# with `sed` to ensure the proper paths are used.
+# For some reason, this does not work properly with a `symlinkJoin`: the
+# `gcloud` binary doesn't seem able to find the installed components.
+runCommand "google-cloud-sdk-${google-cloud-sdk.version}"
+{
+  inherit (google-cloud-sdk) meta;
+  inherit comps;
+  passAsFile = [ "comps" ];
+
+  doInstallCheck = true;
+  installCheckPhase =
+    let
+      compNames = builtins.map (drv: drv.name) comps_;
+    in
+    ''
+      $out/bin/gcloud components list > component_list.txt
+      for comp in ${builtins.toString compNames}; do
+        if [ ! grep ... component_list.txt | grep "Not Installed" ]; then
+          echo "Failed to install component '$comp'"
+          exit 1
+        fi
+      done
+    '';
+}
+  ''
+    mkdir -p $out
+
+    # Install each component
+    for comp in $(cat $compsPath); do
+      echo "installing component $comp"
+      cp -dRf $comp/. $out
+      find $out -type d -exec chmod 744 {} +
+    done
+
+    # Replace references to the original google-cloud-sdk with this one
+    find $out/google-cloud-sdk/bin/ -type f -exec sed -i -e "s#${google-cloud-sdk}#$out#" {} \;
+  ''


### PR DESCRIPTION
###### Description of changes

This commit adds a set of Google Cloud SDK components in `pkgs.google-cloud-sdk.components` which can be installed along with the SDK through `pkgs.google-cloud-sdk.withExtraComponents [ ... ]`.

For example, the bigtable emulator can be installed with the following:

```bash
nix-build -E 'with import <nixpkgs> { }; google-cloud-sdk.withExtraComponents [google-cloud-sdk.components.bigtable]'
```

and later executed with:

```bash
result/bin/gcloud beta emulators bigtable start
```

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
