### PR TITLE
bpftrace: pull upstream fix for binutils-2.39

### DIFF
--- a/pkgs/os-specific/linux/bpftrace/default.nix
+++ b/pkgs/os-specific/linux/bpftrace/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub
+{ lib, stdenv, fetchFromGitHub, fetchpatch
 , cmake, pkg-config, flex, bison
 , llvmPackages, elfutils
 , libbfd, libbpf, libopcodes, bcc
@@ -35,6 +35,17 @@ stdenv.mkDerivation rec {
     rev    = "v${version}";
     sha256 = "sha256-9adZAKSn00W2yNwVDbVB1/O5Y+10c4EkVJGCHyd4Tgg=";
   };
+
+  patches = [
+    # Pull upstream fix for binutils-2.39:
+    #   https://github.com/iovisor/bpftrace/pull/2328
+    (fetchpatch {
+      name = "binutils-2.39.patch";
+      url = "https://github.com/iovisor/bpftrace/commit/3be6e708d514d3378a4fe985ab907643ecbc77ee.patch";
+      sha256 = "sha256-WWEh8ViGw8053nEG/29KeKEHV5ossWPtL/AAV/l+pnY=";
+      excludes = [ "CHANGELOG.md" ];
+    })
+  ];
 
   buildInputs = with llvmPackages;
     [ llvm libclang


### PR DESCRIPTION
Without the change build fails on binutils-2.39 branch as:

    jit_disasm.c:105:17: error: too few arguments to function 'init_disassemble_info'
      105 |                 init_disassemble_info(&info, stdout,
          |                 ^~~~~~~~~~~~~~~~~~~~~

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
