### PR TITLE
linux-wallpaperengine: init at 2022-08-22

### DIFF
--- a/pkgs/applications/graphics/linux-wallpaperengine/default.nix
+++ b/pkgs/applications/graphics/linux-wallpaperengine/default.nix
@@ -1,0 +1,70 @@
+{ lib
+, cmake
+, fetchFromGitHub
+, ffmpeg
+, freeglut
+, glew
+, glm
+, glfw
+, libGL
+, libXpm
+, libXrandr
+, libXxf86vm
+, lz4
+, pkg-config
+, SDL
+, SDL_mixer
+, stdenv
+, zlib
+, freeimage
+}:
+
+stdenv.mkDerivation rec {
+  pname = "linux-wallpaperengine";
+  version = "unstable-2022-10-31";
+
+  src = fetchFromGitHub {
+    owner = "Almamu";
+    repo = pname;
+    rev = "cb6f05ff2774a832b6fcba6678d8765995f0af3e";
+    sha256 = "sha256-f9szX+eLOII5zUCdTQjWcS38WNMCysJErrexxXARJdQ=";
+  };
+
+  patches = [
+    ./sdl-path.patch
+  ];
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [
+    freeimage
+    ffmpeg
+    freeglut
+    glew
+    glm
+    libGL
+    glfw
+    libXpm
+    libXrandr
+    libXxf86vm
+    lz4
+    SDL
+    SDL_mixer.all
+    zlib
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp linux-wallpaperengine $out/bin
+
+    runHook postInstall
+  '';
+
+
+  meta = with lib; {
+    description = "Wallpaper engine compatible with linux";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/graphics/linux-wallpaperengine/sdl-path.patch
+++ b/pkgs/applications/graphics/linux-wallpaperengine/sdl-path.patch
@@ -1,0 +1,20 @@
+--- source/main.cpp.bak	2022-08-02 18:17:47.102786517 +0200
++++ source/main.cpp	2022-08-02 18:17:58.708923529 +0200
+@@ -2,8 +2,8 @@
+ #include <getopt.h>
+ #include <stdlib.h>
+ #include <unistd.h>
+-#include <SDL_mixer.h>
+-#include <SDL.h>
++#include <SDL/SDL_mixer.h>
++#include <SDL/SDL.h>
+ #include <FreeImage.h>
+ #include <sys/stat.h>
+ #include <GL/glew.h>
+@@ -432,4 +432,4 @@
+     delete context;
+ 
+     return 0;
+-}
+\ Pas de fin de ligne à la fin du fichier
++}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1367,6 +1367,8 @@ with pkgs;
 
   linux-router-without-wifi = linux-router.override { useWifiDependencies = false; };
 
+  linux-wallpaperengine = callPackage ../applications/graphics/linux-wallpaperengine { };
+
   metapixel = callPackage ../tools/graphics/metapixel { };
 
   midimonster = callPackage ../tools/audio/midimonster { };


### PR DESCRIPTION
###### Description of changes

This is an open source reimplementation of the proprietary software Wallpaper Engine, it requires the files from Steam to work and should be used with downloaded wallpapers to display them. Not all wallpapers and effects are currently supported, but most of them should work.

[Project page](https://github.com/Almamu/linux-wallpaperengine)

Example of use:
```
linux-wallpaperengine --fps 60 --screen-root eDP-1  ~/.local/share/Steam//steamapps/workshop/content//431960/835043028/
```

This doesn't work with GNOME or Plasma as they constantly redraw the screen, maybe XFCE and MATE do the same 🤷‍♀, tested on i3 and stumpwm without issues.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
