### PR TITLE
python310Packages.omegaconf: 2.2.2 -> 2.2.3

### DIFF
--- a/pkgs/development/python-modules/omegaconf/default.nix
+++ b/pkgs/development/python-modules/omegaconf/default.nix
@@ -1,17 +1,19 @@
 { lib
+, antlr4_9-python3-runtime
 , buildPythonPackage
 , fetchFromGitHub
+, jre_minimal
+, pydevd
 , pytest-mock
 , pytestCheckHook
-, pyyaml
 , pythonOlder
-, jre_minimal
-, antlr4_9-python3-runtime
-, pydevd }:
+, pyyaml
+}:
 
 buildPythonPackage rec {
   pname = "omegaconf";
-  version = "2.2.2";
+  version = "2.2.3";
+  format = "setuptools";
 
   disabled = pythonOlder "3.6";
 
@@ -19,12 +21,8 @@ buildPythonPackage rec {
     owner = "omry";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-bUJ80sa2ot2JSkt29eFwSiKL6R1X1+VVeE9dFIy4Mg0=";
+    hash = "sha256-sJUYi0M/6SBSeKVSJoNY7IbVmzRZVTlek8AyL2cOPAM=";
   };
-
-  postPatch = ''
-    substituteInPlace setup.py --replace 'setup_requires=["pytest-runner"]' 'setup_requires=[]'
-  '';
 
   nativeBuildInputs = [
     jre_minimal
@@ -37,16 +35,18 @@ buildPythonPackage rec {
 
   checkInputs = [
     pydevd
-    pytestCheckHook
     pytest-mock
+    pytestCheckHook
   ];
 
-  pythonImportsCheck = [ "omegaconf" ];
+  pythonImportsCheck = [
+    "omegaconf"
+  ];
 
   meta = with lib; {
-    description = "A framework for configuring complex applications";
+    description = "Framework for configuring complex applications";
     homepage = "https://github.com/omry/omegaconf";
-    license = licenses.free;  # prior bsd license (1988)
+    license = licenses.bsd3;
     maintainers = with maintainers; [ bcdarwin ];
   };
 }


### PR DESCRIPTION
###### Description of changes
https://github.com/omry/omegaconf/releases/tag/v2.2.3
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
