### PR TITLE
perlPackages: Redo all metadata

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -693,6 +693,11 @@ in mkLicense lset) ({
     fullName = "SIL Open Font License 1.1";
   };
 
+  oml = {
+    spdxId = "OML";
+    fullName = "Open Market License";
+  };
+
   openldap = {
     spdxId = "OLDAP-2.8";
     fullName = "Open LDAP Public License v2.8";
@@ -822,6 +827,11 @@ in mkLicense lset) ({
   tcltk = {
     spdxId = "TCL";
     fullName = "TCL/TK License";
+  };
+
+  ucd = {
+    fullName = "Unicode Character Database License";
+    url = "https://fedoraproject.org/wiki/Licensing:UCD";
   };
 
   ufl = {

--- a/pkgs/development/perl-modules/MNI/default.nix
+++ b/pkgs/development/perl-modules/MNI/default.nix
@@ -15,9 +15,10 @@ buildPerlPackage {
 
   doCheck = false;  # TODO: almost all tests fail ... is this a real problem?
 
-  meta = with lib; {
+  meta = {
+    description = "MNI MINC perllib (not used much anymore)";
     homepage = "https://github.com/BIC-MNI/mni-perllib";
-    license = with licenses; [ artistic1 gpl1Plus ];
-    maintainers = with maintainers; [ bcdarwin ];
+    license = with lib.licenses; [ artistic1 gpl1Plus ];
+    maintainers = with lib.maintainers; [ bcdarwin ];
   };
 }

--- a/pkgs/development/perl-modules/Percona-Toolkit/default.nix
+++ b/pkgs/development/perl-modules/Percona-Toolkit/default.nix
@@ -23,10 +23,10 @@ buildPerlPackage rec {
     shortenPerlShebang $(grep -l "/bin/env perl" $out/bin/*)
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Collection of advanced command-line tools to perform a variety of MySQL and system tasks";
     homepage = "https://www.percona.com/software/database-tools/percona-toolkit";
-    license = with licenses; [ gpl2Only ];
-    maintainers = with maintainers; [ izorkin ];
+    license = with lib.licenses; [ gpl2Only ];
+    maintainers = with lib.maintainers; [ izorkin ];
   };
 }

--- a/pkgs/development/perl-modules/Percona-Toolkit/default.nix
+++ b/pkgs/development/perl-modules/Percona-Toolkit/default.nix
@@ -24,9 +24,9 @@ buildPerlPackage rec {
   '';
 
   meta = with lib; {
-    description = "Collection of advanced command-line tools to perform a variety of MySQL and system tasks.";
+    description = "Collection of advanced command-line tools to perform a variety of MySQL and system tasks";
     homepage = "https://www.percona.com/software/database-tools/percona-toolkit";
-    license = with licenses; [ gpl2 ];
+    license = with licenses; [ gpl2Only ];
     maintainers = with maintainers; [ izorkin ];
   };
 }

--- a/pkgs/development/perl-modules/Po4a/default.nix
+++ b/pkgs/development/perl-modules/Po4a/default.nix
@@ -30,8 +30,8 @@ buildPerlPackage rec {
     done
   '';
   meta = {
-    homepage = "https://po4a.org/";
     description = "Tools for helping translation of documentation";
-    license = lib.licenses.gpl2;
+    homepage = "https://po4a.org";
+    license = with lib.licenses; [ gpl2Only ];
   };
 }

--- a/pkgs/development/perl-modules/strip-nondeterminism/default.nix
+++ b/pkgs/development/perl-modules/strip-nondeterminism/default.nix
@@ -34,7 +34,7 @@ buildPerlPackage rec {
   meta = with lib; {
     description = "A Perl module for stripping bits of non-deterministic information";
     homepage = "https://reproducible-builds.org/";
-    license = licenses.gpl3;
+    license = licenses.gpl3Only;
     maintainers = with maintainers; [ pSub ];
   };
 }

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -596,7 +596,7 @@ let
     propagatedBuildInputs = [ URI ];
     meta = {
       description = "Load URI::Escape::XS preferentially over URI::Escape";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -1496,7 +1496,7 @@ let
     };
     meta = {
       description = "Friendlier flags for B";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Only ];
     };
   };
 
@@ -1792,7 +1792,7 @@ let
     propagatedBuildInputs = [ SetIntSpan ];
     meta = {
       description = "Calculate business hours in a time period";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -2485,7 +2485,7 @@ let
     propagatedBuildInputs = [ CatalystPluginSession GDSecurityImage ];
     meta = {
       description = "Create and validate Captcha for Catalyst";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -3381,7 +3381,7 @@ let
     };
     meta = {
       description = "Iterator class";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -4111,7 +4111,7 @@ let
     };
     meta = {
       description = "Simple configuration file class";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -4125,7 +4125,7 @@ let
     propagatedBuildInputs = [ ClassStd ];
     meta = {
       description = "Load and save configuration files in a standard format";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -4373,7 +4373,7 @@ let
     buildInputs = [ CanaryStability ];
     meta = {
       description = "The only real threads in perl";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -5349,7 +5349,7 @@ let
     propagatedBuildInputs = [ URI ];
     meta = {
       description = "Compact many CSS files into one big file";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -5419,7 +5419,7 @@ let
     propagatedBuildInputs = [ ConvertASN1 ];
     meta = {
       description = "Parse a X.509 certificate";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -6815,7 +6815,7 @@ let
 
     meta = {
       description = "DBI driver for Sybase datasources";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Only ];
       broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.DBDsybase.x86_64-darwin
     };
   };
@@ -7108,7 +7108,7 @@ let
     propagatedBuildInputs = [ DBI ];
     meta = {
       description = "Very complete easy-to-use OO interface to DBI";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -7194,7 +7194,7 @@ let
     };
     meta = {
       description = "Find memory cycles in objects";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -7449,7 +7449,7 @@ let
     propagatedBuildInputs = [ LWP ];
     meta = {
       description = "Perl extension for getting MD5 sums for files and urls";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -8315,7 +8315,7 @@ let
     outputs = [ "out" ];
     meta = {
       description = "JIS X 0212 (aka JIS 2000) Encodings";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -8894,7 +8894,7 @@ let
     '';
     meta = {
       description = "Fast CGI module";
-      license = with lib.licenses; [ unfree ]; # Open Market License
+      license = with lib.licenses; [ oml ];
     };
   };
 
@@ -8923,7 +8923,7 @@ let
     };
     meta = {
       description = "A perl-based FastCGI process manager";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ gpl2Plus ];
     };
   };
 
@@ -9127,7 +9127,7 @@ let
     propagatedBuildInputs = [ ClassIterator ];
     meta = {
       description = "Iterator interface for search files";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -9233,7 +9233,7 @@ let
     };
     meta = {
       description = "Find matches to a pattern in a series of files and related functions";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = teams.deshaw.members;
     };
   };
@@ -9373,7 +9373,7 @@ let
     };
     meta = {
       description = "Guess file type from contents";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ asl20 ];
     };
   };
 
@@ -10004,7 +10004,7 @@ let
     propagatedBuildInputs = [ GD ];
     meta = {
       description = "Text utilities for use with GD";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -10292,7 +10292,7 @@ let
     doCheck = false;
     meta = {
       description = "Perl interface to the GNU Privacy Guard";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ gpl2Plus ];
       mainProgram = "gpgmailtunl";
     };
   };
@@ -10324,7 +10324,7 @@ let
     doCheck = false; # no make target 'test'
     meta = {
       description = "HTTP transport for DBI stateless proxy driver DBD::Gofer";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -11515,7 +11515,7 @@ let
     };
     meta = {
       description = "An XS extension for processing HTTP headers";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
       broken =
         stdenv.isi686 # loadable library and perl binaries are mismatched (got handshake key 0x7d40080, needed 0x7dc0080)
         || stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.HTTPHeaderParserXS.x86_64-darwin
@@ -11650,7 +11650,7 @@ let
     buildInputs = [ LWP ];
     meta = {
       description = "Adds encoding() to HTTP::Response";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -12194,7 +12194,7 @@ let
     doCheck = false; # needs access to /dev/tty
     meta = {
       description = "Interactively prompt for user input";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -12208,7 +12208,7 @@ let
     outputs = [ "out" "dev" ]; # no "devdoc"
     meta = {
       description = "Supporting module for SOAP::Lite";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -13099,7 +13099,7 @@ let
     };
     meta = {
       description = "Convert English text to numbers";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -13141,7 +13141,7 @@ let
     };
     meta = {
       description = "Perl French Stemming";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -13154,7 +13154,7 @@ let
     };
     meta = {
       description = "Porter's stemming algorithm for Italian";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -13181,7 +13181,7 @@ let
     };
     meta = {
       description = "Porters stemming algorithm for Denmark";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ gpl2Only ];
     };
   };
 
@@ -13526,7 +13526,7 @@ let
     propagatedBuildInputs = [ FileSlurp ];
     meta = {
       description = "Perl module for manipulating .po entries from GNU gettext";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -14038,7 +14038,7 @@ let
     propagatedBuildInputs = [ LWP ];
     meta = {
       description = "A virtual browser that retries errors";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -14648,7 +14648,7 @@ let
     };
     meta = {
       description = "Random Number Generators";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus publicDomain ];
     };
   };
 
@@ -17352,7 +17352,7 @@ let
     propagatedBuildInputs = [ URI ];
     meta = {
       description = "Perl extension to create signatures for AWS requests";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -17724,7 +17724,7 @@ let
     propagatedBuildInputs = [ IOSocketSSL ListMoreUtils ];
     meta = {
       description = "Not so simple IMAP client library";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -17737,7 +17737,7 @@ let
     };
     meta = {
       description = "Perl extension for manipulating IPv4/IPv6 addresses";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -17894,7 +17894,7 @@ let
     };
     meta = {
       description = "Check a remote host for reachability";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -19295,7 +19295,7 @@ let
     };
     meta = {
       description = "Allow to change perl's destruction level";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -19462,7 +19462,7 @@ let
     };
     meta = {
       description = "Simple flexible means of converting the output of PHP's serialize() into the equivalent Perl memory structure, and vice versa";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -20784,7 +20784,7 @@ let
     };
     meta = {
       description = "Builds trie-ized regexp";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -21180,7 +21180,7 @@ let
     };
     meta = {
       description = "Infinite Sets math";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -21194,7 +21194,7 @@ let
 
     meta = {
       description = "Manages sets of integers, newsrc style";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -21698,7 +21698,7 @@ let
     };
     meta = {
       description = "Efficient resampling and calculation of medians with confidence intervals";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -23148,7 +23148,7 @@ let
     };
     meta = {
       description = "A class to emulate a DEC VT102 terminal";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -23772,7 +23772,7 @@ let
     buildInputs = [ TestDifferences TestNoWarnings ];
     meta = {
       description = "Test binary as hexadecimal string";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -23812,7 +23812,7 @@ let
     propagatedBuildInputs = [ HTTPServerSimple ];
     meta = {
       description = "Test::More functions for HTTP::Server::Simple";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -23928,7 +23928,7 @@ let
     propagatedBuildInputs = [ DevelCycle PadWalker ];
     meta = {
       description = "Verifies code hasn't left circular references";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -25141,7 +25141,7 @@ let
     };
     meta = {
       description = "German grundform reduction";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -25182,7 +25182,7 @@ let
     };
     meta = {
       description = "Perl interface to iconv() codeset conversion function";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ]; # taken from el6
       broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.TextIconv.x86_64-darwin
     };
   };
@@ -25646,7 +25646,7 @@ let
     NIX_CFLAGS_COMPILE = "-DHAS_VPRINTF";
     meta = {
       description = "Remove accents from a string";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ gpl2Only ];
       broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.TextUnaccent.x86_64-darwin
     };
   };
@@ -25848,7 +25848,7 @@ let
     };
     meta = {
       description = "Access the lines of a disk file via a Perl array";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -26053,7 +26053,7 @@ let
     };
     meta = {
       description = "Easily timeout long running operations";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -26067,7 +26067,7 @@ let
     doCheck = false;
     meta = {
       description = "Parse and format time values";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ publicDomain ];
     };
   };
 
@@ -26297,7 +26297,7 @@ let
     propagatedBuildInputs = [ commonsense ];
     meta = {
       description = "Simple data types for common serialisation formats";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -26366,7 +26366,7 @@ let
     };
     meta = {
       description = "Checks if scalar is valid UTF-8";
-      license = with lib.licenses; [ unfree ]; # not clear at all
+      license = with lib.licenses; [ ucd /* and */ artistic1 gpl1Plus ];
     };
   };
 
@@ -26825,7 +26825,7 @@ let
     '';
     meta = {
       description = "Use WWW::Mechanize with CGI applications";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
       broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.WWWMechanizeCGI.x86_64-darwin
     };
   };
@@ -27163,7 +27163,7 @@ let
     patches = [ ../development/perl-modules/xml-grove-utf8.patch ];
     meta = {
       description = "Perl-style XML objects";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -27177,7 +27177,7 @@ let
     propagatedBuildInputs = [ libxml_perl ];
     meta = {
       description = "Yet another Perl SAX XML Writer";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ gpl1Only ];
       mainProgram = "xmlpretty";
     };
   };
@@ -27314,7 +27314,7 @@ let
     };
     meta = {
       description = "A re-usable XPath engine for DOM-like trees";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -3906,7 +3906,7 @@ let
     };
     meta = {
       description = "Interface to LZMA decompression library";
-      license = with lib.licenses; [ artistic1 gpl1Plus gpl21Plus ];
+      license = with lib.licenses; [ artistic1 gpl1Plus lgpl21Plus ];
     };
   };
 
@@ -9206,7 +9206,7 @@ let
     propagatedBuildInputs = [ TextGlob ];
     meta = {
       description = "Nice wrapper for File::Find ala find(1)";
-      license = with lib.licenses; [ artistic1 gpl1Pluartistic1 gpl1Plus ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -10262,7 +10262,7 @@ let
     propagatedBuildInputs = [ pkgs.gnome2.gnome_vfs Glib ];
     meta = {
       description = "(DEPRECATED) Perl interface to the 2.x series of the GNOME VFS";
-      license = with lib.licenses; [ gpl21Plus ];
+      license = with lib.licenses; [ lgpl21Plus ];
     };
   };
 
@@ -15143,7 +15143,7 @@ let
     };
     meta = {
       description = "Temporarily set Config or XSConfig values";
-      license = with lib.licenses; [ artistic1 gpl1Plusartistic1 gpl1Plus  artistic2 ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -27224,7 +27224,7 @@ let
     propagatedBuildInputs = [ XMLLibXML ];
     meta = {
       description = "Interface to the GNOME libxslt library";
-      license = [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -212,6 +212,7 @@ let
     };
     propagatedBuildInputs = [ AlgorithmDiff ];
     meta = {
+      description = "Perl extension for getting the Longest Common Sub-Sequence";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -449,6 +450,7 @@ let
     };
     buildInputs = [ CanaryStability ];
     meta = {
+      description = "The DBI of event loop programming";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -477,6 +479,7 @@ let
     buildInputs = [ CanaryStability ];
     propagatedBuildInputs = [ BDB AnyEvent ];
     meta = {
+      description = "Truly asynchronous berkeley db access";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -1542,6 +1545,7 @@ let
     buildInputs = [ pkgs.db4 ];
     propagatedBuildInputs = [ commonsense ];
     meta = {
+      description = "Asynchronous Berkeley DB access";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -2062,6 +2066,7 @@ let
       sha256 = "a5c91c62cf95fcb868f60eab5c832908f6905221013fea2bce3ff57046d7b6ea";
     };
     meta = {
+      description = "Canary to check perl compatibility for schmorp's modules";
       license = with lib.licenses; [ gpl1Plus ];
     };
   };
@@ -2116,6 +2121,7 @@ let
       sha256 = "0km5fc6r6whxh6h5yd7g1j0bi96sgk0gkda6cardicrw9qmqwkwj";
     };
     meta = {
+      description = "Executable comments";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -2130,6 +2136,7 @@ let
     propagatedBuildInputs = [ CarpAssert ];
     buildInputs = [ TestException ];
     meta = {
+      description = "Convenience assertions for common situations";
       license = with lib.licenses; [ artistic2 ];
     };
   };
@@ -2707,6 +2714,7 @@ let
     };
     buildInputs = [ CatalystRuntime TestLongString TestSimple13 TestWWWMechanize TestWWWMechanizeCatalyst TextCSV XMLSimple ];
     meta = {
+      description = "A view module to help in the convenience of downloading data into many supportable formats";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -2948,6 +2956,7 @@ let
     propagatedBuildInputs = [ CGI FCGI ];
     doCheck = false;
     meta = {
+      description = "CGI Interface for Fast CGI";
       homepage = "https://metacpan.org/module/CGI::Fast";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
@@ -3108,6 +3117,7 @@ let
       sha256 = "07215zzr4ydf49832vn54i3gf2q5b97lydkv8j56wb2svvjs64mz";
     };
     meta = {
+      description = "Automated accessor generation";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -3370,6 +3380,7 @@ let
       sha256 = "db1ba87ca9107f161fe9c1e9e7e267c0026defc26fe3e73bcad8ab8ffc18ef9d";
     };
     meta = {
+      description = "Iterator class";
       license = with lib.licenses; [ unfree ];
     };
   };
@@ -3711,6 +3722,7 @@ let
       sha256 = "0y7m25fksiavzg4xj4cm9zkz8rmnk4iqy7lm01m4nmyqlna3082p";
     };
     meta = {
+      description = "Recursively copy Perl datatypes";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -3812,6 +3824,7 @@ let
       sha256 = "5d1f5df48ce13b4dee1cc9f278ecdbf8177877b0b98815a4eb3c91c3466716f2";
     };
     meta = {
+      description = "Extremely light-weight Lempel-Ziv-Free compression";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -3878,6 +3891,7 @@ let
     doCheck = !stdenv.isDarwin;
 
     meta = {
+      description = "Low-Level Interface to zlib or zlib-ng compression library";
       homepage = "https://github.com/pmqs/Compress-Raw-Zlib";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
@@ -3933,6 +3947,7 @@ let
       sha256 = "1bbg3wp0xcpj04cmm86j1x0j5968jqi5s2c87qs7dgmap1vzk6qa";
     };
     meta = {
+      description = "Generic Config Module";
       license = with lib.licenses; [ artistic2 ];
     };
   };
@@ -4357,6 +4372,7 @@ let
     propagatedBuildInputs = [ AnyEvent Guard commonsense ];
     buildInputs = [ CanaryStability ];
     meta = {
+      description = "The only real threads in perl";
       license = with lib.licenses; [ unfree ];
     };
   };
@@ -4374,6 +4390,7 @@ let
       cd EV
     '';
     meta = {
+      description = "Do events the coro-way, with EV";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -4485,6 +4502,7 @@ let
     };
     propagatedBuildInputs = [ CompressBzip2 DataCompare ModuleSignature ];
     meta = {
+      description = "Write a CHECKSUMS file for a directory as on CPAN";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -5168,6 +5186,7 @@ let
     NIX_CFLAGS_LINK = "-L${lib.getLib pkgs.openssl}/lib -lcrypto";
     buildInputs = [ CryptOpenSSLGuess ];
     meta = {
+      description = "OpenSSL/LibreSSL pseudo-random number generator access";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       broken = stdenv.isDarwin && stdenv.isAarch64; # errors with: 74366 Abort trap: 6
     };
@@ -5804,6 +5823,7 @@ let
     buildInputs = [ TestDeep ];
     propagatedBuildInputs = [ ClassAccessor ];
     meta = {
+      description = "Parse Lisp S-Expressions into perl data structures";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -5817,6 +5837,7 @@ let
     };
     propagatedBuildInputs = [ DataPage MathRound ];
     meta = {
+      description = "Page numbering and spread pagination";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -5933,6 +5954,7 @@ let
       sha256 = "51c9efbf8423853616eaa24841e4d1996b2db0036900617fb1dbc76c75a1f360";
     };
     meta = {
+      description = "Allow complex data structures to be encoded using flat URIs";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -6085,6 +6107,7 @@ let
       sha256 = "29a1926314ce1681a312d6155c29590c771ddacf91b7485873ce449ef209dd04";
     };
     meta = {
+      description = "A simple date object";
       license = with lib.licenses; [ artistic1 gpl2Plus ];
     };
   };
@@ -6440,6 +6463,7 @@ let
     };
     propagatedBuildInputs = [ AnyEvent CompressLZF JSONXS commonsense ];
     meta = {
+      description = "Deliantra suppport module to read/write archetypes, maps etc";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7315,6 +7339,7 @@ let
       sha256 = "757a67e0aa59ae103ea5ca092cbecc025644ebdc326731688ffab6f8823ef4b3";
     };
     meta = {
+      description = "Perl extension for finding the memory usage of Perl variables";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -8202,6 +8227,7 @@ let
     };
     propagatedBuildInputs = [ EmailValid ];
     meta = {
+      description = "Email::Valid which allows dot before at mark";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -8288,6 +8314,7 @@ let
     };
     outputs = [ "out" ];
     meta = {
+      description = "JIS X 0212 (aka JIS 2000) Encodings";
       license = with lib.licenses; [ unfree ];
     };
   };
@@ -8419,6 +8446,7 @@ let
     buildInputs = [ CanaryStability ];
     propagatedBuildInputs = [ commonsense ];
     meta = {
+      description = "Perl interface to libev, a high performance full-featured event loop";
       license = with lib.licenses; [ gpl1Plus ];
     };
   };
@@ -8536,6 +8564,7 @@ let
       sha256 = "1hns15imih8z2h6zv3m1wwmv9fiysacsb52y94v6zf2cmw4kjny0";
     };
     meta = {
+      description = "Lightweight exporting of functions and variables";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -8647,7 +8676,7 @@ let
       sha256 = "165y1cjirbq64w39svkz82cb5jjqkjm8f4c0wqi2lk6050hzf3vq";
     };
     meta = {
-      homepage = "http://gtk2-perl.sourceforge.net";
+      description = "Easily build XS extensions that depend on XS extensions";
       license = with lib.licenses; [ artistic1 gpl1Plus artistic1 gpl1Plus ];
     };
   };
@@ -9097,6 +9126,7 @@ let
     };
     propagatedBuildInputs = [ ClassIterator ];
     meta = {
+      description = "Iterator interface for search files";
       license = with lib.licenses; [ unfree ];
     };
   };
@@ -9175,6 +9205,7 @@ let
     };
     propagatedBuildInputs = [ TextGlob ];
     meta = {
+      description = "Nice wrapper for File::Find ala find(1)";
       license = with lib.licenses; [ artistic1 gpl1Pluartistic1 gpl1Plus ];
     };
   };
@@ -10017,6 +10048,7 @@ let
       sha256 = "3709aa513ce6fd71d1a55a02e34d2f090017d5350a9bd447005653c9b0835b22";
     };
     meta = {
+      description = "Interpolates script options from files into @ARGV or another array";
       license = with lib.licenses; [ artistic1 ];
       maintainers = [ maintainers.pSub ];
     };
@@ -10380,6 +10412,7 @@ let
     };
     propagatedBuildInputs = [ HeapFibonacci SetObject ];
     meta = {
+      description = "GRaph data structures and algorithms";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -11481,8 +11514,9 @@ let
       sha256 = "1vs6sw431nnlnbdy6jii9vqlz30ndlfwdpdgm8a1m6fqngzhzq59";
     };
     meta = {
+      description = "An XS extension for processing HTTP headers";
       license = with lib.licenses; [ unfree ];
-      broken = 
+      broken =
         stdenv.isi686 # loadable library and perl binaries are mismatched (got handshake key 0x7d40080, needed 0x7dc0080)
         || stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.HTTPHeaderParserXS.x86_64-darwin
     };
@@ -11644,6 +11678,7 @@ let
     };
     propagatedBuildInputs = [ AuthenSimple HTTPServerSimple ];
     meta = {
+      description = "Authentication plugin for HTTP::Server::Simple";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -11717,6 +11752,7 @@ let
     };
     propagatedBuildInputs = [ DateTimeFormatICal FreezeThaw IOString TextvFileasData ];
     meta = {
+      description = "Parse iCalendar files into a data structure";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -11982,6 +12018,7 @@ let
       sha256 = "c2c15a254ca74fb8c57d25d7b6cbcaff77a3b4fb5695423f1f80bb423abffea9";
     };
     meta = {
+      description = "Abstract Base Class to build modules to capture output";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -12748,6 +12785,7 @@ let
     };
     propagatedBuildInputs = [ JSONXS ];
     meta = {
+      description = "Support versions 1 and 2 of JSON::XS";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -12897,6 +12935,7 @@ let
     '';
     doCheck = false; # test would need to start apache httpd
     meta = {
+      description = "Wrapper for libapreq2's module/handle API";
       license = with lib.licenses; [ asl20 ];
     };
   };
@@ -13101,6 +13140,7 @@ let
       sha256 = "0vyrspwzaqjxm5mqshf4wvwa3938mkajd1918d9ii2l9m2rn8kwx";
     };
     meta = {
+      description = "Perl French Stemming";
       license = with lib.licenses; [ unfree ];
     };
   };
@@ -13113,6 +13153,7 @@ let
       sha256 = "1207r183s5hlh4mfwa6p46vzm0dhvrs2dnss5s41a0gyfkxp7riq";
     };
     meta = {
+      description = "Porter's stemming algorithm for Italian";
       license = with lib.licenses; [ unfree ];
     };
   };
@@ -13139,6 +13180,7 @@ let
       sha256 = "0mm0m7glm1s6i9f6a78jslw6wh573208arxhq93yriqmw17bwf9f";
     };
     meta = {
+      description = "Porters stemming algorithm for Denmark";
       license = with lib.licenses; [ unfree ];
     };
   };
@@ -14383,6 +14425,7 @@ let
     };
     propagatedBuildInputs = [ MathBigInt ];
     meta = {
+      description = "What Math::BigInts are before they become big";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -14604,6 +14647,7 @@ let
       sha256 = "0k15pk2qx9wrp5xqzhymm1ph4nb314ysrsyr0pjnvn8ii0r241dy";
     };
     meta = {
+      description = "Random Number Generators";
       license = with lib.licenses; [ unfree ];
     };
   };
@@ -15694,6 +15738,7 @@ let
     doCheck = false; # would try to start Apache HTTP server
     passthru.tests = nixosTests.mod_perl;
     meta = {
+      description = "Embed a Perl interpreter in the Apache/2.x HTTP server";
       license = with lib.licenses; [ asl20 ];
       mainProgram = "mp2bug";
     };
@@ -18277,6 +18322,7 @@ let
     };
     propagatedBuildInputs = [ DigestHMAC ];
     meta = {
+      description = "An NTLM authentication module";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.pSub ];
     };
@@ -18523,6 +18569,7 @@ let
       rm t/45_class.t
     '';
     meta = {
+      description = "Perl extension for Apache ZooKeeper";
       homepage = "https://github.com/mark-5/p5-net-zookeeper";
       license = with lib.licenses; [ asl20 ];
       maintainers = teams.deshaw.members ++ [ maintainers.ztzg ];
@@ -18799,6 +18846,7 @@ let
     };
     propagatedBuildInputs = [ IOStringy LWP ];
     meta = {
+      description = "Easy OO parsing of debian control-like files";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -19246,6 +19294,7 @@ let
       sha256 = "0fyiysrq874ncscgdjg522fs29gvqads6ynyhwxwwq1b545srd20";
     };
     meta = {
+      description = "Allow to change perl's destruction level";
       license = with lib.licenses; [ unfree ];
     };
   };
@@ -19870,6 +19919,7 @@ let
       sha256 = "4c8f0a924b19ad78a13da73fe0fb306d32a7b9d10a332c523087fc83a209a8c4";
     };
     meta = {
+      description = "Launch and control background processes";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -20471,6 +20521,7 @@ let
     };
     propagatedBuildInputs = [ PodParser ];
     meta = {
+      description = "Wrap pod paragraphs, leaving verbatim text and code alone";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "podwrap";
     };
@@ -20663,6 +20714,7 @@ let
     };
     propagatedBuildInputs = [ RegexpCommon ];
     meta = {
+      description = "Provide patterns for CIDR blocks";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -20731,6 +20783,7 @@ let
       sha256 = "1yn5l6x3xyic9jxw9jggqsbggcv7rc8ggj4zbnlz9hfvv17gjazv";
     };
     meta = {
+      description = "Builds trie-ized regexp";
       license = with lib.licenses; [ unfree ];
     };
   };
@@ -21166,6 +21219,7 @@ let
       sha256 = "07aiqkyi1p22drpcyrrmv7f8qq6fhrxh007achy2vryxyck1bp53";
     };
     meta = {
+      description = "Basic set operations";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -21630,6 +21684,7 @@ let
     };
     propagatedBuildInputs = [ NumberFormat ];
     meta = {
+      description = "A collection of very basic statistics modules";
       license = with lib.licenses; [ free ];
     };
   };
@@ -22873,6 +22928,7 @@ let
     propagatedBuildInputs = [ IOInteractive TermProgressBar ];
     buildInputs = [ TestMockObject ];
     meta = {
+      description = "Provide a progress meter if run interactively";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -23091,6 +23147,7 @@ let
       sha256 = "f954e0310941d45c0fc3eb4a40f5d3a00d68119e277d303a1e6af11ded6fbd94";
     };
     meta = {
+      description = "A class to emulate a DEC VT102 terminal";
       license = with lib.licenses; [ unfree ];
     };
   };
@@ -23449,6 +23506,7 @@ let
       sha256 = "0mkw18q5agr30djxr1y68rcfw8aq20ws872hmv88f9gnynag8r20";
     };
     meta = {
+      description = "Extremely flexible deep comparison";
       homepage = "https://github.com/rjbs/Test-Deep";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
@@ -23713,6 +23771,7 @@ let
     propagatedBuildInputs = [ SubExporter TextDiff ];
     buildInputs = [ TestDifferences TestNoWarnings ];
     meta = {
+      description = "Test binary as hexadecimal string";
       license = with lib.licenses; [ unfree ];
     };
   };
@@ -25081,6 +25140,7 @@ let
       sha256 = "1p87pgap99lw0nv62i3ghvsi7yg90lhn8vsa3yqp75rd04clybcj";
     };
     meta = {
+      description = "German grundform reduction";
       license = with lib.licenses; [ unfree ];
     };
   };
@@ -25121,6 +25181,7 @@ let
       sha256 = "5b80b7d5e709d34393bcba88971864a17b44a5bf0f9e4bcee383d029e7d2d5c3";
     };
     meta = {
+      description = "Perl interface to iconv() codeset conversion function";
       license = with lib.licenses; [ unfree ];
       broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.TextIconv.x86_64-darwin
     };
@@ -25325,6 +25386,7 @@ let
       sha256 = "c186a50256e0bedfafb17e7ce157e7c52f19503bb79e18ebf06255911f6ead1a";
     };
     meta = {
+      description = "Generate pronounceable passwords";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -25583,6 +25645,7 @@ let
     # https://rt.cpan.org/Public/Bug/Display.html?id=124815
     NIX_CFLAGS_COMPILE = "-DHAS_VPRINTF";
     meta = {
+      description = "Remove accents from a string";
       license = with lib.licenses; [ unfree ];
       broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.TextUnaccent.x86_64-darwin
     };
@@ -25742,6 +25805,7 @@ let
     };
     propagatedBuildInputs = [ TieCacheLRU ];
     meta = {
+      description = "Extends Tie::Cache::LRU with expiring";
       license = with lib.licenses; [ artistic1 ];
     };
   };
@@ -25863,6 +25927,7 @@ let
       sha256 = "0c207850e77efb16618e0aa015507926a3425b34aad5aa6e3e40d83989a085a3";
     };
     meta = {
+      description = "Use regular expressions as hash keys";
       license = with lib.licenses; [ artistic1 ];
     };
   };
@@ -25987,6 +26052,7 @@ let
       sha256 = "1lhmx1x8j6z1k9vn32bcsw7g44cg22icshnnc37djlnlixlxm5lk";
     };
     meta = {
+      description = "Easily timeout long running operations";
       license = with lib.licenses; [ unfree ];
     };
   };
@@ -26169,6 +26235,7 @@ let
     };
     propagatedBuildInputs = [ DispatchClass TryTiny ];
     meta = {
+      description = "Selectively catch exceptions by class name";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -26229,6 +26296,7 @@ let
     };
     propagatedBuildInputs = [ commonsense ];
     meta = {
+      description = "Simple data types for common serialisation formats";
       license = with lib.licenses; [ unfree ];
     };
   };
@@ -26756,6 +26824,7 @@ let
         --replace '#!/usr/bin/perl' '#!${perl}/bin/perl'
     '';
     meta = {
+      description = "Use WWW::Mechanize with CGI applications";
       license = with lib.licenses; [ unfree ];
       broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.WWWMechanizeCGI.x86_64-darwin
     };

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -8273,7 +8273,7 @@ let
     nativeBuildInputs = [ pkgs.ld-is-cc-hook ];
     meta = {
       description = "An Encode::Encoding subclass that detects the encoding of data";
-      license = with lib.licenses; [ free ];
+      license = with lib.licenses; [ mpl11 gpl2Plus lgpl2Plus ]; # taken from fedora
     };
   };
 
@@ -8607,7 +8607,7 @@ let
     propagatedBuildInputs = [ Expect ];
     meta = {
       description = "Wrapper around the Expect module";
-      license = with lib.licenses; [ free ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -10106,7 +10106,7 @@ let
     propagatedBuildInputs = [ Error ];
     meta = {
       description = "This is the Git.pm, plus the other files in the perl/Git directory, from github's git/git";
-      license = with lib.licenses; [ free ];
+      license = with lib.licenses; [ gpl2Plus ];
       maintainers = teams.deshaw.members;
     };
   };
@@ -10582,7 +10582,7 @@ let
     doCheck = false;
     meta = {
       description = "Perl bindings for the GtkImageView widget";
-      license = with lib.licenses; [ free ];
+      license = with lib.licenses; [ lgpl3Plus ];
     };
   };
 
@@ -13484,7 +13484,7 @@ let
     };
     meta = {
       description = "Maketext from already interpolated strings";
-      license = with lib.licenses; [ free ];
+      license = with lib.licenses; [ cc0 ];
     };
   };
 
@@ -14677,7 +14677,7 @@ let
     propagatedBuildInputs = [ ObjectInsideOut ];
     meta = {
       description = "Auto-seeded Mersenne Twister PRNGs";
-      license = with lib.licenses; [ free ];
+      license = with lib.licenses; [ bsd3 ];
     };
   };
 
@@ -17852,7 +17852,7 @@ let
     };
     meta = {
       description = "Minimal MQTT version 3 interface";
-      license = with lib.licenses; [ free ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -19722,7 +19722,7 @@ let
     meta = {
       description = "Determine minimum Perl version of POD directives";
       homepage = "https://user42.tuxfamily.org/pod-minimumversion/index.html";
-      license = with lib.licenses; [ free ];
+      license = with lib.licenses; [ gpl3Plus ];
       mainProgram = "pod-minimumversion";
     };
   };
@@ -20730,7 +20730,7 @@ let
     meta = {
       description = "Date and time regexps";
       homepage = "https://github.com/manwar/Regexp-Common-time";
-      license = with lib.licenses; [ free ];
+      license = with lib.licenses; [ artistic2 mit bsd3 ];
       maintainers = [ maintainers.artturin ];
     };
   };
@@ -21685,7 +21685,7 @@ let
     propagatedBuildInputs = [ NumberFormat ];
     meta = {
       description = "A collection of very basic statistics modules";
-      license = with lib.licenses; [ free ];
+      license = with lib.licenses; [ lgpl2Only ];
     };
   };
 
@@ -24931,7 +24931,7 @@ let
     meta = {
       description = "Module to align text";
       homepage = "https://metacpan.org/release/Text-Aligner";
-      license = with lib.licenses; [ free ];
+      license = with lib.licenses; [ isc ];
     };
   };
 
@@ -25687,7 +25687,7 @@ let
     };
     meta = {
       description = "Extract collocations and Ngrams from text";
-      license = with lib.licenses; [ free ];
+      license = with lib.licenses; [ gpl2Plus ];
       maintainers = [ maintainers.bzizou ];
     };
   };

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -114,7 +114,6 @@ let
       description = "A grep-like tool tailored to working with large trees of source code";
       homepage    = "https://beyondgrep.com";
       license     = licenses.artistic2;
-      maintainers = with maintainers; [ lovek323 ];
     };
   };
 
@@ -713,10 +712,10 @@ let
       url = "mirror://cpan/authors/id/N/NE/NEILB/AppConfig-1.71.tar.gz";
       sha256 = "03vvi3mk4833mx2c6dkm9zhvakf02mb2b7wz9pk9xc7c4mq04xqi";
     };
+    buildInputs = [ TestPod ];
     meta = {
       description = "A bundle of Perl5 modules for reading configuration files and parsing command line arguments";
     };
-    buildInputs = [ TestPod ];
   };
 
   AppFatPacker = buildPerlPackage {
@@ -995,8 +994,7 @@ let
     };
     meta = {
       description = "Module for manipulations of cpio archives";
-      # See https://rt.cpan.org/Public/Bug/Display.html?id=43597#txn-569710
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ]; # See https://rt.cpan.org/Public/Bug/Display.html?id=43597#txn-569710
       mainProgram = "cpio-filter";
     };
   };
@@ -1137,11 +1135,11 @@ let
     };
     perlPreHook = "export LD=$CC";
     propagatedBuildInputs = [ pkgs.libkrb5 ];
+    buildInputs = [ DevelChecklib FileWhich PkgConfig ];
     meta = {
       description = "XS bindings for Kerberos 5";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ DevelChecklib FileWhich PkgConfig ];
   };
 
   AuthenKrb5Admin = buildPerlPackage rec {
@@ -1321,11 +1319,11 @@ let
       sha256 = "c303b7fccfaa1ff4d4c429ab3f15e5ca2a77554ef8c9fc3b8c62ba859e874c98";
     };
     propagatedBuildInputs = [ ScopeGuard ];
+    buildInputs = [ IPCSystemSimple TestFatal ];
     meta = {
       description = "Call methods on native types";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ IPCSystemSimple TestFatal ];
   };
 
   Autodia = buildPerlPackage {
@@ -1336,30 +1334,17 @@ let
       sha256 = "08pl5y18nsvy8ihfzdsbd8rz6a8al09wqfna07zdjfdyib42b0dc";
     };
     propagatedBuildInputs = [ TemplateToolkit XMLSimple ];
+    buildInputs = [ DBI ];
 
     meta = {
       description = "AutoDia, create UML diagrams from source code";
-
-      longDescription = ''
-        AutoDia is a modular application that parses source code, XML or data
-        and produces an XML document in Dia format (or images via graphviz
-        and vcg).  Its goal is to be a UML / DB Schema diagram autocreation
-        package.  The diagrams its creates are standard UML diagrams showing
-        dependencies, superclasses, packages, classes and inheritances, as
-        well as the methods, etc of each class.
-
-        AutoDia supports any language that a Handler has been written for,
-        which includes C, C++, Java, Perl, Python, and more.
-      '';
-
       homepage = "http://www.aarontrevena.co.uk/opensource/autodia/";
       license = lib.licenses.gpl2Plus;
       mainProgram = "autodia.pl";
     };
-    buildInputs = [ DBI ];
   };
 
-  AWSSignature4 = perlPackages.buildPerlModule {
+  AWSSignature4 = buildPerlModule {
     pname = "AWS-Signature4";
     version = "1.02";
     src = fetchurl {
@@ -1414,13 +1399,13 @@ let
       sha256 = "1zs9a4gl63icja055kncgyny6xk1nsk6payfbzczkba3sc8sclh4";
     };
     propagatedBuildInputs = [ BFlags IPCRun Opcodes ];
+    doCheck = false; /* test fails */
     meta = {
       homepage = "https://github.com/rurban/perl-compiler";
       description = "Perl compiler";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "perlcc";
     };
-    doCheck = false; /* test fails */
   };
 
   BCOW = buildPerlPackage {
@@ -1902,12 +1887,12 @@ let
       sha256 = "1nh5iya63q6j2w0cdi24x2ygpi8k8wwccnbh8cisnx8nqmywnhk0";
     };
     buildInputs = [ pkgs.cairo ];
+    propagatedBuildInputs = [ ExtUtilsDepends ExtUtilsPkgConfig ];
     meta = {
       homepage = "http://gtk2-perl.sourceforge.net/";
       description = "Perl interface to the cairo 2D vector graphics library";
       license = lib.licenses.lgpl21Plus;
     };
-    propagatedBuildInputs = [ ExtUtilsDepends ExtUtilsPkgConfig ];
   };
 
   CairoGObject = buildPerlPackage {
@@ -1918,11 +1903,11 @@ let
       sha256 = "0l2wcz77ndmbgvxx34gdm919a3dxh9fixqr47p50n78ysx2692cd";
     };
     buildInputs = [ pkgs.cairo ];
+    propagatedBuildInputs = [ Cairo Glib ];
     meta = {
       description = "Integrate Cairo into the Glib type system";
       license = lib.licenses.lgpl21Plus;
     };
-    propagatedBuildInputs = [ Cairo Glib ];
   };
 
   CallContext = buildPerlPackage {
@@ -2003,11 +1988,11 @@ let
       url = "mirror://cpan/authors/id/F/FE/FERREIRA/Carp-Always-0.16.tar.gz";
       sha256 = "1wb6b0qjga7kvn4p8df6k4g1pl2yzaqiln1713xidh3i454i3alq";
     };
+    buildInputs = [ TestBase ];
     meta = {
       description = "Warns and dies noisily with stack backtraces";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ TestBase ];
   };
 
   CarpAssert = buildPerlPackage {
@@ -2029,10 +2014,10 @@ let
       sha256 = "0axjfl1hp7s4lcfxjj41zcp397dzhjqzd95innzxnz914xkc2p5s";
     };
     propagatedBuildInputs = [ CarpAssert ];
+    buildInputs = [ TestException ];
     meta = {
       license = lib.licenses.artistic2;
     };
-    buildInputs = [ TestException ];
   };
 
   CarpClan = buildPerlPackage {
@@ -2072,11 +2057,11 @@ let
       sha256 = "8565203950a057d43ecd64e9593715d565c2fbd8b02c91f43c53b2111acd3948";
     };
     propagatedBuildInputs = [ CatalystRuntime DataVisitor ];
+    buildInputs = [ HTTPRequestAsCGI ];
     meta = {
       description = "Sensible default end action";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ HTTPRequestAsCGI ];
   };
 
   CatalystActionREST = buildPerlPackage {
@@ -2128,11 +2113,11 @@ let
       sha256 = "0i5ja7690fs9nhxcij6lw51j804sm8s06m5mvk1n8pi8jljrymvw";
     };
     propagatedBuildInputs = [ CatalystModelDBICSchema CatalystPluginAuthentication ];
+    buildInputs = [ TestWarn ];
     meta = {
       description = "A storage class for Catalyst Authentication using DBIx::Class";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ TestWarn ];
   };
 
   CatalystAuthenticationStoreLDAP = buildPerlPackage {
@@ -2146,7 +2131,7 @@ let
     buildInputs = [ TestMockObject TestException NetLDAPServerTest ];
     doCheck = !stdenv.isDarwin; # t/02-realms_api.t and t/50.auth.case.sensitivity.t
     meta = {
-      description= "Authentication from an LDAP Directory";
+      description = "Authentication from an LDAP Directory";
       license = with lib.licenses; [ artistic1 ];
     };
   };
@@ -2174,11 +2159,11 @@ let
     };
     buildInputs = [ CatalystActionRenderView CatalystPluginSession CatalystPluginSessionStateCookie CatalystPluginSessionStoreFile CatalystViewTT CodeTidyAllPluginPerlAlignMooseAttributes PodCoverageTrustPod PodTidy TemplateToolkit TestCPANMeta TestDifferences TestEOL TestKwalitee TestLongString TestMemoryCycle TestNoTabs TestPAUSEPermissions TestPod TestPodCoverage TestWWWMechanize TestWWWMechanizeCatalyst ];
     propagatedBuildInputs = [ CatalystComponentInstancePerContext HTMLFormFuMultiForm RegexpAssemble ];
+    doCheck = false; /* fails with 'open3: exec of .. perl .. failed: Argument list too long at .../TAP/Parser/Iterator/Process.pm line 165.' */
     meta = {
       description = "Catalyst integration for HTML::FormFu";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    doCheck = false; /* fails with 'open3: exec of .. perl .. failed: Argument list too long at .../TAP/Parser/Iterator/Process.pm line 165.' */
   };
 
   CatalystControllerPOD = buildPerlModule {
@@ -2673,13 +2658,13 @@ let
       url = "mirror://cpan/authors/id/T/TO/TODDR/CDB_File-1.05.tar.gz";
       sha256 = "0jzbm59b9q51k00djr1b8c4vjvjkwb577r946vi5s09rasfq8r45";
     };
+    buildInputs = [ TestFatal TestWarnings ];
+    propagatedBuildInputs = [ BCOW ];
     meta = {
       homepage = "https://github.com/toddr/CDB_File";
       description = "Perl extension for access to cdb databases";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ TestFatal TestWarnings ];
-    propagatedBuildInputs = [ BCOW ];
   };
 
   Catmandu = buildPerlModule {
@@ -2791,10 +2776,10 @@ let
       url = "mirror://cpan/authors/id/B/BO/BOWMANBS/CGI-Expand-2.05.tar.gz";
       sha256 = "1ad48nd067j5irjampxpw3zvzpg8wpnpan6szkdc5h64wccd30kf";
     };
+    buildInputs = [ TestException ];
     meta = {
       description = "Convert flat hash to nested data using TT2's dot convention";
     };
-    buildInputs = [ TestException ];
   };
 
   CGIFast = buildPerlPackage {
@@ -2867,11 +2852,11 @@ let
       sha256 = "0zpl7sa8jvv3zba2vcxf3qsrjk7kk2vcznfdpmxydw06x8vczrp5";
     };
     propagatedBuildInputs = [ IOStringy ];
+    buildInputs = [ TestException TestNoWarnings ];
     meta = {
       description = "A Simple totally OO CGI interface that is CGI.pm compliant";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ TestException TestNoWarnings ];
   };
 
   CGIStruct = buildPerlPackage {
@@ -2895,10 +2880,6 @@ let
       url = "mirror://cpan/authors/id/J/JS/JSWARTZ/CHI-0.60.tar.gz";
       sha256 = "c7f1a2b3570a8fede484e933f89ba1729e0abd05935791d146c522dd120ee851";
     };
-    preConfigure = ''
-      # fix error 'Unescaped left brace in regex is illegal here in regex'
-      substituteInPlace lib/CHI/t/Driver/Subcache/l1_cache.pm --replace 'qr/CHI stats: {' 'qr/CHI stats: \{'
-    '';
     buildInputs = [ TestClass TestDeep TestException TestWarn TimeDate ];
     propagatedBuildInputs = [ CarpAssert ClassLoad DataUUID DigestJHash HashMoreUtils JSONMaybeXS ListMoreUtils LogAny Moo MooXTypesMooseLikeNumeric StringRewritePrefix TaskWeaken TimeDuration TimeDurationParse ];
     meta = {
@@ -3213,10 +3194,6 @@ let
       url = "mirror://cpan/authors/id/E/EV/EVO/Class-MakeMethods-1.01.tar.gz";
       sha256 = "0ricb0mn0i06ngfhq5y035yx8i7ahlx83yyqwixqmv6hg4p79b5c";
     };
-    preConfigure = ''
-      # fix error 'Unescaped left brace in regex is illegal here in regex'
-      substituteInPlace tests/xemulator/class_methodmaker/Test.pm --replace 's/(TEST\s{)/$1/g' 's/(TEST\s\{)/$1/g'
-    '';
   };
 
   ClassMethodMaker = buildPerlPackage {
@@ -3457,16 +3434,16 @@ let
       url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Clipboard-0.26.tar.gz";
       sha256 = "886ae43dc8538f9bfc4e07fdbcf09b7fbd6ee59c31f364618c859de14953c58a";
     };
-    meta = {
-      description = "Clipboard - Copy and Paste with any OS";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
-    };
     propagatedBuildInputs = [ CGI ];
     # Disable test on darwin because MacPasteboard fails when not logged in interactively.
     # Mac OS error -4960 (coreFoundationUnknownErr): The unknown error at lib/Clipboard/MacPasteboard.pm line 3.
     # Mac-Pasteboard-0.009.readme: 'NOTE that Mac OS X appears to restrict pasteboard access to processes that are logged in interactively.
     #     Ssh sessions and cron jobs can not create the requisite pasteboard handles, giving coreFoundationUnknownErr (-4960)'
     doCheck = !stdenv.isDarwin;
+    meta = {
+      description = "Clipboard - Copy and Paste with any OS";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
 
@@ -3477,11 +3454,11 @@ let
       url = "mirror://cpan/authors/id/A/AT/ATOOMIC/Clone-0.45.tar.gz";
       sha256 = "1rm9g68fklni63jdkrlgqq6yfj95fm33p2bq90p475gsi8sfxdnb";
     };
+    buildInputs = [ BCOW ];
     meta = {
       description = "Recursively copy Perl datatypes";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ BCOW ];
   };
 
   CloneChoose = buildPerlPackage {
@@ -4129,12 +4106,13 @@ let
     };
     buildInputs = [ CanaryStability ];
     propagatedBuildInputs = [ AnyEvent Coro EV Guard commonsense ];
-    meta = {
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
-    };
     preConfigure = ''
       cd EV
     '';
+    meta = {
+      description = "Do events the coro-way, with EV";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   Corona = buildPerlPackage {
@@ -4337,7 +4315,7 @@ let
     };
   };
 
-  CryptArgon2 = perlPackages.buildPerlModule {
+  CryptArgon2 = buildPerlModule {
     pname = "Crypt-Argon2";
     version = "0.010";
     src = fetchurl {
@@ -4801,6 +4779,7 @@ let
     postInstall = lib.optionalString stdenv.isDarwin ''
       shortenPerlShebang $out/bin/pgplet
     '';
+    doCheck = false; /* test fails with 'No random source available!' */
 
     meta = {
       homepage = "https://github.com/btrott/Crypt-OpenPGP";
@@ -4809,7 +4788,6 @@ let
       maintainers = [ maintainers.sgo ];
       mainProgram = "pgplet";
     };
-    doCheck = false; /* test fails with 'No random source available!' */
   };
 
   CryptOpenSSLAES = buildPerlPackage {
@@ -4863,8 +4841,7 @@ let
     NIX_CFLAGS_LINK = "-L${lib.getLib pkgs.openssl}/lib -lcrypto";
     buildInputs = [ CryptOpenSSLGuess ];
     meta = {
-      # errors with: 74366 Abort trap: 6
-      broken = stdenv.isDarwin && stdenv.isAarch64;
+      broken = stdenv.isDarwin && stdenv.isAarch64; # errors with: 74366 Abort trap: 6
     };
   };
 
@@ -4941,13 +4918,13 @@ let
     };
 
     nativeBuildInputs = [ CanaryStability ];
+    buildInputs = [ CanaryStability ];
 
     meta = {
       description = "Minimal Ed25519 bindings";
       license = lib.licenses.artistic2;
       maintainers = [ maintainers.thoughtpolice ];
     };
-    buildInputs = [ CanaryStability ];
   };
 
   CryptSSLeay = buildPerlPackage {
@@ -5037,11 +5014,11 @@ let
       url = "mirror://cpan/authors/id/M/MD/MDXI/Curses-UI-0.9609.tar.gz";
       sha256 = "1bqf4h8z70f78nzqq5yj4ahvsbhxxal6bc2g301l9qdn2fjjgf0a";
     };
+    propagatedBuildInputs = [ Curses TermReadKey ];
     meta = {
       description = "curses based OO user interface framework";
       license = lib.licenses.artistic1;
     };
-    propagatedBuildInputs = [ Curses TermReadKey ];
   };
 
   CursesUIGrid = buildPerlPackage {
@@ -5091,11 +5068,11 @@ let
       url = "mirror://cpan/authors/id/K/KA/KAZEBURO/Cwd-Guard-0.05.tar.gz";
       sha256 = "0xwf4rmii55k3lp19mpbh00mbgby7rxdk2lk84148bjhp6i7rz3s";
     };
+    buildInputs = [ TestRequires ];
     meta = {
       description = "Temporary changing working directory (chdir)";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ TestRequires ];
   };
 
   DataClone = buildPerlPackage {
@@ -5191,11 +5168,11 @@ let
       sha256 = "c1a539f91c92cbcd8a8d83597ec9a7643fcd8ccf5a94e15382c3765289170066";
     };
     propagatedBuildInputs = [ DateCalc EmailValid FileMMagic ImageSize MIMETypes RegexpCommon ];
+    buildInputs = [ CGI ];
     meta = {
       description = "Validates user input (usually from an HTML form) based on input profile";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ CGI ];
   };
 
   DataGUID = buildPerlPackage {
@@ -5406,12 +5383,12 @@ let
       sha256 = "1pmlxca0a8sv2jjwvhwgqavq6iwys6kf457lby4anjp3f1dpx4yd";
     };
     propagatedBuildInputs = [ MROCompat SubExporter ];
+    buildInputs = [ TestFailWarnings ];
     meta = {
       homepage = "https://github.com/rjbs/data-section";
       description = "Read multiple hunks of data out of your DATA section";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ TestFailWarnings ];
   };
 
   DataSectionSimple = buildPerlPackage {
@@ -5689,10 +5666,10 @@ let
       sed -i "s#/bin/date#${pkgs.coreutils}/bin/date#" lib/Date/Manip/TZ.pm
     '';
     doCheck = !stdenv.isi686; # build freezes during tests on i686
+    buildInputs = [ TestInter ];
     meta = {
       description = "Date manipulation routines";
     };
-    buildInputs = [ TestInter ];
   };
 
   DateSimple = buildPerlPackage {
@@ -5729,11 +5706,11 @@ let
       url = "mirror://cpan/authors/id/W/WY/WYANT/DateTime-Calendar-Julian-0.102.tar.gz";
       sha256 = "0j95dhma66spjyb04zi6rwy7l33hibnrx02mn0znd9m89aiq52s6";
     };
+    propagatedBuildInputs = [ DateTime ];
     meta = {
       description = "Dates in the Julian calendar";
       license = lib.licenses.artistic2;
     };
-    propagatedBuildInputs = [ DateTime ];
   };
 
   DateTimeEventICal = buildPerlPackage {
@@ -5796,11 +5773,11 @@ let
       sha256 = "50a7b9feb287bb14b27323a53c2324486181a3ab6cb3f4c7662d42be901ad8ee";
     };
     propagatedBuildInputs = [ DateTimeFormatBuilder ListMoreUtils ModulePluggable ];
+    buildInputs = [ TestException TestMockTime TestNoWarnings ];
     meta = {
       description = "Flexibly parse strings and turn them into DateTime objects";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ TestException TestMockTime TestNoWarnings ];
   };
 
   DateTimeFormatHTTP = buildPerlModule {
@@ -5839,11 +5816,11 @@ let
       sha256 = "1afslsr2axkamdfjqk6i3w092hp20dznqffk4lgpxmxrd31ni5ql";
     };
     propagatedBuildInputs = [ DateTimeFormatBuilder ];
+    buildInputs = [ Test2Suite ];
     meta = {
       description = "Parses ISO8601 formats";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ Test2Suite ];
   };
 
   DateTimeFormatMail = buildPerlPackage {
@@ -5898,11 +5875,11 @@ let
       sha256 = "16siw0f3a0ilzv5fnfas5s9n92drjy271yf6qvmmpm0vwnjjx1kz";
     };
     propagatedBuildInputs = [ DateTimeFormatBuilder ];
+    buildInputs = [ ModuleBuildTiny ];
     meta = {
       description = "Parse and format PostgreSQL dates and times";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ ModuleBuildTiny ];
   };
 
   DateTimeFormatStrptime = buildPerlPackage {
@@ -6805,16 +6782,16 @@ let
       sha256 = "24ac4174f1f01322063fa4e119b247d371d3260ddca6e778c6c1a0e3f905f58e";
     };
     propagatedBuildInputs = [ FileWhich JSONMaybeXS ];
-    meta = {
-      homepage = "https://github.com/timbunce/devel-nytprof";
-      description = "Powerful fast feature-rich Perl source code profiler";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
-    };
     buildInputs = [ CaptureTiny TestDifferences ];
     nativeBuildInputs = lib.optional stdenv.isDarwin shortenPerlShebang;
     postInstall = lib.optionalString stdenv.isDarwin ''
       shortenPerlShebang $out/bin/*
     '';
+    meta = {
+      homepage = "https://github.com/timbunce/devel-nytprof";
+      description = "Powerful fast feature-rich Perl source code profiler";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   DevelOverloadInfo = buildPerlPackage {
@@ -6957,19 +6934,6 @@ let
     };
   };
 
-  DigestMD5 = buildPerlPackage rec {
-    pname = "Digest-MD5";
-    version = "2.55";
-    src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GA/GAAS/${pname}-${version}.tar.gz";
-      sha256 = "03b198a2d14425d951e5e50a885d3818c3162c8fe4c21e18d7798a9a179d0e3c";
-    };
-    meta = {
-      description = "Perl interface to the MD-5 algorithm";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
-    };
-  };
-
   DigestMD5File = buildPerlPackage {
     pname = "Digest-MD5-File";
     version = "0.08";
@@ -7109,13 +7073,13 @@ let
     postInstall = lib.optionalString stdenv.isDarwin ''
       shortenPerlShebang $out/bin/dzil
     '';
+    doCheck = false;
     meta = {
       homepage = "http://dzil.org/";
       description = "Distribution builder; installer not included!";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "dzil";
     };
-    doCheck = false;
   };
 
   DistZillaPluginBundleTestingMania = buildPerlModule {
@@ -7127,11 +7091,11 @@ let
     };
     buildInputs = [ MooseAutobox TestCPANMeta TestPerlCritic TestVersion ];
     propagatedBuildInputs = [ DistZillaPluginMojibakeTests DistZillaPluginTestCPANChanges DistZillaPluginTestCPANMetaJSON DistZillaPluginTestCompile DistZillaPluginTestDistManifest DistZillaPluginTestEOL DistZillaPluginTestKwalitee DistZillaPluginTestMinimumVersion DistZillaPluginTestNoTabs DistZillaPluginTestPerlCritic DistZillaPluginTestPodLinkCheck DistZillaPluginTestPortability DistZillaPluginTestSynopsis DistZillaPluginTestUnusedVars DistZillaPluginTestVersion PodCoverageTrustPod ];
+    doCheck = false; /* fails with 'open3: exec of .. perl .. failed: Argument list too long at .../TAP/Parser/Iterator/Process.pm line 165.' */
     meta = {
       description = "Test your dist with every testing plugin conceivable";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    doCheck = false; /* fails with 'open3: exec of .. perl .. failed: Argument list too long at .../TAP/Parser/Iterator/Process.pm line 165.' */
   };
 
   DistZillaPluginCheckChangeLog = buildPerlPackage {
@@ -7142,11 +7106,11 @@ let
       sha256 = "b0b34d6d70b56f1944d03c5f0dc3b8f6f24474c816d07b657a116c692c2e052a";
     };
     propagatedBuildInputs = [ DistZilla ];
+    buildInputs = [ PathClass PodCoverage PodCoverageTrustPod PodMarkdown TestDeep TestException TestPod TestPodCoverage ];
     meta = {
       description = "Dist::Zilla with Changes check";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ PathClass PodCoverage PodCoverageTrustPod PodMarkdown TestDeep TestException TestPod TestPodCoverage ];
   };
 
   DistZillaPluginMojibakeTests = buildPerlPackage {
@@ -7157,12 +7121,12 @@ let
       sha256 = "f1fff547ea24a8f7a483406a72ed6c4058d746d9dae963725502ddba025ab380";
     };
     propagatedBuildInputs = [ DistZilla ];
+    buildInputs = [ TestMojibake ];
     meta = {
       homepage = "https://github.com/creaktive/Dist-Zilla-Plugin-MojibakeTests";
       description = "Release tests for source encoding";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ TestMojibake ];
   };
 
   DistZillaPluginPodWeaver = buildPerlPackage {
@@ -7359,12 +7323,12 @@ let
     };
     # buildInputs = [ TestPodLinkCheck ];
     propagatedBuildInputs = [ DistZilla ];
+    buildInputs = [ TestPodLinkCheck ];
     meta = {
       homepage = "https://github.com/rwstauner/Dist-Zilla-Plugin-Test-Pod-LinkCheck";
       description = "Add release tests for POD links";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ TestPodLinkCheck ];
   };
 
   DistZillaPluginTestPortability = buildPerlModule {
@@ -7609,12 +7573,12 @@ let
       url = "mirror://cpan/authors/id/R/RJ/RJBS/Email-MIME-ContentType-1.024.tar.gz";
       sha256 = "42d164ac7ff4dc2ea848e710fe21fa85509a3bcbb91ed2d356e4aba951ed8835";
     };
+    propagatedBuildInputs = [ TextUnidecode ];
     meta = {
       homepage = "https://github.com/rjbs/Email-MIME-ContentType";
       description = "Parse a MIME Content-Type Header";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    propagatedBuildInputs = [ TextUnidecode ];
   };
 
   EmailMIMEEncodings = buildPerlPackage {
@@ -7640,12 +7604,12 @@ let
       sha256 = "4bbec933558d7cc9b8152bad86dd313de277a21a89b4ea83d84e61587e95dbc6";
     };
     propagatedBuildInputs = [ EmailAbstract EmailAddress ReturnValue ];
+    buildInputs = [ MIMETools MailTools ];
     meta = {
       homepage = "https://github.com/rjbs/Email-Send";
       description = "Simply Sending Email";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ MIMETools MailTools ];
   };
 
   EmailOutlookMessage = buildPerlModule {
@@ -7840,7 +7804,6 @@ let
     preCheck = if stdenv.isCygwin then ''
       sed -i"" -e "s@plan tests => 13@plan tests => 10@" t/env.t
       sed -i"" -e "s@ok(env(\"\\\x@#ok(env(\"\\\x@" t/env.t
-      sed -i"" -e "s@ok(\$ENV{\"\\\x@#ok(\$ENV{\"\\\x@" t/env.t
     '' else null;
     meta = {
       description = "Determine the locale encoding";
@@ -8070,20 +8033,6 @@ let
     };
   };
 
-  ExtUtilsCBuilder = buildPerlPackage {
-    pname = "ExtUtils-CBuilder";
-    version = "0.280234";
-    src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AM/AMBS/ExtUtils-CBuilder-0.280234.tar.gz";
-      sha256 = "1hzixkg85mys94a2i658pdr28xhzyrisvknsps691d183zm9a06q";
-    };
-    meta = {
-      description = "Compile and link C code for Perl modules";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
-      homepage = "https://metacpan.org/release/ExtUtils-CBuilder";
-    };
-  };
-
   Expect = buildPerlPackage {
     pname = "Expect";
     version = "1.35";
@@ -8181,11 +8130,11 @@ let
       sha256 = "355878a4a7f901eb18d21f9e21be8c8bfc6aaf9665d34b241bc1d43e32c5b730";
     };
     buildInputs = [ pkgs.gfortran ];
+    propagatedBuildInputs = [ FileWhich ];
     meta = {
       description = "A simple interface to F77 libs";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    propagatedBuildInputs = [ FileWhich ];
   };
 
   ExtUtilsHelpers = buildPerlPackage {
@@ -8377,11 +8326,11 @@ let
       sha256 = "1s11casbv0jmkcl5dk8i2vhfy1nc8rg43d3bg923zassrq4wndym";
     };
     propagatedBuildInputs = [ Moo TypeTiny ];
+    buildInputs = [ ModuleBuildTiny ];
     meta = {
       description = "client library for fastcgi protocol";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ ModuleBuildTiny ];
   };
 
   FCGIProcManager = buildPerlPackage {
@@ -8707,12 +8656,12 @@ let
       sha256 = "0ll8akqmwrh9q3nkxhv2caxlaya1fr20nbhjsjsxmxph5p33fdsr";
     };
     propagatedBuildInputs = [ FileWhich ];
+    preCheck = "export HOME=$TMPDIR";
+    doCheck = !stdenv.isDarwin;
     meta = {
       description = "Find your home and other directories on any platform";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    preCheck = "export HOME=$TMPDIR";
-    doCheck = !stdenv.isDarwin;
   };
 
   FileKeePass = buildPerlPackage {
@@ -8947,11 +8896,11 @@ let
       sha256 = "0n69h793jxz1zkp8ng6yqjwdh0yr0py0c8sg1bf5iyaxlc5s5civ";
     };
     propagatedBuildInputs = [ ClassInspector ];
+    buildInputs = [ FileShareDirInstall ];
     meta = {
       description = "Locate per-dist and per-module shared files";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ FileShareDirInstall ];
   };
 
   FileShareDirInstall = buildPerlPackage {
@@ -8987,11 +8936,11 @@ let
       url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Filesys-Notify-Simple-0.14.tar.gz";
       sha256 = "192m0l4cnfskdmhgaxk3bm1rvbmzxzwgcdgdb60qdqd59cnp3nhz";
     };
+    buildInputs = [ TestSharedFork ];
     meta = {
       description = "Simple and dumb file system watcher";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ TestSharedFork ];
   };
 
   FilesysDiskUsage = buildPerlPackage {
@@ -9170,12 +9119,12 @@ let
       sha256 = "0lxz9fsm4ld3l900zxh2w91wjygk0ifn4miw6q5k4mm67d2c9nwm";
     };
     propagatedBuildInputs = [ CGI DateTimeFormatStrptime HTMLTableExtract JSON JSONParse LWPProtocolHttps StringUtil TextTemplate ];
+    buildInputs = [ TestPod ];
     meta = with lib; {
       homepage = "http://finance-quote.sourceforge.net/";
       description = "Get stock and mutual fund quotes from various exchanges";
       license = licenses.gpl2;
     };
-    buildInputs = [ TestPod ];
   };
 
   FindLib = buildPerlPackage {
@@ -9207,11 +9156,11 @@ let
       url = "mirror://cpan/authors/id/B/BH/BHALLISSY/Font-TTF-1.06.tar.gz";
       sha256 = "4b697d444259759ea02d2c442c9bffe5ffe14c9214084a01f743693a944cc293";
     };
+    buildInputs = [ IOString ];
     meta = {
       description = "TTF font support for Perl";
       license = lib.licenses.artistic2;
     };
-    buildInputs = [ IOString ];
   };
 
   ForksSuper = buildPerlPackage {
@@ -9222,11 +9171,11 @@ let
       sha256 = "0kias11b4zchxy5x9ns2wwjzvzxlzsbap8sq587z9micw5bl7nrk";
     };
     doCheck = false;
+    propagatedBuildInputs = [ URI ];
     meta = {
       description = "Extensions and convenience methods to manage background processes";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    propagatedBuildInputs = [ URI ];
   };
 
   FormValidatorSimple = buildPerlPackage {
@@ -9237,11 +9186,11 @@ let
       sha256 = "fc3a63dc54b962d74586070176adaf5be869f09b561bb30f5fd32ef531792666";
     };
     propagatedBuildInputs = [ ClassAccessor ClassDataAccessor DateCalc DateTimeFormatStrptime EmailValidLoose ListMoreUtils TieIxHash UNIVERSALrequire YAML ];
+    buildInputs = [ CGI ];
     meta = {
       description = "Validation with simple chains of constraints";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ CGI ];
   };
 
   FreezeThaw = buildPerlPackage {
@@ -9572,12 +9521,12 @@ let
       sha256 = "005m3inz12xcsd5sr056cm1kbhmxsx2ly88ifbdv6p6cwz0s05kk";
     };
     buildInputs = [ pkgs.glib ];
+    propagatedBuildInputs = [ ExtUtilsDepends ExtUtilsPkgConfig ];
     meta = {
       homepage = "http://gtk2-perl.sourceforge.net/";
       description = "Perl wrappers for the GLib utility and Object libraries";
       license = lib.licenses.lgpl21Plus;
     };
-    propagatedBuildInputs = [ ExtUtilsDepends ExtUtilsPkgConfig ];
   };
 
   GlibObjectIntrospection = buildPerlPackage {
@@ -9632,11 +9581,11 @@ let
       sha256 = "0g42bfmqq5395m55np95pfj4i1qbrmx2ml4zhi4cw4sx4fdv7drr";
     };
     buildInputs = [ pkgs.gnome2.libgnomecanvas ];
+    propagatedBuildInputs = [ Gtk2 ];
+    doCheck = !stdenv.isDarwin;
     meta = {
       license = lib.licenses.lgpl2Plus;
     };
-    propagatedBuildInputs = [ Gtk2 ];
-    doCheck = !stdenv.isDarwin;
   };
 
   Gnome2VFS = buildPerlPackage {
@@ -9887,12 +9836,12 @@ let
       sha256 = "1mkhwxjjlhr58pd770i9gnf7zy7jj092iv6jfbnb8bvnc5xjr3vx";
     };
     propagatedBuildInputs = [ pkgs.krb5Full.dev ];
+    makeMakerFlags = "--gssapiimpl ${pkgs.krb5Full.dev}";
     meta = {
       maintainers = teams.deshaw.members;
       description = "Perl extension providing access to the GSSAPIv2 library";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    makeMakerFlags = "--gssapiimpl ${pkgs.krb5Full.dev}";
   };
 
   Gtk2 = buildPerlPackage {
@@ -9906,12 +9855,12 @@ let
     # https://rt.cpan.org/Public/Bug/Display.html?id=130742
     # doCheck = !stdenv.isDarwin;
     doCheck = false;
+    propagatedBuildInputs = [ Pango ];
     meta = {
       homepage = "http://gtk2-perl.sourceforge.net/";
       description = "Perl interface to the 2.x series of the Gimp Toolkit library";
       license = lib.licenses.lgpl21Plus;
     };
-    propagatedBuildInputs = [ Pango ];
   };
 
   Gtk2TrayIcon = buildPerlPackage {
@@ -10021,11 +9970,11 @@ let
       url = "mirror://cpan/authors/id/T/TV/TVIGNAUD/Gtk3-SimpleList-0.21.tar.gz";
       sha256 = "1158mnr2ldq02098hqbkwfv64d83zl3a8scll9s09g7k1c86ai0x";
     };
+    propagatedBuildInputs = [ Gtk3 ];
     meta = {
       description = "A simple interface to Gtk3's complex MVC list widget";
       license = lib.licenses.lgpl21Plus;
     };
-    propagatedBuildInputs = [ Gtk3 ];
   };
 
   Guard = buildPerlPackage {
@@ -10084,12 +10033,12 @@ let
       sha256 = "1ig0l859gq00k0r9l85274r2lbvwl7wsndcy52c0m3y9isilm6mw";
     };
     propagatedBuildInputs = [ HashMerge ];
+    buildInputs = [ TestSimple13 ];
 
     meta = {
       license = with lib.licenses; [ artistic1 ];
       description = "Return difference between two hashes as a hash";
     };
-    buildInputs = [ TestSimple13 ];
   };
 
   ham = callPackage ../development/perl-modules/ham { };
@@ -10113,10 +10062,10 @@ let
       sha256 = "0i46agids6pk445gfck80f8z7q3pjvkp0ip1vmhqnq1rcpvj41df";
     };
     propagatedBuildInputs = [ CloneChoose ];
+    buildInputs = [ Clone ClonePP ];
     meta = {
       description = "Merges arbitrarily deep hashes into a single hash";
     };
-    buildInputs = [ Clone ClonePP ];
   };
 
   HashMergeSimple = buildPerlPackage {
@@ -10766,11 +10715,11 @@ let
       url = "mirror://cpan/authors/id/O/OA/OALDERS/HTTP-Date-6.05.tar.gz";
       sha256 = "0awjdbz7x0jd5pna55dwxhs3k6xp3sw6b2zg3p2yndxxvya64p9n";
     };
+    propagatedBuildInputs = [ TimeDate ];
     meta = {
       description = "Date conversion routines";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    propagatedBuildInputs = [ TimeDate ];
   };
 
   HTTPEntityParser = buildPerlModule {
@@ -10796,12 +10745,12 @@ let
       url = "mirror://cpan/authors/id/C/CO/COSIMO/HTTP-DAV-0.49.tar.gz";
       sha256 = "0z4mgb8mc6l5nfsm3ihndjqgpk43q39x1kq9hryy6v8hxkwrscrk";
     };
+    propagatedBuildInputs = [ XMLDOM ];
     meta = {
       description = "WebDAV client library.";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "dave";
     };
-    propagatedBuildInputs = [ XMLDOM ];
   };
 
   HTTPHeadersActionPack = buildPerlPackage {
@@ -10826,9 +10775,9 @@ let
       url = "mirror://cpan/authors/id/M/MA/MARKSMITH/HTTP-HeaderParser-XS-0.20.tar.gz";
       sha256 = "1vs6sw431nnlnbdy6jii9vqlz30ndlfwdpdgm8a1m6fqngzhzq59";
     };
-    meta.broken =
-      stdenv.isi686 # loadable library and perl binaries are mismatched (got handshake key 0x7d40080, needed 0x7dc0080)
-      || stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.HTTPHeaderParserXS.x86_64-darwin
+    meta = {
+      broken = stdenv.isi686 || stdenv.isDarwin; # loadable library and perl binaries are mismatched (got handshake key 0x7d40080, needed 0x7dc0080)
+    };
   };
 
   HTTPHeadersFast = buildPerlModule {
@@ -10918,12 +10867,12 @@ let
       sha256 = "b05290534ec73625c21a0565fc35170890dab163843d95331c292c23f504c69d";
     };
     propagatedBuildInputs = [ LWP ];
+    # tests fail because they require network access
+    doCheck = false;
     meta = {
       description = "A pure Perl HTTP proxy";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    # tests fail because they require network access
-    doCheck = false;
   };
 
   HTTPRequestAsCGI = buildPerlPackage {
@@ -10944,10 +10893,10 @@ let
       sha256 = "1am8lis8107s5npca1xgazdy5sknknzcqyhdmc220s4a4f77n5hh";
     };
     propagatedBuildInputs = [ HTTPMessage ];
+    buildInputs = [ LWP ];
     meta = {
       description = "Adds encoding() to HTTP::Response";
     };
-    buildInputs = [ LWP ];
   };
 
   HTTPServerSimple = buildPerlPackage {
@@ -10958,10 +10907,10 @@ let
       sha256 = "0k6bg7k6mjixfzxdkkdrhqvaqmdhjszx0zsk8g0bimiby6j9z4yq";
     };
     doCheck = false;
+    propagatedBuildInputs = [ CGI ];
     meta = {
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    propagatedBuildInputs = [ CGI ];
   };
 
   HTTPServerSimpleAuthen = buildPerlPackage {
@@ -11332,13 +11281,13 @@ let
       sha256 = "193jvi4800cbcac5n1swj9zgwwqck9c47g0g592ldr7fbfd7zynn";
     };
     propagatedBuildInputs = [ CompressRawBzip2 CompressRawZlib ];
+    # Same as CompressRawZlib
+    doCheck = false && !stdenv.isDarwin;
     meta = {
       description = "IO Interface to compressed data files/buffers";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "streamzip";
     };
-    # Same as CompressRawZlib
-    doCheck = false && !stdenv.isDarwin;
   };
 
   IODigest = buildPerlPackage {
@@ -11372,9 +11321,9 @@ let
       sha256 = "1vncvsx53iiw1yy3drlk44hzx2pk5cial0h74djf9i6s2flndfcd";
     };
     propagatedBuildInputs = [ IOString SubExporter asa ];
+    buildInputs = [ ModuleBuildTiny TestSimple13 ];
     meta = {
     };
-    buildInputs = [ ModuleBuildTiny TestSimple13 ];
   };
 
   IOInteractive = buildPerlPackage {
@@ -11503,12 +11452,12 @@ let
       substituteInPlace lib/IO/Socket/SSL.pm \
         --replace "\$openssldir/cert.pem" "/etc/ssl/certs/ca-certificates.crt"
     '';
+    doCheck = false; # tries to connect to facebook.com etc.
     meta = {
       homepage = "https://github.com/noxxi/p5-io-socket-ssl";
       description = "Nearly transparent SSL encapsulation for IO::Socket::INET";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    doCheck = false; # tries to connect to facebook.com etc.
   };
 
   IOSocketTimeout = buildPerlModule {
@@ -11646,12 +11595,12 @@ let
       sha256 = "00f9wjvhn55zbk3n9il76xvsqy7ddk60lg6phg2rkpx0gwhvyvl1";
     };
     doCheck = false; /* attempts a network connection to localhost */
+    propagatedBuildInputs = [ IOTty ];
+    buildInputs = [ Readonly ];
     meta = {
       description = "System() and background procs w/ piping, redirs, ptys (Unix, Win32)";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    propagatedBuildInputs = [ IOTty ];
-    buildInputs = [ Readonly ];
   };
 
   IPCRun3 = buildPerlPackage {
@@ -11731,18 +11680,6 @@ let
       description = "A tool to read, write and edit EXIF meta information";
       homepage = "https://exiftool.org/";
 
-      longDescription = ''
-        ExifTool is a platform-independent Perl library plus a command-line
-        application for reading, writing and editing meta information in a wide
-        variety of files. ExifTool supports many different metadata formats
-        including EXIF, GPS, IPTC, XMP, JFIF, GeoTIFF, ICC Profile, Photoshop
-        IRB, FlashPix, AFCP and ID3, as well as the maker notes of many digital
-        cameras by Canon, Casio, DJI, FLIR, FujiFilm, GE, GoPro, HP,
-        JVC/Victor, Kodak, Leaf, Minolta/Konica-Minolta, Motorola, Nikon,
-        Nintendo, Olympus/Epson, Panasonic/Leica, Pentax/Asahi, Phase One,
-        Reconyx, Ricoh, Samsung, Sanyo, Sigma/Foveon and Sony.
-      '';
-
       license = with licenses; [ gpl1Plus /* or */ artistic2 ];
       maintainers = [ maintainers.kiloreux ];
       mainProgram = "exiftool";
@@ -11760,12 +11697,6 @@ let
     meta = {
       homepage = "https://github.com/ingydotnet/inline-pm";
       description = "Write Perl Subroutines in Other Programming Languages";
-      longDescription = ''
-        The Inline module allows you to put source code from other
-        programming languages directly "inline" in a Perl script or
-        module. The code is automatically compiled as needed, and then loaded
-        for immediate access from Perl.
-      '';
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -11810,15 +11741,6 @@ let
 
     meta = {
       description = "Inline::Java -- Write Perl classes in Java";
-
-      longDescription = ''
-        The Inline::Java module allows you to put Java source code directly
-        "inline" in a Perl script or module.  A Java compiler is launched and
-        the Java code is compiled.  Then Perl asks the Java classes what
-        public methods have been defined.  These classes and methods are
-        available to the Perl program as if they had been written in Perl.
-      '';
-
       license = lib.licenses.artistic2;
       broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.InlineJava.x86_64-darwin
     };
@@ -11886,11 +11808,11 @@ let
       url = "mirror://cpan/authors/id/E/ET/ETHER/JSON-Any-1.39.tar.gz";
       sha256 = "1hspg6khjb38syn59cysnapc1q77qgavfym3fqr6l2kiydf7ajdf";
     };
+    buildInputs = [ TestFatal TestRequires TestWarnings TestWithoutModule ];
     meta = {
       description = "Wrapper Class for the various JSON classes";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ TestFatal TestRequires TestWarnings TestWithoutModule ];
   };
 
   JSONCreate = buildPerlPackage {
@@ -11914,11 +11836,11 @@ let
       url = "mirror://cpan/authors/id/E/ET/ETHER/JSON-MaybeXS-1.004003.tar.gz";
       sha256 = "1grg8saa318bs4x2wqnww7y0nra7azrzg35bk5pgvkwxzwbkpvjv";
     };
+    buildInputs = [ TestNeeds ];
     meta = {
       description = "Use L<Cpanel::JSON::XS> with a fallback to L<JSON::XS> and L<JSON::PP>";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ TestNeeds ];
   };
 
   JSONPP = buildPerlPackage {
@@ -12066,16 +11988,16 @@ let
         wrapProgram $out/bin/$file --prefix PATH : ${lib.makeBinPath [ pkgs.ghostscript pkgs.potrace ]}
       done
     '';
+    passthru = {
+      tlType = "run";
+      pkgs = [ LaTeXML.tex ];
+    };
     meta = {
       description = "Transforms TeX and LaTeX into XML/HTML/MathML";
       homepage = "https://dlmf.nist.gov/LaTeXML/";
       license = lib.licenses.publicDomain;
       maintainers = with maintainers; [ xworld21 ];
       mainProgram = "latexml";
-    };
-    passthru = {
-      tlType = "run";
-      pkgs = [ LaTeXML.tex ];
     };
   };
 
@@ -12565,11 +12487,11 @@ let
       sha256 = "09v5cipjf634a1176wy2wicibzz51lry0d0yim9rnbfl5j2ggcb3";
     };
     propagatedBuildInputs = [ ExporterTiny ListMoreUtilsXS ];
+    buildInputs = [ TestLeakTrace ];
     meta = {
       description = "Provide the stuff missing in List::Util";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ TestLeakTrace ];
   };
 
   ListMoreUtilsXS = buildPerlPackage {
@@ -12619,11 +12541,11 @@ let
       url = "mirror://cpan/authors/id/S/SB/SBECK/Locale-Codes-3.66.tar.gz";
       sha256 = "1rspbig3zb7l7s1mlsk9n0rrisy8qrzwn0ix6a7sd372arnwvylr";
     };
+    buildInputs = [ TestInter ];
     meta = {
       description = "A distribution of modules to handle locale codes";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ TestInter ];
   };
 
   LocaleGettext = buildPerlPackage {
@@ -12802,11 +12724,11 @@ let
       url = "mirror://cpan/authors/id/H/HA/HAARG/local-lib-2.000024.tar.gz";
       sha256 = "01cav7m6qc1x96wna1viiw6n212f94ks7cik4vj1a1lasixr36rf";
     };
+    propagatedBuildInputs = [ ModuleBuild ];
     meta = {
       description = "Create and use a local lib/ for perl modules with PERL5LIB";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    propagatedBuildInputs = [ ModuleBuild ];
   };
 
   LockFileSimple = buildPerlPackage {
@@ -12888,11 +12810,11 @@ let
       sha256 = "089z5723lwa8jhl57xa5b901xmvj8kgz60rid33a7lv74k2irnd3";
     };
     propagatedBuildInputs = [ DevelGlobalDestruction ParamsValidationCompiler Specio namespaceautoclean ];
+    buildInputs = [ IPCRun3 TestFatal TestNeeds ];
     meta = {
       description = "Dispatches messages to one or more outputs";
       license = lib.licenses.artistic2;
     };
-    buildInputs = [ IPCRun3 TestFatal TestNeeds ];
   };
 
   LogDispatchFileRotate = buildPerlPackage {
@@ -12903,11 +12825,11 @@ let
       sha256 = "0vlmi17p7fky3x58rs7r5mdxi6l5jla8zhlb55kvssxc1w5v2b27";
     };
     propagatedBuildInputs = [ DateManip LogDispatch ];
+    buildInputs = [ PathTiny TestWarn ];
     meta = {
       description = "Log to Files that Archive/Rotate Themselves";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ PathTiny TestWarn ];
   };
 
   Logger = buildPerlPackage {
@@ -13095,11 +13017,11 @@ let
       substituteInPlace Makefile.PL --replace 'if has_module' 'if 0; #'
     '';
     doCheck = !stdenv.isDarwin;
+    checkInputs = [ HTTPDaemon TestFatal TestNeeds TestRequiresInternet ];
     meta = with lib; {
       description = "The World-Wide Web library for Perl";
       license = with licenses; [ artistic1 gpl1Plus ];
     };
-    checkInputs = [ HTTPDaemon TestFatal TestNeeds TestRequiresInternet ];
   };
 
   LWPAuthenOAuth = buildPerlPackage {
@@ -13123,11 +13045,11 @@ let
       url = "mirror://cpan/authors/id/O/OA/OALDERS/LWP-MediaTypes-6.04.tar.gz";
       sha256 = "1n8rg6csv3dsvymg06cmxipimr6cb1g9r903ghm1qsmiv89cl6wg";
     };
+    buildInputs = [ TestFatal ];
     meta = {
       description = "Guess media type for a file or a URL";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ TestFatal ];
   };
 
   LWPProtocolConnect = buildPerlPackage {
@@ -13155,11 +13077,11 @@ let
     patches = [ ../development/perl-modules/lwp-protocol-https-cert-file.patch ];
     propagatedBuildInputs = [ IOSocketSSL LWP ];
     doCheck = false; # tries to connect to https://www.apache.org/.
+    buildInputs = [ TestRequiresInternet ];
     meta = {
       description = "Provide https support for LWP::UserAgent";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ TestRequiresInternet ];
   };
 
   LWPProtocolhttp10 = buildPerlPackage {
@@ -13271,19 +13193,10 @@ let
       sha256 = "16hyl631yk1d5g3jns0n4mkjawlzqnf003brnk6qc3mbkziaifik";
     };
     buildInputs = [ TestException ];
+    propagatedBuildInputs = [ JSON ];
     meta = {
       description = "Object Oriented Authentication-Results Headers";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
-    };
-    propagatedBuildInputs = [ JSON ];
-  };
-
-  MailMaildir = buildPerlPackage {
-    version = "1.0.0";
-    pname = "Mail-Maildir";
-    src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZE/ZEROALTI/Mail-Maildir-100/Mail-Maildir-1.0.0.tar.bz2";
-      sha256 = "1krkqfps6q3ifrhi9450l5gm9199qyfcm6vidllr0dv65kdaqpj4";
     };
   };
 
@@ -13710,13 +13623,13 @@ let
       sha256 = "4afa6dd8cdb97499bd4eca6925861812c29d9f5a0f1ac27ad9d2d9c9b5602894";
     };
     propagatedBuildInputs = [ MathPrimeUtilGMP ];
+    buildInputs = [ TestWarn ];
     meta = {
       homepage = "https://github.com/danaj/Math-Prime-Util";
       description = "Utilities related to prime numbers, including fast sieves and factoring";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
-    buildInputs = [ TestWarn ];
   };
 
   MathPrimeUtilGMP = buildPerlPackage {
@@ -14026,7 +13939,6 @@ let
     meta = with lib; {
       homepage = "https://www.mhonarc.org/";
       description = "A mail-to-HTML converter";
-      maintainers = with maintainers; [ lovek323 ];
       mainProgram = "mhonarc";
       license = licenses.gpl2;
     };
@@ -14309,12 +14221,12 @@ let
       sha256 = "e5bb2acb117792c984628812acb0fec376cb970caee8ede57535e04d762b0e40";
     };
     propagatedBuildInputs = [ ClassAccessorLite ClassMethodModifiers DataOptList ];
+    buildInputs = [ TestSharedFork ];
     meta = {
       homepage = "https://github.com/tokuhirom/Module-Build-Pluggable";
       description = "Module::Build meets plugins";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ TestSharedFork ];
   };
 
   ModuleBuildPluggableCPANfile = buildPerlModule {
@@ -14427,12 +14339,12 @@ let
       url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Module-CPANfile-1.1004.tar.gz";
       sha256 = "08a9a5mybf0llwlfvk7n0q7az6lrrzgzwc3432mcwbb4k8pbxvw8";
     };
+    buildInputs = [ Filepushd ];
     meta = {
       description = "Parse cpanfile";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       homepage = "https://github.com/miyagawa/cpanfile";
     };
-    buildInputs = [ Filepushd ];
   };
 
   ModuleExtractUse = buildPerlModule {
@@ -14486,12 +14398,12 @@ let
       sha256 = "0j143hqxgdkdpj5qssppq72gjr0n73c4f7is6wgrrcchjx905a4f";
     };
     buildInputs = [ TestPod TestPodCoverage ];
+    propagatedBuildInputs = [ BUtils ];
     meta = {
       description = "Information about Perl modules";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "module_info";
     };
-    propagatedBuildInputs = [ BUtils ];
   };
 
   ModuleInstall = buildPerlPackage {
@@ -14659,11 +14571,11 @@ let
       # !!! merge this patch into Perl itself (which contains Module::Pluggable as well)
       ../development/perl-modules/module-pluggable.patch
     ];
+    buildInputs = [ AppFatPacker ];
     meta = {
       description = "Automatically give your module the ability to have plugins";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ AppFatPacker ];
   };
 
   ModulePluggableFast = buildPerlPackage {
@@ -14815,13 +14727,12 @@ let
     makeMakerFlags = "MP_AP_DESTDIR=$out";
     buildInputs = [ pkgs.apacheHttpd ];
     doCheck = false; # would try to start Apache HTTP server
+    passthru.tests = nixosTests.mod_perl;
     meta = {
       description = "Embed a Perl interpreter in the Apache HTTP server";
       license = lib.licenses.asl20;
       mainProgram = "mp2bug";
     };
-
-    passthru.tests = nixosTests.mod_perl;
   };
 
   Mojolicious = buildPerlPackage {
@@ -15148,10 +15059,6 @@ let
     };
     propagatedBuildInputs = [ ClassAccessor ConfigTiny MathCalcUnits ParamsValidate ];
     meta = {
-      description = ''
-        A family of perl modules to streamline writing Naemon,
-        Nagios, Icinga or Shinken (and compatible) plugins
-      '';
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -16047,11 +15954,11 @@ let
       sha256 = "0zpgwzxj6d9k2lbg6v6zd1bcbzjz2h336rm816krbblq6ssvm177";
     };
     propagatedBuildInputs = [ MooseXTypes PathClass ];
+    buildInputs = [ ModuleBuildTiny TestNeeds ];
     meta = {
       description = "A Path::Class type library for Moose";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ ModuleBuildTiny TestNeeds ];
   };
 
   MooseXTypesPathTiny = buildPerlModule {
@@ -16593,11 +16500,11 @@ let
       sha256 = "1rv745c16l3m3w6xx2hjmmgzkdklmzm9imdfiddmdr9hwm8g3xxy";
     };
     propagatedBuildInputs = [ NetDNS ];
+    buildInputs = [ TestException ];
     meta = {
       description = "Mock a DNS Resolver object for testing";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ TestException ];
   };
 
   NetDomainTLD = buildPerlPackage {
@@ -16681,12 +16588,12 @@ let
     };
     propagatedBuildInputs = [ URI ];
     __darwinAllowLocalNetworking = true;
+    doCheck = false; /* wants network */
     meta = {
       homepage = "https://github.com/libwww-perl/Net-HTTP";
       description = "Low-level HTTP connection (client)";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    doCheck = false; /* wants network */
   };
 
   NetHTTPSNB = buildPerlPackage {
@@ -16809,7 +16716,7 @@ let
       sha256 = "1mnnpkmj8kpb7qw50sm8h4sd8py37ssy2xi5hhxzr5whcx0cvhm8";
     };
     meta = {
-      description= "Active Directory Security Identifier manipulation";
+      description = "Active Directory Security Identifier manipulation";
       license = with lib.licenses; [ artistic2 ];
     };
   };
@@ -16823,7 +16730,7 @@ let
     };
     propagatedBuildInputs = [ perlldap NetLDAPServer DataDump NetLDAPSID ];
     meta = {
-      description= "test Net::LDAP code";
+      description = "test Net::LDAP code";
       license = with lib.licenses; [ artistic1 ];
     };
   };
@@ -16931,11 +16838,11 @@ let
     patchPhase = ''
       sed -i 's|$scp = "scp";|$scp = "${pkgs.openssh}/bin/scp";|' SCP.pm
     '';
+    buildInputs = [ NetSSH StringShellQuote ];
     meta = {
       description = "Simple wrappers around ssh and scp commands.";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ NetSSH StringShellQuote ];
   };
 
   NetServer = buildPerlPackage {
@@ -17622,12 +17529,12 @@ let
       sha256 = "c1b2970a8bb666c3de7caac4a8f4dbcc043ab819bbc337692ec7bf27adae4404";
     };
     buildInputs = [ TestWarn ];
+    propagatedBuildInputs = [ Moo ];
     meta = {
       homepage = "https://github.com/dluxhu/perl-parallel-forkmanager";
       description = "A simple parallel processing fork manager";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    propagatedBuildInputs = [ Moo ];
   };
 
   ParallelPipes = buildPerlModule {
@@ -17947,10 +17854,6 @@ let
       url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Path-Tiny-0.114.tar.gz";
       sha256 = "cd0f88f37a58fc3667ec065767fe01e73ee6efa18a112bfd3508cf6579ca00e1";
     };
-    meta = {
-      description = "File path utility";
-      license = lib.licenses.asl20;
-    };
     preConfigure =
       ''
         substituteInPlace lib/Path/Tiny.pm --replace 'use File::Spec 3.40' \
@@ -17959,6 +17862,10 @@ let
     # This appears to be currently failing tests, though I don't know why.
     # -- ocharles
     doCheck = false;
+    meta = {
+      description = "File path utility";
+      license = lib.licenses.asl20;
+    };
   };
 
   PathTools = buildPerlPackage {
@@ -18093,12 +18000,12 @@ let
       sha256 = "4dc8d335de80b25247cdb3f946f0d10d9ba0b3c34b0ed7d00316fd068fd05edc";
     };
     buildInputs = [ TestPod TieIxHash ];
+    propagatedBuildInputs = [ FileShareDirInstall XXX ];
     meta = {
       homepage = "https://github.com/ingydotnet/pegex-pm";
       description = "Acmeist PEG Parser Framework";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    propagatedBuildInputs = [ FileShareDirInstall XXX ];
   };
 
   PerconaToolkit = callPackage ../development/perl-modules/Percona-Toolkit { };
@@ -18636,11 +18543,6 @@ let
     # this module don't disable themselves when "run_network_tests" is
     # not present (see below).
     propagatedBuildInputs = [ pkgs.cacert IOPipely IOTty POETestLoops ];
-    meta = {
-      maintainers = teams.deshaw.members;
-      description = "Portable multitasking and networking framework for any event loop";
-      license = lib.licenses.artistic2;
-    };
     preCheck = ''
       set -x
 
@@ -18657,6 +18559,11 @@ let
 
       set +x
     '';
+    meta = {
+      maintainers = teams.deshaw.members;
+      description = "Portable multitasking and networking framework for any event loop";
+      license = lib.licenses.artistic2;
+    };
   };
 
   POETestLoops = buildPerlPackage {
@@ -19110,11 +19017,11 @@ let
       sha256 = "be9fb8910b108e5d1a66f002b659ad22576e88d779b703dff9d15122c3f80834";
     };
     propagatedBuildInputs = [ MixinLinewise ];
+    buildInputs = [ TestDeep ];
     meta = {
       description = "Read a POD document as a series of trivial events";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ TestDeep ];
   };
 
   PodParser = buildPerlPackage {
@@ -19274,13 +19181,13 @@ let
       sha256 = "0y8vk7wprair2fjqbkjl7g9jv0dn7rv58l7b9yf7819nia8fjygc";
     };
     buildInputs = [ TestDifferences ];
+    propagatedBuildInputs = [ URI ];
     meta = {
       homepage = "https://github.com/rwstauner/Pod-Markdown";
       description = "Convert POD to Markdown";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "pod2markdown";
     };
-    propagatedBuildInputs = [ URI ];
   };
 
   PodMarkdownGithub = buildPerlPackage {
@@ -19415,12 +19322,12 @@ let
     };
     # We cannot change timezones on the fly.
     prePatch = "rm t/04_tzset.t";
+    buildInputs = [ ModuleBuildTiny ];
     meta = {
       homepage = "https://github.com/kazeburo/POSIX-strftime-Compiler";
       description = "GNU C library compatible strftime for loggers and servers";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ ModuleBuildTiny ];
   };
 
   Apprainbarf = buildPerlModule {
@@ -19574,13 +19481,6 @@ let
       homepage = "https://github.com/manwar/Regexp-Common-time";
       description = "Date and time regexps.";
       maintainers = [ maintainers.artturin ];
-      # This module is copyrighted only to ensure proper attribution of
-      # authorship and to ensure that it remains available to all.  This
-      # module is free, open-source software.  This module may be freely used
-      # for any purpose, commercial, public, or private, provided that proper
-      # credit is given, and that no more-restrictive license is applied to
-      # derivative (not dependent) works.
-      # https://metacpan.org/release/MANWAR/Regexp-Common-time-0.13/view/lib/Regexp/Common/time.pm#LICENSE-AND-COPYRIGHT
       license = lib.licenses.free;
     };
   };
@@ -19789,11 +19689,11 @@ let
       sha256 = "0e6f2da3d96903491b43b19c61221cbeea88414264f907312f277daaf144248b";
     };
     buildInputs = [ CGI HTTPServerSimple TestException ];
+    propagatedBuildInputs = [ DateTimeFormatDateParse Error LWP ParamsValidate ];
     meta = {
       description = "Talk to RT installation using REST protocol";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    propagatedBuildInputs = [ DateTimeFormatDateParse Error LWP ParamsValidate ];
   };
 
   SafeIsa = buildPerlPackage {
@@ -20067,7 +19967,7 @@ let
     };
     meta = {
       description = "Library for parsing the output from SGMLS and NSGMLS parsers";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [ gpl2Plus ];
       mainProgram = "sgmlspl.pl";
     };
   };
@@ -20122,12 +20022,12 @@ let
       sha256 = "00fkvmnxiy5mr45rj5qmxmflw0xdkw2gihm48iha2i8smdmi0ng3";
     };
     propagatedBuildInputs = [ ClassInspector IOSessionData LWPProtocolHttps TaskWeaken XMLParser ];
+    buildInputs = [ TestWarn XMLParserLite ];
+    checkInputs = [ HTTPDaemon ];
     meta = {
       description = "Perl's Web Services Toolkit";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ TestWarn XMLParserLite ];
-    checkInputs = [ HTTPDaemon ];
   };
 
   Socket6 = buildPerlPackage {
@@ -20513,12 +20413,11 @@ let
       url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Statistics-Descriptive-3.0800.tar.gz";
       sha256 = "0fgrjr79ai5dn92kypslsi97y7r8iiwmd682lrd47vdz4vmdwkmh";
     };
+    propagatedBuildInputs = [ ListMoreUtils ];
     meta = {
-      #homepage = "http://web-cpan.berlios.de/modules/Statistics-Descriptive/"; # berlios shut down; I found no replacement
       description = "Module of basic descriptive statistical functions";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    propagatedBuildInputs = [ ListMoreUtils ];
   };
 
   StatisticsDistributions = buildPerlPackage {
@@ -20767,7 +20666,6 @@ let
     };
     doCheck = !stdenv.isDarwin;
     meta = {
-      # http://cpansearch.perl.org/src/ROSCH/String-ShellQuote-1.04/README
       description = "Quote strings for passing through the shell";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "shell-quote";
@@ -20873,12 +20771,11 @@ let
       url = "mirror://cpan/authors/id/B/BA/BAKERSCOT/String-Util-1.31.tar.gz";
       sha256 = "0vfjvy04y71f8jsjg0yll28wqlpgn7gbkcrb0i72k0qcliz9mg7v";
     };
+    buildInputs = [ ModuleBuildTiny ];
     meta = {
       description = "String::Util -- String processing utilities";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-
-    buildInputs = [ ModuleBuildTiny ];
   };
 
   strip-nondeterminism = callPackage ../development/perl-modules/strip-nondeterminism { };
@@ -21243,29 +21140,6 @@ let
     };
   };
 
-  SysCPU = buildPerlPackage {
-    pname = "Sys-CPU";
-    version = "0.61";
-    src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MZ/MZSANFORD/Sys-CPU-0.61.tar.gz";
-      sha256 = "1r6976bs86j7zp51m5vh42xlyah951jgdlkimv202413kjvqc2i5";
-    };
-    patches = [
-      # Bug #95400 for Sys-CPU: Tests fail on ARM and AArch64 Linux
-      # https://rt.cpan.org/Public/Bug/Display.html?id=95400
-      (fetchpatch {
-        url = "https://rt.cpan.org/Ticket/Attachment/1359669/721669/0001-Add-support-for-cpu_type-on-ARM-and-AArch64-Linux-pl.patch";
-        sha256 = "0rmazzdy34znksdhh8drc83lk754slhjgvnk4kk27z3kw5gm10m0";
-      })
-      (fetchpatch {
-        url = "https://rt.cpan.org/Ticket/Attachment/1388036/737125/0002-cpu_clock-can-be-undefined-on-an-ARM.patch";
-        sha256 = "0z3wqfahc9av7y34aqp6biq3sf8v8q4yynx7bv290vds50dsjb4w";
-      })
-    ];
-    buildInputs = lib.optional stdenv.isDarwin pkgs.darwin.apple_sdk.frameworks.Carbon;
-    doCheck = !stdenv.isAarch64;
-  };
-
   SysHostnameLong = buildPerlPackage {
     pname = "Sys-Hostname-Long";
     version = "1.5";
@@ -21311,11 +21185,11 @@ let
       sha256 = "43de5ecd20c1da46e8a6f4fceab29e04697a2890a99bf6a91b3ca004a468a241";
     };
     propagatedBuildInputs = [ IPCRun ];
+    buildInputs = [ PodCoverageTrustPod TestCPANMeta TestPod TestPodCoverage ];
     meta = {
       description = "Object for running system commands";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ PodCoverageTrustPod TestCPANMeta TestPod TestPodCoverage ];
   };
 
   SysVirt = buildPerlModule rec {
@@ -21357,11 +21231,11 @@ let
       sha256 = "75b1b2d96155647842587146cefd0de30943b85195e8e3eca51e0f0b8642d61e";
     };
     propagatedBuildInputs = [ CatalystAuthenticationStoreDBIxClass CatalystControllerHTMLFormFu CatalystDevel CatalystManual CatalystPluginAuthorizationACL CatalystPluginAuthorizationRoles CatalystPluginSessionStateCookie CatalystPluginSessionStoreFastMmap CatalystPluginStackTrace CatalystViewTT ];
+    doCheck = false; /* fails with 'open3: exec of .. perl .. failed: Argument list too long at .../TAP/Parser/Iterator/Process.pm line 165.' */
     meta = {
       description = "Everything you need to follow the Catalyst Tutorial";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    doCheck = false; /* fails with 'open3: exec of .. perl .. failed: Argument list too long at .../TAP/Parser/Iterator/Process.pm line 165.' */
   };
 
   TaskFreecellSolverTesting = buildPerlModule {
@@ -21564,12 +21438,12 @@ let
       sha256 = "1dpmy62x1yshf7kwslj85sc8bcgw1m30dh0szmfrp99pysxj7bfn";
     };
     doCheck = !stdenv.isDarwin;
+    propagatedBuildInputs = [ AppConfig ];
+    buildInputs = [ CGI TestLeakTrace ];
     meta = {
       description = "Comprehensive template processing system";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    propagatedBuildInputs = [ AppConfig ];
-    buildInputs = [ CGI TestLeakTrace ];
   };
 
   TemplateGD = buildPerlPackage {
@@ -21622,11 +21496,11 @@ let
       sha256 = "25675292f588bc29d32e710cf3667da9a2a1751e139801770a9fdb18cd2184a6";
     };
     propagatedBuildInputs = [ IOInteractive TermProgressBar ];
+    buildInputs = [ TestMockObject ];
     meta = {
       description = "";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ TestMockObject ];
   };
 
   TermProgressBarSimple = buildPerlPackage {
@@ -21916,11 +21790,11 @@ let
       sha256 = "0x7vy9r5gyxqg3qy966frj8ywkckkv7mc83xy4mkdvrf0h0dhgdy";
     };
     buildInputs = [ IPCRun3 Test2Suite ];
+    propagatedBuildInputs = [ TestSimple13 ];
     meta = {
       description = "Fail if tests warn";
       license = with lib.licenses; [ artistic2 ];
     };
-    propagatedBuildInputs = [ TestSimple13 ];
   };
 
   Test2Suite = buildPerlPackage {
@@ -22743,11 +22617,11 @@ let
       sha256 = "1isg8z6by113zn08l044w6k04y5m5bnns3rqmks8rwdr3qa70csk";
     };
     propagatedBuildInputs = [ ExceptionClass ];
+    buildInputs = [ TestDeep TestDifferences TestException TestWarn ];
     meta = {
       description = "Most commonly needed test functions and features";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ TestDeep TestDifferences TestException TestWarn ];
   };
 
   Testmysqld = buildPerlModule {
@@ -22858,10 +22732,10 @@ let
       sha256 = "1djpfi57s1j6mqb0ii2ca1sj3ym7jjab018inp6vdmsyfjcnhvwz";
     };
     propagatedBuildInputs = [ PathTiny PerlTidy TextDiff ];
+    buildInputs = [ TestPerlCritic ];
     meta = {
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ TestPerlCritic ];
   };
 
   TestPod = buildPerlPackage {
@@ -22910,11 +22784,11 @@ let
       sha256 = "0ycfghsyl9f31kxdppjwx2g5iajrqh3fyywz0x7d8ayndw2hdihi";
     };
     propagatedBuildInputs = [ LWP URIFind ];
+    buildInputs = [ ModuleBuildTiny TestPod ];
     meta = {
       description = "Checks POD for any http 404 links";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ ModuleBuildTiny TestPod ];
   };
 
   TestPortabilityFiles = buildPerlPackage {
@@ -23221,11 +23095,11 @@ let
       sha256 = "1lk5l69bm6yl1zxzz5v6mizzqfinpdhasmi4qjxr1vnwcl9cyc8a";
     };
     propagatedBuildInputs = [ DevelGlobalPhase PackageStash TieIxHash ];
+    buildInputs = [ TestDeep TestTrap ];
     meta = {
       description = "Write tests in a declarative specification style";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ TestDeep TestTrap ];
   };
 
   TestSubCalls = buildPerlPackage {
@@ -23276,7 +23150,6 @@ let
       license = with lib.licenses; [ asl20 ];
       homepage = "https://github.com/dagolden/Test-TempDir-Tiny";
     };
-
   };
 
   TestTCP = buildPerlPackage {
@@ -23286,11 +23159,11 @@ let
       url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Test-TCP-2.22.tar.gz";
       sha256 = "0mvv9rqwrwlcfh8qrs0s47p85rhlnw15d4gbpyi802bddp0c6lry";
     };
+    buildInputs = [ TestSharedFork ];
     meta = {
       description = "Testing TCP program";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ TestSharedFork ];
   };
 
   TestUNIXSock = buildPerlModule rec {
@@ -23300,12 +23173,12 @@ let
       url = "mirror://cpan/authors/id/F/FU/FUJIWARA/${pname}-${version}.tar.gz";
       sha256 = "0gwgd2w16dsppmf1r6yc17ipvs8b62ybsiz2dyzwy4il236b8c1p";
     };
+    buildInputs = [ ModuleBuildTiny ];
+    propagatedBuildInputs = [ TestSharedFork TestTCP ];
     meta = {
       description = "Testing UNIX domain socket program";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ ModuleBuildTiny ];
-    propagatedBuildInputs = [ TestSharedFork TestTCP ];
   };
 
   TestTime = buildPerlPackage {
@@ -23442,11 +23315,11 @@ let
     };
     doCheck = false; # listens on an external port
     propagatedBuildInputs = [ CatalystRuntime WWWMechanize ];
+    buildInputs = [ CatalystPluginSession CatalystPluginSessionStateCookie TestException TestWWWMechanize Testutf8 ];
     meta = {
       description = "Test::WWW::Mechanize for Catalyst";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ CatalystPluginSession CatalystPluginSessionStateCookie TestException TestWWWMechanize Testutf8 ];
   };
 
   TestWWWMechanizeCGI = buildPerlPackage {
@@ -23764,11 +23637,11 @@ let
       url = "mirror://cpan/authors/id/S/SB/SBECK/Test-Inter-1.09.tar.gz";
       sha256 = "1e9f129cc1a001fb95449d385253b38afabf5b466e3b3bd33e4e430f216e177a";
     };
+    buildInputs = [ FileFindRule TestPod TestPodCoverage ];
     meta = {
       description = "Framework for more readable interactive test scripts";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ FileFindRule TestPod TestPodCoverage ];
   };
 
   TextLayout = buildPerlPackage {
@@ -23920,7 +23793,7 @@ let
   };
 
   TextParsewords = buildPerlPackage {
-    pname = "Text-Parsewords";
+    pname = "Text-ParseWords";
     version = "3.30";
     src = fetchurl {
       url = "mirror://cpan/authors/id/C/CH/CHORNY/Text-ParseWords-3.30.tar.gz";
@@ -24043,11 +23916,11 @@ let
       url = "mirror://cpan/authors/id/M/MR/MRAMBERG/Text-SimpleTable-2.07.tar.gz";
       sha256 = "1v8r8qpzg283p2pqqr8dqrak2bxray1b2jmib0qk75jffqw3yv95";
     };
+    propagatedBuildInputs = [ UnicodeLineBreak ];
     meta = {
       description = "Simple eyecandy ASCII tables";
       license = lib.licenses.artistic2;
     };
-    propagatedBuildInputs = [ UnicodeLineBreak ];
   };
 
   TextSoundex = buildPerlPackage {
@@ -24281,11 +24154,11 @@ let
       url = "mirror://cpan/authors/id/C/CJ/CJM/Text-Wrapper-1.05.tar.gz";
       sha256 = "64268e15983a9df47e1d9199a491f394e89f542e54afb33f4b78f3f318e09ab9";
     };
+    buildInputs = [ TestDifferences ];
     meta = {
       description = "Word wrap text by breaking long lines";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ TestDifferences ];
   };
 
   Throwable = buildPerlPackage {
@@ -24404,11 +24277,11 @@ let
       url = "mirror://cpan/authors/id/M/MH/MHX/Tie-Hash-Indexed-0.08.tar.gz";
       sha256 = "043v98xaid6sjch2x9c39s475wm9i13vzf8jg73qm12sby0n5g1p";
     };
+    doCheck = false; /* test fails on some machines */
     meta = {
       description = "Ordered hashes for Perl";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    doCheck = false; /* test fails on some machines */
   };
 
   TieHashMethod = buildPerlPackage {
@@ -24629,9 +24502,9 @@ let
 
     meta = {
       description = "Tools for running a map tile server";
-      homepage = "https://github.com/openstreetmap/tirex";
+      homepage = "https://wiki.openstreetmap.org/wiki/Tirex";
       maintainers = with maintainers; [ jglukasik ];
-      license = with lib.licenses; [ gpl2 ];
+      license = with lib.licenses; [ gpl2Only ];
     };
   };
 
@@ -24672,11 +24545,11 @@ let
       url = "mirror://cpan/authors/id/R/RS/RSAVAGE/Tree-DAG_Node-1.31.tgz";
       sha256 = "016kr76azxzfcpxjkhqp2piyyl6529shjis20mc3g2snfabsd2qw";
     };
+    propagatedBuildInputs = [ FileSlurpTiny ];
     meta = {
       description = "An N-ary tree";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    propagatedBuildInputs = [ FileSlurpTiny ];
   };
 
   TreeSimple = buildPerlPackage {
@@ -24756,11 +24629,11 @@ let
       sha256 = "147axzi07g5akpzbzd2npvdyh9pmzv22a8la1dmylahw2qh15nyk";
     };
     propagatedBuildInputs = [ ExporterTiny ];
+    buildInputs = [ TestMemoryCycle ];
     meta = {
       description = "Tiny, yet Moo(se)-compatible type constraint";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ TestMemoryCycle ];
   };
 
   TypeTinyXS = buildPerlPackage {
@@ -24968,11 +24841,11 @@ let
       sha256 = "1l3g5ygv83vn9y1zpwjdqq5cs4ip2q058q0gmpcf5wp9rsycbjm7";
     };
     propagatedBuildInputs = [ ParamsValidate URI ];
+    buildInputs = [ TestFatal ];
     meta = {
       description = "Build a URI from a set of named parameters";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ TestFatal ];
   };
 
   UriGoogleChart = buildPerlPackage {
@@ -25258,13 +25131,13 @@ let
     };
     propagatedBuildInputs = [ HTMLForm HTMLTree LWP ];
     doCheck = false;
+    buildInputs = [ CGI HTTPServerSimple PathTiny TestDeep TestFatal TestOutput TestWarnings ];
     meta = {
       homepage = "https://github.com/libwww-perl/WWW-Mechanize";
       description = "Handy web browsing in a Perl object";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "mech-dump";
     };
-    buildInputs = [ CGI HTTPServerSimple PathTiny TestDeep TestFatal TestOutput TestWarnings ];
   };
 
   WWWMechanizeCGI = buildPerlPackage {
@@ -25767,8 +25640,7 @@ let
     };
     propagatedBuildInputs = [ XMLParser ];
     meta = {
-      description =
-        "Parse XML and specify what and how to keep/process for individual tags";
+      description = "Parse XML and specify what and how to keep/process for individual tags";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -1349,6 +1349,17 @@ let
 
     meta = {
       description = "AutoDia, create UML diagrams from source code";
+      longDescription = ''
+        AutoDia is a modular application that parses source code, XML or data
+        and produces an XML document in Dia format (or images via graphviz
+        and vcg).  Its goal is to be a UML / DB Schema diagram autocreation
+        package.  The diagrams its creates are standard UML diagrams showing
+        dependencies, superclasses, packages, classes and inheritances, as
+        well as the methods, etc of each class.
+
+        AutoDia supports any language that a Handler has been written for,
+        which includes C, C++, Java, Perl, Python, and more.
+      '';
       homepage = "http://www.aarontrevena.co.uk/opensource/autodia/";
       license = with lib.licenses; [ gpl2Plus ];
       mainProgram = "autodia.pl";
@@ -2918,6 +2929,10 @@ let
       url = "mirror://cpan/authors/id/J/JS/JSWARTZ/CHI-0.60.tar.gz";
       sha256 = "c7f1a2b3570a8fede484e933f89ba1729e0abd05935791d146c522dd120ee851";
     };
+    preConfigure = ''
+      # fix error 'Unescaped left brace in regex is illegal here in regex'
+      substituteInPlace lib/CHI/t/Driver/Subcache/l1_cache.pm --replace 'qr/CHI stats: {' 'qr/CHI stats: \{'
+    '';
     buildInputs = [ TestClass TestDeep TestException TestWarn TimeDate ];
     propagatedBuildInputs = [ CarpAssert ClassLoad DataUUID DigestJHash HashMoreUtils JSONMaybeXS ListMoreUtils LogAny Moo MooXTypesMooseLikeNumeric StringRewritePrefix TaskWeaken TimeDuration TimeDurationParse ];
     meta = {
@@ -3238,6 +3253,10 @@ let
       url = "mirror://cpan/authors/id/E/EV/EVO/Class-MakeMethods-1.01.tar.gz";
       sha256 = "0ricb0mn0i06ngfhq5y035yx8i7ahlx83yyqwixqmv6hg4p79b5c";
     };
+    preConfigure = ''
+      # fix error 'Unescaped left brace in regex is illegal here in regex'
+      substituteInPlace tests/xemulator/class_methodmaker/Test.pm --replace 's/(TEST\s{)/$1/g' 's/(TEST\s\{)/$1/g'
+    '';
   };
 
   ClassMethodMaker = buildPerlPackage {
@@ -7910,6 +7929,7 @@ let
     preCheck = if stdenv.isCygwin then ''
       sed -i"" -e "s@plan tests => 13@plan tests => 10@" t/env.t
       sed -i"" -e "s@ok(env(\"\\\x@#ok(env(\"\\\x@" t/env.t
+      sed -i"" -e "s@ok(\$ENV{\"\\\x@#ok(\$ENV{\"\\\x@" t/env.t
     '' else null;
     meta = {
       description = "Determine the locale encoding";
@@ -10933,7 +10953,9 @@ let
     };
     meta = {
       license = with lib.licenses; [ unfree ];
-      broken = stdenv.isi686 || stdenv.isDarwin; # loadable library and perl binaries are mismatched (got handshake key 0x7d40080, needed 0x7dc0080)
+      broken = 
+        stdenv.isi686 # loadable library and perl binaries are mismatched (got handshake key 0x7d40080, needed 0x7dc0080)
+        || stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.HTTPHeaderParserXS.x86_64-darwin
     };
   };
 
@@ -11847,6 +11869,17 @@ let
 
     meta = with lib; {
       description = "A tool to read, write and edit EXIF meta information";
+      longDescription = ''
+        ExifTool is a platform-independent Perl library plus a command-line
+        application for reading, writing and editing meta information in a wide
+        variety of files. ExifTool supports many different metadata formats
+        including EXIF, GPS, IPTC, XMP, JFIF, GeoTIFF, ICC Profile, Photoshop
+        IRB, FlashPix, AFCP and ID3, as well as the maker notes of many digital
+        cameras by Canon, Casio, DJI, FLIR, FujiFilm, GE, GoPro, HP,
+        JVC/Victor, Kodak, Leaf, Minolta/Konica-Minolta, Motorola, Nikon,
+        Nintendo, Olympus/Epson, Panasonic/Leica, Pentax/Asahi, Phase One,
+        Reconyx, Ricoh, Samsung, Sanyo, Sigma/Foveon and Sony.
+      '';
       homepage = "https://exiftool.org/";
 
       license = with licenses; [ gpl1Plus /* or */ artistic2 ];
@@ -11865,6 +11898,12 @@ let
     buildInputs = [ TestWarn ];
     meta = {
       description = "Write Perl Subroutines in Other Programming Languages";
+      longDescription = ''
+        The Inline module allows you to put source code from other
+        programming languages directly "inline" in a Perl script or
+        module. The code is automatically compiled as needed, and then loaded
+        for immediate access from Perl.
+      '';
       homepage = "https://github.com/ingydotnet/inline-pm";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
@@ -11910,6 +11949,13 @@ let
 
     meta = {
       description = "Write Perl classes in Java";
+      longDescription = ''
+        The Inline::Java module allows you to put Java source code directly
+        "inline" in a Perl script or module.  A Java compiler is launched and
+        the Java code is compiled.  Then Perl asks the Java classes what
+        public methods have been defined.  These classes and methods are
+        available to the Perl program as if they had been written in Perl.
+      '';
       license = with lib.licenses; [ artistic2 ];
       broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.InlineJava.x86_64-darwin
     };
@@ -13385,6 +13431,15 @@ let
     meta = {
       description = "Object Oriented Authentication-Results Headers";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  MailMaildir = buildPerlPackage {
+    version = "1.0.0";
+    pname = "Mail-Maildir";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/Z/ZE/ZEROALTI/Mail-Maildir-100/Mail-Maildir-1.0.0.tar.bz2";
+      sha256 = "1krkqfps6q3ifrhi9450l5gm9199qyfcm6vidllr0dv65kdaqpj4";
     };
   };
 
@@ -15263,6 +15318,10 @@ let
     };
     propagatedBuildInputs = [ ClassAccessor ConfigTiny MathCalcUnits ParamsValidate ];
     meta = {
+      description = ''
+        A family of perl modules to streamline writing Naemon,
+        Nagios, Icinga or Shinken (and compatible) plugins
+      '';
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -21422,6 +21481,29 @@ let
       license = with lib.licenses; [ gpl2Plus ];
       maintainers = [ maintainers.pSub ];
     };
+  };
+
+  SysCPU = buildPerlPackage {
+    pname = "Sys-CPU";
+    version = "0.61";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/M/MZ/MZSANFORD/Sys-CPU-0.61.tar.gz";
+      sha256 = "1r6976bs86j7zp51m5vh42xlyah951jgdlkimv202413kjvqc2i5";
+    };
+    patches = [
+      # Bug #95400 for Sys-CPU: Tests fail on ARM and AArch64 Linux
+      # https://rt.cpan.org/Public/Bug/Display.html?id=95400
+      (fetchpatch {
+        url = "https://rt.cpan.org/Ticket/Attachment/1359669/721669/0001-Add-support-for-cpu_type-on-ARM-and-AArch64-Linux-pl.patch";
+        sha256 = "0rmazzdy34znksdhh8drc83lk754slhjgvnk4kk27z3kw5gm10m0";
+      })
+      (fetchpatch {
+        url = "https://rt.cpan.org/Ticket/Attachment/1388036/737125/0002-cpu_clock-can-be-undefined-on-an-ARM.patch";
+        sha256 = "0z3wqfahc9av7y34aqp6biq3sf8v8q4yynx7bv290vds50dsjb4w";
+      })
+    ];
+    buildInputs = lib.optional stdenv.isDarwin pkgs.darwin.apple_sdk.frameworks.Carbon;
+    doCheck = !stdenv.isAarch64;
   };
 
   SysHostnameLong = buildPerlPackage {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -27899,5 +27899,5 @@ let
   SubExporterUtil = self.SubExporter;
   version = self.Version;
 
-  #Gtk2GladeXML = throw "Gtk2GladeXML has been removed"; # 2022-01-15
+  Gtk2GladeXML = throw "Gtk2GladeXML has been removed"; # 2022-01-15
 }; in self

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -112,8 +112,8 @@ let
 
     meta = with lib; {
       description = "A grep-like tool tailored to working with large trees of source code";
-      homepage    = "https://beyondgrep.com";
-      license     = licenses.artistic2;
+      homepage = "https://beyondgrep.com";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -127,8 +127,8 @@ let
     buildInputs = [ ActionRetry TryTiny ];
     propagatedBuildInputs = [ Moo ];
     meta = {
-      homepage = "https://github.com/hangy/Action-CircuitBreaker";
       description = "Module to try to perform an action, with an option to suspend execution after a number of failures";
+      homepage = "https://github.com/hangy/Action-CircuitBreaker";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -229,8 +229,8 @@ let
     buildInputs = [ Test2Suite ];
     propagatedBuildInputs = [ AlienBuild ArchiveExtract CaptureTiny Filechdir PathTiny ShellConfigGenerate ShellGuess SortVersions URI ];
     meta = {
-      homepage = "https://metacpan.org/pod/Alien::Base::ModuleBuild";
       description = "A Module::Build subclass for building Alien:: modules and their libraries";
+      homepage = "https://metacpan.org/pod/Alien::Base::ModuleBuild";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -246,6 +246,7 @@ let
     buildInputs = [ DevelHide Test2Suite ];
     meta = {
       description = "Build external dependencies for use in CPAN";
+      homepage = "https://metacpan.org/pod/Alien::Build";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -260,7 +261,8 @@ let
     propagatedBuildInputs = [ AlienBuild ];
     buildInputs = [ pkgs.gmp Alienm4 DevelChecklib IOSocketSSL MojoDOM58 NetSSLeay SortVersions Test2Suite URI ];
     meta = {
-      description = "Alien package for the GNU Multiple Precision library.";
+      description = "Alien package for the GNU Multiple Precision library";
+      homepage = "https://metacpan.org/pod/Alien::GMP";
       license = with lib.licenses; [ lgpl3Plus ];
     };
   };
@@ -292,6 +294,7 @@ let
     buildInputs = [ pkgs.libxml2 MojoDOM58 SortVersions Test2Suite URI ];
     meta = {
       description = "Install the C libxml2 library on your system";
+      homepage = "https://metacpan.org/pod/Alien::Libxml2";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -315,6 +318,7 @@ let
     };
     meta = {
       description = "Lets your class/object say it works like something else";
+      homepage = "https://github.com/karenetheridge/asa";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -375,6 +379,7 @@ let
     buildInputs = [ pkgs.gnum4 Alienpatch IOSocketSSL MojoDOM58 NetSSLeay SortVersions Test2Suite URI ];
     meta = {
       description = "Find or build GNU m4";
+      homepage = "https://metacpan.org/pod/Alien::m4";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -390,6 +395,7 @@ let
     buildInputs = [ IOSocketSSL MojoDOM58 NetSSLeay SortVersions Test2Suite URI ];
     meta = {
       description = "Find or build patch";
+      homepage = "https://metacpan.org/pod/Alien::patch";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -403,8 +409,8 @@ let
     };
     propagatedBuildInputs = [ ClassLoader ConvertASCIIArmour DataBuffer DigestMD2 MathBigIntGMP MathPrimeUtil SortVersions TieEncryptedHash ];
     meta = {
-      homepage = "https://github.com/danaj/Alt-Crypt-RSA-BigInt";
       description = "RSA public-key cryptosystem, using Math::BigInt";
+      homepage = "https://github.com/danaj/Alt-Crypt-RSA-BigInt";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -461,8 +467,8 @@ let
     propagatedBuildInputs = [ AnyEvent ];
     doCheck = false; # does an DNS lookup
     meta = {
-      homepage = "https://github.com/potyl/perl-AnyEvent-CacheDNS";
       description = "Simple DNS resolver with caching";
+      homepage = "http://github.com/potyl/perl-AnyEvent-CacheDNS";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -555,6 +561,7 @@ let
     propagatedBuildInputs = [ URI ];
     meta = {
       description = "Load URI::Escape::XS preferentially over URI::Escape";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -586,8 +593,8 @@ let
     doCheck = !stdenv.isLinux;
 
     meta = {
-      homepage = "https://github.com/mschout/apache-authcookie";
       description = "Perl Authentication and Authorization via cookies";
+      homepage = "https://github.com/mschout/apache-authcookie";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -617,8 +624,8 @@ let
     # We cannot change the timezone on the fly.
     prePatch = "rm t/04_tz.t";
     meta = {
-      homepage = "https://github.com/kazeburo/Apache-LogFormat-Compiler";
       description = "Compile a log format string to perl-code";
+      homepage = "https://github.com/kazeburo/Apache-LogFormat-Compiler";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -647,7 +654,7 @@ let
     doCheck = false;
     meta = {
       description = "Test.pm wrapper with helpers for testing Apache";
-      license = lib.licenses.asl20;
+      license = with lib.licenses; [ asl20 ];
     };
   };
 
@@ -682,8 +689,8 @@ let
         --replace 'sed' '${pkgs.gnused}/bin/sed'
     '';
     meta = {
-      homepage = "https://github.com/duncs/clusterssh/wiki";
-      description = "A container for functions of the ClusterSSH programs";
+      description = "Cluster administration tool";
+      homepage = "http://github.com/duncs/clusterssh/wiki";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "cssh";
     };
@@ -699,8 +706,8 @@ let
     buildInputs = [ TestFatal ];
     propagatedBuildInputs = [ CaptureTiny ClassLoad GetoptLongDescriptive IOTieCombine ModulePluggable StringRewritePrefix ];
     meta = {
-      homepage = "https://github.com/rjbs/App-Cmd";
       description = "Write command line apps with less suffering";
+      homepage = "https://github.com/rjbs/App-Cmd";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -715,6 +722,7 @@ let
     buildInputs = [ TestPod ];
     meta = {
       description = "A bundle of Perl5 modules for reading configuration files and parsing command line arguments";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -726,7 +734,7 @@ let
       sha256 = "1kzcbpsf1p7ww45d9fl2w0nfn5jj5pz0r0c649c1lrj5r1nv778j";
     };
     meta = {
-      description = "pack your dependencies onto your script file";
+      description = "Pack your dependencies onto your script file";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "fatpack";
     };
@@ -749,8 +757,8 @@ let
     '';
     propagatedBuildInputs = [ IOSocketSSL ];
     meta = {
-      homepage = "https://github.com/miyagawa/cpanminus";
       description = "Get, unpack, build and install modules from CPAN";
+      homepage = "https://github.com/miyagawa/cpanminus";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "cpanm";
     };
@@ -770,8 +778,8 @@ let
       shortenPerlShebang $out/bin/cpm
     '';
     meta = {
-      homepage = "https://github.com/skaji/cpm";
       description = "A fast CPAN module installer";
+      homepage = "https://github.com/skaji/cpm";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.zakame ];
       mainProgram = "cpm";
@@ -786,9 +794,9 @@ let
       sha256 = "0y644rr7gl49awn27xj556q9i86fddkkn26gnfn52wm19d7aa94a";
     };
     meta = {
-      homepage = "https://github.com/jhthorsen/applify";
       description = "Write object oriented scripts with ease";
-      license = lib.licenses.artistic2;
+      homepage = "https://github.com/jhthorsen/applify";
+      license = with lib.licenses; [ artistic2 ];
       maintainers = [ maintainers.sgo ];
     };
   };
@@ -809,8 +817,8 @@ let
       rm $out/bin/wxchordpro # Wx not supported on darwin
     '';
     meta = {
-      homepage = "https://www.chordpro.org";
       description = "A lyrics and chords formatting program";
+      homepage = "http://www.chordpro.org";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "chordpro";
     };
@@ -843,7 +851,7 @@ let
 
     meta = {
       description = "Manage perl installations in your $HOME";
-      license = lib.licenses.mit;
+      license = with lib.licenses; [ mit ];
       mainProgram = "perlbrew";
     };
   };
@@ -858,7 +866,7 @@ let
     propagatedBuildInputs = [ ArchiveZip ];
     buildInputs = [ ExtUtilsMakeMakerCPANfile TestUseAllModules ];
     meta = {
-      description = "simple CPAN package extractor";
+      description = "Simple CPAN package extractor";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -874,9 +882,9 @@ let
     propagatedBuildInputs = [ Clone ConfigGitLike DBI DateTime EncodeLocale HashMerge IOPager IPCRun3 IPCSystemSimple ListMoreUtils PathClass PerlIOutf8_strict PodParser StringFormatter StringShellQuote TemplateTiny Throwable TypeTiny URIdb libintl-perl ];
     doCheck = false;  # Can't find home directory.
     meta = {
-      homepage = "https://sqitch.org/";
-      description = "Sane database change management";
-      license = lib.licenses.mit;
+      description = "Sensible database change management";
+      homepage = "https://sqitch.org";
+      license = with lib.licenses; [ mit ];
       mainProgram = "sqitch";
     };
   };
@@ -893,9 +901,9 @@ let
         ($out/bin/st --help || true) | grep Usage
       '';
     meta = {
-      description = "A command that computes simple statistics";
-      license = lib.licenses.mit;
+      description = "Simple Statistics";
       homepage = "https://github.com/nferraz/st";
+      license = with lib.licenses; [ mit ];
       maintainers = [ maintainers.eelco ];
       mainProgram = "st";
     };
@@ -912,8 +920,9 @@ let
     propagatedBuildInputs = [ ParamsValidate ];
     doCheck = false;
     meta = {
-      description = "Define validation through subroutine attributes";
-      license = lib.licenses.artistic2;
+      description = "Validate method/function parameters";
+      homepage = "https://metacpan.org/release/Params-Validate";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -939,6 +948,7 @@ let
     propagatedBuildInputs = [ AlgorithmDiff ClassAccessor ];
     meta = {
       description = "Find the differences between two arrays";
+      homepage = "https://github.com/neilb/array-diff-perl";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -953,9 +963,9 @@ let
     buildInputs = [ TestDeep TestSpec TestTrap ];
     propagatedBuildInputs = [ Moose namespaceautoclean ];
     meta = {
-      homepage = "https://github.com/dwburke/perl-Array-FIFO";
       description = "A Simple limitable FIFO array, with sum and average methods";
-      license = lib.licenses.artistic2;
+      homepage = "https://github.com/dwburke/perl-Array-FIFO";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -980,7 +990,7 @@ let
       sha256 = "0nn9k79gihzr9wfksi03jmdgc2ihsb4952ddz1v70xvsq7z9mgkg";
     };
     meta = {
-      description = "ping a huge number of servers in several seconds";
+      description = "Ping a huge number of servers in several seconds";
       license = with lib.licenses; [ artistic2 ];
     };
   };
@@ -1036,6 +1046,7 @@ let
     propagatedBuildInputs = [ FileWhich IPCRun LogLog4perl ];
     meta = {
       description = "API wrapper around the 'tar' utility";
+      license = with lib.licenses; [ gpl3 ];
     };
   };
 
@@ -1062,9 +1073,9 @@ let
       sha256 = "530d59ef0c0935f9862d187187a2d7583b12c639bb67db14f983322b161892d9";
     };
     meta = {
-      homepage = "https://github.com/timj/perl-Astro-FITS-Header/tree/master";
       description = "Object-oriented interface to FITS HDUs";
-      license = lib.licenses.free;
+      homepage = "https://github.com/timj/perl-Astro-FITS-Header";
+      license = with lib.licenses; [ gpl3 ];
     };
   };
 
@@ -1093,7 +1104,7 @@ let
     NIX_CFLAGS_LINK = "-L${pkgs.zlib.out}/lib -lz";
     meta = {
       description = "Fast C metadata and tag reader for all common audio file formats";
-      license = lib.licenses.gpl2;
+      license = with lib.licenses; [ gpl2 ];
     };
   };
 
@@ -1108,7 +1119,7 @@ let
     propagatedBuildInputs = [ DataInteger DigestCRC ScalarString ];
     meta = {
       description = "DEC VMS password hashing";
-      license = lib.licenses.gpl1Plus;
+      license = with lib.licenses; [ gpl1Plus ];
     };
   };
 
@@ -1166,7 +1177,7 @@ let
     '';
     meta = {
       description = "Perl extension for MIT Kerberos 5 admin interface";
-      license = lib.licenses.bsd3;
+      license = with lib.licenses; [ bsd3 ];
     };
   };
 
@@ -1200,8 +1211,8 @@ let
     buildInputs = [ TestNeeds ];
     propagatedBuildInputs = [ DigestHMAC Moo TypeTiny ];
     meta = {
-      homepage = "https://github.com/oalders/authen-oath";
       description = "OATH One Time Passwords";
+      homepage = "https://github.com/oalders/authen-oath";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -1231,7 +1242,7 @@ let
     buildInputs = [ TestNoWarnings ];
     propagatedBuildInputs = [ DataHexDump NetIP ];
     meta = {
-      description = "Provide simple Radius client facilities  ";
+      description = "Provide simple Radius client facilities";
       license = with lib.licenses; [ artistic2 ];
     };
   };
@@ -1276,9 +1287,9 @@ let
     buildInputs = [ TestFailWarnings TestFatal ];
     propagatedBuildInputs = [ AuthenSASLSASLprep CryptURandom Moo PBKDF2Tiny TypeTiny namespaceclean ];
     meta = {
-      homepage = "https://github.com/dagolden/Authen-SCRAM";
       description = "Salted Challenge Response Authentication Mechanism (RFC 5802)";
-      license = lib.licenses.asl20;
+      homepage = "https://github.com/dagolden/Authen-SCRAM";
+      license = with lib.licenses; [ asl20 ];
       maintainers = [ maintainers.sgo ];
     };
   };
@@ -1322,7 +1333,7 @@ let
     buildInputs = [ IPCSystemSimple TestFatal ];
     meta = {
       description = "Call methods on native types";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -1339,7 +1350,7 @@ let
     meta = {
       description = "AutoDia, create UML diagrams from source code";
       homepage = "http://www.aarontrevena.co.uk/opensource/autodia/";
-      license = lib.licenses.gpl2Plus;
+      license = with lib.licenses; [ gpl2Plus ];
       mainProgram = "autodia.pl";
     };
   };
@@ -1367,6 +1378,7 @@ let
     };
     meta = {
       description = "Lexically disable autovivification";
+      homepage = "http://search.cpan.org/dist/autovivification";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -1385,9 +1397,9 @@ let
     propagatedBuildInputs = [ pkgs.zbar PerlMagick ];
     perlPreHook = lib.optionalString stdenv.isDarwin "export LD=$CC";
     meta = {
-      homepage = "https://github.com/mchehab/zbar/tree/master/perl";
       description = "Perl interface to the ZBar Barcode Reader";
-      license = with lib.licenses; [ gpl2Plus ];
+      homepage = "https://metacpan.org/pod/Barcode::ZBar";
+      license = with lib.licenses; [ lgpl21 ];
     };
   };
 
@@ -1401,8 +1413,8 @@ let
     propagatedBuildInputs = [ BFlags IPCRun Opcodes ];
     doCheck = false; /* test fails */
     meta = {
-      homepage = "https://github.com/rurban/perl-compiler";
       description = "Perl compiler";
+      homepage = "https://github.com/rurban/perl-compiler";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "perlcc";
     };
@@ -1430,6 +1442,7 @@ let
     };
     meta = {
       description = "Friendlier flags for B";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -1488,6 +1501,7 @@ let
     propagatedBuildInputs = [ ModuleImplementation SubExporterProgressive ];
     meta = {
       description = "Execute code after a scope finished compilation";
+      homepage = "https://github.com/karenetheridge/B-Hooks-EndOfScope";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -1516,6 +1530,7 @@ let
     buildInputs = [ ExtUtilsDepends ];
     meta = {
       description = "Wrap OP check callbacks";
+      homepage = "https://github.com/karenetheridge/B-Hooks-OP-Check";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -1530,8 +1545,8 @@ let
     buildInputs = [ ModuleBuild TestMemoryCycle TestWeaken TestDeep TestWarn TestException TestDifferences ];
     propagatedBuildInputs = [ DataStag Error Graph HTTPMessage IOString IOStringy IPCRun LWP ListMoreUtils SetScalar TestMost TestRequiresInternet URI XMLDOM XMLLibXML XMLSAX XMLSAXBase XMLSAXWriter XMLTwig XMLWriter YAML DBFile libxml_perl ];
     meta = {
-      homepage = "https://metacpan.org/release/BioPerl";
       description = "Perl modules for biology";
+      homepage = "https://metacpan.org/release/BioPerl";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -1567,8 +1582,8 @@ let
       sha256 = "95c088085c3e83bf680fe6ce16d8264ec26310490f7d1680e416ea7a118f156a";
     };
     meta = {
-      homepage = "https://github.com/ingydotnet/boolean-pm";
       description = "Boolean support for Perl";
+      homepage = "https://github.com/ingydotnet/boolean-pm";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -1598,8 +1613,8 @@ let
     buildInputs = [ FileSlurp ];
     propagatedBuildInputs = [ ClassLoad DirSelf FileShareDir ModulePluggable MooseXGetopt namespaceclean  ];
     meta = {
-      homepage = "https://metacpan.org/release/Bot-Training";
       description = "Plain text training material for bots like Hailo and AI::MegaHAL";
+      homepage = "http://metacpan.org/release/Bot-Training";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "bot-training";
     };
@@ -1615,8 +1630,8 @@ let
     buildInputs = [ FileShareDirInstall ];
     propagatedBuildInputs = [ BotTraining ];
     meta = {
-      homepage = "https://metacpan.org/release/Bot-Training-MegaHAL";
       description = "Provide megahal.trn via Bot::Training";
+      homepage = "http://metacpan.org/release/Bot-Training-MegaHAL";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -1631,8 +1646,8 @@ let
     buildInputs = [ FileShareDirInstall ];
     propagatedBuildInputs = [ BotTraining ];
     meta = {
-      homepage = "https://metacpan.org/release/Bot-Training-StarCraft";
       description = "Provide starcraft.trn via Bot::Training";
+      homepage = "http://metacpan.org/release/Bot-Training-StarCraft";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -1645,9 +1660,9 @@ let
       sha256 = "0g8c7825ng2m0yz5sy6838rvfdl8j3vm29524wjgf66ccfhgn74x";
     };
     meta = {
-      maintainers = teams.deshaw.members;
       description = "BSD process resource limit and priority functions";
-      license = lib.licenses.artistic2;
+      license = with lib.licenses; [ artistic2 ];
+      maintainers = teams.deshaw.members;
     };
   };
 
@@ -1661,9 +1676,9 @@ let
     buildInputs = [ JSONMaybeXS PathTiny TestDeep TestFatal ];
     propagatedBuildInputs = [ CryptURandom Moo TieIxHash boolean namespaceclean ];
     meta = {
-      homepage = "https://github.com/mongodb-labs/mongo-perl-bson";
       description = "BSON serialization and deserialization (EOL)";
-      license = lib.licenses.asl20;
+      homepage = "https://github.com/mongodb-labs/mongo-perl-bson";
+      license = with lib.licenses; [ asl20 ];
     };
   };
 
@@ -1677,9 +1692,9 @@ let
     buildInputs = [ ConfigAutoConf JSONMaybeXS PathTiny TestDeep TestFatal TieIxHash ];
     propagatedBuildInputs = [ BSON boolean JSONXS JSONPP CpanelJSONXS ];
     meta = {
-      homepage = "https://github.com/mongodb-labs/mongo-perl-bson-xs";
       description = "XS implementation of MongoDB's BSON serialization (EOL)";
-      license = lib.licenses.asl20;
+      homepage = "https://github.com/mongodb-labs/mongo-perl-bson-xs";
+      license = with lib.licenses; [ asl20 ];
       platforms = lib.platforms.linux; # configure phase fails with "ld: unknown option: -mmacosx-version-min=10.12"
     };
   };
@@ -1695,6 +1710,7 @@ let
     buildInputs = [ ExtUtilsDepends ];
     meta = {
       description = "Helper functions for op tree manipulation";
+      homepage = "http://search.cpan.org/dist/B-Utils";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -1709,6 +1725,7 @@ let
     propagatedBuildInputs = [ SetIntSpan ];
     meta = {
       description = "Calculate business hours in a time period";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -1721,8 +1738,9 @@ let
     };
     propagatedBuildInputs = [ BusinessISBNData ];
     meta = {
-      description = "Parse and validate ISBNs";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      description = "Work with International Standard Book Numbers";
+      homepage = "https://github.com/briandfoy/business-isbn";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -1735,7 +1753,8 @@ let
     };
     meta = {
       description = "Data pack for Business::ISBN";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      homepage = "https://github.com/briandfoy/business-isbn-data";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -1749,7 +1768,8 @@ let
     propagatedBuildInputs = [ TieCycle ];
     meta = {
       description = "Work with International Standard Music Numbers";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      homepage = "https://github.com/briandfoy/business-ismn";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -1761,8 +1781,9 @@ let
       sha256 = "97ecab15d24d11e2852bf0b28f84c8798bd38402a0a69e17be0e6689b272715e";
     };
     meta = {
-      description = "Work with International Standard Serial Numbers";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      description = "Perl extension for International Standard Serial Numbers";
+      homepage = "https://github.com/briandfoy/business-issn";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -1827,6 +1848,7 @@ let
     buildInputs = [ FileWhich TestRequires TestSharedFork TestTCP ];
     meta = {
       description = "KyotoTycoon client library";
+      homepage = "https://github.com/tokuhirom/Cache-KyotoTycoon";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -1850,7 +1872,7 @@ let
       sha256 = "16m0xafidycrlcvbv3zmbr5pzvqyqyr2qb0khpry99nc4bcld3jy";
     };
     meta = {
-      description = "Perl client for B<memcached>, in C language";
+      description = "Perl client for memcached, in C language";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -1889,9 +1911,9 @@ let
     buildInputs = [ pkgs.cairo ];
     propagatedBuildInputs = [ ExtUtilsDepends ExtUtilsPkgConfig ];
     meta = {
-      homepage = "http://gtk2-perl.sourceforge.net/";
-      description = "Perl interface to the cairo 2D vector graphics library";
-      license = lib.licenses.lgpl21Plus;
+      description = "Perl interface to the cairo 2d vector graphics library";
+      homepage = "http://gtk2-perl.sourceforge.net";
+      license = with lib.licenses; [ lgpl21 ];
     };
   };
 
@@ -1906,7 +1928,8 @@ let
     propagatedBuildInputs = [ Cairo Glib ];
     meta = {
       description = "Integrate Cairo into the Glib type system";
-      license = lib.licenses.lgpl21Plus;
+      homepage = "http://gtk2-perl.sourceforge.net";
+      license = with lib.licenses; [ lgpl21 ];
     };
   };
 
@@ -1943,6 +1966,7 @@ let
     };
     propagatedBuildInputs = [ DevelSymdump ];
     meta = {
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -1954,7 +1978,7 @@ let
       sha256 = "a5c91c62cf95fcb868f60eab5c832908f6905221013fea2bce3ff57046d7b6ea";
     };
     meta = {
-      license = lib.licenses.gpl1Plus;
+      license = with lib.licenses; [ gpl1Plus ];
     };
   };
 
@@ -1977,7 +2001,8 @@ let
     };
     meta = {
       description = "Capture STDOUT and STDERR from Perl, XS or external programs";
-      license = lib.licenses.asl20;
+      homepage = "https://github.com/dagolden/Capture-Tiny";
+      license = with lib.licenses; [ asl20 ];
     };
   };
 
@@ -2003,6 +2028,7 @@ let
       sha256 = "0km5fc6r6whxh6h5yd7g1j0bi96sgk0gkda6cardicrw9qmqwkwj";
     };
     meta = {
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -2016,7 +2042,7 @@ let
     propagatedBuildInputs = [ CarpAssert ];
     buildInputs = [ TestException ];
     meta = {
-      license = lib.licenses.artistic2;
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -2029,6 +2055,7 @@ let
     };
     meta = {
       description = "Report errors from perspective of caller of a \"clan\" of modules";
+      homepage = "https://github.com/karenetheridge/Carp-Clan";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -2042,8 +2069,8 @@ let
     };
     propagatedBuildInputs = [ MenloLegacy PathTiny TryTiny ];
     meta = {
-      homepage = "https://github.com/perl-carton/carton";
       description = "Perl module dependency manager (aka Bundler for Perl)";
+      homepage = "https://github.com/perl-carton/carton";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "carton";
     };
@@ -2089,7 +2116,8 @@ let
     buildInputs = [ ModuleBuildTiny TestException TestMockObject TestNeeds ];
     propagatedBuildInputs = [ CatalystPluginAuthentication ClassAccessor DataUUID StringEscape ];
     meta = {
-      description = "HTTP Basic and Digest authentication";
+      description = "HTTP Basic and Digest authentication for Catalyst";
+      homepage = "https://github.com/perl-catalyst/Catalyst-Authentication-Credential-HTTP";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -2115,7 +2143,7 @@ let
     propagatedBuildInputs = [ CatalystModelDBICSchema CatalystPluginAuthentication ];
     buildInputs = [ TestWarn ];
     meta = {
-      description = "A storage class for Catalyst Authentication using DBIx::Class";
+      description = "Extensible and flexible object <-> relational mapper";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -2131,8 +2159,8 @@ let
     buildInputs = [ TestMockObject TestException NetLDAPServerTest ];
     doCheck = !stdenv.isDarwin; # t/02-realms_api.t and t/50.auth.case.sensitivity.t
     meta = {
-      description = "Authentication from an LDAP Directory";
-      license = with lib.licenses; [ artistic1 ];
+      description = "Authenticate Users against LDAP Directories";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -2161,7 +2189,8 @@ let
     propagatedBuildInputs = [ CatalystComponentInstancePerContext HTMLFormFuMultiForm RegexpAssemble ];
     doCheck = false; /* fails with 'open3: exec of .. perl .. failed: Argument list too long at .../TAP/Parser/Iterator/Process.pm line 165.' */
     meta = {
-      description = "Catalyst integration for HTML::FormFu";
+      description = "HTML Form Creation, Rendering and Validation Framework";
+      homepage = "https://github.com/FormFu/HTML-FormFu";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -2177,7 +2206,8 @@ let
     propagatedBuildInputs = [ CatalystPluginStaticSimple ClassAccessor FileSlurp JSONXS ListMoreUtils PodPOMViewTOC XMLSimple ];
     meta = {
       description = "Serves PODs right from your Catalyst application";
-      license = lib.licenses.bsd3;
+      homepage = "http://search.cpan.org/dist/Catalyst-Controller-POD";
+      license = with lib.licenses; [ bsd3 ];
     };
   };
 
@@ -2191,8 +2221,8 @@ let
     buildInputs = [ FileShareDirInstall TestFatal ];
     propagatedBuildInputs = [ CatalystActionRenderView CatalystPluginConfigLoader CatalystPluginStaticSimple ConfigGeneral FileChangeNotify FileCopyRecursive ModuleInstall TemplateToolkit ];
     meta = {
-      homepage = "http://wiki.catalystframework.org/wiki/";
       description = "Catalyst Development Tools";
+      homepage = "http://dev.catalyst.perl.org";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -2249,8 +2279,8 @@ let
     buildInputs = [ TestFatal TypeTiny ];
     propagatedBuildInputs = [ CGISimple CGIStruct ClassC3AdoptNEXT DataDump HTTPBody ModulePluggable MooseXEmulateClassAccessorFast MooseXGetopt MooseXMethodAttributes MooseXRoleWithOverloading PathClass PerlIOutf8_strict PlackMiddlewareFixMissingBodyInRedirect PlackMiddlewareMethodOverride PlackMiddlewareRemoveRedundantBody PlackMiddlewareReverseProxy PlackTestExternalServer SafeIsa StringRewritePrefix TaskWeaken TextSimpleTable TreeSimpleVisitorFactory URIws ];
     meta = {
-      homepage = "http://wiki.catalystframework.org/wiki/";
       description = "The Catalyst Framework Runtime";
+      homepage = "http://dev.catalyst.perl.org";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "catalyst.pl";
     };
@@ -2266,6 +2296,7 @@ let
     propagatedBuildInputs = [ CatalystRuntime DateTime ];
     meta = {
       description = "Request logging from within Catalyst";
+      homepage = "http://metacpan.org/release/Catalyst-Plugin-AccessLog";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -2351,6 +2382,7 @@ let
     propagatedBuildInputs = [ CatalystPluginSession GDSecurityImage ];
     meta = {
       description = "Create and validate Captcha for Catalyst";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -2387,6 +2419,7 @@ let
     };
     propagatedBuildInputs = [ CatalystPluginFormValidator FormValidatorSimple ];
     meta = {
+      description = "Validation with simple chains of constraints ";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -2400,7 +2433,7 @@ let
     };
     propagatedBuildInputs = [ ClassAccessor LogHandler MROCompat ];
     meta = {
-      description = "Catalyst Plugin for Log::Handler";
+      description = "Log messages to several outputs";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -2415,7 +2448,8 @@ let
     buildInputs = [ HTTPMessage Plack SubOverride TestDeep ];
     propagatedBuildInputs = [ CatalystRuntime Moose PrometheusTiny PrometheusTinyShared ];
     meta = {
-      description = "Prometheus metrics for Catalyst";
+      description = "A tiny Prometheus client";
+      homepage = "https://github.com/robn/Prometheus-Tiny";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -2536,7 +2570,7 @@ let
     };
     propagatedBuildInputs = [ CatalystRuntime strictures ];
     meta = {
-      description = "Handle passing of status messages between screens of a web application";
+      description = "Handle passing of status (success and error) messages between screens of a web application";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -2578,7 +2612,7 @@ let
     };
     propagatedBuildInputs = [ CatalystRuntime ];
     meta = {
-      description = "JSON view for your data";
+      description = "JSON (JavaScript Object Notation) encoder/decoder";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -2661,8 +2695,8 @@ let
     buildInputs = [ TestFatal TestWarnings ];
     propagatedBuildInputs = [ BCOW ];
     meta = {
-      homepage = "https://github.com/toddr/CDB_File";
       description = "Perl extension for access to cdb databases";
+      homepage = "https://github.com/toddr/CDB_File";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -2677,9 +2711,9 @@ let
     propagatedBuildInputs = [ AnyURIEscape AppCmd CGIExpand ConfigOnion CpanelJSONXS DataCompare DataUtil IOHandleUtil LWP ListMoreUtils LogAny MIMETypes ModuleInfo MooXAliases ParserMGC PathIteratorRule PathTiny StringCamelCase TextCSV TextHogan Throwable TryTinyByClass URITemplate UUIDTiny YAMLLibYAML namespaceclean ];
     buildInputs = [ LogAnyAdapterLog4perl LogLog4perl TestDeep TestException TestLWPUserAgent TestPod ];
     meta = {
-      description = "a data toolkit";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      description = "A data toolkit";
       homepage = "https://github.com/LibreCat/Catmandu";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "catmandu";
     };
   };
@@ -2693,7 +2727,7 @@ let
     };
     meta = {
       description = "Get the CDDB info for an audio cd";
-      license = lib.licenses.artistic1;
+      license = with lib.licenses; [ artistic1 ];
       maintainers = [ maintainers.endgame ];
       mainProgram = "cddb.pl";
     };
@@ -2708,7 +2742,7 @@ let
     };
     meta = {
       description = "Parse a CDDB/freedb data file";
-      license = lib.licenses.artistic1;
+      license = with lib.licenses; [ artistic1 ];
     };
   };
 
@@ -2724,7 +2758,8 @@ let
     propagatedBuildInputs = [ HTMLParser ];
     meta = {
       description = "Handle Common Gateway Interface requests and responses";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      homepage = "https://metacpan.org/module/CGI";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -2739,8 +2774,8 @@ let
     buildInputs = [ CGI CaptureTiny ModuleBuildTiny SubIdentify Switch TestNoWarnings TestRequires TryTiny ];
     meta = {
       description = "Compile .cgi scripts to a code reference like ModPerl::Registry";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
       homepage = "https://github.com/miyagawa/CGI-Compile";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -2763,8 +2798,8 @@ let
     buildInputs = [ TestRequires ];
     propagatedBuildInputs = [ CGI ];
     meta = {
-      homepage = "https://github.com/tokuhirom/p5-cgi-emulate-psgi";
       description = "PSGI adapter for CGI";
+      homepage = "https://github.com/tokuhirom/p5-cgi-emulate-psgi";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -2779,6 +2814,7 @@ let
     buildInputs = [ TestException ];
     meta = {
       description = "Convert flat hash to nested data using TT2's dot convention";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -2792,6 +2828,7 @@ let
     propagatedBuildInputs = [ CGI FCGI ];
     doCheck = false;
     meta = {
+      homepage = "https://metacpan.org/module/CGI::Fast";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -2816,7 +2853,8 @@ let
     };
     meta = {
       description = "A lightweight CGI form processing package";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      homepage = "https://github.com/JerilynFranz/perl-CGI-Minimal";
+      license = with lib.licenses; [ mit ];
     };
   };
 
@@ -2869,7 +2907,7 @@ let
     buildInputs = [ TestDeep ];
     meta = {
       description = "Build structures from CGI data";
-      license = lib.licenses.bsd2;
+      license = with lib.licenses; [ bsd2 ];
     };
   };
 
@@ -2897,8 +2935,8 @@ let
     };
     propagatedBuildInputs = [ GD ];
     meta = {
-        description = "A series of charting modules";
-        license = with lib.licenses; [ artistic1 gpl1Plus ];
+      description = "A series of charting modules";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -2923,8 +2961,8 @@ let
       sha256 = "c5185620815701b3fec21314ccd8c5693e6bfd519431527da3370a8164220671";
     };
     meta = {
-      homepage = "https://metacpan.org/pod/CLASS";
       description = "Alias for __PACKAGE__";
+      homepage = "https://metacpan.org/pod/CLASS";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -2963,6 +3001,7 @@ let
     propagatedBuildInputs = [ ModuleRuntime ];
     meta = {
       description = "Lets you build groups of accessors";
+      homepage = "https://metacpan.org/release/Class-Accessor-Grouped";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -3013,6 +3052,7 @@ let
     propagatedBuildInputs = [ AlgorithmC3 ];
     meta = {
       description = "A pragma to use the C3 method resolution order algorithm";
+      homepage = "https://metacpan.org/release/Class-C3";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -3028,6 +3068,7 @@ let
     propagatedBuildInputs = [ MROCompat ];
     meta = {
       description = "Make NEXT suck less";
+      homepage = "https://github.com/karenetheridge/Class-C3-Adopt-NEXT";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -3042,6 +3083,7 @@ let
     buildInputs = [ TestException ];
     propagatedBuildInputs = [ ClassC3 ClassInspector MROCompat ];
     meta = {
+      description = "Load mix-ins or components to your C3-based class";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -3136,7 +3178,7 @@ let
       sha256 = "02r0zylv8c5cb34j0w2kmf8hfw6g6bymfif7z65skzz9kkm3rns7";
     };
     meta = {
-      description = "another class and object builder";
+      description = "Another class and object builder";
       license = with lib.licenses; [ artistic1 ];
     };
   };
@@ -3150,6 +3192,7 @@ let
     };
     meta = {
       description = "Get information about a class and its structure";
+      homepage = "https://metacpan.org/pod/Class::Inspector";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -3171,6 +3214,7 @@ let
       sha256 = "db1ba87ca9107f161fe9c1e9e7e267c0026defc26fe3e73bcad8ab8ffc18ef9d";
     };
     meta = {
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -3220,8 +3264,8 @@ let
     };
     buildInputs = [ TestFatal TestNeeds ];
     meta = {
-      homepage = "https://github.com/moose/Class-Method-Modifiers";
       description = "Provides Moose-like method modifiers";
+      homepage = "https://github.com/moose/Class-Method-Modifiers";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -3249,7 +3293,8 @@ let
     };
     propagatedBuildInputs = [ DevelStackTrace ];
     meta = {
-      description = "A smart return value object";
+      description = "(deprecated) polymorphic return values";
+      homepage = "https://github.com/rjbs/Return-Value";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -3281,8 +3326,8 @@ let
     };
     meta = {
       description = "Minimalist class construction";
-      license = with lib.licenses; [ asl20 ];
       homepage = "https://github.com/dagolden/Class-Tiny";
+      license = with lib.licenses; [ asl20 ];
     };
   };
 
@@ -3296,8 +3341,8 @@ let
     buildInputs = [ TestFatal TestNeeds ];
     propagatedBuildInputs = [ DataOptList PackageStash ];
     meta = {
-      homepage = "https://github.com/moose/Class-Load";
       description = "A working (require \"Class::Name\") and more";
+      homepage = "https://github.com/moose/Class-Load";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -3312,9 +3357,9 @@ let
     buildInputs = [ TestFatal TestNeeds ];
     propagatedBuildInputs = [ ClassLoad ];
     meta = {
-      homepage = "https://github.com/moose/Class-Load-XS";
       description = "XS implementation of parts of Class::Load";
-      license = lib.licenses.artistic2;
+      homepage = "https://github.com/moose/Class-Load-XS";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -3377,6 +3422,7 @@ let
     propagatedBuildInputs = [ CarpAssert ClassDataInheritable ClassISA ];
     meta = {
       description = "Base class for virtual base classes";
+      homepage = "https://metacpan.org/release/Class-Virtual";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -3405,8 +3451,8 @@ let
     propagatedBuildInputs =
       [ ClassMethodModifiers MathRound Moo namespaceclean ];
     meta = {
-      homepage = "https://github.com/patch/cldr-number-pm5";
       description = "Localized number formatters using the Unicode CLDR";
+      homepage = "https://github.com/patch/cldr-number-pm5";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -3421,9 +3467,9 @@ let
     buildInputs = [ PodCoverageTrustPod TestPerlCritic ];
     propagatedBuildInputs = [ CaptureTiny RefUtil SubExporter TermReadKey YAML ];
     meta = {
-      homepage = "https://github.com/reyjrar/CLI-Helpers";
       description = "Subroutines for making simple command line scripts";
-      license = lib.licenses.bsd3;
+      homepage = "https://github.com/reyjrar/CLI-Helpers";
+      license = with lib.licenses; [ bsd ];
     };
   };
 
@@ -3441,7 +3487,8 @@ let
     #     Ssh sessions and cron jobs can not create the requisite pasteboard handles, giving coreFoundationUnknownErr (-4960)'
     doCheck = !stdenv.isDarwin;
     meta = {
-      description = "Clipboard - Copy and Paste with any OS";
+      description = "Copy and paste with any OS";
+      homepage = "http://metacpan.org/release/Clipboard";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -3471,6 +3518,7 @@ let
     buildInputs = [ Clone ClonePP TestWithoutModule ];
     meta = {
       description = "Choose appropriate clone utility";
+      homepage = "https://metacpan.org/release/Clone-Choose";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -3498,6 +3546,7 @@ let
     buildInputs = [ TestClass TestClassMost TestDeep TestDifferences TestException TestFatal TestMost TestWarn TestWarnings librelative ];
     meta = {
       description = "Engine for tidyall, your all-in-one code tidier and validator";
+      homepage = "https://metacpan.org/release/Code-TidyAll";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "tidyall";
     };
@@ -3542,8 +3591,8 @@ let
     buildInputs = [ ModuleBuildTiny ];
     propagatedBuildInputs = [ CaptureTiny Filepushd StringShellQuote Win32ShellQuote ];
     meta = {
-      homepage = "https://github.com/skaji/Command-Runner";
       description = "Run external commands and Perl code refs";
+      homepage = "https://github.com/skaji/Command-Runner";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.zakame ];
     };
@@ -3602,6 +3651,7 @@ let
 
     meta = {
       description = "Low-Level Interface to bzip2 compression library";
+      homepage = "https://github.com/pmqs/Compress-Raw-Bzip2";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -3620,8 +3670,8 @@ let
       EOF
     '';
     meta = {
-      homepage = "https://github.com/pmqs/Compress-Raw-Lzma";
       description = "Low-Level Interface to lzma compression library";
+      homepage = "https://github.com/pmqs/Compress-Raw-Lzma";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -3648,6 +3698,7 @@ let
     doCheck = !stdenv.isDarwin;
 
     meta = {
+      homepage = "https://github.com/pmqs/Compress-Raw-Zlib";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -3685,6 +3736,7 @@ let
     propagatedBuildInputs = [ CaptureTiny ];
     meta = {
       description = "A module to implement some of AutoConf macros in pure perl";
+      homepage = "https://metacpan.org/release/Config-AutoConf";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -3697,7 +3749,7 @@ let
       sha256 = "1bbg3wp0xcpj04cmm86j1x0j5968jqi5s2c87qs7dgmap1vzk6qa";
     };
     meta = {
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -3724,8 +3776,8 @@ let
       sha256 = "a8b3a3a2c9c8c43b92dc401bf2709d6514f15b467fd4f72c48d356335771d6e3";
     };
     meta = {
-      homepage = "https://github.com/schweikert/Config-Grammar";
       description = "A grammar-based, user-friendly config parser";
+      homepage = "https://github.com/schweikert/Config-Grammar";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -3739,8 +3791,8 @@ let
     };
     propagatedBuildInputs = [ MixinLinewise ];
     meta = {
-      homepage = "https://github.com/rjbs/Config-INI";
       description = "Simple .ini-file format";
+      homepage = "https://github.com/rjbs/Config-INI";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -3756,8 +3808,8 @@ let
     buildInputs = [ TestDeep ];
     meta = {
       description = "Load (and optionally decrypt via GnuPG) user/pass identity information ";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
       homepage = "https://github.com/dagolden/Config-Identity";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -3771,6 +3823,7 @@ let
     propagatedBuildInputs = [ IOStringy ];
     meta = {
       description = "A module for reading .ini-style configuration files";
+      homepage = "http://metacpan.org/release/Config-IniFiles";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = teams.deshaw.members;
     };
@@ -3816,8 +3869,8 @@ let
     buildInputs = [ TestFatal ];
     propagatedBuildInputs = [ ModulePluggable MooseXOneArgNew RoleHasMessage RoleIdentifiable Throwable TieIxHash ];
     meta = {
-      homepage = "https://github.com/rjbs/Config-MVP";
       description = "Multivalue-property package-oriented configuration";
+      homepage = "https://github.com/rjbs/Config-MVP";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -3831,8 +3884,8 @@ let
     };
     propagatedBuildInputs = [ ConfigINI ConfigMVP ];
     meta = {
-      homepage = "https://github.com/rjbs/Config-MVP-Reader-INI";
       description = "An MVP config reader for .ini files";
+      homepage = "https://github.com/rjbs/Config-MVP-Reader-INI";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -3859,6 +3912,7 @@ let
     };
     meta = {
       description = "Simple configuration file class";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -3872,6 +3926,7 @@ let
     propagatedBuildInputs = [ ClassStd ];
     meta = {
       description = "Load and save configuration files in a standard format";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -3917,6 +3972,7 @@ let
     '';
     meta = {
       description = "A generic connection to a hierarchical-structured data set";
+      homepage = "https://github.com/whiterabbitsecurity/connector";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -3968,7 +4024,6 @@ let
     };
     buildInputs = [ TestException ];
     meta = {
-      homepage = "https://metacpan.org/pod/Convert::Base32";
       description = "Encoding and decoding of base32 strings";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
@@ -4068,8 +4123,8 @@ let
     buildInputs = [ ModuleBuildTiny TestTime ];
     propagatedBuildInputs = [ URI ];
     meta = {
-      homepage = "https://github.com/kazeburo/Cookie-Baker";
       description = "Cookie string generator / parser";
+      homepage = "https://github.com/kazeburo/Cookie-Baker";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -4094,6 +4149,7 @@ let
     propagatedBuildInputs = [ AnyEvent Guard commonsense ];
     buildInputs = [ CanaryStability ];
     meta = {
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -4110,7 +4166,6 @@ let
       cd EV
     '';
     meta = {
-      description = "Do events the coro-way, with EV";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -4160,8 +4215,8 @@ let
     '';
 
     meta = {
-      homepage = "https://github.com/rjbs/CPAN-Mini";
       description = "Create a minimal mirror of CPAN";
+      homepage = "https://github.com/rjbs/CPAN-Mini";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
       mainProgram = "minicpan";
@@ -4192,8 +4247,8 @@ let
     buildInputs = [ ModuleBuildTiny ];
     propagatedBuildInputs = [ TieHandleOffset ];
     meta = {
-      homepage = "https://github.com/skaji/CPAN-02Packages-Search";
       description = "Search packages in 02packages.details.txt";
+      homepage = "https://github.com/skaji/CPAN-02Packages-Search";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.zakame ];
     };
@@ -4236,9 +4291,9 @@ let
     buildInputs = [ TestDeep TestFailWarnings TestFatal ];
     propagatedBuildInputs = [ CPANDistnameInfo ClassTiny TieHandleOffset URI ];
     meta = {
-      homepage = "https://github.com/Perl-Toolchain-Gang/CPAN-Common-Index";
       description = "Common library for searching CPAN modules, authors and distributions";
-      license = lib.licenses.asl20;
+      homepage = "https://github.com/Perl-Toolchain-Gang/CPAN-Common-Index";
+      license = with lib.licenses; [ asl20 ];
     };
   };
 
@@ -4277,8 +4332,8 @@ let
       sha256 = "1qsjm26556kqxyvj85c7j37mh2xw78fm3i7f58mpqkfawxip4q3k";
     };
     meta = {
-      homepage = "https://github.com/bingos/cpan-perl-releases";
       description = "Mapping Perl releases on CPAN to the location of the tarballs";
+      homepage = "https://github.com/bingos/cpan-perl-releases";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -4292,8 +4347,8 @@ let
     };
     propagatedBuildInputs = [ ArchiveExtract ModulePluggable ObjectAccessor PackageConstants TermUI ];
     meta = {
-      homepage = "https://github.com/jib/cpanplus-devel";
       description = "Ameliorated interface to the CPAN";
+      homepage = "https://github.com/jib/cpanplus-devel";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "cpanp";
     };
@@ -4308,8 +4363,8 @@ let
     };
     propagatedBuildInputs = [ FileHomeDir GetoptLongDescriptive LWPProtocolHttps TermReadKey ];
     meta = {
-      homepage = "https://github.com/rjbs/cpan-uploader";
       description = "Upload things to the CPAN";
+      homepage = "https://github.com/rjbs/CPAN-Uploader";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "cpan-upload";
     };
@@ -4325,7 +4380,7 @@ let
     nativeBuildInputs = [ pkgs.ld-is-cc-hook ];
     meta = {
       description = "Perl interface to the Argon2 key derivation functions";
-      license = lib.licenses.cc0;
+      license = with lib.licenses; [ cc0 ];
     };
   };
 
@@ -4376,6 +4431,7 @@ let
     ];
     meta = {
       description = "Generate shared secret using elliptic-curve Diffie-Hellman function";
+      homepage = "https://metacpan.org/release/Crypt-Curve25519";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -4539,8 +4595,8 @@ let
     };
     propagatedBuildInputs = [ CryptEksblowfish CryptPassphrase ];
     meta = {
-      homepage = "https://github.com/Leont/crypt-passphrase-bcrypt";
       description = "A bcrypt encoder for Crypt::Passphrase";
+      homepage = "https://github.com/Leont/crypt-passphrase-bcrypt";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -4564,7 +4620,9 @@ let
     buildInputs = [ pkgs.unzip ModuleBuildTiny ];
     propagatedBuildInputs = [ ConvertASN1 ];
     meta = {
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      description = "Parse PKCS #10 certificate requests";
+      homepage = "https://github.com/openxpki/Crypt-PKCS10";
+      license = with lib.licenses; [ gpl1 ];
     };
   };
 
@@ -4577,8 +4635,8 @@ let
     };
     propagatedBuildInputs = [ CryptRandomTESHA2 ];
     meta = {
-      homepage = "https://github.com/danaj/Crypt-Random-Seed";
       description = "Provide strong randomness for seeding";
+      homepage = "https://github.com/danaj/Crypt-Random-Seed";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -4610,6 +4668,7 @@ let
     propagatedBuildInputs = [ CaptureTiny ModuleFind Moo SubExporter TypeTiny namespaceclean ];
     meta = {
       description = "Get weak or strong random data from pluggable sources";
+      homepage = "https://github.com/karenetheridge/Crypt-Random-Source";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -4622,8 +4681,8 @@ let
       sha256 = "a0912b42c52be173da528d5527e40d967324bc04ac78d9fc2ddc91ff16fe9633";
     };
     meta = {
-      homepage = "https://github.com/danaj/Crypt-Random-TESHA2";
       description = "Random numbers using timer/schedule entropy, aka userspace voodoo entropy";
+      homepage = "https://github.com/danaj/Crypt-Random-TESHA2";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -4654,8 +4713,8 @@ let
       sha256 = "0cmj620kfg08yvh81bq1sbabdyyc3g9pc6vlngxdxjgn0xvcil9l";
     };
     meta = {
-      homepage = "https://wiki.github.com/toddr/Crypt-RIPEMD160";
       description = "Perl extension for the RIPEMD-160 Hash function";
+      homepage = "http://wiki.github.com/toddr/Crypt-RIPEMD160";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -4715,8 +4774,8 @@ let
     perlPreHook = "export LD=$CC";
     meta = {
       description = "Scrypt password based key derivation function";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
       homepage = "https://github.com/DCIT/perl-Crypt-ScryptKDF";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
   };
@@ -4740,8 +4799,8 @@ let
     NIX_CFLAGS_COMPILE = "-I${pkgs.libsodium.dev}/include";
     NIX_CFLAGS_LINK = "-L${pkgs.libsodium.out}/lib -lsodium";
     meta = {
-      homepage = "https://metacpan.org/release/Crypt-Sodium";
       description = "Perl bindings for libsodium (NaCL)";
+      homepage = "https://metacpan.org/release/Crypt-Sodium";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -4782,8 +4841,8 @@ let
     doCheck = false; /* test fails with 'No random source available!' */
 
     meta = {
-      homepage = "https://github.com/btrott/Crypt-OpenPGP";
       description = "Pure-Perl OpenPGP implementation";
+      homepage = "https://github.com/btrott/Crypt-OpenPGP";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
       mainProgram = "pgplet";
@@ -4825,8 +4884,8 @@ let
     };
     meta = {
       description = "Guess OpenSSL include path";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
       homepage = "https://github.com/akiym/Crypt-OpenSSL-Guess";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -4841,6 +4900,7 @@ let
     NIX_CFLAGS_LINK = "-L${lib.getLib pkgs.openssl}/lib -lcrypto";
     buildInputs = [ CryptOpenSSLGuess ];
     meta = {
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
       broken = stdenv.isDarwin && stdenv.isAarch64; # errors with: 74366 Abort trap: 6
     };
   };
@@ -4868,8 +4928,8 @@ let
     NIX_CFLAGS_COMPILE = "-I${pkgs.openssl.dev}/include";
     NIX_CFLAGS_LINK = "-L${lib.getLib pkgs.openssl}/lib -lcrypto";
     meta = {
-      homepage = "https://github.com/dsully/perl-crypt-openssl-x509";
       description = "Perl extension to OpenSSL's X509 API";
+      homepage = "https://github.com/dsully/perl-crypt-openssl-x509";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -4885,8 +4945,8 @@ let
     buildInputs = [ TestFatal ];
     propagatedBuildInputs = [ DigestHMAC DigestSHA3 Moo TypeTiny namespaceautoclean strictures ];
     meta = {
-      homepage = "https://metacpan.org/release/Crypt-PBKDF2";
       description = "The PBKDF2 password hash algorithm";
+      homepage = "http://metacpan.org/release/Crypt-PBKDF2";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -4922,7 +4982,7 @@ let
 
     meta = {
       description = "Minimal Ed25519 bindings";
-      license = lib.licenses.artistic2;
+      license = with lib.licenses; [ artistic2 ];
       maintainers = [ maintainers.thoughtpolice ];
     };
   };
@@ -4974,6 +5034,7 @@ let
     perlPreHook = lib.optionalString (stdenv.isi686 || stdenv.isDarwin) "export LD=$CC";
     meta = {
       description = "XS based CSS minifier";
+      homepage = "http://metacpan.org/release/CSS-Minifier-XS";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -4989,6 +5050,7 @@ let
     propagatedBuildInputs = [ URI ];
     meta = {
       description = "Compact many CSS files into one big file";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -5003,7 +5065,7 @@ let
     NIX_CFLAGS_LINK = "-lncurses";
     meta = {
       description = "Perl bindings to ncurses";
-      license = lib.licenses.artistic1;
+      license = with lib.licenses; [ artistic1 ];
     };
   };
 
@@ -5016,8 +5078,8 @@ let
     };
     propagatedBuildInputs = [ Curses TermReadKey ];
     meta = {
-      description = "curses based OO user interface framework";
-      license = lib.licenses.artistic1;
+      description = "A curses based OO user interface framework";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -5043,7 +5105,7 @@ let
       sha256 = "sha256-u4SsASQ4x87NtRpab/+08f7jsOrgAi6WzrwuFnUiYhw=";
     };
     meta = {
-      description = "Crypto toolkit";
+      description = "Cryptographic toolkit";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -5058,6 +5120,7 @@ let
     propagatedBuildInputs = [ ConvertASN1 ];
     meta = {
       description = "Parse a X.509 certificate";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -5123,7 +5186,7 @@ let
     propagatedBuildInputs = [ IOInteractiveTiny ];
     meta = {
       description = "Dump with recursive encoding";
-      license = lib.licenses.artistic2;
+      license = with lib.licenses; [ artistic2 ];
       mainProgram = "edumper";
     };
   };
@@ -5184,8 +5247,8 @@ let
     };
     propagatedBuildInputs = [ DataUUID SubExporter ];
     meta = {
-      homepage = "https://github.com/rjbs/Data-GUID";
       description = "Globally unique identifiers";
+      homepage = "https://github.com/rjbs/Data-GUID";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -5198,7 +5261,9 @@ let
       sha256 = "1a9d843e7f667c1c6f77c67af5d77e7462ff23b41937cb17454d03535cd9be70";
     };
     meta = {
-      description = "Hexadecimal Dumper";
+      description = "Hexadecial Dumper";
+      homepage = "https://github.com/neilb/Data-HexDump";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = with maintainers; [ AndersonTorres ];
       mainProgram = "hexdump";
     };
@@ -5252,6 +5317,7 @@ let
     buildInputs = [ TestBits ];
     meta = {
       description = "Pack and unpack big-endian IEEE754 floats and doubles";
+      homepage = "http://metacpan.org/release/Data-IEEE754";
       license = with lib.licenses; [ artistic2 ];
     };
   };
@@ -5274,8 +5340,8 @@ let
     };
     buildInputs = [ ModuleBuildXSUtil TestRequires ];
     meta = {
+      description = "A grep-like program for searching source code";
       homepage = "https://github.com/msgpack/msgpack-perl";
-      description = "MessagePack serializing/deserializing";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
       broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.DataMessagePack.x86_64-darwin
@@ -5291,8 +5357,8 @@ let
     };
     propagatedBuildInputs = [ ParamsUtil SubInstall ];
     meta = {
-      homepage = "https://github.com/rjbs/data-optlist";
       description = "Parse and validate simple name/value option pairs";
+      homepage = "https://github.com/rjbs/Data-OptList";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -5317,7 +5383,7 @@ let
     };
     buildInputs = [ ClassAccessor DataPage TestException ];
     meta = {
-      description = "change long page list to be shorter and well navigate";
+      description = "Change long page list to be shorter and well navigate";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -5341,8 +5407,8 @@ let
     buildInputs = [ TestDeep TestFatal TestOutput ];
     propagatedBuildInputs = [ ClassMethodModifiers ListMoreUtils ModuleRuntime RoleTiny strictures ];
     meta = {
-      homepage = "https://github.com/mattp-/Data-Perl";
       description = "Base classes wrapping fundamental Perl data types";
+      homepage = "https://github.com/tobyink/Data-Perl";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -5356,7 +5422,7 @@ let
     };
     propagatedBuildInputs = [ ClonePP FileHomeDir PackageStash SortNaturally ];
     meta = {
-      description = "colored pretty-print of Perl data structures and objects";
+      description = "Colored & full-featured pretty print of Perl data structures and objects";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -5385,8 +5451,8 @@ let
     propagatedBuildInputs = [ MROCompat SubExporter ];
     buildInputs = [ TestFailWarnings ];
     meta = {
-      homepage = "https://github.com/rjbs/data-section";
       description = "Read multiple hunks of data out of your DATA section";
+      homepage = "https://github.com/rjbs/Data-Section";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -5400,8 +5466,8 @@ let
     };
     buildInputs = [ TestRequires ];
     meta = {
-      homepage = "https://github.com/miyagawa/Data-Section-Simple";
       description = "Read data from __DATA__";
+      homepage = "https://github.com/miyagawa/Data-Section-Simple";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -5415,6 +5481,7 @@ let
     };
     meta = {
       description = "Modules that serialize data structures";
+      homepage = "http://metacpan.org/release/Data-Serializer";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -5471,6 +5538,7 @@ let
     propagatedBuildInputs = [ Moose PathClass namespaceclean ];
     meta = {
       description = "N at a time iteration API";
+      homepage = "http://metacpan.org/release/Data-Stream-Bulk";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -5508,8 +5576,8 @@ let
     };
     propagatedBuildInputs = [ DateTime EncodeBase32GMP MathRandomSecure ];
     meta = {
-      homepage = "https://metacpan.org/release/Data-ULID";
       description = "Universally Unique Lexicographically Sortable Identifier";
+      homepage = "https://metacpan.org/release/Data-ULID";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = with maintainers; [ sgo ];
     };
@@ -5535,8 +5603,8 @@ let
     perlPreHook = lib.optionalString stdenv.isi686 "export LD=$CC"; # fix undefined reference to `__stack_chk_fail_local'
     meta = {
       description = "A selection of utilities for data and data types";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
       homepage = "https://github.com/gfx/Perl-Data-Util";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
       broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.DataUtil.x86_64-darwin
     };
   };
@@ -5573,7 +5641,8 @@ let
     propagatedBuildInputs = [ MathRandomMTAuto ];
     meta = {
       description = "Fast random UUID generator using the Mersenne Twister algorithm";
-      license = lib.licenses.asl20;
+      homepage = "https://metacpan.org/release/Data-UUID-MT";
+      license = with lib.licenses; [ asl20 ];
     };
   };
 
@@ -5588,6 +5657,7 @@ let
     propagatedBuildInputs = [ NetDomainTLD ];
     meta = {
       description = "Domain and host name validation";
+      homepage = "https://metacpan.org/release/Data-Validate-Domain";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -5603,6 +5673,7 @@ let
     propagatedBuildInputs = [ NetAddrIP ];
     meta = {
       description = "IPv4 and IPv6 validation methods";
+      homepage = "https://metacpan.org/release/Data-Validate-IP";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -5669,6 +5740,8 @@ let
     buildInputs = [ TestInter ];
     meta = {
       description = "Date manipulation routines";
+      homepage = "https://github.com/SBECK-github/Date-Manip";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -5694,8 +5767,9 @@ let
     buildInputs = [ CPANMetaCheck TestFatal TestWarnings ];
     propagatedBuildInputs = [ DateTimeLocale DateTimeTimeZone ];
     meta = {
-      description = "A date and time object";
-      license = lib.licenses.artistic2;
+      description = "A date and time object for Perl";
+      homepage = "https://metacpan.org/release/DateTime";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -5708,8 +5782,8 @@ let
     };
     propagatedBuildInputs = [ DateTime ];
     meta = {
-      description = "Dates in the Julian calendar";
-      license = lib.licenses.artistic2;
+      description = "DateTime object in the Julian calendar";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -5747,7 +5821,8 @@ let
     propagatedBuildInputs = [ DateTimeFormatStrptime ParamsValidate ];
     meta = {
       description = "Create DateTime parser classes and objects";
-      license = lib.licenses.artistic2;
+      homepage = "https://metacpan.org/release/DateTime-Format-Builder";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -5819,6 +5894,7 @@ let
     buildInputs = [ Test2Suite ];
     meta = {
       description = "Parses ISO8601 formats";
+      homepage = "https://metacpan.org/release/DateTime-HiRes";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -5847,7 +5923,7 @@ let
     buildInputs = [ ModuleUtil TestMockTime ];
     propagatedBuildInputs = [ Clone DateTime ListMoreUtils ParamsValidate boolean ];
     meta = {
-      description = "Create machine readable date/time with natural parsing logic";
+      description = "Parse informal natural language date/time strings";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "dateparse";
     };
@@ -5878,6 +5954,7 @@ let
     buildInputs = [ ModuleBuildTiny ];
     meta = {
       description = "Parse and format PostgreSQL dates and times";
+      homepage = "https://github.com/lestrrat-p5/DateTime-Format-Pg";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -5893,7 +5970,8 @@ let
     propagatedBuildInputs = [ DateTime ];
     meta = {
       description = "Parse and format strp and strf time patterns";
-      license = lib.licenses.artistic2;
+      homepage = "https://metacpan.org/release/DateTime-Format-Strptime";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -5921,6 +5999,7 @@ let
     propagatedBuildInputs = [ DateTime ];
     meta = {
       description = "Parse and format W3CDTF datetime strings";
+      homepage = "https://metacpan.org/release/DateTime-Format-W3CDTF";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -5936,6 +6015,7 @@ let
     propagatedBuildInputs = [ FileShareDir ParamsValidationCompiler Specio namespaceautoclean ];
     meta = {
       description = "Localization support for DateTime.pm";
+      homepage = "https://metacpan.org/release/DateTime-Locale";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -5950,7 +6030,8 @@ let
     propagatedBuildInputs = [ DateTime ];
     meta = {
       description = "Parse and format RFC3339 datetime strings";
-      license = lib.licenses.cc0;
+      homepage = "http://search.cpan.org/dist/DateTime-Format-RFC3339";
+      license = with lib.licenses; [ cc0 ];
     };
   };
 
@@ -5979,6 +6060,7 @@ let
     propagatedBuildInputs = [ ClassSingleton ParamsValidationCompiler Specio namespaceautoclean ];
     meta = {
       description = "Time zone object base class and factory";
+      homepage = "https://metacpan.org/release/DateTime-TimeZone";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -6035,7 +6117,7 @@ let
     };
     propagatedBuildInputs = [ PadWalker ];
     meta = {
-      description = "Meatier versions of C<caller>";
+      description = "Meatier versions of caller";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -6048,9 +6130,9 @@ let
       sha256 = "1r735yzgvsxkj4m6ks34xva5m21cfzp9qiis2d4ivv99kjskszqm";
     };
     meta = {
-      description = "check that a command is available";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      description = "Check that a command is available";
       homepage = "https://github.com/tokuhirom/Devel-CheckBin";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -6064,8 +6146,8 @@ let
     buildInputs = [ ModuleBuildTiny ];
     meta = {
       description = "Check the compiler's availability";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
       homepage = "https://github.com/tokuhirom/Devel-CheckCompiler";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -6097,8 +6179,8 @@ let
       sha256 = "0lkj2xwc3lhxv7scl43r8kfmls4am0b98sqf5vmf7d72257w6hkg";
     };
     meta = {
-      homepage = "https://metacpan.org/release/Devel-Leak";
       description = "Utility for looking for perl objects that are not reclaimed";
+      homepage = "https://metacpan.org/release/Devel-Leak";
       license = with lib.licenses; [ artistic1 gpl1Plus ]; # According to Debian
     };
   };
@@ -6112,8 +6194,8 @@ let
     };
     propagatedBuildInputs = [ Filepushd ModulePluggable ];
     meta = {
-      homepage = "https://github.com/bingos/devel-patchperl";
       description = "Patch perl source a la Devel::PPPort's buildperl.pl";
+      homepage = "https://github.com/bingos/devel-patchperl";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "patchperl";
     };
@@ -6128,7 +6210,7 @@ let
     };
     buildInputs = [ TestFatal ];
     meta = {
-      description = "obtain the REFCNT value of a referent";
+      description = "Obtain the REFCNT value of a referent";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -6155,7 +6237,7 @@ let
     };
     meta = {
       description = "Print out each line before it is executed (like sh -x)";
-      license = lib.licenses.publicDomain;
+      license = with lib.licenses; [ publicDomain ];
     };
   };
 
@@ -6263,8 +6345,8 @@ let
     buildInputs = [ pkgs.mariadb-connector-c DevelChecklib TestDeep TestDistManifest TestPod ];
     propagatedBuildInputs = [ DBI ];
     meta = {
-      homepage = "https://github.com/gooddata/DBD-MariaDB";
       description = "MariaDB and MySQL driver for the Perl5 Database Interface (DBI)";
+      homepage = "https://github.com/gooddata/DBD-MariaDB";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -6325,6 +6407,7 @@ let
 
     meta = {
       description = "DBI PostgreSQL interface";
+      homepage = "http://search.cpan.org/dist/DBD-Pg";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       platforms = lib.platforms.unix;
     };
@@ -6347,6 +6430,8 @@ let
     doCheck = false;
 
     meta = {
+      description = "DBI driver for Sybase datasources";
+      license = with lib.licenses; [ unfree ];
       broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.DBDsybase.x86_64-darwin
     };
   };
@@ -6416,8 +6501,8 @@ let
       EOF
     '';
     meta = {
-      homepage = "https://dbi.perl.org/";
       description = "Database independent interface for Perl";
+      homepage = "http://dbi.perl.org";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -6432,8 +6517,8 @@ let
     buildInputs = [ DBIxClass TestSimple13 ];
     propagatedBuildInputs = [ DBDSQLite SQLTranslator ];
     meta = {
-      homepage = "https://metacpan.org/pod/DBICx::TestDatabase";
       description = "Create a temporary database from a DBIx::Class::Schema";
+      homepage = "https://metacpan.org/pod/DBICx::TestDatabase";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -6449,8 +6534,8 @@ let
     buildInputs = [ DBDSQLite TestDeep TestException TestWarn ];
     propagatedBuildInputs = [ ClassAccessorGrouped ClassC3Componentised ConfigAny ContextPreserve DBI DataDumperConcise DataPage DevelGlobalDestruction ModuleFind PathClass SQLAbstractClassic ScopeGuard SubName namespaceclean ];
     meta = {
-      homepage = "https://metacpan.org/pod/DBIx::Class";
       description = "Extensible and flexible object <-> relational mapper";
+      homepage = "https://metacpan.org/pod/DBIx::Class";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "dbicadmin";
     };
@@ -6466,8 +6551,8 @@ let
     buildInputs = [ TestDeep TestFatal ];
     propagatedBuildInputs = [ DBIxClass LinguaENInflect SubExporter ];
     meta = {
-      homepage = "https://github.com/frioux/DBIx-Class-Candy";
       description = "Sugar for your favorite ORM, DBIx::Class";
+      homepage = "https://github.com/frioux/DBIx-Class-Candy";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -6497,8 +6582,8 @@ let
     buildInputs = [ DBICxTestDatabase ];
     propagatedBuildInputs = [ DBIxClass ];
     meta = {
-      homepage = "https://metacpan.org/pod/DBIx::Class::DynamicDefault";
       description = "Automatically set and update fields";
+      homepage = "https://metacpan.org/pod/DBIx::Class::DynamicDefault";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -6524,8 +6609,8 @@ let
     buildInputs = [ DBDSQLite DateTimeFormatSQLite TestDeep TestFatal TestRoo aliased ];
     propagatedBuildInputs = [ CarpClan DBIxClassCandy DBIxIntrospector SafeIsa TextBrew ];
     meta = {
-      homepage = "https://github.com/frioux/DBIx-Class-Helpers";
       description = "Simplify the common case stuff for DBIx::Class";
+      homepage = "https://github.com/frioux/DBIx-Class-Helpers";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -6540,8 +6625,8 @@ let
     buildInputs = [ DBDSQLite TestException ];
     propagatedBuildInputs = [ DBIxClass JSONMaybeXS YAML ];
     meta = {
-      homepage = "https://metacpan.org/pod/DBIx::Class::InflateColumn::Serializer";
       description = "Inflators to serialize data structures for DBIx::Class";
+      homepage = "http://metacpan.org/release/DBIx-Class-InflateColumn-Serializer";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -6627,6 +6712,7 @@ let
     propagatedBuildInputs = [ DBI ];
     meta = {
       description = "Very complete easy-to-use OO interface to DBI";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -6639,8 +6725,8 @@ let
     };
     buildInputs = [ TestDeep TestException TestPod TestPodCoverage TestWarn ];
     meta = {
-      homepage = "https://github.com/robkinyon/dbm-deep";
       description = "A pure perl multi-level hash/array DBM that supports transactions";
+      homepage = "https://github.com/robkinyon/dbm-deep";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -6695,7 +6781,7 @@ let
     perlPreHook = lib.optionalString stdenv.isDarwin "export LD=$CC";
     meta = {
       description = "Perl side of the Perl debugger for IntelliJ IDEA and other JetBrains IDEs";
-      license = lib.licenses.mit;
+      license = with lib.licenses; [ mit ];
     };
   };
 
@@ -6708,6 +6794,7 @@ let
     };
     meta = {
       description = "Find memory cycles in objects";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -6721,7 +6808,7 @@ let
     buildInputs = [ ExtUtilsDepends TestRequires ];
     propagatedBuildInputs = [ BHooksEndOfScope BHooksOPCheck SubName ];
     meta = {
-      description = "Adding keywords to perl, in perl";
+      description = "(DEPRECATED) Adding keywords to perl, in perl";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -6748,6 +6835,8 @@ let
     };
     propagatedBuildInputs = [ SubExporterProgressive ];
     meta = {
+      description = "Provides function returning the equivalent of \${^GLOBAL_PHASE} eq 'DESTRUCT' for older perls";
+      homepage = "https://metacpan.org/release/Devel-GlobalDestruction";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -6760,7 +6849,7 @@ let
       sha256 = "1x9jzy3l7gwikj57swzl94qsq03j9na9h1m69azzs7d7ghph58wd";
     };
     meta = {
-      description = "Detect perl's global phase on older perls.";
+      description = "Detect perl's global phase on older perls";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -6788,8 +6877,8 @@ let
       shortenPerlShebang $out/bin/*
     '';
     meta = {
-      homepage = "https://github.com/timbunce/devel-nytprof";
       description = "Powerful fast feature-rich Perl source code profiler";
+      homepage = "https://code.google.com/p/perl-devel-nytprof";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -6804,7 +6893,7 @@ let
     propagatedBuildInputs = [ MROCompat PackageStash SubIdentify ];
     buildInputs = [ TestFatal ];
     meta = {
-      description = "introspect overloaded operators";
+      description = "Introspect overloaded operators";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -6829,7 +6918,8 @@ let
     };
     meta = {
       description = "An object representing a stack trace";
-      license = lib.licenses.artistic2;
+      homepage = "http://metacpan.org/release/Devel-StackTrace";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -6855,6 +6945,7 @@ let
     propagatedBuildInputs = [ DevelStackTrace ];
     meta = {
       description = "Displays stack trace in HTML";
+      homepage = "https://github.com/miyagawa/Devel-StackTrace-AsHTML";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -6881,7 +6972,7 @@ let
     };
     meta = {
       description = "Module that calculates CRC sums of all sorts";
-      license = lib.licenses.publicDomain;
+      license = with lib.licenses; [ publicDomain ];
     };
   };
 
@@ -6894,6 +6985,7 @@ let
     };
     meta = {
       description = "Keyed-Hashing for Message Authentication";
+      homepage = "http://metacpan.org/release/Digest-HMAC";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -6907,7 +6999,7 @@ let
     };
     meta = {
       description = "Perl extension for 32 bit Jenkins Hashing Algorithm";
-      license = lib.licenses.artistic2;
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -6944,6 +7036,7 @@ let
     propagatedBuildInputs = [ LWP ];
     meta = {
       description = "Perl extension for getting MD5 sums for files and urls";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -6981,8 +7074,8 @@ let
       sha256 = "4a68b67c5034f40fbb1344b304cd66caaa5e320eb523005201cc24f76d470c14";
     };
     meta = {
-      homepage = "https://metacpan.org/release/Digest-SHA3";
       description = "Perl extension for SHA-3";
+      homepage = "https://metacpan.org/release/Digest-SHA3";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
       mainProgram = "sha3sum";
@@ -6997,9 +7090,9 @@ let
       sha256 = "sha256-VITN/m68OYwkZfeBx3w++1OKOULNSyDWiBjG//kHT8c=";
     };
     meta = {
-      homepage = "https://github.com/haukex/Digest-SRI";
       description = "Calculate and verify Subresource Integrity hashes (SRI)";
-      license = lib.licenses.gpl3Plus;
+      homepage = "https://github.com/haukex/Digest-SRI";
+      license = with lib.licenses; [ gpl3Plus ];
     };
   };
 
@@ -7012,7 +7105,8 @@ let
     };
     propagatedBuildInputs = [ Moo PathTiny ];
     meta = {
-      description = "treat a directory and a manifest file as a hash/dictionary of keys to texts or blobs";
+      description = "Treat a directory and a manifest file as a hash/dictionary of keys to texts or blobs";
+      homepage = "http://metacpan.org/release/Dir-Manifest";
       license = with lib.licenses; [ mit ];
     };
   };
@@ -7025,8 +7119,8 @@ let
       sha256 = "e251a51abc7d9ba3e708f73c2aa208e09d47a0c528d6254710fa78cc8d6885b5";
     };
     meta = {
-      homepage = "https://github.com/mauke/Dir-Self";
       description = "A __DIR__ constant for the directory your source file is in";
+      homepage = "https://github.com/mauke/Dir-Self";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7040,7 +7134,7 @@ let
     };
     propagatedBuildInputs = [ ExporterTiny ];
     meta = {
-      description = "dispatch on the type (class) of an argument";
+      description = "Dispatch on the type (class) of an argument";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7056,6 +7150,7 @@ let
     propagatedBuildInputs = [ ModuleRuntime ];
     meta = {
       description = "Declare version conflicts for your dist";
+      homepage = "http://metacpan.org/release/Dist-CheckConflicts";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7075,8 +7170,8 @@ let
     '';
     doCheck = false;
     meta = {
-      homepage = "http://dzil.org/";
       description = "Distribution builder; installer not included!";
+      homepage = "http://dzil.org";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "dzil";
     };
@@ -7094,6 +7189,7 @@ let
     doCheck = false; /* fails with 'open3: exec of .. perl .. failed: Argument list too long at .../TAP/Parser/Iterator/Process.pm line 165.' */
     meta = {
       description = "Test your dist with every testing plugin conceivable";
+      homepage = "http://metacpan.org/release/Dist-Zilla-PluginBundle-TestingMania";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7123,8 +7219,8 @@ let
     propagatedBuildInputs = [ DistZilla ];
     buildInputs = [ TestMojibake ];
     meta = {
+      description = "Author tests for source encoding";
       homepage = "https://github.com/creaktive/Dist-Zilla-Plugin-MojibakeTests";
-      description = "Release tests for source encoding";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7138,8 +7234,8 @@ let
     };
     propagatedBuildInputs = [ DistZilla PodElementalPerlMunger PodWeaver ];
     meta = {
-      homepage = "https://github.com/rjbs/Dist-Zilla-Plugin-PodWeaver";
       description = "Weave your Pod together from configuration and Dist::Zilla";
+      homepage = "https://github.com/rjbs/Dist-Zilla-Plugin-PodWeaver";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7154,8 +7250,8 @@ let
     buildInputs = [ TestDeep TestDifferences TestException TestFatal TestMost TestRequires TestSharedFork TestWarn ];
     propagatedBuildInputs = [ DistZillaRoleFileWatcher MooseXHasSugar PodMarkdownGithub ];
     meta = {
-      homepage = "https://github.com/DarwinAwardWinner/Dist-Zilla-Plugin-ReadmeAnyFromPod";
       description = "Automatically convert POD to a README in any format for Dist::Zilla";
+      homepage = "https://github.com/DarwinAwardWinner/Dist-Zilla-Plugin-ReadmeAnyFromPod";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7170,8 +7266,8 @@ let
     buildInputs = [ TestDeep TestDifferences TestException TestMost TestWarn ];
     propagatedBuildInputs = [ DistZillaPluginReadmeAnyFromPod ];
     meta = {
-      homepage = "https://github.com/DarwinAwardWinner/Dist-Zilla-Plugin-ReadmeMarkdownFromPod";
       description = "Automatically convert POD to a README.mkdn for Dist::Zilla";
+      homepage = "https://github.com/DarwinAwardWinner/Dist-Zilla-Plugin-ReadmeMarkdownFromPod";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7187,6 +7283,7 @@ let
     propagatedBuildInputs = [ DistZilla ];
     meta = {
       description = "Release tests for your changelog";
+      homepage = "http://metacpan.org/release/Dist-Zilla-Plugin-Test-CPAN-Changes";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7201,9 +7298,9 @@ let
     buildInputs = [ MooseAutobox TestCPANMetaJSON TestDeep ];
     propagatedBuildInputs = [ DistZilla ];
     meta = {
+      description = "Validate your CPAN META.json files";
       homepage = "http://p3rl.org/Dist::Zilla::Plugin::Test::CPAN::Meta::JSON";
-      description = "Release tests for your META.json";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -7217,8 +7314,8 @@ let
     buildInputs = [ CPANMetaCheck ModuleBuildTiny TestDeep TestMinimumVersion TestWarnings ];
     propagatedBuildInputs = [ DistZilla ];
     meta = {
+      description = "Assert that your Perl files compile OK";
       homepage = "https://github.com/karenetheridge/Dist-Zilla-Plugin-Test-Compile";
-      description = "Common tests to check syntax of your modules, only using core modules";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7233,7 +7330,8 @@ let
     buildInputs = [ TestDeep TestDistManifest TestOutput ];
     propagatedBuildInputs = [ DistZilla ];
     meta = {
-      description = "Release tests for the manifest";
+      description = "Author test that validates a package MANIFEST";
+      homepage = "https://github.com/jawnsy/Test-DistManifest";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7248,8 +7346,9 @@ let
     buildInputs = [ ModuleBuildTiny TestDeep TestEOL TestWarnings ];
     propagatedBuildInputs = [ DistZilla ];
     meta = {
-      description = "Author tests making sure correct line endings are used";
-      license = lib.licenses.artistic2;
+      description = "Check the correct line endings in your project";
+      homepage = "https://github.com/karenetheridge/Test-EOL";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -7263,7 +7362,7 @@ let
     buildInputs = [ ModuleBuildTiny TestDeep TestFatal TestKwalitee ];
     propagatedBuildInputs = [ DistZilla ];
     meta = {
-      description = "Release tests for kwalitee";
+      description = "Test the Kwalitee of a distribution before you release it";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7293,9 +7392,9 @@ let
     propagatedBuildInputs = [ DistZilla ];
     buildInputs = [ ModuleBuildTiny TestDeep TestNoTabs TestRequires ];
     meta = {
-      description = "Author tests that ensure hard tabs are not used";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      description = "Check the presence of tabs in your project";
       homepage = "https://github.com/karenetheridge/Dist-Zilla-Plugin-Test-NoTabs";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -7325,8 +7424,8 @@ let
     propagatedBuildInputs = [ DistZilla ];
     buildInputs = [ TestPodLinkCheck ];
     meta = {
-      homepage = "https://github.com/rwstauner/Dist-Zilla-Plugin-Test-Pod-LinkCheck";
       description = "Add release tests for POD links";
+      homepage = "https://github.com/rwstauner/Dist-Zilla-Plugin-Test-Pod-LinkCheck";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7341,7 +7440,8 @@ let
     buildInputs = [ ModuleBuildTiny TestDeep TestPortabilityFiles TestWarnings ];
     propagatedBuildInputs = [ DistZilla ];
     meta = {
-      description = "Release tests for portability";
+      description = "Author tests for portability";
+      homepage = "https://github.com/karenetheridge/Dist-Zilla-Plugin-Test-Portability";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7372,6 +7472,7 @@ let
     propagatedBuildInputs = [ DistZilla ];
     meta = {
       description = "Release tests for unused variables";
+      homepage = "http://metacpan.org/release/Dist-Zilla-Plugin-Test-UnusedVars";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7387,7 +7488,7 @@ let
     propagatedBuildInputs = [ DistZilla ];
     meta = {
       description = "Release Test::Version tests";
-      license = lib.licenses.artistic2;
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -7402,8 +7503,8 @@ let
     buildInputs = [ ModuleBuildTiny TestDeep TestFatal ];
     meta = {
       description = "Receive notification when something changes a file's contents";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
       homepage = "https://github.com/karenetheridge/Dist-Zilla-Role-FileWatcher";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -7417,7 +7518,7 @@ let
     buildInputs = [ TestCPANMeta TestPod TestPodCoverage ];
     propagatedBuildInputs = [ PathTiny ];
     meta = {
-      description = "Support for C<dotenv> in Perl";
+      description = "Support for dotenv in Perl";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7432,8 +7533,8 @@ let
     propagatedBuildInputs = [ CaptureTiny ClassXSAccessor DevelCheckOS NumberWithError StatisticsCaseResampling ];
     meta = {
       description = "More reliable benchmarking with the least amount of thinking";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
       homepage = "https://github.com/briandfoy/dumbbench";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "dumbbench";
     };
   };
@@ -7447,8 +7548,8 @@ let
     };
     propagatedBuildInputs = [ EmailSimple MROCompat ModulePluggable ];
     meta = {
-      homepage = "https://github.com/rjbs/Email-Abstract";
       description = "Unified interface to mail representations";
+      homepage = "https://github.com/rjbs/Email-Abstract";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7461,7 +7562,8 @@ let
       sha256 = "1vzr0vx4zsw4zbc9xdffc31wnkc1raqmyfiyws06fbyck197i8qg";
     };
     meta = {
-      description = "RFC 2822 Address Parsing";
+      description = "RFC 2822 Address Parsing and Creation";
+      homepage = "https://github.com/rjbs/Email-Address";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7489,7 +7591,7 @@ let
       sha256 = "0gjrrl81z3sfwavgx5kwjd87gj44mlnbbqsm3dgdv1xllw26spwr";
     };
     meta = {
-      description = "Parse and format RFC 2822 email addresses and groups";
+      description = "Parse and format RFC 5322 email addresses and groups";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7502,8 +7604,8 @@ let
       sha256 = "579c617e303b9d874411c7b61b46b59d36f815718625074ae6832e7bb9db5104";
     };
     meta = {
-      homepage = "https://github.com/rjbs/Email-Date-Format";
       description = "Produce RFC 2822 date strings";
+      homepage = "https://github.com/rjbs/Email-Date-Format";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7518,6 +7620,7 @@ let
     propagatedBuildInputs = [ EmailAbstract EmailAddress EmailMIME ];
     meta = {
       description = "Reply to an email message";
+      homepage = "https://github.com/Perl-Email-Project/Email-Reply";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7531,6 +7634,7 @@ let
     };
     meta = {
       description = "Generate world unique message-ids";
+      homepage = "https://github.com/rjbs/Email-MessageID";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7544,8 +7648,8 @@ let
     };
     propagatedBuildInputs = [ EmailAddressXS EmailMIMEContentType EmailMIMEEncodings EmailMessageID EmailSimple MIMETypes ModuleRuntime ];
     meta = {
-      homepage = "https://github.com/rjbs/Email-MIME";
       description = "Easy MIME message handling";
+      homepage = "https://github.com/rjbs/Email-MIME";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7561,8 +7665,9 @@ let
         sha256 = "dcb98b09dc3e8f757ec3882a4234548108bb2d12e3cfadf95a26cef381a9e789";
     };
     meta = {
-        description = "Strip the attachments from an email";
-        license = with lib.licenses; [ artistic1 gpl1Plus ];
+      description = "Strip the attachments from an email";
+      homepage = "https://github.com/rjbs/Email-MIME-Attachment-Stripper";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -7575,8 +7680,8 @@ let
     };
     propagatedBuildInputs = [ TextUnidecode ];
     meta = {
+      description = "Parse and build a MIME Content-Type or Content-Disposition Header";
       homepage = "https://github.com/rjbs/Email-MIME-ContentType";
-      description = "Parse a MIME Content-Type Header";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7590,8 +7695,8 @@ let
     };
     buildInputs = [ CaptureTiny ];
     meta = {
-      homepage = "https://github.com/rjbs/Email-MIME-Encodings";
       description = "A unified interface to MIME encoding and decoding";
+      homepage = "https://github.com/rjbs/Email-MIME-Encodings";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7606,8 +7711,8 @@ let
     propagatedBuildInputs = [ EmailAbstract EmailAddress ReturnValue ];
     buildInputs = [ MIMETools MailTools ];
     meta = {
-      homepage = "https://github.com/rjbs/Email-Send";
       description = "Simply Sending Email";
+      homepage = "https://github.com/rjbs/Email-Send";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7647,8 +7752,8 @@ let
       shortenPerlShebang util/sendmail
     '';
     meta = {
-      homepage = "https://github.com/rjbs/Email-Sender";
       description = "A library for sending email";
+      homepage = "https://github.com/rjbs/Email-Sender";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7662,8 +7767,8 @@ let
     };
     propagatedBuildInputs = [ EmailDateFormat ];
     meta = {
-      homepage = "https://github.com/rjbs/Email-Simple";
       description = "Simple parsing of RFC2822 message format and headers";
+      homepage = "https://github.com/rjbs/Email-Simple";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7678,8 +7783,8 @@ let
     buildInputs = [ Moo TestFatal ];
     propagatedBuildInputs = [ EmailMIME EmailSender ModuleRuntime ParamsUtil ];
     meta = {
-      homepage = "https://github.com/rjbs/Email-Stuffer";
       description = "A more casual approach to creating and sending Email:: emails";
+      homepage = "https://github.com/rjbs/Email-Stuffer";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = with maintainers; [ sgo ];
     };
@@ -7733,9 +7838,9 @@ let
     buildInputs = [ TestBase ];
     propagatedBuildInputs = [ MathGMPz ];
     meta = {
-      homepage = "https://metacpan.org/release/Encode-Base32-GMP";
       description = "High speed Base32 encoding using GMP with BigInt and MD5 support";
-      license = lib.licenses.mit;
+      homepage = "https://metacpan.org/release/Encode-Base32-GMP";
+      license = with lib.licenses; [ mit ];
       maintainers = with maintainers; [ sgo ];
     };
   };
@@ -7750,7 +7855,7 @@ let
     nativeBuildInputs = [ pkgs.ld-is-cc-hook ];
     meta = {
       description = "An Encode::Encoding subclass that detects the encoding of data";
-      license = lib.licenses.free;
+      license = with lib.licenses; [ free ];
     };
   };
 
@@ -7778,7 +7883,7 @@ let
     };
     meta = {
       description = "Extra sets of Chinese encodings";
-      license = lib.licenses.mit;
+      license = with lib.licenses; [ mit ];
     };
   };
 
@@ -7791,6 +7896,7 @@ let
     };
     outputs = [ "out" ];
     meta = {
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -7820,8 +7926,8 @@ let
     };
     meta = {
       description = "Normalize line ending sequences";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
       homepage = "https://github.com/neilb/Encode-Newlines";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -7835,8 +7941,8 @@ let
     buildInputs = [ TestNoWarnings ];
     propagatedBuildInputs = [ NetIDNEncode ];
     meta = {
-      homepage = "http://search.cpan.org/dist/Encode-Punycode";
       description = "Encode plugin for Punycode (RFC 3492)";
+      homepage = "http://search.cpan.org/dist/Encode-Punycode";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7849,6 +7955,8 @@ let
       sha256 = "d2f36b5015f1e35f640159867b60bf5d5cd66b56cd5e42d33f531be68e5eee35";
     };
     meta = {
+      description = "C style enumerated types and bitmask flags in Perl";
+      homepage = "https://github.com/neilb/enum";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7862,6 +7970,7 @@ let
     };
     meta = {
       description = "Perl module that imports environment variables as scalars or arrays";
+      homepage = "http://search.cpan.org/dist/Env";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7889,8 +7998,8 @@ let
     };
     meta = {
       description = "Lexically scoped sanctification of %ENV";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
       homepage = "https://github.com/bingos/env-sanctify";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -7913,7 +8022,7 @@ let
     buildInputs = [ CanaryStability ];
     propagatedBuildInputs = [ commonsense ];
     meta = {
-      license = lib.licenses.gpl1Plus;
+      license = with lib.licenses; [ gpl1Plus ];
     };
   };
 
@@ -7927,6 +8036,7 @@ let
     buildInputs = [ TestFatal TestRequires ];
     meta = {
       description = "Safely and cleanly create closures via string eval";
+      homepage = "http://metacpan.org/release/Eval-Closure";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7941,6 +8051,7 @@ let
     propagatedBuildInputs = [ ArchiveZip ];
     meta = {
       description = "Create a new file in the Excel 2007+ XLSX format";
+      homepage = "http://jmcnamara.github.com/excel-writer-xlsx";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "extract_vba";
     };
@@ -8002,8 +8113,8 @@ let
     buildInputs = [ FennecLite TestException ];
     propagatedBuildInputs = [ MetaBuilder aliased ];
     meta = {
-      homepage = "https://metacpan.org/release/Exporter-Declare";
       description = "Exporting done right";
+      homepage = "http://open-exodus.net/projects/Exporter-Declare";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -8029,6 +8140,7 @@ let
     };
     meta = {
       description = "An exporter with the features of Sub::Exporter but only core dependencies";
+      homepage = "https://metacpan.org/release/Exporter-Tiny";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -8057,7 +8169,7 @@ let
     propagatedBuildInputs = [ Expect ];
     meta = {
       description = "Wrapper around the Expect module";
-      license = lib.licenses.free;
+      license = with lib.licenses; [ free ];
     };
   };
 
@@ -8118,7 +8230,8 @@ let
       sha256 = "165y1cjirbq64w39svkz82cb5jjqkjm8f4c0wqi2lk6050hzf3vq";
     };
     meta = {
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      homepage = "http://gtk2-perl.sourceforge.net";
+      license = with lib.licenses; [ artistic1 gpl1Plus artistic1 gpl1Plus ];
     };
   };
 
@@ -8159,6 +8272,7 @@ let
     };
     meta = {
       description = "Install files from here to there";
+      homepage = "https://metacpan.org/release/ExtUtils-Install";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -8200,6 +8314,7 @@ let
     };
     meta = {
       description = "Create a module Makefile";
+      homepage = "https://metacpan.org/release/ExtUtils-MakeMaker";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "instmodsh";
     };
@@ -8214,7 +8329,7 @@ let
     };
     propagatedBuildInputs = [ ModuleCPANfile ];
     meta = {
-      description = "cpanfile support for EUMM";
+      description = "Cpanfile support for EUMM";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -8235,9 +8350,8 @@ let
     '';
     doCheck = false; # expects test_glib-2.0.pc in PKG_CONFIG_PATH
     meta = {
-      homepage = "http://gtk2-perl.sourceforge.net";
       description = "Simplistic interface to pkg-config";
-      license = lib.licenses.lgpl21Plus;
+      license = with lib.licenses; [ lgpl21Plus ];
     };
   };
 
@@ -8289,7 +8403,7 @@ let
     };
     buildInputs = [ TestBase TestDifferences ];
     meta = {
-      description = "XS++ is just a thin layer over plain XS";
+      description = "XS for C++";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "xspp";
     };
@@ -8328,7 +8442,8 @@ let
     propagatedBuildInputs = [ Moo TypeTiny ];
     buildInputs = [ ModuleBuildTiny ];
     meta = {
-      description = "client library for fastcgi protocol";
+      description = "Client library for fastcgi protocol";
+      homepage = "https://github.com/tokuhirom/p5-fcgi-client";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -8342,6 +8457,7 @@ let
     };
     meta = {
       description = "A perl-based FastCGI process manager";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -8355,6 +8471,7 @@ let
     buildInputs = [ Test2Suite ];
     meta = {
       description = "Check that a library is available for FFI";
+      homepage = "https://metacpan.org/pod/FFI::CheckLib";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -8367,8 +8484,8 @@ let
       sha256 = "dce28e3932762c2ff92aa52d90405c06e898e81cb7b164ccae8966ae77f1dcab";
     };
     meta = {
-      homepage = "https://metacpan.org/release/Fennec-Lite";
       description = "Minimalist Fennec, the commonly used bits";
+      homepage = "http://open-exodus.net/projects/Fennec-Lite";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -8436,6 +8553,7 @@ let
     };
     meta = {
       description = "Run many filetest checks on a tree";
+      homepage = "http://search.cpan.org/dist/File-CheckTree";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -8448,8 +8566,8 @@ let
       sha256 = "6cafafff68bc84215168b55ede0d191dcb57f9a3201b51d61edb2858a2407795";
     };
     meta = {
-      homepage = "https://metacpan.org/dist/File-chmod";
       description = "Implements symbolic and ls chmod modes";
+      homepage = "https://metacpan.org/dist/File-chmod";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -8463,8 +8581,8 @@ let
     };
     propagatedBuildInputs = [ Filechmod ];
     meta = {
-      homepage = "https://github.com/mithun/perl-file-chmod-recursive";
       description = "Run chmod recursively against directories";
+      homepage = "https://github.com/mithun/perl-file-chmod-recursive";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -8489,8 +8607,8 @@ let
     buildInputs = [ CaptureTiny PathTiny ];
     meta = {
       description = "Recursive copying of files and directories within Perl 5 toolchain";
+      homepage = "http://thenceforward.net/perl/modules/File-Copy-Recursive-Reduced";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
-      homepage = "http://thenceforward.net/perl/modules/File-Copy-Recursive-Reduced/";
     };
   };
 
@@ -8526,6 +8644,7 @@ let
     };
     propagatedBuildInputs = [ ClassIterator ];
     meta = {
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -8539,7 +8658,8 @@ let
     propagatedBuildInputs = [ ClassXSAccessor ];
     meta = {
       description = "An object oriented File::Find replacement";
-      license = lib.licenses.artistic2;
+      homepage = "http://metacpan.org/release/File-Find-Object";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -8556,8 +8676,8 @@ let
       tar xf $src */t/sample-data --strip-components=1
     '';
     meta = {
-      homepage = "https://www.shlomifish.org/open-source/projects/File-Find-Object/";
       description = "Alternative interface to File::Find::Object";
+      homepage = "http://www.shlomifish.org/open-source/projects/File-Find-Object";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "findorule";
     };
@@ -8588,6 +8708,7 @@ let
     propagatedBuildInputs = [ FileFindRule ParamsUtil ];
     meta = {
       description = "Common rules for searching for Perl things";
+      homepage = "https://github.com/karenetheridge/File-Find-Rule-Perl";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -8601,7 +8722,7 @@ let
     };
     propagatedBuildInputs = [ TextGlob ];
     meta = {
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [ artistic1 gpl1Pluartistic1 gpl1Plus ];
     };
   };
 
@@ -8613,9 +8734,9 @@ let
       sha256 = "05p9m7kpmjv8bmmbs5chb5fqyshcgmskbbzq5c9qpskbx2w5894n";
     };
     meta = {
-      maintainers = teams.deshaw.members;
-      description = "simple filename and pathname matching";
+      description = "Simple filename and pathname matching";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
+      maintainers = teams.deshaw.members;
     };
   };
 
@@ -8628,6 +8749,7 @@ let
     };
     meta = {
       description = "Find matches to a pattern in a series of files and related functions";
+      license = with lib.licenses; [ unfree ];
       maintainers = teams.deshaw.members;
     };
   };
@@ -8641,9 +8763,9 @@ let
     };
     buildInputs = [ FileSlurper TestCompile UNIVERSALrequire URI ];
     meta = {
-      homepage = "https://github.com/coppit/filehandle-unget/";
       description = "FileHandle which supports multi-byte unget";
-      license = lib.licenses.gpl2;
+      homepage = "https://github.com/coppit/filehandle-unget";
+      license = with lib.licenses; [ gpl2 ];
       maintainers = with maintainers; [ romildo ];
     };
   };
@@ -8660,6 +8782,7 @@ let
     doCheck = !stdenv.isDarwin;
     meta = {
       description = "Find your home and other directories on any platform";
+      homepage = "https://metacpan.org/release/File-HomeDir";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -8704,6 +8827,7 @@ let
     '';
     meta = {
       description = "Determine MIME types of data or files using libmagic";
+      homepage = "https://metacpan.org/release/File::LibMagic";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.FileLibMagic.x86_64-darwin
     };
@@ -8753,7 +8877,7 @@ let
     };
     meta = {
       description = "Guess file type from contents";
-      license = lib.licenses.free; # Some form of BSD4/Apache mix.
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -8768,7 +8892,7 @@ let
     propagatedBuildInputs = [ PerlIOLayers SubExporterProgressive ];
     buildInputs = [ TestFatal TestWarnings ];
     meta = {
-      description = "Memory mapping made simple and safe.";
+      description = "Memory mapping made simple and safe";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -8781,8 +8905,8 @@ let
       sha256 = "6b50b1aab6ec6998a017f6403c2735b3bc1e1cf46187bd134d7eb6df3fc45144";
     };
     meta = {
-      homepage = "https://github.com/neilbowers/File-Modified";
       description = "Checks intelligently if files have changed";
+      homepage = "https://github.com/neilbowers/File-Modified";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -8832,8 +8956,8 @@ let
     })];
     propagatedBuildInputs = [ ClassAccessor ];
     meta = {
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
       description = "Pid File Manipulation";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = teams.deshaw.members;
     };
   };
@@ -8847,7 +8971,8 @@ let
     };
     meta = {
       description = "Change directory temporarily for a limited scope";
-      license = lib.licenses.asl20;
+      homepage = "https://github.com/dagolden/File-pushd";
+      license = with lib.licenses; [ asl20 ];
     };
   };
 
@@ -8860,6 +8985,7 @@ let
     };
     meta = {
       description = "Read a file backwards by lines";
+      homepage = "https://metacpan.org/pod/File::ReadBackwards";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -8882,8 +9008,8 @@ let
     };
     propagatedBuildInputs = [ FileShareDir ];
     meta = {
-      homepage = "https://github.com/ingydotnet/file-share-pm";
       description = "Extend File::ShareDir to Local Libraries";
+      homepage = "https://github.com/ingydotnet/file-share-pm";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -8899,6 +9025,7 @@ let
     buildInputs = [ FileShareDirInstall ];
     meta = {
       description = "Locate per-dist and per-module shared files";
+      homepage = "https://metacpan.org/release/File-ShareDir";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -8912,6 +9039,7 @@ let
     };
     meta = {
       description = "Install shared files";
+      homepage = "https://github.com/Perl-Toolchain-Gang/File-ShareDir-Install";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -8939,6 +9067,7 @@ let
     buildInputs = [ TestSharedFork ];
     meta = {
       description = "Simple and dumb file system watcher";
+      homepage = "https://github.com/miyagawa/Filesys-Notify-Simple";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -9020,8 +9149,8 @@ let
       sha256 = "e379a5ff89420cf39906e5ceff309b8ce958f99f9c3e57ad52b5002a3982d93c";
     };
     meta = {
-      homepage = "https://github.com/neilb/File-Touch";
       description = "Update file access and modification times, optionally creating files if needed";
+      homepage = "https://github.com/neilb/File-Touch";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = teams.deshaw.members;
     };
@@ -9035,7 +9164,7 @@ let
       sha256 = "0hfkaafp6wb0nw19x47wc6wc9mwlw8s2rxiii3ylvzapxxgxjp6k";
     };
     meta = {
-      description = "File::Type uses magic numbers (typically at the start of a file) to determine the MIME type of that file.";
+      description = "Uses magic numbers (typically at the start of a file) to determine the MIME type of that file";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -9049,8 +9178,8 @@ let
     };
     buildInputs = [ TestNoWarnings ];
     meta = {
-      homepage = "https://github.com/tommybutler/file-util/wiki";
       description = "Easy, versatile, portable file handling";
+      homepage = "https://github.com/tommybutler/file-util/wiki";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -9064,8 +9193,8 @@ let
     };
     buildInputs = [ Perlosnames TestException ];
     meta = {
-      homepage = "https://metacpan.org/release/File-Util-Tempdir";
       description = "Cross-platform way to get system-wide & user private temporary directory";
+      homepage = "https://metacpan.org/release/File-Util-Tempdir";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -9079,8 +9208,8 @@ let
       sha256 = "b79dc2244b2d97b6f27167fc3b7799ef61a179040f3abd76ce1e0a3b0bc4e078";
     };
     meta = {
-      homepage = "https://metacpan.org/release/File-Which";
       description = "Perl implementation of the which utility as an API";
+      homepage = "https://metacpan.org/pod/File::Which";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -9093,7 +9222,7 @@ let
       sha256 = "16v61rn0yimpv5kp6b20z2f1c93n5kpsyjvr0gq4w2dc43gfvc8w";
     };
     meta = {
-      description = "Extended globs.";
+      description = "Extended globs";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -9159,7 +9288,7 @@ let
     buildInputs = [ IOString ];
     meta = {
       description = "TTF font support for Perl";
-      license = lib.licenses.artistic2;
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -9228,6 +9357,7 @@ let
     buildInputs = [ HTTPCookieJar HTTPProxy ModuleBuildTiny Plack Starlet TestFakeHTTPD TestRequires TestSharedFork TestTCP TestValgrind URI ];
     meta = {
       description = "Lightning-fast URL fetcher";
+      homepage = "https://github.com/tokuhirom/Furl";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -9241,7 +9371,7 @@ let
     };
     buildInputs = [ TestFatal TestIdentity TestRefcount ];
     meta = {
-      description = "represent an operation awaiting completion";
+      description = "Represent an operation awaiting completion";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -9291,7 +9421,8 @@ let
     propagatedBuildInputs = [ ClassXSAccessor ExceptionClass PathTiny ];
     meta = {
       description = "Verify solutions for solitaire games";
-      license = lib.licenses.mit;
+      homepage = "http://metacpan.org/release/Games-Solitaire-Verify";
+      license = with lib.licenses; [ mit ];
       mainProgram = "verify-solitaire-solution";
     };
   };
@@ -9312,7 +9443,7 @@ let
     makeMakerFlags = "--lib_png_path=${pkgs.libpng.out} --lib_jpeg_path=${pkgs.libjpeg.out} --lib_zlib_path=${pkgs.zlib.out} --lib_ft_path=${pkgs.freetype.out} --lib_fontconfig_path=${pkgs.fontconfig.lib} --lib_xpm_path=${pkgs.xorg.libXpm.out}";
 
     meta = {
-      description = "Interface to Gd Graphics Library";
+      description = "Perl interface to the gd2 graphics library";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "bdf2gdfont.pl";
     };
@@ -9357,6 +9488,7 @@ let
     propagatedBuildInputs = [ GD ];
     meta = {
       description = "Text utilities for use with GD";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -9382,6 +9514,7 @@ let
     buildInputs = [ PathClass TestFatal TestNumberDelta ];
     meta = {
       description = "Perl API for MaxMind's GeoIP2 web services and databases";
+      homepage = "http://metacpan.org/release/GeoIP2";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "web-service-request";
     };
@@ -9395,7 +9528,7 @@ let
       sha256 = "3709aa513ce6fd71d1a55a02e34d2f090017d5350a9bd447005653c9b0835b22";
     };
     meta = {
-      license = lib.licenses.artistic1;
+      license = with lib.licenses; [ artistic1 ];
       maintainers = [ maintainers.pSub ];
     };
   };
@@ -9419,8 +9552,8 @@ let
     buildInputs = [ CPANMetaCheck TestFatal TestWarnings ];
     propagatedBuildInputs = [ ParamsValidate SubExporter ];
     meta = {
-      homepage = "https://github.com/rjbs/Getopt-Long-Descriptive";
       description = "Getopt::Long, but simpler and more powerful";
+      homepage = "https://github.com/rjbs/Getopt-Long-Descriptive";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -9443,9 +9576,9 @@ let
     };
     propagatedBuildInputs = [ Error ];
     meta = {
-      maintainers = teams.deshaw.members;
       description = "This is the Git.pm, plus the other files in the perl/Git directory, from github's git/git";
-      license = lib.licenses.free;
+      license = with lib.licenses; [ free ];
+      maintainers = teams.deshaw.members;
     };
   };
 
@@ -9462,7 +9595,7 @@ let
     '';
     meta = {
       description = "Create fixup commits for topic branches";
-      license = lib.licenses.artistic2;
+      license = with lib.licenses; [ artistic2 ];
       maintainers = [ maintainers.DamienCassou ];
       mainProgram = "git-autofixup";
     };
@@ -9523,9 +9656,9 @@ let
     buildInputs = [ pkgs.glib ];
     propagatedBuildInputs = [ ExtUtilsDepends ExtUtilsPkgConfig ];
     meta = {
-      homepage = "http://gtk2-perl.sourceforge.net/";
       description = "Perl wrappers for the GLib utility and Object libraries";
-      license = lib.licenses.lgpl21Plus;
+      homepage = "http://gtk2-perl.sourceforge.net";
+      license = with lib.licenses; [ lgpl21 ];
     };
   };
 
@@ -9552,7 +9685,8 @@ let
     doCheck = !stdenv.isDarwin;
     meta = {
       description = "Dynamically create Perl language bindings";
-      license = lib.licenses.lgpl2Plus;
+      homepage = "http://gtk2-perl.sourceforge.net";
+      license = with lib.licenses; [ lgpl21 ];
     };
   };
 
@@ -9566,9 +9700,9 @@ let
     buildInputs = [ ExtUtilsDepends ExtUtilsPkgConfig Glib Gnome2Canvas Gnome2VFS Gtk2 ];
     propagatedBuildInputs = [ pkgs.gnome2.libgnomeui ];
     meta = {
+      description = "(DEPRECATED) Perl interface to the 2.x series of the GNOME libraries";
       homepage = "http://gtk2-perl.sourceforge.net";
-      description = "Perl interface to the 2.x series of the GNOME libraries";
-      license = lib.licenses.lgpl21Plus;
+      license = with lib.licenses; [ lgpl21Plus ];
       broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.Gnome2Canvas.x86_64-darwin
     };
   };
@@ -9584,7 +9718,8 @@ let
     propagatedBuildInputs = [ Gtk2 ];
     doCheck = !stdenv.isDarwin;
     meta = {
-      license = lib.licenses.lgpl2Plus;
+      description = "(DEPRECATED) A structured graphics canvas";
+      license = with lib.licenses; [ lgpl2Plus ];
     };
   };
 
@@ -9597,8 +9732,8 @@ let
     };
     propagatedBuildInputs = [ pkgs.gnome2.gnome_vfs Glib ];
     meta = {
-      description = "Perl interface to the 2.x series of the GNOME VFS library";
-      license = lib.licenses.lgpl21Plus;
+      description = "(DEPRECATED) Perl interface to the 2.x series of the GNOME VFS";
+      license = with lib.licenses; [ gpl21Plus ];
     };
   };
 
@@ -9612,8 +9747,8 @@ let
     buildInputs = [ pkgs.libwnck2 pkgs.glib pkgs.gtk2 ];
     propagatedBuildInputs = [ Gtk2 ];
     meta = {
-      description = "Perl interface to the Window Navigator Construction Kit";
-      license = lib.licenses.lgpl21Plus;
+      description = "(DEPRECATED) Perl interface to the Window Navigator";
+      license = with lib.licenses; [ lgpl21Plus ];
     };
   };
 
@@ -9628,6 +9763,7 @@ let
     doCheck = false;
     meta = {
       description = "Perl interface to the GNU Privacy Guard";
+      license = with lib.licenses; [ unfree ];
       mainProgram = "gpgmailtunl";
     };
   };
@@ -9659,6 +9795,7 @@ let
     doCheck = false; # no make target 'test'
     meta = {
       description = "HTTP transport for DBI stateless proxy driver DBD::Gofer";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -9717,6 +9854,7 @@ let
       [ ../development/perl-modules/Google-ProtocolBuffers-multiline-comments.patch ];
     meta = {
       description = "Simple interface to Google Protocol Buffers";
+      homepage = "https://github.com/csirtgadgets/google-protocolbuffers-perl";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "protoc-perl";
     };
@@ -9759,8 +9897,8 @@ let
     buildInputs = [ TestNumberDelta ModulePluggable ];
     propagatedBuildInputs = [ ColorLibrary Moose MooseXAliases MooseXClone MooseXStorage MooseXTypes ];
     meta = {
-      homepage = "https://github.com/gphat/graphics-color";
       description = "Device and library agnostic color spaces";
+      homepage = "https://github.com/gphat/graphics-color";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -9810,9 +9948,9 @@ let
     propagatedBuildInputs = [ MailMboxMessageParser TimeDate ];
     outputs = [ "out" ];
     meta = {
-      homepage = "https://github.com/coppit/grepmail";
       description = "Search mailboxes for mail matching a regular expression";
-      license = lib.licenses.gpl2;
+      homepage = "https://github.com/coppit/grepmail";
+      license = with lib.licenses; [ gpl2 ];
       maintainers = with maintainers; [ romildo ];
     };
   };
@@ -9838,9 +9976,9 @@ let
     propagatedBuildInputs = [ pkgs.krb5Full.dev ];
     makeMakerFlags = "--gssapiimpl ${pkgs.krb5Full.dev}";
     meta = {
-      maintainers = teams.deshaw.members;
       description = "Perl extension providing access to the GSSAPIv2 library";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
+      maintainers = teams.deshaw.members;
     };
   };
 
@@ -9857,9 +9995,9 @@ let
     doCheck = false;
     propagatedBuildInputs = [ Pango ];
     meta = {
-      homepage = "http://gtk2-perl.sourceforge.net/";
       description = "Perl interface to the 2.x series of the Gimp Toolkit library";
-      license = lib.licenses.lgpl21Plus;
+      homepage = "http://gtk2-perl.sourceforge.net";
+      license = with lib.licenses; [ lgpl21Plus ];
     };
   };
 
@@ -9872,7 +10010,8 @@ let
     };
     propagatedBuildInputs = [ pkgs.gtk2 Gtk2 ];
     meta = {
-      license = lib.licenses.gpl2;
+      description = "(DEPRECATED) Perl interface to the EggTrayIcon library";
+      license = with lib.licenses; [ gpl2 ];
       broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.Gtk2TrayIcon.x86_64-darwin
     };
   };
@@ -9890,7 +10029,7 @@ let
     doCheck = false;
     meta = {
       description = "Perl extension for libappindicator";
-      license = lib.licenses.artistic1;
+      license = with lib.licenses; [ artistic1 ];
     };
   };
 
@@ -9909,7 +10048,7 @@ let
     doCheck = false;
     meta = {
       description = "Perl bindings for the GtkImageView widget";
-      license = lib.licenses.free;
+      license = with lib.licenses; [ free ];
     };
   };
 
@@ -9922,7 +10061,7 @@ let
     };
     propagatedBuildInputs = [ pkgs.libunique pkgs.gtk2 Gtk2 ];
     meta = {
-      description = "Use single instance applications";
+      description = "(DEPRECATED) Use single instance applications";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.Gtk2Unique.x86_64-darwin
     };
@@ -9938,8 +10077,8 @@ let
     propagatedBuildInputs = [ pkgs.gtk3 CairoGObject GlibObjectIntrospection ];
     preCheck = lib.optionalString stdenv.isDarwin "rm t/overrides.t"; # Currently failing on macOS
     meta = {
-      description = "Perl interface to the 3.x series of the GTK toolkit";
-      license = lib.licenses.lgpl21Plus;
+      description = "Perl interface to the 3.x series of the gtk+ toolkit";
+      license = with lib.licenses; [ lgpl21Plus ];
     };
   };
 
@@ -9959,6 +10098,7 @@ let
     '';
     meta = {
       description = "Image viewer widget for Gtk3";
+      homepage = "https://github.com/carygravel/gtk3-imageview";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -9973,7 +10113,8 @@ let
     propagatedBuildInputs = [ Gtk3 ];
     meta = {
       description = "A simple interface to Gtk3's complex MVC list widget";
-      license = lib.licenses.lgpl21Plus;
+      homepage = "https://github.com/soig/Gtk3-SimpleList";
+      license = with lib.licenses; [ lgpl21Plus ];
     };
   };
 
@@ -10018,8 +10159,8 @@ let
       shortenPerlShebang $out/bin/hailo
     '';
     meta = {
-      homepage = "https://github.com/hailo/hailo";
       description = "A pluggable Markov engine analogous to MegaHAL";
+      homepage = "http://hailo.org";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "hailo";
     };
@@ -10036,8 +10177,9 @@ let
     buildInputs = [ TestSimple13 ];
 
     meta = {
-      license = with lib.licenses; [ artistic1 ];
       description = "Return difference between two hashes as a hash";
+      homepage = "https://github.com/bolav/hash-diff";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -10065,6 +10207,8 @@ let
     buildInputs = [ Clone ClonePP ];
     meta = {
       description = "Merges arbitrarily deep hashes into a single hash";
+      homepage = "https://metacpan.org/release/Hash-Merge";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -10092,6 +10236,7 @@ let
     };
     meta = {
       description = "Provide the stuff missing in Hash::Util";
+      homepage = "https://metacpan.org/release/Hash-MoreUtils";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -10105,6 +10250,7 @@ let
     };
     meta = {
       description = "Store multiple values per key";
+      homepage = "https://github.com/miyagawa/Hash-MultiValue";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -10166,8 +10312,8 @@ let
     };
     buildInputs = [ pkgs.unzip ];
     meta = {
-      homepage = "https://github.com/chorny/Hook-LexWrap";
       description = "Lexically scoped subroutine wrappers";
+      homepage = "https://github.com/karenetheridge/Hook-LexWrap";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -10206,8 +10352,8 @@ let
     buildInputs = [ ModuleBuildPluggablePPPort TestRequires ];
     perlPreHook = lib.optionalString stdenv.isi686 "export LD=$CC"; # fix undefined reference to `__stack_chk_fail_local'
     meta = {
-      homepage = "https://github.com/tokuhirom/HTML-Escape";
       description = "Extremely fast HTML escaping";
+      homepage = "https://github.com/tokuhirom/HTML-Escape";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.HTMLEscape.x86_64-darwin
     };
@@ -10238,6 +10384,7 @@ let
     propagatedBuildInputs = [ HTMLParser ];
     meta = {
       description = "Class that represents an HTML form element";
+      homepage = "https://github.com/libwww-perl/HTML-Form";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -10253,6 +10400,7 @@ let
     propagatedBuildInputs = [ FontAFM HTMLTree ];
     meta = {
       description = "Base class for HTML formatters";
+      homepage = "https://metacpan.org/release/HTML-Formatter";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -10266,9 +10414,9 @@ let
     };
     propagatedBuildInputs = [ IPCRun URI constant-defer ];
     meta = {
-      homepage = "http://user42.tuxfamily.org/html-formatexternal/index.html";
       description = "HTML to text formatting using external programs";
-      license = lib.licenses.gpl3Plus;
+      homepage = "http://user42.tuxfamily.org/html-formatexternal/index.html";
+      license = with lib.licenses; [ gpl3Plus ];
     };
   };
 
@@ -10311,6 +10459,7 @@ let
     propagatedBuildInputs = [ ConfigAny DataVisitor DateTimeFormatBuilder DateTimeFormatNatural EmailValid HTMLScrubber HTMLTokeParserSimple HashFlatten JSONMaybeXS MooseXAliases MooseXAttributeChained NumberFormat PathClass Readonly RegexpCommon TaskWeaken YAMLLibYAML ];
     meta = {
       description = "HTML Form Creation, Rendering and Validation Framework";
+      homepage = "https://github.com/FormFu/HTML-FormFu";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -10325,8 +10474,8 @@ let
     propagatedBuildInputs = [ CryptCBC CryptDES HTMLFormFu ];
     meta = {
       description = "Handle multi-page/stage forms with FormFu";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
       homepage = "https://github.com/FormFu/HTML-FormFu-MultiForm";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -10372,6 +10521,7 @@ let
     propagatedBuildInputs = [ CGI CacheCache ClassContainer ExceptionClass LogAny ];
     meta = {
       description = "High-performance, dynamic web site authoring system";
+      homepage = "https://metacpan.org/release/HTML-Mason";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -10387,6 +10537,7 @@ let
     propagatedBuildInputs = [ CGIPSGI HTMLMason ];
     meta = {
       description = "PSGI handler for HTML::Mason";
+      homepage = "http://search.cpan.org/dist/HTML-Mason-PSGIHandler";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -10401,6 +10552,7 @@ let
     propagatedBuildInputs = [ HTMLTagset HTTPMessage ];
     meta = {
       description = "HTML parser class";
+      homepage = "https://github.com/libwww-perl/HTML-Parser";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -10542,8 +10694,9 @@ let
     '';
     buildInputs = [ TestException ];
     meta = {
-      description = "HTML::Tidy is an HTML checker in a handy dandy object";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      description = "(X)HTML validation in a Perl object";
+      homepage = "http://github.com/petdance/html-tidy";
+      license = with lib.licenses; [ artistic2 ];
       mainProgram = "webtidy";
     };
   };
@@ -10622,8 +10775,8 @@ let
     };
     buildInputs = [ ModuleBuildTiny ];
     meta = {
-      homepage = "https://github.com/yappo/p5-HTTP-AcceptLanguage";
       description = "Accept-Language header parser and find available language";
+      homepage = "https://github.com/yappo/p5-HTTP-AcceptLanguage";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -10656,8 +10809,8 @@ let
     doCheck = false;
     meta = {
       description = "A minimalist HTTP user agent cookie jar";
-      license = with lib.licenses; [ asl20 ];
       homepage = "https://github.com/dagolden/HTTP-CookieJar";
+      license = with lib.licenses; [ asl20 ];
     };
   };
 
@@ -10671,6 +10824,7 @@ let
     propagatedBuildInputs = [ HTTPMessage ];
     meta = {
       description = "HTTP cookie jars";
+      homepage = "https://github.com/libwww-perl/HTTP-Cookies";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -10704,6 +10858,7 @@ let
     propagatedBuildInputs = [ HTTPMessage ];
     meta = {
       description = "A simple http server class";
+      homepage = "https://github.com/libwww-perl/HTTP-Daemon";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -10718,6 +10873,7 @@ let
     propagatedBuildInputs = [ TimeDate ];
     meta = {
       description = "Date conversion routines";
+      homepage = "https://github.com/libwww-perl/HTTP-Date";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -10733,8 +10889,8 @@ let
     buildInputs = [ HTTPMessage ModuleBuildTiny ];
     meta = {
       description = "PSGI compliant HTTP Entity Parser";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
       homepage = "https://github.com/kazeburo/HTTP-Entity-Parser";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -10747,7 +10903,7 @@ let
     };
     propagatedBuildInputs = [ XMLDOM ];
     meta = {
-      description = "WebDAV client library.";
+      description = "WebDAV client library";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "dave";
     };
@@ -10776,6 +10932,7 @@ let
       sha256 = "1vs6sw431nnlnbdy6jii9vqlz30ndlfwdpdgm8a1m6fqngzhzq59";
     };
     meta = {
+      license = with lib.licenses; [ unfree ];
       broken = stdenv.isi686 || stdenv.isDarwin; # loadable library and perl binaries are mismatched (got handshake key 0x7d40080, needed 0x7dc0080)
     };
   };
@@ -10790,8 +10947,8 @@ let
     buildInputs = [ ModuleBuildTiny TestRequires ];
     propagatedBuildInputs = [ HTTPDate ];
     meta = {
-      homepage = "https://github.com/tokuhirom/HTTP-Headers-Fast";
       description = "Faster implementation of HTTP::Headers";
+      homepage = "https://github.com/tokuhirom/HTTP-Headers-Fast";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -10816,8 +10973,8 @@ let
     buildInputs = [ TryTiny ];
     propagatedBuildInputs = [ EncodeLocale HTTPDate IOHTML LWPMediaTypes URI ];
     meta = {
-      homepage = "https://github.com/libwww-perl/HTTP-Message";
       description = "HTTP style message (base class)";
+      homepage = "https://github.com/libwww-perl/HTTP-Message";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -10896,6 +11053,7 @@ let
     buildInputs = [ LWP ];
     meta = {
       description = "Adds encoding() to HTTP::Response";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -10909,6 +11067,7 @@ let
     doCheck = false;
     propagatedBuildInputs = [ CGI ];
     meta = {
+      description = "Lightweight HTTP server";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -10949,9 +11108,9 @@ let
     };
     propagatedBuildInputs = [ HTTPServerSimple ];
     meta = {
-      description = "PSGI handler for HTTP::Server::Simple";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      description = "Perl Web Server Gateway Interface Specification";
       homepage = "https://github.com/miyagawa/HTTP-Server-Simple-PSGI";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -10964,8 +11123,8 @@ let
     };
     propagatedBuildInputs = [ FileUtilTempdir Logger ];
     meta = {
-      homepage = "https://metacpan.org/release/HTTP-Tiny-Cache";
       description = "Cache HTTP::Tiny responses";
+      homepage = "https://metacpan.org/release/HTTP-Tiny-Cache";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -10980,8 +11139,8 @@ let
     };
     propagatedBuildInputs = [ FileWhich IPCRun3 ];
     meta = {
-      homepage = "https://github.com/miyagawa/HTTP-Tinyish";
       description = "HTTP::Tiny compatible HTTP client wrappers";
+      homepage = "https://github.com/miyagawa/HTTP-Tinyish";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -11008,7 +11167,7 @@ let
     };
     buildInputs = [ pkgs.libpng ];
     meta = {
-      description = "Perl interface to the C library \"libpng\"";
+      description = "Perl interface to libpng";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "pnginspect";
       broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.ImagePNGLibpng.x86_64-darwin
@@ -11025,8 +11184,8 @@ let
     buildInputs = [ pkgs.freetype pkgs.fontconfig pkgs.libjpeg pkgs.libpng ];
     makeMakerFlags = "--incpath ${pkgs.libjpeg.dev}/include --libpath ${pkgs.libjpeg.out}/lib --incpath ${pkgs.libpng.dev}/include --libpath ${pkgs.libpng.out}/lib";
     meta = {
-      homepage = "http://imager.perl.org/";
       description = "Perl extension for Generating 24 bit Images";
+      homepage = "http://imager.perl.org";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -11087,7 +11246,7 @@ let
     makeMakerFlags = "--with-jpeg-includes=${pkgs.libjpeg.dev}/include --with-jpeg-libs=${pkgs.libjpeg.out}/lib --with-png-includes=${pkgs.libpng.dev}/include --with-png-libs=${pkgs.libpng.out}/lib";
     meta = {
       description = "Fast, high-quality fixed-point image resizing";
-      license = lib.licenses.gpl2Plus;
+      license = with lib.licenses; [ gpl2Plus ];
     };
   };
 
@@ -11100,8 +11259,9 @@ let
     };
     buildInputs = [ ModuleBuild ];
     meta = {
-      description = "Read the dimensions of an image in several popular formats";
-      license = with lib.licenses; [ artistic1 lgpl21Plus ];
+      description = "A library to extract height/width from images";
+      homepage = "http://search.cpan.org/dist/Image-Size";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "imgsize";
     };
   };
@@ -11209,8 +11369,8 @@ let
       sha256 = "0nsd9knlbd7if2v6zwj4q978axq0w5hk8ymp61z14a821hjivqjl";
     };
     meta = {
-      homepage = "https://github.com/ingydotnet/io-all-pm";
       description = "IO::All of it to Graham and Damian!";
+      homepage = "https://github.com/ingydotnet/io-all-pm";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -11267,8 +11427,8 @@ let
       sha256 = "ae99009fca1273800f169ecb82f4ed1cc6c76795f156bee5c0093005d572f487";
     };
     meta = {
+      description = "(DEPRECATED) capture STDOUT and STDERR from Perl code, subprocesses or XS";
       homepage = "https://github.com/dagolden/IO-CaptureOutput";
-      description = "Capture STDOUT and STDERR from Perl code, subprocesses or XS";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -11285,6 +11445,7 @@ let
     doCheck = false && !stdenv.isDarwin;
     meta = {
       description = "IO Interface to compressed data files/buffers";
+      homepage = "https://github.com/pmqs/IO-Compress";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "streamzip";
     };
@@ -11323,6 +11484,9 @@ let
     propagatedBuildInputs = [ IOString SubExporter asa ];
     buildInputs = [ ModuleBuildTiny TestSimple13 ];
     meta = {
+      description = "Functions for working with IO::Handle like objects";
+      homepage = "https://github.com/karenetheridge/IO-Handle-Util";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -11335,7 +11499,8 @@ let
     };
     meta = {
       description = "Utilities for interactive I/O";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      homepage = "https://github.com/briandfoy/io-interactive";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -11348,7 +11513,7 @@ let
     };
     meta = {
       description = "Is_interactive() without large deps";
-      license = lib.licenses.artistic2;
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -11379,6 +11544,7 @@ let
     };
     propagatedBuildInputs = [ pkgs.more FileWhich TermReadKey ]; # `more` used in tests
     meta = {
+      description = "Select a pager (possibly perl-based) & pipe it text if a TTY";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "tp";
     };
@@ -11412,6 +11578,7 @@ let
     doCheck = false; # needs access to /dev/tty
     meta = {
       description = "Interactively prompt for user input";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -11424,7 +11591,8 @@ let
     };
     outputs = [ "out" "dev" ]; # no "devdoc"
     meta = {
-      description = "supporting module for SOAP::Lite";
+      description = "Supporting module for SOAP::Lite";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -11454,8 +11622,8 @@ let
     '';
     doCheck = false; # tries to connect to facebook.com etc.
     meta = {
-      homepage = "https://github.com/noxxi/p5-io-socket-ssl";
       description = "Nearly transparent SSL encapsulation for IO::Socket::INET";
+      homepage = "https://github.com/noxxi/p5-io-socket-ssl";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -11504,8 +11672,8 @@ let
     checkPhase = "make test";
     installPhase = "make install";
     meta = {
-      homepage = "http://wiki.github.com/toddr/IO-Stty";
       description = "Change and print terminal line settings";
+      homepage = "http://wiki.github.com/toddr/IO-Stty";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -11527,8 +11695,8 @@ let
       sha256 = "1bv9ampayf4bvyxg4ivy18l8k79jvq55x6gl68b2fg8b62w4sba0";
     };
     meta = {
-      homepage = "https://github.com/rjbs/io-tiecombine";
       description = "Produce tied (and other) separate but combined variables";
+      homepage = "https://github.com/rjbs/IO-TieCombine";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -11568,7 +11736,7 @@ let
     propagatedBuildInputs = [ GeographyCountries ];
     meta = {
       description = "Fast lookup of country codes from IP addresses";
-      license = lib.licenses.mit;
+      license = with lib.licenses; [ mit ];
       mainProgram = "ip2cc";
     };
   };
@@ -11582,7 +11750,7 @@ let
     };
     meta = {
       description = "2-letter, 3-letter, and numerical codes for countries";
-      license = lib.licenses.mit;
+      license = with lib.licenses; [ mit ];
     };
   };
 
@@ -11630,6 +11798,7 @@ let
     };
     meta = {
       description = "Run commands simply, with detailed diagnostics";
+      homepage = "http://thenceforward.net/perl/modules/IPC-System-Simple";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -11655,8 +11824,8 @@ let
       sha256 = "c7d6311eb6c79e983833c9e6b4e8d426d07a9874d20f4bc641b313b99c9bc8a0";
     };
     meta = {
-      homepage = "https://metacpan.org/release/IRC-Utils";
       description = "Common utilities for IRC-related tasks";
+      homepage = "http://metacpan.org/release/IRC-Utils";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = with maintainers; [ sgo ];
     };
@@ -11695,8 +11864,8 @@ let
     };
     buildInputs = [ TestWarn ];
     meta = {
-      homepage = "https://github.com/ingydotnet/inline-pm";
       description = "Write Perl Subroutines in Other Programming Languages";
+      homepage = "https://github.com/ingydotnet/inline-pm";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -11716,8 +11885,8 @@ let
       rm -f t/28autowrap.t
     '';
     meta = {
-      homepage = "https://github.com/ingydotnet/inline-c-pm";
       description = "C Language Support for Inline";
+      homepage = "https://github.com/ingydotnet/inline-c-pm";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -11740,8 +11909,8 @@ let
     doCheck = false;
 
     meta = {
-      description = "Inline::Java -- Write Perl classes in Java";
-      license = lib.licenses.artistic2;
+      description = "Write Perl classes in Java";
+      license = with lib.licenses; [ artistic2 ];
       broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.InlineJava.x86_64-darwin
     };
   };
@@ -11765,6 +11934,7 @@ let
     perlPreHook = lib.optionalString (stdenv.isi686 || stdenv.isDarwin) "export LD=$CC";
     meta = {
       description = "XS based JavaScript minifier";
+      homepage = "http://metacpan.org/release/JavaScript-Minifier-XS";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -11778,8 +11948,8 @@ let
     };
     meta = {
       description = "Avoid XSS with JavaScript value interpolation";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
       homepage = "https://github.com/kazeburo/JavaScript-Value-Escape";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -11810,7 +11980,8 @@ let
     };
     buildInputs = [ TestFatal TestRequires TestWarnings TestWithoutModule ];
     meta = {
-      description = "Wrapper Class for the various JSON classes";
+      description = "(DEPRECATED) Wrapper Class for the various JSON classes";
+      homepage = "https://github.com/karenetheridge/JSON-Any";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -11838,7 +12009,7 @@ let
     };
     buildInputs = [ TestNeeds ];
     meta = {
-      description = "Use L<Cpanel::JSON::XS> with a fallback to L<JSON::XS> and L<JSON::PP>";
+      description = "Use Cpanel::JSON::XS with a fallback to JSON::XS and JSON::PP";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -11878,7 +12049,7 @@ let
       sha256 = "ce8e55e70bef9bcbba2e96af631d10a605900961a22cad977e71aab56c3f2806";
     };
     meta = {
-      description = "Read JSON into a Perl variable";
+      description = "Parse JSON";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "validjson";
     };
@@ -11894,9 +12065,9 @@ let
     buildInputs = [ TestDeep ];
     propagatedBuildInputs = [ DataValidateDomain DataValidateIP Mojolicious NetIDNEncode YAMLLibYAML ];
     meta = {
-      homepage = "https://github.com/mojolicious/json-validator";
       description = "Validate data against a JSON schema";
-      license = lib.licenses.artistic2;
+      homepage = "https://github.com/mojolicious/json-validator";
+      license = with lib.licenses; [ artistic2 ];
       maintainers = [ maintainers.sgo ];
     };
   };
@@ -11911,8 +12082,8 @@ let
     buildInputs = [ TestMockGuard TestRequires ];
     propagatedBuildInputs = [ JSON ModuleRuntime ];
     meta = {
-      homepage = "https://github.com/xaicron/p5-JSON-WebToken";
       description = "JSON Web Token (JWT) implementation";
+      homepage = "https://github.com/xaicron/p5-JSON-WebToken";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -11995,7 +12166,7 @@ let
     meta = {
       description = "Transforms TeX and LaTeX into XML/HTML/MathML";
       homepage = "https://dlmf.nist.gov/LaTeXML/";
-      license = lib.licenses.publicDomain;
+      license = with lib.licenses; [ publicDomain ];
       maintainers = with maintainers; [ xworld21 ];
       mainProgram = "latexml";
     };
@@ -12087,7 +12258,7 @@ let
     '';
     doCheck = false; # test would need to start apache httpd
     meta = {
-      license = lib.licenses.asl20;
+      license = with lib.licenses; [ asl20 ];
     };
   };
 
@@ -12129,8 +12300,8 @@ let
     };
     meta = {
       description = "Add paths relative to the current file to @INC";
-      license = with lib.licenses; [ artistic2 ];
       homepage = "https://github.com/Grinnz/lib-relative";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -12153,8 +12324,8 @@ let
     };
     propagatedBuildInputs = [ LinguaENWords2Nums ];
     meta = {
-      homepage = "https://github.com/neilbowers/Lingua-EN-FindNumber";
-      description = "Locate (written) numbers in English text";
+      description = "Locate (written) numbers in English text ";
+      homepage = "https://github.com/neilb/Lingua-EN-FindNumber";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -12181,8 +12352,8 @@ let
     };
     propagatedBuildInputs = [ LinguaENInflect ];
     meta = {
-      homepage = "https://github.com/neilbowers/Lingua-EN-Inflect-Number";
       description = "Force number of words to singular or plural";
+      homepage = "https://github.com/neilbowers/Lingua-EN-Inflect-Number";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -12198,6 +12369,7 @@ let
     propagatedBuildInputs = [ LinguaENInflectNumber LinguaENNumberIsOrdinal LinguaENTagger ];
     meta = {
       description = "Inflect short English Phrases";
+      homepage = "http://metacpan.org/release/Lingua-EN-Inflect-Phrase";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -12213,6 +12385,7 @@ let
     propagatedBuildInputs = [ LinguaENFindNumber ];
     meta = {
       description = "Detect if English number is ordinal or cardinal";
+      homepage = "http://metacpan.org/release/Lingua-EN-Number-IsOrdinal";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -12227,7 +12400,7 @@ let
     propagatedBuildInputs = [ HTMLParser LinguaStem MemoizeExpireLRU ];
     meta = {
       description = "Part-of-speech tagger for English natural language processing";
-      license = lib.licenses.gpl3;
+      license = with lib.licenses; [ gpl3 ];
     };
   };
 
@@ -12240,6 +12413,7 @@ let
     };
     meta = {
       description = "Convert English text to numbers";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -12252,8 +12426,8 @@ let
     };
     meta = {
       description = "Portuguese language stemming";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
       homepage = "https://github.com/neilb/Lingua-PT-Stemmer";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -12276,6 +12450,7 @@ let
       sha256 = "0vyrspwzaqjxm5mqshf4wvwa3938mkajd1918d9ii2l9m2rn8kwx";
     };
     meta = {
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -12287,6 +12462,7 @@ let
       sha256 = "1207r183s5hlh4mfwa6p46vzm0dhvrs2dnss5s41a0gyfkxp7riq";
     };
     meta = {
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -12299,8 +12475,8 @@ let
     };
     meta = {
       description = "Porter's stemming algorithm for Russian (KOI8-R only)";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
       homepage = "https://github.com/neilb/Lingua-Stem-Ru";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -12312,6 +12488,7 @@ let
       sha256 = "0mm0m7glm1s6i9f6a78jslw6wh573208arxhq93yriqmw17bwf9f";
     };
     meta = {
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -12340,9 +12517,9 @@ let
     buildInputs = [ TestDeep ];
     propagatedBuildInputs = [ Mojolicious ];
     meta = {
-      homepage = "https://github.com/jhthorsen/linkembedder";
       description = "Embed / expand oEmbed resources and other URL / links";
-      license = lib.licenses.artistic2;
+      homepage = "https://github.com/jhthorsen/linkembedder";
+      license = with lib.licenses; [ artistic2 ];
       maintainers = with maintainers; [ sgo ];
     };
   };
@@ -12357,9 +12534,9 @@ let
     buildInputs = [ pkgs.acl ];
     NIX_CFLAGS_LINK = "-L${pkgs.acl.out}/lib -lacl";
     meta = {
-      maintainers = teams.deshaw.members;
       description = "Perl extension for reading and setting Access Control Lists for files by libacl linux library";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
+      maintainers = teams.deshaw.members;
     };
   };
 
@@ -12371,9 +12548,9 @@ let
       sha256 = "60377a74fba90fa465200ee1c7430dbdde69d454d85f9ee101c039803a07e5f5";
     };
     meta = {
-      homepage = "https://github.com/trizen/Linux-DesktopFiles";
       description = "Fast parsing of the Linux desktop files";
-      license = lib.licenses.artistic2;
+      homepage = "https://github.com/trizen/Linux-DesktopFiles";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -12450,8 +12627,9 @@ let
     };
     propagatedBuildInputs = [ ListSomeUtils ListUtilsBy ];
     meta = {
-      description = "Combines List::Util and List::MoreUtils in one bite-sized package";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      description = "Combines List::Util, List::SomeUtils and List::UtilsBy in one bite-sized package";
+      homepage = "https://metacpan.org/release/List-AllUtils";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -12473,8 +12651,8 @@ let
     };
     buildInputs = [ CaptureTiny ];
     meta = {
-      homepage = "http://thenceforward.net/perl/modules/List-Compare/";
       description = "Compare elements of two or more lists";
+      homepage = "http://thenceforward.net/perl/modules/List-Compare";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -12506,6 +12684,7 @@ let
     '';
     meta = {
       description = "Provide the stuff missing in List::Util in XS";
+      homepage = "https://metacpan.org/release/List-MoreUtils-XS";
       license = with lib.licenses; [ asl20 ];
     };
   };
@@ -12521,6 +12700,7 @@ let
     propagatedBuildInputs = [ ModuleImplementation ];
     meta = {
       description = "Provide the stuff missing in List::Util";
+      homepage = "http://metacpan.org/release/List-SomeUtils";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -12544,6 +12724,7 @@ let
     buildInputs = [ TestInter ];
     meta = {
       description = "A distribution of modules to handle locale codes";
+      homepage = "https://github.com/SBECK-github/Locale-Codes";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -12570,7 +12751,7 @@ let
     propagatedBuildInputs = [ LocaleMaketextLexicon ];
     meta = {
       description = "PO file parser for Maketext";
-      license = lib.licenses.mit;
+      license = with lib.licenses; [ mit ];
     };
   };
 
@@ -12584,7 +12765,7 @@ let
     propagatedBuildInputs = [ ConstFast MooXStrictConstructor MooXTypesMooseLike ParamsValidate namespaceautoclean ];
     buildInputs = [ TestDifferences TestException TestHexDifferences TestNoWarnings ];
     meta = {
-      description = "Locale::MO::File - Write or read gettext MO files.";
+      description = "Write or read gettext MO files";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -12598,7 +12779,7 @@ let
     };
     meta = {
       description = "Maketext from already interpolated strings";
-      license = "unrestricted";
+      license = with lib.licenses; [ free ];
     };
   };
 
@@ -12611,7 +12792,8 @@ let
     };
     meta = {
       description = "Use other catalog formats in Maketext";
-      license = "mit";
+      homepage = "http://search.cpan.org/dist/Locale-Maketext-Lexicon";
+      license = with lib.licenses; [ mit ];
       mainProgram = "xgettext.pl";
     };
   };
@@ -12639,6 +12821,7 @@ let
     propagatedBuildInputs = [ FileSlurp ];
     meta = {
       description = "Perl module for manipulating .po entries from GNU gettext";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -12750,8 +12933,8 @@ let
     # Syslog test fails.
     preCheck = "rm t/syslog.t";
     meta = {
-      homepage = "https://github.com/preaction/Log-Any";
       description = "Bringing loggers and listeners together";
+      homepage = "https://github.com/preaction/Log-Any";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -12766,8 +12949,8 @@ let
     propagatedBuildInputs = [ LogAny LogLog4perl ];
     meta = {
       description = "Log::Any adapter for Log::Log4perl";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
       homepage = "https://github.com/preaction/Log-Any-Adapter-Log4perl";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -12780,8 +12963,8 @@ let
     };
     propagatedBuildInputs = [ LogAny TryTiny ];
     meta = {
-      homepage = "https://github.com/silverdirk/perl-Log-Any-Adapter-TAP";
       description = "Logger suitable for use with TAP test files";
+      homepage = "https://github.com/silverdirk/perl-Log-Any-Adapter-TAP";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -12796,8 +12979,8 @@ let
     buildInputs = [ TestFatal ];
     propagatedBuildInputs = [ DataDumperConcise ExporterDeclare Moo ];
     meta = {
-      homepage = "https://github.com/frioux/Log-Contextual";
       description = "Simple logging interface with a contextual log";
+      homepage = "https://github.com/frioux/Log-Contextual";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -12813,7 +12996,8 @@ let
     buildInputs = [ IPCRun3 TestFatal TestNeeds ];
     meta = {
       description = "Dispatches messages to one or more outputs";
-      license = lib.licenses.artistic2;
+      homepage = "https://metacpan.org/release/Log-Dispatch";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -12828,6 +13012,7 @@ let
     buildInputs = [ PathTiny TestWarn ];
     meta = {
       description = "Log to Files that Archive/Rotate Themselves";
+      homepage = "https://github.com/mschout/perl-log-dispatch-filerotate";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -12840,8 +13025,8 @@ let
       sha256 = "0f5078g8lkyw09ijpz7dna5xw6yvpd0m283fdrw3s152xmr43qn2";
     };
     meta = {
-      homepage = "https://metacpan.org/release/Log-ger";
       description = "A lightweight, flexible logging framework";
+      homepage = "https://metacpan.org/release/Log-ger";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -12906,8 +13091,8 @@ let
     };
     meta = {
       description = "Many-Core Engine for Perl providing parallel processing capabilities";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
       homepage = "https://github.com/marioroy/mce-perl";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -12919,8 +13104,8 @@ let
       sha256 = "13n39byny3yif3x6nrj9iriw8jhbhxqavwrrlm277v3f066v9gwg";
     };
     meta = {
-      homepage = "https://mschilli.github.io/log4perl/";
       description = "Log4j implementation for Perl";
+      homepage = "https://mschilli.github.io/log4perl/";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "l4p-tmpl";
     };
@@ -12936,8 +13121,8 @@ let
     buildInputs = [ TestDeep ];
     propagatedBuildInputs = [ LogDispatch ];
     meta = {
-      homepage = "https://github.com/rjbs/log-dispatch-array";
       description = "Log events to an array (reference)";
+      homepage = "https://github.com/rjbs/Log-Dispatch-Array";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -12952,8 +13137,8 @@ let
     buildInputs = [ TestDeep TestFatal ];
     propagatedBuildInputs = [ LogDispatchArray StringFlogger SubExporterGlobExporter ];
     meta = {
-      homepage = "https://github.com/rjbs/Log-Dispatchouli";
       description = "A simple wrapper around Log::Dispatch";
+      homepage = "https://github.com/rjbs/Log-Dispatchouli";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -13048,6 +13233,7 @@ let
     buildInputs = [ TestFatal ];
     meta = {
       description = "Guess media type for a file or a URL";
+      homepage = "https://github.com/libwww-perl/lwp-mediatypes";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -13080,6 +13266,7 @@ let
     buildInputs = [ TestRequiresInternet ];
     meta = {
       description = "Provide https support for LWP::UserAgent";
+      homepage = "https://github.com/libwww-perl/LWP-Protocol-https";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -13123,8 +13310,8 @@ let
     buildInputs = [ ModuleBuildTiny TestFakeHTTPD TestSharedFork TestTCP TestUseAllModules ];
     meta = {
       description = "Override LWP HTTP/HTTPS request's host like /etc/hosts";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
       homepage = "https://github.com/masaki/p5-LWP-UserAgent-DNS-Hosts";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -13138,6 +13325,7 @@ let
     propagatedBuildInputs = [ LWP ];
     meta = {
       description = "A virtual browser that retries errors";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -13223,9 +13411,9 @@ let
     buildInputs = [ FileSlurper TestCompile TestPod TestPodCoverage TextDiff UNIVERSALrequire URI ];
     propagatedBuildInputs = [ FileHandleUnget ];
     meta = {
-      homepage = "https://github.com/coppit/mail-mbox-messageparser";
       description = "A fast and simple mbox folder reader";
-      license = lib.licenses.gpl2;
+      homepage = "https://github.com/coppit/mail-mbox-messageparser";
+      license = with lib.licenses; [ gpl2 ];
       maintainers = with maintainers; [ romildo ];
     };
   };
@@ -13240,6 +13428,7 @@ let
     propagatedBuildInputs = [ IOStringy MIMETypes MailTools URI UserIdentity ];
     meta = {
       description = "Processing MIME messages";
+      homepage = "http://perl.overmeer.net/CPAN";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -13296,8 +13485,8 @@ let
       sha256 = "4413eb49f520a8318151811ccb05a8d542973aada20aa503ad32f9ffc98a39bf";
     };
     meta = {
-      homepage = "https://github.com/Perl-Email-Project/Mail-Sender";
       description = "(DEPRECATED) module for sending mails with attachments through an SMTP server";
+      homepage = "https://github.com/Perl-Email-Project/Mail-Sender";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -13317,9 +13506,10 @@ let
       perl -I blib/lib -MMail::Sendmail -e 'print "1..1\nok 1\n"'
     '';
     meta = {
-      maintainers = teams.deshaw.members;
       description = "Simple platform independent mailer";
+      homepage = "https://github.com/neilb/Mail-Sendmail";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
+      maintainers = teams.deshaw.members;
     };
   };
 
@@ -13340,7 +13530,7 @@ let
     doCheck = false; # The main test performs network access
     meta = {
       description = "An object-oriented implementation of Sender Policy Framework";
-      license = lib.licenses.bsd3;
+      license = with lib.licenses; [ bsd3 ];
       mainProgram = "spfquery";
     };
   };
@@ -13355,7 +13545,8 @@ let
     };
     propagatedBuildInputs = [ TimeDate ];
     meta = {
-      description = "Various e-mail related modules";
+      description = "Various ancient e-mail related modules";
+      homepage = "http://perl.overmeer.net/CPAN";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -13370,6 +13561,7 @@ let
     propagatedBuildInputs = [ MailMessage ];
     meta = {
       description = "Email message exchange";
+      homepage = "http://perl.overmeer.net/CPAN";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -13414,9 +13606,9 @@ let
     };
     buildInputs = [ TestNeeds ];
     meta = {
-      homepage = "https://github.com/Grinnz/Math-Calc-Parser";
       description = "Parse and evaluate mathematical expressions";
-      license = lib.licenses.artistic2;
+      homepage = "https://github.com/Grinnz/Math-Calc-Parser";
+      license = with lib.licenses; [ artistic2 ];
       maintainers = with maintainers; [ sgo ];
     };
   };
@@ -13504,7 +13696,7 @@ let
     };
     meta = {
       description = "This module provides a few functions related to Fibonacci numbers";
-      license = lib.licenses.artistic2;
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -13534,8 +13726,8 @@ let
     buildInputs = [ pkgs.gmp ];
     NIX_CFLAGS_LINK = "-L${pkgs.gmp.out}/lib -lgmp";
     meta = {
-      homepage = "https://github.com/sisyphus/math-gmpz";
       description = "Perl interface to the GMP integer functions";
+      homepage = "https://github.com/sisyphus/math-gmpz";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = with maintainers; [ sgo ];
     };
@@ -13561,6 +13753,7 @@ let
     propagatedBuildInputs = [ MathInt64 ];
     meta = {
       description = "Manipulate 128 bits integers in Perl";
+      homepage = "http://metacpan.org/release/Math-Int128";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       broken = stdenv.is32bit; # compiler doesn't support a 128-bit integer type
     };
@@ -13575,6 +13768,7 @@ let
     };
     meta = {
       description = "Manipulate 64 bits integers in Perl";
+      homepage = "http://metacpan.org/release/Math-Int64";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -13600,7 +13794,7 @@ let
     };
     meta = {
       description = "Perl interface to PARI";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [ artistic1 gpl1Plus gpl2 ];
     };
   };
 
@@ -13625,8 +13819,8 @@ let
     propagatedBuildInputs = [ MathPrimeUtilGMP ];
     buildInputs = [ TestWarn ];
     meta = {
-      homepage = "https://github.com/danaj/Math-Prime-Util";
       description = "Utilities related to prime numbers, including fast sieves and factoring";
+      homepage = "https://github.com/danaj/Math-Prime-Util";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -13643,8 +13837,8 @@ let
     NIX_CFLAGS_COMPILE = "-I${pkgs.gmp.dev}/include";
     NIX_CFLAGS_LINK = "-L${pkgs.gmp.out}/lib -lgmp";
     meta = {
-      homepage = "https://github.com/danaj/Math-Prime-Util-GMP";
       description = "Utilities related to prime numbers, using GMP";
+      homepage = "https://github.com/danaj/Math-Prime-Util-GMP";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -13674,6 +13868,7 @@ let
       sha256 = "0k15pk2qx9wrp5xqzhymm1ph4nb314ysrsyr0pjnvn8ii0r241dy";
     };
     meta = {
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -13687,6 +13882,7 @@ let
     buildInputs = [ TestNoWarnings ];
     meta = {
       description = "Perl interface to the ISAAC PRNG algorithm";
+      homepage = "http://search.cpan.org/dist/Math-Random-ISAAC";
       license = with lib.licenses; [ publicDomain mit artistic2 gpl3 ];
     };
   };
@@ -13701,7 +13897,7 @@ let
     propagatedBuildInputs = [ ObjectInsideOut ];
     meta = {
       description = "Auto-seeded Mersenne Twister PRNGs";
-      license = "unrestricted";
+      license = with lib.licenses; [ free ];
     };
   };
 
@@ -13716,7 +13912,8 @@ let
     propagatedBuildInputs = [ CryptRandomSource MathRandomISAAC ];
     meta = {
       description = "Cryptographically-secure, cross-platform replacement for rand()";
-      license = lib.licenses.artistic2;
+      homepage = "https://github.com/frioux/Math-Random-Secure";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -13748,6 +13945,7 @@ let
     propagatedBuildInputs = [ DataDumperConcise DateTime ListAllUtils MooXStrictConstructor ];
     meta = {
       description = "Code shared by the MaxMind DB reader and writer modules";
+      homepage = "http://metacpan.org/release/MaxMind-DB-Common";
       license = with lib.licenses; [ artistic2 ];
     };
   };
@@ -13763,6 +13961,7 @@ let
     buildInputs = [ PathClass TestBits TestFatal TestNumberDelta TestRequires ];
     meta = {
       description = "Read MaxMind DB files and look up IP addresses";
+      homepage = "http://metacpan.org/release/MaxMind-DB-Reader";
       license = with lib.licenses; [ artistic2 ];
     };
   };
@@ -13778,6 +13977,7 @@ let
     buildInputs = [ NetWorks PathClass TestFatal TestNumberDelta TestRequires ];
     meta = {
       description = "Fast XS implementation of MaxMind DB reader";
+      homepage = "http://metacpan.org/release/MaxMind-DB-Reader-XS";
       license = with lib.licenses; [ artistic2 ];
       broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.MaxMindDBReaderXS.x86_64-darwin
     };
@@ -13795,6 +13995,7 @@ let
     hardeningDisable = [ "format" ];
     meta = {
       description = "Create MaxMind DB database files";
+      homepage = "http://metacpan.org/release/MaxMind-DB-Writer";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.MaxMindDBWriter.x86_64-darwin
     };
@@ -13818,8 +14019,8 @@ let
     };
     meta = {
       description = "Expiry plug-in for Memoize that adds LRU cache expiration";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
       homepage = "https://github.com/neilb/Memoize-ExpireLRU";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -13832,8 +14033,8 @@ let
     };
     propagatedBuildInputs = [ CPANCommonIndex CPANMetaCheck CaptureTiny ExtUtilsHelpers ExtUtilsInstallPaths Filepushd HTTPTinyish ModuleCPANfile ParsePMFile StringShellQuote Win32ShellQuote locallib ];
     meta = {
-      homepage = "https://github.com/miyagawa/cpanminus";
       description = "A CPAN client";
+      homepage = "https://github.com/miyagawa/cpanminus";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -13847,8 +14048,8 @@ let
     };
     propagatedBuildInputs = [ Menlo ];
     meta = {
-      homepage = "https://github.com/miyagawa/cpanminus";
       description = "Legacy internal and client support for Menlo";
+      homepage = "https://github.com/miyagawa/cpanminus";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -13885,8 +14086,8 @@ let
     buildInputs = [ LWPProtocolHttps TestFatal TestNeeds ];
     propagatedBuildInputs = [ IOSocketSSL JSONMaybeXS Moo RefUtil SafeIsa TypeTiny URI ];
     meta = {
-      homepage = "https://github.com/metacpan/metacpan-client";
       description = "A comprehensive, DWIM-featured client to the MetaCPAN API";
+      homepage = "https://github.com/metacpan/metacpan-client";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = with maintainers; [ sgo ];
     };
@@ -13915,7 +14116,7 @@ let
     };
     buildInputs = [ TestFatal ];
     meta = {
-      description = "abstract collection of monitoring metrics";
+      description = "Abstract collection of monitoring metrics";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -13981,8 +14182,8 @@ let
     };
     propagatedBuildInputs = [ MIMECharset ];
     meta = {
-      homepage = "https://metacpan.org/pod/MIME::EncWords";
       description = "Deal with RFC 2047 encoded words (improved)";
+      homepage = "https://metacpan.org/pod/MIME::EncWords";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -14027,7 +14228,7 @@ let
     propagatedBuildInputs = [ MailTools ];
     buildInputs = [ TestDeep ];
     meta = {
-      description = "class for parsed-and-decoded MIME message";
+      description = "Tools to manipulate MIME messages";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -14041,6 +14242,7 @@ let
     };
     meta = {
       description = "Definition of MIME types";
+      homepage = "http://perl.overmeer.net/CPAN";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -14054,9 +14256,9 @@ let
     };
     propagatedBuildInputs = [ Mojolicious YAMLLibYAML ];
     meta = {
-      homepage = "https://github.com/mojolicious/minion";
       description = "A high performance job queue for Perl";
-      license = lib.licenses.artistic2;
+      homepage = "https://github.com/mojolicious/minion";
+      license = with lib.licenses; [ artistic2 ];
       maintainers = [ maintainers.sgo ];
     };
   };
@@ -14071,9 +14273,9 @@ let
     buildInputs = [ ModuleBuildTiny ];
     propagatedBuildInputs = [ Minion MojoSQLite ];
     meta = {
-      homepage = "https://github.com/Grinnz/Minion-Backend-SQLite";
       description = "SQLite backend for Minion job queue";
-      license = lib.licenses.artistic2;
+      homepage = "https://github.com/Grinnz/Minion-Backend-SQLite";
+      license = with lib.licenses; [ artistic2 ];
       maintainers = [ maintainers.sgo ];
     };
   };
@@ -14088,8 +14290,8 @@ let
     buildInputs = [ Testmysqld ];
     propagatedBuildInputs = [ Minion Mojomysql ];
     meta = {
+      description = "MySQL backend for the Minion job queue";
       homepage = "https://github.com/preaction/Minion-Backend-mysql";
-      description = "MySQL backend for Minion job queue";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -14104,8 +14306,8 @@ let
     };
     propagatedBuildInputs = [ PerlIOutf8_strict SubExporter ];
     meta = {
-      homepage = "https://github.com/rjbs/mixin-linewise";
       description = "Write your linewise code for handles; this does the rest";
+      homepage = "https://github.com/rjbs/Mixin-Linewise";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -14133,7 +14335,7 @@ let
       sha256 = "1fff81awg9agfawf3wxx0gpf6vgav8w920rmxsbjg30z75943lli";
     };
     meta = {
-      description = "Micro Objects. Mo is less.";
+      description = "Micro Objects. Mo is less";
       homepage = "https://github.com/ingydotnet/mo-pm";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "mo-inline";
@@ -14148,8 +14350,8 @@ let
       sha256 = "06q0xkg5cwdwafzmb9rkaa305ddv7vli9gpm6n9jnkyaaxbk9f55";
     };
     meta = {
-      description = "temporarily set Config or XSConfig values";
-      license = with lib.licenses; [ artistic1 gpl1Plus artistic2 ];
+      description = "Temporarily set Config or XSConfig values";
+      license = with lib.licenses; [ artistic1 gpl1Plusartistic1 gpl1Plus  artistic2 ];
     };
   };
 
@@ -14162,8 +14364,8 @@ let
       sha256 = "da1c83cee84fab9edb9e31d7f7abac43e1337b2e66015191ec4b6da59298c480";
     };
     meta = {
-      homepage = "https://github.com/chromatic/Modern-Perl";
       description = "Enable all of the features of Modern Perl with one import";
+      homepage = "https://github.com/chromatic/Modern-Perl";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -14178,8 +14380,8 @@ let
     buildInputs = [ ModuleBuildTiny ModuleCPANfile Test2Suite ];
     propagatedBuildInputs = [ YAMLPP ];
     meta = {
-      homepage = "https://github.com/skaji/cpmfile";
       description = "Parse cpmfile";
+      homepage = "https://github.com/skaji/cpmfile";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.zakame ];
     };
@@ -14223,8 +14425,8 @@ let
     propagatedBuildInputs = [ ClassAccessorLite ClassMethodModifiers DataOptList ];
     buildInputs = [ TestSharedFork ];
     meta = {
-      homepage = "https://github.com/tokuhirom/Module-Build-Pluggable";
       description = "Module::Build meets plugins";
+      homepage = "https://github.com/tokuhirom/Module-Build-Pluggable";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -14239,8 +14441,8 @@ let
     buildInputs = [ CaptureTiny TestRequires TestSharedFork ];
     propagatedBuildInputs = [ ModuleBuildPluggable ModuleCPANfile ];
     meta = {
-      homepage = "https://github.com/kazeburo/Module-Build-Pluggable-CPANfile";
       description = "Include cpanfile";
+      homepage = "https://github.com/kazeburo/Module-Build-Pluggable-CPANfile";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -14297,6 +14499,7 @@ let
     perlPreHook = "export LD=$CC";
     meta = {
       description = "A Module::Build class for building XS modules";
+      homepage = "https://github.com/hideo55/Module-Build-XSUtil";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -14310,8 +14513,8 @@ let
     };
     propagatedBuildInputs = [ CaptureTiny DigestSHA1 ];
     meta = {
-      homepage = "https://github.com/ingydotnet/module-compile-pm";
       description = "Perl Module Compilation";
+      homepage = "https://github.com/ingydotnet/module-compile-pm";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -14327,8 +14530,8 @@ let
     buildInputs = [ ExtUtilsMakeMakerCPANfile TestFailWarnings ];
     meta = {
       description = "Generate Kwalitee ratings for a distribution";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
       homepage = "https://cpants.cpanauthors.org";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -14342,8 +14545,8 @@ let
     buildInputs = [ Filepushd ];
     meta = {
       description = "Parse cpanfile";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
       homepage = "https://github.com/miyagawa/cpanfile";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -14386,7 +14589,8 @@ let
     propagatedBuildInputs = [ ModuleRuntime TryTiny ];
     meta = {
       description = "Loads one of several alternate underlying implementations for a module";
-      license = lib.licenses.artistic2;
+      homepage = "http://metacpan.org/release/Module-Implementation";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -14458,8 +14662,8 @@ let
     buildInputs = [ CaptureTiny ];
     propagatedBuildInputs = [ ModuleInstall ];
     meta = {
-      homepage = "https://github.com/bingos/module-install-githubmeta/";
       description = "A Module::Install extension to include GitHub meta information in META.yml";
+      homepage = "https://github.com/bingos/module-install-githubmeta";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -14475,8 +14679,8 @@ let
     buildInputs = [ TestInDistDir ];
     propagatedBuildInputs = [ CaptureTiny IOAll ModuleInstall PodMarkdown ];
     meta = {
-      homepage = "https://github.com/bingos/module-install-readmefrompod/";
       description = "A Module::Install extension to automatically convert POD to a README";
+      homepage = "https://github.com/bingos/module-install-readmefrompod";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -14492,8 +14696,8 @@ let
     buildInputs = [ URI ];
     propagatedBuildInputs = [ ModuleInstall PodMarkdown ];
     meta = {
-      homepage = "http://search.cpan.org/dist/Module-Install-ReadmeMarkdownFromPod/";
       description = "Create README.mkdn from POD";
+      homepage = "http://search.cpan.org/dist/Module-Install-ReadmeMarkdownFromPod";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -14540,6 +14744,7 @@ let
     propagatedBuildInputs = [ ParamsUtil ];
     meta = {
       description = "Parse and examine a Perl distribution MANIFEST file";
+      homepage = "https://github.com/karenetheridge/Module-Manifest";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -14553,8 +14758,8 @@ let
     };
     buildInputs = [ DevelFindPerl ];
     meta = {
-      homepage = "https://github.com/neilbowers/Module-Path";
       description = "Get the full path to a locally installed module";
+      homepage = "https://github.com/neilbowers/Module-Path";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "mpath";
     };
@@ -14624,8 +14829,8 @@ let
     };
     propagatedBuildInputs = [ DistCheckConflicts ];
     meta = {
-      homepage = "https://github.com/karenetheridge/Module-Runtime-Conflicts";
       description = "Provide information on conflicts for Module::Runtime";
+      homepage = "https://github.com/karenetheridge/Module-Runtime-Conflicts";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -14655,7 +14860,7 @@ let
     buildInputs = [ IPCRun ];
     meta = {
       description = "Module signature file manipulation";
-      license = lib.licenses.cc0;
+      license = with lib.licenses; [ cc0 ];
       mainProgram = "cpansign";
     };
   };
@@ -14706,8 +14911,8 @@ let
     };
     meta = {
       description = "Minimalistic HTML/XML DOM parser with CSS selectors";
-      license = with lib.licenses; [ artistic2 ];
       homepage = "https://github.com/Grinnz/Mojo-DOM58";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -14729,8 +14934,7 @@ let
     doCheck = false; # would try to start Apache HTTP server
     passthru.tests = nixosTests.mod_perl;
     meta = {
-      description = "Embed a Perl interpreter in the Apache HTTP server";
-      license = lib.licenses.asl20;
+      license = with lib.licenses; [ asl20 ];
       mainProgram = "mp2bug";
     };
   };
@@ -14743,9 +14947,9 @@ let
       sha256 = "sha256-nkKMVRJpjwXhUTONj6Eq7eKHqzpeQp7D04yApKgsjYg=";
     };
     meta = {
-      homepage = "https://mojolicious.org";
       description = "Real-time web framework";
-      license = lib.licenses.artistic2;
+      homepage = "https://mojolicious.org";
+      license = with lib.licenses; [ artistic2 ];
       maintainers = with maintainers; [ thoughtpolice sgo ];
       mainProgram = "mojo";
     };
@@ -14760,9 +14964,9 @@ let
     };
     propagatedBuildInputs = [ FileWhich IPCRun3 Mojolicious ];
     meta = {
-      homepage = "https://github.com/jhthorsen/mojolicious-plugin-assetpack";
       description = "Compress and convert css, less, sass, javascript and coffeescript files";
-      license = lib.licenses.artistic2;
+      homepage = "https://github.com/jhthorsen/mojolicious-plugin-assetpack";
+      license = with lib.licenses; [ artistic2 ];
       maintainers = with maintainers; [ sgo ];
     };
   };
@@ -14791,8 +14995,8 @@ let
     };
     propagatedBuildInputs = [ MIMEEncWords MIMELite Mojolicious ];
     meta = {
-      homepage = "https://github.com/sharifulin/Mojolicious-Plugin-Mail";
       description = "Mojolicious Plugin for send mail";
+      homepage = "https://github.com/sharifulin/Mojolicious-Plugin-Mail";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -14807,9 +15011,9 @@ let
     };
     propagatedBuildInputs = [ JSONValidator ];
     meta = {
-      homepage = "https://github.com/jhthorsen/mojolicious-plugin-openapi";
       description = "OpenAPI / Swagger plugin for Mojolicious";
-      license = lib.licenses.artistic2;
+      homepage = "https://github.com/jhthorsen/mojolicious-plugin-openapi";
+      license = with lib.licenses; [ artistic2 ];
       maintainers = [ maintainers.sgo ];
     };
   };
@@ -14823,8 +15027,8 @@ let
     };
     propagatedBuildInputs = [ BSDResource CpanelJSONXS FileMap Mojolicious Sereal ];
     meta = {
-      homepage = "https://github.com/mojolicious/mojo-status";
-      description = "Mojolicious server status plugin";
+      description = "Mojolicious server status";
+      homepage = "https://mojolicious.org";
       license = with lib.licenses; [ artistic2 ];
       maintainers = [ maintainers.thoughtpolice ];
     };
@@ -14839,9 +15043,9 @@ let
     };
     propagatedBuildInputs = [ Mojolicious ];
     meta = {
-      homepage = "https://github.com/jhthorsen/mojolicious-plugin-syslog";
       description = "A plugin for enabling a Mojolicious app to log to syslog";
-      license = lib.licenses.artistic2;
+      homepage = "https://github.com/jhthorsen/mojolicious-plugin-syslog";
+      license = with lib.licenses; [ artistic2 ];
       maintainers = [ maintainers.sgo ];
     };
   };
@@ -14855,9 +15059,9 @@ let
     };
     propagatedBuildInputs = [ Mojolicious ];
     meta = {
-      homepage = "https://github.com/marcusramberg/mojolicious-plugin-textexceptions";
       description = "Render exceptions as text in command line user agents";
-      license = lib.licenses.artistic2;
+      homepage = "https://github.com/marcusramberg/mojolicious-plugin-textexceptions";
+      license = with lib.licenses; [ artistic2 ];
       maintainers = [ maintainers.sgo ];
     };
   };
@@ -14871,10 +15075,10 @@ let
     };
     propagatedBuildInputs = [ Mojolicious Filechdir ];
     meta = {
-      homepage = "https://github.com/jhthorsen/mojolicious-plugin-webpack";
       description = "Mojolicious <3 Webpack";
-      license = lib.licenses.artistic2;
-      maintainers = with maintainers; [ sgo ];
+      homepage = "https://github.com/jhthorsen/mojolicious-plugin-webpack";
+      license = with lib.licenses; [ artistic2 ];
+      maintainers = [ maintainers.sgo ];
     };
   };
 
@@ -14887,9 +15091,9 @@ let
     };
     propagatedBuildInputs = [ Mojolicious ProtocolRedisFaster ];
     meta = {
-      homepage = "https://github.com/jhthorsen/mojo-redis";
       description = "Redis driver based on Mojo::IOLoop";
-      license = lib.licenses.artistic2;
+      homepage = "https://github.com/jhthorsen/mojo-redis";
+      license = with lib.licenses; [ artistic2 ];
       maintainers = [ maintainers.sgo ];
     };
   };
@@ -14920,9 +15124,9 @@ let
     buildInputs = [ ModuleBuildTiny ];
     propagatedBuildInputs = [ DBDSQLite Mojolicious SQLAbstract URIdb ];
     meta = {
-      homepage = "https://github.com/Grinnz/Mojo-SQLite";
       description = "A tiny Mojolicious wrapper for SQLite";
-      license = lib.licenses.artistic2;
+      homepage = "https://github.com/Grinnz/Mojo-SQLite";
+      license = with lib.licenses; [ artistic2 ];
       maintainers = [ maintainers.sgo ];
     };
   };
@@ -14937,9 +15141,9 @@ let
     propagatedBuildInputs = [ DBDmysql Mojolicious SQLAbstract ];
     buildInputs = [ TestDeep ];
     meta = {
-      homepage = "https://github.com/jhthorsen/mojo-mysql";
       description = "Mojolicious and Async MySQL/MariaDB";
-      license = lib.licenses.artistic2;
+      homepage = "https://github.com/jhthorsen/mojo-mysql";
+      license = with lib.licenses; [ artistic2 ];
       maintainers = [ maintainers.sgo ];
     };
   };
@@ -14954,9 +15158,9 @@ let
     buildInputs = [ ModuleBuildTiny ];
     propagatedBuildInputs = [ Mojolicious ];
     meta = {
-      homepage = "https://github.com/jberger/Mojo-IOLoop-Delay";
       description = "(DISCOURAGED) Promises/A+ and flow-control helpers";
-      license = lib.licenses.artistic2;
+      homepage = "https://github.com/jberger/Mojo-IOLoop-Delay";
+      license = with lib.licenses; [ artistic2 ];
       maintainers = [ maintainers.zakame ];
     };
   };
@@ -14975,8 +15179,8 @@ let
         --replace "use Mojo::IOLoop;" "use Mojo::IOLoop; use Mojo::IOLoop::Delay;"
     '';
     meta = {
+      description = "(DEPRECATED) run blocking functions asynchronously by forking";
       homepage = "https://github.com/jberger/Mojo-IOLoop-ForkCall";
-      description = "Run blocking functions asynchronously by forking (deprecated)";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.zakame ];
     };
@@ -14992,8 +15196,8 @@ let
     buildInputs = [ ModuleBuildTiny ];
     propagatedBuildInputs = [ Mojolicious ];
     meta = {
-      homepage = "https://github.com/jberger/Mojo-JWT";
       description = "JSON Web Token the Mojo way";
+      homepage = "https://github.com/jberger/Mojo-JWT";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -15009,9 +15213,9 @@ let
     propagatedBuildInputs = [ DBDPg Mojolicious SQLAbstractPg ];
     buildInputs = [ TestDeep ];
     meta = {
-      homepage = "https://github.com/mojolicious/mojo-pg";
-      description = "Mojolicious <3 PostgreSQL";
-      license = lib.licenses.artistic2;
+      description = "Mojolicious ♥ PostgreSQL";
+      homepage = "https://mojolicious.org";
+      license = with lib.licenses; [ artistic2 ];
       maintainers = [ maintainers.sgo ];
     };
   };
@@ -15027,8 +15231,8 @@ let
     propagatedBuildInputs = [ AlgorithmLCSS CHI DataSerializer DevelStackTrace Mojolicious Readonly StringTruncate ];
     doCheck = !stdenv.isDarwin;
     meta = {
-      homepage = "https://github.com/nicomen/mojo-useragent-cached";
       description = "Caching, Non-blocking I/O HTTP, Local file and WebSocket user agent";
+      homepage = "https://github.com/nicomen/mojo-useragent-cached";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -15044,9 +15248,9 @@ let
     buildInputs = [ JSONMaybeXS PathTiny TestDeep TestFatal TimeMoment ];
     propagatedBuildInputs = [ AuthenSASLSASLprep AuthenSCRAM BSON IOSocketSSL NetSSLeay ClassXSAccessor BSONXS TypeTinyXS MozillaCA Moo NetDNS SafeIsa SubQuote TieIxHash TypeTiny UUIDURandom boolean namespaceclean ];
     meta = {
-      homepage = "https://github.com/mongodb-labs/mongo-perl-driver";
       description = "Official MongoDB Driver for Perl (EOL)";
-      license = lib.licenses.asl20;
+      homepage = "https://github.com/mongodb-labs/mongo-perl-driver";
+      license = with lib.licenses; [ asl20 ];
     };
   };
 
@@ -15071,7 +15275,8 @@ let
       sha256 = "e33b6cf5cb2b46ee308513f51e623987a50a89901e81bf19701dce35179f2e74";
     };
     meta = {
-      description = "Portably create pipe() or pipe-like handles";
+      description = "Portably create pipe() or pipe-like handles, one way or another";
+      homepage = "http://search.cpan.org/dist/IO-Pipely";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15104,8 +15309,8 @@ let
       export LD=$CC
     '';
     meta = {
-      homepage = "http://moose.perl.org/";
       description = "A postmodern object system for Perl 5";
+      homepage = "http://moose.perl.org";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.eelco ];
       mainProgram = "moose-outdated";
@@ -15136,7 +15341,8 @@ let
     };
     propagatedBuildInputs = [ Moo ];
     meta = {
-      description = "provide API used in translator modules without translating";
+      description = "Provide API used in translator modules without translating";
+      homepage = "https://metacpan.org/release/MooX-Locale-Passthrough";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15150,7 +15356,8 @@ let
     };
     propagatedBuildInputs = [ LocaleTextDomainOO MooXLocalePassthrough ];
     meta = {
-      description = "provide API used in translator modules without translating";
+      description = "Provide API used in translator modules without translating";
+      homepage = "https://metacpan.org/release/MooX-Locale-TextDomain-OO";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15167,6 +15374,7 @@ let
     preCheck = "rm t/16-namespace_clean.t"; # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=942275
     meta = {
       description = "Explicit Options eXtension for Object Class";
+      homepage = "https://metacpan.org/celogeek/MooX-Options";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15181,7 +15389,8 @@ let
     propagatedBuildInputs = [ RoleTiny ];
     buildInputs = [ Moo ];
     meta = {
-      description = "turn your Moo class into singleton";
+      description = "Turn your Moo class into singleton";
+      homepage = "http://search.cpan.org/dist/MooX-Singleton";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15196,7 +15405,8 @@ let
     propagatedBuildInputs = [ Moo strictures ];
     buildInputs = [ TestFatal ];
     meta = {
-      description = "Make your Moo-based object constructors blow up on unknown attributes.";
+      description = "Make your Moo-based object constructors blow up on unknown attributes";
+      homepage = "https://metacpan.org/release/MooX-StrictConstructor";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15237,7 +15447,8 @@ let
     buildInputs = [ TestFatal ];
     propagatedBuildInputs = [ Moo TypeTiny ];
     meta = {
-      description = "Optimized type checks for Moo + Type::Tiny";
+      description = "Tiny, yet Moo(se)-compatible type constraint";
+      homepage = "https://typetiny.toby.ink";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15253,6 +15464,7 @@ let
     propagatedBuildInputs = [ ListMoreUtils Moose SyntaxKeywordJunction autobox namespaceautoclean ];
     meta = {
       description = "Autoboxed wrappers for Native Perl datatypes";
+      homepage = "https://github.com/moose/Moose-Autobox";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15268,6 +15480,7 @@ let
     propagatedBuildInputs = [ Moose ];
     meta = {
       description = "Abstract base classes for Moose";
+      homepage = "http://metacpan.org/release/MooseX-ABC";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15293,8 +15506,8 @@ let
     buildInputs = [ ModuleBuildTiny MooseXConfigFromFile TestOutput YAML ];
     propagatedBuildInputs = [ AppCmd MooseXGetopt MooseXNonMoose ];
     meta = {
-      homepage = "https://github.com/moose/MooseX-App-Cmd";
       description = "Mashes up MooseX::Getopt and App::Cmd";
+      homepage = "https://github.com/moose/MooseX-App-Cmd";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15309,8 +15522,8 @@ let
     buildInputs = [ Moose TestDeepJSON TestWithoutModule DigestHMAC MooseXTypes ];
     propagatedBuildInputs = [ JSON MooseXRoleParameterized MooseXStorage namespaceautoclean ];
     meta = {
-      homepage = "https://github.com/rjbs/MooseX-Storage-Format-JSONpm";
       description = "A format role for MooseX::Storage using JSON.pm";
+      homepage = "https://github.com/rjbs/MooseX-Storage-Format-JSONpm";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15324,8 +15537,8 @@ let
     };
     propagatedBuildInputs = [ DataOptList ImportInto Moo ];
     meta = {
-      homepage = "https://github.com/Getty/p5-moox";
       description = "Using Moo and MooX:: packages the most lazy way";
+      homepage = "https://github.com/Getty/p5-moox";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15340,7 +15553,7 @@ let
     propagatedBuildInputs = [ Moo strictures ];
     buildInputs = [ TestFatal ];
     meta = {
-      description = "easy aliasing of methods and attributes in Moo";
+      description = "Easy aliasing of methods and attributes in Moo";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15356,6 +15569,7 @@ let
     buildInputs = [ CaptureTiny ];
     meta = {
       description = "Giving an easy Moo style way to make command organized CLI apps";
+      homepage = "https://metacpan.org/release/MooX-Cmd";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15371,6 +15585,7 @@ let
     propagatedBuildInputs = [ Moo SubHandlesVia ];
     meta = {
       description = "Easily translate Moose code to Moo";
+      homepage = "https://metacpan.org/release/MooX-late";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15402,8 +15617,8 @@ let
     makeMakerFlags = "POSTGRES_HOME=${pkgs.postgresql}";
 
     meta = {
-      homepage = "https://github.com/TJC/Test-postgresql";
       description = "PostgreSQL runner for tests";
+      homepage = "https://github.com/TJC/Test-postgresql";
       license = with lib.licenses; [ artistic2 ];
     };
   };
@@ -15430,9 +15645,9 @@ let
     };
     propagatedBuildInputs = [ EnvSanctify FileHomeDir PerlDestructLevel XMLTwig ];
     meta = {
-      description = "Generate suppressions, analyse and test any command with valgrind.";
+      description = "Generate suppressions, analyse and test any command with valgrind";
+      homepage = "http://search.cpan.org/dist/Test-Valgrind";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
-      homepage = "http://search.cpan.org/dist/Test-Valgrind/";
     };
   };
 
@@ -15446,7 +15661,7 @@ let
     buildInputs = [ TestUseAllModules ];
     propagatedBuildInputs = [ MouseXTypes PathClass ];
     meta = {
-      description = "A Path::Class type library for Mouse";
+      description = "Cross-platform path specification manipulation";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15491,8 +15706,8 @@ let
     buildInputs = [ ModuleBuildTiny MouseXConfigFromFile MouseXSimpleConfig TestException TestWarn ];
     propagatedBuildInputs = [ GetoptLongDescriptive Mouse ];
     meta = {
-      homepage = "https://github.com/gfx/mousex-getopt";
       description = "A Mouse role for processing command line options";
+      homepage = "https://github.com/gfx/mousex-getopt";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15517,7 +15732,8 @@ let
     buildInputs = [ ModuleBuildTiny TestException ];
     propagatedBuildInputs = [ Moose ];
     meta = {
-      description = "Extend your attribute interfaces (deprecated)";
+      description = "(DEPRECATED) Extend your attribute interfaces";
+      homepage = "https://github.com/moose/MooseX-AttributeHelpers";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15543,8 +15759,8 @@ let
     buildInputs = [ ModuleBuildTiny TestDeep TestFatal TestRequires TestWithoutModule ];
     propagatedBuildInputs = [ MooseXTypesPathTiny ];
     meta = {
-      homepage = "https://github.com/moose/MooseX-ConfigFromFile";
       description = "An abstract Moose role for setting attributes from a configfile";
+      homepage = "https://github.com/moose/MooseX-ConfigFromFile";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15559,8 +15775,8 @@ let
     buildInputs = [ DevelCheckOS ModuleBuildTiny TestFatal ];
     propagatedBuildInputs = [ MooseXGetopt MooseXTypesPathClass ];
     meta = {
-      homepage = "https://github.com/moose/MooseX-Daemonize";
       description = "Role for daemonizing your Moose based application";
+      homepage = "https://github.com/moose/MooseX-Daemonize";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15590,8 +15806,8 @@ let
     buildInputs = [ ModuleBuildTiny MooseXStrictConstructor PathTiny TestDeep TestFatal TestNeeds TestTrap TestWarnings ];
     propagatedBuildInputs = [ GetoptLongDescriptive MooseXRoleParameterized ];
     meta = {
-      homepage = "https://github.com/moose/MooseX-Getopt";
       description = "A Moose role for processing command line options";
+      homepage = "https://github.com/moose/MooseX-Getopt";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15606,8 +15822,8 @@ let
     buildInputs = [ Moose TestDeep TestDifferences TestException TestMost TestWarn namespaceautoclean ];
     propagatedBuildInputs = [ ClassLoad ListMoreUtils StringRewritePrefix ];
     meta = {
-      homepage = "https://github.com/pshangov/moosex-has-options";
       description = "Succinct options for Moose";
+      homepage = "https://github.com/pshangov/moosex-has-options";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15622,8 +15838,8 @@ let
     buildInputs = [ TestFatal namespaceclean ];
     propagatedBuildInputs = [ SubExporterProgressive ];
     meta = {
-      homepage = "https://github.com/kentfredric/MooseX-Has-Sugar";
       description = "Sugar Syntax for moose 'has' fields";
+      homepage = "https://github.com/kentnl/MooseX-Has-Sugar";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15638,8 +15854,8 @@ let
     buildInputs = [ ModuleBuildTiny TestFatal ];
     propagatedBuildInputs = [ Moose aliased namespaceautoclean ];
     meta = {
-      homepage = "https://github.com/moose/MooseX-LazyRequire";
       description = "Required attributes which fail only when trying to use them";
+      homepage = "https://github.com/moose/MooseX-LazyRequire";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15654,7 +15870,8 @@ let
     propagatedBuildInputs = [ Moose namespaceautoclean ];
     meta = {
       description = "Mark overload code symbols as methods";
-      license = lib.licenses.lgpl21;
+      homepage = "http://metacpan.org/release/MooseX-MarkAsMethods";
+      license = with lib.licenses; [ lgpl21 ];
     };
   };
 
@@ -15668,8 +15885,8 @@ let
     buildInputs = [ MooseXRoleParameterized TestFatal TestNeeds ];
     propagatedBuildInputs = [ Moose namespaceautoclean ];
     meta = {
-      homepage = "https://github.com/karenetheridge/moosex-methodattributes";
       description = "Code attribute introspection";
+      homepage = "https://github.com/moose/MooseX-MethodAttributes";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15685,6 +15902,7 @@ let
     propagatedBuildInputs = [ ListMoreUtils Moose ];
     meta = {
       description = "Easy subclassing of non-Moose classes";
+      homepage = "http://metacpan.org/release/MooseX-NonMoose";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15698,8 +15916,8 @@ let
     };
     propagatedBuildInputs = [ MooseXRoleParameterized ];
     meta = {
-      homepage = "https://github.com/rjbs/moosex-oneargnew";
       description = "Teach ->new to accept single, non-hashref arguments";
+      homepage = "https://github.com/rjbs/MooseX-OneArgNew";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15739,8 +15957,8 @@ let
     buildInputs = [ CPANMetaCheck ModuleBuildTiny TestFatal TestNeeds ];
     propagatedBuildInputs = [ Moose namespaceautoclean ];
     meta = {
+      description = "Moose roles with composition parameters";
       homepage = "https://github.com/moose/MooseX-Role-Parameterized";
-      description = "Roles with composition parameters";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15754,7 +15972,8 @@ let
     };
     propagatedBuildInputs = [ Moose aliased namespaceautoclean ];
     meta = {
-      description = "Roles which support overloading";
+      description = "(DEPRECATED) Roles which support overloading";
+      homepage = "https://github.com/moose/MooseX-Role-WithOverloading";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15769,8 +15988,8 @@ let
     buildInputs = [ ModuleBuildTiny TestFatal TestSimple13 TestTableDriven ];
     propagatedBuildInputs = [ ListSomeUtils MooseXTypesPathTiny ];
     meta = {
-      homepage = "https://github.com/moose/MooseX-Runnable";
       description = "Tag a class as a runnable application";
+      homepage = "https://github.com/moose/MooseX-Runnable";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "mx-run";
     };
@@ -15818,8 +16037,8 @@ let
     buildInputs = [ TestDeep TestDeepType TestFatal TestNeeds TestDeepJSON TestWithoutModule DigestHMAC MooseXTypes ];
     propagatedBuildInputs = [ ModuleRuntime Moose MooseXRoleParameterized PodCoverage StringRewritePrefix namespaceautoclean IOStringy JSON JSONXS JSONMaybeXS CpanelJSONXS YAML YAMLOld YAMLTiny YAMLLibYAML YAMLSyck ];
     meta = {
-      homepage = "https://github.com/moose/MooseX-Storage";
       description = "A serialization framework for Moose classes";
+      homepage = "https://github.com/moose/MooseX-Storage";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15835,7 +16054,8 @@ let
     propagatedBuildInputs = [ Moose namespaceautoclean ];
     meta = {
       description = "Make your object constructors blow up on unknown attributes";
-      license = lib.licenses.artistic2;
+      homepage = "http://metacpan.org/release/MooseX-StrictConstructor";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -15849,8 +16069,8 @@ let
     buildInputs = [ ModuleBuildTiny MooseXRoleParameterized TestFatal TestRequires TestSimple13 ];
     propagatedBuildInputs = [ Moose namespaceautoclean ];
     meta = {
-      homepage = "https://github.com/moose/MooseX-Traits";
       description = "Automatically apply roles at object creation time";
+      homepage = "https://github.com/moose/MooseX-Traits";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15876,8 +16096,8 @@ let
     buildInputs = [ ModuleBuildTiny TestFatal TestRequires ];
     propagatedBuildInputs = [ CarpClan Moose SubExporterForMethods namespaceautoclean ];
     meta = {
-      homepage = "https://github.com/moose/MooseX-Types";
       description = "Organise your Moose types in libraries";
+      homepage = "https://github.com/moose/MooseX-Types";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15892,8 +16112,8 @@ let
     buildInputs = [ ModuleBuildTiny TestDeep TestWarnings ];
     propagatedBuildInputs = [ MooseXTypes ];
     meta = {
-      homepage = "https://github.com/moose/MooseX-Types-Common";
       description = "A library of commonly used type constraints";
+      homepage = "https://github.com/moose/MooseX-Types-Common";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15908,8 +16128,8 @@ let
     buildInputs = [ ModuleBuildTiny TestFatal TestSimple13 ];
     propagatedBuildInputs = [ DateTime MooseXTypes ];
     meta = {
-      homepage = "https://github.com/moose/MooseX-Types-DateTime";
       description = "DateTime related constraints and coercions for Moose";
+      homepage = "https://github.com/moose/MooseX-Types-DateTime";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15924,8 +16144,8 @@ let
     buildInputs = [ ModuleBuildTiny TestFatal TestSimple13 ];
     propagatedBuildInputs = [ DateTimeXEasy MooseXTypesDateTime TimeDurationParse ];
     meta = {
-      homepage = "https://github.com/moose/MooseX-Types-DateTime-MoreCoercions";
       description = "Extensions to MooseX::Types::DateTime";
+      homepage = "https://github.com/moose/MooseX-Types-DateTime-MoreCoercions";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15940,8 +16160,8 @@ let
     buildInputs = [ ModuleBuildTiny TestFatal ];
     propagatedBuildInputs = [ MooseXTypes ];
     meta = {
-      homepage = "https://github.com/moose/MooseX-Types-LoadableClass";
       description = "ClassName type constraint with coercion to load the class";
+      homepage = "https://github.com/moose/MooseX-Types-LoadableClass";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15971,9 +16191,9 @@ let
     buildInputs = [ Filepushd ModuleBuildTiny TestFatal ];
     propagatedBuildInputs = [ MooseXGetopt MooseXTypesStringlike PathTiny ];
     meta = {
-      homepage = "https://github.com/karenetheridge/moosex-types-path-tiny";
       description = "Path::Tiny types and coercions for Moose";
-      license = lib.licenses.asl20;
+      homepage = "https://github.com/karenetheridge/moosex-types-path-tiny";
+      license = with lib.licenses; [ asl20 ];
     };
   };
 
@@ -15987,6 +16207,7 @@ let
     propagatedBuildInputs = [ MooseXTypes ];
     meta = {
       description = "Moose types that check against Perl syntax";
+      homepage = "https://github.com/rjbs/MooseX-Types-Perl";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -16000,9 +16221,9 @@ let
     };
     propagatedBuildInputs = [ MooseXTypes ];
     meta = {
-      homepage = "https://github.com/dagolden/moosex-types-stringlike";
       description = "Moose type constraints for strings or string-like objects";
-      license = lib.licenses.asl20;
+      homepage = "https://github.com/dagolden/MooseX-Types-Stringlike";
+      license = with lib.licenses; [ asl20 ];
     };
   };
 
@@ -16016,7 +16237,8 @@ let
     buildInputs = [ DateTime ModuleBuildTiny MooseXTypesDateTime TestFatal TestNeeds ];
     propagatedBuildInputs = [ DevelPartialDump MooseXTypes ];
     meta = {
-      description = "MooseX::Types::Structured - Structured Type Constraints for Moose";
+      description = "Structured Type Constraints for Moose";
+      homepage = "https://github.com/moose/MooseX-Types-Structured";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -16031,8 +16253,8 @@ let
     buildInputs = [ ModuleBuildTiny TestSimple13 ];
     propagatedBuildInputs = [ MooseXTypesPathClass URIFromHash ];
     meta = {
-      homepage = "https://github.com/moose/MooseX-Types-URI";
       description = "URI related types and coercions for Moose";
+      homepage = "https://github.com/moose/MooseX-Types-URI";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -16046,7 +16268,7 @@ let
     };
     meta = {
       description = "Manipulate / fetch info from MP3 audio files";
-      license = with lib.licenses; [ artistic1 ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -16095,7 +16317,7 @@ let
     buildInputs = [ AnyMoose TestFatal ];
     propagatedBuildInputs = [ Mouse ];
     meta = {
-      description = "Extend attribute interfaces for Mouse";
+      description = "Extend your attribute interfaces for Mouse";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -16114,7 +16336,8 @@ let
 
     meta = {
       description = "Mozilla's CA cert bundle in PEM format";
-      license = lib.licenses.mpl20;
+      homepage = "https://github.com/gisle/mozilla-ca";
+      license = with lib.licenses; [ mpl20 ];
     };
   };
 
@@ -16129,6 +16352,7 @@ let
     };
     meta = {
       description = "Mro::* interface compatibility for Perls < 5.9.5";
+      homepage = "https://metacpan.org/release/MRO-Compat";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -16182,8 +16406,8 @@ let
     };
     propagatedBuildInputs = [ pkgs.mariadb.client FileSlurp StringShellQuote ];
     meta = {
-      homepage = "https://github.com/estrabd/mysqldiff";
       description = "Generates a database upgrade instruction set";
+      homepage = "https://github.com/estrabd/mysqldiff";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
       mainProgram = "mysqldiff";
@@ -16200,8 +16424,8 @@ let
     buildInputs = [ TestNeeds ];
     propagatedBuildInputs = [ SubIdentify namespaceclean ];
     meta = {
-      homepage = "https://github.com/moose/namespace-autoclean";
       description = "Keep imports out of your namespace";
+      homepage = "https://github.com/moose/namespace-autoclean";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -16216,6 +16440,7 @@ let
     propagatedBuildInputs = [ BHooksEndOfScope PackageStash ];
     meta = {
       description = "Keep imports and functions out of your namespace";
+      homepage = "http://search.cpan.org/dist/namespace-clean";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -16228,9 +16453,9 @@ let
       sha256 = "2e5bd58b01c2a66e8049a2f8d9c93e1b5f6dce53e0ee3a481ce6a6f411f2c8f8";
     };
     meta = {
-      homepage = "https://github.com/toddr/Net-Ident";
       description = "Lookup the username on the remote end of a TCP/IP connection";
-      license = lib.licenses.mit;
+      homepage = "https://github.com/toddr/Net-Ident";
+      license = with lib.licenses; [ mit ];
     };
   };
 
@@ -16242,9 +16467,9 @@ let
       sha256 = "05xvbdrqq88npzg14bjm9wmjykzplwirzcm8rp61852hz6c67hwh";
     };
     meta = {
-      homepage = "https://github.com/noxxi/p5-net-inet6glue";
       description = "Make common modules IPv6 ready by hotpatching";
-      license = lib.licenses.artistic1;
+      homepage = "https://github.com/noxxi/p5-net-inet6glue";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -16271,6 +16496,7 @@ let
     propagatedBuildInputs = [ URI ];
     meta = {
       description = "Perl extension to create signatures for AWS requests";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -16284,7 +16510,8 @@ let
     propagatedBuildInputs = [ LWPProtocolHttps Moose ParamsValidate XMLSimple ];
     buildInputs = [ TestException ];
     meta = {
-      description = "Perl interface to the Amazon Elastic Compute Cloud (EC2) environment.";
+      description = "Perl interface to the Amazon Elastic Compute Cloud (EC2) environment";
+      homepage = "https://metacpan.org/dist/Net-Amazon-EC2";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -16364,9 +16591,9 @@ let
     buildInputs = [ TestFatal ];
     preCheck = "rm t/icmp_ps.t t/icmpv6_ps.t"; # ping socket tests fail
     meta = {
-      description = "asyncronously check remote host for reachability";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      description = "Asyncronously check remote host for reachability";
       homepage = "https://github.com/frioux/Net-Async-Ping";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -16443,8 +16670,8 @@ let
     buildInputs = [ FileFindRule ];
     propagatedBuildInputs = [ JSONAny LWP Moose namespaceautoclean ];
     meta = {
-      homepage = "https://github.com/metabrainz/CoverArtArchive";
       description = "Query the coverartarchive.org";
+      homepage = "https://github.com/metabrainz/CoverArtArchive";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -16471,8 +16698,8 @@ let
     '';
 
     meta = {
-      homepage = "http://www.freedesktop.org/wiki/Software/dbus";
       description = "Extension for the DBus bindings";
+      homepage = "http://www.freedesktop.org/wiki/Software/dbus";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -16488,7 +16715,7 @@ let
     makeMakerFlags = "--noonline-tests";
     meta = {
       description = "Perl Interface to the Domain Name System";
-      license = lib.licenses.mit;
+      license = with lib.licenses; [ mit ];
     };
   };
 
@@ -16544,7 +16771,7 @@ let
     propagatedBuildInputs = [ BitVector ClassGomor NetIPv6Addr ];
     preCheck = "rm t/13-gethostsubs.t"; # it performs DNS queries
     meta = {
-      description = "the base framework for frame crafting";
+      description = "The base framework for frame crafting";
       license = with lib.licenses; [ artistic1 ];
     };
   };
@@ -16573,7 +16800,7 @@ let
     buildInputs = [ TestDeep TestDifferences TestException TestMost TestWarn ];
     propagatedBuildInputs = [ CDDBFile Moo ];
     meta = {
-      description = "Perl interface to freedb server(s)";
+      description = "OOP Interface to FreeDB Server(s)";
       license = with lib.licenses; [ artistic1 ];
       broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.NetFreeDB.x86_64-darwin
     };
@@ -16590,8 +16817,8 @@ let
     __darwinAllowLocalNetworking = true;
     doCheck = false; /* wants network */
     meta = {
-      homepage = "https://github.com/libwww-perl/Net-HTTP";
       description = "Low-level HTTP connection (client)";
+      homepage = "https://github.com/libwww-perl/Net-HTTP";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -16605,8 +16832,8 @@ let
     };
     propagatedBuildInputs = [ IOSocketSSL NetHTTP ];
     meta = {
-      homepage = "https://github.com/olegwtf/p5-Net-HTTPS-NB";
       description = "Non-blocking HTTPS client";
+      homepage = "https://github.com/olegwtf/p5-Net-HTTPS-NB";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -16621,7 +16848,9 @@ let
     buildInputs = [ TestNoWarnings ];
     perlPreHook = "export LD=$CC";
     meta = {
-      description = "Internationalizing Domain Names in Applications (IDNA)";
+      description = "Internationalizing Domain Names in Applications (UTS #46)";
+      homepage = "https://metacpan.org/release/Net-IDN-Encode";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -16635,6 +16864,7 @@ let
     propagatedBuildInputs = [ IOSocketSSL ListMoreUtils ];
     meta = {
       description = "Not so simple IMAP client library";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -16647,6 +16877,7 @@ let
     };
     meta = {
       description = "Perl extension for manipulating IPv4/IPv6 addresses";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -16659,8 +16890,8 @@ let
     };
     buildInputs = [ TestException ];
     meta = {
-      homepage = "https://metacpan.org/pod/Net::IP::Lite";
       description = "Perl extension for manipulating IPv4/IPv6 addresses";
+      homepage = "https://metacpan.org/pod/Net::IP::Lite";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -16704,7 +16935,7 @@ let
     propagatedBuildInputs = [ perlldap ConvertASN1 ];
     meta = {
       description = "LDAP server side protocol handling";
-      license = with lib.licenses; [ artistic1 ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -16717,7 +16948,8 @@ let
     };
     meta = {
       description = "Active Directory Security Identifier manipulation";
-      license = with lib.licenses; [ artistic2 ];
+      homepage = "https://github.com/karpet/net-ldap-sid";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -16730,8 +16962,9 @@ let
     };
     propagatedBuildInputs = [ perlldap NetLDAPServer DataDump NetLDAPSID ];
     meta = {
-      description = "test Net::LDAP code";
-      license = with lib.licenses; [ artistic1 ];
+      description = "Test Net::LDAP code";
+      homepage = "https://github.com/karpet/net-ldap-server-test";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -16744,7 +16977,9 @@ let
     };
     buildInputs = [ Test2Suite TestUseAllModules ];
     meta = {
-      description = "Parse, manipulate and lookup IP network blocks";
+      description = "Understand and manipulate IP netmasks";
+      homepage = "http://search.cpan.org/~jmaslak/Net-Netmask";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -16795,6 +17030,7 @@ let
     };
     meta = {
       description = "Check a remote host for reachability";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -16808,6 +17044,7 @@ let
     propagatedBuildInputs = [ NetDNS ];
     meta = {
       description = "Programmable DNS resolver class for offline emulation of DNS";
+      homepage = "https://github.com/bigpresh/Net-DNS-Resolver-Programmable";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -16822,7 +17059,7 @@ let
     propagatedBuildInputs = [ RefUtil StructDumb URI ];
     buildInputs = [ HTTPMessage TestFatal ];
     meta = {
-      description = "export monitoring metrics for F<prometheus>";
+      description = "Export monitoring metrics for prometheus";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -16840,7 +17077,7 @@ let
     '';
     buildInputs = [ NetSSH StringShellQuote ];
     meta = {
-      description = "Simple wrappers around ssh and scp commands.";
+      description = "Simple wrappers around ssh and scp commands";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -16854,7 +17091,7 @@ let
     };
     doCheck = false; # seems to hang waiting for connections
     meta = {
-      description = "Extensible, general Perl server engine";
+      description = "Extensible Perl internet server";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "net-server";
     };
@@ -16981,7 +17218,7 @@ let
       sed -i 's|$ssh = "ssh";|$ssh = "${pkgs.openssh}/bin/ssh";|' SSH.pm
     '';
     meta = {
-      description = "Simple wrappers around ssh commands.";
+      description = "Simple wrappers around ssh commands";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -16996,7 +17233,8 @@ let
     propagatedBuildInputs = [ CryptCurve25519 CryptIDEA CryptX FileHomeDir MathGMP StringCRC32 ];
     preCheck = "export HOME=$TMPDIR";
     meta = {
-      description = "Perl client Interface to SSH";
+      description = "Perl client interface to SSH";
+      homepage = "http://search.cpan.org/dist/Net-SSH-Perl";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -17018,8 +17256,8 @@ let
       export OPENSSL_PREFIX=$(realpath openssl)
     '';
     meta = {
-      description = "Perl extension for using OpenSSL";
-      license = lib.licenses.artistic2;
+      description = "Perl bindings for OpenSSL and LibreSSL";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -17031,7 +17269,7 @@ let
       sha256 = "63e453603da165bc6d1c4ca0b55eda3d2204f040c59304a47782c5aa7886565c";
     };
     meta = {
-      description = "Sends statistics to the stats daemon over UDP";
+      description = "Perl client for Etsy's statsd daemon";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "benchmark.pl";
     };
@@ -17061,8 +17299,8 @@ let
     propagatedBuildInputs = [ JSON LWPProtocolHttps ];
     doCheck = false;
     meta = {
-      homepage = "https://github.com/semifor/Net-Twitter-Lite";
-      description = "A perl interface to the Twitter API";
+      description = "A perl API library for the Twitter API";
+      homepage = "https://github.com/semifor/net-twitter-lite";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -17166,8 +17404,8 @@ let
     buildInputs = [ DevelHide FileShareDirInstall ParallelForkManager TestDifferences TestPod TestPodCoverage TestWarnings ];
     propagatedBuildInputs = [ DataDumperConcise DBMDeep DevelCheckOS FileFindRule FileShareDir ];
     meta = {
-      homepage = "https://github.com/DrHyde/perl-modules-Number-Phone";
       description = "Large suite of perl modules for parsing and dealing with phone numbers";
+      homepage = "https://github.com/DrHyde/perl-modules-Number-Phone";
       license = with lib.licenses; [ artistic1 gpl2 ];
     };
   };
@@ -17253,7 +17491,7 @@ let
     perlPreHook = lib.optionalString stdenv.isDarwin "export LD=$CC";
     propagatedBuildInputs = [ XSParseKeyword XSParseSublike ];
     meta = {
-      description = "simple syntax for lexical field-based objects";
+      description = "A simple syntax for lexical field-based objects";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.zakame ];
     };
@@ -17268,6 +17506,7 @@ let
     };
     meta = {
       description = "Generate cryptographic signatures for objects";
+      homepage = "https://github.com/karenetheridge/Object-Signature";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -17283,7 +17522,7 @@ let
     # The testing mechanism is erorrneous upstream. See http://matrix.cpantesters.org/?dist=Ogg-Vorbis-Header-PurePerl+1.0
     doCheck = false;
     meta = {
-      description = "An object-oriented interface to Ogg Vorbis information and comment fields";
+      description = "Access Ogg Vorbis info and comment fields";
       license = with lib.licenses; [ artistic1 ];
     };
   };
@@ -17323,9 +17562,9 @@ let
     };
     propagatedBuildInputs = [ MojoliciousPluginOpenAPI ];
     meta = {
-      homepage = "https://github.com/jhthorsen/openapi-client";
       description = "A client for talking to an Open API powered server";
-      license = lib.licenses.artistic2;
+      homepage = "https://github.com/jhthorsen/openapi-client";
+      license = with lib.licenses; [ artistic2 ];
       maintainers = [ maintainers.sgo ];
     };
   };
@@ -17364,6 +17603,7 @@ let
     };
     propagatedBuildInputs = [ ArchiveZip XMLTwig ];
     meta = {
+      description = "The Perl Open OpenDocument Connector";
       license = with lib.licenses; [ lgpl21 ];
       maintainers = [ maintainers.wentasah ];
     };
@@ -17428,9 +17668,9 @@ let
       rm t/45_class.t
     '';
     meta = {
-      maintainers = teams.deshaw.members ++ [ maintainers.ztzg ];
       homepage = "https://github.com/mark-5/p5-net-zookeeper";
-      license = lib.licenses.asl20;
+      license = with lib.licenses; [ asl20 ];
+      maintainers = teams.deshaw.members ++ [ maintainers.ztzg ];
     };
   };
 
@@ -17458,7 +17698,8 @@ let
     propagatedBuildInputs = [ PackageStash ParamsUtil SubInstall SubName ];
     meta = {
       description = "Manage deprecation warnings for your distribution";
-      license = lib.licenses.artistic2;
+      homepage = "http://metacpan.org/release/Package-DeprecationManager";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -17486,6 +17727,7 @@ let
     propagatedBuildInputs = [ DistCheckConflicts ModuleImplementation ];
     meta = {
       description = "Routines for manipulating stashes";
+      homepage = "https://github.com/moose/Package-Stash";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "package-stash-conflicts";
     };
@@ -17501,6 +17743,7 @@ let
     buildInputs = [ TestFatal TestRequires ];
     meta = {
       description = "Faster and more correct implementation of the Package::Stash API";
+      homepage = "https://github.com/moose/Package-Stash-XS";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -17515,9 +17758,9 @@ let
     buildInputs = [ pkgs.pango ];
     propagatedBuildInputs = [ Cairo Glib ];
     meta = {
-      homepage = "http://gtk2-perl.sourceforge.net/";
       description = "Layout and render international text";
-      license = lib.licenses.lgpl21Plus;
+      homepage = "http://gtk2-perl.sourceforge.net";
+      license = with lib.licenses; [ lgpl21Plus ];
     };
   };
 
@@ -17531,8 +17774,8 @@ let
     buildInputs = [ TestWarn ];
     propagatedBuildInputs = [ Moo ];
     meta = {
-      homepage = "https://github.com/dluxhu/perl-parallel-forkmanager";
       description = "A simple parallel processing fork manager";
+      homepage = "https://github.com/dluxhu/perl-parallel-forkmanager";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -17546,8 +17789,8 @@ let
     };
     buildInputs = [ ModuleBuildTiny ];
     meta = {
-      homepage = "https://github.com/skaji/Parallel-Pipes";
       description = "Parallel processing using pipe(2) for communication and synchronization";
+      homepage = "https://github.com/skaji/Parallel-Pipes";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.zakame ];
     };
@@ -17587,6 +17830,7 @@ let
     };
     meta = {
       description = "Simple, compact and correct param-checking functions";
+      homepage = "https://metacpan.org/release/Params-Util";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -17603,7 +17847,8 @@ let
     perlPreHook = "export LD=$CC";
     meta = {
       description = "Validate method/function parameters";
-      license = lib.licenses.artistic2;
+      homepage = "https://metacpan.org/release/Params-Validate";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -17618,6 +17863,7 @@ let
     buildInputs = [ Specio Test2PluginNoWarnings Test2Suite TestWithoutModule ];
     meta = {
       description = "Build an optimized subroutine parameter validator once, use it forever";
+      homepage = "http://metacpan.org/release/Params-ValidationCompiler";
       license = with lib.licenses; [ artistic2 ];
     };
   };
@@ -17651,6 +17897,7 @@ let
     };
     meta = {
       description = "Create and manipulate PAR distributions";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -17664,7 +17911,7 @@ let
     propagatedBuildInputs = [ FileHomeDir HTTPDate MooXOptions TimeDurationParse ];
     buildInputs = [ PathTiny ];
     meta = {
-      description = "interface to PAUSE's module permissions file (06perms.txt)";
+      description = "Interface to PAUSE's module permissions file (06perms.txt)";
       homepage = "https://github.com/neilb/PAUSE-Permissions";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "pause-permissions";
@@ -17701,8 +17948,8 @@ let
       sha256 = "457b09897f37d38a7054f9563247365427fe24101622ed4c7f054723a45b58d5";
     };
     meta = {
-      homepage = "https://github.com/bingos/parse-irc";
       description = "A parser for the IRC protocol";
+      homepage = "https://github.com/bingos/parse-irc";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = with maintainers; [ sgo ];
     };
@@ -17718,7 +17965,7 @@ let
     propagatedBuildInputs = [ ParsePMFile ];
     buildInputs = [ ExtUtilsMakeMakerCPANfile TestUseAllModules ];
     meta = {
-      description = "parses local .pm files as PAUSE does";
+      description = "Parses local .pm files as PAUSE does";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -17747,7 +17994,7 @@ let
     };
     buildInputs = [ ExtUtilsMakeMakerCPANfile ];
     meta = {
-      description = "parses .pm file as PAUSE does";
+      description = "Parses .pm file as PAUSE does";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -17783,7 +18030,7 @@ let
     };
     propagatedBuildInputs = [ FileSlurpTiny ];
     meta = {
-      description = "build simple recursive-descent parsers";
+      description = "Build simple recursive-descent parsers";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -17825,8 +18072,8 @@ let
     buildInputs = [ ModuleBuildTiny TestFatal ];
     propagatedBuildInputs = [ Moo MooXTypeTiny TryTiny TypeTiny ];
     meta = {
-      homepage = "https://github.com/karenetheridge/Path-Dispatcher";
       description = "Flexible and extensible dispatch";
+      homepage = "https://github.com/karenetheridge/Path-Dispatcher";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -17842,8 +18089,8 @@ let
     buildInputs = [ Filepushd PathTiny TestDeep TestFilename ];
     meta = {
       description = "Iterative, recursive file finder";
-      license = with lib.licenses; [ asl20 ];
       homepage = "https://github.com/dagolden/Path-Iterator-Rule";
+      license = with lib.licenses; [ asl20 ];
     };
   };
 
@@ -17864,7 +18111,8 @@ let
     doCheck = false;
     meta = {
       description = "File path utility";
-      license = lib.licenses.asl20;
+      homepage = "https://github.com/dagolden/Path-Tiny";
+      license = with lib.licenses; [ asl20 ];
     };
   };
 
@@ -17888,9 +18136,9 @@ let
       sha256 = "b4e21dc59b30265eaaa41b705087ec03447d9c655a14ac40ff46e4de29eabf8e";
     };
     meta = {
-      homepage = "https://github.com/dagolden/PBKDF2-Tiny";
       description = "Minimalist PBKDF2 (RFC 2898) with HMAC-SHA1 or HMAC-SHA2";
-      license = lib.licenses.asl20;
+      homepage = "https://github.com/dagolden/PBKDF2-Tiny";
+      license = with lib.licenses; [ asl20 ];
       maintainers = [ maintainers.sgo ];
     };
   };
@@ -17908,9 +18156,9 @@ let
     # tests fail; look unfinished
     doCheck = false;
     meta = {
-      homepage = "http://ludovic.rousseau.free.fr/softwares/pcsc-perl/";
       description = "Communicate with a smart card using PC/SC";
-      license = lib.licenses.gpl2Plus;
+      homepage = "http://ludovic.rousseau.free.fr/softwares/pcsc-perl/";
+      license = with lib.licenses; [ gpl2Plus ];
       maintainers = with maintainers; [ abbradar ];
       broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.pcscperl.x86_64-darwin
     };
@@ -17926,8 +18174,8 @@ let
     buildInputs = [ TestException TestMemoryCycle ];
     propagatedBuildInputs = [ FontTTF ];
     meta = {
-      description = "Facilitates the creation and modification of PDF files";
-      license = lib.licenses.lgpl21Plus;
+      description = "Create, modify, and examine PDF files";
+      license = with lib.licenses; [ lgpl21Plus ];
     };
   };
 
@@ -17942,7 +18190,8 @@ let
     propagatedBuildInputs = [ FontTTF ];
     meta = {
       description = "Facilitates the creation and modification of PDF files";
-      license = lib.licenses.lgpl21Plus;
+      homepage = "https://metacpan.org/pod/PDF::Builder";
+      license = with lib.licenses; [ lgpl21Plus ];
     };
   };
 
@@ -17984,8 +18233,8 @@ let
     ];
 
     meta = {
-      homepage = "http://pdl.perl.org/";
       description = "Perl Data Language";
+      homepage = "http://pdl.perl.org";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "pdl2";
       platforms = lib.platforms.linux;
@@ -18002,8 +18251,8 @@ let
     buildInputs = [ TestPod TieIxHash ];
     propagatedBuildInputs = [ FileShareDirInstall XXX ];
     meta = {
-      homepage = "https://github.com/ingydotnet/pegex-pm";
       description = "Acmeist PEG Parser Framework";
+      homepage = "https://github.com/ingydotnet/pegex-pm";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -18028,6 +18277,7 @@ let
     };
     meta = {
       description = "List possible $^O ($OSNAME) values, with description";
+      homepage = "https://metacpan.org/release/Perl-osnames";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -18046,8 +18296,8 @@ let
       shortenPerlShebang $out/bin/perlcritic
     '';
     meta = {
-      homepage = "http://perlcritic.com";
       description = "Critique Perl source code for best-practices";
+      homepage = "http://perlcritic.com";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "perlcritic";
     };
@@ -18063,9 +18313,9 @@ let
     buildInputs = [ ModuleBuildTiny ];
     propagatedBuildInputs = [ PPI PathTiny PerlCritic PerlCriticPolicyVariablesProhibitLoopOnHash PerlCriticPulp ];
     meta = {
-      homepage = "https://github.com/Grinnz/Perl-Critic-Community";
       description = "Community-inspired Perl::Critic policies";
-      license = lib.licenses.artistic2;
+      homepage = "https://github.com/Grinnz/Perl-Critic-Community";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -18079,7 +18329,8 @@ let
     propagatedBuildInputs = [ PerlCritic Readonly namespaceautoclean ];
     meta = {
       description = "Policies for Perl::Critic concerned with using Moose";
-      license = lib.licenses.artistic1;
+      homepage = "http://metacpan.org/release/Perl-Critic-Moose";
+      license = with lib.licenses; [ artistic1 ]];
     };
   };
 
@@ -18106,9 +18357,9 @@ let
     };
     propagatedBuildInputs = [ IOString ListMoreUtils PPI PerlCritic PodMinimumVersion ];
     meta = {
-      homepage = "http://user42.tuxfamily.org/perl-critic-pulp/index.html";
       description = "Some add-on policies for Perl::Critic";
-      license = lib.licenses.gpl3Plus;
+      homepage = "http://user42.tuxfamily.org/perl-critic-pulp/index.html";
+      license = with lib.licenses; [ gpl3Plus ];
     };
   };
 
@@ -18120,6 +18371,7 @@ let
       sha256 = "0fyiysrq874ncscgdjg522fs29gvqads6ynyhwxwwq1b545srd20";
     };
     meta = {
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -18225,8 +18477,8 @@ let
     buildInputs = [ TextSoundex ];
     propagatedBuildInputs = [ ConvertASN1 ];
     meta = {
-      homepage = "http://ldap.perl.org/";
       description = "LDAP client library";
+      homepage = "http://ldap.perl.org";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = teams.deshaw.members;
     };
@@ -18256,7 +18508,7 @@ let
     };
     meta = {
       description = "Indent and reformat perl scripts";
-      license = lib.licenses.gpl2Plus;
+      license = with lib.licenses; [ gpl2Plus ];
       mainProgram = "perltidy";
     };
   };
@@ -18270,6 +18522,7 @@ let
     };
     meta = {
       description = "Simple flexible means of converting the output of PHP's serialize() into the equivalent Perl memory structure, and vice versa";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -18288,6 +18541,7 @@ let
     '';
     meta = {
       description = "Pure-Perl Core-Only replacement for pkg-config";
+      homepage = "https://metacpan.org/pod/PkgConfig";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = teams.deshaw.members;
       mainProgram = "ppkg-config";
@@ -18304,8 +18558,8 @@ let
     buildInputs = [ AuthenSimplePasswd CGIEmulatePSGI FileShareDirInstall HTTPRequestAsCGI HTTPServerSimplePSGI IOHandleUtil LWP LWPProtocolhttp10 LogDispatchArray MIMETypes TestMockTimeHiRes TestRequires TestSharedFork TestTCP ];
     propagatedBuildInputs = [ ApacheLogFormatCompiler CookieBaker DevelStackTraceAsHTML FileShareDir FilesysNotifySimple HTTPEntityParser HTTPHeadersFast HTTPMessage TryTiny ];
     meta = {
-      homepage = "https://github.com/plack/Plack";
       description = "Perl Superglue for Web frameworks and Web Servers (PSGI toolkit)";
+      homepage = "https://github.com/plack/Plack";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "plackup";
     };
@@ -18321,7 +18575,7 @@ let
     propagatedBuildInputs = [ AnyEventHTTP LWP Plack ];
     buildInputs = [ TestRequires TestSharedFork TestTCP ];
     meta = {
-      description = "proxy requests";
+      description = "Proxy requests";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -18337,8 +18591,8 @@ let
     buildInputs = [ LWP ModuleBuildTiny TestSharedFork TestTCP ];
     meta = {
       description = "Digest authentication";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
       homepage = "https://github.com/miyagawa/Plack-Middleware-Auth-Digest";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -18353,8 +18607,8 @@ let
     buildInputs = [ ModuleBuildTiny TestRequires ];
     meta = {
       description = "Write logs to Firebug or Webkit Inspector";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
       homepage = "https://github.com/miyagawa/Plack-Middleware-ConsoleLogger";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -18368,8 +18622,8 @@ let
     buildInputs = [ ModuleBuildTiny TestRequires ];
     propagatedBuildInputs = [ ClassMethodModifiers DataDump DataDumperConcise Plack TextMicroTemplate ];
     meta = {
-      homepage = "https://github.com/miyagawa/Plack-Middleware-Debug";
       description = "Display information about the current request/response";
+      homepage = "https://github.com/miyagawa/Plack-Middleware-Debug";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -18398,8 +18652,8 @@ let
     };
     propagatedBuildInputs = [ HTMLParser Plack ];
     meta = {
-      homepage = "https://github.com/Sweet-kid/Plack-Middleware-FixMissingBodyInRedirect";
       description = "Plack::Middleware which sets body for redirect response, if it's not already set";
+      homepage = "https://github.com/Sweet-kid/Plack-Middleware-FixMissingBodyInRedirect";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -18413,7 +18667,7 @@ let
     };
     propagatedBuildInputs = [ Plack ];
     meta = {
-      description = "modify HTTP response headers";
+      description = "Modify HTTP response headers";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -18441,8 +18695,8 @@ let
     };
     propagatedBuildInputs = [ Plack ];
     meta = {
-      homepage = "https://github.com/Sweet-kid/Plack-Middleware-RemoveRedundantBody";
-      description = "Plack::Middleware which sets removes body for HTTP response if it's not required";
+      description = "Plack::Middleware which removes body for HTTP response if it's not required";
+      homepage = "https://github.com/upasana-me/Plack-Middleware-RemoveRedundantBody";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -18457,6 +18711,7 @@ let
     propagatedBuildInputs = [ Plack ];
     meta = {
       description = "Supports app to run as a reverse proxy backend";
+      homepage = "https://github.com/lopnor/Plack-Middleware-ReverseProxy";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -18472,8 +18727,8 @@ let
     buildInputs = [ HTTPCookies LWP ModuleBuildTiny TestFatal TestRequires TestSharedFork TestTCP ];
     meta = {
       description = "Middleware for session management";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
       homepage = "https://github.com/plack/Plack-Middleware-Session";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -18487,8 +18742,8 @@ let
     buildInputs = [ Plack TestSharedFork TestTCP ];
     propagatedBuildInputs = [ LWP ];
     meta = {
-      homepage = "https://github.com/perl-catalyst/Plack-Test-ExternalServer";
       description = "Run HTTP tests on external live servers";
+      homepage = "https://github.com/perl-catalyst/Plack-Test-ExternalServer";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -18506,8 +18761,8 @@ let
       shortenPerlShebang $out/bin/pls
     '';
     meta = {
-      homepage = "https://github.com/FractalBoy/perl-language-server";
       description = "Perl Language Server";
+      homepage = "https://github.com/FractalBoy/perl-language-server";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.artturin ];
       mainProgram = "pls";
@@ -18525,9 +18780,9 @@ let
     };
     propagatedBuildInputs = [ IOString PodParser ];
     meta = {
-      homepage = "http://user42.tuxfamily.org/pod-minimumversion/index.html";
       description = "Determine minimum Perl version of POD directives";
-      license = lib.licenses.free;
+      homepage = "http://user42.tuxfamily.org/pod-minimumversion/index.html";
+      license = with lib.licenses; [ free ];
       mainProgram = "pod-minimumversion";
     };
   };
@@ -18560,9 +18815,10 @@ let
       set +x
     '';
     meta = {
+      description = "Portable, event-loop agnostic eventy networking and multitasking";
+      homepage = "http://poe.perl.org";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = teams.deshaw.members;
-      description = "Portable multitasking and networking framework for any event loop";
-      license = lib.licenses.artistic2;
     };
   };
 
@@ -18575,7 +18831,8 @@ let
     };
     meta = {
       description = "Reusable tests for POE::Loop authors";
-      license = lib.licenses.artistic2;
+      homepage = "http://search.cpan.org/dist/POE-Test-Loops";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = teams.deshaw.members;
       mainProgram = "poe-gen-tests";
     };
@@ -18596,8 +18853,8 @@ let
     preCheck = "rm t/03_document.t";
 
     meta = {
-      homepage = "https://github.com/adamkennedy/PPI";
       description = "Parse, Analyze and Manipulate Perl (without perl)";
+      homepage = "https://github.com/Perl-Critic/PPI";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -18611,7 +18868,7 @@ let
     };
     propagatedBuildInputs = [ PPI Readonly ];
     meta = {
-      description = "Parse Perl string literals and string-literal-like things.";
+      description = "Parse Perl string literals and string-literal-like things";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -18640,7 +18897,7 @@ let
     buildInputs = [ TestDeep ];
     propagatedBuildInputs = [ ExceptionClass PPI Readonly ];
     meta = {
-      description = "Extensions to L<PPI|PPI>";
+      description = "Extensions to PPI|PPI";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -18654,7 +18911,7 @@ let
     };
     meta = {
       description = "Pattern-based Perl Recognizer";
-      license = lib.licenses.artistic2;
+      license = with lib.licenses; [ artistic2 ];
       maintainers = [ maintainers.artturin ];
     };
   };
@@ -18667,7 +18924,7 @@ let
       sha256 = "91b6a5aeb841b1c313498c78fad08e37d17595702dc6205b5ad38ef69949b7ee";
     };
     meta = {
-      description = "Provides a generic interface to running background processes";
+      description = "Run asynchronous child processes under Unix or Windows";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "timed-process";
     };
@@ -18682,7 +18939,7 @@ let
     };
     meta = {
       description = "Perl extension to access the unix process table";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -18696,6 +18953,7 @@ let
     propagatedBuildInputs = [ ProcProcessTable ];
     meta = {
       description = "Find processes by name, PID, or some other attributes";
+      homepage = "https://metacpan.org/release/Proc-Find";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -18753,8 +19011,8 @@ let
     };
     buildInputs = [ HTTPMessage Plack TestException ];
     meta = {
-      homepage = "https://github.com/robn/Prometheus-Tiny";
       description = "A tiny Prometheus client";
+      homepage = "https://github.com/robn/Prometheus-Tiny";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -18769,8 +19027,8 @@ let
     buildInputs = [ DataRandom HTTPMessage Plack TestDifferences TestException ];
     propagatedBuildInputs = [ HashSharedMem JSONXS PrometheusTiny ];
     meta = {
-      homepage = "https://github.com/robn/Prometheus-Tiny-Shared";
       description = "A tiny Prometheus client with a shared database behind it";
+      homepage = "https://github.com/robn/Prometheus-Tiny-Shared";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -18783,8 +19041,8 @@ let
       sha256 = "7ceb6bd80067c904465d4fd1f1715724388c9bdc37c6c2c003a20ce569b7f4e8";
     };
     meta = {
-      homepage = "https://github.com/und3f/protocol-redis";
       description = "Redis protocol parser/encoder with asynchronous capabilities";
+      homepage = "https://github.com/und3f/protocol-redis";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -18799,9 +19057,9 @@ let
     };
     propagatedBuildInputs = [ ProtocolRedis ];
     meta = {
-      homepage = "https://github.com/Grinnz/Protocol-Redis-Faster";
       description = "Optimized pure-perl Redis protocol parser/encoder";
-      license = lib.licenses.artistic2;
+      homepage = "https://github.com/Grinnz/Protocol-Redis-Faster";
+      license = with lib.licenses; [ artistic2 ];
       maintainers = [ maintainers.sgo ];
     };
   };
@@ -18864,8 +19122,8 @@ let
     buildInputs = [ TestScript ];
     propagatedBuildInputs = [ FileFindRulePerl PerlCritic ];
     meta = {
-      homepage = "https://github.com/neilbowers/Perl-MinimumVersion";
       description = "Find a minimum required version of perl for Perl code";
+      homepage = "https://github.com/neilbowers/Perl-MinimumVersion";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "perlver";
     };
@@ -18880,8 +19138,8 @@ let
     };
     propagatedBuildInputs = [ GetoptLongDescriptive ListMoreUtils ModulePath Moose PPI StringRewritePrefix namespaceautoclean ];
     meta = {
-      homepage = "https://github.com/rjbs/Perl-PrereqScanner";
       description = "A tool to scan your Perl code for its prerequisites";
+      homepage = "https://github.com/rjbs/Perl-PrereqScanner";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "scan-perl-prereqs";
     };
@@ -18897,7 +19155,7 @@ let
     propagatedBuildInputs = [ DataDump ModuleCPANfile ModuleFind RegexpTrie URIcpan ];
     buildInputs = [ ExtUtilsMakeMakerCPANfile TestFailWarnings TestUseAllModules ];
     meta = {
-      description = "a tool to scan your Perl code for its prerequisites";
+      description = "A tool to scan your Perl code for its prerequisites";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "scan-perl-prereqs-nqlite";
     };
@@ -18941,7 +19199,7 @@ let
       sha256 = "12559997r7wbhhs0p6cdxdzv7rzviv0nx1hq0dby8q481apn489f";
     };
     meta = {
-      description = "Check POD documents for syntax errors";
+      description = "Verifies POD documentation contents for compliance with the POD format specifications";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "podchecker";
     };
@@ -18971,8 +19229,8 @@ let
     };
     propagatedBuildInputs = [ PodCoverage PodEventual ];
     meta = {
-      homepage = "https://github.com/rjbs/pod-coverage-trustpod";
       description = "Allow a module's pod to contain Pod::Coverage hints";
+      homepage = "https://github.com/rjbs/Pod-Coverage-TrustPod";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -18987,8 +19245,8 @@ let
     buildInputs = [ TestDeep TestDifferences ];
     propagatedBuildInputs = [ MooseXTypes PodEventual StringRewritePrefix StringTruncate ];
     meta = {
-      homepage = "https://github.com/rjbs/Pod-Elemental";
       description = "Work with nestable Pod elements";
+      homepage = "https://github.com/rjbs/Pod-Elemental";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -19003,8 +19261,8 @@ let
     buildInputs = [ TestDifferences ];
     propagatedBuildInputs = [ PPI PodElemental ];
     meta = {
-      homepage = "https://github.com/rjbs/Pod-Elemental-PerlMunger";
       description = "A thing that takes a string of Perl and rewrites its documentation";
+      homepage = "https://github.com/rjbs/Pod-Elemental-PerlMunger";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -19020,6 +19278,7 @@ let
     buildInputs = [ TestDeep ];
     meta = {
       description = "Read a POD document as a series of trivial events";
+      homepage = "https://github.com/rjbs/Pod-Eventual";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -19033,7 +19292,7 @@ let
     };
     meta = {
       description = "Modules for parsing/translating POD format documents";
-      license = lib.licenses.artistic1;
+      license = with lib.licenses; [ artistic1 ];
       mainProgram = "podselect";
     };
   };
@@ -19047,8 +19306,8 @@ let
     };
     buildInputs = [ FileSlurper TestDifferences TextDiff ];
     meta = {
-      homepage = "https://github.com/neilb/Pod-POM";
       description = "POD Object Model";
+      homepage = "https://github.com/neilb/Pod-POM";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "pom2";
     };
@@ -19077,8 +19336,8 @@ let
     };
     propagatedBuildInputs = [ PodAbstract ];
     meta = {
-      homepage = "https://github.com/ktat/Pod-Section";
       description = "Select specified section from Module's POD";
+      homepage = "https://github.com/ktat/Pod-Section";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "podsection";
     };
@@ -19093,8 +19352,8 @@ let
     };
     propagatedBuildInputs = [ PodParser ];
     meta = {
-      homepage = "https://github.com/timj/perl-Pod-LaTeX/tree/master";
       description = "Convert Pod data to formatted Latex";
+      homepage = "http://github.com/timj/perl-Pod-LaTeX/tree/master";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "pod2latex";
     };
@@ -19113,6 +19372,7 @@ let
     '';
     meta = {
       description = "Convert POD data to various other formats";
+      homepage = "https://www.eyrie.org/~eagle/software/podlators";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -19126,9 +19386,9 @@ let
     };
     propagatedBuildInputs = [ FileFindIterator FileHomeDir IPCRun PodParser constant-defer libintl-perl ];
     meta = {
-      homepage = "http://user42.tuxfamily.org/podlinkcheck/index.html";
       description = "Check POD L<> link references";
-      license = lib.licenses.gpl3Plus;
+      homepage = "http://user42.tuxfamily.org/podlinkcheck/index.html";
+      license = with lib.licenses; [ gpl3Plus ];
     };
   };
 
@@ -19141,6 +19401,7 @@ let
     };
     meta = {
       description = "Optimized module loading for forking or non-forking processes";
+      homepage = "https://github.com/karenetheridge/prefork";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -19183,8 +19444,8 @@ let
     buildInputs = [ TestDifferences ];
     propagatedBuildInputs = [ URI ];
     meta = {
-      homepage = "https://github.com/rwstauner/Pod-Markdown";
       description = "Convert POD to Markdown";
+      homepage = "https://github.com/rwstauner/Pod-Markdown";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "pod2markdown";
     };
@@ -19226,7 +19487,8 @@ let
     buildInputs = [ FileShareDirInstall TestDeep ];
     meta = {
       description = "A formatter for spellchecking Pod";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      homepage = "https://github.com/perl-pod/Pod-Spell";
+      license = with lib.licenses; [ artistic2 ];
       mainProgram = "podspell";
     };
   };
@@ -19240,6 +19502,7 @@ let
     };
     meta = {
       description = "Remove POD from Perl code";
+      homepage = "https://github.com/domm/Pod-Strip";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -19254,7 +19517,7 @@ let
     propagatedBuildInputs = [ EncodeNewlines IOString PodWrap TextGlob ];
     buildInputs = [ TestCmd ];
     meta = {
-      description = "a reformatting Pod Processor";
+      description = "A reformatting Pod Processor";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "podtidy";
     };
@@ -19270,8 +19533,8 @@ let
     buildInputs = [ PPI SoftwareLicense TestDifferences ];
     propagatedBuildInputs = [ ConfigMVPReaderINI DateTime ListMoreUtils LogDispatchouli PodElemental ];
     meta = {
-      homepage = "https://github.com/rjbs/Pod-Weaver";
       description = "Weave together a Pod document from an outline";
+      homepage = "https://github.com/rjbs/Pod-Weaver";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -19324,8 +19587,8 @@ let
     prePatch = "rm t/04_tzset.t";
     buildInputs = [ ModuleBuildTiny ];
     meta = {
-      homepage = "https://github.com/kazeburo/POSIX-strftime-Compiler";
       description = "GNU C library compatible strftime for loggers and servers";
+      homepage = "https://github.com/kazeburo/POSIX-strftime-Compiler";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -19342,9 +19605,9 @@ let
       shortenPerlShebang $out/bin/rainbarf
     '';
     meta = {
-      homepage = "https://github.com/creaktive/rainbarf";
       description = "CPU/RAM/battery stats chart bar for tmux (and GNU screen)";
-      license = with lib.licenses; [ artistic1 gpl1Plus  ];
+      homepage = "https://github.com/creaktive/rainbarf";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "rainbarf";
     };
   };
@@ -19358,9 +19621,9 @@ let
     };
     propagatedBuildInputs = [ DigestSHA1 URI ];
     meta = {
-      homepage = "http://razor.sourceforge.net/";
       description = "Collaborative, content-based spam filtering network agent";
-      license = lib.licenses.mit;
+      homepage = "http://razor.sourceforge.net/";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -19374,9 +19637,9 @@ let
     };
     buildInputs = [ ModuleBuildTiny ];
     meta = {
-      homepage = "https://github.com/sanko/readonly";
       description = "Facility for creating read-only scalars, arrays, hashes";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      homepage = "https://github.com/sanko/readonly";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -19389,9 +19652,9 @@ let
     };
     buildInputs = [ ModuleBuildTiny TestFatal ];
     meta = {
-      homepage = "https://github.com/sanko/readonly";
       description = "Faster facility for creating read-only scalars, arrays, hashes";
-      license = lib.licenses.artistic2;
+      homepage = "https://github.com/sanko/readonly";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -19415,9 +19678,9 @@ let
     buildInputs = [ IOString ModuleBuildTiny TestDeep TestFatal TestSharedFork TestTCP ];
     propagatedBuildInputs = [ IOSocketTimeout TryTiny ];
     meta = {
-      homepage = "https://github.com/PerlRedis/perl-redis";
       description = "Perl binding for Redis database";
-      license = lib.licenses.artistic2;
+      homepage = "https://github.com/PerlRedis/perl-redis";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -19478,10 +19741,10 @@ let
     };
     propagatedBuildInputs = [ RegexpCommon ];
     meta = {
+      description = "Date and time regexps";
       homepage = "https://github.com/manwar/Regexp-Common-time";
-      description = "Date and time regexps.";
+      license = with lib.licenses; [ free ];
       maintainers = [ maintainers.artturin ];
-      license = lib.licenses.free;
     };
   };
 
@@ -19515,8 +19778,8 @@ let
       sha256 = "f739dab8df2b06aae5c48f9971251b73704464a32d07d8d025f3c0f869544e89";
     };
     meta = {
-      homepage = "https://github.com/toddr/Regexp-Parser";
       description = "Base class for parsing regexes";
+      homepage = "http://wiki.github.com/toddr/Regexp-Parser";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -19529,6 +19792,7 @@ let
       sha256 = "1yn5l6x3xyic9jxw9jggqsbggcv7rc8ggj4zbnlz9hfvv17gjazv";
     };
     meta = {
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -19542,6 +19806,7 @@ let
     propagatedBuildInputs = [ LWPProtocolHttps ];
     meta = {
       description = "A simple client for interacting with RESTful http/https resources";
+      homepage = "https://github.com/milescrawford/cpan-rest-client";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -19555,8 +19820,8 @@ let
     };
     buildInputs = [ TestLongString TestWWWMechanize TestWWWMechanizeCGI ];
     meta = {
-      homepage = "https://jaldhar.github.io/REST-Utils/";
       description = "Utility functions for REST applications";
+      homepage = "http://jaldhar.github.com/REST-Utils";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -19571,7 +19836,8 @@ let
     propagatedBuildInputs = [ XMLParser ];
     doCheck = false;
     meta = {
-      description = "An implementation of XML-RPC";
+      description = "Data, client and server classes for XML-RPC";
+      homepage = "http://github.com/rjray/rpc-xml";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "make_method";
     };
@@ -19609,6 +19875,7 @@ let
     propagatedBuildInputs = [ MooseXRoleParameterized StringErrf ];
     meta = {
       description = "A thing with a message method";
+      homepage = "https://github.com/rjbs/Role-HasMessage";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -19622,7 +19889,8 @@ let
     };
     propagatedBuildInputs = [ Moose ];
     meta = {
-      description = "A thing with a list of tags";
+      description = "A thing you can identify somehow";
+      homepage = "https://github.com/rjbs/Role-Identifiable";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -19635,7 +19903,7 @@ let
       sha256 = "92ba5712850a74102c93c942eb6e7f62f7a4f8f483734ed289d08b324c281687";
     };
     meta = {
-      description = "Roles. Like a nouvelle cuisine portion size slice of Moose";
+      description = "Roles: a nouvelle cuisine portion size slice of Moose";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -19691,7 +19959,8 @@ let
     buildInputs = [ CGI HTTPServerSimple TestException ];
     propagatedBuildInputs = [ DateTimeFormatDateParse Error LWP ParamsValidate ];
     meta = {
-      description = "Talk to RT installation using REST protocol";
+      description = "Client for RT using REST API";
+      homepage = "https://github.com/RT-Client-REST/RT-Client-REST";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -19763,6 +20032,7 @@ let
     };
     meta = {
       description = "Act on upper scopes";
+      homepage = "http://search.cpan.org/dist/Scope-Upper";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -19780,7 +20050,7 @@ let
     propagatedBuildInputs = [ FileShareDir TieSimple ];
     meta = {
       description = "SDL bindings to Perl";
-      license = lib.licenses.lgpl21Plus;
+      license = with lib.licenses; [ lgpl21Plus ];
     };
   };
 
@@ -19794,6 +20064,7 @@ let
     buildInputs = [ pkgs.xapian DevelLeak ];
     meta = {
       description = "Perl XS frontend to the Xapian C++ search library";
+      homepage = "https://xapian.org";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -19808,9 +20079,9 @@ let
     buildInputs = [ TestDeep TestDifferences TestLongString TestWarn ];
     preBuild = "ls";
     meta = {
-      homepage = "https://github.com/Sereal/Sereal";
       description = "Fast, compact, powerful binary deserialization";
-      license = with lib.licenses; [ artistic2 ];
+      homepage = "https://github.com/Sereal/Sereal";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.thoughtpolice ];
     };
   };
@@ -19824,9 +20095,9 @@ let
     };
     buildInputs = [ SerealDecoder TestDeep TestDifferences TestLongString TestWarn ];
     meta = {
+      description = "Fast, compact, powerful binary serialization";
       homepage = "https://github.com/Sereal/Sereal";
-      description = "Fast, compact, powerful binary deserialization";
-      license = with lib.licenses; [ artistic2 ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.thoughtpolice ];
     };
   };
@@ -19841,9 +20112,8 @@ let
     buildInputs = [ TestDeep TestLongString TestWarn ];
     propagatedBuildInputs = [ SerealDecoder SerealEncoder ];
     meta = {
-      homepage = "https://github.com/Sereal/Sereal";
-      description = "Fast, compact, powerful binary deserialization";
-      license = with lib.licenses; [ artistic2 ];
+      description = "Fast, compact, powerful binary (de-)serialization";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.thoughtpolice ];
     };
   };
@@ -19871,8 +20141,8 @@ let
     };
     buildInputs = [ TestRequires TestSharedFork TestTCP ];
     meta = {
-      homepage = "https://github.com/kazuho/p5-Server-Starter";
       description = "A superdaemon for hot-deploying server programs";
+      homepage = "https://github.com/kazuho/p5-Server-Starter";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "start_server";
     };
@@ -19886,8 +20156,8 @@ let
       sha256 = "32c3df96ef455c71870363acd950ddc4fbc848c594f4bc55b21b44cf979f79a1";
     };
     meta = {
-      homepage = "https://github.com/hoytech/Session-Token";
       description = "Secure, efficient, simple random session token generation";
+      homepage = "https://github.com/hoytech/Session-Token";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -19902,6 +20172,7 @@ let
     };
     meta = {
       description = "Infinite Sets math";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -19914,7 +20185,8 @@ let
     };
 
     meta = {
-      description = "Manages sets of integers";
+      description = "Manages sets of integers, newsrc style";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -19927,7 +20199,7 @@ let
     };
     meta = {
       description = "Unordered collections (sets) of Perl Objects";
-      license = lib.licenses.artistic2;
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -19951,8 +20223,8 @@ let
       sha256 = "dcf8a312134a7c6b82926a0115d93b692472a662d28cdc3a9bdf28984ada9ee3";
     };
     meta = {
-      homepage = "https://github.com/neilb/Smart-Comments";
       description = "Comments that do more than just sit there";
+      homepage = "https://github.com/neilb/Smart-Comments";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -19994,7 +20266,7 @@ let
       sha256 = "0675v45bbsh7vr7kpf36xs2q79g02iq1kmfw22h20xdk4rzqvkqx";
     };
     meta = {
-      description = "Porters stemming algorithm for norwegian.";
+      description = "Porters stemming algorithm for norwegian";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "stemmer-no.pl";
     };
@@ -20008,7 +20280,7 @@ let
       sha256 = "0agwc12jk5kmabnpsplw3wf4ii5w1zb159cpin44x3srb0sr5apg";
     };
     meta = {
-      description = "Porters stemming algorithm for swedish.";
+      description = "Porters stemming algorithm for swedish";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "stemmer-se.pl";
     };
@@ -20042,7 +20314,7 @@ let
     patches = [ ../development/perl-modules/Socket6-sv_undef.patch ];
     meta = {
       description = "IPv6 related part of the C socket.h defines and structure manipulators";
-      license = lib.licenses.bsd3;
+      license = with lib.licenses; [ bsd3 ];
     };
   };
 
@@ -20056,8 +20328,8 @@ let
     buildInputs = [ TryTiny ];
     propagatedBuildInputs = [ DataSection TextTemplate ];
     meta = {
-      homepage = "https://github.com/rjbs/Software-License";
       description = "Packages that provide templated software licenses";
+      homepage = "https://github.com/Perl-Toolchain-Gang/Software-License";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -20073,8 +20345,8 @@ let
     buildInputs = [ TestCheckDeps ];
     meta = {
       description = "Software::License pack for Creative Commons' licenses";
-      license = with lib.licenses; [ lgpl3Plus ];
       homepage = "https://github.com/SineSwiper/Software-License-CCpack";
+      license = with lib.licenses; [ lgpl3Plus ];
     };
   };
 
@@ -20086,7 +20358,7 @@ let
       sha256 = "1kqs10s2plj6c96srk0j8d7xj8dxk1704r7mck8rqk09mg7lqspd";
     };
     meta = {
-      description = "Sort arrays by one or multiple calculated keys";
+      description = "The fastest way to sort anything in Perl";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -20111,6 +20383,7 @@ let
     buildInputs = [ TestFatal TestNeeds ];
     meta = {
       description = "Type constraints and coercions for Perl";
+      homepage = "https://metacpan.org/release/Specio";
       license = with lib.licenses; [ artistic2 ];
     };
   };
@@ -20126,6 +20399,7 @@ let
     buildInputs = [ Filepushd TestFatal ];
     meta = {
       description = "Path::Tiny types and coercions for Specio";
+      homepage = "https://metacpan.org/release/Specio-Library-Path-Tiny";
       license = with lib.licenses; [ asl20 ];
     };
   };
@@ -20163,8 +20437,8 @@ let
     };
     propagatedBuildInputs = [ CryptRC4 DigestPerlMD5 IOStringy OLEStorage_Lite ];
     meta = {
-      homepage = "https://github.com/runrig/spreadsheet-parseexcel/";
       description = "Read information from an Excel file";
+      homepage = "http://github.com/runrig/spreadsheet-parseexcel";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -20235,9 +20509,9 @@ let
     buildInputs = [ TestDeep ];
     propagatedBuildInputs = [ SQLAbstract ];
     meta = {
-      homepage = "https://github.com/mojolicious/sql-abstract-pg";
       description = "PostgreSQL features for SQL::Abstract";
-      license = lib.licenses.artistic2;
+      homepage = "https://mojolicious.org";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -20361,8 +20635,8 @@ let
 
     doCheck = false; # binds to various TCP ports
     meta = {
-      homepage = "https://github.com/miyagawa/Starman";
       description = "High-performance preforking PSGI/Plack web server";
+      homepage = "https://github.com/miyagawa/Starman";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "starman";
     };
@@ -20377,7 +20651,7 @@ let
     };
     propagatedBuildInputs = [ NumberFormat ];
     meta = {
-      license = "open_source";
+      license = with lib.licenses; [ free ];
     };
   };
 
@@ -20390,6 +20664,7 @@ let
     };
     meta = {
       description = "Efficient resampling and calculation of medians with confidence intervals";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -20416,6 +20691,7 @@ let
     propagatedBuildInputs = [ ListMoreUtils ];
     meta = {
       description = "Module of basic descriptive statistical functions";
+      homepage = "http://metacpan.org/release/Statistics-Descriptive";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -20447,8 +20723,8 @@ let
       sha256 = "0fs2n9zw6isfkha2kbqrvl9mwg572x1x0jlfaps0qsyynn846bcv";
     };
     meta = {
-      homepage = "https://plackperl.org";
       description = "Temporary buffer to save bytes";
+      homepage = "https://github.com/plack/Stream-Buffered";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -20461,8 +20737,8 @@ let
       sha256 = "0mwd9xqz4n8qfpi5h5581lbm33qhf7agww18h063icnilrs7km89";
     };
     meta = {
+      description = "Turn on strict and make most warnings fatal";
       homepage = "http://git.shadowcat.co.uk/gitweb/gitweb.cgi?p=p5sagit/strictures.git";
-      description = "Turn on strict and make all warnings fatal";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -20523,8 +20799,8 @@ let
     buildInputs = [ TestBase ModuleBuildTiny ModuleInstallGithubMeta ModuleInstallRepository ModuleInstallReadmeFromPod ModuleInstallReadmeMarkdownFromPod YAML ];
     propagatedBuildInputs = [ AlgorithmDiff ];
     meta = {
-      homepage = "https://github.com/yappo/p5-String-Diff";
       description = "Simple diff to String";
+      homepage = "https://github.com/yappo/p5-String-Diff";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -20541,6 +20817,7 @@ let
     propagatedBuildInputs = [ StringFormatter ];
     meta = {
       description = "A simple sprintf-like dialect";
+      homepage = "https://github.com/rjbs/String-Errf";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -20563,8 +20840,8 @@ let
     };
     propagatedBuildInputs = [ JSONMaybeXS SubExporter ];
     meta = {
-      homepage = "https://github.com/rjbs/String-Flogger";
       description = "String munging for loggers";
+      homepage = "https://github.com/rjbs/String-Flogger";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -20629,6 +20906,7 @@ let
     };
     meta = {
       description = "Random password generator";
+      homepage = "https://github.com/sirhc/string-mkpasswd";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "mkpasswd.pl";
     };
@@ -20653,6 +20931,7 @@ let
     propagatedBuildInputs = [ SubExporter ];
     meta = {
       description = "Rewrite strings based on a set of known prefixes";
+      homepage = "https://github.com/rjbs/String-RewritePrefix";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -20681,8 +20960,8 @@ let
     };
     doCheck = true;
     meta = {
-      license = with lib.licenses; [ gpl2 ];
       description = "Calculate the similarity of two strings";
+      license = with lib.licenses; [ gpl2 ];
     };
   };
 
@@ -20705,8 +20984,8 @@ let
     buildInputs = [ Test2Suite ];
     propagatedBuildInputs = [ ShellGuess ];
     meta = {
-      homepage = "https://metacpan.org/pod/Shell::Config::Generate";
       description = "Portably generate config for any shell";
+      homepage = "https://metacpan.org/pod/Shell::Config::Generate";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -20719,8 +20998,8 @@ let
       sha256 = "4069fa2637e443118ed956d710231d166823d23b2a64eb87b8a46872e865a12b";
     };
     meta = {
-      homepage = "https://metacpan.org/pod/Shell::Guess";
       description = "Make an educated guess about the shell in use";
+      homepage = "https://metacpan.org/pod/Shell::Guess";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -20744,7 +21023,8 @@ let
     };
     propagatedBuildInputs = [ SubExporter ];
     meta = {
-      description = "A module for when strings are too long to be displayed in";
+      description = "A module for when strings are too long to be displayed in...";
+      homepage = "https://github.com/rjbs/String-Truncate";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -20773,7 +21053,8 @@ let
     };
     buildInputs = [ ModuleBuildTiny ];
     meta = {
-      description = "String::Util -- String processing utilities";
+      description = "String processing utility functions";
+      homepage = "https://github.com/scottchiefbaker/String-Util";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -20789,7 +21070,7 @@ let
     };
     buildInputs = [ TestFatal ];
     meta = {
-      description = "make simple lightweight record-like structures";
+      description = "Make simple lightweight record-like structures";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -20803,8 +21084,8 @@ let
     };
     propagatedBuildInputs = [ DataOptList ];
     meta = {
-      homepage = "https://github.com/rjbs/sub-exporter";
       description = "A sophisticated exporter for custom-built routines";
+      homepage = "https://github.com/rjbs/Sub-Exporter";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -20819,8 +21100,8 @@ let
     buildInputs = [ namespaceautoclean ];
     propagatedBuildInputs = [ SubExporter SubName ];
     meta = {
-      homepage = "https://github.com/rjbs/Sub-Exporter-ForMethods";
       description = "Helper routines for using Sub::Exporter to build methods";
+      homepage = "https://github.com/rjbs/Sub-Exporter-ForMethods";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -20834,8 +21115,8 @@ let
     };
     propagatedBuildInputs = [ SubExporter ];
     meta = {
-      homepage = "https://github.com/rjbs/sub-exporter-globexporter";
       description = "Export shared globs with Sub::Exporter collectors";
+      homepage = "https://github.com/rjbs/Sub-Exporter-GlobExporter";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -20849,6 +21130,7 @@ let
     };
     meta = {
       description = "Only use Sub::Exporter if you need it";
+      homepage = "https://github.com/frioux/Sub-Exporter-Progressive";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -20863,7 +21145,8 @@ let
     propagatedBuildInputs = [ ClassMethodModifiers ClassTiny RoleTiny ScalarListUtils TypeTiny ];
     buildInputs = [ TestFatal TestRequires ];
     meta = {
-      description = "alternative handles_via implementation";
+      description = "Alternative handles_via implementation";
+      homepage = "https://metacpan.org/release/Sub-HandlesVia";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -20904,6 +21187,7 @@ let
     };
     meta = {
       description = "Install subroutines into packages easily";
+      homepage = "https://github.com/rjbs/Sub-Install";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -20917,8 +21201,8 @@ let
     };
     buildInputs = [ BC DevelCheckBin ];
     meta = {
-      homepage = "https://github.com/p5sagit/Sub-Name";
       description = "(Re)name a sub";
+      homepage = "https://github.com/p5sagit/Sub-Name";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -20970,8 +21254,8 @@ let
       sha256 = "14z2xjiw931wizcx3mblmby753jspvfm321d6chs907nh0xzdwxl";
     };
     meta = {
-      homepage = "https://github.com/dagolden/sub-uplevel";
       description = "Apparently run a function in a higher stack frame";
+      homepage = "https://github.com/Perl-Toolchain-Gang/Sub-Uplevel";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -20994,9 +21278,9 @@ let
       sha256 = "01gc2lfli282dj6a2pkpxb0vmpyavs323cbdw15gxi06pn5nxxgl";
     };
     meta = {
-      description = "lib/Safe/Hole.pm";
+      description = "Lib/Safe/Hole.pm";
+      homepage = "http://github.com/toddr/Safe-Hole";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
-      homepage = "https://github.com/toddr/Safe-Hole";
       broken = stdenv.isDarwin;
     };
   };
@@ -21010,8 +21294,8 @@ let
     };
     propagatedBuildInputs = [ HTMLEscape HashMerge IPCRun Pegex TextAutoformat YAMLLibYAML ];
     meta = {
-      homepage = "https://github.com/ingydotnet/swim-pm";
       description = "See What I Mean?!";
+      homepage = "https://github.com/ingydotnet/swim-pm";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "swin";
     };
@@ -21074,8 +21358,8 @@ let
     };
     propagatedBuildInputs = [ DataOptList namespaceclean ];
     meta = {
-      homepage = "https://github.com/phaylon/syntax/wiki";
       description = "Activate syntax extensions";
+      homepage = "https://github.com/phaylon/syntax/wiki";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -21090,8 +21374,8 @@ let
     buildInputs = [ TestRequires ];
     propagatedBuildInputs = [ syntax ];
     meta = {
-      homepage = "https://github.com/frioux/Syntax-Keyword-Junction";
       description = "Perl6 style Junction operators in Perl5";
+      homepage = "https://github.com/frioux/Syntax-Keyword-Junction";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -21134,9 +21418,9 @@ let
       sha256 = "0786319d3a3a8bae5d727939244bf17e140b714f52734d5e9f627203e4cf3e3b";
     };
     meta = {
-      description = "Memory informations";
-      maintainers = [ maintainers.pSub ];
+      description = "Memory information";
       license = with lib.licenses; [ gpl2Plus ];
+      maintainers = [ maintainers.pSub ];
     };
   };
 
@@ -21205,6 +21489,9 @@ let
     buildInputs = [ pkgs.libvirt CPANChanges TestPod TestPodCoverage XMLXPath ];
     perlPreHook = lib.optionalString stdenv.isi686 "export LD=$CC"; # fix undefined reference to `__stack_chk_fail_local'
     meta = {
+      description = "Libvirt Perl API";
+      homepage = "http://libvirt.org";
+      license = with lib.licenses; [ gpl1 ];
       broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.SysVirt.x86_64-darwin
     };
   };
@@ -21219,6 +21506,7 @@ let
     doCheck = !stdenv.isDarwin;
     meta = {
       description = "Stream TAP from pgTAP test scripts";
+      homepage = "https://search.cpan.org/dist/Tap-Parser-Sourcehandler-pgTAP";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -21249,7 +21537,8 @@ let
     propagatedBuildInputs = [ EnvPath FileWhich GamesSolitaireVerify InlineC ListMoreUtils MooX StringShellQuote TaskTestRunAllPlugins TemplateToolkit YAMLLibYAML ];
     meta = {
       description = "Install the CPAN dependencies of the Freecell Solver test suite";
-      license = lib.licenses.mit;
+      homepage = "http://metacpan.org/release/Task-FreecellSolver-Testing";
+      license = with lib.licenses; [ mit ];
     };
   };
 
@@ -21273,9 +21562,9 @@ let
     };
     buildInputs = [ TestRun TestRunCmdLine TestRunPluginAlternateInterpreters TestRunPluginBreakOnFailure TestRunPluginColorFileVerdicts TestRunPluginColorSummary TestRunPluginTrimDisplayedFilenames ];
     meta = {
-      homepage = "https://web-cpan.shlomifish.org/modules/Test-Run/";
       description = "Specifications for installing all the Test::Run";
-      license = lib.licenses.mit;
+      homepage = "http://web-cpan.shlomifish.org/modules/Test-Run";
+      license = with lib.licenses; [ mit ];
     };
   };
 
@@ -21288,6 +21577,7 @@ let
     };
     meta = {
       description = "Ensure that a platform has weaken support";
+      homepage = "https://github.com/karenetheridge/Task-Weaken";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -21309,7 +21599,7 @@ let
     makeMakerFlags = lib.optionalString stdenv.isLinux
       "--tclsh=${pkgs.tcl}/bin/tclsh --nousestubs";
     meta = {
-      description = "Tcl extension module for perl";
+      description = "Tcl extension module for Perl";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -21352,8 +21642,8 @@ let
     };
     propagatedBuildInputs = [ TemplateToolkit TextAutoformat ];
     meta = {
-      homepage = "https://github.com/karpet/template-plugin-autoformat";
       description = "TT plugin for Text::Autoformat";
+      homepage = "https://github.com/karpet/template-plugin-autoformat";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -21377,9 +21667,9 @@ let
     };
     propagatedBuildInputs = [ IOAll TemplateToolkit ];
     meta = {
-      maintainers = with maintainers; [ eelco ];
       description = "Perl Template Toolkit Plugin for IO::All";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
+      maintainers = with maintainers; [ eelco ];
     };
   };
 
@@ -21426,6 +21716,7 @@ let
     };
     meta = {
       description = "Template Toolkit reimplemented in as little code as possible";
+      homepage = "https://github.com/karenetheridge/Template-Tiny";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -21442,6 +21733,7 @@ let
     buildInputs = [ CGI TestLeakTrace ];
     meta = {
       description = "Comprehensive template processing system";
+      homepage = "http://www.template-toolkit.org";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -21469,6 +21761,7 @@ let
     };
     meta = {
       description = "Detect encoding of the current terminal";
+      homepage = "https://github.com/miyagawa/Term-Encoding";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -21498,7 +21791,6 @@ let
     propagatedBuildInputs = [ IOInteractive TermProgressBar ];
     buildInputs = [ TestMockObject ];
     meta = {
-      description = "";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -21565,8 +21857,8 @@ let
     doCheck = false;
 
     meta = {
-      homepage = "https://sourceforge.net/projects/perl-trg/";
       description = "Perl extension for the GNU Readline/History Library";
+      homepage = "https://github.com/hirooih/perl-trg";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "perlsh";
     };
@@ -21583,7 +21875,8 @@ let
     outputs = [ "out" ];
 
     meta = {
-      description = "a modified version of T::RL::Perl with several new nonstandard features specific to TTYtter";
+      description = "A Term::ReadLine driver based on Term::ReadLine::Perl, with special features for microblogging and the TTYtter client (q.v)";
+      homepage = "http://www.floodgap.com/software/ttytter";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -21677,7 +21970,7 @@ let
       sha256 = "f2e491796061205b08688802b287792d7d803b08972339fb1070ba05612af885";
     };
     meta = {
-      description = "Perl extension for displaying a progress indicator on a terminal.";
+      description = "Perl extension for displaying a progress indicator on a terminal";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -21704,6 +21997,7 @@ let
       sha256 = "f954e0310941d45c0fc3eb4a40f5d3a00d68119e277d303a1e6af11ded6fbd94";
     };
     meta = {
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -21793,6 +22087,7 @@ let
     propagatedBuildInputs = [ TestSimple13 ];
     meta = {
       description = "Fail if tests warn";
+      homepage = "https://metacpan.org/release/Test2-Plugin-NoWarnings";
       license = with lib.licenses; [ artistic2 ];
     };
   };
@@ -21821,9 +22116,9 @@ let
     propagatedBuildInputs = [ SubExporter ];
     buildInputs = [ TestNeeds ];
     meta = {
-      description = "subtests that you can die your way out of ... but survive";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      description = "Subtests that you can die your way out of ... but survive";
       homepage = "https://github.com/rjbs/Test-Abortable";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -21857,7 +22152,7 @@ let
     };
     buildInputs = [ TestMost TestNoWarnings TestTrap ];
     meta = {
-      description = "Aggregate C<*.t> tests to make them run faster";
+      description = "Aggregate *.t tests to make them run faster";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       broken = true; # This module only works with Test::More version < 1.3, but you have 1.302133
     };
@@ -21886,6 +22181,7 @@ let
     buildInputs = [ TestFatal ];
     meta = {
       description = "Provides a bits_is() subroutine for testing binary data";
+      homepage = "http://metacpan.org/release/Test-Bits";
       license = with lib.licenses; [ artistic2 ];
     };
   };
@@ -21943,8 +22239,8 @@ let
     buildInputs = [ Filepushd Moo Mouse RoleTiny SubExporter TestDeep TestNeeds TestWarnings namespaceclean ];
     propagatedBuildInputs = [ PackageStash SubIdentify ];
     meta = {
-      homepage = "https://github.com/karenetheridge/Test-CleanNamespaces";
       description = "Check for uncleaned imports";
+      homepage = "https://github.com/karenetheridge/Test-CleanNamespaces";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -21959,8 +22255,8 @@ let
       doCheck = false; /* test fails */
     meta = {
       description = "Perl module for portable testing of commands and scripts";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
       homepage = "https://github.com/neilb/Test-Cmd";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -21972,9 +22268,9 @@ let
       sha256 = "0cwm3c4d49mdrbm6vgh78b3x8mk730l0zg8i7xb9z8bkx9pzr8r8";
     };
     meta = {
-      homepage = "https://github.com/danboo/perl-test-command";
-      description = "Test routines for external commands ";
-      license = with lib.licenses; [ artistic1 gpl1 ];
+      description = "Test routines for external commands";
+      homepage = "https://metacpan.org/release/Test-Command";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -21987,7 +22283,7 @@ let
     };
     propagatedBuildInputs = [ UNIVERSALrequire ];
     meta = {
-      description = "Check whether Perl files compile correctly";
+      description = "Assert that your Perl files compile OK";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -22000,8 +22296,8 @@ let
       sha256 = "f55b4f9cf6bc396d0fe8027267685cb2ac4affce897d0967a317fac6db5a8db5";
     };
     meta = {
-      description = "Validate your CPAN META.yml files";
-      license = lib.licenses.artistic2;
+      description = "Validate your CPAN META.json files";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -22030,7 +22326,8 @@ let
     propagatedBuildInputs = [ IOAll ListMoreUtils MooX MooXlate ];
     meta = {
       description = "Split data-driven tests into several test scripts";
-      license = lib.licenses.mit;
+      homepage = "http://metacpan.org/release/Test-Data-Split";
+      license = with lib.licenses; [ mit ];
     };
   };
 
@@ -22042,6 +22339,8 @@ let
       sha256 = "0mkw18q5agr30djxr1y68rcfw8aq20ws872hmv88f9gnynag8r20";
     };
     meta = {
+      homepage = "http://github.com/rjbs/Test-Deep";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -22055,8 +22354,8 @@ let
     buildInputs = [ ModuleBuildTiny ];
     propagatedBuildInputs = [ ExporterLite JSONMaybeXS TestDeep ];
     meta = {
-      homepage = "https://github.com/motemen/perl5-Test-Deep-JSON";
       description = "Compare JSON with Test::Deep";
+      homepage = "https://github.com/motemen/perl5-Test-Deep-JSON";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -22071,8 +22370,8 @@ let
     buildInputs = [ TestFatal TestNeeds ];
     propagatedBuildInputs = [ TestDeep TryTiny ];
     meta = {
-      homepage = "https://github.com/karenetheridge/Test-Deep-Type";
       description = "A Test::Deep plugin for validating type constraints";
+      homepage = "https://github.com/karenetheridge/Test-Deep-Type";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -22115,6 +22414,7 @@ let
     propagatedBuildInputs = [ ModuleManifest ];
     meta = {
       description = "Author test that validates a package MANIFEST";
+      homepage = "https://github.com/jawnsy/Test-DistManifest";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -22128,6 +22428,7 @@ let
     };
     meta = {
       description = "Check the correct line endings in your project";
+      homepage = "https://github.com/karenetheridge/Test-EOL";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -22166,7 +22467,8 @@ let
     buildInputs = [ CaptureTiny ];
     meta = {
       description = "Add test failures if warnings are caught";
-      license = lib.licenses.asl20;
+      homepage = "https://github.com/dagolden/Test-FailWarnings";
+      license = with lib.licenses; [ asl20 ];
     };
   };
 
@@ -22180,9 +22482,9 @@ let
     propagatedBuildInputs = [ HTTPDaemon Plack ];
     buildInputs = [ LWP ModuleBuildTiny TestException TestSharedFork TestTCP TestUseAllModules ];
     meta = {
-      description = "a fake HTTP server";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      description = "A fake HTTP server";
       homepage = "https://github.com/masaki/Test-Fake-HTTPD";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -22195,8 +22497,8 @@ let
     };
     propagatedBuildInputs = [ TryTiny ];
     meta = {
-      homepage = "https://github.com/rjbs/Test-Fatal";
       description = "Incredibly simple helpers for testing code with exceptions";
+      homepage = "https://github.com/rjbs/Test-Fatal";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -22210,8 +22512,9 @@ let
     };
     buildInputs = [ Testutf8 ];
     meta = {
-      description = "Check file attributes";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      description = "Test file attributes";
+      homepage = "https://github.com/briandfoy/test-file";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -22239,8 +22542,8 @@ let
     buildInputs = [ TestFatal ];
     propagatedBuildInputs = [ ClassTiny FileCopyRecursive FileShareDir PathTiny ScopeGuard ];
     meta = {
-      homepage = "https://github.com/kentfredric/Test-File-ShareDir";
       description = "Create a Fake ShareDir for your modules for testing";
+      homepage = "https://github.com/kentnl/Test-File-ShareDir";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -22255,6 +22558,7 @@ let
     propagatedBuildInputs = [ PathTiny ];
     meta = {
       description = "Portable filename comparison";
+      homepage = "https://metacpan.org/release/Test-Filename";
       license = with lib.licenses; [ asl20 ];
     };
   };
@@ -22267,7 +22571,7 @@ let
       sha256 = "0gnh8m81fdrwmzy1fix12grfq7sf7nn0gbf24zlap1gq4kxzpzpw";
     };
     meta = {
-      description = "test code which forks";
+      description = "Test code which forks";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -22295,6 +22599,7 @@ let
     propagatedBuildInputs = [ SubExporter TextDiff ];
     buildInputs = [ TestDifferences TestNoWarnings ];
     meta = {
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -22306,7 +22611,7 @@ let
       sha256 = "0h1zl2l1ljlcxsn0xvin9dwiymnhyhnfnxgzg3f9899g37f4qk3x";
     };
     meta = {
-      description = "test binary strings with hex dump diagnostics";
+      description = "Test binary strings with hex dump diagnostics";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -22319,7 +22624,7 @@ let
       sha256 = "08szivpqfwxnf6cfh0f0rfs4f7xbaxis3bra31l2c5gdk800a0ig";
     };
     meta = {
-      description = "assert the referential identity of a reference";
+      description = "Assert the referential identity of a reference";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -22334,6 +22639,7 @@ let
     propagatedBuildInputs = [ HTTPServerSimple ];
     meta = {
       description = "Test::More functions for HTTP::Server::Simple";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -22376,8 +22682,8 @@ let
     buildInputs = [ PathTiny Plack TestDeep TestFatal TestNeeds TestRequiresInternet TestWarnings ];
     meta = {
       description = "A LWP::UserAgent suitable for simulating and testing network calls";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
       homepage = "https://github.com/karenetheridge/Test-LWP-UserAgent";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -22390,6 +22696,7 @@ let
     };
     meta = {
       description = "Traces memory leaks";
+      homepage = "https://metacpan.org/release/Test-LeakTrace";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -22416,7 +22723,7 @@ let
     };
     propagatedBuildInputs = [ ListMoreUtils ModulePluggable ];
     meta = {
-      description = "do use_ok for modules in search path";
+      description = "Do use_ok for modules in search path";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -22440,6 +22747,7 @@ let
     propagatedBuildInputs = [ DevelCycle PadWalker ];
     meta = {
       description = "Verifies code hasn't left circular references";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -22451,7 +22759,7 @@ let
       sha256 = "1l1f7mwjyfgfbhad13p4wgavnb3mdjs6v3xr2m0rxm5ba8kqard0";
     };
     meta = {
-      description = "assert that code does not cause growth in memory usage";
+      description = "Assert that code does not cause growth in memory usage";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.TestMemoryGrowth.x86_64-darwin
     };
@@ -22466,7 +22774,7 @@ let
     };
     propagatedBuildInputs = [ MetricsAny ];
     meta = {
-      description = "assert that code produces metrics via L<Metrics::Any>";
+      description = "Assert that code produces metrics via Metrics::Any";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -22495,8 +22803,8 @@ let
     };
     propagatedBuildInputs = [ ClassLoad ];
     meta = {
-      homepage = "https://github.com/zigorou/p5-test-mock-guard";
       description = "Simple mock test library using RAII";
+      homepage = "https://github.com/zigorou/p5-test-mock-guard";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -22510,8 +22818,8 @@ let
     };
     propagatedBuildInputs = [ TestDeep URI ];
     meta = {
-      homepage = "https://github.com/odyniec/p5-Test-Mock-HTTP-Tiny.git";
       description = "Record and replay HTTP requests/responses with HTTP::Tiny";
+      homepage = "https://github.com/odyniec/p5-Test-Mock-HTTP-Tiny";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -22576,8 +22884,8 @@ let
     buildInputs = [ AnyEvent ModuleBuildTiny TestClass TestMockTime TestRequires ];
     meta = {
       description = "Replaces actual time with simulated high resolution time";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
       homepage = "https://github.com/tarao/perl5-Test-MockTime-HiRes";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -22589,8 +22897,8 @@ let
       sha256 = "0cqvbwddgh0pfzmh989gkysi9apqj7dp7jkxfa428db9kgzpbzlg";
     };
     meta = {
-      homepage = "https://github.com/creaktive/Test-Mojibake";
       description = "Check your source for encoding misbehavior";
+      homepage = "https://github.com/creaktive/Test-Mojibake";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "scan_mojibake";
     };
@@ -22634,8 +22942,8 @@ let
     buildInputs = [ pkgs.which ModuleBuildTiny TestSharedFork ];
     propagatedBuildInputs = [ ClassAccessorLite DBDmysql FileCopyRecursive ];
     meta = {
-      homepage = "https://github.com/kazuho/p5-test-mysqld";
       description = "Mysqld runner for tests";
+      homepage = "https://github.com/kazuho/p5-test-mysqld";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -22663,6 +22971,7 @@ let
     };
     meta = {
       description = "Check the presence of tabs in your project";
+      homepage = "https://github.com/karenetheridge/Test-NoTabs";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -22676,7 +22985,7 @@ let
     };
     meta = {
       description = "Make sure you didn't emit any warnings while testing";
-      license = lib.licenses.lgpl21;
+      license = with lib.licenses; [ lgpl21 ];
     };
   };
 
@@ -22709,7 +23018,7 @@ let
     propagatedBuildInputs = [ ConfigIdentity PAUSEPermissions ParseLocalDistribution ];
     buildInputs = [ ExtUtilsMakeMakerCPANfile TestUseAllModules ];
     meta = {
-      description = "tests module permissions in your distribution";
+      description = "Tests module permissions in your distribution";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -22734,6 +23043,8 @@ let
     propagatedBuildInputs = [ PathTiny PerlTidy TextDiff ];
     buildInputs = [ TestPerlCritic ];
     meta = {
+      description = "Check that all your files are tidy";
+      homepage = "http://metacpan.org/release/Test-PerlTidy";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -22747,6 +23058,7 @@ let
     };
     meta = {
       description = "Check for POD errors in files";
+      homepage = "http://search.cpan.org/dist/Test-Pod";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -22772,6 +23084,7 @@ let
     propagatedBuildInputs = [ CaptureTiny Moose podlinkcheck ];
     meta = {
       description = "Tests POD for invalid links";
+      homepage = "http://search.cpan.org/dist/Test-Pod-LinkCheck";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -22786,7 +23099,8 @@ let
     propagatedBuildInputs = [ LWP URIFind ];
     buildInputs = [ ModuleBuildTiny TestPod ];
     meta = {
-      description = "Checks POD for any http 404 links";
+      description = "Using this test module will check your POD for any http 404 links";
+      homepage = "http://search.cpan.org/dist/Test-Pod-No404s";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -22812,7 +23126,7 @@ let
       sha256 = "1chf6zizi7x128l3qm1bdqzwjjqm2j4gzajgghaksisn945c4mq4";
     };
     meta = {
-      description = "assert reference counts on objects";
+      description = "Assert reference counts on objects";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -22826,6 +23140,7 @@ let
     };
     meta = {
       description = "Checks to see if the module can be loaded";
+      homepage = "https://github.com/tokuhirom/Test-Requires";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -22853,6 +23168,7 @@ let
     };
     meta = {
       description = "Easily test network connectivity";
+      homepage = "https://metacpan.org/dist/Test-RequiresInternet";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -22879,8 +23195,8 @@ let
     buildInputs = [ TestAbortable TestFatal ];
     propagatedBuildInputs = [ Moose namespaceautoclean ];
     meta = {
-      homepage = "https://github.com/rjbs/Test-Routine";
       description = "Composable units of assertion";
+      homepage = "https://github.com/rjbs/Test-Routine";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -22895,9 +23211,9 @@ let
     buildInputs = [ TestTrap ];
     propagatedBuildInputs = [ IPCSystemSimple ListMoreUtils MooseXStrictConstructor TextSprintfNamed UNIVERSALrequire ];
     meta = {
-      homepage = "https://web-cpan.shlomifish.org/modules/Test-Run/";
       description = "Base class to run standard TAP scripts";
-      license = lib.licenses.mit;
+      homepage = "http://web-cpan.shlomifish.org/modules/Test-Run";
+      license = with lib.licenses; [ mit ];
     };
   };
 
@@ -22912,9 +23228,9 @@ let
     propagatedBuildInputs = [ MooseXGetopt UNIVERSALrequire YAMLLibYAML ];
     doCheck = !stdenv.isDarwin;
     meta = {
-      homepage = "http://web-cpan.berlios.de/modules/Test-Run/";
       description = "Analyze tests from the command line using Test::Run";
-      license = lib.licenses.mit;
+      homepage = "http://web-cpan.berlios.de/modules/Test-Run";
+      license = with lib.licenses; [ mit ];
       mainProgram = "runprove";
     };
   };
@@ -22929,9 +23245,9 @@ let
     buildInputs = [ TestRun TestRunCmdLine TestTrap YAMLLibYAML ];
     propagatedBuildInputs = [ Moose ];
     meta = {
-      homepage = "https://web-cpan.shlomifish.org/modules/Test-Run/";
       description = "Define different interpreters for different test scripts with Test::Run";
-      license = lib.licenses.mit;
+      homepage = "http://web-cpan.shlomifish.org/modules/Test-Run";
+      license = with lib.licenses; [ mit ];
     };
   };
 
@@ -22945,9 +23261,9 @@ let
     buildInputs = [ TestRun TestRunCmdLine TestTrap YAMLLibYAML ];
     propagatedBuildInputs = [ Moose ];
     meta = {
-      homepage = "https://web-cpan.shlomifish.org/modules/Test-Run/";
       description = "Stop processing the entire test suite";
-      license = lib.licenses.mit;
+      homepage = "http://web-cpan.shlomifish.org/modules/Test-Run";
+      license = with lib.licenses; [ mit ];
     };
   };
 
@@ -22963,9 +23279,9 @@ let
     moreInputs = [ TestTrap ]; # Added because tests were failing without it
     doCheck=true;
     meta = {
-      homepage = "https://web-cpan.shlomifish.org/modules/Test-Run/";
       description = "Make the file verdict ('ok', 'NOT OK')";
-      license = lib.licenses.mit;
+      homepage = "http://web-cpan.shlomifish.org/modules/Test-Run";
+      license = with lib.licenses; [ mit ];
     };
   };
 
@@ -22980,9 +23296,9 @@ let
     moreInputs = [ TestTrap ]; # Added because tests were failing without it
     doCheck=true;
     meta = {
-      homepage = "https://web-cpan.shlomifish.org/modules/Test-Run/";
       description = "A Test::Run plugin that";
-      license = lib.licenses.mit;
+      homepage = "http://web-cpan.shlomifish.org/modules/Test-Run";
+      license = with lib.licenses; [ mit ];
     };
   };
 
@@ -22996,9 +23312,9 @@ let
     buildInputs = [ TestRun TestRunCmdLine TestTrap YAMLLibYAML ];
     propagatedBuildInputs = [ Moose ];
     meta = {
-      homepage = "https://web-cpan.shlomifish.org/modules/Test-Run/";
       description = "Trim the first components";
-      license = lib.licenses.mit;
+      homepage = "http://web-cpan.shlomifish.org/modules/Test-Run";
+      license = with lib.licenses; [ mit ];
     };
   };
 
@@ -23013,7 +23329,8 @@ let
     propagatedBuildInputs = [ PathTiny ];
     meta = {
       description = "Tests that an external program is valgrind-clean";
-      license = lib.licenses.mit;
+      homepage = "http://metacpan.org/release/Test-RunValgrind";
+      license = with lib.licenses; [ mit ];
     };
   };
 
@@ -23053,8 +23370,8 @@ let
     };
     buildInputs = [ TestRequires ];
     meta = {
-      homepage = "https://github.com/tokuhirom/Test-SharedFork";
       description = "Fork test";
+      homepage = "https://github.com/tokuhirom/Test-SharedFork";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -23083,7 +23400,7 @@ let
     propagatedBuildInputs = [ TextDiff ];
     meta = {
       description = "Test against data stored in automatically-named file";
-      license = lib.licenses.artistic2;
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -23121,6 +23438,7 @@ let
     };
     meta = {
       description = "Test your SYNOPSIS code";
+      homepage = "http://metacpan.org/release/Test-Synopsis";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -23147,8 +23465,8 @@ let
     };
     meta = {
       description = "Temporary directories that stick around when tests fail";
-      license = with lib.licenses; [ asl20 ];
       homepage = "https://github.com/dagolden/Test-TempDir-Tiny";
+      license = with lib.licenses; [ asl20 ];
     };
   };
 
@@ -23162,6 +23480,7 @@ let
     buildInputs = [ TestSharedFork ];
     meta = {
       description = "Testing TCP program";
+      homepage = "https://github.com/tokuhirom/Test-TCP";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -23177,6 +23496,7 @@ let
     propagatedBuildInputs = [ TestSharedFork TestTCP ];
     meta = {
       description = "Testing UNIX domain socket program";
+      homepage = "https://github.com/fujiwara/Test-UNIXSock";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -23190,6 +23510,7 @@ let
     };
     meta = {
       description = "Overrides the time() and sleep() core functions for testing";
+      homepage = "https://github.com/cho45/Test-Time";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -23217,7 +23538,8 @@ let
     propagatedBuildInputs = [ FileFindObjectRule ];
     meta = {
       description = "Test for trailing space in source files";
-      license = lib.licenses.mit;
+      homepage = "http://metacpan.org/release/Test-TrailingSpace";
+      license = with lib.licenses; [ mit ];
     };
   };
 
@@ -23257,8 +23579,8 @@ let
     };
     buildInputs = [ CPANMetaCheck PadWalker ];
     meta = {
-      homepage = "https://github.com/karenetheridge/Test-Warnings";
       description = "Test for warnings and the lack of them";
+      homepage = "https://github.com/karenetheridge/Test-Warnings";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -23300,9 +23622,9 @@ let
     buildInputs = [ TestLongString ];
     propagatedBuildInputs = [ CarpAssertMore HTTPServerSimple WWWMechanize ];
     meta = {
-      homepage = "https://github.com/petdance/test-www-mechanize";
       description = "Testing-specific WWW::Mechanize subclass";
-      license = lib.licenses.artistic2;
+      homepage = "https://github.com/libwww-perl/WWW-Mechanize";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -23344,6 +23666,7 @@ let
     propagatedBuildInputs = [ Plack ];
     meta = {
       description = "Test PSGI programs using WWW::Mechanize";
+      homepage = "https://github.com/acme/test-www-mechanize-psgi";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -23381,7 +23704,9 @@ let
       sha256 = "09ap457vrlqvw2544j907fbb5crs08hd7sy4syipzxc6wny7v1aw";
     };
     meta = {
-      description = "Align text in columns";
+      description = "Module to align text";
+      homepage = "http://metacpan.org/release/Text-Aligner";
+      license = with lib.licenses; [ free ];
     };
   };
 
@@ -23407,8 +23732,8 @@ let
     };
     propagatedBuildInputs = [ TextReform ];
     meta = {
-      homepage = "https://github.com/neilbowers/Text-Autoformat";
       description = "Automatic text wrapping and reformatting";
+      homepage = "https://github.com/neilb/Text-Autoformat";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -23494,6 +23819,7 @@ let
     propagatedBuildInputs = [ TextCSV ];
     meta = {
       description = "Encoding aware Text::CSV";
+      homepage = "https://github.com/singingfish/Text-CSV-Encoded";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -23507,6 +23833,7 @@ let
     };
     meta = {
       description = "Comma-Separated Values manipulation routines";
+      homepage = "https://metacpan.org/pod/Text::CSV_XS";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -23533,8 +23860,8 @@ let
       sha256 = "0104z7jjv46kqh77rnx8kvmsbr5dy0s56xm01dckq4ly65br0hkx";
     };
     meta = {
-      homepage = "https://metacpan.org/release/Text-Format";
-      description = "Format text";
+      description = "Various subroutines to format text";
+      homepage = "http://www.shlomifish.org/open-source/projects/Text-Format";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = with maintainers; [ bcdarwin ];
     };
@@ -23576,6 +23903,7 @@ let
       sha256 = "1p87pgap99lw0nv62i3ghvsi7yg90lhn8vsa3yqp75rd04clybcj";
     };
     meta = {
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -23611,6 +23939,7 @@ let
       sha256 = "5b80b7d5e709d34393bcba88971864a17b44a5bf0f9e4bcee383d029e7d2d5c3";
     };
     meta = {
+      license = with lib.licenses; [ unfree ];
       broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.TextIconv.x86_64-darwin
     };
   };
@@ -23623,9 +23952,9 @@ let
       sha256 = "922c5c63314f406f4cbb35ec423ac2154d2c2b71a65addb7732c9d240a83fefb";
     };
     meta = {
-      homepage = "https://github.com/wchristian/Test-InDistDir";
       description = "Test environment setup for development with IDE";
-      license = lib.licenses.wtfpl;
+      homepage = "https://github.com/wchristian/Test-InDistDir";
+      license = with lib.licenses; [ wtfpl ];
       maintainers = [ maintainers.sgo ];
     };
   };
@@ -23695,7 +24024,8 @@ let
     };
     meta = {
       description = "Interact with a t/test_manifest file";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      homepage = "https://github.com/briandfoy/test-manifest";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -23713,7 +24043,7 @@ let
     '';
     meta = {
       description = "Convert Markdown syntax to (X)HTML";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [ bsd ];
       mainProgram = "Markdown.pl";
     };
   };
@@ -23728,8 +24058,8 @@ let
     buildInputs = [ Filepushd ];
     perlPreHook = lib.optionalString stdenv.isDarwin "export LD=$CC";
     meta = {
+      description = "Hoedown for Perl5";
       homepage = "https://github.com/tokuhirom/Text-Markdown-Hoedown";
-      description = "hoedown for Perl5";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -23743,8 +24073,8 @@ let
     };
     propagatedBuildInputs = [ PerlMinimumVersion ];
     meta = {
-      homepage = "https://github.com/rjbs/Test-MinimumVersion";
       description = "Does your code require newer perl than you think?";
+      homepage = "https://github.com/rjbs/Test-MinimumVersion";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -23773,7 +24103,7 @@ let
     propagatedBuildInputs = [ HTMLParser TextMarkdown ];
     meta = {
       description = "Convert MultiMarkdown syntax to (X)HTML";
-      license = lib.licenses.bsd3;
+      license = with lib.licenses; [ bsd3 ];
       mainProgram = "MultiMarkdown.pl";
     };
   };
@@ -23786,9 +24116,9 @@ let
       sha256 = "535430919e6fdf6ce55ff76e9892afccba3b7d4160db45f3ac43b0f92ffcd049";
     };
     meta = {
-      homepage = "https://github.com/dagolden/Test-Number-Delta";
       description = "Compare the difference between numbers against a given tolerance";
-      license = "apache";
+      homepage = "https://github.com/dagolden/Test-Number-Delta";
+      license = with lib.licenses; [ asl20 ];
     };
   };
 
@@ -23827,7 +24157,7 @@ let
     propagatedBuildInputs = [ TextDiff ];
     meta = {
       description = "Patches text with given patch";
-      license = lib.licenses.gpl2;
+      license = with lib.licenses; [ gpl2 ];
     };
   };
 
@@ -23905,7 +24235,8 @@ let
     };
     meta = {
       description = "Allows conversion between Roman and Arabic algarisms";
-      license = lib.licenses.bsd3;
+      homepage = "https://github.com/creaktive/Text-Roman";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -23919,7 +24250,7 @@ let
     propagatedBuildInputs = [ UnicodeLineBreak ];
     meta = {
       description = "Simple eyecandy ASCII tables";
-      license = lib.licenses.artistic2;
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -23942,7 +24273,8 @@ let
     buildInputs = [ TestWarn ];
     meta = {
       description = "Sprintf-like function with named conversions";
-      license = lib.licenses.mit;
+      homepage = "http://metacpan.org/release/Text-Sprintf-Named";
+      license = with lib.licenses; [ mit ];
     };
   };
 
@@ -23955,9 +24287,9 @@ let
     };
     propagatedBuildInputs = [ TextAligner ];
     meta = {
-      homepage = "https://www.shlomifish.org/open-source/projects/docmake/";
       description = "Organize Data in Tables";
-      license = lib.licenses.isc;
+      homepage = "http://metacpan.org/release/Text-Table";
+      license = with lib.licenses; [ isc ];
     };
   };
 
@@ -24005,8 +24337,8 @@ let
     buildInputs = [ ModuleBuildTiny ];
 
     meta = {
-      homepage = "https://github.com/gfx/p5-Test-Vars";
-      description = "Detects unused variables";
+      description = "Detects unused variables in perl modules";
+      homepage = "https://github.com/houseabsolute/p5-Test-Vars";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -24022,7 +24354,7 @@ let
     propagatedBuildInputs = [ FileFindRulePerl ];
     meta = {
       description = "Check to see that version's in modules are sane";
-      license = lib.licenses.artistic2;
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -24049,6 +24381,7 @@ let
     # https://rt.cpan.org/Public/Bug/Display.html?id=124815
     NIX_CFLAGS_COMPILE = "-DHAS_VPRINTF";
     meta = {
+      license = with lib.licenses; [ unfree ];
       broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.TextUnaccent.x86_64-darwin
     };
   };
@@ -24070,8 +24403,8 @@ let
       sha256 = "df82f09c5940830b25a49f1c8162fa24d371e602880edef8d9a4d4bfd66b8bd7";
     };
     meta = {
-      homepage = "https://github.com/2shortplanks/Test-utf8";
       description = "Handy utf8 tests";
+      homepage = "https://github.com/2shortplanks/Test-utf8/tree";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -24085,7 +24418,7 @@ let
     };
     meta = {
       description = "Extract collocations and Ngrams from text";
-      license = lib.licenses.free;
+      license = with lib.licenses; [ free ];
       maintainers = [ maintainers.bzizou ];
     };
   };
@@ -24123,8 +24456,8 @@ let
     };
     propagatedBuildInputs = [ AlgorithmDiff HTMLParser ];
     meta = {
-      homepage = "https://metacpan.org/release/Text-WordDiff";
       description = "Track changes between documents";
+      homepage = "https://metacpan.org/release/Text-WordDiff";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -24170,8 +24503,8 @@ let
     };
     propagatedBuildInputs = [ DevelStackTrace Moo ];
     meta = {
-      homepage = "https://github.com/rjbs/Throwable";
       description = "A role for classes that can be thrown";
+      homepage = "https://github.com/rjbs/Throwable";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -24199,7 +24532,7 @@ let
     };
     propagatedBuildInputs = [ TieCacheLRU ];
     meta = {
-      license = lib.licenses.artistic1;
+      license = with lib.licenses; [ artistic1 ];
     };
   };
 
@@ -24212,7 +24545,8 @@ let
     };
     meta = {
       description = "Cycle through a list of values via a scalar";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      homepage = "https://github.com/briandfoy/tie-cycle";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -24240,6 +24574,7 @@ let
     };
     meta = {
       description = "Access the lines of a disk file via a Perl array";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -24264,9 +24599,9 @@ let
       sha256 = "ee9f39055dc695aa244a252f56ffd37f8be07209b337ad387824721206d2a89e";
     };
     meta = {
-      homepage = "https://github.com/dagolden/tie-handle-offset";
       description = "Tied handle that hides the beginning of a file";
-      license = lib.licenses.asl20;
+      homepage = "https://github.com/dagolden/tie-handle-offset";
+      license = with lib.licenses; [ asl20 ];
     };
   };
 
@@ -24314,7 +24649,7 @@ let
       sha256 = "0c207850e77efb16618e0aa015507926a3425b34aad5aa6e3e40d83989a085a3";
     };
     meta = {
-      license = lib.licenses.artistic1;
+      license = with lib.licenses; [ artistic1 ];
     };
   };
 
@@ -24373,6 +24708,7 @@ let
     };
     meta = {
       description = "Rounded or exact English expression of durations";
+      homepage = "https://github.com/neilbowers/Time-Duration";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -24388,6 +24724,7 @@ let
     propagatedBuildInputs = [ ExporterLite ];
     meta = {
       description = "Parse string that represents time duration";
+      homepage = "https://github.com/neilb/Time-Duration-Parse";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -24401,6 +24738,7 @@ let
     };
     meta = {
       description = "Efficiently compute time from local and GMT time";
+      homepage = "http://metacpan.org/release/Time-Local";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -24427,6 +24765,7 @@ let
       sha256 = "1lhmx1x8j6z1k9vn32bcsw7g44cg22icshnnc37djlnlixlxm5lk";
     };
     meta = {
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -24440,6 +24779,7 @@ let
     doCheck = false;
     meta = {
       description = "Parse and format time values";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -24452,7 +24792,7 @@ let
     };
     meta = {
       description = "A Perl module to deal with time periods";
-      license = lib.licenses.gpl1;
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.winpat ];
     };
   };
@@ -24519,7 +24859,8 @@ let
     buildInputs = [ pkgs.xorg.libX11 pkgs.libpng ];
     doCheck = false;            # Expects working X11.
     meta = {
-      license = lib.licenses.tcltk;
+      description = "Tk - a Graphical User Interface Toolkit";
+      license = with lib.licenses; [ tcltk ];
     };
   };
 
@@ -24534,6 +24875,7 @@ let
     buildInputs = [ Tk ];
     doCheck = false;            # Expects working X11.
     meta = {
+      description = "A toolbar widget for Perl/Tk";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -24587,7 +24929,8 @@ let
     buildInputs = [ CPANMetaCheck CaptureTiny ];
     meta = {
       description = "Minimal try/catch with proper preservation of $@";
-      license = lib.licenses.mit;
+      homepage = "https://github.com/p5sagit/Try-Tiny";
+      license = with lib.licenses; [ mit ];
     };
   };
 
@@ -24614,7 +24957,7 @@ let
     propagatedBuildInputs = [ AnyEvent Plack ];
     buildInputs = [ TestRequires TestSharedFork TestTCP ];
     meta = {
-      description = "AnyEvent HTTP server for PSGI (like Thin)";
+      description = "AnyEvent HTTP server for PSGI";
       homepage = "https://github.com/miyagawa/Twiggy";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "twiggy";
@@ -24632,6 +24975,7 @@ let
     buildInputs = [ TestMemoryCycle ];
     meta = {
       description = "Tiny, yet Moo(se)-compatible type constraint";
+      homepage = "https://typetiny.toby.ink";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -24644,8 +24988,8 @@ let
       sha256 = "bcc34a31f7dc1d30cc803889b5c8f90e4773b73b5becbdb3860f5abe7e22ff00";
     };
     meta = {
-      homepage = "https://metacpan.org/release/Type-Tiny-XS";
       description = "Provides an XS boost for some of Type::Tiny's built-in type constraints";
+      homepage = "https://metacpan.org/release/Type-Tiny-XS";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -24659,6 +25003,7 @@ let
     };
     propagatedBuildInputs = [ commonsense ];
     meta = {
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -24670,8 +25015,8 @@ let
       sha256 = "522da9f274786fe2cba99bc77cc1c81d2161947903d7fad10bd62dfb7f11990f";
     };
     meta = {
-      homepage = "https://github.com/chromatic/UNIVERSAL-can";
       description = "Work around buggy code calling UNIVERSAL::can() as a function";
+      homepage = "https://github.com/chromatic/UNIVERSAL-can";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -24684,8 +25029,8 @@ let
       sha256 = "0avzv9j32aab6l0rd63n92v0pgliz1p4yabxxjfq275hdh1mcsfi";
     };
     meta = {
-      homepage = "https://github.com/chromatic/UNIVERSAL-isa";
       description = "Attempt to recover from people calling UNIVERSAL::isa as a function";
+      homepage = "https://github.com/karenetheridge/UNIVERSAL-isa";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -24698,7 +25043,7 @@ let
       sha256 = "b2a736a87967a143dab58c8a110501d5235bcdd2c8b2a3bfffcd3c0bd06b38ed";
     };
     meta = {
-      description = "Require() modules from a variable";
+      description = "Require() modules from a variable [deprecated]";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -24713,6 +25058,7 @@ let
     perlPreHook = lib.optionalString stdenv.isi686 "export LD=$CC"; # fix undefined reference to `__stack_chk_fail_local'
     meta = {
       description = "Unicode case-folding for case-insensitive lookups";
+      homepage = "http://metacpan.org/release/Unicode-CaseFold";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -24773,8 +25119,8 @@ let
     };
     buildInputs = [ TestFatal ];
     meta = {
-      homepage = "https://github.com/chansen/p5-unicode-utf8";
       description = "Encoding and decoding of UTF-8 encoding form";
+      homepage = "https://github.com/chansen/p5-unicode-utf8";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = with maintainers; [ sgo ];
     };
@@ -24798,8 +25144,8 @@ let
     };
     buildInputs = [ TestNeeds ];
     meta = {
-      homepage = "https://github.com/libwww-perl/URI";
       description = "Uniform Resource Identifiers (absolute and relative)";
+      homepage = "https://github.com/libwww-perl/URI";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -24814,6 +25160,7 @@ let
     propagatedBuildInputs = [ URINested ];
     meta = {
       description = "Database URIs";
+      homepage = "https://search.cpan.org/dist/URI-db";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -24828,6 +25175,7 @@ let
     propagatedBuildInputs = [ URI ];
     meta = {
       description = "Find URIs in arbitrary text";
+      homepage = "http://metacpan.org/release/URI-Find";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "urifind";
     };
@@ -24844,7 +25192,8 @@ let
     buildInputs = [ TestFatal ];
     meta = {
       description = "Build a URI from a set of named parameters";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      homepage = "http://metacpan.org/release/URI-FromHash";
+      license = with lib.licenses; [ artistic2 ];
     };
   };
 
@@ -24867,6 +25216,7 @@ let
     };
     meta = {
       description = "Collect information about a user";
+      homepage = "http://perl.overmeer.net/CPAN";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -24891,6 +25241,7 @@ let
     propagatedBuildInputs = [ URI ];
     meta = {
       description = "Nested URIs";
+      homepage = "https://metacpan.org/release/URI-Nested";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -24934,8 +25285,8 @@ let
     propagatedBuildInputs = [ CPANDistnameInfo URI ];
     meta = {
       description = "URLs that refer to things on the CPAN";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
       homepage = "https://github.com/rjbs/URI-cpan";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -24948,8 +25299,8 @@ let
     };
     propagatedBuildInputs = [ URI ];
     meta = {
-      homepage = "https://metacpan.org/release/URI-ws";
       description = "WebSocket support for URI package";
+      homepage = "http://perl.wdlabs.com/URI-ws";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -24996,9 +25347,9 @@ let
     };
     propagatedBuildInputs = [ CryptURandom ];
     meta = {
-      homepage = "https://github.com/dagolden/UUID-URandom";
       description = "UUIDs based on /dev/urandom or the Windows Crypto API";
-      license = lib.licenses.asl20;
+      homepage = "https://github.com/dagolden/UUID-URandom";
+      license = with lib.licenses; [ asl20 ];
     };
   };
 
@@ -25011,6 +25362,7 @@ let
     };
     meta = {
       description = "Associate user-defined magic to variables from Perl";
+      homepage = "http://search.cpan.org/dist/Variable-Magic";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -25037,8 +25389,8 @@ let
     };
     outputs = [ "out" ];
     meta = {
-      description = "Edit a directory in $EDITOR";
-      license = with lib.licenses; [ gpl1 ];
+      description = "File manager USING vim itself";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.chreekat ];
       mainProgram = "vidir";
     };
@@ -25068,6 +25420,7 @@ let
     propagatedBuildInputs = [ DateTimeFormatISO8601 VMEC2 ];
     meta = {
       description = "Cache credentials respecting expiration time for IAM roles";
+      homepage = "http://search.cpan.org/dist/VM-EC2-Security-CredentialCache";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -25082,9 +25435,9 @@ let
     outputs = [ "out" ];
     propagatedBuildInputs = [ CGI CSSDOM ConfigGeneral LWP LocaleCodes NetIP TermReadKey ];
     meta = {
+      description = "W3C Link Checker";
       homepage = "https://validator.w3.org/checklink";
-      description = "A tool to check links and anchors in Web pages or full Web sites";
-      license = lib.licenses.w3c;
+      license = with lib.licenses; [ w3c ];
       mainProgram = "checklink";
     };
   };
@@ -25116,9 +25469,9 @@ let
       sha256 = "1x4h5m5fkwaa0gbn6zp9mjrhr3r989w8wyrjxiii3dqm3xghnj60";
     };
     meta = {
-      description = "parser and builder for application/x-www-form-urlencoded";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      description = "Parser and builder for application/x-www-form-urlencoded";
       homepage = "https://github.com/kazeburo/WWW-Form-UrlEncoded";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -25133,8 +25486,8 @@ let
     doCheck = false;
     buildInputs = [ CGI HTTPServerSimple PathTiny TestDeep TestFatal TestOutput TestWarnings ];
     meta = {
-      homepage = "https://github.com/libwww-perl/WWW-Mechanize";
       description = "Handy web browsing in a Perl object";
+      homepage = "https://github.com/libwww-perl/WWW-Mechanize";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "mech-dump";
     };
@@ -25153,6 +25506,7 @@ let
         --replace '#!/usr/bin/perl' '#!${perl}/bin/perl'
     '';
     meta = {
+      license = with lib.licenses; [ unfree ];
       broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.WWWMechanizeCGI.x86_64-darwin
     };
   };
@@ -25220,8 +25574,8 @@ let
     buildInputs = [ DBDMock ListMoreUtils PodCoverageTrustPod TestException TestKwalitee TestPod TestPodCoverage ];
     propagatedBuildInputs = [ ClassAccessor ClassFactory ClassObservable DBI DataUUID DateTimeFormatStrptime FileSlurp LogDispatch LogLog4perl XMLSimple ];
     meta = {
-      homepage = "https://github.com/jonasbn/perl-workflow";
       description = "Simple, flexible system to implement workflows";
+      homepage = "https://github.com/jonasbn/perl-workflow";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -25263,6 +25617,7 @@ let
     patchPhase = "sed -ie 's,-L/usr/X11R6/lib/,-L${pkgs.xorg.libX11.out}/lib/ -L${pkgs.xorg.libXext.out}/lib/ -L${pkgs.xorg.libXScrnSaver}/lib/,' IdleTime.pm";
     meta = {
       description = "Get the idle time of X11";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -25288,9 +25643,9 @@ let
     propagatedBuildInputs = [ X11Protocol ];
     buildInputs = [ EncodeHanExtra ModuleUtil ];
     meta = {
-      description = "Miscellaneous helpers for X11::Protocol connections.";
-      license = with lib.licenses; [ gpl1Plus gpl3Plus ];
+      description = "Miscellaneous helpers for X11::Protocol connections";
       homepage = "http://user42.tuxfamily.org/x11-protocol-other/index.html";
+      license = with lib.licenses; [ gpl1Plus gpl3Plus ];
     };
   };
 
@@ -25327,7 +25682,7 @@ let
     NIX_CFLAGS_LINK = "-lxcb -lxcb-util -lxcb-xinerama -lxcb-icccm";
     doCheck = false; # requires an X server
     meta = {
-      description = "XCB bindings for X";
+      description = "Perl bindings for libxcb";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -25396,6 +25751,7 @@ let
     propagatedBuildInputs = [ XMLTreePP ];
     meta = {
       description = "Parse/write/merge/edit RSS/RDF/Atom syndication feeds";
+      homepage = "http://perl.overmeer.net/CPAN";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -25456,6 +25812,7 @@ let
     patches = [ ../development/perl-modules/xml-grove-utf8.patch ];
     meta = {
       description = "Perl-style XML objects";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -25469,6 +25826,7 @@ let
     propagatedBuildInputs = [ libxml_perl ];
     meta = {
       description = "Yet another Perl SAX XML Writer";
+      license = with lib.licenses; [ unfree ];
       mainProgram = "xmlpretty";
     };
   };
@@ -25495,7 +25853,7 @@ let
     };
     propagatedBuildInputs = [ XMLLibXML ];
     meta = {
-      description = "XML::LibXML based XML::Simple clone";
+      description = "An API for simple XML files";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -25519,7 +25877,7 @@ let
       sha256 = "af803d38036a3184e124a682e5466f1bc107f48a89ef35b0c7647e11a073fe2d";
     };
     meta = {
-      license = "unknown";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -25573,8 +25931,8 @@ let
     buildInputs = [ PathTiny ];
     propagatedBuildInputs = [ XMLParser ];
     meta = {
-      description = "Modules for parsing and evaluating XPath statements";
-      license = lib.licenses.artistic2;
+      description = "Parse and evaluate XPath statements";
+      license = with lib.licenses; [ artistic2 ];
       mainProgram = "xpath";
     };
   };
@@ -25588,6 +25946,7 @@ let
     };
     meta = {
       description = "A re-usable XPath engine for DOM-like trees";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -25611,8 +25970,8 @@ let
     # disable tests that require network
     preCheck = "rm t/{26-xmlrpc.t,37-mod_xmlrpc.t}";
     meta = {
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
       description = "Client and server implementation of XML-RPC protocol";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -25625,8 +25984,8 @@ let
     };
     propagatedBuildInputs = [ DateTimeFormatMail DateTimeFormatW3CDTF XMLParser ];
     meta = {
-      homepage = "http://perl-rss.sourceforge.net/";
       description = "Creates and updates RSS files";
+      homepage = "http://metacpan.org/release/XML-RSS";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -25697,8 +26056,8 @@ let
     };
     propagatedBuildInputs = [ XMLFilterBufferText XMLNamespaceSupport XMLSAXBase ];
     meta = {
-      homepage = "https://github.com/perigrin/xml-sax-writer";
       description = "SAX2 XML Writer";
+      homepage = "https://github.com/perigrin/xml-sax-writer";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -25781,6 +26140,7 @@ let
     propagatedBuildInputs = [ TreeDAGNode XMLFilterBufferText XMLSAX ];
     meta = {
       description = "Validate XML against a subset of W3C XML Schema";
+      license = with lib.licenses; [ unfree ];
     };
   };
 
@@ -25802,7 +26162,8 @@ let
     };
     buildInputs = [ ExtUtilsDepends TestFatal TestSimple13 ];
     meta = {
-      description = "XS pointer backed objects using sv_magic";
+      description = "Opaque, extensible XS pointer backed objects using sv_magic";
+      homepage = "https://github.com/karenetheridge/XS-Object-Magic";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -25849,8 +26210,8 @@ let
     propagatedBuildInputs = [ YAMLPP ];
     meta = {
       description = "See Your Data in the Nude";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
       homepage = "https://github.com/ingydotnet/xxx-pm";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -25865,8 +26226,8 @@ let
     buildInputs = [ TestBase TestDeep TestYAML ];
 
     meta = {
-      homepage = "https://github.com/ingydotnet/yaml-pm";
       description = "YAML Ain't Markup Language (tm)";
+      homepage = "https://github.com/ingydotnet/yaml-pm";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -25880,8 +26241,8 @@ let
     };
     buildInputs = [ TestYAML TestBase ];
     meta = {
-      homepage = "https://github.com/ingydotnet/yaml-old-pm";
       description = "Old YAML.pm Legacy Code";
+      homepage = "https://github.com/ingydotnet/yaml-old-pm";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -25896,7 +26257,8 @@ let
     perlPreHook = lib.optionalString stdenv.isDarwin "export LD=$CC";
     meta = {
       description = "Fast, lightweight YAML loader and dumper";
-      license = lib.licenses.mit;
+      homepage = "http://github.com/toddr/YAML-Syck";
+      license = with lib.licenses; [ mit ];
     };
   };
 
@@ -25927,7 +26289,7 @@ let
     };
     buildInputs = [ TestDeep TestWarn ];
     meta = {
-      description = "YAML Framework";
+      description = "YAML 1.2 Processor";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -25942,8 +26304,8 @@ let
     buildInputs = [ NetHTTP TestFailWarnings TestFatal ];
     propagatedBuildInputs = [ HTTPHeadersActionPack HTTPMessage HashMultiValue IOHandleUtil ModuleRuntime Plack SubExporter TryTiny ];
     meta = {
-      homepage = "http://metacpan.org/release/Web-Machine";
       description = "A Perl port of Webmachine";
+      homepage = "http://metacpan.org/release/Web-Machine";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -25958,8 +26320,8 @@ let
     buildInputs = [ ModuleBuildTiny ];
     propagatedBuildInputs = [ JSON LWPProtocolHttps ];
     meta = {
-      homepage = "https://github.com/mikegrb/WebService-Linode";
       description = "Perl Interface to the Linode.com API";
+      homepage = "https://github.com/mikegrb/WebService-Linode";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -25973,7 +26335,7 @@ let
     };
     buildInputs = [ ClassAccessor LWP ];
     meta = {
-      description = "Provides access to the W3C's online Markup validator";
+      description = "Access the W3Cs online HTML validator";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -26000,7 +26362,7 @@ let
 
     meta = {
       description = "Run Zonemaster tests from the command line";
-      license = lib.licenses.bsd3;
+      license = with lib.licenses; [ bsd3 ];
       maintainers = with lib.maintainers; [ qbit ];
     };
   };
@@ -26022,7 +26384,7 @@ let
 
     meta = {
       description = "A tool to check the quality of a DNS zone";
-      license = lib.licenses.bsd3;
+      license = with lib.licenses; [ bsd3 ];
     };
   };
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -3660,7 +3660,7 @@ let
     meta = {
       description = "Subroutines for making simple command line scripts";
       homepage = "https://github.com/reyjrar/CLI-Helpers";
-      license = with lib.licenses; [ bsd ];
+      license = with lib.licenses; [ bsd3 ];
     };
   };
 
@@ -25286,7 +25286,7 @@ let
     '';
     meta = {
       description = "Convert Markdown syntax to (X)HTML";
-      license = with lib.licenses; [ bsd ];
+      license = with lib.licenses; [ bsd3 ];
       mainProgram = "Markdown.pl";
     };
   };

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -110,7 +110,7 @@ let
     # tests fails on nixos and hydra because of different purity issues
     doCheck = false;
 
-    meta = with lib; {
+    meta = {
       description = "A grep-like tool tailored to working with large trees of source code";
       homepage = "https://beyondgrep.com";
       license = with lib.licenses; [ artistic2 ];
@@ -155,6 +155,10 @@ let
       sha256 = "1y92k4nqkscfwpriv8q7c90rjfj85lvwq1k96niv2glk8d37dcf9";
     };
     propagatedBuildInputs = [ AlgorithmDiff ];
+    meta = {
+      description = "Represent a series of changes in annotate form";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   AlgorithmC3 = buildPerlPackage {
@@ -193,6 +197,10 @@ let
       sha256 = "0l8pk7ziz72d022hsn4xldhhb9f5649j5cgpjdibch0xng24ms1h";
     };
     buildInputs = [ pkgs.unzip ];
+    meta = {
+      description = "Compute 'intelligent' differences between two files / lists";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   AlgorithmLCSS = buildPerlPackage {
@@ -217,6 +225,10 @@ let
       sha256 = "1kqn13wd0lfjrf6h19b9kgdqqwp7k2d9yfq5i0wvii0xi8jqh1lw";
     };
     propagatedBuildInputs = [ AlgorithmDiff ];
+    meta = {
+      description = "Three-way merge and diff";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   AlienBaseModuleBuild = buildPerlModule {
@@ -307,6 +319,10 @@ let
       sha256 = "1syyqzy462501kn5ma9gl6xbmcahqcn4qpafhsmpz0nd0x2m4l63";
     };
     buildInputs = [ ModuleBuildTiny ];
+    meta = {
+      description = "Use shorter versions of class names";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   asa = buildPerlPackage {
@@ -355,6 +371,10 @@ let
     buildInputs = [ ArchiveExtract ];
     TIDYP_DIR = pkgs.tidyp;
     propagatedBuildInputs = [ FileShareDir ];
+    meta = {
+      description = "Building, finding and using tidyp library";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   AlienWxWidgets = buildPerlModule {
@@ -366,6 +386,10 @@ let
     };
     propagatedBuildInputs = [ pkgs.pkg-config pkgs.gtk2 pkgs.wxGTK30 ModulePluggable ];
     buildInputs = [ LWPProtocolHttps ];
+    meta = {
+      description = "Building, finding and using wxWidgets binaries";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   Alienm4 = buildPerlPackage {
@@ -496,6 +520,10 @@ let
       sha256 = "5cfa53416124176f6f4cd32b00ea8ca79a2d5df51258683989cd04fe86e25013";
     };
     propagatedBuildInputs = [ AnyEvent commonsense ];
+    meta = {
+      description = "Simple but non-blocking HTTP/HTTPS client";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   AnyEventI3 = buildPerlPackage {
@@ -549,6 +577,10 @@ let
       sha256 = "0dc55mpayrixwx8dwql0vj0jalg4rlb3k64rprc84bl0z8vkx9m8";
     };
     propagatedBuildInputs = [ Moose Mouse ];
+    meta = {
+      description = "(DEPRECATED) use Moo instead!";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   AnyURIEscape = buildPerlPackage {
@@ -667,6 +699,10 @@ let
     };
     propagatedBuildInputs = [ CaptureTiny ClassLoad ];
     buildInputs = [ TestKwalitee TestPod ];
+    meta = {
+      description = "Dispatcher module for command line interface programs";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   AppClusterSSH = buildPerlModule {
@@ -936,6 +972,10 @@ let
 
     buildInputs = [ TestNoWarnings ];
     propagatedBuildInputs = [ Moo TypeTiny ];
+    meta = {
+      description = "Perl extension for comparing arrays";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   ArrayDiff = buildPerlPackage {
@@ -1484,6 +1524,10 @@ let
       echo "LIB = ${pkgs.db.out}/lib" > config.in
       echo "INCLUDE = ${pkgs.db.dev}/include" >> config.in
     '';
+    meta = {
+      description = "Perl extension for Berkeley DB version 2, 3, 4, 5 or 6";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   BDB = buildPerlPackage rec {
@@ -1570,6 +1614,10 @@ let
       sha256 = "09m96p8c0ipgz42li2ywdgy0vxb57mb5nf59j9gw7yzc3xkslv9w";
     };
     propagatedBuildInputs = [ CarpClan ];
+    meta = {
+      description = "Efficient bit vector, set of integers and 'big int' math library";
+      license = with lib.licenses; [ artistic1 gpl1Plus lgpl2Only ];
+    };
   };
 
   BKeywords = buildPerlPackage rec {
@@ -1612,6 +1660,10 @@ let
     ];
     perlPreHook = "export LD=$CC";
     buildInputs = [ ExtUtilsCppGuess ExtUtilsTypemapsDefault ExtUtilsXSpp ModuleBuildWithXSpp ];
+    meta = {
+      description = "Bindings for the Boost Geometry library";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   BotTraining = buildPerlPackage {
@@ -1836,6 +1888,10 @@ let
     };
     propagatedBuildInputs = [ DigestSHA1 Error IPCShareLite ];
     doCheck = false; # randomly fails
+    meta = {
+      description = "The Cache Interface";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   CacheFastMmap = buildPerlPackage {
@@ -1846,6 +1902,10 @@ let
       sha256 = "0lkrsr582h714jpmh5dv4szz5f7rm466xqxbavj7l9w0p40f4him";
     };
     buildInputs = [ TestDeep ];
+    meta = {
+      description = "Uses an mmap'ed file to act as a shared memory interprocess cache";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   CacheKyotoTycoon = buildPerlModule {
@@ -1873,6 +1933,10 @@ let
       sha256 = "1aa2mjn5767b13063nnsrwcikrnbspby7j1c5q007bzaq0gcbcri";
     };
     propagatedBuildInputs = [ StringCRC32 ];
+    meta = {
+      description = "Client library for memcached (memory cache daemon)";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   CacheMemcachedFast = buildPerlPackage {
@@ -1897,6 +1961,10 @@ let
     };
     propagatedBuildInputs = [ DBFile FileNFSLock HeapFibonacci IOString TimeDate ];
     doCheck = false; # can time out
+    meta = {
+      description = "Memory based implementation of the Cache interface";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   CacheSimpleTimedExpiry = buildPerlPackage {
@@ -1966,6 +2034,10 @@ let
       sha256 = "12dv5ssf3y7yjz9mrrqnfzx8nf4ydk1qijf5fx59495671zzqsp7";
     };
     propagatedBuildInputs = [ CryptRC4 TextPDF ];
+    meta = {
+      description = "PDF manipulation library";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   capitalization = buildPerlPackage {
@@ -1977,7 +2049,8 @@ let
     };
     propagatedBuildInputs = [ DevelSymdump ];
     meta = {
-      license = with lib.licenses; [ unfree ];
+      description = "No capitalization on method names";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -2001,6 +2074,10 @@ let
       sha256 = "14j3lk6fhfzda5d3d7z6f373ng3fzxazzwpjyziysrhic1v3b4mq";
     };
     propagatedBuildInputs = [ HTMLTiny LWP ];
+    meta = {
+      description = "A Perl implementation of the reCAPTCHA API";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   CaptureTiny = buildPerlPackage {
@@ -2142,6 +2219,10 @@ let
     };
     buildInputs = [ ModuleBuildTiny TestLongString TestSimple13 TestWWWMechanize TestWWWMechanizeCatalyst ];
     propagatedBuildInputs = [ AuthenHtpasswd CatalystPluginAuthentication ];
+    meta = {
+      description = "Authen::Htpasswd based user storage/authentication";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   CatalystAuthenticationStoreDBIxClass = buildPerlPackage {
@@ -2336,6 +2417,10 @@ let
     };
     propagatedBuildInputs = [ CatalystRuntime ClassThrowable ];
     buildInputs = [ CatalystPluginAuthentication CatalystPluginAuthorizationRoles CatalystPluginSession CatalystPluginSessionStateCookie TestWWWMechanizeCatalyst ];
+    meta = {
+      description = "ACL support for Catalyst applications";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   CatalystPluginAuthorizationRoles = buildPerlPackage {
@@ -2405,6 +2490,10 @@ let
       sha256 = "0w8r3bbxqnlykvra6sx3sh3wh8ylkj914xg5ql6nw11ddy56jaly";
     };
     propagatedBuildInputs = [ CatalystRuntime ConfigAny DataVisitor ];
+    meta = {
+      description = "Load config files of various types";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   CatalystPluginFormValidator = buildPerlPackage {
@@ -2502,6 +2591,10 @@ let
       sha256 = "1skvw3i9wv02kz1bz937zh7wfxvhf54i8zppln3ly6bcp6rcgcg9";
     };
     propagatedBuildInputs = [ CatalystPluginSession ];
+    meta = {
+      description = "Maintain session IDs using cookies";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   CatalystPluginSessionStoreFastMmap = buildPerlPackage {
@@ -2512,6 +2605,10 @@ let
       sha256 = "0x3j6zv3wr41jlwr6yb2jpmcx019ibyn11y8653ffnwhpzbpzsxs";
     };
     propagatedBuildInputs = [ CacheFastMmap CatalystPluginSession ];
+    meta = {
+      description = "FastMmap session storage backend";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   CatalystPluginSessionStoreFile = buildPerlPackage {
@@ -2650,6 +2747,10 @@ let
       sha256 = "0iq4ci8m6g2c4g01fvdl568y7pjz28f3widk986v3pyhr7ll8j88";
     };
     propagatedBuildInputs = [ CatalystRuntime MooseXTraitsPluggable ];
+    meta = {
+      description = "Automatic Trait Loading and Resolution for Catalyst Components";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   CatalystXRoleApplicator = buildPerlPackage {
@@ -2660,6 +2761,10 @@ let
       sha256 = "0vwaapxn8g5hs2xp63c4dwv9jmapmji4272fakssvgc9frklg3p2";
     };
     propagatedBuildInputs = [ CatalystRuntime MooseXRelatedClassRoles ];
+    meta = {
+      description = "Apply roles to your Catalyst application-related classes";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   CatalystTraitForRequestProxyBase = buildPerlPackage {
@@ -2797,6 +2902,10 @@ let
       url = "mirror://cpan/authors/id/A/AG/AGENT/CGI-Cookie-XS-0.18.tar.gz";
       sha256 = "1iixvnm0l1q24vdlnayb4vd8fns2bdlhm6zb7fpi884ppm5cp6a6";
     };
+    meta = {
+      description = "HTTP Cookie parser in pure C";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   CGIEmulatePSGI = buildPerlPackage {
@@ -2853,6 +2962,10 @@ let
     };
 
     propagatedBuildInputs = [ CGI ];
+    meta = {
+      description = "Easily generate and process stateful forms";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   CGIMinimal = buildPerlModule {
@@ -2891,6 +3004,10 @@ let
       sha256 = "1xsl2pz1jrh127pq0b01yffnj4mnp9nvkp88h5mndrscq9hn8xa6";
     };
     propagatedBuildInputs = [ CGI ];
+    meta = {
+      description = "Persistent session data in CGI applications";
+      license = with lib.licenses; [ artistic1 ];
+    };
   };
 
   CGISimple = buildPerlModule {
@@ -3003,6 +3120,10 @@ let
       sha256 = "1lilrjy1s0q5hyr0888kf0ifxjyl2iyk4vxil4jsv0sgh39lkgx5";
     };
     propagatedBuildInputs = [ ClassAccessor ];
+    meta = {
+      description = "Make chained accessors";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   ClassAccessorGrouped = buildPerlPackage {
@@ -3055,6 +3176,10 @@ let
       sha256 = "117dmsrb30a09zlrv919fb5h5rg8r4asa24i99k04n2habgbv9g1";
     };
     propagatedBuildInputs = [ Clone ];
+    meta = {
+      description = "Useful base class for deriving other modules";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   ClassC3 = buildPerlPackage {
@@ -3138,6 +3263,10 @@ let
       url = "mirror://cpan/authors/id/C/CL/CLACO/Class-Data-Accessor-0.04004.tar.gz";
       sha256 = "0578m3rplk41059rkkjy1009xrmrdivjnv8yxadwwdk1vzidc8n1";
     };
+    meta = {
+      description = "Inheritable, overridable class and instance data accessor creation";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   ClassDataInheritable = buildPerlPackage {
@@ -3146,6 +3275,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/T/TM/TMTM/Class-Data-Inheritable-0.08.tar.gz";
       sha256 = "0jpi38wy5xh6p1mg2cbyjjw76vgbccqp46685r27w8hmxb7gwrwr";
+    };
+    meta = {
+      description = "Inheritable, overridable class data";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -3169,6 +3302,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/P/PH/PHRED/Class-Factory-1.06.tar.gz";
       sha256 = "c37a2d269eb935f36a23e113480ae0946fa7c12a12781396a1226c8e435f30f5";
+    };
+    meta = {
+      description = "Base class for dynamic factory classes";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -3219,6 +3356,10 @@ let
       url = "mirror://cpan/authors/id/S/SM/SMUELLER/Class-ISA-0.36.tar.gz";
       sha256 = "0r5r574i6wgxm8zsq4bc34d0dzprrh6h6mpp1nhlks1qk97g65l8";
     };
+    meta = {
+      description = "Report the search path for a class's ISA tree";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   ClassIterator = buildPerlPackage {
@@ -3257,6 +3398,10 @@ let
       # fix error 'Unescaped left brace in regex is illegal here in regex'
       substituteInPlace tests/xemulator/class_methodmaker/Test.pm --replace 's/(TEST\s{)/$1/g' 's/(TEST\s\{)/$1/g'
     '';
+    meta = {
+      description = "Generate common types of methods";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   ClassMethodMaker = buildPerlPackage {
@@ -3325,6 +3470,10 @@ let
       url = "mirror://cpan/authors/id/S/SH/SHAY/Class-Singleton-1.6.tar.gz";
       sha256 = "1942j9g0b4c88nvs3jghh3y31mlhbpwrx35xdcb2jaaiv7q17fi7";
     };
+    meta = {
+      description = "Implementation of a 'Singleton' class";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   ClassThrowable = buildPerlPackage {
@@ -3333,6 +3482,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/K/KM/KMX/Class-Throwable-0.13.tar.gz";
       sha256 = "1kmwzdxvp9ca2z44vl0ygkfygdbxqkilzjd8vqhc4vdmvbh136nw";
+    };
+    meta = {
+      description = "A minimal lightweight exception class";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -3390,6 +3543,10 @@ let
       sha256 = "3ef18733a0f03c113f3bcf8ac50476e09ca1fe6234f4aaacaa24dfca95168094";
     };
     propagatedBuildInputs = [ ClassISA ];
+    meta = {
+      description = "Allow other classes and objects to respond to events in yours";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   ClassStd = buildPerlModule {
@@ -3414,9 +3571,9 @@ let
     };
     propagatedBuildInputs = [ ClassStd ];
     checkInputs = [ TestPod TestPodCoverage ];
-    meta = with lib; {
+    meta = {
       description = "Faster but less secure than Class::Std";
-      license = with licenses; [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -3429,6 +3586,10 @@ let
     };
     propagatedBuildInputs = [ ClassInspector ];
     buildInputs = [ TestRequires ];
+    meta = {
+      description = "Unload a class";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   ClassVirtual = buildPerlPackage {
@@ -3729,6 +3890,10 @@ let
       url = "mirror://cpan/authors/id/F/FE/FERREIRA/Compress-unLZMA-0.05.tar.gz";
       sha256 = "1f0pcpcjjj60whqc5sc5jd0dd7z3si4fnp268w4ykmcjini03s2d";
     };
+    meta = {
+      description = "Interface to LZMA decompression library";
+      license = with lib.licenses; [ artistic1 gpl1Plus gpl21Plus ];
+    };
   };
 
   ConfigAny = buildPerlPackage {
@@ -3957,6 +4122,10 @@ let
       sha256 = "0cjj2f0pj9y3cx1lgk2qp6arsnyaacf7kj6v33iqczn59f798r0h";
     };
     buildInputs = [ TestPod ];
+    meta = {
+      description = "Read/Write .ini style files with as little code as possible";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   ConfigVersioned = buildPerlPackage {
@@ -4032,6 +4201,10 @@ let
       url = "mirror://cpan/authors/id/T/TI/TIMLEGGE/Convert-ASN1-0.33.tar.gz";
       sha256 = "0xk0s2rnwjb7ydhwfinpjcbw25im54b8cs7r9hj3m7n7412h1pqz";
     };
+    meta = {
+      description = "ASN.1 Encode/Decode library";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   ConvertBase32 = buildPerlPackage {
@@ -4098,6 +4271,10 @@ let
       sha256 = "1s8gxfg4xqp543aqanv5lbp64vqqyw6ic4x3fm4imkk1h3amjb6d";
     };
     propagatedBuildInputs = [ SymbolUtil ];
+    meta = {
+      description = "Define TRUE and FALSE constants";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   curry = buildPerlPackage {
@@ -4120,6 +4297,10 @@ let
       url = "mirror://cpan/authors/id/K/KR/KRYDE/constant-defer-6.tar.gz";
       sha256 = "1ykgk0rd05p7kyrdxbv047fj7r0b4ix9ibpkzxp6h8nak0qjc8bv";
     };
+    meta = {
+      description = "Constant subs with deferred value calculation";
+      license = with lib.licenses; [ gpl3Plus ];
+    };
   };
 
   ContextPreserve = buildPerlPackage {
@@ -4130,6 +4311,10 @@ let
       sha256 = "07zxgmb11bn4zj3w9g1zwbb9iv4jyk5q7hc0nv59knvv5i64m489";
     };
     buildInputs = [ TestException TestSimple13 ];
+    meta = {
+      description = "Run code after a subroutine call, preserving the context the subroutine would have seen if it were the last statement in the caller";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   CookieBaker = buildPerlModule {
@@ -4156,6 +4341,10 @@ let
       sha256 = "1616rcn2qn1cwiv3rxb8mq5fmwxpj4gya1lxxxq2w952h03p3fd3";
     };
     propagatedBuildInputs = [ CGICookieXS ];
+    meta = {
+      description = "HTTP Cookie parser in C (Please use CGI::Cookie::XS instead)";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   Coro = buildPerlPackage {
@@ -4410,6 +4599,10 @@ let
       url = "mirror://cpan/authors/id/D/DP/DPARIS/Crypt-Blowfish-2.14.tar.gz";
       sha256 = "1cb7g8cyfs9alrfdykxhs8m6azj091fmcycz6p5vkxbbzcgl7cs6";
     };
+    meta = {
+      description = "Perl Blowfish encryption module";
+      license = with lib.licenses; [ unfreeRedistributable ];
+    };
   };
 
   CryptCAST5_PP = buildPerlPackage {
@@ -4432,6 +4625,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/L/LD/LDS/Crypt-CBC-2.33.tar.gz";
       sha256 = "0ig698lmpjz7fslnznxm0609lvlnvf4f3s370082nzycnqhxww3a";
+    };
+    meta = {
+      description = "Encrypt Data with Cipher Block Chaining Mode";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -4462,6 +4659,10 @@ let
       url = "mirror://cpan/authors/id/D/DP/DPARIS/Crypt-DES-2.07.tar.gz";
       sha256 = "1rypxlhpd1jc0c327aghgl9y6ls47drmpvn0a40b4k3vhfsypc9d";
     };
+    meta = {
+      description = "Perl DES encryption module";
+      license = with lib.licenses; [ unfreeRedistributable ];
+    };
   };
 
   CryptDES_EDE3 = buildPerlPackage {
@@ -4487,6 +4688,10 @@ let
       sha256 = "0pvzlgwpx8fzdy64ki15155vhsj30i9zxmw6i4p7irh17d1g7368";
     };
     propagatedBuildInputs = [ MathBigIntGMP ];
+    meta = {
+      description = "Diffie-Hellman key exchange system";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   CryptDHGMP = buildPerlPackage {
@@ -4499,6 +4704,10 @@ let
     buildInputs = [ pkgs.gmp DevelChecklib TestRequires ];
     NIX_CFLAGS_COMPILE = "-I${pkgs.gmp.dev}/include";
     NIX_CFLAGS_LINK = "-L${pkgs.gmp.out}/lib -lgmp";
+    meta = {
+      description = "Crypt::DH Using GMP Directly";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   CryptDSA = buildPerlPackage {
@@ -4523,7 +4732,7 @@ let
       url = "mirror://cpan/authors/id/A/AP/APPEL/Crypt-ECB-2.22.tar.gz";
       sha256 = "f5af62e908cd31a34b2b813135a0718016fd003ffa0021ffbdd84c50158267aa";
     };
-    meta = with lib; {
+    meta = {
       description = "Use block ciphers using ECB mode";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
@@ -4538,6 +4747,10 @@ let
     };
     propagatedBuildInputs = [ ClassMix ];
     perlPreHook = lib.optionalString (stdenv.isi686 || stdenv.isDarwin) "export LD=$CC";
+    meta = {
+      description = "The Eksblowfish block cipher";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   CryptFormat = buildPerlPackage {
@@ -4561,6 +4774,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/D/DP/DPARIS/Crypt-IDEA-1.10.tar.gz";
       sha256 = "0690lzlyjqgmnb94dq7dm5n6pgybg10fkpgfycgzr814370pig9k";
+    };
+    meta = {
+      description = "Perl interface to IDEA block cipher";
+      license = with lib.licenses; [ unfreeRedistributable ];
     };
   };
 
@@ -4626,6 +4843,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/R/RS/RSAVAGE/Crypt-PasswdMD5-1.40.tgz";
       sha256 = "0j0r74f18nk63phddzqbf7wqma2ci4p4bxvrwrxsy0aklbp6lzdp";
+    };
+    meta = {
+      description = "Provide interoperable MD5-based crypt() functions";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -4713,6 +4934,10 @@ let
       url = "mirror://cpan/authors/id/S/SI/SIFUKURT/Crypt-RC4-2.02.tar.gz";
       sha256 = "1sp099cws0q225h6j4y68hmfd1lnv5877gihjs40f8n2ddf45i2y";
     };
+    meta = {
+      description = "Perl implementation of the RC4 encryption algorithm";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   CryptRandPasswd = buildPerlPackage {
@@ -4721,6 +4946,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/N/NE/NEILB/Crypt-RandPasswd-0.06.tar.gz";
       sha256 = "0ca8544371wp4vvqsa19lnhl02hczpkbwkgsgm65ziwwim3r1gdi";
+    };
+    meta = {
+      description = "Random password generator based on FIPS-181";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -4748,6 +4977,10 @@ let
     };
     propagatedBuildInputs = [ DigestSHA1 ];
     perlPreHook = lib.optionalString (stdenv.isi686 || stdenv.isDarwin) "export LD=$CC";
+    meta = {
+      description = "Emulate MySQL PASSWORD() function";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   CryptRijndael = buildPerlPackage {
@@ -4757,6 +4990,10 @@ let
       url = "mirror://cpan/authors/id/L/LE/LEONT/Crypt-Rijndael-1.15.tar.gz";
       sha256 = "0qs1b6ma4sj0ip5d8544fzgc1bbankc4qlmznp8hay8dk5arp650";
     };
+    meta = {
+      description = "Crypt::CBC compliant Rijndael encryption module";
+      license = with lib.licenses; [ gpl3Only ];
+    };
   };
 
   CryptUnixCryptXS = buildPerlPackage {
@@ -4765,6 +5002,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/B/BO/BORISZ/Crypt-UnixCrypt_XS-0.11.tar.gz";
       sha256 = "1ajg3x6kwxy4x9p3nw1j36qjxpjvdpi9wkca5gfd86y9q8939sv2";
+    };
+    meta = {
+      description = "Perl xs interface for a portable traditional crypt function";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -4805,6 +5046,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/B/BJ/BJKUIT/Crypt-SmbHash-0.12.tar.gz";
       sha256 = "0dxivcqmabkhpz5xzph6rzl8fvq9xjy26b2ci77pv5gsmdzari38";
+    };
+    meta = {
+      description = "Perl-only implementation of lanman and nt md4 hash functions, for use in Samba style smbpasswd entries";
+      license = with lib.licenses; [ gpl2Plus ];
     };
   };
 
@@ -4877,9 +5122,9 @@ let
     };
     NIX_CFLAGS_COMPILE = "-I${pkgs.openssl.dev}/include";
     NIX_CFLAGS_LINK = "-L${lib.getLib pkgs.openssl}/lib -lcrypto";
-    meta = with lib; {
+    meta = {
       description = "Perl wrapper around OpenSSL's AES library";
-      license = with licenses; [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -4892,6 +5137,10 @@ let
     };
     NIX_CFLAGS_COMPILE = "-I${pkgs.openssl.dev}/include";
     NIX_CFLAGS_LINK = "-L${lib.getLib pkgs.openssl}/lib -lcrypto";
+    meta = {
+      description = "OpenSSL's multiprecision integer arithmetic";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   CryptOpenSSLGuess = buildPerlPackage {
@@ -4935,6 +5184,10 @@ let
     NIX_CFLAGS_COMPILE = "-I${pkgs.openssl.dev}/include";
     NIX_CFLAGS_LINK = "-L${lib.getLib pkgs.openssl}/lib -lcrypto";
     buildInputs = [ CryptOpenSSLGuess ];
+    meta = {
+      description = "RSA encoding and decoding, using the openSSL libraries";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   CryptOpenSSLX509 = buildPerlPackage rec {
@@ -5017,6 +5270,10 @@ let
     makeMakerFlags = "--libpath=${lib.getLib pkgs.openssl}/lib --incpath=${pkgs.openssl.dev}/include";
     buildInputs = [ PathClass ];
     propagatedBuildInputs = [ BytesRandomSecure LWPProtocolHttps ];
+    meta = {
+      description = "OpenSSL support for LWP";
+      license = with lib.licenses; [ artistic2 ];
+    };
   };
 
   CSSDOM = buildPerlPackage {
@@ -5027,6 +5284,10 @@ let
       sha256 = "09phb6c9czpcp9imq06khm54kspsx6hnvfrjxramx663ygmpifb5";
     };
     propagatedBuildInputs = [ Clone ];
+    meta = {
+      description = "Document Object Model for Cascading Style Sheets";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   CSSMinifier = buildPerlPackage {
@@ -5036,9 +5297,9 @@ let
       url = "mirror://cpan/authors/id/P/PM/PMICHAUX/CSS-Minifier-0.01.tar.gz";
       sha256 = "0Kk0m46LfoOrcM+IVM+7Qv8pwfbHyCmPIlfdIaoMf+8=";
     };
-    meta = with lib; {
+    meta = {
       description = "Perl extension for minifying CSS";
-      license = licenses.artistic1;
+      license = with lib.licenses; [ artistic1 ];
       maintainers = teams.determinatesystems.members;
     };
   };
@@ -5179,6 +5440,10 @@ let
       sha256 = "1gg8rqbv3x6a1lrpabv6vnlab53zxmpwz2ygad9fcx4gygqj12l1";
     };
     propagatedBuildInputs = [ Clone FileFindRule ];
+    meta = {
+      description = "Compare perl data structures";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   DataDump = buildPerlPackage {
@@ -5231,6 +5496,10 @@ let
       sha256 = "2611c4a1a3038594d79ea4ed14d9e15a9af8f77105f51667795fe4f8a53427e4";
     };
     propagatedBuildInputs = [ CryptRijndael DataFloat HTTPLite ParamsClassify ];
+    meta = {
+      description = "Entropy (randomness) management";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   DataFloat = buildPerlModule {
@@ -5239,6 +5508,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/Data-Float-0.013.tar.gz";
       sha256 = "e2b1523d858930b8bbdbd196f08235f5e678b84919ba87712e26313b9c27518a";
+    };
+    meta = {
+      description = "Details of the floating point data type";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -5309,6 +5582,10 @@ let
       sha256 = "1vfrkygdaq0k7006i83jwavg9wgszfcyzbl9b7fp37z2acmyda5k";
     };
     buildInputs = [ TestException ];
+    meta = {
+      description = "Handle data in a hierarchical structure";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   DataICal = buildPerlPackage {
@@ -5347,6 +5624,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/Data-Integer-0.006.tar.gz";
       sha256 = "0m53zxhx9sn49yqh7azlpyy9m65g54v8cd2ha98y77337gg7xdv3";
+    };
+    meta = {
+      description = "Details of the native integer data type";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -5391,6 +5672,10 @@ let
     };
     propagatedBuildInputs = [ ClassAccessorChained ];
     buildInputs = [ TestException ];
+    meta = {
+      description = "Help when paging through sets of results";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   DataPagePageset = buildPerlModule {
@@ -5413,6 +5698,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/R/RA/RAZINF/Data-Password-1.12.tar.gz";
       sha256 = "830cde81741ff384385412e16faba55745a54a7cc019dd23d7ed4f05d551a961";
+    };
+    meta = {
+      description = "Perl extension for assessing password quality";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -5584,6 +5873,10 @@ let
       sha256 = "0y4wls4jlwd6prvd77szymddhq9sfj06kaqnk4frlvd0zh83djxb";
     };
     buildInputs = [ DebugShowStuff ];
+    meta = {
+      description = "Taint-aware, XML-ish data serialization";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   DataULID = buildPerlPackage {
@@ -5608,6 +5901,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/M/MW/MWX/Data-Uniqid-0.12.tar.gz";
       sha256 = "b6919ba49b9fe98bfdf3e8accae7b9b7f78dc9e71ebbd0b7fef7a45d99324ccb";
+    };
+    meta = {
+      description = "Perl extension for simple genrating of unique id's";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -5646,6 +5943,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/R/RJ/RJBS/Data-UUID-1.226.tar.gz";
       sha256 = "0lv4k4ibxwkw7zz9hw97s34za9nvjxb4kbmgmx5sj4fll3zmfg89";
+    };
+    meta = {
+      description = "Globally/Universally Unique Identifiers (GUIDs/UUIDs)";
+      license = with lib.licenses; [ bsd0 ];
     };
   };
 
@@ -5720,6 +6021,10 @@ let
     };
     buildInputs = [ TestNeeds ];
     propagatedBuildInputs = [ Moose TieToObject namespaceclean ];
+    meta = {
+      description = "Visitor style traversal of Perl data structures";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   DateCalc = buildPerlPackage {
@@ -5731,6 +6036,10 @@ let
     };
     propagatedBuildInputs = [ BitVector ];
     doCheck = false; # some of the checks rely on the year being <2015
+    meta = {
+      description = "Gregorian calendar date calculations";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   DateExtract = buildPerlPackage {
@@ -5742,6 +6051,10 @@ let
     };
     buildInputs = [ TestMockTime ];
     propagatedBuildInputs = [ DateTimeFormatNatural ];
+    meta = {
+      description = "Extract probable dates from strings";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   DateManip = buildPerlPackage {
@@ -5828,6 +6141,10 @@ let
       sha256 = "f9408789a461107766ca1a232bb3ec1e702eec7ca8167401ea6ec3f4b6d0b5a5";
     };
     propagatedBuildInputs = [ DateTimeSet ];
+    meta = {
+      description = "DateTime::Set extension for create basic recurrence sets";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   DateTimeFormatBuilder = buildPerlPackage {
@@ -6178,6 +6495,10 @@ let
       sha256 = "15621qh5gaan1sgmk9y9svl70nm8viw17x5h1kf0zknkk8lmw77j";
     };
     buildInputs = [ CaptureTiny MockConfig ];
+    meta = {
+      description = "Check that a library is available";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   DevelCheckOS = buildPerlPackage {
@@ -6188,6 +6509,10 @@ let
       sha256 = "1jjqwrx8mydyhqwwjlgimribz0yq0b6q66xnr6mgvyn63pdajhvg";
     };
     propagatedBuildInputs = [ FileFindRule ];
+    meta = {
+      description = "Check what OS we're running on";
+      license = with lib.licenses; [ gpl2Only artistic1 ];
+    };
   };
 
   DevelLeak = buildPerlPackage rec {
@@ -6301,6 +6626,10 @@ let
       sha256 = "16rhgchwlnnvjklca0d4sa3lmlj29zc0iwclk41y5fz6kg8c2qjs";
     };
     propagatedBuildInputs = [ DBI SQLStatement TextCSV_XS ];
+    meta = {
+      description = "DBI driver for CSV files";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   DBDMock = buildPerlModule {
@@ -6312,6 +6641,10 @@ let
     };
     propagatedBuildInputs = [ DBI ];
     buildInputs = [ ModuleBuildTiny TestException ];
+    meta = {
+      description = "Mock database driver for testing";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   DBDSQLite = buildPerlPackage {
@@ -6347,10 +6680,10 @@ let
 
     preCheck = "rm t/65_db_config.t"; # do not run failing tests
 
-    meta = with lib; {
+    meta = {
       description = "Self Contained SQLite RDBMS in a DBI Driver";
-      license = with licenses; [ artistic1 gpl1Plus ];
-      platforms = platforms.unix;
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      platforms = lib.platforms.unix;
     };
   };
 
@@ -6386,6 +6719,10 @@ let
     doCheck = false;
 
   #  makeMakerFlags = "MYSQL_HOME=${mysql}";
+    meta = {
+      description = "MySQL driver for the Perl5 Database Interface (DBI)";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   DBDOracle = buildPerlPackage {
@@ -6405,6 +6742,10 @@ let
     postBuild = lib.optionalString stdenv.isDarwin ''
       install_name_tool -add_rpath "${pkgs.oracle-instantclient.lib}/lib" blib/arch/auto/DBD/Oracle/Oracle.bundle
     '';
+    meta = {
+      description = "Oracle database driver for the DBI module";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   DBDPg = buildPerlPackage {
@@ -6472,6 +6813,10 @@ let
       INCLUDE = ${pkgs.db.dev}/include
       EOF
     '';
+    meta = {
+      description = "Perl5 access to Berkeley DB version 1.x";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   DBI = buildPerlPackage {
@@ -6616,6 +6961,10 @@ let
       sha256 = "05zhniyzl31nq410ywhxm0vmvac53h7ax42hjs9mmpvf45ipahj1";
     };
     propagatedBuildInputs = [ DBIxClass HTMLWidget ];
+    meta = {
+      description = "Like FromForm but with DBIx::Class and HTML::Widget";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   DBIxClassHelpers = buildPerlPackage {
@@ -6704,6 +7053,10 @@ let
       sha256 = "7a2a978fb6d9feaa3e4b109c71c963b26a008a2d130c5876ecf24c5a72338a1d";
     };
     propagatedBuildInputs = [ DBI ];
+    meta = {
+      description = "Database-independent schema objects";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   DBIxSearchBuilder = buildPerlPackage {
@@ -6787,6 +7140,10 @@ let
 
     propagatedBuildInputs = [ DBI Moo ];
     buildInputs = [ DBDSQLite TestFatal TestRoo ];
+    meta = {
+      description = "Detect what database you are connected to";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   DevelCamelcadedb = buildPerlPackage {
@@ -6880,6 +7237,10 @@ let
       url = "mirror://cpan/authors/id/D/DC/DCANTRELL/Devel-Hide-0.0013.tar.gz";
       sha256 = "1jvyy3yasiwyjsn9ay9sja3ch4wcjc4wk5l22vjsclq29z7vphvg";
     };
+    meta = {
+      description = "Forces the unavailability of specified Perl modules (for testing)";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   DevelNYTProf = buildPerlPackage {
@@ -6926,6 +7287,10 @@ let
     };
     propagatedBuildInputs = [ ClassTiny SubExporter namespaceclean ];
     buildInputs = [ TestSimple13 TestWarnings ];
+    meta = {
+      description = "Partial dumping of data structures, optimized for argument printing";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   DevelStackTrace = buildPerlPackage {
@@ -7042,6 +7407,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/M/MI/MIKEM/DigestMD4/Digest-MD4-1.9.tar.gz";
       sha256 = "19ma1hmvgiznq95ngzvm6v4dfxc9zmi69k8iyfcg6w14lfxi0lb6";
+    };
+    meta = {
+      description = "Perl interface to the MD4 Algorithm";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -7745,7 +8114,7 @@ let
     };
     propagatedBuildInputs = [ EmailMIME EmailSender IOAll IOString OLEStorage_Lite ];
     preCheck = "rm t/internals.t t/plain_jpeg_attached.t"; # these tests expect EmailMIME version 1.946 and fail with 1.949 (the output difference in benign)
-    meta = with lib; {
+    meta = {
       homepage = "https://www.matijs.net/software/msgconv/";
       description = "A .MSG to mbox converter";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
@@ -7818,6 +8187,10 @@ let
     };
     propagatedBuildInputs = [ IOCaptureOutput MailTools NetDNS NetDomainTLD ];
     doCheck = false;
+    meta = {
+      description = "Check validity of Internet email addresses";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   EmailValidLoose = buildPerlPackage {
@@ -8030,6 +8403,10 @@ let
       url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Error-0.17029.tar.gz";
       sha256 = "1p3spyarrh8y14d3j9s71xcndjlr70x3f8c3nvaddbij628zf8qs";
     };
+    meta = {
+      description = "Error/exception handling in an OO-ish way";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   EV = buildPerlPackage {
@@ -8099,6 +8476,10 @@ let
       sha256 = "03gf4cdgrjnljgrlxkvbh2cahsyzn0zsh2zcli7b1lrqn7wgpwrk";
     };
     propagatedBuildInputs = [ ClassDataInheritable DevelStackTrace ];
+    meta = {
+      description = "An Exception Object Class";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   ExceptionDied = buildPerlModule {
@@ -8110,6 +8491,10 @@ let
     };
     buildInputs = [ TestAssert TestUnitLite ];
     propagatedBuildInputs = [ ExceptionBase constantboolean ];
+    meta = {
+      description = "Convert simple die into real exception object";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   ExceptionWarning = buildPerlModule {
@@ -8121,6 +8506,10 @@ let
     };
     buildInputs = [ TestAssert TestUnitLite ];
     propagatedBuildInputs = [ ExceptionBase ];
+    meta = {
+      description = "Convert simple warn into real exception object";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   ExporterDeclare = buildPerlModule {
@@ -8227,6 +8616,10 @@ let
       url = "mirror://cpan/authors/id/N/NW/NWCLARK/ExtUtils-Constant-0.25.tar.gz";
       sha256 = "6933d0e963b62281ef7561068e6aecac8c4ac2b476b2bba09ab0b90fbac9d757";
     };
+    meta = {
+      description = "Generate XS code to import C header constants";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   ExtUtilsCppGuess = buildPerlPackage {
@@ -8240,6 +8633,10 @@ let
     nativeBuildInputs = [ pkgs.ld-is-cc-hook ];
     propagatedBuildInputs = [ CaptureTiny ];
     buildInputs = [ ModuleBuild ];
+    meta = {
+      description = "Guess C++ compiler and flags";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   ExtUtilsDepends = buildPerlPackage {
@@ -8393,6 +8790,10 @@ let
       url = "mirror://cpan/authors/id/S/SM/SMUELLER/ExtUtils-Typemap-1.00.tar.gz";
       sha256 = "1iqz0xlscg655gnwb2h1wrjj70llblps1zznl29qn1mv5mvibc5i";
     };
+    meta = {
+      description = "Read/Write/Modify Perl/XS typemap files";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   ExtUtilsTypemapsDefault = buildPerlModule {
@@ -8401,6 +8802,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/S/SM/SMUELLER/ExtUtils-Typemaps-Default-1.05.tar.gz";
       sha256 = "1phmha0ks95kvzl00r1kgnd5hvg7qb1q9jmzjmw01p5zgs1zbyix";
+    };
+    meta = {
+      description = "A set of useful typemaps";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -8412,6 +8817,10 @@ let
       sha256 = "8cced386e3d544c5ec2deb3aed055b72ebcfc2ea9a6c807da87c4245272fe80a";
     };
     propagatedBuildInputs = [ ParseRecDescent TieIxHash ];
+    meta = {
+      description = "Automatic Perl XS glue code generation";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   ExtUtilsXSpp = buildPerlModule {
@@ -8438,6 +8847,10 @@ let
     };
     buildInputs = [ ExceptionWarning TestAssert TestUnitLite ];
     propagatedBuildInputs = [ ExceptionDied ];
+    meta = {
+      description = "Thrown when core function has a fatal error";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   FCGI = buildPerlPackage {
@@ -8450,6 +8863,10 @@ let
     postPatch = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
       sed -i '/use IO::File/d' Makefile.PL
     '';
+    meta = {
+      description = "Fast CGI module";
+      license = with lib.licenses; [ unfree ]; # Open Market License
+    };
   };
 
   FCGIClient = buildPerlModule {
@@ -8519,9 +8936,9 @@ let
     };
     buildInputs = [ Test2Suite TestRequires TestWithoutModule ];
     propagatedBuildInputs = [ ModulePluggable Moo TypeTiny namespaceautoclean ];
-    meta = with lib; {
+    meta = {
       description = "Watch for changes to files, cross-platform style";
-      license = licenses.artistic2;
+      license = with lib.licenses; [artistic2 ];
     };
   };
 
@@ -8531,6 +8948,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/File-chdir-0.1010.tar.gz";
       sha256 = "009b8p2fzj4nhl03fpkhrn0rsh7myxqbrf69iqpzd86p1gs23hgg";
+    };
+    meta = {
+      description = "A more sensible way to change directories";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -8547,6 +8968,10 @@ let
     '';
     propagatedBuildInputs = [ IPCSystemSimple ];
     buildInputs = [ FileWhich ];
+    meta = {
+      description = "Use the Freedesktop.org base directory specification";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   FileBOM = buildPerlModule {
@@ -8615,6 +9040,10 @@ let
       sha256 = "0mqivx4nbzagl3s2kxka72050sfb75xvn25j8a0f6ic3ibvir5yk";
     };
     buildInputs = [ PathTiny TestDeep TestFatal TestFile TestWarnings ];
+    meta = {
+      description = "Perl extension for recursively copying files and directories";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   FileCopyRecursiveReduced = buildPerlPackage {
@@ -8653,6 +9082,10 @@ let
       sha256 = "169c01e3dae2f629767bec1a9f1cdbd6ec6d713d1501e0b2786e4dd1235635b8";
     };
     propagatedBuildInputs = [ FileBaseDir URI ];
+    meta = {
+      description = "Object to handle .desktop files";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   FileFindIterator = buildPerlPackage {
@@ -8815,6 +9248,10 @@ let
       sha256 = "c30c688027a52ff4f58cd69d6d8ef35472a7cf106d4ce94eb73a796ba7c7ffa7";
     };
     propagatedBuildInputs = [ CryptRijndael ];
+    meta = {
+      description = "Interface to KeePass V1 and V2 database files";
+      license = with lib.licenses; [ gpl2Only gpl3Only ];
+    };
   };
 
   Filelchown = buildPerlModule {
@@ -8861,6 +9298,10 @@ let
       sha256 = "1zs8gfngqsd6jbsqajf95kql3bshsis1nf16y8v4l5i33s3s9cqm";
     };
     propagatedBuildInputs = [ HTTPDate ];
+    meta = {
+      description = "Parse directory listing";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   FileLoadLines = buildPerlPackage {
@@ -8886,6 +9327,10 @@ let
     };
     doCheck = false; # Failed test 'desktop file is the right one'
     buildInputs = [ FileBaseDir FileDesktopEntry EncodeLocale ];
+    meta = {
+      description = "Determine file type from the file name";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   FileMMagic = buildPerlPackage {
@@ -8938,6 +9383,10 @@ let
       url = "mirror://cpan/authors/id/P/PE/PETDANCE/File-Next-1.18.tar.gz";
       sha256 = "1vy2dqpc1nbjrnga08xr2hcxxfzifc5s2lfam5lf3djya0wwn07r";
     };
+    meta = {
+      description = "File-finding iterator";
+      license = with lib.licenses; [ artistic2 ];
+    };
   };
 
   FileNFSLock = buildPerlPackage {
@@ -8946,6 +9395,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/B/BB/BBB/File-NFSLock-1.29.tar.gz";
       sha256 = "0dzssj15faz9cn1w3xi7jwm64gyjyazapv4bkgglw5l1njcibm31";
+    };
+    meta = {
+      description = "Perl module to do NFS (or not) locking";
+      license = with lib.licenses; [ artistic1 gpl1Only ];
     };
   };
 
@@ -9016,6 +9469,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/S/SH/SHLOMIF/File-Remove-1.60.tar.gz";
       sha256 = "19lc9xr8w38i4bq3mbr0hadmyjm1dgyh6587gmlxbipdzx02lvp8";
+    };
+    meta = {
+      description = "Remove files and directories";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -9269,10 +9726,10 @@ let
     };
     propagatedBuildInputs = [ CGI DateTimeFormatStrptime HTMLTableExtract JSON JSONParse LWPProtocolHttps StringUtil TextTemplate ];
     buildInputs = [ TestPod ];
-    meta = with lib; {
+    meta = {
       homepage = "http://finance-quote.sourceforge.net/";
       description = "Get stock and mutual fund quotes from various exchanges";
-      license = licenses.gpl2;
+      license = with lib.licenses; [gpl2 ];
     };
   };
 
@@ -9283,7 +9740,7 @@ let
       url = "mirror://cpan/authors/id/Y/YA/YANNK/Find-Lib-1.04.tar.gz";
       sha256 = "0lg88v0sqfpq4d3jwvk6c9blqnpxbz8f4s22zr3b1qb160g94wqx";
     };
-    meta = with lib; {
+    meta = {
       description = "Helper to smartly find libs to use in the filesystem tree";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
@@ -9295,6 +9752,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/G/GA/GAAS/Font-AFM-1.20.tar.gz";
       sha256 = "32671166da32596a0f6baacd0c1233825a60acaf25805d79c81a3f18d6088bc1";
+    };
+    meta = {
+      description = "Interface to Adobe Font Metrics files";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -9350,6 +9811,10 @@ let
       sha256 = "0h8gakd6b9770n2xhld1hhqghdar3hrq2js4mgiwxy86j4r0hpiw";
     };
     doCheck = false;
+    meta = {
+      description = "Converting Perl structures to strings and back";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   FunctionParameters = buildPerlPackage {
@@ -9521,6 +9986,10 @@ let
     };
     makeMakerFlags = "LIBS=-L${pkgs.geoip}/lib INC=-I${pkgs.geoip}/include";
     doCheck = false; # seems to access the network
+    meta = {
+      description = "Look up location and network information by IP Address";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   GeoIP2 = buildPerlPackage {
@@ -9560,6 +10029,10 @@ let
       url = "mirror://cpan/authors/id/J/JV/JV/Getopt-Long-2.52.tar.gz";
       sha256 = "1yh5fykxrw68pvdvhvjh3wfs7a1s29xqwm5fxw2mqg9mfg1sgiwx";
     };
+    meta = {
+      description = "Extended processing of command line options";
+      license = with lib.licenses; [ artistic1 gpl2Plus ];
+    };
   };
 
   GetoptLongDescriptive = buildPerlPackage {
@@ -9584,6 +10057,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/G/GW/GWARD/Getopt-Tabular-0.3.tar.gz";
       sha256 = "0xskl9lcj07sdfx5dkma5wvhhgf5xlsq0khgh8kk34dm6dv0dpwv";
+    };
+    meta = {
+      description = "Table-driven argument parsing for Perl 5";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -9951,9 +10428,9 @@ let
     buildInputs = [ pkgs.graphviz TestPod ];
     propagatedBuildInputs = [ FileWhich IPCRun ParseRecDescent XMLTwig XMLXPath ];
 
-    meta = with lib; {
+    meta = {
       description = "Perl interface to the GraphViz graphing tool";
-      license = licenses.artistic2;
+      license = with lib.licenses; [artistic2 ];
     };
   };
 
@@ -9984,6 +10461,10 @@ let
     };
     buildInputs = [ ModuleBuildTiny ];
     propagatedBuildInputs = [ CryptCBC DataUUID ];
+    meta = {
+      description = "Perl implementation of GNTP Protocol (Client Part)";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   GSSAPI = buildPerlPackage {
@@ -10145,6 +10626,10 @@ let
       url = "mirror://cpan/authors/id/M/ML/MLEHMANN/Guard-1.023.tar.gz";
       sha256 = "34c4ddf91fc93d1090d86da14df706d175b1610c67372c01e12ce9555d4dd1dc";
     };
+    meta = {
+      description = "Safe cleanup blocks";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   HamAPRSFAP = buildPerlPackage {
@@ -10155,10 +10640,10 @@ let
       sha256 = "e01b455d46f44710dbcf21b6fa843f09358ce60eee1c4141bc74e0a204d3a020";
     };
     propagatedBuildInputs = [ DateCalc ];
-    meta = with lib; {
+    meta = {
       description = "Finnish APRS Parser (Fabulous APRS Parser)";
       maintainers = with maintainers; [ andrew-d ];
-      license = with licenses; [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -10214,6 +10699,10 @@ let
     };
     buildInputs = [ TestAssertions ];
     propagatedBuildInputs = [ LogTrace ];
+    meta = {
+      description = "Flatten/unflatten complex data hashes";
+      license = with lib.licenses; [ gpl2Only ];
+    };
   };
 
   HashMerge = buildPerlPackage {
@@ -10312,6 +10801,10 @@ let
       url = "mirror://cpan/authors/id/E/ET/ETHER/Hash-Util-FieldHash-Compat-0.11.tar.gz";
       sha256 = "06vlygjyk7rkkw0di3252mma141w801qn3xk40aa2yskbfklcbk4";
     };
+    meta = {
+      description = "Use Hash::Util::FieldHash or ties, depending on availability";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   HeapFibonacci = buildPerlPackage {
@@ -10320,6 +10813,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/J/JM/JMM/Heap-0.80.tar.gz";
       sha256 = "1plv2djbyhvkdcw2ic54rdqb745cwksxckgzvw7ssxiir7rjknnc";
+    };
+    meta = {
+      description = "Perl extensions for keeping data partially sorted";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -10360,6 +10857,10 @@ let
       sha256 = "f3ef1af108f27fef15ebec66479f251ce08aa49bd00b0462c9c80c86b4b6b32b";
     };
     propagatedBuildInputs = [ HTMLTree ];
+    meta = {
+      description = "Perl extension for HTML::Element(3)";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   HTMLEscape = buildPerlModule {
@@ -10626,6 +11127,10 @@ let
       sha256 = "1qbad8ayffpx7wj76ip05p6rh9p1lkir6qknpl76zy679ghlsp8s";
     };
     buildInputs = [ TestBase ];
+    meta = {
+      description = "CSS Selector to XPath compiler";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   HTMLScrubber = buildPerlPackage {
@@ -10637,6 +11142,10 @@ let
     };
     propagatedBuildInputs = [ HTMLParser ];
     buildInputs = [ TestDifferences TestMemoryCycle ];
+    meta = {
+      description = "Perl extension for scrubbing/sanitizing HTML";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   HTMLStripScripts = buildPerlPackage {
@@ -10678,6 +11187,10 @@ let
       rm t/30_tree.t
     '';
     propagatedBuildInputs = [ HTMLElementExtended ];
+    meta = {
+      description = "Perl module for extracting the content contained in tables within an HTML document, either as text or encoded element trees";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   HTMLTagset = buildPerlPackage {
@@ -10686,6 +11199,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/P/PE/PETDANCE/HTML-Tagset-3.20.tar.gz";
       sha256 = "1qh8249wgr4v9vgghq77zh1d2zs176bir223a8gh3k9nksn7vcdd";
+    };
+    meta = {
+      description = "Data tables useful in parsing HTML";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -10698,6 +11215,10 @@ let
     };
     propagatedBuildInputs = [ CGI ];
     buildInputs = [ TestPod ];
+    meta = {
+      description = "Perl module to use HTML-like templating language";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   HTMLTidy = buildPerlPackage {
@@ -10742,6 +11263,10 @@ let
       sha256 = "17aa1v62sp8ycxcicwhankmj4brs6nnfclk9z7mf1rird1f164gd";
     };
     propagatedBuildInputs = [ HTMLParser SubOverride ];
+    meta = {
+      description = "Easy to use HTML::TokeParser interface";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   HTMLTree = buildPerlModule {
@@ -10784,6 +11309,10 @@ let
     doCheck = false;
     propagatedBuildInputs = [ ClassAccessorChained ClassDataAccessor DateCalc EmailValid HTMLScrubber HTMLTree ModulePluggableFast ];
     buildInputs = [ TestNoWarnings ];
+    meta = {
+      description = "HTML Widget And Validation Framework";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   HTTPAcceptLanguage = buildPerlModule {
@@ -10983,6 +11512,10 @@ let
       sha256 = "0z77nflj8zdcfg70kc93glq5kmd6qxn2nf7h70x4xhfg25wkvr1q";
     };
     buildInputs = [ CGI ];
+    meta = {
+      description = "Lightweight HTTP implementation";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   HTTPMessage = buildPerlPackage {
@@ -11036,6 +11569,10 @@ let
       url = "mirror://cpan/authors/id/K/KA/KAZUHO/HTTP-Parser-XS-0.17.tar.gz";
       sha256 = "02d84xq1mm53c7jl33qyb7v5w4372vydp74z6qj0vc96wcrnhkkr";
     };
+    meta = {
+      description = "A fast, primitive HTTP request parser";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   HTTPProxy = buildPerlPackage {
@@ -11062,6 +11599,10 @@ let
       sha256 = "1smwmiarwcgq7vjdblnb6ldi2x1s5sk5p15p7xvm5byiqq3znnwl";
     };
     propagatedBuildInputs = [ ClassAccessor HTTPMessage ];
+    meta = {
+      description = "Set up a CGI environment from an HTTP::Request";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   HTTPResponseEncoding = buildPerlPackage {
@@ -11320,6 +11861,10 @@ let
       sha256 = "15fa4hpw2rqg2iadyz10rnv99hns78wph5qlh3257a3mbfjjyyla";
     };
     doCheck = false; # nondeterministic
+    meta = {
+      description = "Advanced manipulation of IMAP services w/ referral support";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   Importer = buildPerlPackage {
@@ -11481,6 +12026,10 @@ let
       sha256 = "14kz7z4xw179aya3116wxac29l4y2wmwrba087lya4v2gxdgiz4g";
     };
     propagatedBuildInputs = [ PerlIOviadynamic ];
+    meta = {
+      description = "Calculate digests while reading or writing";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   IOHTML = buildPerlPackage {
@@ -11546,6 +12095,10 @@ let
       url = "mirror://cpan/authors/id/R/RA/RANI/IO-LockedFile-0.23.tar.gz";
       sha256 = "1dgq8zfkaszisdb5hz8jgcl0xc3qpv7bbv562l31xgpiddm7xnxi";
     };
+    meta = {
+      description = "Supply object methods for locking files";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   IOMultiplex = buildPerlPackage {
@@ -11554,6 +12107,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/B/BB/BBB/IO-Multiplex-1.16.tar.gz";
       sha256 = "74d22c44b5ad2e7190e2786e8a17d74bbf4cef89b4d1157ba33598b5a2720dad";
+    };
+    meta = {
+      description = "Supply object methods for locking files";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -11627,6 +12184,10 @@ let
     };
     propagatedBuildInputs = [ Socket6 ];
     doCheck = false;
+    meta = {
+      description = "[DEPRECATED] Object interface for AF_INET/AF_INET6 domain sockets";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   IOSocketSSL = buildPerlPackage {
@@ -11672,6 +12233,10 @@ let
       url = "mirror://cpan/authors/id/G/GA/GAAS/IO-String-1.08.tar.gz";
       sha256 = "2a3f4ad8442d9070780e58ef43722d19d1ee21a803bf7c8206877a10482de5a0";
     };
+    meta = {
+      description = "Emulate file interface for in-core strings";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   IOStringy = buildPerlPackage {
@@ -11680,6 +12245,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/C/CA/CAPOEIRAB/IO-Stringy-2.113.tar.gz";
       sha256 = "0kpycb56l6ilvmdx9swx9wpj1x3vfnqdflfjd6dn6spnz750y8ji";
+    };
+    meta = {
+      description = "I/O on in-core objects like strings and arrays";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -11707,6 +12276,10 @@ let
       url = "mirror://cpan/authors/id/N/NE/NEILB/IO-Tee-0.66.tar.gz";
       sha256 = "1q2jhp02rywrbyhvl2lv6qp70dcv5cfalrx3cc4c7y8nclhfg71d";
     };
+    meta = {
+      description = "Multiplex output to multiple output handles";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   IOTieCombine = buildPerlPackage {
@@ -11731,6 +12304,10 @@ let
       sha256 = "06mmyr4fkkix1z0j8hnhrccn93isnabf3408kqavn2v2hw7wrya3";
     };
     doCheck = !stdenv.isDarwin;  # openpty fails in the sandbox
+    meta = {
+      description = "Low-level allocate a pseudo-Tty, import constants";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   IPCConcurrencyLimit = buildPerlPackage {
@@ -11800,6 +12377,10 @@ let
       url = "mirror://cpan/authors/id/R/RJ/RJBS/IPC-Run3-0.048.tar.gz";
       sha256 = "0r9m8q78bg7yycpixd7738jm40yz71p2q7inm766kzsw3g6c709x";
     };
+    meta = {
+      description = "Run a subprocess with input/ouput redirection";
+      license = with lib.licenses; [ artistic1 gpl1Plus bsd3 ];
+    };
   };
 
   IPCShareLite = buildPerlPackage {
@@ -11808,6 +12389,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/A/AN/ANDYA/IPC-ShareLite-0.17.tar.gz";
       sha256 = "1gz7dbwxrzbzdsjv11kb49jlf9q6lci2va6is0hnavd93nwhdm0l";
+    };
+    meta = {
+      description = "Lightweight interface to shared memory";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -11867,7 +12452,7 @@ let
       shortenPerlShebang $out/bin/exiftool
     '';
 
-    meta = with lib; {
+    meta = {
       description = "A tool to read, write and edit EXIF meta information";
       longDescription = ''
         ExifTool is a platform-independent Perl library plus a command-line
@@ -11882,7 +12467,7 @@ let
       '';
       homepage = "https://exiftool.org/";
 
-      license = with licenses; [ gpl1Plus /* or */ artistic2 ];
+      license = with lib.licenses; [ gpl1Plus /* or */ artistic2 ];
       maintainers = [ maintainers.kiloreux ];
       mainProgram = "exiftool";
     };
@@ -11967,6 +12552,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/R/RO/ROSCH/IPC-Signal-1.00.tar.gz";
       sha256 = "1l3g0zrcwf2whwjhbpwdcridb7c77mydwxvfykqg1h6hqb4gj8bw";
+    };
+    meta = {
+      description = "Utility functions dealing with signals";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -12170,6 +12759,10 @@ let
       url = "mirror://cpan/authors/id/M/MA/MARKOV/Object-Realize-Later-0.21.tar.gz";
       sha256 = "1nfqssld7pcdw9sj4mkfnh75w51wl14i1h7npj9fld4fri09cywg";
     };
+    meta = {
+      description = "Delayed creation of objects";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   LaTeXML = buildPerlPackage rec {
@@ -12315,6 +12908,10 @@ let
       url = "mirror://cpan/authors/id/G/GU/GUIDO/libintl-perl-1.32.tar.gz";
       sha256 = "19gbbh9w3rl805mv6mg1q80fsrg610h098qhf7ycnkjnyac84440";
     };
+    meta = {
+      description = "Portable l10n and i10n functions";
+      license = with lib.licenses; [ gpl3Only ];
+    };
   };
 
   libnet = buildPerlPackage {
@@ -12359,6 +12956,10 @@ let
       sha256 = "1jy9af0ljyzj7wakqli0437zb2vrbplqj4xhab7bfj2xgfdhawa5";
     };
     propagatedBuildInputs = [ XMLParser ];
+    meta = {
+      description = "Collection of Perl modules for working with XML";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   LinguaENFindNumber = buildPerlPackage {
@@ -12486,6 +13087,10 @@ let
     };
     doCheck = false;
     propagatedBuildInputs = [ LinguaPTStemmer LinguaStemFr LinguaStemIt LinguaStemRu LinguaStemSnowballDa SnowballNorwegian SnowballSwedish TextGerman ];
+    meta = {
+      description = "Stemming of words";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   LinguaStemFr = buildPerlPackage {
@@ -12686,6 +13291,10 @@ let
       url = "mirror://cpan/authors/id/D/DA/DAVIDO/List-BinarySearch-0.25.tar.gz";
       sha256 = "0ap8y9rsjxg75887klgij90mf459f8dwy0dbx1g06h30pmqk04f8";
     };
+    meta = {
+      description = "Binary Search within a sorted array";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   ListCompare = buildPerlPackage {
@@ -12758,6 +13367,10 @@ let
       url = "mirror://cpan/authors/id/P/PE/PEVANS/List-UtilsBy-0.11.tar.gz";
       sha256 = "0nkpylkqccxanr8wc7j9wg6jdrizybjjd6p8q3jbh7f29cxz9pgs";
     };
+    meta = {
+      description = "Higher-order list utility functions";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   LocaleCodes = buildPerlPackage {
@@ -12785,6 +13398,10 @@ let
       sha256 = "05cwqjxxary11di03gg3fm6j9lbvg1dr2wpr311c1rwp8salg7ch";
     };
     LANG="C";
+    meta = {
+      description = "Perl extension for emulating gettext-related API";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   LocaleMaketextLexiconGetcontext = buildPerlPackage {
@@ -12967,6 +13584,10 @@ let
       url = "mirror://cpan/authors/id/S/SC/SCHWIGON/lockfile-simple/LockFile-Simple-0.208.tar.gz";
       sha256 = "18pk5a030dsg1h6wd8c47wl8pzrpyh9zi9h2c9gs9855nab7iis5";
     };
+    meta = {
+      description = "Simple file locking scheme";
+      license = with lib.licenses; [ artistic1 gpl2Plus ];
+    };
   };
 
   LogAny = buildPerlPackage {
@@ -13126,6 +13747,10 @@ let
       url = "mirror://cpan/authors/id/B/BB/BBC/Log-Trace-1.070.tar.gz";
       sha256 = "1qrnxn9b05cqyw1286djllnj8wzys10754glxx6z5hihxxc85jwy";
     };
+    meta = {
+      description = "Provides a unified approach to tracing";
+      license = with lib.licenses; [ gpl1Only ];
+    };
   };
 
   MCE = buildPerlPackage {
@@ -13249,9 +13874,9 @@ let
     '';
     doCheck = !stdenv.isDarwin;
     checkInputs = [ HTTPDaemon TestFatal TestNeeds TestRequiresInternet ];
-    meta = with lib; {
+    meta = {
       description = "The World-Wide Web library for Perl";
-      license = with licenses; [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -13388,6 +14013,10 @@ let
     # which doesn't look like it will get fixed anytime soon.
     doCheck = false;
     buildInputs = [ ModuleBuildTiny TestRequiresInternet ];
+    meta = {
+      description = "Permits recording, and later playing back of LWP requests";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   LWPxParanoidAgent = buildPerlPackage {
@@ -13399,6 +14028,10 @@ let
     };
     doCheck = false; # 3 tests fail, probably because they try to connect to the network
     propagatedBuildInputs = [ LWP NetDNS ];
+    meta = {
+      description = "Subclass of LWP::UserAgent that protects you from harm";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   maatkit = callPackage ../development/perl-modules/maatkit { };
@@ -13411,10 +14044,10 @@ let
       sha256 = "1a82pacp6pph3y2agdihzr4vc0phx85mq5am9czc81g8n484b35x";
     };
     buildInputs = [ pkgs.darwin.apple_sdk.frameworks.ApplicationServices ];
-    meta = with lib; {
+    meta = {
       description = "Manipulate Mac OS X pasteboards";
-      license = with licenses; [ artistic1 gpl1Plus ];
-      platforms = platforms.darwin;
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      platforms = lib.platforms.darwin;
       mainProgram = "pbtool";
     };
   };
@@ -13441,6 +14074,10 @@ let
       url = "mirror://cpan/authors/id/Z/ZE/ZEROALTI/Mail-Maildir-100/Mail-Maildir-1.0.0.tar.bz2";
       sha256 = "1krkqfps6q3ifrhi9450l5gm9199qyfcm6vidllr0dv65kdaqpj4";
     };
+    meta = {
+      description = "Handle Maildir folders";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   MailBox = buildPerlPackage {
@@ -13454,6 +14091,10 @@ let
     doCheck = false;
 
     propagatedBuildInputs = [ DevelGlobalDestruction FileRemove Later MailTransport ];
+    meta = {
+      description = "Manage a mailbox, a folder with messages";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   MailMboxMessageParser = buildPerlPackage {
@@ -13498,6 +14139,10 @@ let
     propagatedBuildInputs = [ CryptOpenSSLRSA MailAuthenticationResults MailTools NetDNS ];
     doCheck = false; # tries to access the domain name system
     buildInputs = [ NetDNSResolverMock TestRequiresInternet YAMLLibYAML ];
+    meta = {
+      description = "Signs/verifies Internet mail with DKIM/DomainKey signatures";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   MailIMAPClient = buildPerlPackage {
@@ -13508,6 +14153,10 @@ let
       sha256 = "0znf035ikaxyfishv507qq6g691xvbnziqlcwfikkj2l1kan88hw";
     };
     propagatedBuildInputs = [ ParseRecDescent ];
+    meta = {
+      description = "An IMAP Client API";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   MailPOP3Client = buildPerlPackage {
@@ -13529,6 +14178,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/P/PD/PDWARREN/Mail-RFC822-Address-0.3.tar.gz";
       sha256 = "351ef4104ecb675ecae69008243fae8243d1a7e53c681eeb759e7b781684c8a7";
+    };
+    meta = {
+      description = "Perl extension for validating email addresses according to RFC822";
+      license = with lib.licenses; [ mit ];
     };
   };
 
@@ -13641,6 +14294,10 @@ let
       url = "mirror://cpan/authors/id/M/MI/MIKER/Math-Base-Convert-0.11.tar.gz";
       sha256 = "8c0971355f24c93b79e77ad54a4570090a1a598fcb9b86f5c17eba42f38b40e0";
     };
+    meta = {
+      description = "Very fast base to base conversion";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   MathLibm = buildPerlPackage {
@@ -13649,6 +14306,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/D/DS/DSLEWART/Math-Libm-1.00.tar.gz";
       sha256 = "0xn2a950mzzs5q1c4q98ckysn9dz20x7r35g02zvk35chgr0klxz";
+    };
+    meta = {
+      description = "Perl extension for the C math library, libm";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -13707,6 +14368,10 @@ let
     NIX_CFLAGS_COMPILE = "-I${pkgs.gmp.dev}/include";
     NIX_CFLAGS_LINK = "-L${pkgs.gmp.out}/lib -lgmp";
     propagatedBuildInputs = [ MathBigInt ];
+    meta = {
+      description = "Backend library for Math::BigInt etc. based on GMP";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   MathBigIntLite = buildPerlPackage {
@@ -13731,6 +14396,10 @@ let
     };
     nativeBuildInputs = [ pkgs.ld-is-cc-hook ];
     buildInputs = [ ExtUtilsCppGuess ExtUtilsTypemapsDefault ExtUtilsXSpp ModuleBuildWithXSpp TestDeep ];
+    meta = {
+      description = "Polygon clipping in 2D";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   MathConvexHullMonotoneChain = buildPerlPackage {
@@ -13739,6 +14408,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/S/SM/SMUELLER/Math-ConvexHull-MonotoneChain-0.01.tar.gz";
       sha256 = "1xcl7cz62ydddji9qzs4xsfxss484jqjlj4iixa4aci611cw92r8";
+    };
+    meta = {
+      description = "Andrew's monotone chain algorithm for finding a convex hull in 2D";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -13796,6 +14469,10 @@ let
       sha256 = "0b206k2q5cznld45cjhgm0as0clc9hk135ds8qafbkl3k175w1vj";
     };
     propagatedBuildInputs = [ ClassAccessor ParamsValidate ];
+    meta = {
+      description = "Compute Voronoi diagrams from sets of points";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   MathInt128 = buildPerlPackage {
@@ -13862,6 +14539,10 @@ let
     };
     propagatedBuildInputs = [ MathLibm constant-defer ];
     buildInputs = [ DataFloat MathBigIntLite NumberFraction ];
+    meta = {
+      description = "Points on a path through the 2-D plane";
+      license = with lib.licenses; [ gpl3Plus ];
+    };
   };
 
   MathPrimeUtil = buildPerlPackage {
@@ -13979,6 +14660,10 @@ let
       url = "mirror://cpan/authors/id/G/GR/GROMMEL/Math-Round-0.07.tar.gz";
       sha256 = "09wkvqj4hfq9y0fimri967rmhnq90dc2wf20lhlmqjp5hsd359vk";
     };
+    meta = {
+      description = "Perl extension for rounding numbers";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   MathVecStat = buildPerlPackage {
@@ -13987,6 +14672,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/A/AS/ASPINELLI/Math-VecStat-0.08.tar.gz";
       sha256 = "03bdcl9pn2bc9b50c50nhnr7m9wafylnb3v21zlch98h9c78x6j0";
+    };
+    meta = {
+      description = "Some basic numeric stats on vectors";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -14062,6 +14751,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/M/MJ/MJD/Memoize-1.03.tgz";
       sha256 = "5239cc5f644a50b0de9ffeaa51fa9991eb06ecb1bf4678873e3ab89af9c0daf3";
+    };
+    meta = {
+      description = "Make functions faster by trading space for time";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -14192,11 +14885,11 @@ let
 
     installTargets = [ "install" ];
 
-    meta = with lib; {
+    meta = {
       homepage = "https://www.mhonarc.org/";
       description = "A mail-to-HTML converter";
       mainProgram = "mhonarc";
-      license = licenses.gpl2;
+      license = with lib.licenses; [ gpl2 ];
     };
   };
 
@@ -14224,7 +14917,7 @@ let
     buildInputs = [ ProcWaitStat ];
     meta = {
       description = "Construct and optionally mail MIME messages";
-      license = lib.licenses.gpl2Plus;
+      license = with lib.licenses; [ gpl2Plus ];
     };
   };
 
@@ -14540,6 +15233,10 @@ let
       sha256 = "0d39fjg9c0n820bk3fb50vvlwhdny4hdl69xmlyzql5xzp4cicsk";
     };
     propagatedBuildInputs = [ ExtUtilsCppGuess ExtUtilsXSpp ];
+    meta = {
+      description = "XS++ enhanced flavour of Module::Build";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   ModuleBuildXSUtil = buildPerlModule {
@@ -14846,6 +15543,10 @@ let
       sha256 = "0pq758wlasmh77xyd2xh75m5b2x14s8pnsv63g5356gib1q5gj08";
     };
     propagatedBuildInputs = [ UNIVERSALrequire ];
+    meta = {
+      description = "Fast plugins with instantiation";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   ModuleRefresh = buildPerlPackage {
@@ -14942,6 +15643,10 @@ let
       sha256 = "0g7qs6vqg91xpwg1cdy91m3kh9m1zbkzyz1qsy453b572xdscf0d";
     };
     buildInputs = [ pkgs.unzip ];
+    meta = {
+      description = "Handle versions of loaded modules with flexible result interface";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   ModuleVersionsReport = buildPerlPackage {
@@ -15479,6 +16184,10 @@ let
     };
     propagatedBuildInputs = [ ModuleRuntime ];
     buildInputs = [ Moo TestFatal ];
+    meta = {
+      description = "Some Moosish types and a type builder";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   MooXTypesMooseLikeNumeric = buildPerlPackage {
@@ -15553,6 +16262,10 @@ let
     };
     buildInputs = [ TestFatal ];
     propagatedBuildInputs = [ Moose ];
+    meta = {
+      description = "Easy aliasing of methods and attributes in Moose";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   MooseXAppCmd = buildPerlModule {
@@ -15779,6 +16492,10 @@ let
       sha256 = "0kjydmkxh8hpkbbmsgd5wrkhgq7w69lgfg6lx4s5g2xpqfkqmqz7";
     };
     propagatedBuildInputs = [ Moose ];
+    meta = {
+      description = "Attribute that returns the instance to allow for chaining";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   MooseXAttributeHelpers = buildPerlModule {
@@ -15806,6 +16523,10 @@ let
     };
     propagatedBuildInputs = [ DataVisitor HashUtilFieldHashCompat namespaceautoclean ];
     buildInputs = [ ModuleBuildTiny ];
+    meta = {
+      description = "Fine-grained cloning support for Moose objects";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   MooseXConfigFromFile = buildPerlModule {
@@ -15989,6 +16710,9 @@ let
       sha256 = "17vynkf6m5d039qkr4in1c9lflr8hnwp1fgzdwhj4q6jglipmnrh";
     };
     propagatedBuildInputs = [ MooseXRoleParameterized ];
+    meta = { description = "Apply roles to a class related to yours";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   MooseXParamsValidate = buildPerlPackage {
@@ -16062,6 +16786,10 @@ let
       sha256 = "1mdil9ckgmgr78z59p8wfa35ixn5855ndzx14y01dvfxpiv5gf55";
     };
     propagatedBuildInputs = [ Moose ];
+    meta = {
+      description = "Name your accessors foo() and set_foo()";
+      license = with lib.licenses; [ artistic2 ];
+    };
   };
 
   MooseXSetOnce = buildPerlPackage {
@@ -16073,6 +16801,10 @@ let
     };
     buildInputs = [ TestFatal ];
     propagatedBuildInputs = [ Moose ];
+    meta = {
+      description = "Write-once, read-many attributes for Moose";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   MooseXSingleton = buildPerlModule {
@@ -16084,6 +16816,10 @@ let
     };
     buildInputs = [ ModuleBuildTiny TestFatal TestRequires TestWarnings ];
     propagatedBuildInputs = [ Moose ];
+    meta = {
+      description = "Turn your Moose class into a singleton";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   MooseXStorage = buildPerlPackage {
@@ -16143,6 +16879,10 @@ let
     };
     buildInputs = [ TestException ];
     propagatedBuildInputs = [ ListMoreUtils Moose namespaceautoclean ];
+    meta = {
+      description = "Trait loading and resolution for Moose";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   MooseXTypes = buildPerlModule {
@@ -16364,6 +17104,10 @@ let
     perlPreHook = "export LD=$CC";
     NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isi686 "-fno-stack-protector";
     hardeningDisable = lib.optional stdenv.isi686 "stackprotector";
+    meta = {
+      description = "Moose minus the antlers";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   MouseXNativeTraits = buildPerlPackage {
@@ -16429,6 +17173,10 @@ let
     doCheck = false; # The main test performs network access
     nativeBuildInputs = [ pkgs.pkg-config ];
     propagatedBuildInputs = [ pkgs.libdiscid ];
+    meta = {
+      description = "- Perl interface for the MusicBrainz libdiscid library";
+      license = with lib.licenses; [ mit ];
+    };
   };
 
   MusicBrainz = buildPerlModule {
@@ -16440,6 +17188,10 @@ let
     };
     propagatedBuildInputs = [ Mojolicious ];
     doCheck = false; # Test performs network access.
+    meta = {
+      description = "API to search the musicbrainz.org database";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   MustacheSimple = buildPerlPackage {
@@ -16586,6 +17338,10 @@ let
       [ ../development/perl-modules/net-amazon-mechanicalturk.patch ];
     propagatedBuildInputs = [ DigestHMAC LWPProtocolHttps XMLParser ];
     doCheck = false; /* wants network */
+    meta = {
+      description = "Amazon Mechanical Turk SDK for Perl";
+      license = with lib.licenses; [ asl20 ];
+    };
   };
 
   NetAmazonS3 = buildPerlPackage {
@@ -17078,6 +17834,10 @@ let
       sha256 = "70835a926e1c5a8d0324c72fffee82eeb7ec6c141dee04fd446820b64f71c552";
     };
     propagatedBuildInputs = [ NetCIDRLite Socket6 ];
+    meta = {
+      description = "Patricia Trie perl module for fast IP address lookups";
+      license = with lib.licenses; [ gpl2Plus ];
+    };
   };
 
   NetPing = buildPerlPackage {
@@ -17213,6 +17973,10 @@ let
       sha256 = "001a6dcfahf7kkyirqkc8jd4fh4fkal7n7vm9c4dblqrvmdc8abv";
     };
     propagatedBuildInputs = [ IOSocketSSL ];
+    meta = {
+      description = "SSL support for Net::SMTP";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   NetSMTPTLS = buildPerlPackage {
@@ -17223,6 +17987,10 @@ let
       sha256 = "19g48kabj22v66jbf69q78xplhi7r1y2kdbddfwh4xy3g9k75rzg";
     };
     propagatedBuildInputs = [ DigestHMAC IOSocketSSL ];
+    meta = {
+      description = "An SMTP client supporting TLS and AUTH";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   NetSMTPTLSButMaintained = buildPerlPackage {
@@ -17233,6 +18001,10 @@ let
       sha256 = "0vi5cv7f9i96hgp3q3jpxzn1ysn802kh5xc304f8b7apf67w15bb";
     };
     propagatedBuildInputs = [ DigestHMAC IOSocketSSL ];
+    meta = {
+      description = "An SMTP client supporting TLS and AUTH (DEPRECATED, use Net::SMTPS instead)";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   NetSNMP = buildPerlModule {
@@ -17378,6 +18150,10 @@ let
       substituteInPlace IP.pm --replace " AutoLoader" ""
     '';
     buildInputs = [ RegexpIPv6 ];
+    meta = {
+      description = "Perl extension for looking up the whois information for ip addresses";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   NetWorks = buildPerlPackage {
@@ -17402,6 +18178,10 @@ let
       url = "mirror://cpan/authors/id/F/FE/FERREIRA/Number-Bytes-Human-0.11.tar.gz";
       sha256 = "0b3gprpbcrdwc2gqalpys5m2ngilh5injhww8y0gf3dln14rrisz";
     };
+    meta = {
+      description = "Convert byte count to human readable format";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   NumberCompare = buildPerlPackage {
@@ -17410,6 +18190,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/R/RC/RCLAMP/Number-Compare-0.03.tar.gz";
       sha256 = "09q8i0mxvr7q9vajwlgawsi0hlpc119gnhq4hc933d03x0vkfac3";
+    };
+    meta = {
+      description = "Numeric comparisons";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -17651,6 +18435,10 @@ let
     '';
 
     doCheck = false;
+    meta = {
+      description = "Perl OpenGL bindings";
+      license = with lib.licenses; [ artistic1 gpl1Plus ]; # taken from EPEL
+    };
   };
 
   OpenOfficeOODoc = buildPerlPackage {
@@ -17676,6 +18464,10 @@ let
       sha256 = "1jdbkp18ka2m4akjp9b0dbw2lqnzgwpq435cnh6hwwa79bbrfkmb";
     };
     propagatedBuildInputs = [ CryptDHGMP XMLSimple ];
+    meta = {
+      description = "Libraries shared between Net::OpenID::Consumer and Net::OpenID::Server";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   NetOpenIDConsumer = buildPerlPackage {
@@ -17687,6 +18479,10 @@ let
     };
     propagatedBuildInputs = [ JSON NetOpenIDCommon ];
     buildInputs = [ CGI ];
+    meta = {
+      description = "Library for consumers of OpenID identities";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   NetOpenSSH = buildPerlPackage {
@@ -17878,6 +18674,10 @@ let
       sha256 = "052r198xyrsv8wz21gijdigz2cgnidsa37nvyfzdiz4rv1fc33ir";
     };
     perlPreHook = lib.optionalString stdenv.isi686 "export LD=$CC"; # fix undefined reference to `__stack_chk_fail_local'
+    meta = {
+      description = "Argument type classification";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   ParamsUtil = buildPerlPackage {
@@ -17984,6 +18784,10 @@ let
       url = "mirror://cpan/authors/id/C/CO/CORION/parent-0.238.tar.gz";
       sha256 = "1lfjqjxsvgpsn6ycah4z0qygkykj4v8ca3cdki61k2p2ygg8zx9q";
     };
+    meta = {
+      description = "Establish an ISA relationship with base classes at compile time";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   ParseDebControl = buildPerlPackage {
@@ -17994,8 +18798,8 @@ let
       sha256 = "0ad78qri4sg9agghqdm83xsjgks94yvffs23kppy7mqjy8gwwjxn";
     };
     propagatedBuildInputs = [ IOStringy LWP ];
-    meta = with lib; {
-      license = with licenses; [ artistic1 gpl1Plus ];
+    meta = {
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -18077,6 +18881,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/D/DS/DSCHWEI/Parse-Syslog-1.10.tar.gz";
       sha256 = "659a2145441ef36d9835decaf83da308fcd03f49138cb3d90928e8bfc9f139d9";
+    };
+    meta = {
+      description = "Parse Unix syslog files";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -18184,6 +18992,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/X/XS/XSAWYERX/PathTools-3.75.tar.gz";
       sha256 = "a558503aa6b1f8c727c0073339081a77888606aa701ada1ad62dd9d8c3f945a2";
+    };
+    meta = {
+      description = "Get pathname of current working directory";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -18325,6 +19137,10 @@ let
       url = "mirror://cpan/authors/id/N/NO/NOBULL/perl5lib-1.02.tar.gz";
       sha256 = "1b6fgs8wy2a7ff8rr1qdvdghhvlpr1pv760k4i2c8lq1hhjnkf94";
     };
+    meta = {
+      description = "Honour PERL5LIB even in taint mode";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   Perlosnames = buildPerlPackage {
@@ -18389,7 +19205,7 @@ let
     meta = {
       description = "Policies for Perl::Critic concerned with using Moose";
       homepage = "https://metacpan.org/release/Perl-Critic-Moose";
-      license = with lib.licenses; [ artistic1 ]];
+      license = with lib.licenses; [ artistic1 ];
     };
   };
 
@@ -18455,6 +19271,10 @@ let
       url = "mirror://cpan/authors/id/S/SH/SHLOMIF/PerlIO-eol-0.17.tar.gz";
       sha256 = "1fayp27vcmypqyzcd4003036h3g5zy6jk1ia25frdca58pzcpk6f";
     };
+    meta = {
+      description = "PerlIO layer for normalizing line endings";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   PerlIOgzip = buildPerlPackage {
@@ -18493,6 +19313,10 @@ let
       url = "mirror://cpan/authors/id/A/AL/ALEXMV/PerlIO-via-dynamic-0.14.tar.gz";
       sha256 = "0jbb3xpbqzmr625blvnjszd69l3cwxzi7bhmkj5x48dgv3s7mkca";
     };
+    meta = {
+      description = "Dynamic PerlIO layers";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   PerlIOviasymlink = buildPerlPackage {
@@ -18510,6 +19334,10 @@ let
       # causes build failure for perl5.18+
       rm -r  inc
     '';
+    meta = {
+      description = "PerlIO layers for create symlinks";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   PerlIOviaTimeout = buildPerlModule {
@@ -18556,6 +19384,10 @@ let
       ''
         sed -i -e 's|my \$INC_magick = .*|my $INC_magick = "-I${pkgs.imagemagick.dev}/include/ImageMagick";|' Makefile.PL
       '';
+    meta = {
+      description = "Objected-oriented Perl interface to ImageMagick. Use it to read, manipulate, or write an image or image sequence from within a Perl script";
+      license = with lib.licenses; [ imagemagick ];
+    };
   };
 
   PerlTidy = buildPerlPackage rec {
@@ -19024,6 +19856,10 @@ let
       url = "mirror://cpan/authors/id/B/BI/BILBO/Proc-SafeExec-1.5.tar.gz";
       sha256 = "1b4d0908bcac563d34a7e5be61c5da3eee98e4a6c7fa68c2670cc5844b5a2d78";
     };
+    meta = {
+      description = "Convenient utility for executing external commands in various ways";
+      license = with lib.licenses; [ gpl1Only bsd2 ];
+    };
   };
 
   ProcSimple = buildPerlPackage {
@@ -19059,6 +19895,10 @@ let
       sha256 = "1g3l8jzx06x4l4p0x7fyn4wvg6plfzl420irwwb9v447wzsn6xfh";
     };
     propagatedBuildInputs = [ IPCSignal ];
+    meta = {
+      description = "Interpret and act on wait() status values";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   PrometheusTiny = buildPerlPackage {
@@ -19131,6 +19971,10 @@ let
       sha256 = "08jmazvrmvp8jn15p2n3c1h3f2cbkr07xjzy197jb8x724vx0dsq";
     };
     buildInputs = [ ModuleBuildTiny ];
+    meta = {
+      description = "WebSocket protocol";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   ProtocolHTTP2 = buildPerlModule {
@@ -19142,6 +19986,10 @@ let
       sha256 = "0jm6jq1wszjrrcypyi642m2i8wgni50wdnzh9dzfkyjazdc00sn2";
     };
     buildInputs = [ AnyEvent ModuleBuildTiny NetSSLeay TestLeakTrace TestSharedFork TestTCP ];
+    meta = {
+      description = "HTTP/2 protocol implementation (RFC 7540)";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   PSGI = buildPerlPackage {
@@ -19150,6 +19998,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/PSGI-1.102.tar.gz";
       sha256 = "0iqzxs8fv63510knm3zr3jr3ky4x7diwd7y24mlshzci81kl8v55";
+    };
+    meta = {
+      description = "Perl Web Server Gateway Interface Specification";
+      license = with lib.licenses; [ cc-by-sa-25 ];
     };
   };
 
@@ -19160,6 +20012,10 @@ let
       url = "mirror://cpan/authors/id/R/RO/ROBIN/PadWalker-2.5.tar.gz";
       sha256 = "1l0cga0ny43x5xpqw9nrdwbznvqpj35ni39a0wrayihihjxnmch7";
     };
+    meta = {
+      description = "Play with other peoples' lexical variables";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   Perl6Junction = buildPerlPackage {
@@ -19168,6 +20024,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/C/CF/CFRANKS/Perl6-Junction-1.60000.tar.gz";
       sha256 = "0r3in9pyrm6wfrhcvxbq5w1617x8x5537lxj9hdzks4pa7l7a8yh";
+    };
+    meta = {
+      description = "Perl6 style Junction operators in Perl5";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -19533,6 +20393,10 @@ let
       url = "mirror://cpan/authors/id/K/KH/KHW/Pod-Simple-3.42.tar.gz";
       sha256 = "1icagrjqw1azmff82h17cbrhqgql7rg21gz64mjpiqqq0cpfpz59";
     };
+    meta = {
+      description = "Framework for parsing Pod";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   PodSpell = buildPerlPackage {
@@ -19618,6 +20482,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/K/KW/KWILLIAMS/Probe-Perl-0.03.tar.gz";
       sha256 = "0c9wiaz0mqqknafr4jdr0g2gdzxnn539182z0icqaqvp5qgd5r6r";
+    };
+    meta = {
+      description = "Information about the currently running perl";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -19725,6 +20593,10 @@ let
       sha256 = "8ae5c4e85299e5c8bddd1b196f2eea38f00709e0dc0cb60454dc9114ae3fff0d";
     };
     propagatedBuildInputs = [ Readonly ];
+    meta = {
+      description = "Companion module for Readonly.pm, to speed up read-only scalar variables";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   Redis = buildPerlModule {
@@ -19763,6 +20635,10 @@ let
       url = "mirror://cpan/authors/id/R/RS/RSAVAGE/Regexp-Assemble-0.38.tgz";
       sha256 = "0hp4v8mghmpflq9l9fqrkjg4cw0d3ha2nrmnsnzwjwqvmvwyfsx0";
     };
+    meta = {
+      description = "Assemble multiple Regular Expressions into a single RE";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   RegexpCommon = buildPerlPackage {
@@ -19772,9 +20648,9 @@ let
       url = "mirror://cpan/authors/id/A/AB/ABIGAIL/Regexp-Common-2017060201.tar.gz";
       sha256 = "ee07853aee06f310e040b6bf1a0199a18d81896d3219b9b35c9630d0eb69089b";
     };
-    meta = with lib; {
+    meta = {
       description = "Provide commonly requested regular expressions";
-      license = licenses.mit;
+      license = with lib.licenses; [ mit ];
     };
   };
 
@@ -19826,6 +20702,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/S/SA/SALVA/Regexp-IPv6-0.03.tar.gz";
       sha256 = "d542d17d75ce93631de8ba2156da0e0b58a755c409cd4a0d27a3873a26712ce2";
+    };
+    meta = {
+      description = "Regular expression for IPv6 addresses";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -19908,6 +20788,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/R/RJ/RJBS/Return-Value-1.666005.tar.gz";
       sha256 = "1b2hfmdl19zi1z3npzv9wf6dh1g0xd88i70b4233ds9icnln08lf";
+    };
+    meta = {
+      description = "Create context-sensitive return values";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -20006,6 +20890,10 @@ let
     };
     propagatedBuildInputs = [ locallib ];
     doCheck = false; /* creates files in HOME */
+    meta = {
+      description = "A simple pure perl RSS parser";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   RTClientREST = buildPerlModule {
@@ -20057,6 +20945,10 @@ let
       url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/Scalar-String-0.003.tar.gz";
       sha256 = "f54a17c9b78713b02cc43adfadf60b49467e7634d31317e8b9e9e97c26d68b52";
     };
+    meta = {
+      description = "String aspects of scalars";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   SCGI = buildPerlModule {
@@ -20067,6 +20959,10 @@ let
       sha256 = "196rj47mh4fq2vlnw595q391zja5v6qg7s3sy0vy8igfyid8rdsq";
     };
     preConfigure = "export HOME=$(mktemp -d)";
+    meta = {
+      description = "This module is for implementing an SCGI interface for an application server";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   ScopeGuard = buildPerlPackage {
@@ -20184,9 +21080,9 @@ let
       url = "mirror://cpan/authors/id/C/CO/COOK/Device-SerialPort-1.04.tar.gz";
       sha256 = "1mz9a2qzkz6fbz76wcwmp48h6ckjxpcazb70q03acklvndy5d4nk";
     };
-    meta = with lib; {
+    meta = {
       description = "Linux/POSIX emulation of Win32::SerialPort functions.";
-      license = with licenses; [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "modemtest";
     };
   };
@@ -20429,6 +21325,10 @@ let
       url = "mirror://cpan/authors/id/N/NE/NEILB/Sort-Versions-1.62.tar.gz";
       sha256 = "1aifzm79ky03gi2lwxyx4mk6yky8x215j0kz4f0jbgkf803k6pxz";
     };
+    meta = {
+      description = "A perl 5 module for sorting of revision-like numbers";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   Specio = buildPerlPackage {
@@ -20469,6 +21369,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/I/IN/INGY/Spiffy-0.46.tar.gz";
       sha256 = "18qxshrjh0ibpzjm2314157mxlibh3smyg64nr4mq990hh564n4g";
+    };
+    meta = {
+      description = "Spiffy Perl Interface Framework For You";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -20556,6 +21460,10 @@ let
     };
     propagatedBuildInputs = [ DBI SQLAbstract ];
     buildInputs = [ TestDeep TestException ];
+    meta = {
+      description = "Portable LIMIT emulation";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   SQLAbstractPg = buildPerlPackage {
@@ -20599,6 +21507,10 @@ let
     };
     buildInputs = [ MathBaseConvert TestDeep TextSoundex ];
     propagatedBuildInputs = [ Clone ModuleRuntime ParamsUtil ];
+    meta = {
+      description = "SQL parsing and processing engine";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   SQLTokenizer = buildPerlPackage {
@@ -20607,6 +21519,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/I/IZ/IZUT/SQL-Tokenizer-0.24.tar.gz";
       sha256 = "1qa2dfbzdlr5qqdam9yn78z5w3al5r8577x06qan8wv58ay6ka7s";
+    };
+    meta = {
+      description = "A simple SQL tokenizer";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -20659,6 +21575,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/B/BI/BINGOS/Sort-Naturally-1.03.tar.gz";
       sha256 = "eaab1c5c87575a7826089304ab1f8ffa7f18e6cd8b3937623e998e865ec1e746";
+    };
+    meta = {
+      description = "Sort lexically, but sort numeral parts numerically";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -20762,6 +21682,10 @@ let
       url = "mirror://cpan/authors/id/M/MI/MIKEK/Statistics-Distributions-1.02.tar.gz";
       sha256 = "1j1kswl98f4i9dn176f9aa3y9bissx2sscga5jm3gjl4pxm3k7zr";
     };
+    meta = {
+      description = "Perl module for calculating critical values and upper probabilities of common statistical distributions";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   StatisticsTTest = buildPerlPackage {
@@ -20772,6 +21696,10 @@ let
       sha256 = "0rkifgzm4rappiy669dyi6lyxn2sdqaf0bl6gndlfa67b395kndj";
     };
     propagatedBuildInputs = [ StatisticsDescriptive StatisticsDistributions ];
+    meta = {
+      description = "Perl module to perform T-test on 2 independent samples Statistics::TTest::Sufficient - Perl module to perfrom T-Test on 2 indepdent samples using sufficient statistics";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   StreamBuffered = buildPerlPackage {
@@ -20809,6 +21737,10 @@ let
       url = "mirror://cpan/authors/id/J/JH/JHI/String-Approx-3.28.tar.gz";
       sha256 = "43201e762d8699cb0ac2c0764a5454bdc2306c0771014d6c8fba821480631342";
     };
+    meta = {
+      description = "Perl extension for approximate matching (fuzzy matching)";
+      license = with lib.licenses; [ artistic2 gpl2Only ];
+    };
   };
 
   StringCamelCase = buildPerlPackage {
@@ -20817,6 +21749,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/H/HI/HIO/String-CamelCase-0.04.tar.gz";
       sha256 = "1a8i4yzv586svd0pbxls7642vvmyiwzh4x2xyij8gbnfxsydxhw9";
+    };
+    meta = {
+      description = "Camelcase, de-camelcase";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -20839,6 +21775,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/L/LE/LEEJO/String-CRC32-2.tar.gz";
       sha256 = "0bfrpnkgfakd4apv366p63z4vzypzvhj3yyqaw9dg7zca2pgxdzd";
+    };
+    meta = {
+      description = "Perl interface for cyclic redundancy check generation";
+      license = with lib.licenses; [ publicDomain ];
     };
   };
 
@@ -20888,6 +21828,10 @@ let
         url = "mirror://cpan/authors/id/E/EV/EVO/String-Escape-2010.002.tar.gz";
         sha256 = "12ls7f7847i4qcikkp3skwraqvjphjiv2zxfhl5d49326f5myr7x";
     };
+    meta = {
+      description = "Backslash escapes, quoted phrase, word elision, etc";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   StringFlogger = buildPerlPackage {
@@ -20912,6 +21856,10 @@ let
       url = "mirror://cpan/authors/id/S/SR/SREZIC/String-Format-1.18.tar.gz";
       sha256 = "0y77frxzjifd4sw0j19cc346ysas1mya84rdxaz279lyin7plhcy";
     };
+    meta = {
+      description = "sprintf-like string formatting capabilities with arbitrary format definitions";
+      license = with lib.licenses; [ gpl2Only ];
+    };
   };
 
   StringFormatter = buildPerlPackage {
@@ -20922,9 +21870,9 @@ let
       sha256 = "0mlwm0rirv46gj4h072q8gdync5zxxsxy8p028gdyrhczl942dc3";
     };
     propagatedBuildInputs = [ SubExporter ];
-    meta = with lib; {
+    meta = {
       description = "Build sprintf-like functions of your own";
-      license = licenses.gpl2;
+      license = with lib.licenses; [ gpl2 ];
     };
   };
 
@@ -20935,10 +21883,10 @@ let
       url = "mirror://cpan/authors/id/N/NE/NEILB/String-Interpolate-0.32.tar.gz";
       sha256 = "15fwbpz3jdpdgmz794iw9hz2caxrnrw9pdwprxxkanpm92cdhaf7";
     };
-    meta = with lib; {
+    meta = {
       # https://metacpan.org/pod/String::Interpolate
       description = "String::Interpolate - Wrapper for builtin the Perl interpolation engine.";
-      license = licenses.gpl1Plus;
+      license = with lib.licenses; [ gpl1Plus ];
     };
     propagatedBuildInputs = [ PadWalker SafeHole ];
   };
@@ -20977,6 +21925,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/S/SH/SHLOMIF/String-Random-0.31.tar.gz";
       sha256 = "0p4pmf3k6c01j8clfx54167rva9mf82bkh9aj5qdrix2cgpd2jjb";
+    };
+    meta = {
+      description = "Perl module to generate random strings based on a pattern";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -21031,6 +21983,10 @@ let
       url = "mirror://cpan/authors/id/F/FL/FLORA/Shell-Command-0.06.tar.gz";
       sha256 = "1lgc2rb3b5a4lxvbq0cbg08qk0n2i88srxbsz93bwi3razpxxr7k";
     };
+    meta = {
+      description = "Cross-platform functions emulating common shell commands";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   ShellConfigGenerate = buildPerlPackage {
@@ -21071,6 +22027,10 @@ let
       sha256 = "12nw7h2yiybhdw0vnnpc7bif8ylhsn6kqf6s39dsrf9h54iq9yrs";
     };
     propagatedBuildInputs = [ LinguaENInflectPhrase TextUnidecode namespaceclean ];
+    meta = {
+      description = "Convert Strings to English Program Identifiers";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   StringTruncate = buildPerlPackage {
@@ -21274,6 +22234,10 @@ let
       sha256 = "1d955qn44brkcfif3gi0q2vvvqahny6rax0vr068x5i9yz0ng6lk";
     };
     buildInputs = [ TestFatal ];
+    meta = {
+      description = "Perl extension for easily overriding subroutines";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   SubQuote = buildPerlPackage {
@@ -21327,6 +22291,10 @@ let
       sha256 = "1ysgi38zx236cxz539k6d6rw5z0vc70rrglsaf5fk6rnwilw2g6n";
     };
     propagatedBuildInputs = [ (pkgs.subversionClient.override { inherit perl; }) ];
+    meta = {
+      description = "A simple interface to subversion's editor interface";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   SafeHole = buildPerlModule {
@@ -21368,6 +22336,10 @@ let
       sha256 = "0xbdjdgzfj9zwa4j3ipr8bfk7bcici4hk89hq5d27rhg2isljd9i";
     };
     doCheck = false;                             # FIXME: 2/293 test failures
+    meta = {
+      description = "A switch statement for Perl, do not use if you can use given/when";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   SymbolGet = buildPerlPackage {
@@ -21405,6 +22377,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/D/DE/DEXTER/Symbol-Util-0.0203.tar.gz";
       sha256 = "0cnwwrd5d6i80f33s7n2ak90rh4s53ss7q57wndrpkpr4bfn3djm";
+    };
+    meta = {
+      description = "Additional utils for Perl symbols manipulation";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -21462,10 +22438,10 @@ let
       url = "mirror://cpan/authors/id/T/TO/TODDR/Sys-Mmap-0.20.tar.gz";
       sha256 = "1kz22l7sh2mibliixyshc9958bqlkzsb13agcibp7azii4ncw80q";
     };
-    meta = with lib; {
+    meta = {
       description = "Use mmap to map in a file as a Perl variable";
       maintainers = with maintainers; [ peterhoeg ];
-      license = with licenses; [ gpl2Plus ];
+      license = with lib.licenses; [ gpl2Plus ];
     };
   };
 
@@ -21504,6 +22480,10 @@ let
     ];
     buildInputs = lib.optional stdenv.isDarwin pkgs.darwin.apple_sdk.frameworks.Carbon;
     doCheck = !stdenv.isAarch64;
+    meta = {
+      description = "Perl extension for getting CPU information. Currently only number of CPU's supported.";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   SysHostnameLong = buildPerlPackage {
@@ -21514,6 +22494,10 @@ let
       sha256 = "1jv5n8jv48c1p8svjsigyxndv1ygsq8wgwj9c7ypx1vaf3rns679";
     };
     doCheck = false; # no `hostname' in stdenv
+    meta = {
+      description = "Try every conceivable way to get full hostname";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   SysSigAction = buildPerlPackage {
@@ -21633,6 +22617,10 @@ let
     };
     propagatedBuildInputs = [ CGICompile CGIEmulatePSGI CGIPSGI Corona FCGI FCGIClient FCGIProcManager HTTPServerSimplePSGI IOHandleUtil NetFastCGI PSGI PlackAppProxy PlackMiddlewareAuthDigest PlackMiddlewareConsoleLogger PlackMiddlewareDebug PlackMiddlewareDeflater PlackMiddlewareHeader PlackMiddlewareReverseProxy PlackMiddlewareSession Starlet Starman Twiggy ];
     buildInputs = [ ModuleBuildTiny TestSharedFork ];
+    meta = {
+      description = "Plack bundle";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   TaskTestRunAllPlugins = buildPerlModule {
@@ -21738,6 +22726,10 @@ let
       sha256 = "1hq7jy6zg1iaslsyi05afz0i944y9jnv3nb4krkxjfmzwy5gw106";
     };
     propagatedBuildInputs = [ TemplateToolkit ];
+    meta = {
+      description = "Allow calling of class methods on arbitrary classes";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   TemplatePluginIOAll = buildPerlPackage {
@@ -21763,6 +22755,10 @@ let
       sha256 = "1mqqqs0dhfr6bp1305j9ns05q4pq1n3f561l6p8848k5ml3dh87a";
     };
     propagatedBuildInputs = [ TemplateToolkit ];
+    meta = {
+      description = "Encodes text to be safe in JavaScript";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   TemplatePluginJSONEscape = buildPerlPackage {
@@ -21773,6 +22769,10 @@ let
       sha256 = "051a8b1d3bc601d58fc51e246067d36450cfe970278a0456e8ab61940f13cd86";
     };
     propagatedBuildInputs = [ JSON TemplateToolkit ];
+    meta = {
+      description = "Adds a .json vmethod and a json filter";
+      license = with lib.licenses; [ bsd0 ];
+    };
   };
 
   TemplateTimer = buildPerlPackage {
@@ -21886,6 +22886,10 @@ let
     };
     propagatedBuildInputs = [ TermProgressBarQuiet ];
     buildInputs = [ TestMockObject ];
+    meta = {
+      description = "Simpler progress bars";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   TermReadKey = let
@@ -21912,6 +22916,10 @@ let
     nativeBuildInputs = lib.optionals cross [
       buildPerl.pkgs.TermReadKey
     ];
+    meta = {
+      description = "A perl module for simple terminal control";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   TermReadLineGnu = buildPerlPackage {
@@ -21987,10 +22995,10 @@ let
       sha256 = "1mrx7g74qvkdis7x7zq1zs0b7q2fsz59g4hxvg140r8bq1wzav3x";
     };
     propagatedBuildInputs = [ TermReadKey TextAutoformat ];
-    meta = with lib; {
+    meta = {
       homepage = "https://metacpan.org/release/Term-Shell";
       description = "A simple command-line shell framework";
-      license = with licenses; [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -22000,6 +23008,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/B/BR/BRONSON/Term-ShellUI-0.92.tar.gz";
       sha256 = "3279c01c76227335eeff09032a40f4b02b285151b3576c04cacd15be05942bdb";
+    };
+    meta = {
+      description = "A fully-featured shell-like command line environment";
+      license = with lib.licenses; [ mit ];
     };
   };
 
@@ -22091,6 +23103,10 @@ let
       sha256 = "e1ded85ae3d76b59c03b8697f4a6cb01ae31bd62a9354f5bb7d18f9e927b485f";
     };
     propagatedBuildInputs = [ TermVT102 ];
+    meta = {
+      description = "A Term::VT102 that grows automatically to accomodate whatever you print to it";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   TermAnimation = buildPerlPackage {
@@ -22213,6 +23229,10 @@ let
     };
     buildInputs = [ ClassInspector TestUnitLite ];
     propagatedBuildInputs = [ ExceptionBase constantboolean ];
+    meta = {
+      description = "Assertion methods for those who like JUnit";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   TestAssertions = buildPerlPackage {
@@ -22223,6 +23243,10 @@ let
       sha256 = "10026w4r3yv6k3vc6cby7d61mxddlqh0ls6z39c82f17awfy9p7w";
     };
     propagatedBuildInputs = [ LogTrace ];
+    meta = {
+      description = "A simple set of building blocks for both unit and runtime testing";
+      license = with lib.licenses; [ gpl2Only ];
+    };
   };
 
   TestAggregate = buildPerlModule {
@@ -22250,6 +23274,10 @@ let
     };
     propagatedBuildInputs = [ Spiffy ];
     buildInputs = [ AlgorithmDiff TextDiff ];
+    meta = {
+      description = "A Data Driven Testing Framework";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   TestBits = buildPerlPackage {
@@ -22523,6 +23551,10 @@ let
       sha256 = "0cxm7s4bg0xpxa6l6996a6iq3brr4j7p4hssnkc6dxv4fzq16sqm";
     };
     propagatedBuildInputs = [ SubUplevel ];
+    meta = {
+      description = "Test exception-based code";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   TestExpect = buildPerlPackage {
@@ -22734,6 +23766,10 @@ let
     };
     propagatedBuildInputs = [ JSONAny ];
     buildInputs = [ TestDifferences ];
+    meta = {
+      description = "Test JSON data";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   TestKwalitee = buildPerlPackage {
@@ -22817,6 +23853,10 @@ let
       url = "mirror://cpan/authors/id/R/RG/RGARCIA/Test-LongString-0.17.tar.gz";
       sha256 = "0kwp7rfr1i2amz4ckigkv13ah7jr30q6l5k4wk0vxl84myg39i5b";
     };
+    meta = {
+      description = "Tests strings for equality, with more helpful failures";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   TestMemoryCycle = buildPerlPackage {
@@ -22870,9 +23910,9 @@ let
     };
     buildInputs = [ ClassInspector TestAssert TestUnitLite ];
     propagatedBuildInputs = [ FatalException Moose namespaceclean ];
-    meta = with lib; {
+    meta = {
       description = "Simulating other classes";
-      license = licenses.lgpl2Plus;
+      license = with lib.licenses; [ lgpl2Plus ];
     };
   };
 
@@ -22915,6 +23955,10 @@ let
     };
     propagatedBuildInputs = [ SUPER ];
     buildInputs = [ TestWarnings ];
+    meta = {
+      description = "Override subroutines in a module for unit testing";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   SUPER = buildPerlModule {
@@ -22953,6 +23997,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/D/DD/DDICK/Test-MockTime-0.17.tar.gz";
       sha256 = "1y820qsq7yf7r6smy5c6f0mpf2cis2q24vwmpim1svv0n8cf2qrk";
+    };
+    meta = {
+      description = "Replaces actual time with simulated time";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -23078,6 +24126,10 @@ let
       url = "mirror://cpan/authors/id/E/ET/ETHER/Test-Object-0.08.tar.gz";
       sha256 = "65278964147837313f4108e55b59676e8a364d6edf01b3dc198aee894ab1d0bb";
     };
+    meta = {
+      description = "Thoroughly testing objects via registered handlers";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   TestOutput = buildPerlPackage {
@@ -23088,6 +24140,10 @@ let
       sha256 = "193y1xjvgc1p9pdgdwps2127knvpz9wc1xh6gmr74y3ihmqz7f7q";
     };
     propagatedBuildInputs = [ CaptureTiny ];
+    meta = {
+      description = "Utilities to test STDOUT and STDERR messages";
+      license = with lib.licenses; [ artistic2 ];
+    };
   };
 
   TestPAUSEPermissions = buildPerlPackage {
@@ -23113,6 +24169,10 @@ let
       sha256 = "28f806b5412c7908b56cf1673084b8b44ce1cb54c9417d784d91428e1a04096e";
     };
     propagatedBuildInputs = [ MCE PerlCritic ];
+    meta = {
+      description = "Use Perl::Critic in test programs";
+      license = with lib.licenses; [ artistic1 gpl1 ];
+    };
   };
 
   TestPerlTidy = buildPerlModule rec {
@@ -23153,6 +24213,10 @@ let
       sha256 = "1m203mhgfilz7iqc8mxaw4lw02fz391mni3n25sfx7nryylwrja8";
     };
     propagatedBuildInputs = [ PodCoverage ];
+    meta = {
+      description = "Check for pod coverage in your distribution";
+      license = with lib.licenses; [ artistic2 ];
+    };
   };
 
   TestPodLinkCheck = buildPerlModule {
@@ -23265,6 +24329,10 @@ let
 
     propagatedBuildInputs = [ Moo MooXTypesMooseLike SubInstall strictures ];
     buildInputs = [ CaptureTiny ];
+    meta = {
+      description = "Composable, reusable tests with roles and Moo";
+      license = with lib.licenses; [ asl20 ];
+    };
   };
 
   TestRoutine = buildPerlPackage {
@@ -23427,6 +24495,10 @@ let
     buildInputs = [ Test2Suite ];
 
     propagatedBuildInputs = [ CaptureTiny ProbePerl ];
+    meta = {
+      description = "Basic cross-platform tests for scripts";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   TestScriptRun = buildPerlPackage {
@@ -23509,6 +24581,10 @@ let
       sha256 = "cbc1e9b35a05e71febc13e5ef547a31c8249899bb6011dbdc9d9ff366ddab6c2";
     };
     propagatedBuildInputs = [ HookLexWrap ];
+    meta = {
+      description = "Track the number of times subs are called";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   TestSynopsis = buildPerlPackage {
@@ -23735,6 +24811,10 @@ let
     };
     propagatedBuildInputs = [ WWWMechanizeCGI ];
     buildInputs = [ TestLongString TestWWWMechanize ];
+    meta = {
+      description = "Test CGI applications with Test::WWW::Mechanize";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   TestWWWMechanizePSGI = buildPerlPackage {
@@ -23761,6 +24841,10 @@ let
       sha256 = "1wy0488yg15kahfafnlmlhppxik7d0z00wxwj9fszrsq2h6crz6y";
     };
     propagatedBuildInputs = [ XMLLibXML ];
+    meta = {
+      description = "Test XML and HTML content and structure with XPath expressions";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   TestYAML = buildPerlPackage {
@@ -23803,6 +24887,10 @@ let
     ASPELL_CONF = "dict-dir ${pkgs.aspellDicts.en}/lib/aspell";
     NIX_CFLAGS_COMPILE = "-I${pkgs.aspell}/include";
     NIX_CFLAGS_LINK = "-L${pkgs.aspell}/lib -laspell";
+    meta = {
+      description = "Perl interface to the GNU Aspell library";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   TextAutoformat = buildPerlPackage {
@@ -23867,6 +24955,10 @@ let
       url = "mirror://cpan/authors/id/K/KC/KCIVEY/Text-Brew-0.02.tar.gz";
       sha256 = "0k7nxglbx5pxl693zrj1fsi094sf1a3vqsrn73inzz7r3j28a6xa";
     };
+    meta = {
+      description = "An implementation of the Brew edit distance";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   TextCharWidth = buildPerlPackage {
@@ -23875,6 +24967,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/K/KU/KUBOTA/Text-CharWidth-0.04.tar.gz";
       sha256 = "abded5f4fdd9338e89fd2f1d8271c44989dae5bf50aece41b6179d8e230704f8";
+    };
+    meta = {
+      description = "Get number of occupied columns of a string on terminal";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -23995,6 +25091,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/R/RC/RCLAMP/Text-Glob-0.11.tar.gz";
       sha256 = "11sj62fynfgwrlgkv5a051cq6yn0pagxqjsz27dxx8phsd4wv706";
+    };
+    meta = {
+      description = "Match globbing patterns against text";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -24250,6 +25350,10 @@ let
       url = "mirror://cpan/authors/id/B/BH/BHALLISSY/Text-PDF-0.31.tar.gz";
       sha256 = "0s5cimfr4wwzgv15k30x83ncg1257jwsvmbmb86lp02rw5g537yz";
     };
+    meta = {
+      description = "Module for manipulating PDF files";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   TextQuoted = buildPerlPackage {
@@ -24280,6 +25384,10 @@ let
 
     propagatedBuildInputs = [ ClassAccessor IOStringy ListMoreUtils Readonly TextAutoformat ];
     buildInputs = [ TestException ];
+    meta = {
+      description = "Read record-oriented files";
+      license = with lib.licenses; [ gpl2Only ];
+    };
   };
 
   TextReflow = buildPerlPackage {
@@ -24343,6 +25451,10 @@ let
       url = "mirror://cpan/authors/id/R/RJ/RJBS/Text-Soundex-3.05.tar.gz";
       sha256 = "f6dd55b4280b25dea978221839864382560074e1d6933395faee2510c2db60ed";
     };
+    meta = {
+      description = "Implementation of the soundex algorithm";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   TextSprintfNamed = buildPerlModule {
@@ -24382,6 +25494,10 @@ let
       url = "mirror://cpan/authors/id/D/DA/DARREN/Text-TabularDisplay-1.38.tar.gz";
       sha256 = "1s46s4pg5mpfllx3icf4vnqz9iadbbdbsr5p7pr6gdjnzbx902gb";
     };
+    meta = {
+      description = "Display text in formatted table output";
+      license = with lib.licenses; [ gpl2Plus ];
+    };
   };
 
   TextTemplate = buildPerlPackage {
@@ -24392,6 +25508,10 @@ let
       sha256 = "1dd2c788c05303ed9a970e1881109642151fa93e02c7a80d4c70608276bab1ee";
     };
     buildInputs = [ TestMoreUTF8 TestWarnings ];
+    meta = {
+      description = "Expand template text with embedded Perl";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   TestTrap = buildPerlModule {
@@ -24475,6 +25595,10 @@ let
       url = "mirror://cpan/authors/id/S/SB/SBURKE/Text-Unidecode-1.30.tar.gz";
       sha256 = "1imii0p6wvhrxsr5z2zhazpx5vl4l4ybf1y2c5hy480xvi6z293c";
     };
+    meta = {
+      description = "Plain ASCII transliterations of Unicode tex";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   Testutf8 = buildPerlPackage {
@@ -24527,6 +25651,10 @@ let
       sha256 = "0cxbgx879bsskmnhjzamgsa5862ddixyx4yr77lafmwimnaxjg74";
     };
     propagatedBuildInputs = [ URI ];
+    meta = {
+      description = "Module for translating Wiki formatted text into other formats";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   TextWordDiff = buildPerlPackage {
@@ -24721,6 +25849,10 @@ let
       url = "mirror://cpan/authors/id/E/ET/ETHER/Tie-RefHash-1.40.tar.gz";
       sha256 = "1mvyjab8pv1yfimvlh4gxxpm3xzny4pinymdr8hgdd9gim8izkss";
     };
+    meta = {
+      description = "Use references as hash keys";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   TieRegexpHash = buildPerlPackage {
@@ -24770,6 +25902,10 @@ let
       url = "mirror://cpan/authors/id/N/NU/NUFFIN/Tie-ToObject-0.03.tar.gz";
       sha256 = "1x1smn1kw383xc5h9wajxk9dlx92bgrbf7gk4abga57y6120s6m3";
     };
+    meta = {
+      description = "Tie to an existing object";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   TimeDate = buildPerlPackage {
@@ -24778,6 +25914,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/A/AT/ATOOMIC/TimeDate-2.33.tar.gz";
       sha256 = "1cjyc0yi873597r7xcp9yz0l1c46ik2kxwfrn00zbrlx0d5rrdn0";
+    };
+    meta = {
+      description = "Miscellaneous timezone manipulations routines";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -24999,6 +26139,10 @@ let
     };
     propagatedBuildInputs = [ TreeSimple ];
     buildInputs = [ TestException ];
+    meta = {
+      description = "A factory object for dispensing Visitor objects";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   TryTiny = buildPerlPackage {
@@ -25152,6 +26296,10 @@ let
       url = "mirror://cpan/authors/id/B/BR/BRADFITZ/Unicode-CheckUTF8-1.03.tar.gz";
       sha256 = "97f84daf033eb9b49cd8fe31db221fef035a5c2ee1d757f3122c88cf9762414c";
     };
+    meta = {
+      description = "Checks if scalar is valid UTF-8";
+      license = with lib.licenses; [ unfree ]; # not clear at all
+    };
   };
 
   UnicodeLineBreak = buildPerlPackage {
@@ -25174,6 +26322,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/G/GA/GAAS/GAAS/Unicode-String-2.10.tar.gz";
       sha256 = "0s4vp8k7ag7z9lsnnkpa9mnch83kxhp9gh7yiapld5a7rq712jl9";
+    };
+    meta = {
+      description = "String of Unicode characters (UTF-16BE)";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -25214,6 +26366,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/T/TA/TAFFY/Unix-Getrusage-0.03.tar.gz";
       sha256 = "76cde1cee2453260b85abbddc27cdc9875f01d2457e176e03dcabf05fb444d12";
+    };
+    meta = {
+      description = "Perl interface to the Unix getrusage system call";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -25287,6 +26443,10 @@ let
       sha256 = "00hq5cpsk7sa04n0wg52qhpqf9i2849yyvw2zk83ayh1qqpc50js";
     };
     propagatedBuildInputs = [ URI ];
+    meta = {
+      description = "Generate Google Chart URIs";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   UserIdentity = buildPerlPackage {
@@ -25311,6 +26471,10 @@ let
       sha256 = "0bdv6mrdijcq46r3lmz801rscs63f8p9qqliy2safd6fds4rj55v";
     };
     propagatedBuildInputs = [ URI ];
+    meta = {
+      description = "Support IMAP URI";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   URINested = buildPerlModule {
@@ -25541,6 +26705,10 @@ let
     NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-return-type";
     buildInputs = [ pkgs.curl ];
     doCheck = false; # performs network access
+    meta = {
+      description = "Perl extension interface for libcurl";
+      license = with lib.licenses; [ mit ];
+    };
   };
 
   WWWFormUrlEncoded = buildPerlModule {
@@ -25631,6 +26799,10 @@ let
       url = "mirror://cpan/authors/id/R/RO/ROBIN/Want-0.29.tar.gz";
       sha256 = "1xsjylbxxcbkjazqms49ipi94j1hd2ykdikk29cq7dscil5p9r5l";
     };
+    meta = {
+      description = "A generalisation of wantarray";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   Win32ShellQuote = buildPerlPackage {
@@ -25674,6 +26846,10 @@ let
     #   Error: Unable to initialize GTK, is DISPLAY set properly?"
     doCheck = false;
     buildInputs = [ ExtUtilsXSpp ];
+    meta = {
+      description = "Interface to the wxWidgets cross-platform GUI toolkit";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   WxGLCanvas = buildPerlPackage {
@@ -25685,6 +26861,10 @@ let
     };
     propagatedBuildInputs = [ pkgs.libGLU Wx ];
     doCheck = false;
+    meta = {
+      description = "wxPerl demo helper for Wx::GLCanvas";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   X11IdleTime = buildPerlPackage {
@@ -25713,6 +26893,10 @@ let
     buildInputs = [ pkgs.xlibsWrapper ];
     NIX_CFLAGS_LINK = "-lX11";
     doCheck = false; # requires an X server
+    meta = {
+      description = "Perl module for the X Window System Protocol, version 11";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   X11ProtocolOther = buildPerlPackage {
@@ -25741,6 +26925,10 @@ let
     buildInputs = [ pkgs.xlibsWrapper pkgs.xorg.libXtst pkgs.xorg.libXi ];
     NIX_CFLAGS_LINK = "-lX11 -lXext -lXtst";
     doCheck = false; # requires an X server
+    meta = {
+      description = "Provides GUI testing/interaction routines";
+      license = with lib.licenses; [ gpl2Only ];
+    };
   };
 
   X11XCB = buildPerlPackage {
@@ -25821,6 +27009,10 @@ let
       sha256 = "0phpkc4li43m2g44hdcvyxzy9pymqwlqhh5hwp2xc0cv8l5lp8lb";
     };
     propagatedBuildInputs = [ XMLRegExp libxml_perl ];
+    meta = {
+      description = "Interface to XML::DOM toolset";
+      license = with lib.licenses; [ gpl2Only ];
+    };
   };
 
   XMLFeedPP = buildPerlPackage {
@@ -25846,6 +27038,10 @@ let
       sha256 = "8fd2126d3beec554df852919f4739e689202cbba6a17506e9b66ea165841a75c";
     };
     doCheck = false;
+    meta = {
+      description = "Filter to put all characters() in one event";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   XMLFilterXInclude = buildPerlPackage {
@@ -25856,6 +27052,10 @@ let
       sha256 = "98746f3c1f6f049491fec203d455bb8f8c9c6e250f041904dda5d78e21187f93";
     };
     doCheck = false;
+    meta = {
+      description = "XInclude as a SAX Filter";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   XMLFilterSort = buildPerlPackage {
@@ -25924,6 +27124,10 @@ let
     buildInputs = [ AlienBuild AlienLibxml2 ]
       ++ lib.optionals stdenv.isDarwin (with pkgs; [ libiconv zlib ]);
     propagatedBuildInputs = [ XMLSAX ];
+    meta = {
+      description = "Perl Binding for libxml2";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   XMLLibXMLSimple = buildPerlPackage {
@@ -25949,6 +27153,10 @@ let
     };
     buildInputs = [ pkgs.pkg-config pkgs.zlib pkgs.libxml2 pkgs.libxslt ];
     propagatedBuildInputs = [ XMLLibXML ];
+    meta = {
+      description = "Interface to the GNOME libxslt library";
+      license = [ artistic1 gpl1Plus ];
+    };
   };
 
   XMLMini = buildPerlPackage {
@@ -25959,7 +27167,8 @@ let
       sha256 = "af803d38036a3184e124a682e5466f1bc107f48a89ef35b0c7647e11a073fe2d";
     };
     meta = {
-      license = with lib.licenses; [ unfree ];
+      description = "Perl implementation of the XML::Mini XML create/parse interface";
+      license = with lib.licenses; [ gpl3Plus ];
     };
   };
 
@@ -25969,6 +27178,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/P/PE/PERIGRIN/XML-NamespaceSupport-1.12.tar.gz";
       sha256 = "1vz5pbi4lm5fhq2slrs2hlp6bnk29863abgjlcx43l4dky2rbsa7";
+    };
+    meta = {
+      description = "A simple generic namespace processor";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -25987,6 +27200,10 @@ let
     '';
     makeMakerFlags = "EXPATLIBPATH=${pkgs.expat.out}/lib EXPATINCPATH=${pkgs.expat.dev}/include";
     propagatedBuildInputs = [ LWP ];
+    meta = {
+      description = "A perl module for parsing XML documents";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   XMLParserLite = buildPerlPackage {
@@ -26038,6 +27255,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/T/TJ/TJMATHER/XML-RegExp-0.04.tar.gz";
       sha256 = "0m7wj00a2kik7wj0azhs1zagwazqh3hlz4255n75q21nc04r06fz";
+    };
+    meta = {
+      description = "Regular expressions for XML tokens";
+      license = with lib.licenses; [ gpl2Plus];
     };
   };
 
@@ -26097,6 +27318,10 @@ let
     postInstall = ''
       perl -MXML::SAX -e "XML::SAX->add_parser(q(XML::SAX::PurePerl))->save_parsers()"
       '';
+    meta = {
+      description = "Simple API for XML";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   XMLSAXBase = buildPerlPackage {
@@ -26152,6 +27377,10 @@ let
       sha256 = "1xd00821y795fy2rag8aizb5wsbbzfxgmdf9qwpvdxn3pgpyzz85";
     };
     propagatedBuildInputs = [ XMLParser ];
+    meta = {
+      description = "Perl extension for comparing XML documents";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   XMLSimple = buildPerlPackage {
@@ -26162,6 +27391,10 @@ let
       sha256 = "1y6vh328zrh085d40852v4ij2l4g0amxykswxd1nfhd2pspds7sk";
     };
     propagatedBuildInputs = [ XMLSAXExpat ];
+    meta = {
+      description = "An API for simple XML files";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   XMLTokeParser = buildPerlPackage {
@@ -26222,7 +27455,7 @@ let
     propagatedBuildInputs = [ TreeDAGNode XMLFilterBufferText XMLSAX ];
     meta = {
       description = "Validate XML against a subset of W3C XML Schema";
-      license = with lib.licenses; [ unfree ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -26232,6 +27465,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/J/JO/JOSEPHW/XML-Writer-0.900.tar.gz";
       sha256 = "07qd806kcs7si7qakx3x5p68xq2jdmkxdrns987kaayg7syzbj3k";
+    };
+    meta = {
+      description = "Module for creating a XML document object oriented with on the fly validating towards the given DTD";
+      license = with lib.licenses; [ gpl1Only ];
     };
   };
 
@@ -26351,6 +27588,10 @@ let
       url = "mirror://cpan/authors/id/E/ET/ETHER/YAML-Tiny-1.73.tar.gz";
       sha256 = "0i3p4nz8ysrsrs6vlzc6gkjcfpcaf05xjc7lwbjkw7lg5shmycdw";
     };
+    meta = {
+      description = "Read/Write YAML files with as little code as possible";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   YAMLLibYAML = buildPerlPackage {
@@ -26359,6 +27600,10 @@ let
     src = fetchurl {
       url = "mirror://cpan/authors/id/T/TI/TINITA/YAML-LibYAML-0.83.tar.gz";
       sha256 = "sha256-tHF1tP85etdaT3eB09g8CGN9pv8LrjJq87OJ2FS+xJA=";
+    };
+    meta = {
+      description = "Perl YAML Serialization using XS and libyaml";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -26485,7 +27730,7 @@ let
     buildInputs = [ DevelChecklib ModuleInstall ModuleInstallXSUtil TestFatal pkgs.ldns pkgs.libidn2 pkgs.openssl pkgs.pkg-config ];
     meta = {
       description = "Perl wrapper for the ldns DNS library";
-      license = lib.licenses.bsd3;
+      license = with lib.licenses; [ bsd3 ];
     };
   };
 
@@ -26585,5 +27830,5 @@ let
   SubExporterUtil = self.SubExporter;
   version = self.Version;
 
-  Gtk2GladeXML = throw "Gtk2GladeXML has been removed"; # 2022-01-15
+  #Gtk2GladeXML = throw "Gtk2GladeXML has been removed"; # 2022-01-15
 }; in self

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -468,7 +468,7 @@ let
     doCheck = false; # does an DNS lookup
     meta = {
       description = "Simple DNS resolver with caching";
-      homepage = "http://github.com/potyl/perl-AnyEvent-CacheDNS";
+      homepage = "https://github.com/potyl/perl-AnyEvent-CacheDNS";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -690,7 +690,7 @@ let
     '';
     meta = {
       description = "Cluster administration tool";
-      homepage = "http://github.com/duncs/clusterssh/wiki";
+      homepage = "https://github.com/duncs/clusterssh/wiki";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "cssh";
     };
@@ -818,7 +818,7 @@ let
     '';
     meta = {
       description = "A lyrics and chords formatting program";
-      homepage = "http://www.chordpro.org";
+      homepage = "https://www.chordpro.org";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "chordpro";
     };
@@ -1389,7 +1389,7 @@ let
     };
     meta = {
       description = "Lexically disable autovivification";
-      homepage = "http://search.cpan.org/dist/autovivification";
+      homepage = "https://search.cpan.org/dist/autovivification";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -1625,7 +1625,7 @@ let
     propagatedBuildInputs = [ ClassLoad DirSelf FileShareDir ModulePluggable MooseXGetopt namespaceclean  ];
     meta = {
       description = "Plain text training material for bots like Hailo and AI::MegaHAL";
-      homepage = "http://metacpan.org/release/Bot-Training";
+      homepage = "https://metacpan.org/release/Bot-Training";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "bot-training";
     };
@@ -1642,7 +1642,7 @@ let
     propagatedBuildInputs = [ BotTraining ];
     meta = {
       description = "Provide megahal.trn via Bot::Training";
-      homepage = "http://metacpan.org/release/Bot-Training-MegaHAL";
+      homepage = "https://metacpan.org/release/Bot-Training-MegaHAL";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -1658,7 +1658,7 @@ let
     propagatedBuildInputs = [ BotTraining ];
     meta = {
       description = "Provide starcraft.trn via Bot::Training";
-      homepage = "http://metacpan.org/release/Bot-Training-StarCraft";
+      homepage = "https://metacpan.org/release/Bot-Training-StarCraft";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -1721,7 +1721,7 @@ let
     buildInputs = [ ExtUtilsDepends ];
     meta = {
       description = "Helper functions for op tree manipulation";
-      homepage = "http://search.cpan.org/dist/B-Utils";
+      homepage = "https://search.cpan.org/dist/B-Utils";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -2217,7 +2217,7 @@ let
     propagatedBuildInputs = [ CatalystPluginStaticSimple ClassAccessor FileSlurp JSONXS ListMoreUtils PodPOMViewTOC XMLSimple ];
     meta = {
       description = "Serves PODs right from your Catalyst application";
-      homepage = "http://search.cpan.org/dist/Catalyst-Controller-POD";
+      homepage = "https://search.cpan.org/dist/Catalyst-Controller-POD";
       license = with lib.licenses; [ bsd3 ];
     };
   };
@@ -2307,7 +2307,7 @@ let
     propagatedBuildInputs = [ CatalystRuntime DateTime ];
     meta = {
       description = "Request logging from within Catalyst";
-      homepage = "http://metacpan.org/release/Catalyst-Plugin-AccessLog";
+      homepage = "https://metacpan.org/release/Catalyst-Plugin-AccessLog";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -3507,7 +3507,7 @@ let
     doCheck = !stdenv.isDarwin;
     meta = {
       description = "Copy and paste with any OS";
-      homepage = "http://metacpan.org/release/Clipboard";
+      homepage = "https://metacpan.org/release/Clipboard";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -3842,7 +3842,7 @@ let
     propagatedBuildInputs = [ IOStringy ];
     meta = {
       description = "A module for reading .ini-style configuration files";
-      homepage = "http://metacpan.org/release/Config-IniFiles";
+      homepage = "https://metacpan.org/release/Config-IniFiles";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = teams.deshaw.members;
     };
@@ -4733,7 +4733,7 @@ let
     };
     meta = {
       description = "Perl extension for the RIPEMD-160 Hash function";
-      homepage = "http://wiki.github.com/toddr/Crypt-RIPEMD160";
+      homepage = "https://wiki.github.com/toddr/Crypt-RIPEMD160";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -4965,7 +4965,7 @@ let
     propagatedBuildInputs = [ DigestHMAC DigestSHA3 Moo TypeTiny namespaceautoclean strictures ];
     meta = {
       description = "The PBKDF2 password hash algorithm";
-      homepage = "http://metacpan.org/release/Crypt-PBKDF2";
+      homepage = "https://metacpan.org/release/Crypt-PBKDF2";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -5053,7 +5053,7 @@ let
     perlPreHook = lib.optionalString (stdenv.isi686 || stdenv.isDarwin) "export LD=$CC";
     meta = {
       description = "XS based CSS minifier";
-      homepage = "http://metacpan.org/release/CSS-Minifier-XS";
+      homepage = "https://metacpan.org/release/CSS-Minifier-XS";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -5336,7 +5336,7 @@ let
     buildInputs = [ TestBits ];
     meta = {
       description = "Pack and unpack big-endian IEEE754 floats and doubles";
-      homepage = "http://metacpan.org/release/Data-IEEE754";
+      homepage = "https://metacpan.org/release/Data-IEEE754";
       license = with lib.licenses; [ artistic2 ];
     };
   };
@@ -5500,7 +5500,7 @@ let
     };
     meta = {
       description = "Modules that serialize data structures";
-      homepage = "http://metacpan.org/release/Data-Serializer";
+      homepage = "https://metacpan.org/release/Data-Serializer";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -5557,7 +5557,7 @@ let
     propagatedBuildInputs = [ Moose PathClass namespaceclean ];
     meta = {
       description = "N at a time iteration API";
-      homepage = "http://metacpan.org/release/Data-Stream-Bulk";
+      homepage = "https://metacpan.org/release/Data-Stream-Bulk";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -6049,7 +6049,7 @@ let
     propagatedBuildInputs = [ DateTime ];
     meta = {
       description = "Parse and format RFC3339 datetime strings";
-      homepage = "http://search.cpan.org/dist/DateTime-Format-RFC3339";
+      homepage = "https://search.cpan.org/dist/DateTime-Format-RFC3339";
       license = with lib.licenses; [ cc0 ];
     };
   };
@@ -6426,7 +6426,7 @@ let
 
     meta = {
       description = "DBI PostgreSQL interface";
-      homepage = "http://search.cpan.org/dist/DBD-Pg";
+      homepage = "https://search.cpan.org/dist/DBD-Pg";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       platforms = lib.platforms.unix;
     };
@@ -6521,7 +6521,7 @@ let
     '';
     meta = {
       description = "Database independent interface for Perl";
-      homepage = "http://dbi.perl.org";
+      homepage = "https://dbi.perl.org";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -6645,7 +6645,7 @@ let
     propagatedBuildInputs = [ DBIxClass JSONMaybeXS YAML ];
     meta = {
       description = "Inflators to serialize data structures for DBIx::Class";
-      homepage = "http://metacpan.org/release/DBIx-Class-InflateColumn-Serializer";
+      homepage = "https://metacpan.org/release/DBIx-Class-InflateColumn-Serializer";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -6937,7 +6937,7 @@ let
     };
     meta = {
       description = "An object representing a stack trace";
-      homepage = "http://metacpan.org/release/Devel-StackTrace";
+      homepage = "https://metacpan.org/release/Devel-StackTrace";
       license = with lib.licenses; [ artistic2 ];
     };
   };
@@ -7004,7 +7004,7 @@ let
     };
     meta = {
       description = "Keyed-Hashing for Message Authentication";
-      homepage = "http://metacpan.org/release/Digest-HMAC";
+      homepage = "https://metacpan.org/release/Digest-HMAC";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7125,7 +7125,7 @@ let
     propagatedBuildInputs = [ Moo PathTiny ];
     meta = {
       description = "Treat a directory and a manifest file as a hash/dictionary of keys to texts or blobs";
-      homepage = "http://metacpan.org/release/Dir-Manifest";
+      homepage = "https://metacpan.org/release/Dir-Manifest";
       license = with lib.licenses; [ mit ];
     };
   };
@@ -7169,7 +7169,7 @@ let
     propagatedBuildInputs = [ ModuleRuntime ];
     meta = {
       description = "Declare version conflicts for your dist";
-      homepage = "http://metacpan.org/release/Dist-CheckConflicts";
+      homepage = "https://metacpan.org/release/Dist-CheckConflicts";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7190,7 +7190,7 @@ let
     doCheck = false;
     meta = {
       description = "Distribution builder; installer not included!";
-      homepage = "http://dzil.org";
+      homepage = "https://dzil.org";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "dzil";
     };
@@ -7208,7 +7208,7 @@ let
     doCheck = false; /* fails with 'open3: exec of .. perl .. failed: Argument list too long at .../TAP/Parser/Iterator/Process.pm line 165.' */
     meta = {
       description = "Test your dist with every testing plugin conceivable";
-      homepage = "http://metacpan.org/release/Dist-Zilla-PluginBundle-TestingMania";
+      homepage = "https://metacpan.org/release/Dist-Zilla-PluginBundle-TestingMania";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7302,7 +7302,7 @@ let
     propagatedBuildInputs = [ DistZilla ];
     meta = {
       description = "Release tests for your changelog";
-      homepage = "http://metacpan.org/release/Dist-Zilla-Plugin-Test-CPAN-Changes";
+      homepage = "https://metacpan.org/release/Dist-Zilla-Plugin-Test-CPAN-Changes";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7318,7 +7318,7 @@ let
     propagatedBuildInputs = [ DistZilla ];
     meta = {
       description = "Validate your CPAN META.json files";
-      homepage = "http://p3rl.org/Dist::Zilla::Plugin::Test::CPAN::Meta::JSON";
+      homepage = "https://p3rl.org/Dist::Zilla::Plugin::Test::CPAN::Meta::JSON";
       license = with lib.licenses; [ artistic2 ];
     };
   };
@@ -7491,7 +7491,7 @@ let
     propagatedBuildInputs = [ DistZilla ];
     meta = {
       description = "Release tests for unused variables";
-      homepage = "http://metacpan.org/release/Dist-Zilla-Plugin-Test-UnusedVars";
+      homepage = "https://metacpan.org/release/Dist-Zilla-Plugin-Test-UnusedVars";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7962,7 +7962,7 @@ let
     propagatedBuildInputs = [ NetIDNEncode ];
     meta = {
       description = "Encode plugin for Punycode (RFC 3492)";
-      homepage = "http://search.cpan.org/dist/Encode-Punycode";
+      homepage = "https://search.cpan.org/dist/Encode-Punycode";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -7990,7 +7990,7 @@ let
     };
     meta = {
       description = "Perl module that imports environment variables as scalars or arrays";
-      homepage = "http://search.cpan.org/dist/Env";
+      homepage = "https://search.cpan.org/dist/Env";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -8056,7 +8056,7 @@ let
     buildInputs = [ TestFatal TestRequires ];
     meta = {
       description = "Safely and cleanly create closures via string eval";
-      homepage = "http://metacpan.org/release/Eval-Closure";
+      homepage = "https://metacpan.org/release/Eval-Closure";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -8071,7 +8071,7 @@ let
     propagatedBuildInputs = [ ArchiveZip ];
     meta = {
       description = "Create a new file in the Excel 2007+ XLSX format";
-      homepage = "http://jmcnamara.github.com/excel-writer-xlsx";
+      homepage = "https://jmcnamara.github.com/excel-writer-xlsx";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "extract_vba";
     };
@@ -8573,7 +8573,7 @@ let
     };
     meta = {
       description = "Run many filetest checks on a tree";
-      homepage = "http://search.cpan.org/dist/File-CheckTree";
+      homepage = "https://search.cpan.org/dist/File-CheckTree";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -8678,7 +8678,7 @@ let
     propagatedBuildInputs = [ ClassXSAccessor ];
     meta = {
       description = "An object oriented File::Find replacement";
-      homepage = "http://metacpan.org/release/File-Find-Object";
+      homepage = "https://metacpan.org/release/File-Find-Object";
       license = with lib.licenses; [ artistic2 ];
     };
   };
@@ -8697,7 +8697,7 @@ let
     '';
     meta = {
       description = "Alternative interface to File::Find::Object";
-      homepage = "http://www.shlomifish.org/open-source/projects/File-Find-Object";
+      homepage = "https://www.shlomifish.org/open-source/projects/File-Find-Object";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "findorule";
     };
@@ -9441,7 +9441,7 @@ let
     propagatedBuildInputs = [ ClassXSAccessor ExceptionClass PathTiny ];
     meta = {
       description = "Verify solutions for solitaire games";
-      homepage = "http://metacpan.org/release/Games-Solitaire-Verify";
+      homepage = "https://metacpan.org/release/Games-Solitaire-Verify";
       license = with lib.licenses; [ mit ];
       mainProgram = "verify-solitaire-solution";
     };
@@ -9534,7 +9534,7 @@ let
     buildInputs = [ PathClass TestFatal TestNumberDelta ];
     meta = {
       description = "Perl API for MaxMind's GeoIP2 web services and databases";
-      homepage = "http://metacpan.org/release/GeoIP2";
+      homepage = "https://metacpan.org/release/GeoIP2";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "web-service-request";
     };
@@ -10180,7 +10180,7 @@ let
     '';
     meta = {
       description = "A pluggable Markov engine analogous to MegaHAL";
-      homepage = "http://hailo.org";
+      homepage = "https://hailo.org";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "hailo";
     };
@@ -10435,7 +10435,7 @@ let
     propagatedBuildInputs = [ IPCRun URI constant-defer ];
     meta = {
       description = "HTML to text formatting using external programs";
-      homepage = "http://user42.tuxfamily.org/html-formatexternal/index.html";
+      homepage = "https://user42.tuxfamily.org/html-formatexternal/index.html";
       license = with lib.licenses; [ gpl3Plus ];
     };
   };
@@ -10557,7 +10557,7 @@ let
     propagatedBuildInputs = [ CGIPSGI HTMLMason ];
     meta = {
       description = "PSGI handler for HTML::Mason";
-      homepage = "http://search.cpan.org/dist/HTML-Mason-PSGIHandler";
+      homepage = "https://search.cpan.org/dist/HTML-Mason-PSGIHandler";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -10715,7 +10715,7 @@ let
     buildInputs = [ TestException ];
     meta = {
       description = "(X)HTML validation in a Perl object";
-      homepage = "http://github.com/petdance/html-tidy";
+      homepage = "https://github.com/petdance/html-tidy";
       license = with lib.licenses; [ artistic2 ];
       mainProgram = "webtidy";
     };
@@ -11282,7 +11282,7 @@ let
     buildInputs = [ ModuleBuild ];
     meta = {
       description = "A library to extract height/width from images";
-      homepage = "http://search.cpan.org/dist/Image-Size";
+      homepage = "https://search.cpan.org/dist/Image-Size";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "imgsize";
     };
@@ -11695,7 +11695,7 @@ let
     installPhase = "make install";
     meta = {
       description = "Change and print terminal line settings";
-      homepage = "http://wiki.github.com/toddr/IO-Stty";
+      homepage = "https://wiki.github.com/toddr/IO-Stty";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -11847,7 +11847,7 @@ let
     };
     meta = {
       description = "Common utilities for IRC-related tasks";
-      homepage = "http://metacpan.org/release/IRC-Utils";
+      homepage = "https://metacpan.org/release/IRC-Utils";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = with maintainers; [ sgo ];
     };
@@ -11980,7 +11980,7 @@ let
     perlPreHook = lib.optionalString (stdenv.isi686 || stdenv.isDarwin) "export LD=$CC";
     meta = {
       description = "XS based JavaScript minifier";
-      homepage = "http://metacpan.org/release/JavaScript-Minifier-XS";
+      homepage = "https://metacpan.org/release/JavaScript-Minifier-XS";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -12415,7 +12415,7 @@ let
     propagatedBuildInputs = [ LinguaENInflectNumber LinguaENNumberIsOrdinal LinguaENTagger ];
     meta = {
       description = "Inflect short English Phrases";
-      homepage = "http://metacpan.org/release/Lingua-EN-Inflect-Phrase";
+      homepage = "https://metacpan.org/release/Lingua-EN-Inflect-Phrase";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -12431,7 +12431,7 @@ let
     propagatedBuildInputs = [ LinguaENFindNumber ];
     meta = {
       description = "Detect if English number is ordinal or cardinal";
-      homepage = "http://metacpan.org/release/Lingua-EN-Number-IsOrdinal";
+      homepage = "https://metacpan.org/release/Lingua-EN-Number-IsOrdinal";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -12746,7 +12746,7 @@ let
     propagatedBuildInputs = [ ModuleImplementation ];
     meta = {
       description = "Provide the stuff missing in List::Util";
-      homepage = "http://metacpan.org/release/List-SomeUtils";
+      homepage = "https://metacpan.org/release/List-SomeUtils";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -12838,7 +12838,7 @@ let
     };
     meta = {
       description = "Use other catalog formats in Maketext";
-      homepage = "http://search.cpan.org/dist/Locale-Maketext-Lexicon";
+      homepage = "https://search.cpan.org/dist/Locale-Maketext-Lexicon";
       license = with lib.licenses; [ mit ];
       mainProgram = "xgettext.pl";
     };
@@ -13808,7 +13808,7 @@ let
     propagatedBuildInputs = [ MathInt64 ];
     meta = {
       description = "Manipulate 128 bits integers in Perl";
-      homepage = "http://metacpan.org/release/Math-Int128";
+      homepage = "https://metacpan.org/release/Math-Int128";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       broken = stdenv.is32bit; # compiler doesn't support a 128-bit integer type
     };
@@ -13823,7 +13823,7 @@ let
     };
     meta = {
       description = "Manipulate 64 bits integers in Perl";
-      homepage = "http://metacpan.org/release/Math-Int64";
+      homepage = "https://metacpan.org/release/Math-Int64";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -13937,7 +13937,7 @@ let
     buildInputs = [ TestNoWarnings ];
     meta = {
       description = "Perl interface to the ISAAC PRNG algorithm";
-      homepage = "http://search.cpan.org/dist/Math-Random-ISAAC";
+      homepage = "https://search.cpan.org/dist/Math-Random-ISAAC";
       license = with lib.licenses; [ publicDomain mit artistic2 gpl3 ];
     };
   };
@@ -14000,7 +14000,7 @@ let
     propagatedBuildInputs = [ DataDumperConcise DateTime ListAllUtils MooXStrictConstructor ];
     meta = {
       description = "Code shared by the MaxMind DB reader and writer modules";
-      homepage = "http://metacpan.org/release/MaxMind-DB-Common";
+      homepage = "https://metacpan.org/release/MaxMind-DB-Common";
       license = with lib.licenses; [ artistic2 ];
     };
   };
@@ -14016,7 +14016,7 @@ let
     buildInputs = [ PathClass TestBits TestFatal TestNumberDelta TestRequires ];
     meta = {
       description = "Read MaxMind DB files and look up IP addresses";
-      homepage = "http://metacpan.org/release/MaxMind-DB-Reader";
+      homepage = "https://metacpan.org/release/MaxMind-DB-Reader";
       license = with lib.licenses; [ artistic2 ];
     };
   };
@@ -14032,7 +14032,7 @@ let
     buildInputs = [ NetWorks PathClass TestFatal TestNumberDelta TestRequires ];
     meta = {
       description = "Fast XS implementation of MaxMind DB reader";
-      homepage = "http://metacpan.org/release/MaxMind-DB-Reader-XS";
+      homepage = "https://metacpan.org/release/MaxMind-DB-Reader-XS";
       license = with lib.licenses; [ artistic2 ];
       broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.MaxMindDBReaderXS.x86_64-darwin
     };
@@ -14050,7 +14050,7 @@ let
     hardeningDisable = [ "format" ];
     meta = {
       description = "Create MaxMind DB database files";
-      homepage = "http://metacpan.org/release/MaxMind-DB-Writer";
+      homepage = "https://metacpan.org/release/MaxMind-DB-Writer";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.MaxMindDBWriter.x86_64-darwin
     };
@@ -14644,7 +14644,7 @@ let
     propagatedBuildInputs = [ ModuleRuntime TryTiny ];
     meta = {
       description = "Loads one of several alternate underlying implementations for a module";
-      homepage = "http://metacpan.org/release/Module-Implementation";
+      homepage = "https://metacpan.org/release/Module-Implementation";
       license = with lib.licenses; [ artistic2 ];
     };
   };
@@ -14752,7 +14752,7 @@ let
     propagatedBuildInputs = [ ModuleInstall PodMarkdown ];
     meta = {
       description = "Create README.mkdn from POD";
-      homepage = "http://search.cpan.org/dist/Module-Install-ReadmeMarkdownFromPod";
+      homepage = "https://search.cpan.org/dist/Module-Install-ReadmeMarkdownFromPod";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = [ maintainers.sgo ];
     };
@@ -15335,7 +15335,7 @@ let
     };
     meta = {
       description = "Portably create pipe() or pipe-like handles, one way or another";
-      homepage = "http://search.cpan.org/dist/IO-Pipely";
+      homepage = "https://search.cpan.org/dist/IO-Pipely";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15449,7 +15449,7 @@ let
     buildInputs = [ Moo ];
     meta = {
       description = "Turn your Moo class into singleton";
-      homepage = "http://search.cpan.org/dist/MooX-Singleton";
+      homepage = "https://search.cpan.org/dist/MooX-Singleton";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15539,7 +15539,7 @@ let
     propagatedBuildInputs = [ Moose ];
     meta = {
       description = "Abstract base classes for Moose";
-      homepage = "http://metacpan.org/release/MooseX-ABC";
+      homepage = "https://metacpan.org/release/MooseX-ABC";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15705,7 +15705,7 @@ let
     propagatedBuildInputs = [ EnvSanctify FileHomeDir PerlDestructLevel XMLTwig ];
     meta = {
       description = "Generate suppressions, analyse and test any command with valgrind";
-      homepage = "http://search.cpan.org/dist/Test-Valgrind";
+      homepage = "https://search.cpan.org/dist/Test-Valgrind";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15929,7 +15929,7 @@ let
     propagatedBuildInputs = [ Moose namespaceautoclean ];
     meta = {
       description = "Mark overload code symbols as methods";
-      homepage = "http://metacpan.org/release/MooseX-MarkAsMethods";
+      homepage = "https://metacpan.org/release/MooseX-MarkAsMethods";
       license = with lib.licenses; [ lgpl21 ];
     };
   };
@@ -15961,7 +15961,7 @@ let
     propagatedBuildInputs = [ ListMoreUtils Moose ];
     meta = {
       description = "Easy subclassing of non-Moose classes";
-      homepage = "http://metacpan.org/release/MooseX-NonMoose";
+      homepage = "https://metacpan.org/release/MooseX-NonMoose";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -16113,7 +16113,7 @@ let
     propagatedBuildInputs = [ Moose namespaceautoclean ];
     meta = {
       description = "Make your object constructors blow up on unknown attributes";
-      homepage = "http://metacpan.org/release/MooseX-StrictConstructor";
+      homepage = "https://metacpan.org/release/MooseX-StrictConstructor";
       license = with lib.licenses; [ artistic2 ];
     };
   };
@@ -16499,7 +16499,7 @@ let
     propagatedBuildInputs = [ BHooksEndOfScope PackageStash ];
     meta = {
       description = "Keep imports and functions out of your namespace";
-      homepage = "http://search.cpan.org/dist/namespace-clean";
+      homepage = "https://search.cpan.org/dist/namespace-clean";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -16758,7 +16758,7 @@ let
 
     meta = {
       description = "Extension for the DBus bindings";
-      homepage = "http://www.freedesktop.org/wiki/Software/dbus";
+      homepage = "https://www.freedesktop.org/wiki/Software/dbus";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -17037,7 +17037,7 @@ let
     buildInputs = [ Test2Suite TestUseAllModules ];
     meta = {
       description = "Understand and manipulate IP netmasks";
-      homepage = "http://search.cpan.org/~jmaslak/Net-Netmask";
+      homepage = "https://search.cpan.org/~jmaslak/Net-Netmask";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -17293,7 +17293,7 @@ let
     preCheck = "export HOME=$TMPDIR";
     meta = {
       description = "Perl client interface to SSH";
-      homepage = "http://search.cpan.org/dist/Net-SSH-Perl";
+      homepage = "https://search.cpan.org/dist/Net-SSH-Perl";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -17757,7 +17757,7 @@ let
     propagatedBuildInputs = [ PackageStash ParamsUtil SubInstall SubName ];
     meta = {
       description = "Manage deprecation warnings for your distribution";
-      homepage = "http://metacpan.org/release/Package-DeprecationManager";
+      homepage = "https://metacpan.org/release/Package-DeprecationManager";
       license = with lib.licenses; [ artistic2 ];
     };
   };
@@ -17922,7 +17922,7 @@ let
     buildInputs = [ Specio Test2PluginNoWarnings Test2Suite TestWithoutModule ];
     meta = {
       description = "Build an optimized subroutine parameter validator once, use it forever";
-      homepage = "http://metacpan.org/release/Params-ValidationCompiler";
+      homepage = "https://metacpan.org/release/Params-ValidationCompiler";
       license = with lib.licenses; [ artistic2 ];
     };
   };
@@ -18293,7 +18293,7 @@ let
 
     meta = {
       description = "Perl Data Language";
-      homepage = "http://pdl.perl.org";
+      homepage = "https://pdl.perl.org";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "pdl2";
       platforms = lib.platforms.linux;
@@ -18388,7 +18388,7 @@ let
     propagatedBuildInputs = [ PerlCritic Readonly namespaceautoclean ];
     meta = {
       description = "Policies for Perl::Critic concerned with using Moose";
-      homepage = "http://metacpan.org/release/Perl-Critic-Moose";
+      homepage = "https://metacpan.org/release/Perl-Critic-Moose";
       license = with lib.licenses; [ artistic1 ]];
     };
   };
@@ -18417,7 +18417,7 @@ let
     propagatedBuildInputs = [ IOString ListMoreUtils PPI PerlCritic PodMinimumVersion ];
     meta = {
       description = "Some add-on policies for Perl::Critic";
-      homepage = "http://user42.tuxfamily.org/perl-critic-pulp/index.html";
+      homepage = "https://user42.tuxfamily.org/perl-critic-pulp/index.html";
       license = with lib.licenses; [ gpl3Plus ];
     };
   };
@@ -18537,7 +18537,7 @@ let
     propagatedBuildInputs = [ ConvertASN1 ];
     meta = {
       description = "LDAP client library";
-      homepage = "http://ldap.perl.org";
+      homepage = "https://ldap.perl.org";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = teams.deshaw.members;
     };
@@ -18840,7 +18840,7 @@ let
     propagatedBuildInputs = [ IOString PodParser ];
     meta = {
       description = "Determine minimum Perl version of POD directives";
-      homepage = "http://user42.tuxfamily.org/pod-minimumversion/index.html";
+      homepage = "https://user42.tuxfamily.org/pod-minimumversion/index.html";
       license = with lib.licenses; [ free ];
       mainProgram = "pod-minimumversion";
     };
@@ -18890,7 +18890,7 @@ let
     };
     meta = {
       description = "Reusable tests for POE::Loop authors";
-      homepage = "http://search.cpan.org/dist/POE-Test-Loops";
+      homepage = "https://search.cpan.org/dist/POE-Test-Loops";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = teams.deshaw.members;
       mainProgram = "poe-gen-tests";
@@ -19412,7 +19412,7 @@ let
     propagatedBuildInputs = [ PodParser ];
     meta = {
       description = "Convert Pod data to formatted Latex";
-      homepage = "http://github.com/timj/perl-Pod-LaTeX/tree/master";
+      homepage = "https://github.com/timj/perl-Pod-LaTeX/tree/master";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "pod2latex";
     };
@@ -19446,7 +19446,7 @@ let
     propagatedBuildInputs = [ FileFindIterator FileHomeDir IPCRun PodParser constant-defer libintl-perl ];
     meta = {
       description = "Check POD L<> link references";
-      homepage = "http://user42.tuxfamily.org/podlinkcheck/index.html";
+      homepage = "https://user42.tuxfamily.org/podlinkcheck/index.html";
       license = with lib.licenses; [ gpl3Plus ];
     };
   };
@@ -19838,7 +19838,7 @@ let
     };
     meta = {
       description = "Base class for parsing regexes";
-      homepage = "http://wiki.github.com/toddr/Regexp-Parser";
+      homepage = "https://wiki.github.com/toddr/Regexp-Parser";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -19880,7 +19880,7 @@ let
     buildInputs = [ TestLongString TestWWWMechanize TestWWWMechanizeCGI ];
     meta = {
       description = "Utility functions for REST applications";
-      homepage = "http://jaldhar.github.com/REST-Utils";
+      homepage = "https://jaldhar.github.com/REST-Utils";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -19896,7 +19896,7 @@ let
     doCheck = false;
     meta = {
       description = "Data, client and server classes for XML-RPC";
-      homepage = "http://github.com/rjray/rpc-xml";
+      homepage = "https://github.com/rjray/rpc-xml";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "make_method";
     };
@@ -20091,7 +20091,7 @@ let
     };
     meta = {
       description = "Act on upper scopes";
-      homepage = "http://search.cpan.org/dist/Scope-Upper";
+      homepage = "https://search.cpan.org/dist/Scope-Upper";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -20497,7 +20497,7 @@ let
     propagatedBuildInputs = [ CryptRC4 DigestPerlMD5 IOStringy OLEStorage_Lite ];
     meta = {
       description = "Read information from an Excel file";
-      homepage = "http://github.com/runrig/spreadsheet-parseexcel";
+      homepage = "https://github.com/runrig/spreadsheet-parseexcel";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -20750,7 +20750,7 @@ let
     propagatedBuildInputs = [ ListMoreUtils ];
     meta = {
       description = "Module of basic descriptive statistical functions";
-      homepage = "http://metacpan.org/release/Statistics-Descriptive";
+      homepage = "https://metacpan.org/release/Statistics-Descriptive";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -21338,7 +21338,7 @@ let
     };
     meta = {
       description = "Lib/Safe/Hole.pm";
-      homepage = "http://github.com/toddr/Safe-Hole";
+      homepage = "https://github.com/toddr/Safe-Hole";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       broken = stdenv.isDarwin;
     };
@@ -21572,7 +21572,7 @@ let
     perlPreHook = lib.optionalString stdenv.isi686 "export LD=$CC"; # fix undefined reference to `__stack_chk_fail_local'
     meta = {
       description = "Libvirt Perl API";
-      homepage = "http://libvirt.org";
+      homepage = "https://libvirt.org";
       license = with lib.licenses; [ gpl1 ];
       broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.SysVirt.x86_64-darwin
     };
@@ -21619,7 +21619,7 @@ let
     propagatedBuildInputs = [ EnvPath FileWhich GamesSolitaireVerify InlineC ListMoreUtils MooX StringShellQuote TaskTestRunAllPlugins TemplateToolkit YAMLLibYAML ];
     meta = {
       description = "Install the CPAN dependencies of the Freecell Solver test suite";
-      homepage = "http://metacpan.org/release/Task-FreecellSolver-Testing";
+      homepage = "https://metacpan.org/release/Task-FreecellSolver-Testing";
       license = with lib.licenses; [ mit ];
     };
   };
@@ -21645,7 +21645,7 @@ let
     buildInputs = [ TestRun TestRunCmdLine TestRunPluginAlternateInterpreters TestRunPluginBreakOnFailure TestRunPluginColorFileVerdicts TestRunPluginColorSummary TestRunPluginTrimDisplayedFilenames ];
     meta = {
       description = "Specifications for installing all the Test::Run";
-      homepage = "http://web-cpan.shlomifish.org/modules/Test-Run";
+      homepage = "https://web-cpan.shlomifish.org/modules/Test-Run";
       license = with lib.licenses; [ mit ];
     };
   };
@@ -21958,7 +21958,7 @@ let
 
     meta = {
       description = "A Term::ReadLine driver based on Term::ReadLine::Perl, with special features for microblogging and the TTYtter client (q.v)";
-      homepage = "http://www.floodgap.com/software/ttytter";
+      homepage = "https://www.floodgap.com/software/ttytter";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -22263,7 +22263,7 @@ let
     buildInputs = [ TestFatal ];
     meta = {
       description = "Provides a bits_is() subroutine for testing binary data";
-      homepage = "http://metacpan.org/release/Test-Bits";
+      homepage = "https://metacpan.org/release/Test-Bits";
       license = with lib.licenses; [ artistic2 ];
     };
   };
@@ -22408,7 +22408,7 @@ let
     propagatedBuildInputs = [ IOAll ListMoreUtils MooX MooXlate ];
     meta = {
       description = "Split data-driven tests into several test scripts";
-      homepage = "http://metacpan.org/release/Test-Data-Split";
+      homepage = "https://metacpan.org/release/Test-Data-Split";
       license = with lib.licenses; [ mit ];
     };
   };
@@ -22421,7 +22421,7 @@ let
       sha256 = "0mkw18q5agr30djxr1y68rcfw8aq20ws872hmv88f9gnynag8r20";
     };
     meta = {
-      homepage = "http://github.com/rjbs/Test-Deep";
+      homepage = "https://github.com/rjbs/Test-Deep";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -23126,7 +23126,7 @@ let
     buildInputs = [ TestPerlCritic ];
     meta = {
       description = "Check that all your files are tidy";
-      homepage = "http://metacpan.org/release/Test-PerlTidy";
+      homepage = "https://metacpan.org/release/Test-PerlTidy";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -23140,7 +23140,7 @@ let
     };
     meta = {
       description = "Check for POD errors in files";
-      homepage = "http://search.cpan.org/dist/Test-Pod";
+      homepage = "https://search.cpan.org/dist/Test-Pod";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -23166,7 +23166,7 @@ let
     propagatedBuildInputs = [ CaptureTiny Moose podlinkcheck ];
     meta = {
       description = "Tests POD for invalid links";
-      homepage = "http://search.cpan.org/dist/Test-Pod-LinkCheck";
+      homepage = "https://search.cpan.org/dist/Test-Pod-LinkCheck";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -23182,7 +23182,7 @@ let
     buildInputs = [ ModuleBuildTiny TestPod ];
     meta = {
       description = "Using this test module will check your POD for any http 404 links";
-      homepage = "http://search.cpan.org/dist/Test-Pod-No404s";
+      homepage = "https://search.cpan.org/dist/Test-Pod-No404s";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -23294,7 +23294,7 @@ let
     propagatedBuildInputs = [ IPCSystemSimple ListMoreUtils MooseXStrictConstructor TextSprintfNamed UNIVERSALrequire ];
     meta = {
       description = "Base class to run standard TAP scripts";
-      homepage = "http://web-cpan.shlomifish.org/modules/Test-Run";
+      homepage = "https://web-cpan.shlomifish.org/modules/Test-Run";
       license = with lib.licenses; [ mit ];
     };
   };
@@ -23328,7 +23328,7 @@ let
     propagatedBuildInputs = [ Moose ];
     meta = {
       description = "Define different interpreters for different test scripts with Test::Run";
-      homepage = "http://web-cpan.shlomifish.org/modules/Test-Run";
+      homepage = "https://web-cpan.shlomifish.org/modules/Test-Run";
       license = with lib.licenses; [ mit ];
     };
   };
@@ -23344,7 +23344,7 @@ let
     propagatedBuildInputs = [ Moose ];
     meta = {
       description = "Stop processing the entire test suite";
-      homepage = "http://web-cpan.shlomifish.org/modules/Test-Run";
+      homepage = "https://web-cpan.shlomifish.org/modules/Test-Run";
       license = with lib.licenses; [ mit ];
     };
   };
@@ -23362,7 +23362,7 @@ let
     doCheck=true;
     meta = {
       description = "Make the file verdict ('ok', 'NOT OK')";
-      homepage = "http://web-cpan.shlomifish.org/modules/Test-Run";
+      homepage = "https://web-cpan.shlomifish.org/modules/Test-Run";
       license = with lib.licenses; [ mit ];
     };
   };
@@ -23379,7 +23379,7 @@ let
     doCheck=true;
     meta = {
       description = "A Test::Run plugin that";
-      homepage = "http://web-cpan.shlomifish.org/modules/Test-Run";
+      homepage = "https://web-cpan.shlomifish.org/modules/Test-Run";
       license = with lib.licenses; [ mit ];
     };
   };
@@ -23395,7 +23395,7 @@ let
     propagatedBuildInputs = [ Moose ];
     meta = {
       description = "Trim the first components";
-      homepage = "http://web-cpan.shlomifish.org/modules/Test-Run";
+      homepage = "https://web-cpan.shlomifish.org/modules/Test-Run";
       license = with lib.licenses; [ mit ];
     };
   };
@@ -23411,7 +23411,7 @@ let
     propagatedBuildInputs = [ PathTiny ];
     meta = {
       description = "Tests that an external program is valgrind-clean";
-      homepage = "http://metacpan.org/release/Test-RunValgrind";
+      homepage = "https://metacpan.org/release/Test-RunValgrind";
       license = with lib.licenses; [ mit ];
     };
   };
@@ -23520,7 +23520,7 @@ let
     };
     meta = {
       description = "Test your SYNOPSIS code";
-      homepage = "http://metacpan.org/release/Test-Synopsis";
+      homepage = "https://metacpan.org/release/Test-Synopsis";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -23620,7 +23620,7 @@ let
     propagatedBuildInputs = [ FileFindObjectRule ];
     meta = {
       description = "Test for trailing space in source files";
-      homepage = "http://metacpan.org/release/Test-TrailingSpace";
+      homepage = "https://metacpan.org/release/Test-TrailingSpace";
       license = with lib.licenses; [ mit ];
     };
   };
@@ -23787,7 +23787,7 @@ let
     };
     meta = {
       description = "Module to align text";
-      homepage = "http://metacpan.org/release/Text-Aligner";
+      homepage = "https://metacpan.org/release/Text-Aligner";
       license = with lib.licenses; [ free ];
     };
   };
@@ -23943,7 +23943,7 @@ let
     };
     meta = {
       description = "Various subroutines to format text";
-      homepage = "http://www.shlomifish.org/open-source/projects/Text-Format";
+      homepage = "https://www.shlomifish.org/open-source/projects/Text-Format";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       maintainers = with maintainers; [ bcdarwin ];
     };
@@ -24355,7 +24355,7 @@ let
     buildInputs = [ TestWarn ];
     meta = {
       description = "Sprintf-like function with named conversions";
-      homepage = "http://metacpan.org/release/Text-Sprintf-Named";
+      homepage = "https://metacpan.org/release/Text-Sprintf-Named";
       license = with lib.licenses; [ mit ];
     };
   };
@@ -24370,7 +24370,7 @@ let
     propagatedBuildInputs = [ TextAligner ];
     meta = {
       description = "Organize Data in Tables";
-      homepage = "http://metacpan.org/release/Text-Table";
+      homepage = "https://metacpan.org/release/Text-Table";
       license = with lib.licenses; [ isc ];
     };
   };
@@ -24820,7 +24820,7 @@ let
     };
     meta = {
       description = "Efficiently compute time from local and GMT time";
-      homepage = "http://metacpan.org/release/Time-Local";
+      homepage = "https://metacpan.org/release/Time-Local";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -25140,7 +25140,7 @@ let
     perlPreHook = lib.optionalString stdenv.isi686 "export LD=$CC"; # fix undefined reference to `__stack_chk_fail_local'
     meta = {
       description = "Unicode case-folding for case-insensitive lookups";
-      homepage = "http://metacpan.org/release/Unicode-CaseFold";
+      homepage = "https://metacpan.org/release/Unicode-CaseFold";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -25257,7 +25257,7 @@ let
     propagatedBuildInputs = [ URI ];
     meta = {
       description = "Find URIs in arbitrary text";
-      homepage = "http://metacpan.org/release/URI-Find";
+      homepage = "https://metacpan.org/release/URI-Find";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       mainProgram = "urifind";
     };
@@ -25274,7 +25274,7 @@ let
     buildInputs = [ TestFatal ];
     meta = {
       description = "Build a URI from a set of named parameters";
-      homepage = "http://metacpan.org/release/URI-FromHash";
+      homepage = "https://metacpan.org/release/URI-FromHash";
       license = with lib.licenses; [ artistic2 ];
     };
   };
@@ -25444,7 +25444,7 @@ let
     };
     meta = {
       description = "Associate user-defined magic to variables from Perl";
-      homepage = "http://search.cpan.org/dist/Variable-Magic";
+      homepage = "https://search.cpan.org/dist/Variable-Magic";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -25502,7 +25502,7 @@ let
     propagatedBuildInputs = [ DateTimeFormatISO8601 VMEC2 ];
     meta = {
       description = "Cache credentials respecting expiration time for IAM roles";
-      homepage = "http://search.cpan.org/dist/VM-EC2-Security-CredentialCache";
+      homepage = "https://search.cpan.org/dist/VM-EC2-Security-CredentialCache";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -25726,7 +25726,7 @@ let
     buildInputs = [ EncodeHanExtra ModuleUtil ];
     meta = {
       description = "Miscellaneous helpers for X11::Protocol connections";
-      homepage = "http://user42.tuxfamily.org/x11-protocol-other/index.html";
+      homepage = "https://user42.tuxfamily.org/x11-protocol-other/index.html";
       license = with lib.licenses; [ gpl1Plus gpl3Plus ];
     };
   };
@@ -26067,7 +26067,7 @@ let
     propagatedBuildInputs = [ DateTimeFormatMail DateTimeFormatW3CDTF XMLParser ];
     meta = {
       description = "Creates and updates RSS files";
-      homepage = "http://metacpan.org/release/XML-RSS";
+      homepage = "https://metacpan.org/release/XML-RSS";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -26339,7 +26339,7 @@ let
     perlPreHook = lib.optionalString stdenv.isDarwin "export LD=$CC";
     meta = {
       description = "Fast, lightweight YAML loader and dumper";
-      homepage = "http://github.com/toddr/YAML-Syck";
+      homepage = "https://github.com/toddr/YAML-Syck";
       license = with lib.licenses; [ mit ];
     };
   };
@@ -26387,7 +26387,7 @@ let
     propagatedBuildInputs = [ HTTPHeadersActionPack HTTPMessage HashMultiValue IOHandleUtil ModuleRuntime Plack SubExporter TryTiny ];
     meta = {
       description = "A Perl port of Webmachine";
-      homepage = "http://metacpan.org/release/Web-Machine";
+      homepage = "https://metacpan.org/release/Web-Machine";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -1089,7 +1089,7 @@ let
     propagatedBuildInputs = [ FileWhich IPCRun LogLog4perl ];
     meta = {
       description = "API wrapper around the 'tar' utility";
-      license = with lib.licenses; [ gpl3 ];
+      license = with lib.licenses; [ gpl3Plus ];
     };
   };
 
@@ -1118,7 +1118,7 @@ let
     meta = {
       description = "Object-oriented interface to FITS HDUs";
       homepage = "https://github.com/timj/perl-Astro-FITS-Header";
-      license = with lib.licenses; [ gpl3 ];
+      license = with lib.licenses; [ gpl3Plus ];
     };
   };
 
@@ -1147,7 +1147,7 @@ let
     NIX_CFLAGS_LINK = "-L${pkgs.zlib.out}/lib -lz";
     meta = {
       description = "Fast C metadata and tag reader for all common audio file formats";
-      license = with lib.licenses; [ gpl2 ];
+      license = with lib.licenses; [ gpl2Plus ];
     };
   };
 
@@ -1453,7 +1453,7 @@ let
     meta = {
       description = "Perl interface to the ZBar Barcode Reader";
       homepage = "https://metacpan.org/pod/Barcode::ZBar";
-      license = with lib.licenses; [ lgpl21 ];
+      license = with lib.licenses; [ lgpl21Plus ];
     };
   };
 
@@ -1633,7 +1633,7 @@ let
     };
     meta = {
       description = "Lists of reserved barewords and symbol names";
-      license = with lib.licenses; [ artistic1 gpl2 ];
+      license = with lib.licenses; [ artistic1 gpl2Only ];
     };
   };
 
@@ -1996,7 +1996,7 @@ let
     meta = {
       description = "Perl interface to the cairo 2d vector graphics library";
       homepage = "http://gtk2-perl.sourceforge.net";
-      license = with lib.licenses; [ lgpl21 ];
+      license = with lib.licenses; [ lgpl21Only ];
     };
   };
 
@@ -2012,7 +2012,7 @@ let
     meta = {
       description = "Integrate Cairo into the Glib type system";
       homepage = "http://gtk2-perl.sourceforge.net";
-      license = with lib.licenses; [ lgpl21 ];
+      license = with lib.licenses; [ lgpl21Only ];
     };
   };
 
@@ -4880,7 +4880,7 @@ let
     meta = {
       description = "Parse PKCS #10 certificate requests";
       homepage = "https://github.com/openxpki/Crypt-PKCS10";
-      license = with lib.licenses; [ gpl1 ];
+      license = with lib.licenses; [ gpl1Only ];
     };
   };
 
@@ -5589,7 +5589,7 @@ let
     };
     meta = {
       description = "Make binary data human-readable";
-      license = with lib.licenses; [ artistic1 gpl2 ];
+      license = with lib.licenses; [ artistic1 gpl2Only ];
     };
   };
 
@@ -9249,7 +9249,7 @@ let
     meta = {
       description = "FileHandle which supports multi-byte unget";
       homepage = "https://github.com/coppit/filehandle-unget";
-      license = with lib.licenses; [ gpl2 ];
+      license = with lib.licenses; [ gpl2Only ];
       maintainers = with maintainers; [ romildo ];
     };
   };
@@ -10187,7 +10187,7 @@ let
     meta = {
       description = "Perl wrappers for the GLib utility and Object libraries";
       homepage = "http://gtk2-perl.sourceforge.net";
-      license = with lib.licenses; [ lgpl21 ];
+      license = with lib.licenses; [ lgpl21Only ];
     };
   };
 
@@ -10215,7 +10215,7 @@ let
     meta = {
       description = "Dynamically create Perl language bindings";
       homepage = "http://gtk2-perl.sourceforge.net";
-      license = with lib.licenses; [ lgpl21 ];
+      license = with lib.licenses; [ lgpl21Only ];
     };
   };
 
@@ -10480,7 +10480,7 @@ let
     meta = {
       description = "Search mailboxes for mail matching a regular expression";
       homepage = "https://github.com/coppit/grepmail";
-      license = with lib.licenses; [ gpl2 ];
+      license = with lib.licenses; [ gpl2Only ];
       maintainers = with maintainers; [ romildo ];
     };
   };
@@ -10545,7 +10545,7 @@ let
     propagatedBuildInputs = [ pkgs.gtk2 Gtk2 ];
     meta = {
       description = "(DEPRECATED) Perl interface to the EggTrayIcon library";
-      license = with lib.licenses; [ gpl2 ];
+      license = with lib.licenses; [ gpl2Plus ];
       broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.Gtk2TrayIcon.x86_64-darwin
     };
   };
@@ -13086,7 +13086,7 @@ let
     propagatedBuildInputs = [ HTMLParser LinguaStem MemoizeExpireLRU ];
     meta = {
       description = "Part-of-speech tagger for English natural language processing";
-      license = with lib.licenses; [ gpl3 ];
+      license = with lib.licenses; [ gpl3Only ];
     };
   };
 
@@ -14151,7 +14151,7 @@ let
     meta = {
       description = "A fast and simple mbox folder reader";
       homepage = "https://github.com/coppit/mail-mbox-messageparser";
-      license = with lib.licenses; [ gpl2 ];
+      license = with lib.licenses; [ gpl2Only ];
       maintainers = with maintainers; [ romildo ];
     };
   };
@@ -14380,7 +14380,7 @@ let
     };
     meta = {
       description = "Human-readable unit-aware calculator";
-      license = with lib.licenses; [ artistic1 gpl2 ];
+      license = with lib.licenses; [ artistic1 gpl2Only ];
       mainProgram = "ucalc";
     };
   };
@@ -14569,7 +14569,7 @@ let
     };
     meta = {
       description = "Perl interface to PARI";
-      license = with lib.licenses; [ artistic1 gpl1Plus gpl2 ];
+      license = with lib.licenses; [ artistic1 gpl1Plus gpl2Only ];
     };
   };
 
@@ -14663,7 +14663,7 @@ let
     meta = {
       description = "Perl interface to the ISAAC PRNG algorithm";
       homepage = "https://search.cpan.org/dist/Math-Random-ISAAC";
-      license = with lib.licenses; [ publicDomain mit artistic2 gpl3 ];
+      license = with lib.licenses; [ publicDomain mit artistic2 gpl1Plus ];
     };
   };
 
@@ -14933,7 +14933,7 @@ let
       homepage = "https://www.mhonarc.org/";
       description = "A mail-to-HTML converter";
       mainProgram = "mhonarc";
-      license = with lib.licenses; [ gpl2 ];
+      license = with lib.licenses; [ gpl2Only ];
     };
   };
 
@@ -16696,7 +16696,7 @@ let
     meta = {
       description = "Mark overload code symbols as methods";
       homepage = "https://metacpan.org/release/MooseX-MarkAsMethods";
-      license = with lib.licenses; [ lgpl21 ];
+      license = with lib.licenses; [ lgpl21Only ];
     };
   };
 
@@ -18294,7 +18294,7 @@ let
     meta = {
       description = "Large suite of perl modules for parsing and dealing with phone numbers";
       homepage = "https://github.com/DrHyde/perl-modules-Number-Phone";
-      license = with lib.licenses; [ artistic1 gpl2 ];
+      license = with lib.licenses; [ artistic1 gpl2Only asl20 ];
     };
   };
 
@@ -18497,7 +18497,7 @@ let
     propagatedBuildInputs = [ ArchiveZip XMLTwig ];
     meta = {
       description = "The Perl Open OpenDocument Connector";
-      license = with lib.licenses; [ lgpl21 ];
+      license = with lib.licenses; [ lgpl21Only ];
       maintainers = [ maintainers.wentasah ];
     };
   };
@@ -21927,7 +21927,7 @@ let
     propagatedBuildInputs = [ SubExporter ];
     meta = {
       description = "Build sprintf-like functions of your own";
-      license = with lib.licenses; [ gpl2 ];
+      license = with lib.licenses; [ gpl2Only ];
     };
   };
 
@@ -22027,7 +22027,7 @@ let
     doCheck = true;
     meta = {
       description = "Calculate the similarity of two strings";
-      license = with lib.licenses; [ gpl2 ];
+      license = with lib.licenses; [ gpl2Only ];
     };
   };
 
@@ -22612,7 +22612,7 @@ let
     meta = {
       description = "Libvirt Perl API";
       homepage = "https://libvirt.org";
-      license = with lib.licenses; [ gpl1 ];
+      license = with lib.licenses; [ gpl2Plus artistic1 ];
       broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.SysVirt.x86_64-darwin
     };
   };
@@ -22840,7 +22840,7 @@ let
     propagatedBuildInputs = [ TemplateToolkit ];
     meta = {
       description = "Rudimentary profiling for Template Toolkit";
-      license = with lib.licenses; [ artistic2 gpl3 ];
+      license = with lib.licenses; [ artistic2 gpl3Only ];
     };
   };
 
@@ -24174,7 +24174,7 @@ let
     };
     meta = {
       description = "Make sure you didn't emit any warnings while testing";
-      license = with lib.licenses; [ lgpl21 ];
+      license = with lib.licenses; [ lgpl21Only ];
     };
   };
 
@@ -24230,7 +24230,7 @@ let
     propagatedBuildInputs = [ MCE PerlCritic ];
     meta = {
       description = "Use Perl::Critic in test programs";
-      license = with lib.licenses; [ artistic1 gpl1 ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -25401,7 +25401,7 @@ let
     propagatedBuildInputs = [ TextDiff ];
     meta = {
       description = "Patches text with given patch";
-      license = with lib.licenses; [ gpl2 ];
+      license = with lib.licenses; [ gpl2Only ];
     };
   };
 
@@ -25749,7 +25749,7 @@ let
     '';
     meta = {
       description = "Line wrapping module with support for multibyte, fullwidth, and combining characters and languages without whitespaces between words";
-      license = with lib.licenses; [ artistic1 gpl2 ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 


### PR DESCRIPTION
###### Description of changes

![image](https://user-images.githubusercontent.com/4971975/185889905-b7dc618f-2296-4869-be28-d3f26d220afb.png)

- Gives some packages a homepage, fetched from metacpan
- Normalizes all descriptions
- Uses https for the homepage where possible
- Gives all packages a description
- Gives all packages a license
- Replaces depcreated/unclear licenses
- Fixes meta indentation and ordering

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
