### PR TITLE
aptly: 1.4.0 -> 1.5.0

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -74,6 +74,15 @@ with lib.maintainers; {
     enableFeatureFreezePing = true;
   };
 
+  bitnomial = {
+    # Verify additions to this team with at least one already existing member of the team.
+    members = [
+      cdepillabout
+    ];
+    scope = "Group registration for packages maintained by Bitnomial.";
+    shortName = "Bitnomial employees";
+  };
+
   blockchains = {
     members = [
       mmahut

--- a/pkgs/tools/misc/aptly/default.nix
+++ b/pkgs/tools/misc/aptly/default.nix
@@ -1,47 +1,43 @@
-{ lib, buildGoPackage, fetchFromGitHub, installShellFiles, makeWrapper, gnupg, bzip2, xz, graphviz }:
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles, makeWrapper, gnupg, bzip2, xz, graphviz, testers, aptly }:
 
-let
+buildGoModule rec {
+  pname = "aptly";
+  version = "1.5.0";
 
-  version = "1.4.0";
-  rev = "v${version}";
-
-  aptlySrc = fetchFromGitHub {
-    inherit rev;
+  src = fetchFromGitHub {
     owner = "aptly-dev";
     repo = "aptly";
-    sha256 = "06cq761r3bxybb9xn58jii0ggp79mcp3810z1r2z3xcvplwhwnhy";
+    rev = "v${version}";
+    sha256 = "sha256-LqGOLXXaGfQfoj2r+aY9SdOKUDI9+22EsHKBhHMidyk=";
   };
 
-  aptlyCompletionSrc = fetchFromGitHub {
-    rev = "1.0.1";
-    owner = "aptly-dev";
-    repo = "aptly-bash-completion";
-    sha256 = "0dkc4z687yk912lpv8rirv0nby7iny1zgdvnhdm5b47qmjr1sm5q";
-  };
-
-in
-
-buildGoPackage {
-  pname = "aptly";
-  inherit version;
-
-  src = aptlySrc;
-
-  goPackagePath = "github.com/aptly-dev/aptly";
+  vendorSha256 = "sha256-6l3OFKFTtFWT68Ylav6woczBlMhD75C9ZoQ6OeLz0Cs=";
 
   nativeBuildInputs = [ installShellFiles makeWrapper ];
 
+  ldflags = [ "-s" "-w" "-X main.Version=${version}" ];
+
   postInstall = ''
-    installShellCompletion --bash ${aptlyCompletionSrc}/aptly
+    installShellCompletion --bash --name aptly completion.d/aptly
+    installShellCompletion --zsh --name _aptly completion.d/_aptly
     wrapProgram "$out/bin/aptly" \
       --prefix PATH ":" "${lib.makeBinPath [ gnupg bzip2 xz graphviz ]}"
   '';
+
+  doCheck = false;
+
+  passthru.tests.version = testers.testVersion {
+    package = aptly;
+    command = "aptly version";
+  };
 
   meta = with lib; {
     homepage = "https://www.aptly.info";
     description = "Debian repository management tool";
     license = licenses.mit;
     platforms = platforms.unix;
-    maintainers = [ maintainers.montag451 ];
+    maintainers = with maintainers; [ montag451 ];
+    changelog =
+      "https://github.com/aptly-dev/aptly/releases/tag/v${version}";
   };
 }

--- a/pkgs/tools/misc/aptly/default.nix
+++ b/pkgs/tools/misc/aptly/default.nix
@@ -36,7 +36,7 @@ buildGoModule rec {
     description = "Debian repository management tool";
     license = licenses.mit;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ montag451 ];
+    maintainers = with maintainers; [ montag451 ] ++ teams.bitnomial.members;
     changelog =
       "https://github.com/aptly-dev/aptly/releases/tag/v${version}";
   };


### PR DESCRIPTION
###### Description of changes

This bumps `aptly` to 1.5.0: https://github.com/aptly-dev/aptly/releases/tag/v1.5.0

This is a reincarnation of https://github.com/NixOS/nixpkgs/pull/183684, which was closed for some reason.

cc @aaronjheng from https://github.com/NixOS/nixpkgs/pull/183684 and @floki from the bump to 1.4.0 in https://github.com/NixOS/nixpkgs/pull/101959

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
