### PR TITLE
python3Packages.python-socks: Fix sandboxed build on Darwin

### DIFF
--- a/pkgs/development/python-modules/python-socks/default.nix
+++ b/pkgs/development/python-modules/python-socks/default.nix
@@ -19,6 +19,8 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.6.1";
 
+  __darwinAllowLocalNetworking = true;
+
   src = fetchFromGitHub {
     owner = "romis2012";
     repo = pname;


### PR DESCRIPTION
###### Description of changes

```
=========================== short test summary info ============================
ERROR tests/test_misc.py::test_is_ip_address[::10] - Exception: The proxy ser...
ERROR tests/test_misc.py::test_is_ip_address[::11] - Exception: The proxy ser...
ERROR tests/test_misc.py::test_is_ip_address[127.0.0.10] - Exception: The pro...
ERROR tests/test_misc.py::test_is_ip_address[127.0.0.11] - Exception: The pro...
...
ERROR tests/test_resolvers.py::test_asyncio_resolver - Exception: The proxy s...
ERROR tests/test_resolvers.py::test_trio_resolver - Exception: The proxy serv...
ERROR tests/test_resolvers.py::test_anyio_resolver - Exception: The proxy ser...
ERROR tests/test_resolvers.py::test_curio_resolver - Exception: The proxy ser...
================== 1 skipped, 1 warning, 270 errors in 16.26s ==================
```

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).