### PR TITLE
karabiner-elements: init at 14.8.0

### DIFF
--- a/pkgs/os-specific/darwin/karabiner-elements/default.nix
+++ b/pkgs/os-specific/darwin/karabiner-elements/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, cpio, xar, undmg, ... }:
+{ lib, stdenv, fetchurl, cpio, xar, undmg }:
 
 stdenv.mkDerivation rec {
   pname = "karabiner-elements";
@@ -41,9 +41,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = ''
-      Karabiner-Elements is a powerful utility for keyboard customization on macOS Sierra (10.12) or later.
-    '';
+    description = "Karabiner-Elements is a powerful utility for keyboard customization on macOS Sierra (10.12) or later.";
     homepage = "https://karabiner-elements.pqrs.org/";
     platforms = platforms.darwin;
     maintainers = with maintainers; [ Enzime ];

--- a/pkgs/os-specific/darwin/karabiner-elements/default.nix
+++ b/pkgs/os-specific/darwin/karabiner-elements/default.nix
@@ -1,0 +1,52 @@
+{ lib, stdenv, fetchurl, cpio, xar, undmg, ... }:
+
+stdenv.mkDerivation rec {
+  pname = "karabiner-elements";
+  version = "14.8.0";
+
+  src = fetchurl {
+    url = "https://github.com/pqrs-org/Karabiner-Elements/releases/download/v${version}/Karabiner-Elements-${version}.dmg";
+    sha256 = "sha256-sQJgK3EoJf8wcr0iL9iZXl6NJArptUDTrDeNKwgEfuM=";
+  };
+
+  outputs = [ "out" "driver" ];
+
+  nativeBuildInputs = [ cpio xar undmg ];
+
+  unpackPhase = ''
+    undmg $src
+    xar -xf Karabiner-Elements.pkg
+    cd Installer.pkg
+    zcat Payload | cpio -i
+    cd ../Karabiner-DriverKit-VirtualHIDDevice.pkg
+    zcat Payload | cpio -i
+    cd ..
+  '';
+
+  sourceRoot = ".";
+
+  postPatch = ''
+    for f in *.pkg/Library/Launch{Agents,Daemons}/*.plist; do
+      substituteInPlace $f \
+        --replace "/Library/" "$out/Library/"
+    done
+  '';
+
+  installPhase = ''
+    mkdir -p $out $driver
+    cp -R Installer.pkg/Applications Installer.pkg/Library $out
+    cp -R Karabiner-DriverKit-VirtualHIDDevice.pkg/Applications Karabiner-DriverKit-VirtualHIDDevice.pkg/Library $driver
+
+    cp "$out/Library/Application Support/org.pqrs/Karabiner-Elements/package-version" "$out/Library/Application Support/org.pqrs/Karabiner-Elements/version"
+  '';
+
+  meta = with lib; {
+    description = ''
+      Karabiner-Elements is a powerful utility for keyboard customization on macOS Sierra (10.12) or later.
+    '';
+    homepage = "https://karabiner-elements.pqrs.org/";
+    platforms = platforms.darwin;
+    maintainers = with maintainers; [ Enzime ];
+    license = licenses.unlicense;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24032,6 +24032,8 @@ with pkgs;
 
   jujuutils = callPackage ../os-specific/linux/jujuutils { };
 
+  karabiner-elements = callPackage ../os-specific/darwin/karabiner-elements { };
+
   kbd = callPackage ../os-specific/linux/kbd { };
 
   kbdlight = callPackage ../os-specific/linux/kbdlight { };


### PR DESCRIPTION
###### Description of changes

https://karabiner-elements.pqrs.org/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
