### PR TITLE
python3Packages.azure-core: Fix sandboxed build on Darwin

### DIFF
--- a/pkgs/development/python-modules/azure-core/default.nix
+++ b/pkgs/development/python-modules/azure-core/default.nix
@@ -21,6 +21,8 @@ buildPythonPackage rec {
   pname = "azure-core";
   disabled = pythonOlder "3.6";
 
+  __darwinAllowLocalNetworking = true;
+
   src = fetchPypi {
     inherit pname version;
     extension = "zip";


### PR DESCRIPTION
###### Description of changes

```
=========================== short test summary info ============================
ERROR tests/test_authentication.py::test_azure_key_credential_policy_raises
ERROR tests/test_authentication.py::test_azure_key_credential_updates - Value...
ERROR tests/test_authentication.py::test_azure_sas_credential_updates - Value...
ERROR tests/test_authentication.py::test_azure_sas_credential_policy_raises
...
ERROR tests/async_tests/test_rest_trio_transport.py::test_decompress_compressed_header_stream
ERROR tests/async_tests/test_rest_trio_transport.py::test_decompress_compressed_header_stream_body_content
ERROR tests/async_tests/test_retry_policy_async.py::test_retry_code_class_variables
ERROR tests/async_tests/test_retry_policy_async.py::test_retry_types - ValueE...
=============== 872 deselected, 3 warnings, 222 errors in 18.33s ===============
```

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).