### PR TITLE
cg3: init at version 1.3.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13349,6 +13349,15 @@
       fingerprint = "EE59 5E29 BB5B F2B3 5ED2  3F1C D276 FF74 6700 7335";
     }];
   };
+  unhammer = {
+    email = "unhammer@fsfe.org";
+    github = "unhammer";
+    githubId = 56868;
+    name = "Kevin Brubeck Unhammer";
+    keys = [{
+      fingerprint = "50D4 8796 0B86 3F05 4B6A  12F9 7426 06DE 766A C60C";
+    }];
+  };
   uniquepointer = {
     email = "uniquepointer@mailbox.org";
     matrix = "@uniquepointer:matrix.org";

--- a/pkgs/development/interpreters/cg3/default.nix
+++ b/pkgs/development/interpreters/cg3/default.nix
@@ -1,0 +1,61 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, runCommand
+, dieHook
+, cmake
+, icu
+, boost
+}:
+
+let cg3 = stdenv.mkDerivation rec {
+  pname = "cg3";
+  version = "1.3.7";
+
+  src = fetchFromGitHub {
+    owner = "GrammarSoft";
+    repo = "${pname}";
+    rev = "v${version}";
+    sha256 = "Ena3dGoZsXOIY6mbvnfI0H7QqRifoxWIBKQrK3yQSmY=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    icu
+    boost
+  ];
+
+  doCheck = true;
+
+  passthru.tests.minimal = runCommand "${pname}-test" {
+      buildInputs = [
+        cg3
+        dieHook
+      ];
+    } ''
+      echo 'DELIMITERS = "."; ADD (tag) (*);' >grammar.cg3
+      printf '"<a>"\n\t"a" tag\n\n' >want.txt
+      printf '"<a>"\n\t"a"\n\n' | vislcg3 -g grammar.cg3 >got.txt
+      diff -s want.txt got.txt || die "Grammar application did not produce expected parse"
+      touch $out
+    '';
+
+
+  # TODO, consider optionals:
+  # - Enable tcmalloc unless darwin?
+  # - Enable python bindings?
+
+  meta = with lib; {
+    homepage = "https://github.com/GrammarSoft/cg3";
+    description = "Constraint Grammar interpreter, compiler and applicator vislcg3";
+    maintainers = with maintainers; [ unhammer ];
+    license = licenses.gpl3Plus;
+    platforms = platforms.all;
+  };
+};
+
+in
+  cg3

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14587,6 +14587,8 @@ with pkgs;
 
   ceptre = callPackage ../development/interpreters/ceptre { };
 
+  cg3 = callPackage ../development/interpreters/cg3 { };
+
   cling = callPackage ../development/interpreters/cling { };
 
   clips = callPackage ../development/interpreters/clips { };


### PR DESCRIPTION
###### Description of changes

The VISL CG-3 Constraint Grammar parser/compiler/runner. CG is a method for rule-based disambiguation and parsing of natural language. See https://visl.sdu.dk/constraint_grammar.html and https://visl.sdu.dk/cg3.html . 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] (nothing depends on it yet) Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

