### PR TITLE
umr: unstable-2021-02-18 -> unstable-2022-08-23

### DIFF
--- a/pkgs/development/misc/umr/default.nix
+++ b/pkgs/development/misc/umr/default.nix
@@ -1,25 +1,28 @@
 { lib, stdenv, fetchgit, bash-completion, cmake, pkg-config
-, libdrm, libpciaccess, llvmPackages, ncurses
+, json_c, libdrm, libpciaccess, llvmPackages, nanomsg, ncurses, SDL2
 }:
 
 stdenv.mkDerivation rec {
   pname = "umr";
-  version = "unstable-2021-02-18";
+  version = "unstable-2022-08-23";
 
   src = fetchgit {
     url = "https://gitlab.freedesktop.org/tomstdenis/umr";
-    rev = "79e17f8f2807ed707fc1be369d0aad536f6dbc97";
-    sha256 = "IwTkHEuJ82hngPjFVIihU2rSolLBqHxQTNsP8puYPaY=";
+    rev = "87f814b1ffdbac8bfddd8529d344a7901cd7e112";
+    hash = "sha256-U1VP1AicSGWzBwzz99i7+3awATZocw5jaqtAxuRNaBE=";
   };
 
   nativeBuildInputs = [ cmake pkg-config llvmPackages.llvm.dev ];
 
   buildInputs = [
     bash-completion
+    json_c
     libdrm
     libpciaccess
     llvmPackages.llvm
+    nanomsg
     ncurses
+    SDL2
   ];
 
   # Remove static libraries (there are no dynamic libraries in there)


### PR DESCRIPTION
###### Description of changes
Update package, now it even has a gui: https://gitlab.freedesktop.org/tomstdenis/umr
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
