### PR TITLE
ripe-atlas-tools: init at 3.0.2

### DIFF
--- a/pkgs/tools/networking/ripe-atlas-tools/default.nix
+++ b/pkgs/tools/networking/ripe-atlas-tools/default.nix
@@ -1,0 +1,95 @@
+{ lib
+, python3
+, fetchFromGitHub
+, installShellFiles
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "ripe-atlas-tools";
+  version = "3.0.2";
+
+  src = fetchFromGitHub {
+    owner = "RIPE-NCC";
+    repo = "ripe-atlas-tools";
+    rev = "v${version}";
+    sha256 = "sha256-5AMqBXxJZOtI0/2NrEjrUfNXWKc7sn6kZX26766LBUM=";
+  };
+
+  postPatch = ''
+    # This mapping triggers network access on docs generation: https://github.com/RIPE-NCC/ripe-atlas-tools/issues/235
+    sed -i '/^intersphinx_mapping/d' docs/conf.py
+    # TODO: Ensure user-agent is picked up during build, remove me when https://github.com/RIPE-NCC/ripe-atlas-tools/pull/236
+    echo "include ripe/atlas/tools/user-agent" >> MANIFEST.in
+  '';
+
+  nativeBuildInputs = with python3.pkgs; [
+    sphinx-rtd-theme
+    sphinxHook
+    installShellFiles
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    ripe-atlas-cousteau
+    ripe-atlas-sagan
+    ujson
+    ipy
+    python-dateutil
+    requests
+    tzlocal
+    pyyaml
+    pyopenssl
+  ];
+
+  preBuild = ''
+    echo "RIPE Atlas Tools [NixOS ${lib.trivial.version}] ${version}" > ripe/atlas/tools/user-agent
+  '';
+
+  postInstall = ''
+    installShellCompletion --cmd ripe-atlas --bash ./ripe-atlas-bash-completion.sh
+  '';
+
+  pythonImportsCheck = [
+    "ripe.atlas.tools"
+  ];
+
+  checkInputs = with python3.pkgs; [
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # Network tests: https://github.com/RIPE-NCC/ripe-atlas-tools/issues/234
+    "test_arg_from_file"
+    "test_arg_from_stdin"
+    # We injected our user-agent so the tests will fail
+    "test_user_agent_mac"
+    "test_user_agent_windows"
+    "test_user_agent_xdg_absent"
+    "test_user_agent_xdg_present"
+  ];
+
+  disabledTestPaths = [
+    # Relies on `ripe-atlas` being available in the PATH, installed with autocompletions
+    "tests/test_bash_completion.py"
+    # AS lookups are not mocked up: https://github.com/RIPE-NCC/ripe-atlas-tools/blob/master/tests/renderers/test_traceroute_aspath.py#L26
+    "tests/renderers/test_traceroute_aspath.py"
+    # We already build Sphinx so we do not need to test it
+    "tests/test_docs.py"
+  ];
+
+  HOME = "$TMPDIR"; # for cache generation.
+
+  # Necessary because it confuse the tests when it does "from ripe.atlas.sagan import X"
+  # version.py is used by Sphinx tests.
+  preCheck = ''
+    rm -rf ripe
+    mkdir -p ripe/atlas/tools
+    echo "__version__ = \"${version}\"" > ripe/atlas/tools/version.py
+  '';
+
+  meta = with lib; {
+    description = "RIPE ATLAS project tools";
+    homepage = "https://github.com/RIPE-NCC/ripe-atlas-tools";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4649,6 +4649,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) AppKit Security;
   };
 
+  ripe-atlas-tools = callPackage ../tools/networking/ripe-atlas-tools { };
+
   roundcube = callPackage ../servers/roundcube { };
 
   roundcubePlugins = dontRecurseIntoAttrs (callPackage ../servers/roundcube/plugins { });


### PR DESCRIPTION
##### Motivation for this change
RIPE Atlas tools are command line tooling for the RIPE Atlas measurements project: https://atlas.ripe.net/measurements/ which is very useful to measure state of services across multiple point of presence.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
