### PR TITLE
ocamlPackages.fmt: 0.8.9 → 0.9.0

### DIFF
--- a/pkgs/development/ocaml-modules/angstrom/default.nix
+++ b/pkgs/development/ocaml-modules/angstrom/default.nix
@@ -17,7 +17,7 @@ buildDunePackage rec {
   checkInputs = [ alcotest ppx_let ];
   buildInputs = [ ocaml-syntax-shims ];
   propagatedBuildInputs = [ bigstringaf result ];
-  doCheck = lib.versionAtLeast ocaml.version "4.05";
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
 
   meta = {
     homepage = "https://github.com/inhabitedtype/angstrom";

--- a/pkgs/development/ocaml-modules/base64/default.nix
+++ b/pkgs/development/ocaml-modules/base64/default.nix
@@ -14,7 +14,7 @@ buildDunePackage rec {
   };
 
   # otherwise fmt breaks evaluation
-  doCheck = lib.versionAtLeast ocaml.version "4.05";
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
   checkInputs = [ alcotest bos rresult ];
 
   meta = {

--- a/pkgs/development/ocaml-modules/bigarray-overlap/default.nix
+++ b/pkgs/development/ocaml-modules/bigarray-overlap/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildDunePackage, fetchurl
+{ lib, buildDunePackage, ocaml, fetchurl
 , bigarray-compat, alcotest, astring, fpath, bos, findlib, pkg-config
 }:
 
@@ -20,7 +20,7 @@ buildDunePackage rec {
 
   nativeBuildInputs = [ findlib pkg-config ];
   checkInputs = [ alcotest astring fpath bos ];
-  doCheck = true;
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
 
   meta = with lib; {
     homepage = "https://github.com/dinosaure/overlap";

--- a/pkgs/development/ocaml-modules/bigstringaf/default.nix
+++ b/pkgs/development/ocaml-modules/bigstringaf/default.nix
@@ -21,7 +21,7 @@ buildDunePackage rec {
   nativeBuildInputs = [ pkg-config ];
   checkInputs = [ alcotest ];
   propagatedBuildInputs = [ bigarray-compat ];
-  doCheck = lib.versionAtLeast ocaml.version "4.05";
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
 
   meta = {
     description = "Bigstring intrinsics and fast blits based on memcpy/memmove";

--- a/pkgs/development/ocaml-modules/callipyge/default.nix
+++ b/pkgs/development/ocaml-modules/callipyge/default.nix
@@ -23,8 +23,8 @@ buildDunePackage rec {
 
   propagatedBuildInputs = [ fmt eqaf ];
 
-  # alcotest isn't available for OCaml < 4.05 due to fmt
-  doCheck = lib.versionAtLeast ocaml.version "4.05";
+  # alcotest isn't available for OCaml < 4.08 due to fmt
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
   checkInputs = [ alcotest ];
 
   meta = {

--- a/pkgs/development/ocaml-modules/caqti/default.nix
+++ b/pkgs/development/ocaml-modules/caqti/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, buildDunePackage
+{ lib, fetchFromGitHub, buildDunePackage, ocaml
 , cppo, logs, ptime, uri, bigstringaf
 , re, cmdliner, alcotest }:
 
@@ -20,7 +20,7 @@ buildDunePackage rec {
   propagatedBuildInputs = [ logs ptime uri bigstringaf ];
   checkInputs = [ re cmdliner alcotest ];
 
-  doCheck = true;
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
 
   meta = {
     description = "Unified interface to relational database libraries";

--- a/pkgs/development/ocaml-modules/checkseum/default.nix
+++ b/pkgs/development/ocaml-modules/checkseum/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, buildDunePackage, dune-configurator, pkg-config
+{ lib, fetchurl, buildDunePackage, ocaml, dune-configurator, pkg-config
 , bigarray-compat, optint
 , fmt, rresult, bos, fpath, astring, alcotest
 , withFreestanding ? false
@@ -36,7 +36,7 @@ buildDunePackage rec {
     rresult
   ];
 
-  doCheck = true;
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
 
   meta = {
     description = "ADLER-32 and CRC32C Cyclic Redundancy Check";

--- a/pkgs/development/ocaml-modules/cow/default.nix
+++ b/pkgs/development/ocaml-modules/cow/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, buildDunePackage, alcotest
+{ lib, fetchurl, buildDunePackage, ocaml, alcotest
 , uri, xmlm, omd, ezjsonm }:
 
 buildDunePackage rec {
@@ -15,7 +15,7 @@ buildDunePackage rec {
 
   propagatedBuildInputs = [ xmlm uri ezjsonm omd ];
   checkInputs = [ alcotest ];
-  doCheck = true;
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
 
   meta = with lib; {
     description = "Caml on the Web";

--- a/pkgs/development/ocaml-modules/cstruct/default.nix
+++ b/pkgs/development/ocaml-modules/cstruct/default.nix
@@ -15,8 +15,8 @@ buildDunePackage rec {
 
   propagatedBuildInputs = [ bigarray-compat ];
 
-  # alcotest isn't available for OCaml < 4.05 due to fmt
-  doCheck = lib.versionAtLeast ocaml.version "4.05";
+  # alcotest isn't available for OCaml < 4.08 due to fmt
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
   checkInputs = [ alcotest ];
 
   meta = {

--- a/pkgs/development/ocaml-modules/cstruct/sexp.nix
+++ b/pkgs/development/ocaml-modules/cstruct/sexp.nix
@@ -10,8 +10,8 @@ buildDunePackage rec {
 
   minimumOCamlVersion = "4.03";
 
-  # alcotest is only available on OCaml >= 4.05 due to fmt
-  doCheck = lib.versionAtLeast ocaml.version "4.05";
+  # alcotest is only available on OCaml >= 4.08 due to fmt
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
   checkInputs = [ alcotest ];
 
   propagatedBuildInputs = [ cstruct sexplib ];

--- a/pkgs/development/ocaml-modules/decompress/default.nix
+++ b/pkgs/development/ocaml-modules/decompress/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, buildDunePackage
+{ lib, fetchurl, buildDunePackage, ocaml
 , checkseum, bigarray-compat, optint, cmdliner
 , bigstringaf, alcotest, camlzip, base64, ctypes, fmt
 }:
@@ -19,7 +19,7 @@ buildDunePackage rec {
   buildInputs = [ cmdliner ];
   propagatedBuildInputs = [ optint bigarray-compat checkseum ];
   checkInputs = [ alcotest bigstringaf ctypes fmt camlzip base64 ];
-  doCheck = true;
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
 
   meta = {
     description = "Pure OCaml implementation of Zlib";

--- a/pkgs/development/ocaml-modules/dispatch/default.nix
+++ b/pkgs/development/ocaml-modules/dispatch/default.nix
@@ -17,7 +17,7 @@ buildDunePackage rec {
 
   checkInputs = [ alcotest ];
 
-  doCheck = lib.versionAtLeast ocaml.version "4.05";
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
 
   meta = {
     inherit (src.meta) homepage;

--- a/pkgs/development/ocaml-modules/domain-name/default.nix
+++ b/pkgs/development/ocaml-modules/domain-name/default.nix
@@ -15,7 +15,7 @@ buildDunePackage rec {
 
   checkInputs = [ alcotest ];
 
-  doCheck = lib.versionAtLeast ocaml.version "4.05";
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
 
   meta = {
     homepage = "https://github.com/hannesm/domain-name";

--- a/pkgs/development/ocaml-modules/duration/default.nix
+++ b/pkgs/development/ocaml-modules/duration/default.nix
@@ -11,7 +11,7 @@ buildDunePackage rec {
     sha256 = "sha256-rRT7daWm9z//fvFyEXiSXuVVzw8jsj46sykYS8DBzmk=";
   };
 
-  doCheck = lib.versionAtLeast ocaml.version "4.05";
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
   checkInputs = [ alcotest ];
 
   meta = {

--- a/pkgs/development/ocaml-modules/emile/default.nix
+++ b/pkgs/development/ocaml-modules/emile/default.nix
@@ -25,9 +25,9 @@ buildDunePackage rec {
   ];
 
   # technically emile is available for ocaml >= 4.03, but alcotest
-  # and angstrom (fmt) are only available for >= 4.05. Disabling
-  # tests for < 4.05 at least improves the error message
-  doCheck = lib.versionAtLeast ocaml.version "4.05";
+  # and angstrom (fmt) are only available for >= 4.08. Disabling
+  # tests for < 4.08 at least improves the error message
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
   checkInputs = [ alcotest ];
 
   meta = with lib; {

--- a/pkgs/development/ocaml-modules/faraday/default.nix
+++ b/pkgs/development/ocaml-modules/faraday/default.nix
@@ -17,7 +17,7 @@ buildDunePackage rec {
 
   checkInputs = [ alcotest ];
   propagatedBuildInputs = [ bigstringaf ];
-  doCheck = lib.versionAtLeast ocaml.version "4.05";
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
 
   meta = {
     description = "Serialization library built for speed and memory efficiency";

--- a/pkgs/development/ocaml-modules/ff/default.nix
+++ b/pkgs/development/ocaml-modules/ff/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitLab, buildDunePackage, zarith, alcotest }:
+{ lib, fetchFromGitLab, buildDunePackage, ocaml, zarith, alcotest }:
 
 buildDunePackage rec {
   pname = "ff";
@@ -21,7 +21,7 @@ buildDunePackage rec {
     alcotest
   ];
 
-  doCheck = true;
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
 
   meta = {
     homepage = "https://gitlab.com/dannywillems/ocaml-ff";

--- a/pkgs/development/ocaml-modules/fmt/default.nix
+++ b/pkgs/development/ocaml-modules/fmt/default.nix
@@ -1,21 +1,20 @@
-{ lib, stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg, cmdliner, seq, stdlib-shims }:
+{ lib, stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg, cmdliner }:
 
-if lib.versionOlder ocaml.version "4.05"
+if lib.versionOlder ocaml.version "4.08"
 then throw "fmt is not available for OCaml ${ocaml.version}"
 else
 
 stdenv.mkDerivation rec {
-  version = "0.8.9";
+  version = "0.9.0";
   pname = "ocaml${ocaml.version}-fmt";
 
   src = fetchurl {
     url = "https://erratique.ch/software/fmt/releases/fmt-${version}.tbz";
-    sha256 = "0gkkkj4x678vxdda4xaw2dd44qjacavsvn5nx8gydfwah6pjbkxk";
+    sha256 = "sha256-8fsggFoi3XWhN9cnBKNw53ic9r32OUjmgX0cImwUEmE=";
   };
 
   nativeBuildInputs = [ ocaml findlib ocamlbuild topkg ];
   buildInputs = [ cmdliner topkg ];
-  propagatedBuildInputs = [ seq stdlib-shims ];
 
   strictDeps = true;
 

--- a/pkgs/development/ocaml-modules/gmap/default.nix
+++ b/pkgs/development/ocaml-modules/gmap/default.nix
@@ -15,7 +15,7 @@ buildDunePackage rec {
 
   checkInputs = [ alcotest ];
 
-  doCheck = lib.versionAtLeast ocaml.version "4.05";
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
 
   meta = {
     description = "Heterogenous maps over a GADT";

--- a/pkgs/development/ocaml-modules/graphql/parser.nix
+++ b/pkgs/development/ocaml-modules/graphql/parser.nix
@@ -1,10 +1,10 @@
-{ lib, buildDunePackage, ocaml, fetchurl, alcotest, fmt, menhir, re }:
+{ lib, buildDunePackage, fetchurl, alcotest, fmt, menhir, re }:
 
 buildDunePackage rec {
   pname = "graphql_parser";
   version = "0.14.0";
 
-  minimalOCamlVersion = "4.05";
+  minimalOCamlVersion = "4.08";
 
   src = fetchurl {
     url = "https://github.com/andreas/ocaml-graphql-server/releases/download/${version}/graphql-${version}.tbz";
@@ -16,7 +16,7 @@ buildDunePackage rec {
 
   checkInputs = [ alcotest ];
 
-  doCheck = lib.versionAtLeast ocaml.version "4.08";
+  doCheck = true;
 
   meta = {
     homepage = "https://github.com/andreas/ocaml-graphql-server";

--- a/pkgs/development/ocaml-modules/h2/default.nix
+++ b/pkgs/development/ocaml-modules/h2/default.nix
@@ -43,7 +43,7 @@ buildDunePackage rec {
   ];
 
   # Tests fail with 4.06
-  doCheck = lib.versionAtLeast ocaml.version "4.07";
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
   preCheck = ''
     ln -s "${http2-frame-test-case}" lib_test/http2-frame-test-case
   '';

--- a/pkgs/development/ocaml-modules/httpaf/default.nix
+++ b/pkgs/development/ocaml-modules/httpaf/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, fetchpatch, buildDunePackage
+{ lib, fetchFromGitHub, fetchpatch, buildDunePackage, ocaml
 , angstrom, faraday, alcotest
 }:
 
@@ -17,7 +17,7 @@ buildDunePackage rec {
 
   checkInputs = [ alcotest ];
   propagatedBuildInputs = [ angstrom faraday ];
-  doCheck = true;
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
 
   meta = {
     description = "A high-performance, memory-efficient, and scalable web server for OCaml";

--- a/pkgs/development/ocaml-modules/imagelib/default.nix
+++ b/pkgs/development/ocaml-modules/imagelib/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, buildDunePackage
+{ lib, fetchurl, buildDunePackage, ocaml
 , decompress, stdlib-shims, alcotest
 }:
 
@@ -16,7 +16,7 @@ buildDunePackage rec {
 
   propagatedBuildInputs = [ decompress stdlib-shims ];
 
-  doCheck = true;
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
   checkInputs = [ alcotest ];
 
   meta = {

--- a/pkgs/development/ocaml-modules/logs/default.nix
+++ b/pkgs/development/ocaml-modules/logs/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv, fetchurl, ocaml, findlib, ocamlbuild
 , topkg, result, lwt, cmdliner, fmt
+, fmtSupport ? lib.versionAtLeast ocaml.version "4.08"
 , js_of_ocaml
 , jsooSupport ? true
 }:
@@ -22,13 +23,14 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ ocaml findlib ocamlbuild topkg ];
-  buildInputs = [ fmt cmdliner lwt topkg ]
+  buildInputs = [ cmdliner lwt topkg ]
+    ++ lib.optional fmtSupport fmt
     ++ lib.optional jsooSupport js_of_ocaml;
   propagatedBuildInputs = [ result ];
 
   strictDeps = true;
 
-  buildPhase = "${topkg.run} build --with-js_of_ocaml ${lib.boolToString jsooSupport}";
+  buildPhase = "${topkg.run} build --with-js_of_ocaml ${lib.boolToString jsooSupport} --with-fmt ${lib.boolToString fmtSupport}";
 
   inherit (topkg) installPhase;
 

--- a/pkgs/development/ocaml-modules/luv/default.nix
+++ b/pkgs/development/ocaml-modules/luv/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildDunePackage, fetchurl
+{ lib, buildDunePackage, ocaml, fetchurl
 , ctypes, result
 , alcotest
 , file
@@ -23,7 +23,7 @@ buildDunePackage rec {
   nativeBuildInputs = [ file ];
   propagatedBuildInputs = [ ctypes result ];
   checkInputs = [ alcotest ];
-  doCheck = true;
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
 
   meta = with lib; {
     homepage = "https://github.com/aantron/luv";

--- a/pkgs/development/ocaml-modules/ppx_blob/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_blob/default.nix
@@ -13,7 +13,7 @@ buildDunePackage rec {
 
   checkInputs = [ alcotest ];
   propagatedBuildInputs = [ ppxlib ];
-  doCheck = lib.versionAtLeast ocaml.version "4.05";
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
 
   meta = with lib; {
     homepage = "https://github.com/johnwhitington/ppx_blob";

--- a/pkgs/development/ocaml-modules/rpclib/default.nix
+++ b/pkgs/development/ocaml-modules/rpclib/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, buildDunePackage
+{ lib, fetchurl, buildDunePackage, ocaml
 , alcotest
 , base64, cmdliner, rresult, xmlm, yojson
 }:
@@ -18,7 +18,7 @@ buildDunePackage rec {
   propagatedBuildInputs = [ base64 rresult xmlm ];
   checkInputs = [ alcotest ];
 
-  doCheck = true;
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
 
   meta = with lib; {
     homepage = "https://github.com/mirage/ocaml-rpc";

--- a/pkgs/development/ocaml-modules/ssl/default.nix
+++ b/pkgs/development/ocaml-modules/ssl/default.nix
@@ -23,7 +23,7 @@ buildDunePackage rec {
   buildInputs = [ dune-configurator ];
   propagatedBuildInputs = [ openssl ];
 
-  doCheck = lib.versionAtLeast ocaml.version "4.06";
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
   checkInputs = [ alcotest ];
   preCheck = ''
     mkdir -p _build/default/tests/

--- a/pkgs/development/ocaml-modules/terminal/default.nix
+++ b/pkgs/development/ocaml-modules/terminal/default.nix
@@ -17,7 +17,7 @@ buildDunePackage rec {
 
   propagatedBuildInputs = [ stdlib-shims uutf uucp ];
 
-  doCheck = lib.versionAtLeast ocaml.version "4.05";
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
   checkInputs = [ alcotest fmt ];
 
   meta = with lib; {

--- a/pkgs/development/ocaml-modules/terminal_size/default.nix
+++ b/pkgs/development/ocaml-modules/terminal_size/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildDunePackage, fetchurl, alcotest }:
+{ lib, buildDunePackage, ocaml, fetchurl, alcotest }:
 
 buildDunePackage rec {
   pname = "terminal_size";
@@ -12,7 +12,7 @@ buildDunePackage rec {
   };
 
   checkInputs = [ alcotest ];
-  doCheck = true;
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
 
   meta = with lib; {
     description = "Get the dimensions of the terminal";

--- a/pkgs/development/ocaml-modules/uecc/default.nix
+++ b/pkgs/development/ocaml-modules/uecc/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitLab, buildDunePackage, bigstring, alcotest, cstruct, hex }:
+{ lib, fetchFromGitLab, buildDunePackage, ocaml, bigstring, alcotest, cstruct, hex }:
 
 buildDunePackage rec {
   pname = "uecc";
@@ -23,7 +23,7 @@ buildDunePackage rec {
     hex
   ];
 
-  doCheck = true;
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
 
   meta = {
     description = "Bindings for ECDH and ECDSA for 8-bit, 32-bit, and 64-bit processors";

--- a/pkgs/development/ocaml-modules/yuscii/default.nix
+++ b/pkgs/development/ocaml-modules/yuscii/default.nix
@@ -1,5 +1,6 @@
 { alcotest
 , buildDunePackage
+, ocaml
 , fetchzip
 , gcc
 , fmt
@@ -10,6 +11,8 @@
 buildDunePackage rec {
   pname = "yuscii";
   version = "0.3.0";
+
+  minimalOCamlVersion = "4.03";
 
   src = fetchzip {
     url = "https://github.com/mirage/yuscii/releases/download/v${version}/yuscii-v${version}.tbz";
@@ -24,7 +27,7 @@ buildDunePackage rec {
     fmt
     uutf
   ];
-  doCheck = true;
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
 
   meta = {
     description = "A simple mapper between UTF-7 to Unicode according RFC2152";


### PR DESCRIPTION
###### Description of changes

https://github.com/dbuenzli/fmt/blob/v0.9.0/CHANGES.md#v090-2021-10-22-zagreb
Requires OCaml 4.08, less dependencies.
This will make it easier to update `cmdliner`.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
