### PR TITLE
ovmf: expose EFI prefixes and refactor qemu-vm with it

### DIFF
--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -98,12 +98,6 @@ let
   addDeviceNames =
     imap1 (idx: drive: drive // { device = driveDeviceName idx; });
 
-  efiPrefix =
-    if pkgs.stdenv.hostPlatform.isx86 then "${pkgs.OVMF.fd}/FV/OVMF"
-    else if pkgs.stdenv.isAarch64 then "${pkgs.OVMF.fd}/FV/AAVMF"
-    else throw "No EFI firmware available for platform";
-  efiFirmware = "${efiPrefix}_CODE.fd";
-  efiVarsDefault = "${efiPrefix}_VARS.fd";
 
   # Shell script to start the VM.
   startVM =
@@ -218,14 +212,14 @@ let
               ${qemu}/bin/qemu-img create -f qcow2 $diskImage "60M"
               ${if cfg.useEFIBoot then ''
                 efiVars=$out/efi-vars.fd
-                cp ${efiVarsDefault} $efiVars
+                cp ${cfg.efi.variables} $efiVars
                 chmod 0644 $efiVars
               '' else ""}
             '';
           buildInputs = [ pkgs.util-linux ];
           QEMU_OPTS = "-nographic -serial stdio -monitor none"
                       + lib.optionalString cfg.useEFIBoot (
-                        " -drive if=pflash,format=raw,unit=0,readonly=on,file=${efiFirmware}"
+                        " -drive if=pflash,format=raw,unit=0,readonly=on,file=${cfg.efi.firmware}"
                       + " -drive if=pflash,format=raw,unit=1,file=$efiVars");
         }
         ''
@@ -705,7 +699,30 @@ in
             manager.
             useEFIBoot is ignored if useBootLoader == false.
           '';
+        };
+
+    virtualisation.efi = {
+      firmware = mkOption {
+        type = types.path;
+        default = pkgs.OVMF.firmware;
+        defaultText = "pkgs.OVMF.firmware";
+        description =
+          lib.mdDoc ''
+            Firmware binary for EFI implementation, defaults to OVMF.
+          '';
       };
+
+      variables = mkOption {
+        type = types.path;
+        default = pkgs.OVMF.variables;
+        defaultText = "pkgs.OVMF.variables";
+        description =
+          lib.mdDoc ''
+            Platform-specific flash binary for EFI variables, implementation-dependent to the EFI firmware.
+            Defaults to OVMF.
+          '';
+      };
+    };
 
     virtualisation.useDefaultFilesystems =
       mkOption {
@@ -928,7 +945,7 @@ in
         ''-append "$(cat ${config.system.build.toplevel}/kernel-params) init=${config.system.build.toplevel}/init regInfo=${regInfo}/registration ${consoles} $QEMU_KERNEL_PARAMS"''
       ])
       (mkIf cfg.useEFIBoot [
-        "-drive if=pflash,format=raw,unit=0,readonly=on,file=${efiFirmware}"
+        "-drive if=pflash,format=raw,unit=0,readonly=on,file=${cfg.efi.firmware}"
         "-drive if=pflash,format=raw,unit=1,file=$NIX_EFI_VARS"
       ])
       (mkIf (cfg.bios != null) [

--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, edk2, util-linux, nasm, acpica-tools
+{ stdenv, nixosTests, lib, edk2, util-linux, nasm, acpica-tools
 , csmSupport ? false, seabios ? null
 , secureBoot ? false
 , httpSupport ? false
@@ -19,9 +19,15 @@ let
     throw "Unsupported architecture";
 
   version = lib.getVersion edk2;
+
+  suffixes = {
+    x86_64 = "FV/OVMF";
+    aarch64 = "FV/AAVMF";
+  };
+
 in
 
-edk2.mkDerivation projectDscPath {
+edk2.mkDerivation projectDscPath (finalAttrs: {
   pname = "OVMF";
   inherit version;
 
@@ -62,10 +68,23 @@ edk2.mkDerivation projectDscPath {
 
   dontPatchELF = true;
 
+  passthru =
+  let
+    cpuName = stdenv.hostPlatform.parsed.cpu.name;
+    suffix = suffixes."${cpuName}" or (throw "Host cpu name `${cpuName}` is not supported in this OVMF derivation!");
+    prefix = "${finalAttrs.finalPackage.fd}/${suffix}";
+  in {
+    firmware  = "${prefix}_CODE.fd";
+    variables = "${prefix}_VARS.fd";
+    # This will test the EFI firmware for the host platform as part of the NixOS Tests setup.
+    tests.basic-systemd-boot = nixosTests.systemd-boot.basic;
+  };
+
   meta = {
     description = "Sample UEFI firmware for QEMU and KVM";
     homepage = "https://github.com/tianocore/tianocore.github.io/wiki/OVMF";
     license = lib.licenses.bsd2;
     platforms = ["x86_64-linux" "i686-linux" "aarch64-linux" "x86_64-darwin"];
+    maintainers = [ lib.maintainers.raitobezarius ];
   };
-}
+})

--- a/pkgs/development/compilers/edk2/default.nix
+++ b/pkgs/development/compilers/edk2/default.nix
@@ -89,7 +89,7 @@ edk2 = buildStdenv.mkDerivation {
   passthru = {
     mkDerivation = projectDscPath: attrsOrFun: buildStdenv.mkDerivation (finalAttrs:
     let
-      attrs = if lib.isFunction attrsOrFun then (attrsOrFun finalAttrs) else attrsOrFun;
+      attrs = lib.toFunction attrsOrFun finalAttrs;
     in
     {
       inherit (edk2) src;

--- a/pkgs/development/compilers/edk2/default.nix
+++ b/pkgs/development/compilers/edk2/default.nix
@@ -87,7 +87,11 @@ edk2 = buildStdenv.mkDerivation {
   };
 
   passthru = {
-    mkDerivation = projectDscPath: attrs: buildStdenv.mkDerivation ({
+    mkDerivation = projectDscPath: attrsOrFun: buildStdenv.mkDerivation (finalAttrs:
+    let
+      attrs = if lib.isFunction attrsOrFun then (attrsOrFun finalAttrs) else attrsOrFun;
+    in
+    {
       inherit (edk2) src;
 
       depsBuildBuild = [ buildPackages.stdenv.cc ] ++ attrs.depsBuildBuild or [];


### PR DESCRIPTION
###### Description of changes

In summary:
- EDK2 `mkDerivation` supports functional-style `mkDerivation` ;
- OVMF exposes EFI prefixes in `passthru` as `firmware` and `variables`
- `virtualisation/qemu-vm` uses it to pass them in the machinery, consolidating it ;
- adding myself as a maintainer of OVMF as I know well the ecosystem and am interested into maintaining it

**How to test this?** : `nix-build nixos/tests/systemd-boot.nix -A basic`, it if works, then QEMU's EFI still works fine. :)

It is pretty common to require the EFI firmware and variables of OVMF, this exposes it in `passthru` as suggested by @roberth on Matrix.
`qemu-vm` can be refactored with this, showing an example of usage.
This makes it easier to consolidate and add new architectures that OVMF supports, e.g. RISC-V, Raspberry Pi, etc.
I tested `systemd-boot.basic` test with this, which relies on EFI, so it should have tested this part of the code.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
