### PR TITLE
[Backport release-22.05] rustup: also patch binaries in libexec

### DIFF
--- a/pkgs/development/tools/rust/rustup/0001-dynamically-patchelf-binaries.patch
+++ b/pkgs/development/tools/rust/rustup/0001-dynamically-patchelf-binaries.patch
@@ -1,8 +1,8 @@
 diff --git a/src/dist/component/package.rs b/src/dist/component/package.rs
-index 3beddf54..0f859b8d 100644
+index 73a533b5..408ab815 100644
 --- a/src/dist/component/package.rs
 +++ b/src/dist/component/package.rs
-@@ -113,6 +113,7 @@ impl Package for DirectoryPackage {
+@@ -113,6 +113,7 @@ fn install<'a>(
                      } else {
                          builder.move_file(path.clone(), &src_path)?
                      }
@@ -10,13 +10,13 @@ index 3beddf54..0f859b8d 100644
                  }
                  "dir" => {
                      if self.copy {
-@@ -135,6 +136,29 @@ impl Package for DirectoryPackage {
+@@ -135,6 +136,29 @@ fn components(&self) -> Vec<String> {
      }
  }
  
 +fn nix_patchelf_if_needed(dest_path: &Path, src_path: &Path) {
 +    let (is_bin, is_lib) = if let Some(p) = src_path.parent() {
-+        (p.ends_with("bin"), p.ends_with("lib"))
++        (p.ends_with("bin") || p.ends_with("libexec"), p.ends_with("lib"))
 +    } else {
 +        (false, false)
 +    };
@@ -38,5 +38,5 @@ index 3beddf54..0f859b8d 100644
 +}
 +
  #[derive(Debug)]
- pub struct TarPackage<'a>(DirectoryPackage, temp::Dir<'a>);
+ pub(crate) struct TarPackage<'a>(DirectoryPackage, temp::Dir<'a>);
  


### PR DESCRIPTION
###### Description of changes

Backport #186059 to NixOS 22.05

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I confirmed that rustup is still working and that `~/.rustup/toolchains/nightly-2022-08-25-x86_64-unknown-linux-gnu/libexec/rust-analyzer-proc-macro-srv` is now patched, where it was not before.

cc maintainer, committer @Mic92