### PR TITLE
python310Packages.atomman: 1.4.4 -> 1.4.5

### DIFF
--- a/pkgs/development/python-modules/atomman/default.nix
+++ b/pkgs/development/python-modules/atomman/default.nix
@@ -4,6 +4,7 @@
 , cython
 , datamodeldict
 , fetchFromGitHub
+, fetchpatch
 , matplotlib
 , numericalunits
 , numpy
@@ -12,6 +13,7 @@
 , potentials
 , pymatgen
 , pytest
+, pytestCheckHook
 , pythonOlder
 , pythonAtLeast
 , requests
@@ -21,18 +23,43 @@
 }:
 
 buildPythonPackage rec {
-  version = "1.4.4";
+  version = "1.4.5";
   pname = "atomman";
   format = "setuptools";
 
-  disabled = pythonOlder "3.6" || pythonAtLeast "3.10";
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "usnistgov";
     repo = "atomman";
     rev = "v${version}";
-    hash = "sha256-iLAB0KMtrTCyGpx+81QfHDPVDhq8OA6CDL/ipVRpyo0=";
+    hash = "sha256-wXz/uHjXKHVKJu/HoFF2mADSBLp6UGF9ivOp2ZOz/Ys=";
   };
+
+  patches = [
+    # Fix several tests that are failing on master.
+    # https://github.com/usnistgov/atomman/pull/9
+    (fetchpatch {
+      name = "fix-tests-1.patch";
+      url = "https://github.com/usnistgov/atomman/commit/d255977a5e0ce4584e2c886f6c55ccb9f5932731.patch";
+      hash = "sha256-lBFOgcozY85JfQVsVjd51Jf9mrokwQuYdxa8l7VzkqU=";
+    })
+    (fetchpatch {
+      name = "fix-tests-2.patch";
+      url = "https://github.com/usnistgov/atomman/commit/de4177f28ad7c48d482cb606f323128e2fcb86aa.patch";
+      hash = "sha256-+YpwdKCT/OTue3b2GOk9Jagg26r1PTTV2Zg+GGBd8sM=";
+    })
+    (fetchpatch {
+      name = "fix-tests-3.patch";
+      url = "https://github.com/usnistgov/atomman/commit/10b168493ee883348699f1e42680423cec84bed5.patch";
+      hash = "sha256-b4f3POjiceq3xApfjnKAs9dEf1trCiTIyu7hMPL0ZTw=";
+    })
+    (fetchpatch {
+      name = "fix-tests-4.patch";
+      url = "https://github.com/usnistgov/atomman/commit/057d24c70427bab3c7c530251ceb5f4e27eb5c56.patch";
+      hash = "sha256-FTg/GNRZ5xigGW8SpUTIw2/GEzOxwb1rsv2wGebmZOk=";
+    })
+  ];
 
   propagatedBuildInputs = [
     cython
@@ -48,22 +75,25 @@ buildPythonPackage rec {
     xmltodict
   ];
 
+  preCheck = ''
+    # By default, pytestCheckHook imports atomman from the current directory
+    # instead of from where `pip` installs it and fails due to missing Cython
+    # modules. Fix this by removing atomman from the current directory.
+    #
+    rm -r atomman
+  '';
+
   checkInputs = [
     ase
     phonopy
     pymatgen
     pytest
+    pytestCheckHook
   ];
 
-  checkPhase = ''
-    # pytestCheckHook doesn't work
-    pytest tests -k "not test_rootdir and not test_version \
-      and not test_atomic_mass and not imageflags \
-      and not test_build_unit and not test_set_and_get_in_units \
-      and not test_set_literal and not test_scalar_model " \
-      --ignore tests/plot/test_interpolate.py \
-      --ignore tests/tools/test_vect_angle.py
-  '';
+  disabledTests = [
+    "test_unique_shifts_prototype" # needs network access to download database files
+  ];
 
   pythonImportsCheck = [
     "atomman"


### PR DESCRIPTION
In addition, fix up some tests to simplify future maintenance of the build and add a few more comments to explain what I investigated.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
