### PR TITLE
nixos/docs: updated MBR partitioning steps

### DIFF
--- a/nixos/doc/manual/from_md/installation/installing.chapter.xml
+++ b/nixos/doc/manual/from_md/installation/installing.chapter.xml
@@ -247,6 +247,15 @@ OK
         </listitem>
         <listitem>
           <para>
+            Set the <emphasis>root</emphasis> partition’s boot flag to
+            on. This allows the disk to be booted from.
+          </para>
+          <programlisting>
+# parted /dev/sda -- set 1 boot on
+</programlisting>
+        </listitem>
+        <listitem>
+          <para>
             Finally, add a <emphasis>swap</emphasis> partition. The size
             required will vary according to needs, here a 8GiB one is
             created.

--- a/nixos/doc/manual/from_md/installation/installing.chapter.xml
+++ b/nixos/doc/manual/from_md/installation/installing.chapter.xml
@@ -247,8 +247,8 @@ OK
         </listitem>
         <listitem>
           <para>
-            Set the <emphasis>root</emphasis> partition’s boot flag to
-            on. This allows the disk to be booted from.
+            Set the root partition’s boot flag to on. This allows the
+            disk to be booted from.
           </para>
           <programlisting>
 # parted /dev/sda -- set 1 boot on

--- a/nixos/doc/manual/installation/installing.chapter.md
+++ b/nixos/doc/manual/installation/installing.chapter.md
@@ -183,7 +183,13 @@ update /etc/fstab.
     # parted /dev/sda -- mkpart primary 1MB -8GB
     ```
 
-3.  Finally, add a *swap* partition. The size required will vary
+3.  Set the *root* partition's boot flag to on. This allows the disk to be booted from.
+
+    ```ShellSession
+    # parted /dev/sda -- set 1 boot on
+    ```
+
+4.  Finally, add a *swap* partition. The size required will vary
     according to needs, here a 8GiB one is created.
 
     ```ShellSession

--- a/nixos/doc/manual/installation/installing.chapter.md
+++ b/nixos/doc/manual/installation/installing.chapter.md
@@ -183,7 +183,7 @@ update /etc/fstab.
     # parted /dev/sda -- mkpart primary 1MB -8GB
     ```
 
-3.  Set the *root* partition's boot flag to on. This allows the disk to be booted from.
+3.  Set the root partition's boot flag to on. This allows the disk to be booted from.
 
     ```ShellSession
     # parted /dev/sda -- set 1 boot on


### PR DESCRIPTION
###### Description of changes

Updated the Partitioning section of the NixOS install manual for legacy boot (MBR). It was missing the step to toggle the root partition's boot flag.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
