### PR TITLE
mdbook-toc: init at 0.9.0

### DIFF
--- a/pkgs/tools/text/mdbook-toc/default.nix
+++ b/pkgs/tools/text/mdbook-toc/default.nix
@@ -1,0 +1,25 @@
+{ lib, stdenv, fetchFromGitHub, rustPlatform, CoreServices }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "mdbook-toc";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = "badboy";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-7JpMBQqglLn33HwMBuIR5Hc0ISmzLPjQXGJVRwwl4OU=";
+  };
+
+  cargoSha256 = "sha256-Vj9DSjJtkexKly8IWlGEQkVrjSHcK1/2i+2g2Ht0eUo=";
+
+  buildInputs = lib.optionals stdenv.isDarwin [ CoreServices ];
+
+  meta = with lib; {
+    description = "A preprocessor for mdbook to add inline Table of Contents support";
+    homepage = "https://github.com/badboy/mdbook-toc";
+    license = [ licenses.mpl20 ];
+    maintainers = with maintainers; [ matthiasbeyer ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8408,6 +8408,10 @@ with pkgs;
     openssl = openssl_1_1;
   };
 
+  mdbook-toc = callPackage ../tools/text/mdbook-toc {
+    inherit (darwin.apple_sdk.frameworks) CoreServices;
+  };
+
   mdbook-admonish = callPackage ../tools/text/mdbook-admonish {
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };


### PR DESCRIPTION
###### Description of changes

Adds `mdbook-toc`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
