### PR TITLE
yabai: 3.3.10 -> 4.0.4

### DIFF
--- a/pkgs/os-specific/darwin/yabai/default.nix
+++ b/pkgs/os-specific/darwin/yabai/default.nix
@@ -1,39 +1,179 @@
-{ lib, stdenv, fetchFromGitHub, darwin, xxd }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchzip
+, writeShellScript
+, installShellFiles
+, testers
+, yabai
+, xxd
+, xcodebuild
+, Carbon
+, Cocoa
+, ScriptingBridge
+  # This needs to be from SDK 10.13 or higher, SLS APIs introduced in that version get used
+, SkyLight
+}:
 
-stdenv.mkDerivation rec {
+let
   pname = "yabai";
-  version = "3.3.10";
+  version = "4.0.2";
 
-  src = fetchFromGitHub {
-    owner = "koekeishiya";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-8O6//T894C32Pba3F2Z84Z6VWeCXlwml3xsXoIZGqL0=";
+  test-version = testers.testVersion {
+    package = yabai;
+    version = "yabai-v${version}";
   };
 
-  nativeBuildInputs = [ xxd ];
-
-  buildInputs = with darwin.apple_sdk.frameworks; [
-    Carbon
-    Cocoa
-    ScriptingBridge
-    SkyLight
-  ];
-
-  installPhase = ''
-    mkdir -p $out/bin
-    mkdir -p $out/share/man/man1/
-    cp ./bin/yabai $out/bin/yabai
-    cp ./doc/yabai.1 $out/share/man/man1/yabai.1
-  '';
-
-  meta = with lib; {
-    description = ''
-      A tiling window manager for macOS based on binary space partitioning
+  _meta = with lib; {
+    description = "A tiling window manager for macOS based on binary space partitioning";
+    longDescription = ''
+      yabai is a window management utility that is designed to work as an extension to the built-in
+      window manager of macOS. yabai allows you to control your windows, spaces and displays freely
+      using an intuitive command line interface and optionally set user-defined keyboard shortcuts
+      using skhd and other third-party software.
     '';
     homepage = "https://github.com/koekeishiya/yabai";
-    platforms = platforms.darwin;
-    maintainers = with maintainers; [ cmacrae shardy ];
+    changelog = "https://github.com/koekeishiya/yabai/blob/v${version}/CHANGELOG.md";
     license = licenses.mit;
+    platforms = platforms.darwin;
+    maintainers = with maintainers; [
+      cmacrae
+      shardy
+      ivar
+    ];
   };
-}
+in
+{
+  # Unfortunately compiling yabai from source on aarch64-darwin is a bit complicated. We use the precompiled binary instead for now.
+  # See the comments on https://github.com/NixOS/nixpkgs/pull/188322 for more information.
+  aarch64-darwin = stdenv.mkDerivation {
+    inherit pname version;
+
+    src = fetchzip {
+      url = "https://github.com/koekeishiya/yabai/releases/download/v${version}/yabai-v${version}.tar.gz";
+      sha256 = "sha256-RwARzK3e0e2N3ndFNikfo8srDjeo6jsWN2xQ18bXt/I=";
+    };
+
+    nativeBuildInputs = [
+      installShellFiles
+    ];
+
+    dontConfigure = true;
+    dontBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out
+      cp -r ./bin $out
+      installManPage ./doc/yabai.1
+
+      runHook postInstall
+    '';
+
+    passthru.tests.version = test-version;
+
+    meta = _meta // {
+      sourceProvenance = with lib.sourceTypes; [
+        binaryNativeCode
+      ];
+    };
+  };
+
+  x86_64-darwin = stdenv.mkDerivation rec {
+    inherit pname version;
+
+    src = fetchFromGitHub {
+      owner = "koekeishiya";
+      repo = "yabai";
+      rev = "v${version}";
+      sha256 = "sha256-DXDdjI4kkLcRUNtMoSu7fJ0f3fUty88o5ZS6lJz0cGU=";
+    };
+
+    nativeBuildInputs = [
+      installShellFiles
+      xcodebuild
+      xxd
+    ];
+
+    buildInputs = [
+      Carbon
+      Cocoa
+      ScriptingBridge
+      SkyLight
+    ];
+
+    dontConfigure = true;
+    enableParallelBuilding = true;
+
+    postPatch = ''
+      # aarch64 code is compiled on all targets, which causes our Apple SDK headers to error out.
+      # Since multilib doesnt work on darwin i dont know of a better way of handling this.
+      substituteInPlace makefile \
+        --replace "-arch arm64e" "" \
+        --replace "-arch arm64" "" \
+        --replace "clang" "${stdenv.cc.targetPrefix}clang"
+
+      # `NSScreen::safeAreaInsets` is only available on macOS 12.0 and above, which frameworks arent packaged.
+      # When a lower OS version is detected upstream just returns 0, so we can hardcode that at compiletime.
+      # https://github.com/koekeishiya/yabai/blob/v4.0.2/src/workspace.m#L109
+      substituteInPlace src/workspace.m \
+        --replace 'return screen.safeAreaInsets.top;' 'return 0;'
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/{bin,share/icons/hicolor/scalable/apps}
+
+      cp ./bin/yabai $out/bin/yabai
+      ln -s ${loadScriptingAddition} $out/bin/yabai-load-sa
+      cp ./assets/icon/icon.svg $out/share/icons/hicolor/scalable/apps/yabai.svg
+      installManPage ./doc/yabai.1
+
+      runHook postInstall
+    '';
+
+    # Defining this here exposes it as a passthru attribute, which is useful because it allows us to run `builtins.hashFile` on it in pure-eval mode.
+    # With that we can programatically generate an `/etc/sudoers.d` entry which disables the password requirement, so that a user-agent can run it at login.
+    loadScriptingAddition = writeShellScript "yabai-load-sa" ''
+      # For whatever reason the regular commands to load the scripting addition do not work, yabai will throw an error.
+      # The installation command mutably installs binaries to '/System', but then fails to start them. Manually running
+      # the bins as root does start the scripting addition, so this serves as a more user-friendly way to do that.
+
+      set -euo pipefail
+
+      if [[ "$EUID" != 0 ]]; then
+          echo "error: the scripting-addition loader must ran as root. try 'sudo $0'"
+          exit 1
+      fi
+
+      loaderPath="/Library/ScriptingAdditions/yabai.osax/Contents/MacOS/mach_loader";
+
+      if ! test -x "$loaderPath"; then
+          echo "could not locate the scripting-addition loader at '$loaderPath', installing it..."
+          echo "note: this may display an error"
+
+          eval "$(dirname "''${BASH_SOURCE[0]}")/yabai --install-sa" || true
+          sleep 1
+      fi
+
+      echo "executing loader..."
+      eval "$loaderPath"
+      echo "scripting-addition started"
+    '';
+
+    passthru.tests.version = test-version;
+
+    meta = _meta // {
+      longDescription = _meta.longDescription + ''
+        Note that due to a nix-only bug the scripting addition cannot be launched using the regular
+        procedure. Instead, you can use the provided `yabai-load-sa` script.
+      '';
+
+      sourceProvenance = with lib.sourceTypes; [
+        fromSource
+      ];
+    };
+  };
+}.${stdenv.hostPlatform.system} or (throw "Unsupported platform ${stdenv.hostPlatform.system}")

--- a/pkgs/os-specific/darwin/yabai/default.nix
+++ b/pkgs/os-specific/darwin/yabai/default.nix
@@ -1,5 +1,6 @@
 { lib
 , stdenv
+, stdenvNoCC
 , fetchFromGitHub
 , fetchzip
 , writeShellScript
@@ -17,7 +18,7 @@
 
 let
   pname = "yabai";
-  version = "4.0.2";
+  version = "4.0.4";
 
   test-version = testers.testVersion {
     package = yabai;
@@ -46,12 +47,12 @@ in
 {
   # Unfortunately compiling yabai from source on aarch64-darwin is a bit complicated. We use the precompiled binary instead for now.
   # See the comments on https://github.com/NixOS/nixpkgs/pull/188322 for more information.
-  aarch64-darwin = stdenv.mkDerivation {
+  aarch64-darwin = stdenvNoCC.mkDerivation {
     inherit pname version;
 
     src = fetchzip {
       url = "https://github.com/koekeishiya/yabai/releases/download/v${version}/yabai-v${version}.tar.gz";
-      sha256 = "sha256-RwARzK3e0e2N3ndFNikfo8srDjeo6jsWN2xQ18bXt/I=";
+      sha256 = "sha256-NS8tMUgovhWqc6WdkNI4wKee411i/e/OE++JVc86kFE=";
     };
 
     nativeBuildInputs = [
@@ -87,7 +88,7 @@ in
       owner = "koekeishiya";
       repo = "yabai";
       rev = "v${version}";
-      sha256 = "sha256-DXDdjI4kkLcRUNtMoSu7fJ0f3fUty88o5ZS6lJz0cGU=";
+      sha256 = "sha256-TeT+8UAV2jR60XvTs4phkp611Gi0nzLmQnezLA0xb44=";
     };
 
     nativeBuildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36495,7 +36495,10 @@ with pkgs;
 
   xzoom = callPackage ../tools/X11/xzoom {};
 
-  yabai = callPackage ../os-specific/darwin/yabai { };
+  yabai = darwin.apple_sdk_11_0.callPackage ../os-specific/darwin/yabai {
+    inherit (darwin.apple_sdk.frameworks) Cocoa Carbon ScriptingBridge;
+    inherit (darwin.apple_sdk_11_0.frameworks) SkyLight;
+  };
 
   yacreader = libsForQt5.callPackage ../applications/graphics/yacreader { };
 


### PR DESCRIPTION
###### Description of changes
This updates yabai to the latest version, which is required (from what I can tell) for it to function properly on modern MacOS versions. The old version used to flash and swap window positions constantly for me on 12.5.1, and that's entirely fixed with this update.

One thing I couldn't get to work natively is loading their scripting addition, which allows for more control over windows/spaces.
```shell
~/nix/nixpkgs > ./result/bin/yabai --load-sa                                                                                                                           
yabai: scripting-addition either failed to load or could not inject payload into Dock.app! Error: -1708
```
After looking into it i found those commands execute `/Library/ScriptingAdditions/yabai.osax/Contents/MacOS/mach_loader` under the hood, curiously doing that manually with `sudo mach_loader` loads the scripting addition just fine. That's not very intuitive though, so I wrote a script which does it for you which can be integrated into the home-manager/nix-darwin modules in the future. Notified upstream of the problem here: https://github.com/koekeishiya/yabai/discussions/1244#discussioncomment-3478453

I couldn't get cross compilation for aarch64-darwin to work, so ive marked it as broken on there. Highly doubt that's a regression anyways.

See [the changelog](https://github.com/koekeishiya/yabai/blob/v4.0.2/CHANGELOG.md) for more information.

cc @cmacrae @shardulbee

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and “core” functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
