### PR TITLE
gbenchmark: fix pkg-config file

### DIFF
--- a/pkgs/development/libraries/gbenchmark/default.nix
+++ b/pkgs/development/libraries/gbenchmark/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, gtest }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, gtest }:
 
 stdenv.mkDerivation rec {
   pname = "gbenchmark";
@@ -12,6 +12,13 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/google/benchmark/commit/2a78e8cbe9b104834d96c78ccc9f9513a29f8c71.patch";
+      sha256 = "sha256-Y4OhSi3ceXgpUvYJUJ3NJBFN51j8gEg9AcyXBNtcIRo=";
+    })
+  ];
 
   postPatch = ''
     cp -r ${gtest.src} googletest


### PR DESCRIPTION
###### Description of changes
Fixes the the cmake install path being prefixed with the absolute paths to lib and include.
With the current code the library is impossible to use with pkg-config
```
babbaj@nixos:~ ❯ nix build nixpkgs#gbenchmark
babbaj@nixos:~ ❯ cat result/lib/pkgconfig/benchmark.pc
prefix=/nix/store/yf25swipsphj343waql8pf2qszg65wjs-gbenchmark-1.6.1
exec_prefix=${prefix}
libdir=${prefix}//nix/store/yf25swipsphj343waql8pf2qszg65wjs-gbenchmark-1.6.1/lib
includedir=${prefix}//nix/store/yf25swipsphj343waql8pf2qszg65wjs-gbenchmark-1.6.1/include

Name: benchmark
Description: Google microbenchmark framework
Version: 1.6.1

Libs: -L${libdir} -lbenchmark
Libs.private: -lpthread
Cflags: -I${includedir}
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
