### PR TITLE
tessen: init at unstable-2022-08-04

### DIFF
--- a/pkgs/tools/security/tessen/default.nix
+++ b/pkgs/tools/security/tessen/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, stdenvNoCC
+, fetchFromSourcehut
+, makeWrapper
+, installShellFiles
+, wtype
+, wl-clipboard
+, pass
+, bemenu
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "tessen";
+  version = "unstable-2022-08-04";
+
+  src = fetchFromSourcehut {
+    owner = "~ayushnix";
+    repo  = pname;
+    rev = "8758a09345f6eef24764de4a0efad737f12562c8";
+    sha256  = "sha256-U6obXpYzIprOJ+b3QiE+eDOq1s0DYiwM55qTga9/8TE=";
+  };
+
+  nativeBuildInputs = [ makeWrapper installShellFiles ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -D tessen $out/bin/tessen
+    wrapProgram $out/bin/tessen --prefix PATH : ${ lib.makeBinPath [ bemenu pass wtype wl-clipboard ] }
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    installManPage man/*
+    installShellCompletion --cmd tessen \
+      --bash completion/tessen.bash-completion \
+      --fish completion/tessen.fish-completion
+    install -Dm644 config $out/share/tessen/config
+  '';
+
+  meta = with lib; {
+    homepage = "https://sr.ht/~ayushnix/tessen";
+    description = "An interactive menu to autotype and copy Pass and GoPass data";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ monaaraj ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31058,6 +31058,8 @@ with pkgs;
 
   termtosvg = callPackage ../tools/misc/termtosvg { };
 
+  tessen = callPackage ../tools/security/tessen { };
+
   inherit (callPackage ../applications/graphics/tesseract {
     inherit (darwin.apple_sdk.frameworks) Accelerate CoreGraphics CoreVideo;
   })


### PR DESCRIPTION
###### Description of changes
https://git.sr.ht/~ayushnix/tessen
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
