### PR TITLE
mimeo: 2021.11 -> 2022.7

### DIFF
--- a/pkgs/tools/misc/mimeo/default.nix
+++ b/pkgs/tools/misc/mimeo/default.nix
@@ -1,12 +1,13 @@
 { lib, fetchurl, desktop-file-utils, file, python3Packages }:
 
-python3Packages.buildPythonApplication rec {
+let version = "2022.7";
+in python3Packages.buildPythonApplication {
   pname = "mimeo";
-  version = "2021.11";
+  inherit version;
 
   src = fetchurl {
-    url = "https://xyne.dev/projects/mimeo/src/${pname}-${version}.tar.xz";
-    sha256 = "1fi8svn4hg2hmvv28j026sks1hc0v8wh974g7ixcwfcg2xda6c4p";
+    url = "https://xyne.dev/projects/mimeo/src/mimeo-${version}.tar.xz";
+    hash = "sha256-xzWPMtlKj35mkE04jcGalbf/94qEOOUi9pvZgSPgdj8=";
   };
 
   buildInputs = [ file desktop-file-utils ];
@@ -31,7 +32,7 @@ python3Packages.buildPythonApplication rec {
   meta = with lib; {
     description = "Open files by MIME-type or file name using regular expressions";
     homepage = "https://xyne.dev/projects/mimeo/";
-    license = [ licenses.gpl2 ];
+    license = [ licenses.gpl2Only ];
     maintainers = [ maintainers.rycee ];
     platforms = platforms.unix;
   };


### PR DESCRIPTION


###### Description of changes

Bump version. Also make license field more specific.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).