### PR TITLE
python3Packages.sphinxHook: Add support for multiple builders

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -744,6 +744,53 @@ with the exception of `other` (see `format` in
   unittestFlags = [ "-s" "tests" "-v" ];
 ```
 
+##### Using sphinxHook {#using-sphinxhook}
+
+The `sphinxHook` is a helpful tool to build documentation and manpages
+using the popular Sphinx documentation generator.
+It is setup to automatically find common documentation source paths and
+render them using the default `html` style.
+
+```
+  outputs = [
+    "out"
+    "doc"
+  ];
+
+  nativeBuildInputs = [
+    sphinxHook
+  ];
+```
+
+The hook will automatically build and install the artifact into the
+`doc` output, if it exists. It also provides an automatic diversion
+for the artifacts of the `man` builder into the `man` target.
+
+```
+  outputs = [
+    "out"
+    "doc"
+    "man"
+  ];
+
+  # Use multiple builders
+  sphinxBuilders = [
+    "singlehtml"
+    "man"
+  ];
+```
+
+Overwrite `sphinxRoot` when the hook is unable to find your
+documentation source root.
+
+```
+  # Configure sphinxRoot for uncommon paths
+  sphinxRoot = "weird/docs/path";
+```
+
+The hook is also available to packages outside the python ecosystem by
+referencing it using `python3.pkgs.sphinxHook`.
+
 ### Develop local package {#develop-local-package}
 
 As a Python developer you're likely aware of [development mode](http://setuptools.readthedocs.io/en/latest/setuptools.html#development-mode)
@@ -1273,6 +1320,7 @@ are used in `buildPythonPackage`.
 - `pythonRemoveBinBytecode` to remove bytecode from the `/bin` folder.
 - `setuptoolsBuildHook` to build a wheel using `setuptools`.
 - `setuptoolsCheckHook` to run tests with `python setup.py test`.
+- `sphinxHook` to build documentation and manpages using Sphinx.
 - `venvShellHook` to source a Python 3 `venv` at the `venvDir` location. A
   `venv` is created if it does not yet exist. `postVenvCreation` can be used to
   to run commands only after venv is first created.

--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -1317,6 +1317,8 @@ are used in `buildPythonPackage`.
 - `pytestCheckHook` to run tests with `pytest`. See [example usage](#using-pytestcheckhook).
 - `pythonCatchConflictsHook` to check whether a Python package is not already existing.
 - `pythonImportsCheckHook` to check whether importing the listed modules works.
+- `pythonRelaxDepsHook` will relax Python dependencies restrictions for the package.
+  See [example usage](#using-pythonrelaxdepshook).
 - `pythonRemoveBinBytecode` to remove bytecode from the `/bin` folder.
 - `setuptoolsBuildHook` to build a wheel using `setuptools`.
 - `setuptoolsCheckHook` to run tests with `python setup.py test`.
@@ -1326,8 +1328,6 @@ are used in `buildPythonPackage`.
   to run commands only after venv is first created.
 - `wheelUnpackHook` to move a wheel to the correct folder so it can be installed
   with the `pipInstallHook`.
-- `pythonRelaxDepsHook` will relax Python dependencies restrictions for the package.
-  See [example usage](#using-pythonrelaxdepshook).
 - `unittestCheckHook` will run tests with `python -m unittest discover`. See [example usage](#using-unittestcheckhook).
 
 ### Development mode {#development-mode}

--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -6,6 +6,7 @@
 , isPy3k
 , ensureNewerSourcesForZipFilesHook
 , findutils
+, installShellFiles
 }:
 
 let
@@ -190,6 +191,6 @@ in rec {
   sphinxHook = callPackage ({ sphinx }:
     makeSetupHook {
       name = "python${python.pythonVersion}-sphinx-hook";
-      deps = [ sphinx ];
+      deps = [ sphinx installShellFiles ];
     } ./sphinx-hook.sh) {};
 }

--- a/pkgs/development/interpreters/python/hooks/sphinx-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/sphinx-hook.sh
@@ -69,5 +69,4 @@ installSphinxPhase() {
     runHook postInstallSphinx
 }
 
-preDistPhases+=" buildSphinxPhase"
-postPhases+=" installSphinxPhase"
+preDistPhases+=" buildSphinxPhase installSphinxPhase"

--- a/pkgs/development/interpreters/python/hooks/sphinx-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/sphinx-hook.sh
@@ -1,16 +1,3 @@
-# This hook automatically finds Sphinx documentation, builds it in html format
-# and installs it.
-#
-# This hook knows about several popular locations in which subdirectory
-# documentation may be, but in very unusual cases $sphinxRoot directory can be
-# set explicitly.
-#
-# Name of the directory relative to ${doc:-$out}/share/doc is normally also
-# deduced automatically, but can be overridden with $sphinxOutdir variable.
-#
-# Sphinx build system can depend on arbitrary amount of python modules, client
-# code is responsible for ensuring that all dependencies are present.
-
 # shellcheck shell=bash
 echo "Sourcing sphinx-hook"
 

--- a/pkgs/development/interpreters/python/hooks/sphinx-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/sphinx-hook.sh
@@ -6,7 +6,7 @@ declare -a __sphinxBuilders
 buildSphinxPhase() {
     echo "Executing buildSphinxPhase"
 
-    local __sphinxRoot="" o
+    local __sphinxRoot=""
     runHook preBuildSphinx
 
     if [[ -n "${sphinxRoot:-}" ]] ; then  # explicit root
@@ -16,10 +16,10 @@ buildSphinxPhase() {
         fi
         __sphinxRoot=$sphinxRoot
     else
-        for o in doc docs doc/source docs/source ; do
-            if [[ -f "$o/conf.py" ]] ; then
-                echo "Sphinx documentation found in $o"
-                __sphinxRoot=$o
+        for candidate in doc docs doc/source docs/source ; do
+            if [[ -f "$candidate/conf.py" ]] ; then
+                echo "Sphinx documentation found in $candidate"
+                __sphinxRoot=$candidate
                 break
             fi
         done

--- a/pkgs/development/interpreters/python/hooks/sphinx-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/sphinx-hook.sh
@@ -11,10 +11,17 @@
 # Sphinx build system can depend on arbitrary amount of python modules, client
 # code is responsible for ensuring that all dependencies are present.
 
-buildSphinxPhase() {
-    local __sphinxRoot="" o
+# shellcheck shell=bash
+echo "Sourcing sphinx-hook"
 
+declare -a __sphinxBuilders
+
+buildSphinxPhase() {
+    echo "Executing buildSphinxPhase"
+
+    local __sphinxRoot="" o
     runHook preBuildSphinx
+
     if [[ -n "${sphinxRoot:-}" ]] ; then  # explicit root
         if ! [[ -f "${sphinxRoot}/conf.py" ]] ; then
             echo 2>&1 "$sphinxRoot/conf.py: no such file"
@@ -35,20 +42,42 @@ buildSphinxPhase() {
         echo 2>&1 "Sphinx documentation not found, use 'sphinxRoot' variable"
         exit 1
     fi
-    sphinx-build -M html "${__sphinxRoot}" ".sphinx/html" -v
+
+    if [ -n "${sphinxBuilders-}" ]; then
+        eval "__sphinxBuilders=($sphinxBuilders)"
+    else
+        __sphinxBuilders=(html)
+    fi
+
+    for __builder in "${__sphinxBuilders[@]}"; do
+        echo "Executing sphinx-build with ${__builder} builder"
+        sphinx-build -M "${__builder}" "${__sphinxRoot}" ".sphinx/${__builder}" -v
+    done
 
     runHook postBuildSphinx
 }
 
 installSphinxPhase() {
+    echo "Executing installSphinxPhase"
+
     local docdir=""
     runHook preInstallSphinx
 
-    docdir="${doc:-$out}/share/doc/${sphinxOutdir:-$name}"
-    mkdir -p "$docdir"
+    for __builder in "${__sphinxBuilders[@]}"; do
+        # divert output for man builder
+        if [ "$__builder" == "man" ]; then
+            installManPage .sphinx/man/man/*
 
-    cp -r .sphinx/html/html "$docdir/"
-    rm -fr "${docdir}/html/_sources" "${docdir}/html/.buildinfo"
+        else
+            # shellcheck disable=2154
+            docdir="${doc:-$out}/share/doc/${pname}"
+
+            mkdir -p "$docdir"
+
+            cp -r ".sphinx/${__builder}/${__builder}" "$docdir/"
+            rm -fr "${docdir}/${__builder}/_sources" "${docdir}/${__builder}/.buildinfo"
+        fi
+    done
 
     runHook postInstallSphinx
 }

--- a/pkgs/tools/backup/borgbackup/default.nix
+++ b/pkgs/tools/backup/borgbackup/default.nix
@@ -33,12 +33,14 @@ python3.pkgs.buildPythonApplication rec {
     setuptools-scm
 
     # docs
-    sphinx
+    sphinxHook
     guzzle_sphinx_theme
 
     # shell completions
     installShellFiles
   ];
+
+  sphinxBuilders = [ "singlehtml" "man" ];
 
   buildInputs = [
     libb2
@@ -67,14 +69,6 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   postInstall = ''
-    make -C docs singlehtml
-    mkdir -p $out/share/doc/borg
-    cp -R docs/_build/singlehtml $out/share/doc/borg/html
-
-    make -C docs man
-    mkdir -p $out/share/man
-    cp -R docs/_build/man $out/share/man/man1
-
     installShellCompletion --cmd borg \
       --bash scripts/shell_completions/bash/borg \
       --fish scripts/shell_completions/fish/borg.fish \


### PR DESCRIPTION
Description in commits, but basically:

- Support for multiple builders, think `html` and `man`; default to `html`
- Drop `sphinxOutdir`, because it has become unwieldy to pass the path with multiple builders, it is also unused
- Move the hook documentation from the hook script into the python.section.md and add examples
- Migrate `borgbackup` to `sphinxHook`

cc @KAction

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
