### PR TITLE
adguardhome: 0.107.9 - 0.107.11

### DIFF
--- a/pkgs/servers/adguardhome/bins.nix
+++ b/pkgs/servers/adguardhome/bins.nix
@@ -1,23 +1,23 @@
 { fetchurl, fetchzip }:
 {
 x86_64-darwin = fetchzip {
-  sha256 = "sha256-SLGzciTzzvW0DTG8v6lNb1IovbOjxBFgFVjNY6MEyKY=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.9/AdGuardHome_darwin_amd64.zip";
+  sha256 = "sha256-QS/GMUXZ3FlBDfgLXEUeqWb4jNDXaRpRlieWjxmMe5U=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.11/AdGuardHome_darwin_amd64.zip";
 };
 aarch64-darwin = fetchzip {
-  sha256 = "sha256-d7hnCM7BJuYfSH89jv516uVyKTMueQmVKQxEeTGIDUE=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.9/AdGuardHome_darwin_arm64.zip";
+  sha256 = "sha256-LQcIlQUbL7fDQQKKEr5HdL87O/dv7sD4ESqAxfeMo28=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.11/AdGuardHome_darwin_arm64.zip";
 };
 i686-linux = fetchurl {
-  sha256 = "sha256-wTmUF6NHWis4dyw/bPjAjvZ0aQ1l1BCDlm6eLu4m/0o=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.9/AdGuardHome_linux_386.tar.gz";
+  sha256 = "sha256-VIvQ+dhPi+gCGoCwwmnNscFPqfTCNqZdZsMYFYSFCuE=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.11/AdGuardHome_linux_386.tar.gz";
 };
 x86_64-linux = fetchurl {
-  sha256 = "sha256-Mxe9Gb1ErrZZl3a+0SqC/0ghoeV51X93YxIOs9gM2lY=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.9/AdGuardHome_linux_amd64.tar.gz";
+  sha256 = "sha256-aTZ/nfzJBJX7pV/xn/7QwPvK95GY5DIzeNs4O/6UBDw=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.11/AdGuardHome_linux_amd64.tar.gz";
 };
 aarch64-linux = fetchurl {
-  sha256 = "sha256-SyHuzXAe24Nf0v9Ds3Z+cbXoIVLCJSj243I6B0XWBlM=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.9/AdGuardHome_linux_arm64.tar.gz";
+  sha256 = "sha256-aYPMMjI7azFtGUvPy2KnS0o7lTmtsOaOVgIFCWkfNi4=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.11/AdGuardHome_linux_arm64.tar.gz";
 };
 }

--- a/pkgs/servers/adguardhome/default.nix
+++ b/pkgs/servers/adguardhome/default.nix
@@ -7,7 +7,7 @@ in
 
 stdenv.mkDerivation rec {
   pname = "adguardhome";
-  version = "0.107.9";
+  version = "0.107.11";
   src = sources.${system} or (throw "Source for ${pname} is not available for ${system}");
 
   installPhase = ''


### PR DESCRIPTION
###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

