### PR TITLE
msmtp: we always provide a path to msmtp

### DIFF
--- a/pkgs/applications/networking/msmtp/paths.patch
+++ b/pkgs/applications/networking/msmtp/paths.patch
@@ -1,8 +1,18 @@
-35cab741af069571cf4c55e0ce1ae96617d5778c nixify
 diff --git a/scripts/msmtpq/msmtpq b/scripts/msmtpq/msmtpq
-index d8b4039..1ab89f8 100755
+index d8b4039..1f2a7b5 100755
 --- a/scripts/msmtpq/msmtpq
 +++ b/scripts/msmtpq/msmtpq
+@@ -60,8 +60,8 @@ err() { dsp '' "$@" '' ; exit 1 ; }
+ ##   e.g. ( export MSMTP=/path/to/msmtp )
+ if [ "$MSMTP" = "" ] ; then  # If MSMTP is unset or empty...
+   MSMTP=msmtp
+-elif [ ! -x "$MSMTP" ] ; then
+-  log -e 1 "msmtpq : can't find the msmtp executable [ $MSMTP ]"   # if not found - complain ; quit
++# elif [ ! -x "$MSMTP" ] ; then
++#   log -e 1 "msmtpq : can't find the msmtp executable [ $MSMTP ]"   # if not found - complain ; quit
+ fi
+ ##
+ ## set the queue var to the location of the msmtp queue directory
 @@ -71,7 +71,7 @@ fi
  ##            ( chmod 0700 msmtp.queue )
  ##


### PR DESCRIPTION
###### Description of changes

resholve sets the MSMTP variable to msmtp which the script then tries to resolve, fails and calls the `log` function that isn't defined yet: https://github.com/marlam/msmtp-mirror/issues/93

We don't need the check, as we ensure it's there.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
