### PR TITLE
vid-stab: 1.1.0 -> unstable-2022-05-30, fix linking against it with clang

### DIFF
--- a/pkgs/development/libraries/vid-stab/default.nix
+++ b/pkgs/development/libraries/vid-stab/default.nix
@@ -2,18 +2,18 @@
 
 stdenv.mkDerivation rec {
   pname = "vid.stab";
-  version = "1.1.0";
+  version = "unstable-2022-05-30";
 
   src = fetchFromGitHub {
     owner = "georgmartius";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "0a3frpm2kdbx7vszhg64p3alisag73bcspl7fp3a2f1kgq7rbh38";
+    rev = "90c76aca2cb06c3ff6f7476a7cd6851b39436656";
+    sha256 = "sha256-p1VRnkBeUpET3O2FmaJMyN5/EoSOQLdmRIVbzZcQaKY=";
   };
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = lib.optionals stdenv.cc.isClang [ openmp ];
+  propagatedBuildInputs = lib.optionals stdenv.cc.isClang [ openmp ];
 
   meta = with lib; {
     description = "Video stabilization library";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17846,7 +17846,6 @@ with pkgs;
     libmfx = if stdenv.isDarwin then null else intel-media-sdk;
     libpulseaudio = if stdenv.isDarwin then null else libpulseaudio;
     samba = if stdenv.isDarwin then null else samba;
-    vid-stab = if stdenv.isDarwin then null else vid-stab;
     inherit (darwin.apple_sdk.frameworks)
       Cocoa CoreServices CoreAudio AVFoundation MediaToolbox
       VideoDecodeAcceleration;


### PR DESCRIPTION
 - vid-stab 1.1.0 (current release) hardcodes libgomp in its pkg-config.
   Current git version includes a commit fixing this, so this change
   updates to the git versions
 - placing openmp in `buildInputs` causes it not to be present when
   linking against vid-stab, causing linking to fail. Move it to
   `propagatedBuildInputs` to resolve
 - the all-packages.nix change enables vid-stab in (for example) ffmpeg
   on macos (where it was previously disabled).

###### Description of changes

Changes: https://github.com/georgmartius/vid.stab/compare/60d65da212c0d834cdfdc95d3404d42eab686d16...90c76aca2cb06c3ff6f7476a7cd6851b39436656

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin (and checked an ffmpeg-full build on the same)
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
