### PR TITLE
jtdx: init at 159

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2177,6 +2177,12 @@
     githubId = 543423;
     name = "Alex Wied";
   };
+  CesarGallego = {
+    email = "gallego.cesar@gmail.com";
+    github = "CesarGallego";
+    githubId = 7999138;
+    name = "César Gallego Rodríguez";
+  };
   cfhammill = {
     email = "cfhammill@gmail.com";
     github = "cfhammill";

--- a/pkgs/applications/radio/jtdx/default.nix
+++ b/pkgs/applications/radio/jtdx/default.nix
@@ -1,0 +1,44 @@
+{ lib, stdenv, fetchFromGitHub, asciidoc, asciidoctor, autoconf, automake, cmake,
+  docbook_xsl, fftw, fftwFloat, gfortran, libtool, libusb1, qtbase,
+  qtmultimedia, qtserialport, qttools, boost, texinfo, wrapQtAppsHook, jtdxhamlib, libsForQt5 }:
+
+stdenv.mkDerivation rec {
+  pname = "jtdx";
+  version = "2.2.159";
+
+  src = fetchFromGitHub {
+    owner = "jtdx-project";
+    repo = "jtdx";
+    rev = "159";
+    sha256 = "sha256-5KlFBlzG3hKFFGO37c+VN+FvZKSnTQXvSorB+Grns8w=";
+  };
+
+  nativeBuildInputs = [
+    asciidoc asciidoctor autoconf automake cmake docbook_xsl gfortran libtool
+    qttools texinfo wrapQtAppsHook libsForQt5.qtwebsockets
+  ];
+  buildInputs = [ fftw fftwFloat libusb1 qtbase qtmultimedia qtserialport boost jtdxhamlib ];
+
+  meta = with lib; {
+    description = "JTDX is a fork of WSJT-X, an amateur radio communication program using very weak signals";
+    longDescription = ''
+      JTDX means "JT modes for DXing", it is being developed with main focus on
+      the sensitivity and decoding efficiency, both, in overcrowded and half
+      empty HF band conditions.
+
+      It is open source software distributed under the GPL v3 license, and is
+      based on the WSJT-X r6462 source code.
+
+      Optimal candidate selection logic, four/five pass decoding and decoders
+      based on the matched filters making JTDX performance quite different from
+      WSJT-X software for operation on the HF bands.
+
+      Almost all work goes around JT65 mode, decoding efficieny of JT9 mode is
+      the same as in WSJT-X and might be addressed in the future JTDX versions.
+    '';
+    homepage = "https://sourceforge.net/projects/jtdx/files/";
+    license = with licenses; [ gpl3Plus ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ CesarGallego nilp0inter ];
+  };
+}

--- a/pkgs/development/libraries/jtdxhamlib/default.nix
+++ b/pkgs/development/libraries/jtdxhamlib/default.nix
@@ -1,0 +1,81 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, perl
+, swig
+, gd
+, ncurses
+, python3
+, libxml2
+, tcl
+, libusb-compat-0_1
+, pkg-config
+, autoconf
+, automake
+, boost
+, libtool
+, perlPackages
+, pythonBindings ? true
+, tclBindings ? true
+, perlBindings ? true
+}:
+
+stdenv.mkDerivation rec {
+  pname = "jtdxhamlib";
+  version = "159";
+
+  src = fetchFromGitHub {
+    owner = "jtdx-project";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-20nrI+XICdYGgsydFP7DM/zMMcOMBCHz8JZUM10IOmc=";
+  };
+
+  nativeBuildInputs = [
+    swig
+    pkg-config
+    libtool
+    autoconf
+    automake
+  ];
+
+  buildInputs = [
+    gd
+    libxml2
+    libusb-compat-0_1
+    boost
+  ] ++ lib.optionals pythonBindings [ python3 ncurses ]
+    ++ lib.optionals tclBindings [ tcl ]
+    ++ lib.optionals perlBindings [ perl perlPackages.ExtUtilsMakeMaker ];
+
+  preConfigure = ''
+    ./bootstrap
+  '';
+
+  configureFlags = lib.optionals perlBindings [ "--with-perl-binding" ]
+    ++ lib.optionals tclBindings [ "--with-tcl-binding" "--with-tcl=${tcl}/lib/" ]
+    ++ lib.optionals pythonBindings [ "--with-python-binding" ]
+    ++ [ "--disable-winradio" "--without-cxx-binding" ];
+
+  installPhase = ''
+    make install-strip
+  '';
+
+  meta = with lib; {
+    description = "Ham radio control library modified for JTDX";
+    longDescription = ''
+    This is a fork of Hamlib modified for JTDX.
+
+    Hamlib provides a standardized programming interface that applications
+    can use to send the appropriate commands to a radio.
+
+    Also included in the package is a simple radio control program 'rigctl',
+    which lets one control a radio transceiver or receiver, either from
+    command line interface or in a text-oriented interactive interface.
+    '';
+    license = with licenses; [ gpl2Plus lgpl2Plus ];
+    homepage = "https://github.com/jtdx-project/jtdxhamlib";
+    maintainers = with maintainers; [ CesarGallego nilp0inter ];
+    platforms = with platforms; unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18520,6 +18520,8 @@ with pkgs;
   hamlib_3 = callPackage ../development/libraries/hamlib { };
   hamlib_4 = callPackage ../development/libraries/hamlib/4.nix { };
 
+  jtdxhamlib = callPackage ../development/libraries/jtdxhamlib { };
+
   heimdal = callPackage ../development/libraries/kerberos/heimdal.nix {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security SystemConfiguration;
     autoreconfHook = buildPackages.autoreconfHook269;
@@ -31720,6 +31722,8 @@ with pkgs;
   wp-cli = callPackage ../development/tools/wp-cli { };
 
   wsjtx = qt5.callPackage ../applications/radio/wsjtx { };
+
+  jtdx = qt5.callPackage ../applications/radio/jtdx { };
 
   wxhexeditor = callPackage ../applications/editors/wxhexeditor {
     wxGTK = wxGTK31;


### PR DESCRIPTION
###### Description of changes

JTDX is forked from  WSJT-X, a computer  program  dedicated to amateur
radio communication using very weak signals. 

JTDX is widely used among ham-radio operators for its user friendliness and documentation. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

We tested the main user binary with a ham-radio device, and by proxy the rest of binaries that are used by the main binary.