### PR TITLE
wiringpi: init at 2.61-1

### DIFF
--- a/pkgs/os-specific/linux/wiringpi/default.nix
+++ b/pkgs/os-specific/linux/wiringpi/default.nix
@@ -1,0 +1,78 @@
+{ lib
+, stdenv
+, symlinkJoin
+, fetchFromGitHub
+}:
+
+let
+  version = "2.61-1";
+  mkSubProject = { subprj # The only mandatory argument
+  , buildInputs ? []
+  , src ? fetchFromGitHub {
+    owner = "WiringPi";
+    repo = "WiringPi";
+    rev = version;
+    sha256 = "sha256-VxAaPhaPXd9xYt663Ju6SLblqiSLizauhhuFqCqbO5M=";
+  }
+  }: stdenv.mkDerivation rec {
+    pname = "wiringpi-${subprj}";
+    inherit version src;
+    sourceRoot = "source/${subprj}";
+    inherit buildInputs;
+    # Remove (meant for other OSs) lines from Makefiles
+    preInstall = ''
+      sed -i "/chown root/d" Makefile
+      sed -i "/chmod/d" Makefile
+    '';
+    makeFlags = [
+      "DESTDIR=${placeholder "out"}"
+      "PREFIX=/."
+      # On NixOS we don't need to run ldconfig during build:
+      "LDCONFIG=echo"
+    ];
+  };
+  passthru = {
+    inherit mkSubProject;
+    wiringPi = mkSubProject {
+      subprj = "wiringPi";
+    };
+    devLib = mkSubProject {
+      subprj = "devLib";
+      buildInputs = [
+        passthru.wiringPi
+      ];
+    };
+    wiringPiD = mkSubProject {
+      subprj = "wiringPiD";
+      buildInputs = [
+        passthru.wiringPi
+        passthru.devLib
+      ];
+    };
+    gpio = mkSubProject {
+      subprj = "gpio";
+      buildInputs = [
+        passthru.wiringPi
+        passthru.devLib
+      ];
+    };
+  };
+in
+
+symlinkJoin {
+  name = "wiringpi-${version}";
+  inherit passthru;
+  paths = [
+    passthru.wiringPi
+    passthru.devLib
+    passthru.wiringPiD
+    passthru.gpio
+  ];
+  meta = with lib; {
+    description = "Gordon's Arduino wiring-like WiringPi Library for the Raspberry Pi (Unofficial Mirror for WiringPi bindings)";
+    homepage = "https://github.com/WiringPi/WiringPi";
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ doronbehar ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11985,6 +11985,8 @@ with pkgs;
 
   wireguard-tools = callPackage ../tools/networking/wireguard-tools { };
 
+  wiringpi = callPackage ../os-specific/linux/wiringpi { };
+
   wg-friendly-peer-names = callPackage ../tools/networking/wg-friendly-peer-names { };
 
   wg-netmanager = callPackage ../tools/networking/wg-netmanager {


### PR DESCRIPTION
###### Description of changes

Package mainly meant for Raspberry Pi, consists of many small packages which are part of a monorepo: https://github.com/WiringPi/WiringPi

On a non Raspberry Pi hardware, running `./result/bin/gpio readall` will result in a hardware error.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
