### PR TITLE
libsForQt5.qtdbusextended: init at 0.0.3

### DIFF
--- a/pkgs/development/libraries/qtdbusextended/default.nix
+++ b/pkgs/development/libraries/qtdbusextended/default.nix
@@ -1,0 +1,38 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, qmake
+, wrapQtAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "qtdbusextended";
+  version = "0.0.3";
+
+  src = fetchFromGitHub {
+    owner = "nemomobile";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-tUp7OhNBXwomR2tO4UOaR0vJQ3GTirMk/hRl1cMk61o=";
+  };
+
+  postPatch = ''
+    substituteInPlace src/src.pro \
+      --replace '$$[QT_INSTALL_LIBS]' "$out/lib" \
+      --replace '$$[QT_INSTALL_HEADERS]' "$out/include" \
+      --replace '$$[QMAKE_MKSPECS]' "$out/mkspecs"
+  '';
+
+  nativeBuildInputs = [
+    qmake
+    wrapQtAppsHook
+  ];
+
+  meta = with lib; {
+    description = "Qt provides several classes for DBus communication";
+    homepage = "https://github.com/nemomobile/qtdbusextended";
+    license = licenses.lgpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ rewine ];
+  };
+}

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -195,6 +195,8 @@ in (kdeFrameworks // plasmaMobileGear // plasma5 // plasma5.thirdParty // kdeGea
 
   qt5ct = callPackage ../tools/misc/qt5ct { };
 
+  qtdbusextended = callPackage ../development/libraries/qtdbusextended { };
+
   qtfeedback = callPackage ../development/libraries/qtfeedback { };
 
   qtforkawesome = callPackage ../development/libraries/qtforkawesome { };


### PR DESCRIPTION
###### Description of changes

Build dependencies of [deepin-music](https://github.com/linuxdeepin/deepin-music) and [deepin-movie-reborn](https://github.com/linuxdeepin/deepin-movie-reborn)

Move from https://github.com/linuxdeepin/dde-nixos/blob/main/packages/library/qtdbusextended/default.nix
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
