### PR TITLE
nixos/tests/ec2: pass -F backing image format as it is now necessary

### DIFF
--- a/nixos/tests/common/ec2.nix
+++ b/nixos/tests/common/ec2.nix
@@ -3,6 +3,7 @@
 with pkgs.lib;
 
 {
+  # image must be an attrset of the form: { path, format }
   makeEc2Test = { name, image, userData, script, hostname ? "ec2-instance", sshPublicKey ? null, meta ? {} }:
     let
       metaData = pkgs.stdenv.mkDerivation {
@@ -37,7 +38,9 @@ with pkgs.lib;
                 "-f",
                 "qcow2",
                 "-o",
-                "backing_file=${image}",
+                "backing_file=${image.path}",
+                "-F",
+                "${image.format}",
                 disk_image,
             ]
         )

--- a/nixos/tests/ec2.nix
+++ b/nixos/tests/ec2.nix
@@ -55,7 +55,10 @@ let
       }
     ];
   }).config;
-  image = "${imageCfg.system.build.amazonImage}/${imageCfg.amazonImage.name}.vhd";
+  image = {
+    path = "${imageCfg.system.build.amazonImage}/${imageCfg.amazonImage.name}.vhd";
+    format = "vpc";
+  };
 
   sshKeys = import ./ssh-keys.nix pkgs;
   snakeOilPrivateKey = sshKeys.snakeOilPrivateKey.text;

--- a/nixos/tests/image-contents.nix
+++ b/nixos/tests/image-contents.nix
@@ -23,18 +23,23 @@ let
       }
     ];
   }).config;
-  image = (import ../lib/make-disk-image.nix {
-    inherit pkgs config;
-    lib = pkgs.lib;
+  image = let
     format = "qcow2";
-    contents = [{
-      source = pkgs.writeText "testFile" "contents";
-      target = "/testFile";
-      user = "1234";
-      group = "5678";
-      mode = "755";
-    }];
-  }) + "/nixos.qcow2";
+  in
+  {
+    path = (import ../lib/make-disk-image.nix {
+      inherit pkgs config format;
+      lib = pkgs.lib;
+      contents = [{
+        source = pkgs.writeText "testFile" "contents";
+        target = "/testFile";
+        user = "1234";
+        group = "5678";
+        mode = "755";
+      }];
+    }) + "/nixos.${format}";
+    inherit format;
+  };
 
 in makeEc2Test {
   name = "image-contents";

--- a/nixos/tests/openstack-image.nix
+++ b/nixos/tests/openstack-image.nix
@@ -9,20 +9,23 @@ with pkgs.lib;
 with import common/ec2.nix { inherit makeTest pkgs; };
 
 let
-  image = (import ../lib/eval-config.nix {
-    inherit system;
-    modules = [
-      ../maintainers/scripts/openstack/openstack-image.nix
-      ../modules/testing/test-instrumentation.nix
-      ../modules/profiles/qemu-guest.nix
-      {
-        # Needed by nixos-rebuild due to lack of network access.
-        system.extraDependencies = with pkgs; [
-          stdenv
-        ];
-      }
-    ];
-  }).config.system.build.openstackImage + "/nixos.qcow2";
+  image = {
+    path = (import ../lib/eval-config.nix {
+      inherit system;
+      modules = [
+        ../maintainers/scripts/openstack/openstack-image.nix
+        ../modules/testing/test-instrumentation.nix
+        ../modules/profiles/qemu-guest.nix
+        {
+          # Needed by nixos-rebuild due to lack of network access.
+          system.extraDependencies = with pkgs; [
+            stdenv
+          ];
+        }
+      ];
+    }).config.system.build.openstackImage + "/nixos.qcow2";
+    format = "qcow2";
+  };
 
   sshKeys = import ./ssh-keys.nix pkgs;
   snakeOilPrivateKey = sshKeys.snakeOilPrivateKey.text;


### PR DESCRIPTION
###### Description of changes

This performs a cleanup necessary since a certain version of QEMU (7 maybe?) as `qemu-img` requires the backing image file format now to be passed.
It seems like some EC2-based tests are broken BTW, due to conflicting definitions on serial port.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
