### PR TITLE
emacs.pkgs.tree-sitter-langs: Link to each grammar's query files

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/tree-sitter-langs/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/tree-sitter-langs/default.nix
@@ -17,7 +17,8 @@ let
   inherit (melpaStablePackages) tree-sitter-langs;
 
   libSuffix = if stdenv.isDarwin then "dylib" else "so";
-  soName = g: lib.removeSuffix "-grammar" (lib.removePrefix "tree-sitter-" g.pname) + "." + libSuffix;
+  langName = g: lib.removeSuffix "-grammar" (lib.removePrefix "tree-sitter-" g.pname);
+  soName = g: langName g + "." + libSuffix;
 
   grammarDir = runCommand "emacs-tree-sitter-grammars" {
     # Fake same version number as upstream language bundle to prevent triggering runtime downloads
@@ -28,6 +29,7 @@ let
   '' + lib.concatStringsSep "\n" (map (
     g: "ln -s ${g}/parser $out/langs/bin/${soName g}") plugins
   ));
+  siteDir = "$out/share/emacs/site-lisp/elpa/${tree-sitter-langs.pname}-${tree-sitter-langs.version}";
 
 in
 melpaStablePackages.tree-sitter-langs.overrideAttrs(old: {
@@ -35,6 +37,19 @@ melpaStablePackages.tree-sitter-langs.overrideAttrs(old: {
     substituteInPlace ./tree-sitter-langs-build.el \
     --replace "tree-sitter-langs-grammar-dir tree-sitter-langs--dir"  "tree-sitter-langs-grammar-dir \"${grammarDir}/langs\""
   '';
+
+  postInstall =
+    old.postInstall or ""
+    + lib.concatStringsSep "\n"
+      (map
+        (g: ''
+          if [[ -d "${g}/queries" ]]; then
+            mkdir -p ${siteDir}/queries/${langName g}/
+            for f in ${g}/queries/*; do
+              ln -sfn "$f" ${siteDir}/queries/${langName g}/
+            done
+          fi
+        '') plugins);
 
   passthru = old.passthru or {} // {
     inherit plugins;

--- a/pkgs/development/tools/parsing/tree-sitter/grammar.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammar.nix
@@ -50,6 +50,9 @@ stdenv.mkDerivation rec {
     runHook preInstall
     mkdir $out
     mv parser $out/
+    if [[ -d "$src/queries" ]]; then
+      cp -r $src/queries $out/
+    fi
     runHook postInstall
   '';
 }


### PR DESCRIPTION
###### Description of changes
Package the query files provided by grammars and link to them from `tree-sitter-langs`.

This makes syntax highlighting works properly for languages which `tree-sitter-langs` doesn't provide query files and updates the ones it provides to the latest upstream files.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
