### PR TITLE
ucommon: remove broken openssl support

### DIFF
--- a/pkgs/development/libraries/ucommon/default.nix
+++ b/pkgs/development/libraries/ucommon/default.nix
@@ -1,13 +1,6 @@
 { lib, stdenv, fetchurl, pkg-config
-, openssl ? null, zlib ? null, gnutls ? null
+, gnutls
 }:
-
-let
-  xor = a: b: (a || b) && (!(a && b));
-in
-
-assert xor (openssl != null) (gnutls != null);
-assert !(xor (openssl != null) (zlib != null));
 
 stdenv.mkDerivation rec {
   pname = "ucommon";
@@ -29,8 +22,8 @@ stdenv.mkDerivation rec {
       --replace 'ifndef UCOMMON_SYSRUNTIME' 'if 0'
   '';
 
-  # ucommon.pc has link time depdendencies on -lssl, -lcrypto, -lz, -lgnutls
-  propagatedBuildInputs = [ openssl zlib gnutls ];
+  # ucommon.pc has link time depdendencies on -lusecure -lucommon -lgnutls
+  propagatedBuildInputs = [ gnutls ];
 
   doCheck = true;
 
@@ -38,7 +31,6 @@ stdenv.mkDerivation rec {
     description = "C++ library to facilitate using C++ design patterns";
     homepage = "https://www.gnu.org/software/commoncpp/";
     license = lib.licenses.lgpl3Plus;
-
     maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21711,10 +21711,7 @@ with pkgs;
 
   utmps = skawarePackages.utmps;
 
-  ucommon = callPackage ../development/libraries/ucommon {
-    openssl = null;
-    zlib = null;
-  };
+  ucommon = callPackage ../development/libraries/ucommon { };
 
   v8 = callPackage ../development/libraries/v8 { };
 


### PR DESCRIPTION
fails to compile and the interface to activate it is a bit ugly: ``ucommon.override { openssl = pkgs.openssl; zlib = pkgs.zlib; gnutls = null; ``

```
ucommon> make[2]: Entering directory '/build/ucommon-7.0.0/openssl'
ucommon> /nix/store/3j918i1nbwhby0y38bn2r438rjhh8f4d-bash-5.1-p16/bin/bash ../libtool  --tag=CXX   --mode=compile g++ -DHAVE_CONFIG_H -I. -I..    -I../inc  -Wno-long-long -pthread -fno-check-new -finline -fvisibility=hidden -I/nix/store/bndpy6l47hpy78njsjzskc37xbb2dbsj-ucommon-7.0.0/include -std=c++14 -c -o secure.lo secure.cpp
ucommon> libtool: compile:  g++ -DHAVE_CONFIG_H -I. -I.. -I../inc -Wno-long-long -pthread -fno-check-new -finline -fvisibility=hidden -I/nix/store/bndpy6l47hpy78njsjzskc37xbb2dbsj-ucommon-7.0.0/include -std=c++14 -c secure.cpp  -fPIC -DPIC -o .libs/secure.o
ucommon> /nix/store/3j918i1nbwhby0y38bn2r438rjhh8f4d-bash-5.1-p16/bin/bash ../libtool  --tag=CXX   --mode=compile g++ -DHAVE_CONFIG_H -I. -I..    -I../inc  -Wno-long-long -pthread -fno-check-new -finline -fvisibility=hidden -I/nix/store/bndpy6l47hpy78njsjzskc37xbb2dbsj-ucommon-7.0.0/include -std=c++14 -c -o digest.lo digest.cpp
ucommon> libtool: compile:  g++ -DHAVE_CONFIG_H -I. -I.. -I../inc -Wno-long-long -pthread -fno-check-new -finline -fvisibility=hidden -I/nix/store/bndpy6l47hpy78njsjzskc37xbb2dbsj-ucommon-7.0.0/include -std=c++14 -c digest.cpp  -fPIC -DPIC -o .libs/digest.o
ucommon> digest.cpp: In member function 'void ucommon::Digest::set(const char*)':
ucommon> digest.cpp:40:23: error: invalid use of incomplete type 'EVP_MD_CTX' {aka 'struct evp_md_ctx_st'}
ucommon>    40 |         context = new EVP_MD_CTX;
ucommon>       |                       ^~~~~~~~~~
ucommon> In file included from /nix/store/4cq6vq5s3nscayqribkdsz36a2h75cw3-openssl-1.1.1q-dev/include/openssl/crypto.h:25,
ucommon>                  from /nix/store/4cq6vq5s3nscayqribkdsz36a2h75cw3-openssl-1.1.1q-dev/include/openssl/comp.h:16,
ucommon>                  from /nix/store/4cq6vq5s3nscayqribkdsz36a2h75cw3-openssl-1.1.1q-dev/include/openssl/ssl.h:17,
ucommon>                  from local.h:27,
ucommon>                  from digest.cpp:19:
ucommon> /nix/store/4cq6vq5s3nscayqribkdsz36a2h75cw3-openssl-1.1.1q-dev/include/openssl/ossl_typ.h:92:16: note: forward declaration of 'EVP_MD_CTX' {aka 'struct evp_md_ctx_st'}
ucommon>    92 | typedef struct evp_md_ctx_st EVP_MD_CTX;
ucommon>       |                ^~~~~~~~~~~~~
ucommon> digest.cpp: In member function 'void ucommon::Digest::release()':
ucommon> digest.cpp:49:9: error: 'EVP_MD_CTX_cleanup' was not declared in this scope; did you mean 'EVP_MD_CTX_create'?
ucommon>    49 |         EVP_MD_CTX_cleanup((EVP_MD_CTX *)context);
ucommon>       |         ^~~~~~~~~~~~~~~~~~
ucommon>       |         EVP_MD_CTX_create
ucommon> digest.cpp:52:28: error: invalid application of 'sizeof' to incomplete type 'EVP_MD_CTX' {aka 'evp_md_ctx_st'}
ucommon>    52 |         memset(context, 0, sizeof(EVP_MD_CTX));
ucommon>       |                            ^~~~~~~~~~~~~~~~~~
ucommon> digest.cpp:53:9: warning: possible problem detected in invocation of 'operator delete' [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wdelete-incomplete-Wdelete-incomplete8;;]
ucommon>    53 |         delete (EVP_MD_CTX *)context;
ucommon>       |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucommon> digest.cpp:53:16: warning: invalid use of incomplete type 'struct evp_md_ctx_st'
ucommon>    53 |         delete (EVP_MD_CTX *)context;
ucommon>       |                ^~~~~~~~~~~~~~~~~~~~~
ucommon> In file included from /nix/store/4cq6vq5s3nscayqribkdsz36a2h75cw3-openssl-1.1.1q-dev/include/openssl/crypto.h:25,
ucommon>                  from /nix/store/4cq6vq5s3nscayqribkdsz36a2h75cw3-openssl-1.1.1q-dev/include/openssl/comp.h:16,
ucommon>                  from /nix/store/4cq6vq5s3nscayqribkdsz36a2h75cw3-openssl-1.1.1q-dev/include/openssl/ssl.h:17,
ucommon>                  from local.h:27,
ucommon>                  from digest.cpp:19:
ucommon> /nix/store/4cq6vq5s3nscayqribkdsz36a2h75cw3-openssl-1.1.1q-dev/include/openssl/ossl_typ.h:92:16: note: forward declaration of 'struct evp_md_ctx_st'
ucommon>    92 | typedef struct evp_md_ctx_st EVP_MD_CTX;
ucommon>       |                ^~~~~~~~~~~~~
ucommon> digest.cpp:53:9: note: neither the destructor nor the class-specific 'operator delete' will be called, even if they are declared when the class is defined
ucommon>    53 |         delete (EVP_MD_CTX *)context;
ucommon>       |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
ucommon> digest.cpp: In member function 'void ucommon::Digest::reset()':
ucommon> digest.cpp:74:27: error: invalid use of incomplete type 'EVP_MD_CTX' {aka 'struct evp_md_ctx_st'}
ucommon>    74 |             context = new EVP_MD_CTX;
ucommon>       |                           ^~~~~~~~~~
ucommon> In file included from /nix/store/4cq6vq5s3nscayqribkdsz36a2h75cw3-openssl-1.1.1q-dev/include/openssl/crypto.h:25,
ucommon>                  from /nix/store/4cq6vq5s3nscayqribkdsz36a2h75cw3-openssl-1.1.1q-dev/include/openssl/comp.h:16,
ucommon>                  from /nix/store/4cq6vq5s3nscayqribkdsz36a2h75cw3-openssl-1.1.1q-dev/include/openssl/ssl.h:17,
ucommon>                  from local.h:27,
ucommon>                  from digest.cpp:19:
ucommon> /nix/store/4cq6vq5s3nscayqribkdsz36a2h75cw3-openssl-1.1.1q-dev/include/openssl/ossl_typ.h:92:16: note: forward declaration of 'EVP_MD_CTX' {aka 'struct evp_md_ctx_st'}
ucommon>    92 | typedef struct evp_md_ctx_st EVP_MD_CTX;
ucommon>       |                ^~~~~~~~~~~~~
ucommon> make[2]: *** [Makefile:501: digest.lo] Error 1
ucommon> make[2]: Leaving directory '/build/ucommon-7.0.0/openssl'
ucommon> make[1]: *** [Makefile:641: all-recursive] Error 1
ucommon> make[1]: Leaving directory '/build/ucommon-7.0.0'
ucommon> make: *** [Makefile:436: all] Error 2
```

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
