### PR TITLE
tdfgo: init at git commit 9f0b3325eed3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15087,4 +15087,10 @@
     github = "yisuidenghua";
     githubId = 102890144;
   };
+  crinklywrappr = {
+    email = "crinklywrappr@pm.me";
+    name = "Daniel Fitzpatrick";
+    github = "crinklywrappr";
+    githubId = 56522;
+  };
 }

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2719,6 +2719,12 @@
     githubId = 34543609;
     name = "creator54";
   };
+  crinklywrappr = {
+    email = "crinklywrappr@pm.me";
+    name = "Daniel Fitzpatrick";
+    github = "crinklywrappr";
+    githubId = 56522;
+  };
   cript0nauta = {
     email = "shareman1204@gmail.com";
     github = "cript0nauta";
@@ -15086,11 +15092,5 @@
     name = "Milena Yisui";
     github = "yisuidenghua";
     githubId = 102890144;
-  };
-  crinklywrappr = {
-    email = "crinklywrappr@pm.me";
-    name = "Daniel Fitzpatrick";
-    github = "crinklywrappr";
-    githubId = 56522;
   };
 }

--- a/pkgs/tools/misc/tdfgo/default.nix
+++ b/pkgs/tools/misc/tdfgo/default.nix
@@ -2,13 +2,15 @@
 
 buildGo118Module rec {
   pname = "tdfgo";
-  version = "v0.0.0-9f0b3315eed32409639a05aca55d7a0252681193";
+  version = "unstable-2022-08-25";
+
   src = fetchFromGitHub {
     owner = "digitallyserviced";
     repo = "tdfgo";
     rev = "9f0b3315eed32409639a05aca55d7a0252681193";
     sha256 = "sha256-Lr4+bXdVxYbCXKVzE+fjeLD559HuABK6lOLJ0sBBGNY=";
   };
+
   vendorSha256 = "sha256-T6PSs5NfXSXvzlq67rIDbzURyA+25df3nMMfufo0fow=";
 
   meta = with lib; {
@@ -17,6 +19,6 @@ buildGo118Module rec {
     homepage = "https://github.com/digitallyserviced/tdfgo";
     license = licenses.cc0;
     platforms = platforms.linux;
-    maintainers = with maintainers; [crinklywrappr];
+    maintainers = with maintainers; [ crinklywrappr ];
   };
 }

--- a/pkgs/tools/misc/tdfgo/default.nix
+++ b/pkgs/tools/misc/tdfgo/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildGo118Module, fetchFromGitHub }:
+
+buildGo118Module rec {
+  pname = "tdfgo";
+  version = "v0.0.0-9f0b3315eed32409639a05aca55d7a0252681193";
+  src = fetchFromGitHub {
+    owner = "digitallyserviced";
+    repo = "tdfgo";
+    rev = "9f0b3315eed32409639a05aca55d7a0252681193";
+    sha256 = "sha256-Lr4+bXdVxYbCXKVzE+fjeLD559HuABK6lOLJ0sBBGNY=";
+  };
+  vendorSha256 = "sha256-T6PSs5NfXSXvzlq67rIDbzURyA+25df3nMMfufo0fow=";
+
+  meta = with lib; {
+    description = "TheDraw font parser and console text renderer.";
+    longDescription = "Supports more fonts than `tdfiglet`, and packs more features.";
+    homepage = "https://github.com/digitallyserviced/tdfgo";
+    license = licenses.cc0;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [crinklywrappr];
+  };
+}

--- a/pkgs/tools/misc/tdfgo/default.nix
+++ b/pkgs/tools/misc/tdfgo/default.nix
@@ -1,6 +1,6 @@
-{ lib, buildGo118Module, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub }:
 
-buildGo118Module rec {
+buildGoModule rec {
   pname = "tdfgo";
   version = "unstable-2022-08-25";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12059,6 +12059,8 @@ with pkgs;
 
   td = callPackage ../tools/misc/td { };
 
+  tdfgo = callPackage ../tools/misc/tdfgo { };
+
   tftp-hpa = callPackage ../tools/networking/tftp-hpa {};
 
   tigervnc = callPackage ../tools/admin/tigervnc {};


### PR DESCRIPTION
###### `tdfgo`

[Repo](https://github.com/digitallyserviced/tdfgo)

[TheDraw](https://en.wikipedia.org/wiki/TheDraw) font parser and console text renderer.

It exists as an improvement over `tdfiglet` - in general it supports more fonts, and packs more features.

AFAIK there are no tests or versioning yet.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
