### PR TITLE
pwsafe: 1.14.0 -> 1.15.0

### DIFF
--- a/pkgs/applications/misc/pwsafe/default.nix
+++ b/pkgs/applications/misc/pwsafe/default.nix
@@ -2,19 +2,18 @@
 , cmake, pkg-config, zip, gettext, perl
 , wxGTK30, libXext, libXi, libXt, libXtst, xercesc
 , qrencode, libuuid, libyubikey, yubikey-personalization
-, curl, openssl, file
+, curl, openssl, file, gitUpdater
 }:
 
 stdenv.mkDerivation rec {
   pname = "pwsafe";
-  version = "1.14.0"; # do NOT update to 3.x Windows releases
-  # nixpkgs-update: no auto update
+  version = "1.15.0"; # do NOT update to 3.x Windows releases
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    hash = "sha256-s3IXe4gTwUOzQslNfWrcN/srrG9Jv02zfkGgiZN3C1s=";
+    hash = "sha256-EyyQHp2MlGgUnikClgvP7I313Bh6H3yVPXel8Z/U6gQ=";
   };
 
   nativeBuildInputs = [
@@ -52,6 +51,12 @@ stdenv.mkDerivation rec {
   '';
 
   installFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  passthru.updateScript = gitUpdater {
+    inherit pname version;
+    ignoredVersions = "^([^1]|1[^.])"; # ignore anything other than 1.x
+    url = src.gitRepoUrl;
+  };
 
   meta = with lib; {
     description = "A password database utility";


### PR DESCRIPTION
###### Description of changes

https://github.com/pwsafe/pwsafe/releases/tag/1.15.0

This PR also introduces an update script and removes the directive for nixpkgs-update that prevents it from running. The Windows/Linux version conflict issue described in #151601 is avoided by restricting the update script to considering 1.x versions only.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
