### PR TITLE
pacman: 5.2.2 -> 6.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11542,6 +11542,12 @@
       fingerprint = "AE8C 0836 FDF6 3FFC 9580  C588 B156 8953 B193 9F1C";
     }];
   };
+  samlukeyes123 = {
+    email = "samlukeyes123@gmail.com";
+    github = "SamLukeYes";
+    githubId = 12882091;
+    name = "Sam L. Yes";
+  };
   samrose = {
     email = "samuel.rose@gmail.com";
     github = "samrose";

--- a/pkgs/tools/package-management/pacman/default.nix
+++ b/pkgs/tools/package-management/pacman/default.nix
@@ -1,41 +1,102 @@
-{ stdenv, lib, fetchurl, pkg-config, m4, perl, libarchive, openssl, zlib, bzip2,
-xz, curl, runtimeShell }:
+{ lib
+, stdenv
+, fetchpatch
+, fetchurl
+, asciidoc
+, binutils
+, bzip2
+, coreutils
+, curl
+, gnupg
+, gpgme
+, installShellFiles
+, libarchive
+, makeWrapper
+, meson
+, ninja
+, openssl
+, perl
+, pkg-config
+, xz
+, zlib
+
+# Tells pacman where to find ALPM hooks provided by packages.
+# This path is very likely to be used in an Arch-like root.
+, sysHookDir ? "/usr/share/libalpm/hooks/"
+}:
 
 stdenv.mkDerivation rec {
   pname = "pacman";
-  version = "5.2.2";
+  version = "6.0.1";
 
   src = fetchurl {
-    url = "https://sources.archlinux.org/other/${pname}/${pname}-${version}.tar.gz";
-    sha256 = "1829jcc300fxidr3cahx5kpnxkpg500daqgn2782hg5m5ygil85v";
+    url = "https://sources.archlinux.org/other/${pname}/${pname}-${version}.tar.xz";
+    hash = "sha256-DbYUVuVqpJ4mDokcCwJb4hAxnmKxVSHynT6TsA079zE=";
   };
 
-  enableParallelBuilding = true;
-
-  configureFlags = [
-    # trying to build docs fails with a2x errors, unable to fix through asciidoc
-    "--disable-doc"
-
-    "--sysconfdir=/etc"
-    "--localstatedir=/var"
-    "--with-scriptlet-shell=${runtimeShell}"
+  nativeBuildInputs = [
+    asciidoc
+    installShellFiles
+    makeWrapper
+    meson
+    ninja
+    pkg-config
   ];
 
-  installFlags = [ "sysconfdir=${placeholder "out"}/etc" ];
+  buildInputs = [
+    bzip2
+    curl
+    gpgme
+    libarchive
+    openssl
+    perl
+    xz
+    zlib
+  ];
 
-  nativeBuildInputs = [ pkg-config m4 ];
-  buildInputs = [ curl perl libarchive openssl zlib bzip2 xz ];
+  patches = [
+    ./dont-create-empty-dirs.patch
+    # Add keyringdir meson option to configure the keyring directory
+    (fetchpatch {
+      url = "https://gitlab.archlinux.org/pacman/pacman/-/commit/79bd512181af12ec80fd8f79486fc9508fa4a1b3.patch";
+      hash = "sha256-ivTPwWe06Q5shn++R6EY0x3GC0P4X0SuC+F5sndfAtM=";
+    })
+  ];
 
-  postFixup = ''
-    substituteInPlace $out/bin/repo-add \
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace "install_dir : SYSCONFDIR" "install_dir : '$out/etc'" \
+      --replace "join_paths(DATAROOTDIR, 'libalpm/hooks/')" "'${sysHookDir}'" \
+      --replace "join_paths(PREFIX, DATAROOTDIR, get_option('keyringdir'))" "'\$KEYRING_IMPORT_DIR'"
+    substituteInPlace doc/meson.build \
+      --replace "/bin/true" "${coreutils}/bin/true"
+    substituteInPlace scripts/repo-add.sh.in \
       --replace bsdtar "${libarchive}/bin/bsdtar"
+    substituteInPlace scripts/pacman-key.sh.in \
+      --replace "local KEYRING_IMPORT_DIR='@keyringdir@'" "" \
+      --subst-var-by keyringdir '\$KEYRING_IMPORT_DIR' \
+      --replace "--batch --check-trustdb" "--batch --check-trustdb --allow-weak-key-signatures"
+  ''; # the line above should be removed once Arch migrates to gnupg 2.3.x
+
+  mesonFlags = [
+    "--sysconfdir=/etc"
+    "--localstatedir=/var"
+  ];
+
+  postInstall = ''
+    installShellCompletion --bash scripts/pacman --zsh scripts/_pacman
+    wrapProgram $out/bin/makepkg \
+      --prefix PATH : ${lib.makeBinPath [ binutils ]}
+    wrapProgram $out/bin/pacman-key \
+      --prefix PATH : ${lib.makeBinPath [ gnupg ]}
   '';
 
   meta = with lib; {
     description = "A simple library-based package manager";
-    homepage = "https://www.archlinux.org/pacman/";
-    license = licenses.gpl2;
+    homepage = "https://archlinux.org/pacman/";
+    changelog = "https://gitlab.archlinux.org/pacman/pacman/-/raw/v${version}/NEWS";
+    license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ mt-caret ];
+    maintainers = with maintainers; [ samlukeyes123 ];
   };
 }

--- a/pkgs/tools/package-management/pacman/dont-create-empty-dirs.patch
+++ b/pkgs/tools/package-management/pacman/dont-create-empty-dirs.patch
@@ -1,0 +1,20 @@
+diff --git a/meson.build b/meson.build
+index c8ee42fd..610401ca 100644
+--- a/meson.build
++++ b/meson.build
+@@ -414,15 +414,6 @@ install_data(
+   'proto/proto.install',
+   install_dir : join_paths(DATAROOTDIR, 'pacman'))
+ 
+-foreach path : [
+-	join_paths(LOCALSTATEDIR, 'lib/pacman/'),
+-	join_paths(LOCALSTATEDIR, 'cache/pacman/pkg/'),
+-	join_paths(DATAROOTDIR, 'makepkg-template/'),
+-	join_paths(DATAROOTDIR, 'libalpm/hooks/'),
+-	]
+-	meson.add_install_script('sh', '-c', 'mkdir -p "$DESTDIR/@0@"'.format(path))
+-endforeach
+-
+ TEST_ENV = environment()
+ TEST_ENV.set('PMTEST_SCRIPTLIB_DIR', join_paths(meson.project_source_root(), 'scripts/library/'))
+ TEST_ENV.set('PMTEST_LIBMAKEPKG_DIR', join_paths(meson.project_build_root(), 'scripts/libmakepkg/'))


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes https://github.com/NixOS/nixpkgs/pull/161115#issuecomment-1113997146
Closes https://github.com/NixOS/nixpkgs/pull/161115

It looks like the buffer overflow is caused by the scriptlet shell setting introduced by https://github.com/NixOS/nixpkgs/commit/6208273727c27a6bd5111fedc48535bc2d9eb47b. AFAIK, it is very unlikely to use pacman on the host NixOS, but more likely to target an Arch-like chroot without nix store. Leaving the scriptlet shell setting as default (`/bin/sh`) works just fine. Otherwise, `hardeningDisable = ["fortify"]` would be necessary to avoid the segmentation fault, and the target root needs to have `/nix/store` bind mounted.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
