### PR TITLE
rocm: 5.2.1 → 5.2.3

### DIFF
--- a/pkgs/development/compilers/hip/default.nix
+++ b/pkgs/development/compilers/hip/default.nix
@@ -28,13 +28,13 @@
 let
   hip = stdenv.mkDerivation rec {
     pname = "hip";
-    version = "5.2.1";
+    version = "5.2.3";
 
     src = fetchFromGitHub {
       owner = "ROCm-Developer-Tools";
       repo = "HIP";
       rev = "rocm-${version}";
-      hash = "sha256-aXI55bdhAuPUEdQZukKAdtLWA+8UIxjPJ4LTamR/ENk=";
+      hash = "sha256-QaN666Rku2Tkio2Gm5/3RD8D5JgmCZLe0Yun1fGxa8U=";
     };
 
     # - fix bash paths
@@ -100,13 +100,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "hip";
-  version = "5.2.1";
+  version = "5.2.3";
 
   src = fetchFromGitHub {
     owner = "ROCm-Developer-Tools";
     repo = "hipamd";
     rev = "rocm-${version}";
-    hash = "sha256-YsvM+HjoBiukXAMCdE/dpQNMnpP6XRXDuxV1487rok0=";
+    hash = "sha256-9YZBFn1jpOiX0X9rcpsFDNhas9vfxNkNnbsWSi7unPU=";
   };
 
   nativeBuildInputs = [ cmake python3 makeWrapper perl ];

--- a/pkgs/development/compilers/llvm/rocm/default.nix
+++ b/pkgs/development/compilers/llvm/rocm/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, buildPackages, fetchFromGitHub, callPackage, wrapCCWith, overrideCC }:
 
 let
-  version = "5.2.1";
+  version = "5.2.3";
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";
     repo = "llvm-project";

--- a/pkgs/development/libraries/rocclr/default.nix
+++ b/pkgs/development/libraries/rocclr/default.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "rocclr";
-  version = "5.2.1";
+  version = "5.2.3";
 
   src = fetchFromGitHub {
     owner = "ROCm-Developer-Tools";
     repo = "ROCclr";
     rev = "rocm-${version}";
-    hash = "sha256-bNIc1JF8f88xC18BheKZCZYjWb4gUZOMWlt/5198iGE=";
+    hash = "sha256-DER6PBYXmZRgwFNVU5rpn87HrXMR+HnQf8cwHioUals=";
   };
 
   patches = [

--- a/pkgs/tools/system/rocm-smi/default.nix
+++ b/pkgs/tools/system/rocm-smi/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "rocm-smi";
-  version = "5.2.0";
+  version = "5.2.3";
 
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";
     repo = "rocm_smi_lib";
     rev = "rocm-${version}";
-    hash = "sha256-7e8nCCyFhecfC4TJrpqMI5buVZstynYgDWaa+LF85GA=";
+    hash = "sha256-D3ZH6xJe2C9rUCsJPOf9QlStecU90/iYi4wrXVvPff0=";
   };
 
   nativeBuildInputs = [ cmake wrapPython ];


### PR DESCRIPTION
###### Description of changes
ROCm 5.2.3 was released, there’s a changelog on GitHub this time: https://github.com/RadeonOpenCompute/ROCm/releases/tag/rocm-5.2.3
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

(For the llvm fork, a new version was published, but no content changed, so it’s the same hash.)

I checked some OpenCL and hip examples.

Builds are on the flakebi cachix, so you can use

```
cachix use flakebi
nix-build -A hip
nix-build -A rocm-opencl-icd
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

cc @InternetUnexplorer