### PR TITLE
gomod2nix: init at 1.5.0

### DIFF
--- a/pkgs/build-support/go/gomod2nix/default.nix
+++ b/pkgs/build-support/go/gomod2nix/default.nix
@@ -1,0 +1,435 @@
+{ stdenv
+, stdenvNoCC
+, runCommand
+, buildEnv
+, lib
+, fetchgit
+, jq
+, cacert
+, pkgs
+, pkgsBuildBuild
+, runtimeShell
+, writeScript
+, gomod2nix
+}:
+let
+
+  inherit (builtins) substring toJSON hasAttr trace split readFile elemAt;
+  inherit (lib)
+    concatStringsSep replaceStrings removePrefix optionalString pathExists
+    optional concatMapStrings fetchers filterAttrs mapAttrs mapAttrsToList
+    warnIf optionalAttrs platforms
+    ;
+
+  parseGoMod = import ./parser.nix;
+
+  # Internal only build-time attributes
+  internal =
+    let
+      mkInternalPkg = name: src: pkgsBuildBuild.runCommand "gomod2nix-${name}"
+        {
+          inherit (pkgsBuildBuild.go) GOOS GOARCH;
+          nativeBuildInputs = [ pkgsBuildBuild.go ];
+        } ''
+        export HOME=$(mktemp -d)
+        go build -o $out ${src}
+      '';
+    in
+    {
+
+      # Create a symlink tree of vendored sources
+      symlink = mkInternalPkg "symlink" ./symlink/symlink.go;
+
+      # Install development dependencies from tools.go
+      install = mkInternalPkg "symlink" ./install/install.go;
+
+    };
+
+  fetchGoModule =
+    { hash
+    , goPackagePath
+    , version
+    , go
+    }:
+    stdenvNoCC.mkDerivation {
+      name = "${baseNameOf goPackagePath}_${version}";
+      builder = ./fetch.sh;
+      inherit goPackagePath version;
+      nativeBuildInputs = [
+        go
+        jq
+        cacert
+      ];
+      outputHashMode = "recursive";
+      outputHashAlgo = null;
+      outputHash = hash;
+      impureEnvVars = fetchers.proxyImpureEnvVars ++ [ "GOPROXY" ];
+    };
+
+  mkVendorEnv =
+    { go
+    , modulesStruct
+    , localReplaceCommands ? [ ]
+    , defaultPackage ? ""
+    , goMod
+    , pwd
+    }:
+    let
+      localReplaceCommands =
+        let
+          localReplaceAttrs = filterAttrs (n: v: hasAttr "path" v) goMod.replace;
+          commands = (
+            mapAttrsToList
+              (name: value: (
+                ''
+                  mkdir -p $(dirname vendor/${name})
+                  ln -s ${pwd + "/${value.path}"} vendor/${name}
+                ''
+              ))
+              localReplaceAttrs);
+        in
+        if goMod != null then commands else [ ];
+
+      sources = mapAttrs
+        (goPackagePath: meta: fetchGoModule {
+          goPackagePath = meta.replaced or goPackagePath;
+          inherit (meta) version hash;
+          inherit go;
+        })
+        modulesStruct.mod;
+    in
+    runCommand "vendor-env"
+      {
+        nativeBuildInputs = [ go ];
+        json = toJSON (filterAttrs (n: _: n != defaultPackage) modulesStruct.mod);
+
+        sources = toJSON (filterAttrs (n: _: n != defaultPackage) sources);
+
+        passthru = {
+          inherit sources;
+        };
+
+        passAsFile = [ "json" "sources" ];
+      }
+      (
+        ''
+          mkdir vendor
+
+          export GOCACHE=$TMPDIR/go-cache
+          export GOPATH="$TMPDIR/go"
+
+          ${internal.symlink}
+          ${concatStringsSep "\n" localReplaceCommands}
+
+          mv vendor $out
+        ''
+      );
+
+  # Return a Go attribute and error out if the Go version is older than was specified in go.mod.
+  selectGo = attrs: goMod: attrs.go or (if goMod == null then pkgs.go else
+  (
+    let
+      goVersion = goMod.go;
+      goAttrs = lib.reverseList (builtins.filter
+        (
+          attr: lib.hasPrefix "go_" attr && lib.versionAtLeast pkgs.${attr}.version goVersion
+        )
+        (lib.attrNames pkgs));
+      goAttr = elemAt goAttrs 0;
+    in
+    (
+      if goAttrs != [ ]
+      then pkgs.${goAttr}
+      else throw "go.mod specified Go version ${goVersion}, but no compatible Go attribute could be found."
+    )
+  ));
+
+  # Strip extra data that Go adds to versions, and fall back to a version based on the date if it's a placeholder value.
+  # This is data that Nix can't handle in the version attribute.
+  stripVersion = version:
+    let
+      parts = elemAt (split "(\\+|-)" (removePrefix "v" version));
+      v = parts 0;
+      d = parts 2;
+    in
+    if v != "0.0.0" then v else "unstable-" + (concatStringsSep "-" [
+      (substring 0 4 d)
+      (substring 4 2 d)
+      (substring 6 2 d)
+    ]);
+
+  mkGoEnv =
+    { pwd
+    }@attrs:
+    let
+      goMod = parseGoMod (readFile "${toString pwd}/go.mod");
+      modulesStruct = fromTOML (readFile "${toString pwd}/gomod2nix.toml");
+
+      go = selectGo attrs goMod;
+
+      vendorEnv = mkVendorEnv {
+        inherit go modulesStruct pwd goMod;
+      };
+
+    in
+    stdenv.mkDerivation (removeAttrs attrs [ "pwd" ] // {
+      name = "${baseNameOf goMod.module}-env";
+
+      dontUnpack = true;
+      dontConfigure = true;
+      dontInstall = true;
+
+      CGO_ENABLED = attrs.CGO_ENABLED or go.CGO_ENABLED;
+
+      propagatedBuildInputs = [ go ];
+
+      GO_NO_VENDOR_CHECKS = "1";
+
+      GO111MODULE = "on";
+      GOFLAGS = "-mod=vendor";
+
+      preferLocalBuild = true;
+
+      buildPhase = ''
+        mkdir $out
+
+        export GOCACHE=$TMPDIR/go-cache
+        export GOPATH="$out"
+        export GOSUMDB=off
+        export GOPROXY=off
+
+      '' + optionalString (pathExists (pwd + "/tools.go")) ''
+        mkdir source
+        cp ${pwd + "/go.mod"} source/go.mod
+        cp ${pwd + "/go.sum"} source/go.sum
+        cp ${pwd + "/tools.go"} source/tools.go
+        cd source
+        cp -rL ${vendorEnv} vendor
+
+        ${internal.install}
+      '';
+    });
+
+  buildGoApplication =
+    { modules ? pwd + "/gomod2nix.toml"
+    , src ? pwd
+    , pwd ? null
+    , nativeBuildInputs ? [ ]
+    , allowGoReference ? false
+    , meta ? { }
+    , passthru ? { }
+    , tags ? [ ]
+    , ldflags ? [ ]
+
+      # needed for buildFlags{,Array} warning
+    , buildFlags ? ""
+    , buildFlagsArray ? ""
+
+    , ...
+    }@attrs:
+    let
+      modulesStruct = if modules == null then { } else fromTOML (readFile modules);
+
+      goModPath = "${toString pwd}/go.mod";
+
+      goMod =
+        if pwd != null && pathExists goModPath
+        then parseGoMod (readFile goModPath)
+        else null;
+
+      go = selectGo attrs goMod;
+
+      defaultPackage = modulesStruct.goPackagePath or "";
+
+      vendorEnv = mkVendorEnv {
+        inherit go modulesStruct defaultPackage goMod pwd;
+      };
+
+      pname = attrs.pname or baseNameOf defaultPackage;
+
+    in
+    warnIf (buildFlags != "" || buildFlagsArray != "")
+      "Use the `ldflags` and/or `tags` attributes instead of `buildFlags`/`buildFlagsArray`"
+      stdenv.mkDerivation
+      (optionalAttrs (defaultPackage != "")
+        {
+          inherit pname;
+          version = stripVersion (modulesStruct.mod.${defaultPackage}).version;
+          src = vendorEnv.passthru.sources.${defaultPackage};
+        } // optionalAttrs (hasAttr "subPackages" modulesStruct) {
+        subPackages = modulesStruct.subPackages;
+      } // attrs // {
+        nativeBuildInputs = [ go ] ++ nativeBuildInputs;
+
+        inherit (go) GOOS GOARCH;
+
+        GO_NO_VENDOR_CHECKS = "1";
+        CGO_ENABLED = attrs.CGO_ENABLED or go.CGO_ENABLED;
+
+        GO111MODULE = "on";
+        GOFLAGS = [ "-mod=vendor" ] ++ lib.optionals (!allowGoReference) [ "-trimpath" ];
+
+        configurePhase = attrs.configurePhase or ''
+          runHook preConfigure
+
+          export GOCACHE=$TMPDIR/go-cache
+          export GOPATH="$TMPDIR/go"
+          export GOSUMDB=off
+          export GOPROXY=off
+          cd "$modRoot"
+
+          ${optionalString (modulesStruct != { }) ''
+            if [ -n "${vendorEnv}" ]; then
+              rm -rf vendor
+              cp -rL ${vendorEnv} vendor
+            fi
+          ''}
+
+          runHook postConfigure
+        '';
+
+        buildPhase = attrs.buildPhase or ''
+          runHook preBuild
+
+          exclude='\(/_\|examples\|Godeps\|testdata'
+          if [[ -n "$excludedPackages" ]]; then
+            IFS=' ' read -r -a excludedArr <<<$excludedPackages
+            printf -v excludedAlternates '%s\\|' "''${excludedArr[@]}"
+            excludedAlternates=''${excludedAlternates%\\|} # drop final \| added by printf
+            exclude+='\|'"$excludedAlternates"
+          fi
+          exclude+='\)'
+
+          buildGoDir() {
+            local cmd="$1" dir="$2"
+
+            . $TMPDIR/buildFlagsArray
+
+            declare -a flags
+            flags+=($buildFlags "''${buildFlagsArray[@]}")
+            flags+=(''${tags:+-tags=${lib.concatStringsSep "," tags}})
+            flags+=(''${ldflags:+-ldflags="$ldflags"})
+            flags+=("-v" "-p" "$NIX_BUILD_CORES")
+
+            if [ "$cmd" = "test" ]; then
+              flags+=(-vet=off)
+              flags+=($checkFlags)
+            fi
+
+            local OUT
+            if ! OUT="$(go $cmd "''${flags[@]}" $dir 2>&1)"; then
+              if echo "$OUT" | grep -qE 'imports .*?: no Go files in'; then
+                echo "$OUT" >&2
+                return 1
+              fi
+              if ! echo "$OUT" | grep -qE '(no( buildable| non-test)?|build constraints exclude all) Go (source )?files'; then
+                echo "$OUT" >&2
+                return 1
+              fi
+            fi
+            if [ -n "$OUT" ]; then
+              echo "$OUT" >&2
+            fi
+            return 0
+          }
+
+          getGoDirs() {
+            local type;
+            type="$1"
+            if [ -n "$subPackages" ]; then
+              echo "$subPackages" | sed "s,\(^\| \),\1./,g"
+            else
+              find . -type f -name \*$type.go -exec dirname {} \; | grep -v "/vendor/" | sort --unique | grep -v "$exclude"
+            fi
+          }
+
+          if (( "''${NIX_DEBUG:-0}" >= 1 )); then
+            buildFlagsArray+=(-x)
+          fi
+
+          if [ ''${#buildFlagsArray[@]} -ne 0 ]; then
+            declare -p buildFlagsArray > $TMPDIR/buildFlagsArray
+          else
+            touch $TMPDIR/buildFlagsArray
+          fi
+          if [ -z "$enableParallelBuilding" ]; then
+              export NIX_BUILD_CORES=1
+          fi
+          for pkg in $(getGoDirs ""); do
+            echo "Building subPackage $pkg"
+            buildGoDir install "$pkg"
+          done
+        '' + optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+          # normalize cross-compiled builds w.r.t. native builds
+          (
+            dir=$GOPATH/bin/${go.GOOS}_${go.GOARCH}
+            if [[ -n "$(shopt -s nullglob; echo $dir/*)" ]]; then
+              mv $dir/* $dir/..
+            fi
+            if [[ -d $dir ]]; then
+              rmdir $dir
+            fi
+          )
+        '' + ''
+          runHook postBuild
+        '';
+
+        doCheck = attrs.doCheck or true;
+        checkPhase = attrs.checkPhase or ''
+          runHook preCheck
+
+          # We do not set trimpath for tests, in case they reference test assets
+          export GOFLAGS=''${GOFLAGS//-trimpath/}
+
+          for pkg in $(getGoDirs test); do
+            buildGoDir test "$pkg"
+          done
+
+          runHook postCheck
+        '';
+
+        installPhase = attrs.installPhase or ''
+          runHook preInstall
+
+          mkdir -p $out
+          dir="$GOPATH/bin"
+          [ -e "$dir" ] && cp -r $dir $out
+
+          runHook postInstall
+        '';
+
+        strictDeps = true;
+
+        disallowedReferences = optional (!allowGoReference) go;
+
+        passthru = {
+          inherit go vendorEnv;
+        } // optionalAttrs (hasAttr "goPackagePath" modulesStruct) {
+
+          updateScript =
+            let
+              generatorArgs =
+                if hasAttr "subPackages" modulesStruct
+                then
+                  concatStringsSep " "
+                    (
+                      map (subPackage: modulesStruct.goPackagePath + "/" + subPackage) modulesStruct.subPackages
+                    )
+                else modulesStruct.goPackagePath;
+
+            in
+            writeScript "${pname}-updater" ''
+              #!${runtimeShell}
+              ${optionalString (pwd != null) "cd ${toString pwd}"}
+              exec ${gomod2nix}/bin/gomod2nix generate ${generatorArgs}
+            '';
+
+        } // passthru;
+
+        meta = { platforms = go.meta.platforms or platforms.all; } // meta;
+      });
+
+in
+{
+  inherit buildGoApplication mkGoEnv;
+}

--- a/pkgs/build-support/go/gomod2nix/fetch.sh
+++ b/pkgs/build-support/go/gomod2nix/fetch.sh
@@ -1,0 +1,13 @@
+source $stdenv/setup
+
+export HOME=$(mktemp -d)
+
+# Call once first outside of subshell for better error reporting
+go mod download "$goPackagePath@$version"
+
+dir=$(go mod download --json "$goPackagePath@$version" | jq -r .Dir)
+
+chmod -R +w $dir
+find $dir -iname ".ds_store" | xargs -r rm -rf
+
+cp -r $dir $out

--- a/pkgs/build-support/go/gomod2nix/install/install.go
+++ b/pkgs/build-support/go/gomod2nix/install/install.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+	"go/parser"
+	"go/token"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+const filename = "tools.go"
+
+func main() {
+	fset := token.NewFileSet()
+
+	var src []byte
+	{
+		f, err := os.Open(filename)
+		if err != nil {
+			panic(err)
+		}
+
+		src, err = io.ReadAll(f)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	f, err := parser.ParseFile(fset, filename, src, parser.ImportsOnly)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	for _, s := range f.Imports {
+		path, err := strconv.Unquote(s.Path.Value)
+		if err != nil {
+			panic(err)
+		}
+
+		cmd := exec.Command("go", "install", path)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+
+		fmt.Printf("Executing '%s'\n", cmd)
+
+		err = cmd.Start()
+		if err != nil {
+			panic(err)
+		}
+
+		err = cmd.Wait()
+		if err != nil {
+			panic(err)
+		}
+	}
+}

--- a/pkgs/build-support/go/gomod2nix/parser.nix
+++ b/pkgs/build-support/go/gomod2nix/parser.nix
@@ -1,0 +1,173 @@
+# Parse go.mod in Nix
+# Returns a Nix structure with the contents of the go.mod passed in
+# in normalised form.
+
+let
+  inherit (builtins) elemAt mapAttrs split foldl' match filter typeOf hasAttr length;
+
+  # Strip lines with comments & other junk
+  stripStr = s: elemAt (split "^ *" (elemAt (split " *$" s) 0)) 2;
+  stripLines = initialLines: foldl' (acc: f: f acc) initialLines [
+    # Strip comments
+    (lines: map
+      (l: stripStr (elemAt (splitString "//" l) 0))
+      lines)
+
+    # Strip leading tabs characters
+    (lines: map (l: elemAt (match "(\t)?(.*)" l) 1) lines)
+
+    # Filter empty lines
+    (filter (l: l != ""))
+  ];
+
+  # Parse lines into a structure
+  parseLines = lines: (foldl'
+    (acc: l:
+      let
+        m = match "([^ )]*) *(.*)" l; # Match the current line
+        directive = elemAt m 0; # The directive (replace, require & so on)
+        rest = elemAt m 1; # The rest of the current line
+
+        # Maintain parser state (inside parens or not)
+        inDirective =
+          if rest == "(" then directive
+          else if rest == ")" then null
+          else acc.inDirective
+        ;
+
+      in
+      {
+        data = (acc.data // (
+          # If a we're in a directive and it's closing, no-op
+          if directive == "" && rest == ")" then { }
+
+          # If a directive is opening create the directive attrset
+          else if inDirective != null && rest == "(" && ! hasAttr inDirective acc.data then {
+            ${inDirective} = { };
+          }
+
+          # If we're closing any paren, no-op
+          else if rest == "(" || rest == ")" then { }
+
+          # If we're in a directive that has rest data assign it to the directive in the output
+          else if inDirective != null then {
+            ${inDirective} = acc.data.${inDirective} // { ${directive} = rest; };
+          }
+
+          # Replace directive has unique structure and needs special casing
+          else if directive == "replace" then
+            (
+              let
+                # Split `foo => bar` into segments
+                segments = split " => " rest;
+                getSegment = elemAt segments;
+              in
+              assert length segments == 3; {
+                # Assert well formed
+                replace = acc.data.replace // {
+                  # Structure segments into attrset
+                  ${getSegment 0} = "=> ${getSegment 2}";
+                };
+              }
+            )
+
+          # The default operation is to just assign the value
+          else {
+            ${directive} = rest;
+          }
+        )
+        );
+        inherit inDirective;
+      })
+    {
+      # Default foldl' state
+      inDirective = null;
+      # The actual return data we're interested in (default empty structure)
+      data = {
+        require = { };
+        replace = { };
+        exclude = { };
+      };
+    }
+    lines
+  ).data;
+
+  # Normalise directives no matter what syntax produced them
+  # meaning that:
+  # replace github.com/nix-community/trustix/packages/go-lib => ../go-lib
+  #
+  # and:
+  # replace (
+  #     github.com/nix-community/trustix/packages/go-lib => ../go-lib
+  # )
+  #
+  # gets the same structural representation.
+  #
+  # Addtionally this will create directives that are entirely missing from go.mod
+  # as an empty attrset so it's output is more consistent.
+  normaliseDirectives = data: (
+    let
+      normaliseString = s:
+        let
+          m = builtins.match "([^ ]+) (.+)" s;
+        in
+        {
+          ${elemAt m 0} = elemAt m 1;
+        };
+      require = data.require or { };
+      replace = data.replace or { };
+      exclude = data.exclude or { };
+    in
+    data // {
+      require =
+        if typeOf require == "string" then normaliseString require
+        else require;
+      replace =
+        if typeOf replace == "string" then normaliseString replace
+        else replace;
+    }
+  );
+
+  # Parse versions and dates from go.mod version string
+  parseVersion = ver:
+    let
+      m = elemAt (match "([^-]+)-?([^-]*)-?([^-]*)" ver);
+      v = elemAt (match "([^+]+)\\+?(.*)" (m 0));
+    in
+    {
+      version = v 0;
+      versionSuffix = v 1;
+      date = m 1;
+      rev = m 2;
+    };
+
+  # Parse package paths & versions from replace directives
+  parseReplace = data: (
+    data // {
+      replace =
+        mapAttrs
+          (_: v:
+            let
+              m = match "=> ([^ ]+) (.+)" v;
+              m2 = match "=> ([^ ]+)" v;
+            in
+            if m != null then {
+              goPackagePath = elemAt m 0;
+              version = elemAt m 1;
+            } else {
+              path = elemAt m2 0;
+            })
+          data.replace;
+    }
+  );
+
+  splitString = sep: s: filter (t: t != [ ]) (split sep s);
+
+in
+contents:
+foldl' (acc: f: f acc) (splitString "\n" contents) [
+  stripLines
+  parseLines
+  normaliseDirectives
+  parseReplace
+]

--- a/pkgs/build-support/go/gomod2nix/symlink/symlink.go
+++ b/pkgs/build-support/go/gomod2nix/symlink/symlink.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+type Package struct {
+	GoPackagePath string `json:"-"`
+	Version       string `json:"version"`
+	Hash          string `json:"hash"`
+	ReplacedPath  string `json:"replaced,omitempty"`
+}
+
+type Sources map[string]string
+
+func populateStruct(path string, data interface{}) {
+	pathVal := os.Getenv(path)
+	if len(path) == 0 {
+		panic(fmt.Sprintf("env var '%s' was unset", path))
+	}
+	path = pathVal
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		panic(err)
+	}
+
+	err = json.Unmarshal(b, &data)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func main() {
+	sources := make(Sources)
+	pkgs := make(map[string]*Package)
+
+	populateStruct("sourcesPath", &sources)
+
+	populateStruct("jsonPath", &pkgs)
+
+	keys := make([]string, 0, len(pkgs))
+	for key := range pkgs {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	makeSymlinks(keys, sources)
+}
+
+func makeSymlinks(keys []string, sources Sources) {
+	// Iterate, in reverse order
+	for i := len(keys) - 1; i >= 0; i-- {
+		key := keys[i]
+		src := sources[key]
+
+		paths := []string{key}
+
+		for _, path := range paths {
+			vendorDir := filepath.Join("vendor", filepath.Dir(path))
+			if err := os.MkdirAll(vendorDir, 0o755); err != nil {
+				panic(err)
+			}
+
+			vendorPath := filepath.Join("vendor", path)
+			if _, err := os.Stat(vendorPath); err == nil {
+				populateVendorPath(vendorPath, src)
+				continue
+			}
+
+			// If the file doesn't already exist, just create a simple symlink
+			err := os.Symlink(src, vendorPath)
+			if err != nil {
+				panic(err)
+			}
+		}
+	}
+}
+
+func populateVendorPath(vendorPath string, src string) {
+	files, err := os.ReadDir(src)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, f := range files {
+		innerSrc := filepath.Join(src, f.Name())
+		dst := filepath.Join(vendorPath, f.Name())
+		if err := os.Symlink(innerSrc, dst); err != nil {
+			// assume it's an existing directory, try to link the directory content instead.
+			// TODO should we do this recursively?
+			files, err := os.ReadDir(innerSrc)
+			if err != nil {
+				panic(err)
+			}
+			for _, f := range files {
+				srcFile := filepath.Join(innerSrc, f.Name())
+				dstFile := filepath.Join(dst, f.Name())
+				if err := os.Symlink(srcFile, dstFile); err != nil {
+					fmt.Println("ignoring symlink error", srcFile, dstFile)
+				}
+			}
+		}
+	}
+}

--- a/pkgs/development/tools/gomod2nix/default.nix
+++ b/pkgs/development/tools/gomod2nix/default.nix
@@ -1,0 +1,42 @@
+{ stdenv
+, callPackage
+, go
+, lib
+, makeWrapper
+, installShellFiles
+, fetchFromGitHub
+, buildGoApplication
+, mkGoEnv
+, writeShellScript
+}:
+
+buildGoApplication {
+  pwd = ./.;
+
+  allowGoReference = true;
+
+  nativeBuildInputs = [ makeWrapper installShellFiles ];
+
+  passthru = {
+    inherit buildGoApplication mkGoEnv;
+    updateScript = writeShellScript "gomod2nix-update" ''
+      exec ${./update.sh} ${toString ../../../../.}
+    '';
+  };
+
+  postInstall = lib.optionalString (stdenv.buildPlatform == stdenv.targetPlatform) ''
+    installShellCompletion --cmd gomod2nix \
+      --bash <($out/bin/gomod2nix completion bash) \
+      --fish <($out/bin/gomod2nix completion fish) \
+      --zsh <($out/bin/gomod2nix completion zsh)
+  '' + ''
+    wrapProgram $out/bin/gomod2nix --prefix PATH : ${lib.makeBinPath [ go ]}
+  '';
+
+  meta = {
+    description = "Convert applications using Go modules -> Nix";
+    homepage = "https://github.com/nix-community/gomod2nix";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.adisbladis ];
+  };
+}

--- a/pkgs/development/tools/gomod2nix/gomod2nix.toml
+++ b/pkgs/development/tools/gomod2nix/gomod2nix.toml
@@ -1,0 +1,37 @@
+schema = 3
+goPackagePath = "github.com/nix-community/gomod2nix"
+
+[mod]
+  [mod."github.com/BurntSushi/toml"]
+    version = "v1.1.0"
+    hash = "sha256-1Mib3Aj/YhrlwA3o3x9orRRkVlYa5JRDQfNdtaUyeu0="
+  [mod."github.com/inconshreveable/mousetrap"]
+    version = "v1.0.0"
+    hash = "sha256-ogTuLrV40FwS4ueo4hh6hi1wPywOI+LyIqfNjsibwNY="
+  [mod."github.com/nix-community/go-nix"]
+    version = "v0.0.0-20220612195009-5f5614f7ca47"
+    hash = "sha256-eBPzib8STUZnDpLFpWZz+F00thbp1P/98oiEE/XWE+M="
+  [mod."github.com/nix-community/gomod2nix"]
+    version = "v1.5.0"
+    hash = "sha256-jdiCsEelo9Wc8VyaLXKV75m4oZl0bFOw2DNRVYUvbRg="
+  [mod."github.com/sirupsen/logrus"]
+    version = "v1.8.1"
+    hash = "sha256-vUIDlLXYBD74+JqdoSx+W3J6r5cOk63heo0ElsHizoM="
+  [mod."github.com/spf13/cobra"]
+    version = "v1.4.0"
+    hash = "sha256-I6j9sD61Ztcc2W/WGeWo3ggYtnGTxNxZ2EFPdtO0UEY="
+  [mod."github.com/spf13/pflag"]
+    version = "v1.0.5"
+    hash = "sha256-w9LLYzxxP74WHT4ouBspH/iQZXjuAh2WQCHsuvyEjAw="
+  [mod."golang.org/x/mod"]
+    version = "v0.5.1"
+    hash = "sha256-+r/pAtwGHJiGISV/je8ZPXCFukTTGbZ8y0p3zb8wGcs="
+  [mod."golang.org/x/sys"]
+    version = "v0.0.0-20220610221304-9f5ed59c137d"
+    hash = "sha256-/qCatdMn+M1Lbu10CK0kQtLCmYDBXtIQ1kdy2F/2hlc="
+  [mod."golang.org/x/tools"]
+    version = "v0.0.0-20210106214847-113979e3529a"
+    hash = "sha256-VdoV0LIBWehslesNW1ETJ1WmO4KsGojC2HDdNAjGzsI="
+  [mod."golang.org/x/xerrors"]
+    version = "v0.0.0-20220609144429-65e65417b02f"
+    hash = "sha256-tl8pv3oddbz2+KoIp7PFDKsxjQF8ocjPF8XPsY3sw38="

--- a/pkgs/development/tools/gomod2nix/update.sh
+++ b/pkgs/development/tools/gomod2nix/update.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i bash -p gomod2nix
+set -euo pipefail
+
+nixpkgs_dir="$1"
+
+# Builder sources directory
+builder_dir=$(readlink -f "$nixpkgs_dir/pkgs/build-support/go/gomod2nix")
+
+# Regenerate gomod2nix package
+gomod2nix generate "github.com/nix-community/gomod2nix"
+
+# Get gomod2nix sources to copy builder expressions
+store_path=$(nix-build "$nixpkgs_dir" --no-out-link -A gomod2nix.src)
+
+# Clear out any existing builder expressions
+rm -rf "$builder_dir"
+cp -r --no-preserve=mode,ownership "$store_path/builder" "$builder_dir"
+
+# Test the generated build
+nix-build "$nixpkgs_dir" --no-out-link -A gomod2nix

--- a/pkgs/tools/misc/trillian/default.nix
+++ b/pkgs/tools/misc/trillian/default.nix
@@ -1,32 +1,15 @@
 { lib
-, buildGoModule
+, gomod2nix
 , fetchFromGitHub
 }:
 
-buildGoModule rec {
+gomod2nix.buildGoApplication {
   pname = "trillian";
-  version = "1.5.0";
-  vendorSha256 = "sha256-235uQK4E/GLl5XLBd6lkTIgWIjT9MZZGnyfZbOoTFo0=";
-
-  src = fetchFromGitHub {
-    owner = "google";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-XZHVGuIN+5mFbaxOprhdHlpgz2NE2NsJxGWJciDMUqI=";
-  };
-
-  subPackages = [
-    "cmd/trillian_log_server"
-    "cmd/trillian_log_signer"
-    "cmd/createtree"
-    "cmd/deletetree"
-    "cmd/updatetree"
-  ];
-
-  meta = with lib; {
+  pwd = ./.;
+  meta = {
     homepage = "https://github.com/google/trillian";
     description = "A transparent, highly scalable and cryptographically verifiable data store.";
-    license = [ licenses.asl20 ];
-    maintainers = [ maintainers.adisbladis ];
+    license = [ lib.licenses.asl20 ];
+    maintainers = [ lib.maintainers.adisbladis ];
   };
 }

--- a/pkgs/tools/misc/trillian/gomod2nix.toml
+++ b/pkgs/tools/misc/trillian/gomod2nix.toml
@@ -1,0 +1,167 @@
+schema = 3
+subPackages = ["cmd/trillian_log_server", "cmd/trillian_log_signer", "cmd/createtree", "cmd/deletetree", "cmd/updatetree"]
+goPackagePath = "github.com/google/trillian"
+
+[mod]
+  [mod."bitbucket.org/creachadair/shell"]
+    version = "v0.0.7"
+    hash = "sha256-8tCzjb26WacDChPL08BLPiAPSwspr+GYJGiSMHVPdA8="
+  [mod."cloud.google.com/go"]
+    version = "v0.102.1"
+    hash = "sha256-rv3MHFvIrN6AcrmWcWGSQwgaZLbjJMmJFi3bsfHoiO4="
+  [mod."cloud.google.com/go/compute"]
+    version = "v1.7.0"
+    hash = "sha256-g+n7L36LC+NP4KaiEu9fCMn6S9fkxjp4PCLOp/oXV38="
+  [mod."cloud.google.com/go/monitoring"]
+    version = "v1.1.0"
+    hash = "sha256-FnOrzs16NCqaFtb+3I0aYoDVUjg/3ooloMhybz0OiGE="
+  [mod."cloud.google.com/go/spanner"]
+    version = "v1.36.0"
+    hash = "sha256-FHTrjvWrLJC6u6h4+sp1MNlK3kbaUSi1eVO0jJrXMaM="
+  [mod."cloud.google.com/go/trace"]
+    version = "v1.0.0"
+    hash = "sha256-ezdTxi65b4Gkdo2vnc0ATso1upWLgombwPwwUaq+kFw="
+  [mod."contrib.go.opencensus.io/exporter/stackdriver"]
+    version = "v0.13.12"
+    hash = "sha256-iUSrc8XdiJOj1OdPEnwGja8WpsvuhdIivjTboZMfZoE="
+  [mod."github.com/aws/aws-sdk-go"]
+    version = "v1.37.0"
+    hash = "sha256-dJcjUQG3N7QzSmJsM7/P/DtUr2clheGSncX3/ZYlK7Y="
+  [mod."github.com/beorn7/perks"]
+    version = "v1.0.1"
+    hash = "sha256-h75GUqfwJKngCJQVE5Ao5wnO3cfKD9lSIteoLp/3xJ4="
+  [mod."github.com/census-instrumentation/opencensus-proto"]
+    version = "v0.3.0"
+    hash = "sha256-BsfAB8Mnqc/LFUjUrCT/WpkcYtdSyba4Zu+BnCmgND0="
+  [mod."github.com/cespare/xxhash/v2"]
+    version = "v2.1.2"
+    hash = "sha256-YV9SmXDtmmgQylQUfrUgQLAPfqYexcHxegMBT+IX9qM="
+  [mod."github.com/cncf/udpa/go"]
+    version = "v0.0.0-20210930031921-04548b0d99d4"
+    hash = "sha256-3E8BNhFNIdSJg92cUmfB2fAUawpcQPQxtSDO8S5h7Is="
+  [mod."github.com/cncf/xds/go"]
+    version = "v0.0.0-20211011173535-cb28da3451f1"
+    hash = "sha256-Vn9KOztHYqlX4zO+MZ28NFYz7BpdZibKhUD3gAN/igo="
+  [mod."github.com/coreos/go-semver"]
+    version = "v0.3.0"
+    hash = "sha256-ielBK5+kGscOuygfFNNr5iKuuF1qKBiXLlK8eGuA4Bw="
+  [mod."github.com/coreos/go-systemd/v22"]
+    version = "v22.3.2"
+    hash = "sha256-rPrbVhxorJrdhUCrTH67imhVIuu4j5brPf4fJtpgnA4="
+  [mod."github.com/envoyproxy/go-control-plane"]
+    version = "v0.10.2-0.20220325020618-49ff273808a1"
+    hash = "sha256-AKavO3tfcwHcax33tBhF4id7kKkNeqb6suCJx16ELsQ="
+  [mod."github.com/envoyproxy/protoc-gen-validate"]
+    version = "v0.3.0-java"
+    hash = "sha256-x3uvwbEgeijJhPUEfHr9YG4uw+2EM3ILmd2N33fh/Pg="
+  [mod."github.com/go-sql-driver/mysql"]
+    version = "v1.6.0"
+    hash = "sha256-mMIiUN5XUXxYOpdlMQMFzYB4AX2xrpGgkkEBL0jLKrg="
+  [mod."github.com/gogo/protobuf"]
+    version = "v1.3.2"
+    hash = "sha256-pogILFrrk+cAtb0ulqn9+gRZJ7sGnnLLdtqITvxvG6c="
+  [mod."github.com/golang/glog"]
+    version = "v1.0.0"
+    hash = "sha256-bglITqRgzi52zc6FoYYnfCvrjFWV4RVOacPCnbEBom4="
+  [mod."github.com/golang/groupcache"]
+    version = "v0.0.0-20210331224755-41bb18bfe9da"
+    hash = "sha256-7Gs7CS9gEYZkbu5P4hqPGBpeGZWC64VDwraSKFF+VR0="
+  [mod."github.com/golang/mock"]
+    version = "v1.6.0"
+    hash = "sha256-fWdnMQisRbiRzGT3ISrUHovquzLRHWvcv1JEsJFZRno="
+  [mod."github.com/golang/protobuf"]
+    version = "v1.5.2"
+    hash = "sha256-IVwooaIo46iq7euSSVWTBAdKd+2DUaJ67MtBao1DpBI="
+  [mod."github.com/google/go-cmp"]
+    version = "v0.5.8"
+    hash = "sha256-8zkIo+Sr1NXMnj3PNmvjX2sZKnAKWXOFvmnX7D9bwxQ="
+  [mod."github.com/google/trillian"]
+    version = "v1.5.0"
+    hash = "sha256-FR/38pmpKK/i0NqFxva24kDqryblpVUfXRs0MJ/TCAI="
+  [mod."github.com/googleapis/enterprise-certificate-proxy"]
+    version = "v0.1.0"
+    hash = "sha256-fxaElfiGGh1mLmltkFpVFdiuaagrLZLTW9btVpK13wg="
+  [mod."github.com/googleapis/gax-go/v2"]
+    version = "v2.4.0"
+    hash = "sha256-zzat4+3iF2XBTQ6RZAUgsCbfK0HgO0nYhM4utA5dqz0="
+  [mod."github.com/grpc-ecosystem/go-grpc-middleware"]
+    version = "v1.3.0"
+    hash = "sha256-seaTQMNz/lWzpR3ex2gSM1Yo2yD2q6bJQZvB1L3CONk="
+  [mod."github.com/jmespath/go-jmespath"]
+    version = "v0.4.0"
+    hash = "sha256-xpT9g2qIXmPq7eeHUXHiDqJeQoHCudh44G/KCSFbcuo="
+  [mod."github.com/matttproud/golang_protobuf_extensions"]
+    version = "v1.0.1"
+    hash = "sha256-ystDNStxR90j4CK+AMcEQ5oyYFRgWoGdvWlS0XQMDLQ="
+  [mod."github.com/prometheus/client_golang"]
+    version = "v1.13.0"
+    hash = "sha256-5nC5FuGuAB71k6Dm4vBcmpPpBAKfvArO/yr7e9rfQfg="
+  [mod."github.com/prometheus/client_model"]
+    version = "v0.2.0"
+    hash = "sha256-LTHxYPRgoggl+v89ly2/RkyPIuJlmZRdGs6ZRtK3zkk="
+  [mod."github.com/prometheus/common"]
+    version = "v0.37.0"
+    hash = "sha256-B2v0WsP8uKWYBpZcrog/sQXStIXwWZcVLmfPgnh1ZZA="
+  [mod."github.com/prometheus/procfs"]
+    version = "v0.8.0"
+    hash = "sha256-hgrilokQsXCOCCvwgOSfuErxoFAQpXM/+zNJKcMVHyM="
+  [mod."github.com/prometheus/prometheus"]
+    version = "v2.5.0+incompatible"
+    hash = "sha256-oTy1WyLEgduNcLB9QGztYZ93kOGBHpzsFeF3HXFUJbA="
+  [mod."github.com/transparency-dev/merkle"]
+    version = "v0.0.1"
+    hash = "sha256-pbAVN6/keLV6oFYx4Mwder3i0Yvt3UwlAOsiomRjbuQ="
+  [mod."go.etcd.io/etcd/api/v3"]
+    version = "v3.5.4"
+    hash = "sha256-9CJIQOnvp1Nyulgw1/R9vEq6gT4DDwW8zRSBxDI4CWY="
+  [mod."go.etcd.io/etcd/client/pkg/v3"]
+    version = "v3.5.4"
+    hash = "sha256-EqHkVeXEvkceGU2ITV8r45CqVBYRvJnxbt9n3+dWrS0="
+  [mod."go.etcd.io/etcd/client/v3"]
+    version = "v3.5.4"
+    hash = "sha256-QgvbZJyALDQbfrjNw2RQ+9nHvgD/WX9vdpdmoQcYxCY="
+  [mod."go.opencensus.io"]
+    version = "v0.23.0"
+    hash = "sha256-R3O9GyNtv6j0ic7s+2xkLLaLzbJEop0Otj1nJDFBjsg="
+  [mod."go.uber.org/atomic"]
+    version = "v1.9.0"
+    hash = "sha256-D8OtLaViqPShz1w8ijhIHmjw9xVaRu0qD2hXKj63r4Q="
+  [mod."go.uber.org/multierr"]
+    version = "v1.8.0"
+    hash = "sha256-WHWgw6hLI4tPKEqJt+WC38yt64OGCXfkUJDem6mM+Mw="
+  [mod."go.uber.org/zap"]
+    version = "v1.21.0"
+    hash = "sha256-ZqIYkENfis3vlN4Z1Ejdn9Nn0pU89tHtcAYcR+b2Kb0="
+  [mod."golang.org/x/net"]
+    version = "v0.0.0-20220722155237-a158d28d115b"
+    hash = "sha256-TccMT2GgC1qKp8Yxk1zShJVvr29GemCqKSNJeYkjLo4="
+  [mod."golang.org/x/oauth2"]
+    version = "v0.0.0-20220622183110-fd043fe589d2"
+    hash = "sha256-VLffpTpx3DlUzXB8mKiJfFzm4ZmgnLSUuLB5Ir0WQUg="
+  [mod."golang.org/x/sync"]
+    version = "v0.0.0-20220722155255-886fb9371eb4"
+    hash = "sha256-ZZyIlxh+nqsOiWHstW7eHXN7RhHnbSL2eDIzcve07Q0="
+  [mod."golang.org/x/sys"]
+    version = "v0.0.0-20220722155257-8c9f86f7a55f"
+    hash = "sha256-mXgFTb2vfUEjTPA6PX7CZTvKGJWaxoU2QplyI1GjC+w="
+  [mod."golang.org/x/text"]
+    version = "v0.3.7"
+    hash = "sha256-XH2pUzzQx95O0rak00grQvfACfL+EmZiV7ZzJBkX+XY="
+  [mod."golang.org/x/xerrors"]
+    version = "v0.0.0-20220609144429-65e65417b02f"
+    hash = "sha256-tl8pv3oddbz2+KoIp7PFDKsxjQF8ocjPF8XPsY3sw38="
+  [mod."google.golang.org/api"]
+    version = "v0.92.0"
+    hash = "sha256-I6HTrgj6FoEkhJqgx6v1Vg/yUfDjow/tkkgmSy57qrc="
+  [mod."google.golang.org/appengine"]
+    version = "v1.6.7"
+    hash = "sha256-zIxGRHiq4QBvRqkrhMGMGCaVL4iM4TtlYpAi/hrivS4="
+  [mod."google.golang.org/genproto"]
+    version = "v0.0.0-20220706185917-7780775163c4"
+    hash = "sha256-ZiYU5xiLv7lmg3cn9FCOEKTKSnno8AtH4QQ0KbLHhvU="
+  [mod."google.golang.org/grpc"]
+    version = "v1.48.0"
+    hash = "sha256-sF2W+L5IHiCO1t/SsHpmht1tPiXJ2RBiiosk+BngfKA="
+  [mod."google.golang.org/protobuf"]
+    version = "v1.28.1"
+    hash = "sha256-sTJYgvlv5is7vHNxcuigF2lNASp0QonhUgnrguhfHSU="

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22220,6 +22220,10 @@ with pkgs;
 
   go2nix = callPackage ../development/tools/go2nix { };
 
+  gomod2nix = callPackage ../development/tools/gomod2nix {
+    inherit (callPackage ../build-support/go/gomod2nix { }) buildGoApplication mkGoEnv;
+  };
+
   leaps = callPackage ../development/tools/leaps { };
 
   vgo2nix = callPackage ../development/tools/vgo2nix { };


### PR DESCRIPTION
###### Description of changes

This adds gomod2nix, a generator for Nix expressions using Go modules (and the associated build infrastructure).
It has quite some differences to `buildGoModule` which are laid out in https://www.tweag.io/blog/2021-03-04-gomod2nix/.

I don't feel quite ready yet to promote `buildGoApplication` and `mkGoEnv` to first-class top-level attributes so in nixpkgs these will be accessed by `gomod2nix.buildGoApplication` & `gomod2nix.mkGoEnv` respectively.

This is developed external over at https://github.com/tweag/gomod2nix/.

This work has been sponsored by both the NLNet Foundation under the NGI Zero program and by Tweag.

--- 

Due to a mistake this is a new instance of #188035. See that PR for previous discussion.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
