### PR TITLE
eclint: init at 0.3.4

### DIFF
--- a/pkgs/development/tools/eclint/default.nix
+++ b/pkgs/development/tools/eclint/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildGoModule
+, fetchFromGitLab
+}:
+
+buildGoModule
+rec {
+  pname = "eclint";
+  version = "0.3.4";
+
+  src = fetchFromGitLab {
+    owner = "greut";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-inO41C/Ompyfy4CHPK4ksNU19KIcGyPgF/ptZC0GWXg=";
+  };
+
+  vendorSha256 = "sha256-imVQnPoKOjed9XlikLWvudmlJklRrLFHKtNZoAmznZg=";
+
+  meta = with lib; {
+    homepage = "https://gitlab.com/greut/eclint";
+    description = "EditorConfig linter written in Go";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lucperkins ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16121,6 +16121,8 @@ with pkgs;
 
   easypdkprog = callPackage ../development/embedded/easypdkprog { };
 
+  eclint = callPackage ../development/tools/eclint { };
+
   editorconfig-checker = callPackage ../development/tools/misc/editorconfig-checker { };
 
   editorconfig-core-c = callPackage ../development/tools/misc/editorconfig-core-c { };


### PR DESCRIPTION
###### Description of changes

Adds the [eclint](https://gitlab.com/greut/eclint) tool to Nixpkgs (specifically the version written in Go).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
