### PR TITLE
gruvbox-material-icons-gtk: init at unstable-2021-07-25

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14242,6 +14242,13 @@
     githubId = 36407913;
     name = "Uli Baum";
   };
+  xerbalind = {
+    name = "Xander Bil";
+    email = "xandbi1@gmail.com";
+    matrix = "@xander:matrix.icth.xyz";
+    github = "xerbalind";
+    githubId = 47951455;
+  };
   xfnw = {
     email = "xfnw+nixos@riseup.net";
     github = "xfnw";

--- a/pkgs/data/icons/gruvbox-material-icons-gtk/default.nix
+++ b/pkgs/data/icons/gruvbox-material-icons-gtk/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, gtk3
+, gtk-engine-murrine
+, hicolor-icon-theme
+, breeze-icons
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gruvbox-material-gtk";
+  version = "unstable-2021-07-25";
+
+  src = fetchFromGitHub {
+    owner = "TheGreatMcPain";
+    repo = pname;
+    rev = "cc255d43322ad646bb35924accb0778d5e959626";
+    sha256 = "sha256-1O34p9iZelqRFBloOSZkxV0Z/7Jffciptpj3fwXPHbc=";
+  };
+
+  nativeBuildInputs = [ gtk3 ];
+
+  propagatedBuildInputs = [ breeze-icons hicolor-icon-theme ];
+
+  propagatedUserEnvPkgs = [ gtk-engine-murrine ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/icons
+    cp -r icons/Gruvbox-Material-Dark $out/share/icons
+    gtk-update-icon-cache $out/share/icons/Gruvbox-Material-Dark
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Gruvbox material icons for GTK based desktop environments";
+    homepage = "https://github.com/TheGreatMcPain/gruvbox-material-gtk";
+    license = licenses.mit;
+    maintainers = [ maintainers.xerbalind ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25281,6 +25281,10 @@ with pkgs;
     inherit (plasma5Packages) breeze-icons;
   };
 
+  gruvbox-material-icons-gtk = callPackage ../data/icons/gruvbox-material-icons-gtk {
+    inherit (plasma5Packages) breeze-icons;
+  };
+
   gubbi-font = callPackage ../data/fonts/gubbi { };
 
   gyre-fonts = callPackage ../data/fonts/gyre {};


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Gruvbox material themed icons from https://github.com/TheGreatMcPain/gruvbox-material-gtk.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
