### PR TITLE
python3Packages.python3-otr: init at 2.0.1

### DIFF
--- a/pkgs/development/python-modules/python3-otr/default.nix
+++ b/pkgs/development/python-modules/python3-otr/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, isPy3k
+, fetchFromGitHub
+, fetchpatch
+, buildPythonPackage
+, gmpy2
+, zope_interface
+, python3-application
+, cryptography
+}:
+
+buildPythonPackage rec {
+  pname = "python3-otr";
+  version = "2.0.1";
+
+  disabled = !isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "AGProjects";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-XsJQIRZj04TkoWIddOc0evXwNFP/IYF/z/nO7mC0aVY=";
+  };
+
+  patches = [
+    # Apply bugfix commit that is not yet part of a release
+    (fetchpatch {
+      name = "fix-requirements.patch";
+      url = "https://github.com/AGProjects/python3-otr/commit/fbb42e3d288f693b6b2b55cbed327f8b475e937e.patch";
+      sha256 = "sha256-xoqKmLPU3es8exHvnn9n9DZdMaZ/BZ4MZsAiCy0Isks=";
+    })
+    (fetchpatch {
+      name = "fix-secret-bytes.patch";
+      url = "https://github.com/AGProjects/python3-otr/commit/c5f84a575166794e65611a13a83a0ed3fcd06279.patch";
+      sha256 = "sha256-KBpRMeJdrg5RkoMys6zsxyXDemPySRSMZj4/5qAA6w8=";
+    })
+  ];
+
+  propagatedBuildInputs = [ gmpy2 zope_interface python3-application cryptography ];
+
+  pythonImportsCheck = [ "otr" ];
+
+  meta = with lib; {
+    description = "Off-The-Record Messaging protocol implementation for Python";
+    homepage = "https://github.com/AGProjects/python3-otr";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ yureien ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8710,6 +8710,8 @@ in {
 
   python3-openid = callPackage ../development/python-modules/python3-openid { };
 
+  python3-otr = callPackage ../development/python-modules/python3-otr { };
+
   python-awair = callPackage ../development/python-modules/python-awair { };
 
   python3-saml = callPackage ../development/python-modules/python3-saml { };


### PR DESCRIPTION
###### Description of changes

https://github.com/AGProjects/python3-otr

Off-The-Record Messaging protocol implementation for Python

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
