### PR TITLE
removeReferencesTo: kill lone hashes

### DIFF
--- a/pkgs/build-support/remove-references-to/remove-references-to.sh
+++ b/pkgs/build-support/remove-references-to/remove-references-to.sh
@@ -27,7 +27,7 @@ for i in "$@"; do
 done
 
 for target in "${targets[@]}" ; do
-    sed -i -e "s|@storeDir@/$target-|@storeDir@/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-|g" "${regions[@]}"
+    sed -i -e "s|$target|eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee|g" "${regions[@]}"
 done
 
 for region in "${regions[@]}"; do


### PR DESCRIPTION
Nix counts any occurrence of a store path's *hash* as a reference, even without a store directory prefix. The current version only kills references of the form `/nix/store/<hash>-`, which can fail e.g. for compressed files.

This change might break things, but only in a good way: it will reveal references that weren't supposed to be there (though I doubt we have any instances of this in nixpkgs).

cc @lheckemann 