### PR TITLE
lib: add toIntBase function to parse hex and octal integer strings

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -369,6 +369,7 @@ let
         fixedWidthString
         fixedWidthNumber
         toInt
+        toIntBase
         toIntBase10
         readPathsFromFile
         fileContents

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -3001,4 +3001,60 @@ rec {
             levenshtein ainfix binfix <= k;
       in
       f;
+
+  /* Parse string as an int with the specified base.
+
+     The base can be from 2 to 16, inclusive.
+
+     Case insensitive. Leading zeroes are allowed. A leading - or + sign is allowed. Base prefixes like 0x are not supported.
+
+     Type: int -> string -> int
+
+     Example:
+       toIntBase 10 "123"
+       => 123
+       toIntBase 16 "beef"
+       => 48879
+       toIntBase 8 "-777"
+       => -511
+       toIntBase 2 "10101010"
+       => 170
+       toIntBase 16 "0xABC"
+       => error: toIntBase: invalid character 'x' in base 16 integer string
+  */
+  toIntBase = base: str:
+    assert lib.assertMsg (base >= 2 && base <= 16) "toIntBase: invalid base: ${toString base}";
+    assert lib.assertMsg (builtins.stringLength str > 0) "toIntBase: empty string";
+    let
+      alphabet = { "0" = 0; "1" = 1; "2" = 2; "3" = 3; "4" = 4; "5" = 5; "6" = 6; "7" = 7; "8" = 8; "9" = 9; "a" = 10; "b" = 11; "c" = 12; "d" = 13; "e" = 14; "f" = 15; };
+
+      # Remove an optional leading -/+. Return a list of digit characters and a -1 or 1 depending on the sign.
+      processSign = str:
+        let list = stringToCharacters str;
+            first = builtins.elemAt list 0;
+        in
+          if first == "-" then { sign = -1; digits = lib.lists.drop 1 list; }
+            else if first == "+" then { sign = 1; digits = lib.lists.drop 1 list; }
+            else { sign = 1; digits = list; };
+
+      result = processSign (toLower str);
+      digits = result.digits;
+      sign = result.sign;
+      numDigits = builtins.length digits;
+      invalidCharErrorMsg = digit: "toIntBase: invalid character '${digit}' in base ${toString base} integer string";
+
+      go = i: n:
+        let
+          digit = builtins.elemAt digits i;
+          add = alphabet."${digit}" or (throw (invalidCharErrorMsg digit));
+        in
+        if i >= numDigits then n
+        else
+          assert lib.assertMsg (add < base) (invalidCharErrorMsg digit);
+          go (i + 1) (n * base + add);
+
+    in
+      assert lib.assertMsg (numDigits > 0) "toIntBase: invalid integer string";
+      sign * go 0 0;
+
 }

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -109,6 +109,7 @@ let
     toHexString
     fromHexString
     toInt
+    toIntBase
     toIntBase10
     toShellVars
     types
@@ -1569,6 +1570,40 @@ runTests {
       value = false;
     };
   };
+
+  testToIntBase = testAllTrue [
+    ( 0 == toIntBase 10 "0")
+    ( 0 == toIntBase 2 "0")
+    ( 0 == toIntBase 2 "00000000000000")
+    ( 123 == toIntBase 10 "123")
+    ( 123 == toIntBase 10 "0000123")
+    ( -123 == toIntBase 10 "-0000123")
+    ( 123 == toIntBase 8 "173")
+    ( 48879 == toIntBase 16 "BEEF")
+    ( -48879 == toIntBase 16 "-Beef")
+    ( 64206 == toIntBase 16 "+face")
+    ( 4613973002748035588 == toIntBase 2 "100000000001000001000000000000000001000000010100000001000000100")
+    ( -4613973002748035588 == toIntBase 2 "-100000000001000001000000000000000001000000010100000001000000100")
+    ( 9223372036854775807 == toIntBase 16 "7FFFFFFFFFFFFFFF")
+    ( -9223372036854775807 == toIntBase 16 "-7FFFFFFFFFFFFFFF")
+  ];
+
+  testToIntBaseFails = testAllTrue [
+    ( builtins.tryEval (toIntBase 10 "" ) == { success = false; value = false; } )
+    ( builtins.tryEval (toIntBase 10 " " ) == { success = false; value = false; } )
+    ( builtins.tryEval (toIntBase 10 " 1" ) == { success = false; value = false; } )
+    ( builtins.tryEval (toIntBase 10 "1 " ) == { success = false; value = false; } )
+    ( builtins.tryEval (toIntBase 10 "-" ) == { success = false; value = false; } )
+    ( builtins.tryEval (toIntBase 10 "+" ) == { success = false; value = false; } )
+    ( builtins.tryEval (toIntBase 10 "- " ) == { success = false; value = false; } )
+    ( builtins.tryEval (toIntBase 10 "10beef" ) == { success = false; value = false; } )
+    ( builtins.tryEval (toIntBase 16 "0xbeef" ) == { success = false; value = false; } )
+    ( builtins.tryEval (toIntBase 2 "0777" ) == { success = false; value = false; } )
+    ( builtins.tryEval (toIntBase 1 "0" ) == { success = false; value = false; } )
+    ( builtins.tryEval (toIntBase 0 "0" ) == { success = false; value = false; } )
+    ( builtins.tryEval (toIntBase (-1) "0" ) == { success = false; value = false; } )
+    ( builtins.tryEval (toIntBase 17 "0" ) == { success = false; value = false; } )
+  ];
 
   testHasAttrByPathTrue = {
     expr = hasAttrByPath [ "a" "b" ] {


### PR DESCRIPTION
###### Description of changes
I'd like to parse octal and hexadecimal integer strings in my code.

This PR adds a function to parse integer strings with different bases, called `toIntBase`.

```
toIntBase 10 "123"
=> 123
toIntBase 16 "beef"
=> 48879
toIntBase 8 "-777"
=> -511
toIntBase 2 "10101010"
=> 170
toIntBase 16 "0xABC"
=> error: toIntBase: invalid character 'x' in base 16 integer string
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
