### PR TITLE
python3Packages.requests: Fix sandboxed build on Darwin

### DIFF
--- a/pkgs/development/python-modules/requests/default.nix
+++ b/pkgs/development/python-modules/requests/default.nix
@@ -20,6 +20,8 @@ buildPythonPackage rec {
   version = "2.28.1";
   disabled = pythonOlder "3.7";
 
+  __darwinAllowLocalNetworking = true;
+
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-fFWZsQL+3apmHIJsVqtP7ii/0X9avKHrvj5/GdfJeYM=";


### PR DESCRIPTION
###### Description of changes

Fixes the check phase:

```
=========================== short test summary info ============================
FAILED tests/test_lowlevel.py::test_chunked_upload_uses_only_specified_host_header
FAILED tests/test_lowlevel.py::test_chunked_upload_doesnt_skip_host_header
FAILED tests/test_lowlevel.py::test_chunked_upload
FAILED tests/test_lowlevel.py::test_conflicting_content_lengths
FAILED tests/test_lowlevel.py::test_digestauth_401_count_reset_on_redirect
FAILED tests/test_lowlevel.py::test_chunked_encoding_error
FAILED tests/test_lowlevel.py::test_json_decode_compatibility_for_alt_utf_encodings
FAILED tests/test_lowlevel.py::test_fragment_not_sent_with_request
FAILED tests/test_lowlevel.py::test_fragment_update_on_redirect
FAILED tests/test_lowlevel.py::test_redirect_rfc1808_to_non_ascii_location
FAILED tests/test_lowlevel.py::test_digestauth_only_on_4xx
FAILED tests/test_lowlevel.py::test_digestauth_401_only_sent_once
FAILED tests/test_testserver.py::TestTestServer::test_basic_waiting_server
FAILED tests/test_testserver.py::TestTestServer::test_server_closes
FAILED tests/test_testserver.py::TestTestServer::test_basic
FAILED tests/test_testserver.py::TestTestServer::test_request_recovery_with_bigger_timeout
FAILED tests/test_testserver.py::TestTestServer::test_basic_response
FAILED tests/test_testserver.py::TestTestServer::test_text_response
FAILED tests/test_testserver.py::TestTestServer::test_server_finishes_when_no_connections
================= 19 failed, 220 passed, 13 skipped in 11.20s ==================
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).