### PR TITLE
libstemmer: unstable-2017-03-02 -> 2.2.0

### DIFF
--- a/pkgs/development/libraries/libstemmer/default.nix
+++ b/pkgs/development/libraries/libstemmer/default.nix
@@ -1,21 +1,34 @@
-{ lib, stdenv, fetchFromGitHub, cmake }:
+{ lib, stdenv, fetchFromGitHub, perl }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "libstemmer";
-  version = "unstable-2017-03-02";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
-    owner = "zvelo";
-    repo = "libstemmer";
-    rev = "78c149a3a6f262a35c7f7351d3f77b725fc646cf";
-    sha256 = "06md6n6h1f2zvnjrpfrq7ng46l1x12c14cacbrzmh5n0j98crpq7";
+    owner = "snowballstem";
+    repo = "snowball";
+    rev = "v${version}";
+    sha256 = "sha256-qXrypwv/I+5npvGHGsHveijoui0ZnoGYhskCfLkewVE=";
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ perl ];
+
+  prePatch = ''
+    patchShebangs .
+  '';
+
+  makeTarget = "libstemmer.a";
+
+  installPhase = ''
+    runHook preInstall
+    install -Dt $out/lib libstemmer.a
+    install -Dt $out/include include/libstemmer.h
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "Snowball Stemming Algorithms";
-    homepage = "http://snowball.tartarus.org/";
+    homepage = "https://snowballstem.org/";
     license = licenses.bsd3;
     maintainers = with maintainers; [ fpletz ];
     platforms = platforms.all;


### PR DESCRIPTION
###### Description of changes

Bump & use new repo.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).