### PR TITLE
python3Packages.pytest-aiohttp: Fix sandboxed build on Darwin

### DIFF
--- a/pkgs/development/python-modules/pytest-aiohttp/default.nix
+++ b/pkgs/development/python-modules/pytest-aiohttp/default.nix
@@ -14,6 +14,8 @@ buildPythonPackage rec {
 
   format = "setuptools";
 
+  __darwinAllowLocalNetworking = true;
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "39ff3a0d15484c01d1436cbedad575c6eafbf0f57cdf76fb94994c97b5b8c5a4";


### PR DESCRIPTION
###### Description of changes

```
============================= test session starts ==============================
platform darwin -- Python 3.10.6, pytest-7.1.2, pluggy-1.0.0
rootdir: /private/tmp/nix-build-python3.10-pytest-aiohttp-1.0.4.drv-0/pytest-of-_nixbld1/pytest-0/test_aiohttp_plugin0
plugins: aiohttp-1.0.4, asyncio-0.19.0
asyncio: mode=auto
collected 8 items

test_aiohttp_plugin.py FFF...EE                                          [100%]

==================================== ERRORS ====================================
______________ ERROR at setup of test_custom_port_aiohttp_client _______________

    @pytest.fixture
    def unused_tcp_port() -> int:
>       return _unused_port(socket.SOCK_STREAM)

/nix/store/mqsrdaf2d3v2j2ndwa99xm7g58hlzfp7-python3.10-pytest-asyncio-0.19.0/lib/python3.10/site-packages/pytest_asyncio/plugin.py:503:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

socket_type = <SocketKind.SOCK_STREAM: 1>

    def _unused_port(socket_type: int) -> int:
        """Find an unused localhost port from 1024-65535 and return it."""
        with contextlib.closing(socket.socket(type=socket_type)) as sock:
>           sock.bind(("127.0.0.1", 0))
E           PermissionError: [Errno 1] Operation not permitted

/nix/store/mqsrdaf2d3v2j2ndwa99xm7g58hlzfp7-python3.10-pytest-asyncio-0.19.0/lib/python3.10/site-packages/pytest_asyncio/plugin.py:497: PermissionError
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).