### PR TITLE
lib.modules: support strings with absolute paths in `disabledModules`

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -433,7 +433,9 @@ rec {
       # modules recursively. It returns the final list of unique-by-key modules
       filterModules = modulesPath: { disabled, modules }:
         let
-          moduleKey = m: if isString m then toString modulesPath + "/" + m else toString m;
+          moduleKey = m: if isString m && (builtins.substring 0 1 m != "/")
+            then toString modulesPath + "/" + m
+            else toString m;
           disabledKeys = map moduleKey disabled;
           keyFilter = filter (attrs: ! elem attrs.key disabledKeys);
         in map (attrs: attrs.module) (builtins.genericClosure {

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -130,6 +130,7 @@ checkConfigOutput '^true$' "$@" ./define-enable.nix ./define-attrsOfSub-foo-enab
 set -- config.enable ./define-enable.nix ./declare-enable.nix
 checkConfigOutput '^true$' "$@"
 checkConfigOutput '^false$' "$@" ./disable-define-enable.nix
+checkConfigOutput '^false$' "$@" ./disable-define-enable-string-path.nix
 checkConfigError "The option .*enable.* does not exist. Definition values:\n\s*- In .*: true" "$@" ./disable-declare-enable.nix
 checkConfigError "attribute .*enable.* in selection path .*config.enable.* not found" "$@" ./disable-define-enable.nix ./disable-declare-enable.nix
 checkConfigError "attribute .*enable.* in selection path .*config.enable.* not found" "$@" ./disable-enable-modules.nix

--- a/lib/tests/modules/disable-define-enable-string-path.nix
+++ b/lib/tests/modules/disable-define-enable-string-path.nix
@@ -1,0 +1,5 @@
+{ lib, ... }:
+
+{
+  disabledModules = [ (toString ./define-enable.nix) ];
+}


### PR DESCRIPTION
#### Copy of commit message
This is particularly useful for disabling modules defined in a flake.
Example:
```nix
disabledModules = [ "${flake}/modules/mymodule.nix" ];
```
Previously, absolute string paths were internally prepended with `modulesPath`, which caused the module filtering to fail.


#### Discussion

A workaround for disabling a flake module is to convert the string to a path, which
requires discarding the string context:
```nix
disabledModules = [ (/. + (builtins.unsafeDiscardStringContext "${flake}/modules/mymodule.nix")) ];
```

Here is [a flake](https://github.com/erikarvstedt/flake-disable-modules/) which demos this fix:
```bash
nix eval --no-write-lock-file github:erikarvstedt/flake-disable-modules#before
# error: module2.nix was included
nix eval --no-write-lock-file github:erikarvstedt/flake-disable-modules#after
# Success
```
Note: `--no-write-lock-file` is required due to https://github.com/NixOS/nix/issues/6352