### PR TITLE
vcv-rack: 2.0.6 -> 2.1.2

### DIFF
--- a/pkgs/applications/audio/vcv-rack/default.nix
+++ b/pkgs/applications/audio/vcv-rack/default.nix
@@ -1,4 +1,5 @@
 { alsa-lib
+, cmake
 , copyDesktopItems
 , curl
 , fetchFromBitbucket
@@ -23,7 +24,6 @@
 , makeDesktopItem
 , makeWrapper
 , pkg-config
-, rtaudio
 , rtmidi
 , speex
 , stdenv
@@ -75,13 +75,35 @@ let
   fundamental-source = fetchFromGitHub {
     owner = "VCVRack";
     repo = "Fundamental";
-    rev = "533397cdcad5c6401ebd3937d6c1663de2473627"; # tip of branch v2
-    sha256 = "QnwOgrYxiCa/7t/u6F63Ks8C9E8k6T+hia4JZFhp1LI=";
+    rev = "03bd00b96ad19e0575939bb7a0b8b08eff22f076"; # tip of branch v2
+    sha256 = "1rd5yvdr6k03mc3r2y7wxhmiqd69jfvqmpqagxb83y1mn0zfv0pr";
+  };
+  vcv-rtaudio = stdenv.mkDerivation rec {
+    pname = "vcv-rtaudio";
+    version = "unstable-2020-01-30";
+
+    src = fetchFromGitHub {
+      owner = "VCVRack";
+      repo = "rtaudio";
+      rev = "ece277bd839603648c80c8a5f145678e13bc23f3"; # tip of master branch
+      sha256 = "11gpl0ak757ilrq4fi0brj0chmlcr1hihc32yd7qza4fxjw2yx2v";
+    };
+
+    nativeBuildInputs = [ cmake pkg-config ];
+
+    buildInputs = [ alsa-lib libjack2 libpulseaudio ];
+
+    cmakeFlags = [
+      "-DRTAUDIO_API_ALSA=ON"
+      "-DRTAUDIO_API_PULSE=ON"
+      "-DRTAUDIO_API_JACK=ON"
+      "-DRTAUDIO_API_CORE=OFF"
+    ];
   };
 in
 stdenv.mkDerivation rec {
   pname = "VCV-Rack";
-  version = "2.0.6";
+  version = "2.1.2";
 
   desktopItems = [
     (makeDesktopItem {
@@ -101,7 +123,7 @@ stdenv.mkDerivation rec {
     owner = "VCVRack";
     repo = "Rack";
     rev = "v${version}";
-    sha256 = "vvGx8tnE7gMiboVUTywIzBB1q/IfiJ8TPnSHvmfHUQg=";
+    sha256 = "0583izk3j36mg7wm30ss2387j9dqsbbxkxrdh3993azb4q5naf02";
   };
 
   patches = [
@@ -137,8 +159,6 @@ stdenv.mkDerivation rec {
       --replace 'zenityBin[] = "zenity"' 'zenityBin[] = "${gnome.zenity}/bin/zenity"'
   '';
 
-  enableParallelBuilding = true;
-
   nativeBuildInputs = [
     copyDesktopItems
     imagemagick
@@ -161,9 +181,9 @@ stdenv.mkDerivation rec {
     libjack2
     libpulseaudio
     libsamplerate
-    rtaudio
     rtmidi
     speex
+    vcv-rtaudio
     zstd
   ];
 


### PR DESCRIPTION
In order to make this latest version of VCV Rack build, I had to
use VCV's fork of the RtAudio library, which has diverged from the
official RtAudio releases. I also disabled parallel builds because
they seemed to be causing non-deterministic build failures.

It is possible that the VCV team will eventually make new releases
of Rack that can again be built against the latest official release
of RtAudio; if that ever happens we can stop packaging VCV Rack
wit its own version of the library.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
