### PR TITLE
zathuraPkgs.zathura_pdf_mupdf: 0.3.7 -> 0.3.8

### DIFF
--- a/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
+++ b/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
@@ -9,16 +9,21 @@
 , openjpeg
 , pkg-config
 , zathura_core
+, tesseract
+, leptonica
+, mujs
 }:
 
 stdenv.mkDerivation rec {
-  version = "0.3.7";
+  version = "0.3.8";
   pname = "zathura-pdf-mupdf";
 
   src = fetchurl {
     url = "https://pwmt.org/projects/${pname}/download/${pname}-${version}.tar.xz";
-    sha256 = "07d2ds9yqfrl20z3yfgc55vwg10mwmcg2yvpr4j66jjd5mlal01g";
+    sha256 = "sha256-wgW0z1ANjP6ezqreVOX6jUzRKYzYXxem9QxkclkRYhc=";
   };
+
+  patches = [ ./fix-mupdf-1.20.patch ];
 
   nativeBuildInputs = [ meson ninja pkg-config ];
 
@@ -31,14 +36,10 @@ stdenv.mkDerivation rec {
     mupdf
     openjpeg
     zathura_core
+    tesseract
+    leptonica
+    mujs
   ] ++ lib.optional stdenv.isDarwin gtk-mac-integration;
-
-  mesonFlags = [
-    "-Dlink-external=true"
-  ];
-
-  # avoid: undefined symbol: gumbo_destroy_output
-  NIX_LDFLAGS = [ "-lgumbo" ];
 
   PKG_CONFIG_ZATHURA_PLUGINDIR= "lib/zathura";
 

--- a/pkgs/applications/misc/zathura/pdf-mupdf/fix-mupdf-1.20.patch
+++ b/pkgs/applications/misc/zathura/pdf-mupdf/fix-mupdf-1.20.patch
@@ -1,0 +1,24 @@
+From 5a5bb2634812f4c0530f5688a06269aaa4cd11dd Mon Sep 17 00:00:00 2001
+From: Osama Rebach <osamarebach@gmail.com>
+Date: Fri, 19 Aug 2022 13:39:49 +0100
+Subject: [PATCH] fix fz_search_stext_page
+
+---
+ zathura-pdf-mupdf/search.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/zathura-pdf-mupdf/search.c b/zathura-pdf-mupdf/search.c
+index f84dea0..419e5f4 100644
+--- a/zathura-pdf-mupdf/search.c
++++ b/zathura-pdf-mupdf/search.c
+@@ -41,7 +41,7 @@ pdf_page_search_text(zathura_page_t* page, void* data, const char* text, zathura
+ 
+   fz_quad* hit_bbox = fz_malloc_array(mupdf_page->ctx, N_SEARCH_RESULTS, fz_quad);
+   int num_results = fz_search_stext_page(mupdf_page->ctx, mupdf_page->text,
+-      text, hit_bbox, N_SEARCH_RESULTS);
++      text, NULL, hit_bbox, N_SEARCH_RESULTS);
+ 
+   fz_rect r;
+   for (int i = 0; i < num_results; i++) {
+-- 
+2.37.1


### PR DESCRIPTION
###### Description of changes

Also fix build with mupdf >= 1.20. Fixes #187305.

Patch by @osama-re.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
