### PR TITLE
python3Packages.cachecontrol: Fix sandboxed build on Darwin

### DIFF
--- a/pkgs/development/python-modules/cachecontrol/default.nix
+++ b/pkgs/development/python-modules/cachecontrol/default.nix
@@ -18,6 +18,8 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.6";
 
+  __darwinAllowLocalNetworking = true;
+
   src = fetchFromGitHub {
     owner = "ionrock";
     repo = pname;


### PR DESCRIPTION
###### Description of changes

```
Executing pytestCheckPhase
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/nix/store/m80vrnbydy0dnh9ln6qmxkmdl18p9gj2-python3.10-pytest-7.1.2/lib/python3.10/site-packages/_pytest/main.py", line 264, in wrap_sessio
n
INTERNALERROR>     config._do_configure()
INTERNALERROR>   File "/nix/store/m80vrnbydy0dnh9ln6qmxkmdl18p9gj2-python3.10-pytest-7.1.2/lib/python3.10/site-packages/_pytest/config/__init__.py", line 995, in
_do_configure
INTERNALERROR>     self.hook.pytest_configure.call_historic(kwargs=dict(config=self))
INTERNALERROR>   File "/nix/store/rydqrp44fixl6rwmzxc5fg4b24vgaqvj-python3.10-pluggy-1.0.0/lib/python3.10/site-packages/pluggy/_hooks.py", line 277, in call_histo
ric
INTERNALERROR>     res = self._hookexec(self.name, self.get_hookimpls(), kwargs, False)
INTERNALERROR>   File "/nix/store/rydqrp44fixl6rwmzxc5fg4b24vgaqvj-python3.10-pluggy-1.0.0/lib/python3.10/site-packages/pluggy/_manager.py", line 80, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
INTERNALERROR>   File "/nix/store/rydqrp44fixl6rwmzxc5fg4b24vgaqvj-python3.10-pluggy-1.0.0/lib/python3.10/site-packages/pluggy/_callers.py", line 60, in _multical
l
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>   File "/nix/store/rydqrp44fixl6rwmzxc5fg4b24vgaqvj-python3.10-pluggy-1.0.0/lib/python3.10/site-packages/pluggy/_result.py", line 60, in get_result
INTERNALERROR>     raise ex[1].with_traceback(ex[2])
INTERNALERROR>   File "/nix/store/rydqrp44fixl6rwmzxc5fg4b24vgaqvj-python3.10-pluggy-1.0.0/lib/python3.10/site-packages/pluggy/_callers.py", line 39, in _multical
l
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/private/tmp/nix-build-python3.10-cachecontrol-0.12.11.drv-0/source/tests/conftest.py", line 140, in pytest_configure
INTERNALERROR>     ip, port = get_free_port()
INTERNALERROR>   File "/private/tmp/nix-build-python3.10-cachecontrol-0.12.11.drv-0/source/tests/conftest.py", line 130, in get_free_port
INTERNALERROR>     s.bind(("", 0))
INTERNALERROR> PermissionError: [Errno 1] Operation not permitted
```

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).