### PR TITLE
Fix glibc locales on cross endian

### DIFF
--- a/nixos/modules/config/i18n.nix
+++ b/nixos/modules/config/i18n.nix
@@ -10,12 +10,12 @@ with lib;
     i18n = {
       glibcLocales = mkOption {
         type = types.path;
-        default = pkgs.buildPackages.glibcLocales.override {
+        default = pkgs.glibcLocales.override {
           allLocales = any (x: x == "all") config.i18n.supportedLocales;
           locales = config.i18n.supportedLocales;
         };
         defaultText = literalExpression ''
-          pkgs.buildPackages.glibcLocales.override {
+          pkgs.glibcLocales.override {
             allLocales = any (x: x == "all") config.i18n.supportedLocales;
             locales = config.i18n.supportedLocales;
           }

--- a/pkgs/development/libraries/glibc/locales.nix
+++ b/pkgs/development/libraries/glibc/locales.nix
@@ -19,19 +19,26 @@ callPackage ./common.nix { inherit stdenv; } {
 
   extraNativeBuildInputs = [ glibc ];
 
-  # Awful hack: `localedef' doesn't allow the path to `locale-archive'
-  # to be overriden, but you *can* specify a prefix, i.e. it will use
-  # <prefix>/<path-to-glibc>/lib/locale/locale-archive.  So we use
-  # $TMPDIR as a prefix, meaning that the locale-archive is placed in
-  # $TMPDIR/nix/store/...-glibc-.../lib/locale/locale-archive.
-  buildPhase =
-    ''
+  LOCALEDEF_FLAGS = [
+    (if stdenv.hostPlatform.isLittleEndian
+    then "--little-endian"
+    else "--big-endian")
+  ];
+
+  buildPhase = ''
+      # Awful hack: `localedef' doesn't allow the path to `locale-archive'
+      # to be overriden, but you *can* specify a prefix, i.e. it will use
+      # <prefix>/<path-to-glibc>/lib/locale/locale-archive.  So we use
+      # $TMPDIR as a prefix, meaning that the locale-archive is placed in
+      # $TMPDIR/nix/store/...-glibc-.../lib/locale/locale-archive.
+      LOCALEDEF_FLAGS+=" --prefix=$TMPDIR"
+
       mkdir -p $TMPDIR/"${buildPackages.glibc.out}/lib/locale"
 
       echo 'C.UTF-8/UTF-8 \' >> ../glibc-2*/localedata/SUPPORTED
 
       # Hack to allow building of the locales (needed since glibc-2.12)
-      sed -i -e 's,^$(rtld-prefix) $(common-objpfx)locale/localedef,localedef --prefix='$TMPDIR',' ../glibc-2*/localedata/Makefile
+      sed -i -e 's,^$(rtld-prefix) $(common-objpfx)locale/localedef,localedef $(LOCALEDEF_FLAGS),' ../glibc-2*/localedata/Makefile
     ''
       + lib.optionalString (!allLocales) ''
       # Check that all locales to be built are supported


### PR DESCRIPTION
###### Description of changes

When cross-compiling between systems which have different endianness, the locale-archive from `glibcLocales` is unusable since it follows the host system's endianness.

cc @shlevy if you see any drawback of undoing your commit aebb024b2f35d826f99d3e97caeff8522ff6e3c7

Not sure if I should target `staging` but since it basically will trigger rebuilds of all NixOS systems...

Currently tested only by comparing the hexdump of `${glibcLocales}/lib/locales/locale-archive` and  `${glibc}/lib/locales/locale-archive`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] cross x86_64-linux -> ppc64
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
