### PR TITLE
prometheus: 2.36.0 -> 2.38.0

### DIFF
--- a/pkgs/servers/monitoring/prometheus/default.nix
+++ b/pkgs/servers/monitoring/prometheus/default.nix
@@ -19,6 +19,7 @@
 , enableLinode ? true
 , enableMarathon ? true
 , enableMoby ? true
+, enableNomad ? true
 , enableOpenstack ? true
 , enablePuppetDB ? true
 , enableScaleway ? true
@@ -30,10 +31,10 @@
 }:
 
 let
-  version = "2.36.0";
+  version = "2.38.0";
   webUiStatic = fetchurl {
     url = "https://github.com/prometheus/prometheus/releases/download/v${version}/prometheus-web-ui-${version}.tar.gz";
-    sha256 = "sha256-C+Np2mqAYQ1RUqYmql0eudPD/SpWmxdMQLe85SenIA4=";
+    sha256 = "sha256-0CcWHJYso9iI1isCa2ZKYtNpfqcUt5sj23xkufxv6rw=";
   };
 in
 buildGoModule rec {
@@ -44,10 +45,10 @@ buildGoModule rec {
     rev = "v${version}";
     owner = "prometheus";
     repo = "prometheus";
-    sha256 = "sha256-FJXNCGIVj1OVWXwbXY6k65lXJCe1MqiqK7tw8nGWrEg=";
+    sha256 = "sha256-5s2Q3xjublHAQSB6MaxZTMOPS0T6/Bn5Ki8NCkBYM2E=";
   };
 
-  vendorSha256 = "sha256-kmAQGRFmGRJ3LuGLMcSc0bJuwMsKhYVUIqQ9vDSH0Cc=";
+  vendorSha256 = "sha256-wfHdfW4D4ESbglUUjAl5a93aJqLuQkqKHMChHGnCmCg=";
 
   excludedPackages = [ "documentation/prometheus-mixin" ];
 
@@ -85,6 +86,8 @@ buildGoModule rec {
       "echo - github.com/prometheus/prometheus/discovery/marathon"}
     ${lib.optionalString (enableMoby)
       "echo - github.com/prometheus/prometheus/discovery/moby"}
+    ${lib.optionalString (enableNomad)
+      "echo - github.com/prometheus/prometheus/discovery/nomad"}
     ${lib.optionalString (enableOpenstack)
       "echo - github.com/prometheus/prometheus/discovery/openstack"}
     ${lib.optionalString (enablePuppetDB)


### PR DESCRIPTION
###### Description of changes
https://github.com/prometheus/prometheus/releases/tag/v2.37.0
https://github.com/prometheus/prometheus/releases/tag/v2.38.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
