### PR TITLE
ycmd: unstable-2020-02-22 -> unstable-2022-08-15

### DIFF
--- a/pkgs/development/tools/misc/ycmd/default.nix
+++ b/pkgs/development/tools/misc/ycmd/default.nix
@@ -1,33 +1,35 @@
-{ stdenv, lib, fetchFromGitHub, cmake, llvmPackages, boost, python
+{ stdenv, lib, fetchFromGitHub, cmake, ninja, python
 , withGocode ? true, gocode
 , withGodef ? true, godef
 , withGotools? true, gotools
 , withTypescript ? true, nodePackages
+, abseil-cpp, boost, llvmPackages
 , fixDarwinDylibNames, Cocoa
 }:
 
 stdenv.mkDerivation {
   pname = "ycmd";
-  version = "unstable-2020-02-22";
+  version = "unstable-2022-08-15";
   disabled = !python.isPy3k;
 
   # required for third_party directory creation
   src = fetchFromGitHub {
-    owner = "Valloric";
+    owner = "ycm-core";
     repo = "ycmd";
-    rev = "9a6b86e3a156066335b678c328f226229746bae5";
-    sha256 = "sha256-xzLELjp4DsG6mkzaFqpuquSa0uoaZWrYLrKr/mzrqrA=";
+    rev = "323d4b60f077bd07945f25a60c4584843ca851fb";
+    sha256 = "sha256-5IpXMQc3QIkKJkUrOPSRzciLvL1nhQw6wlP+pVnIucE=";
     fetchSubmodules = true;
   };
 
-  nativeBuildInputs = [ cmake ]
+  nativeBuildInputs = [ cmake ninja ]
     ++ lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
-  buildInputs = [ boost llvmPackages.libclang ]
+  buildInputs = with python.pkgs; with llvmPackages; [ abseil-cpp boost libllvm.all libclang.all ]
+    ++  [ jedi jedi-language-server pybind11 ]
     ++ lib.optional stdenv.isDarwin Cocoa;
 
   buildPhase = ''
-    export EXTRA_CMAKE_ARGS=-DPATH_TO_LLVM_ROOT=${llvmPackages.clang-unwrapped}
-    ${python.interpreter} build.py --system-libclang --clang-completer --system-boost
+    export EXTRA_CMAKE_ARGS="-DPATH_TO_LLVM_ROOT=${llvmPackages.libllvm} -DUSE_SYSTEM_ABSEIL=true"
+    ${python.interpreter} build.py --system-libclang --clang-completer --ninja
   '';
 
   dontConfigure = true;
@@ -50,7 +52,7 @@ stdenv.mkDerivation {
     " ycmd/__main__.py
 
     mkdir -p $out/lib/ycmd
-    cp -r ycmd/ CORE_VERSION libclang.so.* libclang.dylib* ycm_core.so $out/lib/ycmd/
+    cp -r ycmd/ CORE_VERSION *.so* *.dylib* $out/lib/ycmd/
 
     mkdir -p $out/bin
     ln -s $out/lib/ycmd/ycmd/__main__.py $out/bin/ycmd
@@ -82,15 +84,14 @@ stdenv.mkDerivation {
   # python won't be thrown off by argv[0]
   postFixup = ''
     substituteInPlace $out/lib/ycmd/ycmd/__main__.py \
-      --replace $out/lib/ycmd/ycmd/__main__.py $out/bin/ycmd \
       --replace __file__ "'$out/lib/ycmd/ycmd/__main__.py'"
   '';
 
   meta = with lib; {
     description = "A code-completion and comprehension server";
-    homepage = "https://github.com/Valloric/ycmd";
+    homepage = "https://github.com/ycm-core/ycmd";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ rasendubi cstrahan lnl7 ];
+    maintainers = with maintainers; [ rasendubi cstrahan lnl7 siriobalmelli ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
Resolves autocompletion error
'ValueError: The given version is not in the right format. Use something like "3.8" or "3".'
when YouCompleteMe vim plugin is used with current python3.

Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>