### PR TITLE
python310Packages.paranoid-crypto: init at unstable-20220819

### DIFF
--- a/pkgs/development/python-modules/paranoid-crypto/default.nix
+++ b/pkgs/development/python-modules/paranoid-crypto/default.nix
@@ -1,0 +1,70 @@
+{ lib
+, absl-py
+, buildPythonPackage
+, cryptography
+, fetchFromGitHub
+, fpylll
+, gmpy
+, protobuf
+, pybind11
+, pytestCheckHook
+, pythonOlder
+, scipy
+, sympy
+}:
+
+buildPythonPackage rec {
+  pname = "paranoid-crypto";
+  version = "unstable-20220819";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "paranoid_crypto";
+    # https://github.com/google/paranoid_crypto/issues/11
+    rev = "8abccc1619748b93979d1c26234b90d26e88a12e";
+    hash = "sha256-4yF7WAFAGGhvWTV/y5dGVA/+9r1dqrXU/0/6Edgw3ow=";
+  };
+
+  nativeBuildInputs = [
+    protobuf
+    pybind11
+  ];
+
+  propagatedBuildInputs = [
+    absl-py
+    cryptography
+    gmpy
+    scipy
+    sympy
+    protobuf
+  ];
+
+  checkInputs = [
+    fpylll
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "protobuf==3.20.*" "protobuf"
+  '';
+
+  disabledTestPaths = [
+    # Import issue
+    "paranoid_crypto/lib/randomness_tests/"
+  ];
+
+  pythonImportsCheck = [
+    "paranoid_crypto"
+  ];
+
+  meta = with lib; {
+    description = "Library contains checks for well known weaknesses on cryptographic artifacts";
+    homepage = "https://github.com/google/paranoid_crypto";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6500,6 +6500,8 @@ in {
 
   paramz = callPackage ../development/python-modules/paramz { };
 
+  paranoid-crypto = callPackage ../development/python-modules/paranoid-crypto { };
+
   parfive = callPackage ../development/python-modules/parfive { };
 
   parquet = callPackage ../development/python-modules/parquet { };


### PR DESCRIPTION
###### Description of changes
Library contains checks for well known weaknesses on cryptographic artifacts

https://github.com/google/paranoid_crypto

Related to https://github.com/NixOS/nixpkgs/issues/81418
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
