### PR TITLE
Fix erlang-ls build error with Erlang/OTP ≥ 25

### DIFF
--- a/pkgs/development/beam-modules/erlang-ls/default.nix
+++ b/pkgs/development/beam-modules/erlang-ls/default.nix
@@ -11,6 +11,9 @@ let
       proper = super.proper.overrideAttrs (_: {
         configurePhase = "true";
       });
+      redbug = super.redbug.overrideAttrs (_: {
+        patchPhase = "sed -i 's/, warnings_as_errors//' rebar.config";
+      });
     });
   };
 in

--- a/pkgs/development/beam-modules/erlang-ls/default.nix
+++ b/pkgs/development/beam-modules/erlang-ls/default.nix
@@ -12,7 +12,9 @@ let
         configurePhase = "true";
       });
       redbug = super.redbug.overrideAttrs (_: {
-        patchPhase = "sed -i 's/, warnings_as_errors//' rebar.config";
+        patchPhase = ''
+          substituteInPlace rebar.config --replace ", warnings_as_errors" ""
+          '';
       });
     });
   };


### PR DESCRIPTION
###### Description of changes

The redbug dependency fails to build on Erlang/OTP 25 due to some deprecation warnings and having `warnings_as_errors` in `rebar.conf`:

```
❯ nix-shell -p beam.packages.erlangR25.erlang-ls
these 7 derivations will be built:
  /nix/store/2fw11viy3fvfacrvqbgxp2wbaz6wb9vf-zipper-1.0.1.drv
  /nix/store/7zrhs55q64lmp2rfvnn4gk9rvr6d2m7a-redbug-2.0.6.drv
  /nix/store/cli9ynskxk6i901ja5kq0j2k4nw57sg6-tdiff-0.1.2.drv
  /nix/store/d0i24cl1802sq85n2jnk6xwyy1x7afl4-uuid-2.0.1.drv
  /nix/store/xz3v4b45d69g2vvza93g94abxalqxhlf-elvis_core-1.3.1.drv
  /nix/store/y73by0pmbgh9jvbfk9jiar8a1gksrl3z-yamerl-git.drv
  /nix/store/5rwk21ndgb1xj1j8pvsfcwsbxyfnlv4m-erlang-ls-0.35.0.drv
building '/nix/store/7zrhs55q64lmp2rfvnn4gk9rvr6d2m7a-redbug-2.0.6.drv'...
unpacking sources
unpacking source archive /nix/store/zsykc4z3q807j3ap5ss9q5qlam9cbcv4-hex-source-redbug-2.0.6
source root is hex-source-redbug-2.0.6
patching sources
updateAutotoolsGnuConfigScriptsPhase
configuring
no configure script, doing nothing
building
===> Errors loading plugin rebar3_hex. Run rebar3 with DEBUG=1 set to see errors.
===> Errors loading plugin rebar3_hex. Run rebar3 with DEBUG=1 set to see errors.
===> Analyzing applications...
===> Compiling redbug
===> Compiling src/redbug_targ.erl failed
src/redbug_targ.erl:545:17: ct_slave:start/2 is deprecated and will be removed in OTP 27; use ?CT_PEER(), or the 'peer' module instead
src/redbug_targ.erl:553:17: ct_slave:start/2 is deprecated and will be removed in OTP 27; use ?CT_PEER(), or the 'peer' module instead
src/redbug_targ.erl:561:39: ct_slave:stop/1 is deprecated and will be removed in OTP 27; use ?CT_PEER(), or the 'peer' module instead

error: builder for '/nix/store/7zrhs55q64lmp2rfvnn4gk9rvr6d2m7a-redbug-2.0.6.drv' failed with exit code 1;
       last 10 log lines:
       > building
       > ===> Errors loading plugin rebar3_hex. Run rebar3 with DEBUG=1 set to see errors.
       > ===> Errors loading plugin rebar3_hex. Run rebar3 with DEBUG=1 set to see errors.
       > ===> Analyzing applications...
       > ===> Compiling redbug
       > ===> Compiling src/redbug_targ.erl failed
       > src/redbug_targ.erl:545:17: ct_slave:start/2 is deprecated and will be removed in OTP 27; use ?CT_PEER(), or the 'peer' module instead
       > src/redbug_targ.erl:553:17: ct_slave:start/2 is deprecated and will be removed in OTP 27; use ?CT_PEER(), or the 'peer' module instead
       > src/redbug_targ.erl:561:39: ct_slave:stop/1 is deprecated and will be removed in OTP 27; use ?CT_PEER(), or the 'peer' module instead
       >
       For full logs, run 'nix log /nix/store/7zrhs55q64lmp2rfvnn4gk9rvr6d2m7a-redbug-2.0.6.drv'.
error: 1 dependencies of derivation '/nix/store/5rwk21ndgb1xj1j8pvsfcwsbxyfnlv4m-erlang-ls-0.35.0.drv' failed to build
```

This patches the rebar.conf file to remove the `warnings_as_errors` option.

(Is this an acceptable way to fix this?)

(There is a redbug issue at https://github.com/massemanet/redbug/issues/18 so hopefully this will be fixed upstream eventually.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
