### PR TITLE
python3.pkgs.sphinxcontrib-openapi: unbreak, switch to cilium fork

### DIFF
--- a/pkgs/development/python-modules/picobox/default.nix
+++ b/pkgs/development/python-modules/picobox/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, flask
+, isPy27
+, pytestCheckHook
+, pythonAtLeast
+, setuptools-scm
+}:
+
+buildPythonPackage rec {
+  pname = "picobox";
+  version = "2.2.0";
+
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "ikalnytskyi";
+    repo = pname;
+    rev = "refs/tags/${version}";
+    hash = "sha256-B2A8GMhBFU/mb/JiiqtP+HvpPj5FYwaYO3gQN2QI6z0=";
+  };
+
+  patches = [
+    (fetchpatch {
+      # already in master, but no new release yet.
+      # https://github.com/ikalnytskyi/picobox/issues/55
+      url = "https://github.com/ikalnytskyi/picobox/commit/1fcc4a0c26a7cd50ee3ef6694139177b5dfb2be0.patch";
+      hash = "sha256-/NIEzTFlZ5wG7jHT/YdySYoxT/UhSk29Up9/VqjG/jg=";
+      includes = [
+        "tests/test_box.py"
+        "tests/test_stack.py"
+      ];
+    })
+  ];
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  checkInputs = [
+    flask
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "picobox"
+  ];
+
+  meta = with lib; {
+    description = "Opinionated dependency injection framework";
+    homepage = "https://github.com/ikalnytskyi/picobox";
+    license = licenses.mit;
+    maintainers = with maintainers; [ flokli ];
+  };
+}

--- a/pkgs/development/python-modules/sphinx-mdinclude/default.nix
+++ b/pkgs/development/python-modules/sphinx-mdinclude/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchpatch
+, fetchPypi
+, flit-core
+, docutils
+, mistune
+, pygments
+}:
+
+buildPythonPackage rec {
+  pname = "sphinx-mdinclude";
+  version = "0.5.2";
+  format = "flit";
+
+  src = fetchPypi {
+    pname = "sphinx_mdinclude";
+    inherit version;
+    hash = "sha256-F7UVe1xNrz+vCbJOCxwyJQoxfwSCORW+qu9vDH7oEPc=";
+  };
+
+  nativeBuildInputs = [ flit-core ];
+  propagatedBuildInputs = [ mistune docutils ];
+
+  checkInputs = [ pygments ];
+
+  meta = with lib; {
+    homepage = "https://github.com/miyakogi/m2r";
+    description = "Sphinx extension for including or writing pages in Markdown format.";
+    longDescription = ''
+      A simple Sphinx extension that enables including Markdown documents from within
+      reStructuredText.
+      It provides the .. mdinclude:: directive, and automatically converts the content of
+      Markdown documents to reStructuredText format.
+
+      sphinx-mdinclude is a fork of m2r and m2r2, focused only on providing a Sphinx extension.
+    '';
+    license = licenses.mit;
+    maintainers = with maintainers; [ flokli ];
+  };
+}

--- a/pkgs/development/python-modules/sphinxcontrib-openapi/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-openapi/default.nix
@@ -1,26 +1,46 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, deepmerge
+, fetchFromGitHub
+, fetchpatch
 , isPy27
 , setuptools-scm
-, m2r
-, pyyaml
 , jsonschema
+, picobox
+, pyyaml
+, sphinx-mdinclude
 , sphinxcontrib_httpdomain
 }:
 
 buildPythonPackage rec {
   pname = "sphinxcontrib-openapi";
-  version = "0.7.0";
+  version = "unstable-2022-08-26";
   disabled = isPy27;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "1c1bd10d7653912c59a42f727c62cbb7b75f7905ddd9ccc477ebfd1bc69f0cf3";
+  # Switch to Cilums' fork of openapi, which uses m2r instead of mdinclude,
+  # as m2r is unmaintained and incompatible with the version of mistune.
+  # See
+  # https://github.com/cilium/cilium/commit/b9862461568dd41d4dc8924711d4cc363907270b and
+  # https://github.com/cilium/openapi/commit/cd829a05caebd90b31e325d4c9c2714b459d135f
+  # for details.
+  src = fetchFromGitHub {
+    owner = "cilium";
+    repo = "openapi";
+    rev = "0ea3332fa6482114f1a8248a32a1eacb61aebb69";
+    hash = "sha256-a/oVMg9gGTD+NClfpC2SpjbY/mIcZEVLLOR0muAg5zY=";
   };
 
   nativeBuildInputs = [ setuptools-scm ];
-  propagatedBuildInputs = [ pyyaml jsonschema m2r sphinxcontrib_httpdomain ];
+  propagatedBuildInputs = [
+    deepmerge
+    jsonschema
+    picobox
+    pyyaml
+    sphinx-mdinclude
+    sphinxcontrib_httpdomain
+  ];
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
   doCheck = false;
 
@@ -29,5 +49,4 @@ buildPythonPackage rec {
     description = "OpenAPI (fka Swagger) spec renderer for Sphinx";
     license = licenses.bsd0;
   };
-
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6736,6 +6736,8 @@ in {
 
   pickleshare = callPackage ../development/python-modules/pickleshare { };
 
+  picobox = callPackage ../development/python-modules/picobox { };
+
   picos = callPackage ../development/python-modules/picos { };
 
   pid = callPackage ../development/python-modules/pid { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10348,6 +10348,8 @@ in {
 
   sphinx-navtree = callPackage ../development/python-modules/sphinx-navtree { };
 
+  sphinx-mdinclude = callPackage ../development/python-modules/sphinx-mdinclude { };
+
   sphinx_pypi_upload = callPackage ../development/python-modules/sphinx_pypi_upload { };
 
   sphinx-rtd-theme = callPackage ../development/python-modules/sphinx-rtd-theme { };


### PR DESCRIPTION
###### Description of changes

This fork uses m2r instead of mdinclude.
 
m2r is unmaintained and incompatible with recent versions of mistune (and old ones are insecure).
 
See
 
 - https://github.com/cilium/cilium/commit/b9862461568dd41d4dc8924711d4cc363907270b
 - https://github.com/cilium/openapi/commit/cd829a05caebd90b31e325d4c9c2714b459d135f
 
for details.

This PR also packages `picobox` and `sphinx_mdinclude`, which are new dependencies of `sphinxcontrib-openapi`.

Due to `picobox` being [incompatible with Python 3.10 currently](https://github.com/ikalnytskyi/picobox/issues/55), this only unbreaks `python39.pkgs.sphinxcontrib-openapi`, but it's better than not being able to render openapi stuff at all.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
