### PR TITLE
linkerd: 2.11.2 -> 2.12.0

### DIFF
--- a/pkgs/applications/networking/cluster/linkerd/default.nix
+++ b/pkgs/applications/networking/cluster/linkerd/default.nix
@@ -2,7 +2,7 @@
 
 (callPackage ./generic.nix { }) {
   channel = "stable";
-  version = "2.11.2";
-  sha256 = "sha256-6FlOHnOmqZ2jqx9qFMPA5jkxBaNqzeCwsepwXR1Imss=";
-  vendorSha256 = "sha256-wM5qIjabg9ICJcLi8QV9P4G4E7Rn3ctVCqdm2GO8RyU=";
+  version = "2.12.0";
+  sha256 = "0p8k5c0gzpmqp7qrhfcjrhbgwd2mzsn2qpsv7ym0ywjkvrkg3355";
+  vendorSha256 = "sha256-qjXpzS1ctEQfXFjzyBUiIp6+oqABedpwHqDxQz0DJ8U=";
 }

--- a/pkgs/applications/networking/cluster/linkerd/edge.nix
+++ b/pkgs/applications/networking/cluster/linkerd/edge.nix
@@ -2,7 +2,7 @@
 
 (callPackage ./generic.nix { }) {
   channel = "edge";
-  version = "22.6.1";
-  sha256 = "sha256-YM6d2bWcjoNMEbgXVR79tcklTRqAhzm6SzJU2k+7BNU=";
-  vendorSha256 = "sha256-i+AbrzN9d9CGZcGj/D4xnYlamp0iOlq2xcax14/GqEE=";
+  version = "22.8.2";
+  sha256 = "114lfq5d5b09zg14iwnmaf0vmm183xr37q7b4bj3m8zbzhpbk7xx";
+  vendorSha256 = "sha256-hKdokt5QW50oc2z8UFMq78DRWpwPlL5tSf2F0rQNEQ8=";
 }

--- a/pkgs/applications/networking/cluster/linkerd/generic.nix
+++ b/pkgs/applications/networking/cluster/linkerd/generic.nix
@@ -53,6 +53,6 @@ buildGoModule rec {
     downloadPage = "https://github.com/linkerd/linkerd2/";
     homepage = "https://linkerd.io/";
     license = licenses.asl20;
-    maintainers = with maintainers; [ Gonzih bryanasdev000 ];
+    maintainers = with maintainers; [ bryanasdev000 Gonzih superherointj ];
   };
 }

--- a/pkgs/applications/networking/cluster/linkerd/update-edge.sh
+++ b/pkgs/applications/networking/cluster/linkerd/update-edge.sh
@@ -7,7 +7,7 @@ cd $(dirname "$0")
 
 VERSION=$(curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} \
     --silent https://api.github.com/repos/linkerd/linkerd2/releases | \
-    jq 'map(.tag_name)' | grep edge | sed 's/["|,| ]//g' | sed 's/edge-//' | sort -V -r | head -n1)
+    jq 'map(.tag_name)' | grep -v -e '-rc' | grep edge | sed 's/["|,| ]//g' | sed 's/edge-//' | sort -V -r | head -n1)
 
 SHA256=$(nix-prefetch-url --quiet --unpack https://github.com/linkerd/linkerd2/archive/refs/tags/edge-${VERSION}.tar.gz)
 

--- a/pkgs/applications/networking/cluster/linkerd/update-stable.sh
+++ b/pkgs/applications/networking/cluster/linkerd/update-stable.sh
@@ -7,7 +7,7 @@ cd $(dirname "$0")
 
 VERSION=$(curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} \
     --silent https://api.github.com/repos/linkerd/linkerd2/releases | \
-    jq 'map(.tag_name)' | grep stable | sed 's/["|,| ]//g' | sed 's/stable-//' | sort -V -r | head -n1)
+    jq 'map(.tag_name)' | grep -v -e '-rc' | grep stable | sed 's/["|,| ]//g' | sed 's/stable-//' | sort -V -r | head -n1)
 
 SHA256=$(nix-prefetch-url --quiet --unpack https://github.com/linkerd/linkerd2/archive/refs/tags/stable-${VERSION}.tar.gz)
 


### PR DESCRIPTION
linkerd: 2.11.2 -> 2.12.0
linkerd_edge: 22.6.1 -> 22.8.2
linkerd: skip release candidate versions in update script
linkerd: add superherointj as maintainer