### PR TITLE
xdaliclock: 2.44 -> 2.45

### DIFF
--- a/pkgs/tools/misc/xdaliclock/default.nix
+++ b/pkgs/tools/misc/xdaliclock/default.nix
@@ -1,23 +1,40 @@
-{ lib, stdenv, fetchurl, libX11, xorgproto, libXt, libICE, libSM, libXext }:
+{ lib, stdenv, fetchurl
+, gtk3
+, wrapGAppsHook
+, pkg-config }:
 
 stdenv.mkDerivation rec {
   pname = "xdaliclock";
-  version = "2.44";
+  version = "2.45";
 
   src = fetchurl {
-    url="https://www.jwz.org/xdaliclock/${pname}-${version}.tar.gz";
-    sha256 = "1gsgnsm6ql0mcg9zpdkhws3g23r3a92bc3rpg4qbgbmd02nvj3c0";
+    url = "https://www.jwz.org/xdaliclock/${pname}-${version}.tar.gz";
+    hash = "sha256-GHjSUuRHCAVwWcDMRb2ng1aNbheu+xnUBNLqSpPkZeQ=";
   };
 
   # Note: don't change this to set sourceRoot, or updateAutotoolsGnuConfigScriptsHook
   # on aarch64 doesn't find the files to patch and the aarch64 build fails!
   preConfigure = "cd X11";
 
-  buildInputs = [ libX11 xorgproto libXt libICE libSM libXext ];
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook
+  ];
+  buildInputs = [
+    gtk3
+  ];
 
   preInstall = ''
-    mkdir -vp $out/bin $out/share/man/man1
+    mkdir -vp $out/bin $out/share/man/man1 $out/share/gsettings-schemas/$name/glib-2.0/schemas $out/share/pixmaps $out/share/applications
+
+    # https://www.jwz.org/blog/2022/08/dali-clock-2-45-released/#comment-236762
+    gappsWrapperArgs+=(--set MESA_GL_VERSION_OVERRIDE 3.1)
   '';
+
+  installFlags = [
+    "GTK_ICONDIR=${placeholder "out"}/share/pixmaps/"
+    "GTK_APPDIR=${placeholder "out"}/share/applications/"
+  ];
 
   meta = with lib; {
     description = "A clock application that morphs digits when they are changed";


### PR DESCRIPTION
###### Description of changes
https://www.jwz.org/blog/2022/08/dali-clock-2-45-released/

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).