### PR TITLE
klipper: additional config options

### DIFF
--- a/nixos/modules/services/misc/klipper.nix
+++ b/nixos/modules/services/misc/klipper.nix
@@ -35,6 +35,30 @@ in
         description = lib.mdDoc "Path of the API socket to create.";
       };
 
+      mutableConfig = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = lib.mdDoc ''
+          Whether to copy the config to a mutable directory instead of using the one directly from the nix store.
+          This will only copy the config if the file at `services.klipper.mutableConfigPath` doesn't exist.
+        '';
+      };
+
+      mutableConfigFolder = mkOption {
+        type = types.path;
+        default = "/var/lib/klipper";
+        description = lib.mdDoc "Path to mutable Klipper config file.";
+      };
+
+      configFile = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = lib.mdDoc ''
+          Path to default Klipper config.
+        '';
+      };
+
       octoprintIntegration = mkOption {
         type = types.bool;
         default = false;
@@ -62,8 +86,8 @@ in
       };
 
       settings = mkOption {
-        type = format.type;
-        default = { };
+        type = types.nullOr format.type;
+        default = null;
         description = lib.mdDoc ''
           Configuration for Klipper. See the [documentation](https://www.klipper3d.org/Overview.html#configuration-and-tuning-guides)
           for supported values.
@@ -80,6 +104,10 @@ in
                 building of firmware and addition of klipper-flash tools for manual flashing.
                 This will add `klipper-flash-$mcu` scripts to your environment which can be called to flash the firmware.
               '');
+              serial = mkOption {
+                type = types.nullOr path;
+                description = lib.mdDoc "Path to serial port this printer is connected to. Leave `null` to derive it from `service.klipper.settings`.";
+              };
               configFile = mkOption {
                 type = path;
                 description = lib.mdDoc "Path to firmware config which is generated using `klipper-genconf`";
@@ -95,19 +123,25 @@ in
     assertions = [
       {
         assertion = cfg.octoprintIntegration -> config.services.octoprint.enable;
-        message = "Option klipper.octoprintIntegration requires Octoprint to be enabled on this system. Please enable services.octoprint to use it.";
+        message = "Option services.klipper.octoprintIntegration requires Octoprint to be enabled on this system. Please enable services.octoprint to use it.";
       }
       {
         assertion = cfg.user != null -> cfg.group != null;
-        message = "Option klipper.group is not set when a user is specified.";
+        message = "Option services.klipper.group is not set when services.klipper.user is specified.";
       }
       {
-        assertion = foldl (a: b: a && b) true (mapAttrsToList (mcu: _: mcu != null -> (hasAttrByPath [ "${mcu}" "serial" ] cfg.settings)) cfg.firmwares);
-        message = "Option klipper.settings.$mcu.serial must be set when klipper.firmware.$mcu is specified";
+        assertion = cfg.settings != null -> foldl (a: b: a && b) true (mapAttrsToList (mcu: _: mcu != null -> (hasAttrByPath [ "${mcu}" "serial" ] cfg.settings)) cfg.firmwares);
+        message = "Option services.klipper.settings.$mcu.serial must be set when settings.klipper.firmware.$mcu is specified";
+      }
+      {
+        assertion = (cfg.configFile != null) != (cfg.settings != null);
+        message = "You need to either specify services.klipper.settings or services.klipper.defaultConfig.";
       }
     ];
 
-    environment.etc."klipper.cfg".source = format.generate "klipper.cfg" cfg.settings;
+    environment.etc = mkIf (!cfg.mutableConfig) {
+      "klipper.cfg".source = if cfg.settings != null then format.generate "klipper.cfg" cfg.settings else cfg.configFile;
+    };
 
     services.klipper = mkIf cfg.octoprintIntegration {
       user = config.services.octoprint.user;
@@ -118,15 +152,34 @@ in
       let
         klippyArgs = "--input-tty=${cfg.inputTTY}"
           + optionalString (cfg.apiSocket != null) " --api-server=${cfg.apiSocket}";
+        printerConfigPath =
+          if cfg.mutableConfig
+          then cfg.mutableConfigFolder + "/printer.cfg"
+          else "/etc/klipper.cfg";
+        printerConfigFile =
+          if cfg.settings != null
+          then format.generate "klipper.cfg" cfg.settings
+          else cfg.configFile;
       in
       {
         description = "Klipper 3D Printer Firmware";
         wantedBy = [ "multi-user.target" ];
         after = [ "network.target" ];
+        preStart = ''
+          mkdir -p ${cfg.mutableConfigFolder}
+          ${lib.optionalString (cfg.mutableConfig) ''
+            [ -e ${printerConfigPath} ] || {
+              cp ${printerConfigFile} ${printerConfigPath}
+              chmod +w ${printerConfigPath}
+            }
+          ''}
+          mkdir -p ${cfg.mutableConfigFolder}/gcodes
+        '';
 
         serviceConfig = {
-          ExecStart = "${cfg.package}/lib/klipper/klippy.py ${klippyArgs} /etc/klipper.cfg";
+          ExecStart = "${cfg.package}/lib/klipper/klippy.py ${klippyArgs} ${printerConfigPath}";
           RuntimeDirectory = "klipper";
+          StateDirectory = "klipper";
           SupplementaryGroups = [ "dialout" ];
           WorkingDirectory = "${cfg.package}/lib";
           OOMScoreAdjust = "-999";
@@ -134,6 +187,7 @@ in
           CPUSchedulingPriority = 99;
           IOSchedulingClass = "realtime";
           IOSchedulingPriority = 0;
+          UMask = "0002";
         } // (if cfg.user != null then {
           Group = cfg.group;
           User = cfg.user;
@@ -146,8 +200,9 @@ in
     environment.systemPackages =
       with pkgs;
       let
+        default = a: b: if a != null then a else b;
         firmwares = filterAttrs (n: v: v!= null) (mapAttrs
-          (mcu: { enable, configFile }: if enable then pkgs.klipper-firmware.override {
+          (mcu: { enable, configFile, serial }: if enable then pkgs.klipper-firmware.override {
             mcu = lib.strings.sanitizeDerivationName mcu;
             firmwareConfig = configFile;
           } else null)
@@ -156,11 +211,14 @@ in
           (mcu: firmware: pkgs.klipper-flash.override {
             mcu = lib.strings.sanitizeDerivationName mcu;
             klipper-firmware = firmware;
-            flashDevice = cfg.settings."${mcu}".serial;
+            flashDevice = default cfg.firmwares."${mcu}".serial cfg.settings."${mcu}".serial;
             firmwareConfig = cfg.firmwares."${mcu}".configFile;
           })
           firmwares;
       in
       [ klipper-genconf ] ++ firmwareFlasher ++ attrValues firmwares;
   };
+  meta.maintainers = [
+    maintainers.cab404
+  ];
 }


### PR DESCRIPTION
###### Description of changes

This allows for easier interop with Moonraker, as well as giving an
ability to store klipper configuration files in /var/lib/klipper, thus not
littering /etc with all the backups SAVE_CONFIG does.

~~For backward compatibility, default config location is left as it is, however it would be nice to move it to /var/lib/klipper.~~

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
