### PR TITLE
jemalloc: support page size up to 64KB on AArch64

### DIFF
--- a/pkgs/development/libraries/jemalloc/default.nix
+++ b/pkgs/development/libraries/jemalloc/default.nix
@@ -30,6 +30,9 @@ stdenv.mkDerivation rec {
       "--disable-thp"
       "je_cv_thp=no"
     ]
+    # AArch64 has configurable page size up to 64k. The default configuration
+    # for jemalloc only supports 4k page sizes.
+    ++ lib.optional stdenv.isAarch64 "--with-lg-page=16"
   ;
 
   NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin "-Wno-error=array-bounds";


### PR DESCRIPTION
###### Description of changes

The default build configuration only supports page sizes up to 4KB.
AArch64 systems (among other architectures) can be configured with
larger page sizes. nixpkgs's jemalloc currently crashes in these
situations.

Doing some research revealed that this same change is already applied in [Fedora](https://src.fedoraproject.org/rpms/jemalloc/blob/rawhide/f/jemalloc.spec#_39), [Debian](https://salsa.debian.org/debian/jemalloc/-/blob/master/debian/rules#L8) as well as [ALARM](https://github.com/archlinuxarm/PKGBUILDs/commit/4efd481729babaa8fc96a9f6dfc82e90a06ec636) (coincidentally, as of 10 hours ago).

Example issue caused by the current jemalloc configuration: running `nslookup` just crashes on my AArch64 NixOS system using 16K page sizes:
```
[nix-shell:~]$ nslookup
<jemalloc>: Unsupported system page size
<jemalloc>: Unsupported system page size
mem.c:465: INSIST(ctx != ((void *)0)) failed, back trace
/nix/store/qq7qwfc4ypspyqvnkxgn18njq6qlf655-bind-9.18.5-lib/lib/libisc-9.18.5.so(+0x3a640)[0x3ff9ec6a640]
/nix/store/qq7qwfc4ypspyqvnkxgn18njq6qlf655-bind-9.18.5-lib/lib/libisc-9.18.5.so(isc_assertion_failed+0x14)[0x3ff9ec6a574]
/nix/store/qq7qwfc4ypspyqvnkxgn18njq6qlf655-bind-9.18.5-lib/lib/libisc-9.18.5.so(isc__mem_create+0x1e8)[0x3ff9ec7d8d0]
nslookup(setup_libs+0x88)[0x40cd70]
nslookup(main+0xd4)[0x407254]
/nix/store/3rz8shlg3mql8ki5w5fxyipifs6mjf9v-glibc-2.35-163/lib/libc.so.6(+0x273f4)[0x3ff9e7d73f4]
/nix/store/3rz8shlg3mql8ki5w5fxyipifs6mjf9v-glibc-2.35-163/lib/libc.so.6(__libc_start_main+0x98)[0x3ff9e7d74d0]
nslookup(_start+0x30)[0x407570]
Aborted (core dumped)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
