### PR TITLE
deheader: init at 1.8

### DIFF
--- a/pkgs/development/tools/misc/deheader/default.nix
+++ b/pkgs/development/tools/misc/deheader/default.nix
@@ -1,0 +1,68 @@
+{ lib
+, stdenv
+, python3
+, xmlto
+, docbook-xsl-nons
+, fetchFromGitLab
+, installShellFiles
+}:
+
+stdenv.mkDerivation rec {
+  pname = "deheader";
+  version = "1.8";
+  outputs = [ "out" "man" ];
+
+  src = fetchFromGitLab {
+    owner = "esr";
+    repo = "deheader";
+    rev = version;
+    sha256 = "sha256-sjxgUtdsi/sfxOViDj7l8591TSYwtCzDQcHsk9ClXuM=";
+  };
+
+  buildInputs = [ python3 ];
+
+  nativeBuildInputs = [ xmlto docbook-xsl-nons installShellFiles ];
+
+  # With upstream Makefile, xmlto is called without "--skip-validation". It
+  # makes it require a lot of dependencies, yet ultimately it fails
+  # nevertheless in attempt to fetch something from SourceForge.
+  #
+  # Need to set "foundMakefile" so "make check" tests are run.
+  buildPhase = ''
+    runHook preBuild
+
+    xmlto man --skip-validation deheader.xml
+    patchShebangs ./deheader
+    foundMakefile=1
+
+    runHook postBuild
+  '';
+
+  doCheck = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 ./deheader -t $out/bin
+    installManPage ./deheader.1
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Tool to find and optionally remove unneeded includes in C or C++ source files";
+    longDescription = ''
+      This tool takes a list of C or C++ sourcefiles and generates a report
+      on which #includes can be omitted from them -- the test, for each foo.c
+      or foo.cc or foo.cpp, is simply whether 'rm foo.o; make foo.o' returns a
+      zero status. Optionally, with the -r option, the unneeded headers are removed.
+      The tool also reports on headers required for strict portability.
+    '';
+    homepage = "http://catb.org/~esr/deheader";
+    changelog = "https://gitlab.com/esr/deheader/-/blob/master/NEWS.adoc";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ kaction ];
+
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3679,6 +3679,8 @@ with pkgs;
 
   dedup = callPackage ../tools/backup/dedup { };
 
+  deheader = callPackage ../development/tools/misc/deheader { };
+
   dehydrated = callPackage ../tools/admin/dehydrated { };
 
   deja-dup = callPackage ../applications/backup/deja-dup { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


