### PR TITLE
bintools-wrapper: Set ZERO_AR_DATE and re-enable LC_UUID on Darwin

### DIFF
--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -309,10 +309,10 @@ stdenv.mkDerivation {
     ''
 
     ###
-    ### Remove LC_UUID
+    ### Remove certain timestamps from final binaries
     ###
     + optionalString (stdenv.targetPlatform.isDarwin && !(bintools.isGNU or false)) ''
-      echo "-no_uuid" >> $out/nix-support/libc-ldflags-before
+      echo "export ZERO_AR_DATE=1" >> $out/nix-support/setup-hook
     ''
 
     + ''


### PR DESCRIPTION
## Background

(See #178366)

macOS uses UUIDs to associate binaries with the corresponding debug symbol bundles (`.dSYM`). #77632 added `-no_uuid` to the linker flags in the wrapper so UUIDs aren't added in order to improve reproducibility. This breaks normal symbolication for debugging and profiling.

However, the UUIDs generated by `ld64` [should be deterministic](https://github.com/tpoechtrager/cctools-port/blob/43f32a4c61b5ba7fde011e816136c550b1b3146f/cctools/ld64/src/ld/OutputFile.cpp#L3717-L3719) by default, based on the contents of the output file. See related discussion in the Chromium list: https://groups.google.com/a/chromium.org/g/security-dev/c/xAL44GDnaVI/m/qJJm5mNkAAAJ

## Why is the UUID not deterministic?

Since `LC_UUID` is supposed to be deterministic, there must be some differences in the input. I built `libuv` twice, and here is [the diffoscope output](https://gist.githubusercontent.com/zhaofengli/a07b4e25ff4aa84bb8b4d096d9c2147a/raw/3e92a559f029da947280518e3ca010be0d5acee2/libuv-diff-2.html) against the two build directories.

Immediately we see the values of the SymDebugTable symbols (`N_STAB`) are different:

```diff
   Symbol {
     Name: /private/tmp/nix-build-libuv-1.44.2.drv-1/source/src/.libs/libuv_la-fs-poll.o (12596)
     Type: SymDebugTable (0x66)
     Section:  (0x0)
     RefType: ReferenceFlagUndefinedLazy (0x1)
     Flags [ (0x0)
     ]
-    Value: 0x6307EE91
+    Value: 0x6307F1B8
   }
```

This `0x6307F1B8` value is a timestamp generated [here](https://github.com/apple-opensource/ld64/blob/e28c028b20af187a16a7161d89e91868a450cadc/src/ld/OutputFile.cpp#L7214-L7227). To disable it, we can simply [set `ZERO_AR_DATE`](https://github.com/tpoechtrager/cctools-port/blob/43f32a4c61b5ba7fde011e816136c550b1b3146f/cctools/ld64/src/ld/Options.cpp#L4518-L4520).

## But a `--check` build still shows differences!

Sadly, without sandboxing, `--check` builds expose a different `$out` to the builder, leading to a different UUID in the resulting binaries ([logs](https://gist.github.com/zhaofengli/628b2c8135391a2cf64d9c7649f82432)). If `--keep-failed` is used, the different build directories for subsequent builds also cause the UUID to change (e.g., `/private/tmp/nix-build-libuv-1.44.2.drv-0` and `/private/tmp/nix-build-libuv-1.44.2.drv-1`).

The UUIDs seem to be stable across initial builds and `--check` builds with the same build directory.

## How do I test that this works without rebuilding stdenv?

I have a branch with an overridden stdenv (`stdenvWip`) that uses a modified `bintools-wrapper`: https://github.com/zhaofengli/nixpkgs/commits/darwin-uuid-wip. To test:

```console
$ nix-build -A libuvWip --no-out-link
[...]
 ***      UUID of libuv.1.dylib in $out:     uuid D7737082-E47B-3BC7-851B-44D4540BAC19
/nix/store/nasrlj1wz0lhm0aj1k90fs8cf5w65wni-libuv-1.44.2
$ sudo nix-store --delete /nix/store/nasrlj1wz0lhm0aj1k90fs8cf5w65wni-libuv-1.44.2
[...]
$ nix-build -A libuvWip --no-out-link
[...]
 ***      UUID of libuv.1.dylib in $out:     uuid D7737082-E47B-3BC7-851B-44D4540BAC19
/nix/store/nasrlj1wz0lhm0aj1k90fs8cf5w65wni-libuv-1.44.2
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
