### PR TITLE
`command-not-found` flake support

### DIFF
--- a/nixos/modules/programs/command-not-found/command-not-found.pl
+++ b/nixos/modules/programs/command-not-found/command-not-found.pl
@@ -27,7 +27,7 @@ sub nix_shell_run {
     my ($package, $ARGV) = @_;
     if ($ENV{"NIX_AUTO_RUN_FLAKE"} // "") {
         # relies on flake registry
-        exec("nix", "shell", "nixpkgs#" . $package, "--command", shell_quote("exec", @ARGV));
+        exec("nix", "shell", "nixpkgs#" . $package, "--command", @ARGV);
     } else {
         exec("nix-shell", "-p", $package, "--run", shell_quote("exec", @ARGV));
     }

--- a/nixos/modules/programs/command-not-found/command-not-found.pl
+++ b/nixos/modules/programs/command-not-found/command-not-found.pl
@@ -24,7 +24,7 @@ my $res = $dbh->selectall_arrayref(
 my $len = !defined $res ? 0 : scalar @$res;
 
 sub nix_shell_run {
-    my ($package, $ARGV) = @_;
+    my ($package, @ARGV) = @_;
     if ($ENV{"NIX_AUTO_RUN_FLAKE"} // "") {
         # relies on flake registry
         exec("nix", "shell", "nixpkgs#" . $package, "--command", @ARGV);
@@ -49,7 +49,7 @@ if ($len == 0) {
                 }
             }
         }
-        nix_shell_run($package, $ARGV);
+        nix_shell_run($package, @ARGV);
     } else {
         print STDERR <<EOF;
 The program '$program' is not in your PATH. You can make it available in an
@@ -71,7 +71,7 @@ EOF
             # so we start from 1
             $choice = <STDIN> + 0;
             if (1 <= $choice && $choice <= $len) {
-                nix_shell_run(@$res[$choice - 1]->{package}, $ARGV);
+                nix_shell_run(@$res[$choice - 1]->{package}, @ARGV);
             }
         }
     } else {

--- a/nixos/modules/programs/command-not-found/command-not-found.pl
+++ b/nixos/modules/programs/command-not-found/command-not-found.pl
@@ -23,6 +23,16 @@ my $res = $dbh->selectall_arrayref(
 
 my $len = !defined $res ? 0 : scalar @$res;
 
+sub nix_shell_run {
+    my ($package, $ARGV) = @_;
+    if ($ENV{"NIX_AUTO_RUN_FLAKE"} // "") {
+        # relies on flake registry
+        exec("nix", "shell", "nixpkgs#" . $package, "--command", shell_quote("exec", @ARGV));
+    } else {
+        exec("nix-shell", "-p", $package, "--run", shell_quote("exec", @ARGV));
+    }
+}
+
 if ($len == 0) {
     print STDERR "$program: command not found\n";
 } elsif ($len == 1) {
@@ -39,12 +49,7 @@ if ($len == 0) {
                 }
             }
         }
-        if ($ENV{"NIX_AUTO_RUN_FLAKE"} // "") {
-            # relies on flake registry
-            exec("nix", "shell", "nixpkgs#" . $package, "--command", shell_quote(@ARGV));
-        } else {
-            exec("nix-shell", "-p", $package, "--run", shell_quote("exec", @ARGV));
-        }
+        nix_shell_run($package, $ARGV);
     } else {
         print STDERR <<EOF;
 The program '$program' is not in your PATH. You can make it available in an
@@ -66,14 +71,7 @@ EOF
             # so we start from 1
             $choice = <STDIN> + 0;
             if (1 <= $choice && $choice <= $len) {
-                if ($ENV{"NIX_AUTO_RUN_FLAKE"} // "") {
-                    # relies on flake registry
-                    exec("nix", "shell", "nixpkgs#" . @$res[$choice - 1]->{package},
-                        "--command", shell_quote(@ARGV));
-                } else {
-                    exec("nix-shell", "-p", @$res[$choice - 1]->{package},
-                        "--run", shell_quote("exec", @ARGV));
-                }
+                nix_shell_run(@$res[$choice - 1]->{package}, $ARGV);
             }
         }
     } else {


### PR DESCRIPTION
###### Description of changes

Fixes https://github.com/NixOS/nixpkgs/issues/185692.

Add support for `nix shell` to `command-not-found` to benefit from flake's nix expression evaluation caching [0], and to benefit NixOS systems by using the system's version of nixpkgs (if flake's nixpkgs has been pinned to nixos's with `nix.registry.nixpkgs.flake = nixpkgs`[1])

To enable, set the environment variable NIX_AUTO_RUN_FLAKE.

[0] https://www.tweag.io/blog/2020-06-25-eval-cache/
[1] https://www.tweag.io/blog/2020-07-31-nixos-flakes#pinning-nixpkgs

###### Things done

- Built on platform(s)
    - [x] 86_64-linux