### PR TITLE
[22.05] python3Packages.nbconvert: use mistune 2.x

### DIFF
--- a/pkgs/development/python-modules/karton-dashboard/default.nix
+++ b/pkgs/development/python-modules/karton-dashboard/default.nix
@@ -43,5 +43,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/CERT-Polska/karton-dashboard";
     license = with licenses; [ bsd3 ];
     maintainers = with maintainers; [ fab ];
+    broken = versionAtLeast mistune.version "2";
   };
 }

--- a/pkgs/development/python-modules/lektor/default.nix
+++ b/pkgs/development/python-modules/lektor/default.nix
@@ -79,5 +79,6 @@ buildPythonPackage rec {
     homepage = "https://www.getlektor.com/";
     license = licenses.bsd0;
     maintainers = with maintainers; [ costrouc ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/m2r/default.nix
+++ b/pkgs/development/python-modules/m2r/default.nix
@@ -29,5 +29,6 @@ buildPythonPackage rec {
     description = "Markdown to reStructuredText converter";
     license = licenses.mit;
     maintainers = with maintainers; [ SuperSandro2000 ];
+    broken = versionAtLeast mistune.version "2";
   };
 }

--- a/pkgs/development/python-modules/mistune/default.nix
+++ b/pkgs/development/python-modules/mistune/default.nix
@@ -11,5 +11,5 @@ self: rec {
     sha256 = "sha256-nuCmYFPiJnq6dyxx4GiR+o8a9tSwHV6E4me0Vw1NmAg=";
     format = "pyproject";
   };
-  mistune = mistune_0_8;
+  mistune = mistune_2_0;
 }

--- a/pkgs/development/python-modules/mrkd/default.nix
+++ b/pkgs/development/python-modules/mrkd/default.nix
@@ -24,5 +24,6 @@ buildPythonPackage rec {
     description = "Write man pages using Markdown, and convert them to Roff or HTML";
     homepage = "https://github.com/refi64/mrkd";
     license = licenses.bsd2;
+    broken = versionAtLeast mistune.version "2";
   };
 }

--- a/pkgs/development/python-modules/nbconvert/default.nix
+++ b/pkgs/development/python-modules/nbconvert/default.nix
@@ -3,6 +3,7 @@
 , buildPythonPackage
 , defusedxml
 , fetchPypi
+, fetchpatch
 , ipywidgets
 , jinja2
 , jupyterlab-pygments
@@ -30,10 +31,22 @@ buildPythonPackage rec {
   # various exporter templates
   patches = [
     ./templates.patch
+
+    # Use mistune 2.x
+    (fetchpatch {
+      name = "support-mistune-2.x.patch";
+      url = "https://github.com/jupyter/nbconvert/commit/e870d9a4a61432a65bee5466c5fa80c9ee28966e.patch";
+      hash = "sha256-kdOmE7BnkRy2lsNQ2OVrEXXZntJUPJ//b139kSsfKmI=";
+      excludes = [ "pyproject.toml" ];
+    })
   ];
 
   postPatch = ''
     substituteAllInPlace ./nbconvert/exporters/templateexporter.py
+
+    # Use mistune 2.x
+    substituteInPlace setup.py \
+        --replace "mistune>=0.8.1,<2" "mistune>=2.0.3,<3"
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/nbconvert/default.nix
+++ b/pkgs/development/python-modules/nbconvert/default.nix
@@ -9,7 +9,7 @@
 , jupyterlab-pygments
 , lib
 , markupsafe
-, mistune
+, mistune_2_0
 , nbclient
 , pandocfilters
 , pyppeteer
@@ -56,7 +56,7 @@ buildPythonPackage rec {
     jinja2
     jupyterlab-pygments
     markupsafe
-    mistune
+    mistune_2_0
     nbclient
     pandocfilters
     tinycss2

--- a/pkgs/development/python-modules/nbconvert/default.nix
+++ b/pkgs/development/python-modules/nbconvert/default.nix
@@ -19,12 +19,12 @@
 
 buildPythonPackage rec {
   pname = "nbconvert";
-  version = "6.5.0";
+  version = "6.5.3";
   format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-Ij5G4nq+hZa4rtVDAfrbukM7f/6oGWpo/Xsf9Qnu6Z0=";
+    hash = "sha256-EO1pPEz9PGNYPIfKXDovbth0FFEDWV84JO/Mjfy3Uiw=";
   };
 
   # Add $out/share/jupyter to the list of paths that are used to search for

--- a/pkgs/development/python-modules/schema-salad/default.nix
+++ b/pkgs/development/python-modules/schema-salad/default.nix
@@ -53,5 +53,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/common-workflow-language/schema_salad";
     license = with licenses; [ asl20 ];
     maintainers = with maintainers; [ veprbl ];
+    broken = true;
   };
 }


### PR DESCRIPTION
###### Description of changes

Backport of #187151, #186804 to get opsdroid on 22.05 buildable again.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
