### PR TITLE
python3Packages.django-cryptography: init at 1.1

### DIFF
--- a/pkgs/development/python-modules/django-cryptography/default.nix
+++ b/pkgs/development/python-modules/django-cryptography/default.nix
@@ -1,0 +1,43 @@
+{ buildPythonPackage
+, cryptography
+, django
+, django-appconf
+, fetchFromGitHub
+, lib
+, python
+, pythonOlder }:
+
+buildPythonPackage rec {
+  pname = "django-cryptography";
+  version = "1.1";
+  disabled = pythonOlder "3.7";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "georgemarshall";
+    repo = "django-cryptography";
+    rev = "refs/tags/${version}";
+    hash = "sha256-C3E2iT9JdLvF+1g+xhZ8dPDjjh25JUxLAtTMnalIxPk=";
+  };
+
+  propagatedBuildInputs = [
+    cryptography
+    django
+    django-appconf
+  ];
+
+  pythonImportsCheck = [ "django_cryptography" ];
+
+  checkPhase = ''
+    runHook preCheck
+    ${python.interpreter} ./runtests.py
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/georgemarshall/django-cryptography";
+    description = "A set of primitives for performing cryptography in Django";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ centromere ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2489,6 +2489,8 @@ in {
 
   django-cors-headers = callPackage ../development/python-modules/django-cors-headers { };
 
+  django-cryptography = callPackage ../development/python-modules/django-cryptography { };
+
   django-csp = callPackage ../development/python-modules/django-csp { };
 
   django-debug-toolbar = callPackage ../development/python-modules/django-debug-toolbar { };


### PR DESCRIPTION
###### Description of changes

> A set of primitives for easily encrypting data in Django, wrapping the Python [Cryptography](https://cryptography.io/) library. Also provided is a drop in replacement for Django's own cryptographic primitives, using [Cryptography](https://cryptography.io/) as the backend provider.

[Homepage](https://github.com/georgemarshall/django-cryptography)

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).