### PR TITLE
wasmtime: 0.39.1 -> 0.40.0

### DIFF
--- a/pkgs/development/interpreters/wasmtime/default.nix
+++ b/pkgs/development/interpreters/wasmtime/default.nix
@@ -2,17 +2,24 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "wasmtime";
-  version = "0.39.1";
+  version = "0.40.0";
 
   src = fetchFromGitHub {
     owner = "bytecodealliance";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-cU03wm1+V++mV7j7VyMtjAYrPldzTysNzpJ8m0q4Rx8=";
+    sha256 = "sha256-i3dtjKy5YTyNkEaDcGxsrd4lbyUBd25OARESbJVK9uY=";
     fetchSubmodules = true;
   };
 
-  cargoSha256 = "sha256-DnThste0SbBdpGAUYhmwbdQFNEB3LozyDf0X8r2A90Q=";
+  cargoSha256 = "sha256-wlcYdZ8Akkpicyw74sh4CNwSstCtUJxf+oSEL/mUtKc=";
+
+  cargoBuildFlags = [
+    "--package wasmtime-cli"
+    "--package wasmtime-c-api"
+  ];
+
+  outputs = [ "out" "dev" ];
 
   # We disable tests on x86_64-darwin because Hydra runners do not
   # support SSE3, SSSE3, SSE4.1 and SSE4.2 at this time. This is
@@ -30,6 +37,18 @@ rustPlatform.buildRustPackage rec {
     "--skip=commands::compile::test::test_x64_presets_compile"
     "--skip=traps::parse_dwarf_info"
   ];
+
+  postInstall = ''
+    # move libs from out to dev
+    install -d -m 0755 $dev/lib
+    install -m 0644 ''${!outputLib}/lib/* $dev/lib
+    rm -r ''${!outputLib}/lib
+
+    install -d -m0755 $dev/include/wasmtime
+    install -m0644 $src/crates/c-api/include/*.h $dev/include
+    install -m0644 $src/crates/c-api/include/wasmtime/*.h $dev/include/wasmtime
+    install -m0644 $src/crates/c-api/wasm-c-api/include/* $dev/include
+  '';
 
   meta = with lib; {
     description = "Standalone JIT-style runtime for WebAssembly, using Cranelift";


### PR DESCRIPTION
###### Description of changes

Includes the c-api provided by https://github.com/NixOS/nixpkgs/pull/161029. Given this was contributed by @cmm, I have kept authorship and I have just adapted their contribution to include wasmtime 0.40.0 as well as the `dev` output.

I have also fixed the initial contribution so that it works on Darwin (given the library extension is .dylib, not .so).

* build wasmtime c-api libraries & headers as the "dev" output.

* bump wasmtime source version to 0.40.0.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
