### PR TITLE
rqlite: init at 7.6.1

### DIFF
--- a/pkgs/servers/sql/rqlite/default.nix
+++ b/pkgs/servers/sql/rqlite/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "rqlite";
+  version = "7.6.1";
+
+  src = fetchFromGitHub {
+    owner = "rqlite";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-WvEnMAz3dKG8xMlQzm7E0TmAgvsrRED50bb4Ved1+4U=";
+  };
+
+  vendorSha256 = "sha256-qirt5g7dcjAnceejrBnfhDpA4LSEj7eOuznSlfUBUgo=";
+
+  subPackages = [ "cmd/rqlite" "cmd/rqlited" "cmd/rqbench" ];
+
+  # Leaving other flags from https://github.com/rqlite/rqlite/blob/master/package.sh
+  # since automatically retriving those is nontrivial and inessential
+  ldflags = [
+    "-X github.com/rqlite/rqlite/cmd.Version=${src.rev}"
+  ];
+
+  # Tests are in a different subPackage which fails trying to access the network
+  doCheck = false;
+
+  meta = with lib; {
+    description = "The lightweight, distributed relational database built on SQLite";
+    homepage = "https://github.com/rqlite/rqlite";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dit7ya ];
+  };
+}

--- a/pkgs/servers/sql/rqlite/default.nix
+++ b/pkgs/servers/sql/rqlite/default.nix
@@ -21,6 +21,7 @@ buildGoModule rec {
   # Leaving other flags from https://github.com/rqlite/rqlite/blob/master/package.sh
   # since automatically retriving those is nontrivial and inessential
   ldflags = [
+    "-s" "-w"
     "-X github.com/rqlite/rqlite/cmd.Version=${src.rev}"
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21100,6 +21100,8 @@ with pkgs;
 
   rover = callPackage ../development/tools/rover { };
 
+  rqlite = callPackage ../servers/sql/rqlite { };
+
   rshell = python3.pkgs.callPackage ../development/embedded/rshell { };
 
   rttr = callPackage ../development/libraries/rttr { };


### PR DESCRIPTION
###### Description of changes

The lightweight, distributed relational database built on SQLite
https://github.com/rqlite/rqlite

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
