### PR TITLE
Revert "keycloak: 18.0.0 -> 19.0.1"

### DIFF
--- a/pkgs/servers/keycloak/default.nix
+++ b/pkgs/servers/keycloak/default.nix
@@ -13,11 +13,11 @@
 
 stdenv.mkDerivation rec {
   pname = "keycloak";
-  version = "19.0.1";
+  version = "18.0.0";
 
   src = fetchzip {
     url = "https://github.com/keycloak/keycloak/releases/download/${version}/keycloak-${version}.zip";
-    sha256 = "sha256-3hqnFH0zWvgOgpQHV4eMqTGzUWEoRwxvOcOUL2s8YQk=";
+    sha256 = "0fxf9m50hpjplj077z2zjp0qibixz5y4lbc8159cnxbd4gzpkaaf";
   };
 
   nativeBuildInputs = [ makeWrapper jre ];


### PR DESCRIPTION
Reverts NixOS/nixpkgs#183434 which breaks **Keycloak** on master.