### PR TITLE
[22.05] Backport Gnome 42 Updates

### DIFF
--- a/nixos/tests/installed-tests/default.nix
+++ b/nixos/tests/installed-tests/default.nix
@@ -92,6 +92,7 @@ in
   fwupd = callInstalledTest ./fwupd.nix {};
   gcab = callInstalledTest ./gcab.nix {};
   gdk-pixbuf = callInstalledTest ./gdk-pixbuf.nix {};
+  geocode-glib = callInstalledTest ./geocode-glib.nix {};
   gjs = callInstalledTest ./gjs.nix {};
   glib-networking = callInstalledTest ./glib-networking.nix {};
   gnome-photos = callInstalledTest ./gnome-photos.nix {};

--- a/pkgs/applications/audio/rhythmbox/default.nix
+++ b/pkgs/applications/audio/rhythmbox/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , lib
 , fetchurl
-, fetchpatch
 , pkg-config
 , meson
 , ninja
@@ -29,28 +28,20 @@
 , json-glib
 , itstool
 , wrapGAppsHook
+, desktop-file-utils
 , gst_all_1
 , gst_plugins ? with gst_all_1; [ gst-plugins-good gst-plugins-ugly ]
+, check
 }:
 
 stdenv.mkDerivation rec {
   pname = "rhythmbox";
-  version = "3.4.5";
+  version = "3.4.6";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "l+u8YPN4sibaRbtEbYmQL26hgx4j8Q76ujZVk7HnTyo=";
+    sha256 = "+VaCEM5V5BHpKcj7leERohHb0ZzEf1ePKRxdMZtesDQ=";
   };
-
-  patches = [
-    # Fix stuff linking against rhythmdb not finding libxml headers
-    # included by rhythmdb.h header.
-    # https://gitlab.gnome.org/GNOME/rhythmbox/-/merge_requests/147
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/rhythmbox/-/commit/7e8c7b803a45b7badf350132f8e78e3d75b99a21.patch";
-      sha256 = "5CE/NVlmx7FItNJCVQxx+x0DCYhUkAi/UuksfAiyWBg=";
-    })
-  ];
 
   nativeBuildInputs = [
     pkg-config
@@ -60,6 +51,7 @@ stdenv.mkDerivation rec {
     glib
     itstool
     wrapGAppsHook
+    desktop-file-utils
   ];
 
   buildInputs = [
@@ -95,9 +87,16 @@ stdenv.mkDerivation rec {
     libnotify
   ] ++ gst_plugins;
 
-  postInstall = ''
-    glib-compile-schemas "$out/share/glib-2.0/schemas"
-  '';
+  checkInputs = [
+    check
+  ];
+
+  mesonFlags = [
+    "-Dtests=disabled"
+  ];
+
+  # Requires DISPLAY
+  doCheck = false;
 
   preFixup = ''
     gappsWrapperArgs+=(

--- a/pkgs/applications/backup/deja-dup/default.nix
+++ b/pkgs/applications/backup/deja-dup/default.nix
@@ -22,14 +22,14 @@
 
 stdenv.mkDerivation rec {
   pname = "deja-dup";
-  version = "43.3";
+  version = "43.4";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "World";
     repo = pname;
     rev = version;
-    sha256 = "sha256-HOIBAzR+7OZ1RO+MSpCQKShcikdtWCjdMUO2rE2TxiM=";
+    sha256 = "sha256-8eqrBQrMvS4cta5RP0ibo4Zc3B8hlkftxaRyvb6JuEY=";
   };
 
   patches = [

--- a/pkgs/applications/misc/orca/default.nix
+++ b/pkgs/applications/misc/orca/default.nix
@@ -34,13 +34,13 @@
 
 buildPythonApplication rec {
   pname = "orca";
-  version = "42.1";
+  version = "42.2";
 
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "6p6dLehwg4ewUqe+FqXmnOqfZ2jfrrRee9meRmNxYt4=";
+    sha256 = "mXHp/aGqK9ZKdrMxcxNcZBWaSQssS8/757lUj+38eCw=";
   };
 
   patches = [

--- a/pkgs/applications/networking/mailreaders/evolution/evolution-ews/default.nix
+++ b/pkgs/applications/networking/mailreaders/evolution/evolution-ews/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   pname = "evolution-ews";
-  version = "3.44.1";
+  version = "3.44.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "LJNidefwnQtOtWgMVb/4Xw2A0lU4R2Gm0Z3XfOaU/oM=";
+    sha256 = "xXPzlxA8FybyS+Tz+f0gzrvJtEW6CysOt8lI/YQVBho=";
   };
 
   nativeBuildInputs = [ cmake gettext intltool pkg-config ];

--- a/pkgs/applications/networking/mailreaders/evolution/evolution-ews/default.nix
+++ b/pkgs/applications/networking/mailreaders/evolution/evolution-ews/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   pname = "evolution-ews";
-  version = "3.44.2";
+  version = "3.44.3";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "xXPzlxA8FybyS+Tz+f0gzrvJtEW6CysOt8lI/YQVBho=";
+    sha256 = "hcysooh6+FvwSORzx7bELF9WQasFpbxM/Oo04rb1vhc=";
   };
 
   nativeBuildInputs = [ cmake gettext intltool pkg-config ];

--- a/pkgs/applications/networking/mailreaders/evolution/evolution/default.nix
+++ b/pkgs/applications/networking/mailreaders/evolution/evolution/default.nix
@@ -46,11 +46,11 @@
 
 stdenv.mkDerivation rec {
   pname = "evolution";
-  version = "3.44.2";
+  version = "3.44.3";
 
   src = fetchurl {
     url = "mirror://gnome/sources/evolution/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "+scGznpXP42WdzfxWtDr66Q6h/48p1f4VBID2ZG+BjM=";
+    sha256 = "U2sR9BM99vIW8nr5okgaGe164Ivi1KE7EoBhwmKjZJk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/video/pitivi/default.nix
+++ b/pkgs/applications/video/pitivi/default.nix
@@ -1,19 +1,16 @@
 { lib
 , fetchurl
-, fetchpatch
 , pkg-config
 , gettext
 , itstool
 , python3
 , wrapGAppsHook
-, python3Packages
 , gst_all_1
 , gtk3
 , gobject-introspection
 , libpeas
 , librsvg
 , gnome
-, gnome-desktop
 , libnotify
 , gsound
 , meson
@@ -21,15 +18,15 @@
 , gsettings-desktop-schemas
 }:
 
-python3Packages.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "pitivi";
-  version = "2021.05";
+  version = "2022.06";
 
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/pitivi/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "z1aTxGxCqw2hSi5Zv89LyIBgS0HpzTqo0uvcYIJ7dcc=";
+    sha256 = "Uz0448bSEcK9DpXiuWsPCDO98NXUd6zgffYRWDUGyDg=";
   };
 
   patches = [
@@ -37,13 +34,6 @@ python3Packages.buildPythonApplication rec {
     # and saves them to the generated binary. This would make the build-time
     # dependencies part of the closure so we remove it.
     ./prevent-closure-contamination.patch
-
-    # Fix build with meson 0.61
-    # https://gitlab.gnome.org/GNOME/pitivi/-/merge_requests/414
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/pitivi/-/commit/ddf2369d1fc6fddd63f676cc905a8b8e96291a4c.patch";
-      sha256 = "MC4naGnqhrYlFBFHZaSzbOzrqaNK5/Xv5jBmCu0fLQE=";
-    })
   ];
 
   nativeBuildInputs = [
@@ -61,9 +51,7 @@ python3Packages.buildPythonApplication rec {
     gtk3
     libpeas
     librsvg
-    gnome-desktop
     gsound
-    gnome.adwaita-icon-theme
     gsettings-desktop-schemas
     libnotify
   ] ++ (with gst_all_1; [
@@ -77,14 +65,13 @@ python3Packages.buildPythonApplication rec {
     gst-devtools
   ]);
 
-  pythonPath = with python3Packages; [
+  pythonPath = with python3.pkgs; [
     pygobject3
     gst-python
-    pyxdg
     numpy
     pycairo
     matplotlib
-    dbus-python
+    librosa
   ];
 
   postPatch = ''

--- a/pkgs/desktops/gnome/apps/gnome-boxes/default.nix
+++ b/pkgs/desktops/gnome/apps/gnome-boxes/default.nix
@@ -13,7 +13,6 @@
 , gtk3
 , gtksourceview4
 , gtk-vnc
-, freerdp
 , libvirt
 , spice-gtk
 , python3
@@ -55,16 +54,15 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-boxes";
-  version = "42.1";
+  version = "42.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "lvXQEbdQjbVhvw0WbA6p6LEhgFxA5dnzYRkkXBUXIIA=";
+    sha256 = "98K8oU3K4oONsR+iyA4jQI41SBeK+GGg1NDcxql4ABU=";
   };
 
   patches = [
-    # Fix path to libgovf-0.1.so (and libgtk-frdp-0.1.so when enabling rdp meson option)
-    # in the gir file. We patch gobject-introspection to hardcode absolute paths but
+    # Fix path to libgovf-0.1.so in the gir file. We patch gobject-introspection to hardcode absolute paths but
     # our Meson patch will only pass the info when install_dir is absolute as well.
     ./fix-gir-lib-path.patch
   ];
@@ -93,7 +91,6 @@ stdenv.mkDerivation rec {
   buildInputs = [
     acl
     cyrus_sasl
-    freerdp
     gdbm
     glib
     glib-networking

--- a/pkgs/desktops/gnome/apps/gnome-boxes/fix-gir-lib-path.patch
+++ b/pkgs/desktops/gnome/apps/gnome-boxes/fix-gir-lib-path.patch
@@ -9,14 +9,3 @@
  )
  
  govf_dep = declare_dependency(
---- a/subprojects/gtk-frdp/src/meson.build
-+++ b/subprojects/gtk-frdp/src/meson.build
-@@ -50,7 +50,7 @@ gtk_frdp_lib = shared_library('gtk-frdp-' + api_version,
-   gtk_frdp_sources,
-   dependencies: gtk_frdp_deps,
-   install: true,
--  install_dir: libdir
-+  install_dir: get_option ('prefix') / libdir
- )
- 
- gtk_frdp_dep = declare_dependency(

--- a/pkgs/desktops/gnome/apps/gnome-maps/default.nix
+++ b/pkgs/desktops/gnome/apps/gnome-maps/default.nix
@@ -30,11 +30,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-maps";
-  version = "42.2";
+  version = "42.3";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-Xm0bDKfMk56pGq39pWM6hl6oX6VlADaGGyv+8L/QabE=";
+    sha256 = "sha256-5FZGf6zzyP0QyThrXnTEPZWVrZ+3Ulf32gFK+YPWnNE=";
   };
 
   doCheck = true;

--- a/pkgs/desktops/gnome/core/evolution-data-server/default.nix
+++ b/pkgs/desktops/gnome/core/evolution-data-server/default.nix
@@ -45,13 +45,13 @@
 
 stdenv.mkDerivation rec {
   pname = "evolution-data-server";
-  version = "3.44.2";
+  version = "3.44.3";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/evolution-data-server/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "Ltcq/k1rsXD4co+uoJB/7hAhLf3nqfq4L7zIPQ8i8Cg=";
+    sha256 = "kEOrU/NB2hAxXFUDhKazIEMBk/yNeGHdJcTpsuC+Qls=";
   };
 
   patches = [

--- a/pkgs/desktops/gnome/core/gnome-calculator/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-calculator/default.nix
@@ -25,11 +25,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-calculator";
-  version = "42.1";
+  version = "42.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-calculator/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "700k5Cpl3IYOYgbztHC30jPCripNSWXYhZqp6oo5Ws0=";
+    sha256 = "M9qxvKQ2WNZlIJWLD2dMsK0xhc/TDBLkWef2lIHFxqA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome/core/sushi/default.nix
+++ b/pkgs/desktops/gnome/core/sushi/default.nix
@@ -23,11 +23,11 @@
 
 stdenv.mkDerivation rec {
   pname = "sushi";
-  version = "41.2";
+  version = "42.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/sushi/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "tZ+0LJllxzYfdilt0qNARatlUGXqQUPeWsiyygyq6l4=";
+    sha256 = "RdjbevRaeXhOejRYjRSeqVXIvkS7gqNuiWgpQFt8iCA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/geocode-glib/default.nix
+++ b/pkgs/development/libraries/geocode-glib/default.nix
@@ -1,30 +1,62 @@
-{ fetchurl, lib, stdenv, meson, ninja, pkg-config, gettext, gtk-doc, docbook_xsl, gobject-introspection, gnome, libsoup, json-glib, glib }:
+{ fetchurl
+, lib
+, stdenv
+, meson
+, ninja
+, pkg-config
+, gettext
+, gtk-doc
+, docbook-xsl-nons
+, gobject-introspection
+, gnome
+, libsoup
+, json-glib
+, glib
+, nixosTests
+}:
 
 stdenv.mkDerivation rec {
   pname = "geocode-glib";
-  version = "3.26.2";
+  version = "3.26.3";
 
   outputs = [ "out" "dev" "devdoc" "installedTests" ];
 
   src = fetchurl {
-    url = "mirror://gnome/sources/geocode-glib/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1l8g0f13xgkrk335afr9w8k46mziwb2jnyhl07jccl5yl37q9zh1";
+    url = "mirror://gnome/sources/geocode-glib/${lib.versions.majorMinor version}/geocode-glib-${version}.tar.xz";
+    sha256 = "Hf6ug7kOzMobbPfc98XjsxeCjPC1YgXERx7w+RGZl2Y=";
   };
-
-  nativeBuildInputs = [ meson ninja pkg-config gettext gtk-doc docbook_xsl gobject-introspection ];
-  buildInputs = [ glib libsoup json-glib ];
 
   patches = [
     ./installed-tests-path.patch
   ];
 
-  postPatch = ''
-    substituteInPlace geocode-glib/tests/meson.build --subst-var-by "installedTests" "$installedTests"
-  '';
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    gettext
+    gtk-doc
+    docbook-xsl-nons
+    gobject-introspection
+  ];
+
+  buildInputs = [
+    glib
+    libsoup
+    json-glib
+  ];
+
+  mesonFlags = [
+    "-Dsoup2=${lib.boolToString (lib.versionOlder libsoup.version "2.99")}"
+    "-Dinstalled_test_prefix=${placeholder "installedTests"}"
+  ];
 
   passthru = {
     updateScript = gnome.updateScript {
       packageName = pname;
+    };
+    tests = {
+      installed-tests = nixosTests.installed-tests.geocode-glib;
     };
   };
 

--- a/pkgs/development/libraries/geocode-glib/installed-tests-path.patch
+++ b/pkgs/development/libraries/geocode-glib/installed-tests-path.patch
@@ -1,8 +1,20 @@
 --- a/geocode-glib/tests/meson.build
 +++ b/geocode-glib/tests/meson.build
 @@ -1,4 +1,4 @@
--install_dir = get_option('libexecdir') + '/installed-tests/geocode-glib'
-+install_dir = '@installedTests@/libexec/installed-tests/geocode-glib'
+-install_dir = get_option('prefix') / get_option('datadir') / 'installed-tests' / library_name
++install_dir = get_option('installed_test_prefix') / 'share' / 'installed-tests' / library_name
  
  e = executable('geo-uri',
                 'geo-uri.c',
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -1,6 +1,9 @@
+ option('enable-installed-tests',
+        type: 'boolean', value: true,
+        description: 'Build & install test programs')
++option('installed_test_prefix',
++       type: 'string', value: '',
++       description: 'Prefix for installed tests')
+ option('enable-introspection',
+         type: 'boolean', value: true,
+         description: 'Whether to enable the introspection generation')


### PR DESCRIPTION
###### Description of changes

This backports #179849, which was marked as backport, but failed to auto-backport. The reason it failed was that 034fead67edab4d4e94ecc1c3daab1855787ea8d was not applied yet in 22.05.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
