### PR TITLE
python310Packages.peaqevcore: 5.10.5 -> 5.12.0

### DIFF
--- a/pkgs/development/python-modules/peaqevcore/default.nix
+++ b/pkgs/development/python-modules/peaqevcore/default.nix
@@ -6,14 +6,14 @@
 
 buildPythonPackage rec {
   pname = "peaqevcore";
-  version = "5.10.5";
+  version = "5.10.6";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-rW9QWbnG1sURiWNYxYuACqK3kGS7hIjswcwR5cVwwVg=";
+    hash = "sha256-RmJo6gQTLWYfybMVQ8EvQNjovtr8bEEyt+IjOXldXrQ=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/peaqevcore/default.nix
+++ b/pkgs/development/python-modules/peaqevcore/default.nix
@@ -6,14 +6,14 @@
 
 buildPythonPackage rec {
   pname = "peaqevcore";
-  version = "5.10.6";
+  version = "5.11.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-RmJo6gQTLWYfybMVQ8EvQNjovtr8bEEyt+IjOXldXrQ=";
+    hash = "sha256-SH88adHjFNStd+rpGuQ4bqNwHASI/sSL2lHOn9BdpiI=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/peaqevcore/default.nix
+++ b/pkgs/development/python-modules/peaqevcore/default.nix
@@ -6,14 +6,14 @@
 
 buildPythonPackage rec {
   pname = "peaqevcore";
-  version = "5.11.1";
+  version = "5.11.2";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-8d/NPW1PX4car7ZT2htkpXDvAwAgPDSU6MEmRNu63Uk=";
+    hash = "sha256-zVN3PyOQZvVjfrAjX113VUhUtnqeSNCzgfig6obMNCw=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/peaqevcore/default.nix
+++ b/pkgs/development/python-modules/peaqevcore/default.nix
@@ -6,14 +6,14 @@
 
 buildPythonPackage rec {
   pname = "peaqevcore";
-  version = "5.11.0";
+  version = "5.11.1";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-SH88adHjFNStd+rpGuQ4bqNwHASI/sSL2lHOn9BdpiI=";
+    hash = "sha256-8d/NPW1PX4car7ZT2htkpXDvAwAgPDSU6MEmRNu63Uk=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/peaqevcore/default.nix
+++ b/pkgs/development/python-modules/peaqevcore/default.nix
@@ -6,14 +6,14 @@
 
 buildPythonPackage rec {
   pname = "peaqevcore";
-  version = "5.11.2";
+  version = "5.12.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-zVN3PyOQZvVjfrAjX113VUhUtnqeSNCzgfig6obMNCw=";
+    hash = "sha256-iriCCsmdHEZ/tZtCn+G2VDBFCv/DvBjPEO6aW7YmL3M=";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Description of changes
Update to latest upstream release 5.12.0
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
