### PR TITLE
writers.makePythonWriter: fix cross compile

### DIFF
--- a/pkgs/build-support/writers/default.nix
+++ b/pkgs/build-support/writers/default.nix
@@ -237,7 +237,7 @@ let
   # makePythonWriter takes python and compatible pythonPackages and produces python script writer,
   # which validates the script with flake8 at build time. If any libraries are specified,
   # python.withPackages is used as interpreter, otherwise the "bare" python is used.
-  makePythonWriter = python: pythonPackages: name: { libraries ? [], flakeIgnore ? [] }:
+  makePythonWriter = python: pythonPackages: buildPythonPackages: name: { libraries ? [], flakeIgnore ? [] }:
   let
     ignoreAttribute = optionalString (flakeIgnore != []) "--ignore ${concatMapStringsSep "," escapeShellArg flakeIgnore}";
   in
@@ -248,7 +248,7 @@ let
       else "${python.withPackages (ps: libraries)}/bin/python"
     ;
     check = optionalString python.isPy3k (writeDash "pythoncheck.sh" ''
-      exec ${pythonPackages.flake8}/bin/flake8 --show-source ${ignoreAttribute} "$1"
+      exec ${buildPythonPackages.flake8}/bin/flake8 --show-source ${ignoreAttribute} "$1"
     '');
   } name;
 
@@ -264,7 +264,7 @@ let
   #
   #   print Test.a
   # ''
-  writePyPy2 = makePythonWriter pkgs.pypy2 pkgs.pypy2Packages;
+  writePyPy2 = makePythonWriter pkgs.pypy2 pkgs.pypy2Packages buildPackages.pypy2Packages;
 
   # writePyPy2Bin takes the same arguments as writePyPy2 but outputs a directory (like writeScriptBin)
   writePyPy2Bin = name:
@@ -282,7 +282,7 @@ let
   #   """)
   #   print(y[0]['test'])
   # ''
-  writePython3 = makePythonWriter pkgs.python3 pkgs.python3Packages;
+  writePython3 = makePythonWriter pkgs.python3 pkgs.python3Packages buildPackages.python3Packages;
 
   # writePython3Bin takes the same arguments as writePython3 but outputs a directory (like writeScriptBin)
   writePython3Bin = name:
@@ -300,7 +300,7 @@ let
   #   """)
   #   print(y[0]['test'])
   # ''
-  writePyPy3 = makePythonWriter pkgs.pypy3 pkgs.pypy3Packages;
+  writePyPy3 = makePythonWriter pkgs.pypy3 pkgs.pypy3Packages buildPackages.pypy3Packages;
 
   # writePyPy3Bin takes the same arguments as writePyPy3 but outputs a directory (like writeScriptBin)
   writePyPy3Bin = name:


### PR DESCRIPTION
###### Description of changes
The check script needs to run at build time. Add a new argument to `makePythonWriter` for the appropriate `buildPackages` version of `pythonPackages`, and use this to run the check script.

After this change, these two lines in `nix repl` will now complete successfully.
 
```
nix-repl> :b writers.writePython3 "test-script" {} "print('Hello!')\n"

nix-repl> :b pkgsCross.aarch64-multiplatform.writers.writePython3 "test-script" {} "print('Hello!')\n"
```

Before, the second line would fail like this:

```
error: builder for '/nix/store/0yidrsfnlhhh4jn4xca58fz7666q74zy-test-script.drv' failed with exit code 2;
       last 2 log lines:
       > /nix/store/5jgqfaqxsjjfidm1favliblann879d1q-python3.10-flake8-5.0.4-aarch64-unknown-linux-gnu/bin/.flake8-wrapped: /nix/store/5jgqfaqxsjjfidm1favliblann879d1q-python3.10-flake8-5.0.4-aarch64-unknown-linux-gnu/bin/flake8: line 3: syntax error near unexpected token `lambda'
       > /nix/store/5jgqfaqxsjjfidm1favliblann879d1q-python3.10-flake8-5.0.4-aarch64-unknown-linux-gnu/bin/.flake8-wrapped: /nix/store/5jgqfaqxsjjfidm1favliblann879d1q-python3.10-flake8-5.0.4-aarch64-unknown-linux-gnu/bin/flake8: line 3: `import sys;import site;import functools;sys.argv[0] = '/nix/store/5jgqfaqxsjjfidm1favliblann879d1q-python3.10-flake8-5.0.4-aarch64-unknown-linux-gnu/bin/flake8';functools.reduce(lambda k, p: site.addsitedir(p, k), ['/nix/store/5jgqfaqxsjjfidm1favliblann879d1q-python3.10-flake8-5.0.4-aarch64-unknown-linux-gnu/lib/python3.10/site-packages','/nix/store/ckdq3han6zsm5s3n8rwxagbxh53fw171-python3.10-mccabe-0.7.0-aarch64-unknown-linux-gnu/lib/python3.10/site-packages','/nix/store/968bgf17i3id7zq4pj4zn2qfiyqzx1fr-python3.10-pycodestyle-2.9.1-aarch64-unknown-linux-gnu/lib/python3.10/site-packages','/nix/store/iqg6xfg3ymmh1r7a67zd6n4kn3bvb88p-python3.10-pyflakes-2.5.0-aarch64-unknown-linux-gnu/lib/python3.10/site-packages'], site._init_pathinfo());'
       For full logs, run 'nix log /nix/store/0yidrsfnlhhh4jn4xca58fz7666q74zy-test-script.drv'.
[0 built (1 failed)]
```

I ran into this problem trying to cross compile `nitter`, which uses `writePython3` in its module.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
