### PR TITLE
baresip: 1.1.0 -> 2.6.0, librem: 1.0.0 -> 2.6.0,  libre: 2.0.1 -> 2.6.1 

### DIFF
--- a/pkgs/applications/networking/instant-messengers/baresip/default.nix
+++ b/pkgs/applications/networking/instant-messengers/baresip/default.nix
@@ -24,13 +24,13 @@
 , libvpx
 }:
 stdenv.mkDerivation rec {
-  version = "1.1.0";
+  version = "2.6.0";
   pname = "baresip";
   src = fetchFromGitHub {
     owner = "baresip";
     repo = "baresip";
     rev = "v${version}";
-    sha256 = "sha256-9mc1Beo7/iNhDXSDC/jiTL+lJRt8ah/1xF1heoHTE+g=";
+    sha256 = "sha256-YcXLRhW7PyvK0R1+7DOjmtxg+Ajq9u7fvZFQO7DJapQ=";
   };
   postPatch = ''
     patchShebangs modules/ctrl_dbus/gen.sh

--- a/pkgs/development/libraries/libre/default.nix
+++ b/pkgs/development/libraries/libre/default.nix
@@ -1,12 +1,12 @@
 { lib, stdenv, fetchFromGitHub, zlib, openssl }:
 stdenv.mkDerivation rec {
-  version = "2.0.1";
+  version = "2.6.1";
   pname = "libre";
   src = fetchFromGitHub {
     owner = "baresip";
     repo = "re";
     rev = "v${version}";
-    sha256 = "sha256-/1J9cs0W96CtnHAoX/jg3FLGD9coa0eOEgf8uMQHuUk=";
+    sha256 = "sha256-S+RvD7sXn8yjGAHv1OqiJJMAA45r8N1Rhz89d8yGv1Q=";
   };
   buildInputs = [ zlib openssl ];
   makeFlags = [ "USE_ZLIB=1" "USE_OPENSSL=1" "PREFIX=$(out)" ]

--- a/pkgs/development/libraries/librem/default.nix
+++ b/pkgs/development/libraries/librem/default.nix
@@ -1,12 +1,12 @@
 { lib, stdenv, fetchFromGitHub, zlib, openssl, libre }:
 stdenv.mkDerivation rec {
-  version = "1.0.0";
+  version = "2.6.0";
   pname = "librem";
   src = fetchFromGitHub {
     owner = "baresip";
     repo = "rem";
     rev = "v${version}";
-    sha256 = "sha256-6Xe9zT0qLLGe1+QCQ9NALoDTaRhHpaTLbCbA+kV7hOA=";
+    sha256 = "sha256-Rn3KKYW5OBInZYaDhwYVyPvL3UiuRG8CyHtPvW1S0Zo=";
   };
   buildInputs = [ zlib openssl libre ];
   makeFlags = [


### PR DESCRIPTION
###### Description of changes

releases
- baresip https://github.com/baresip/baresip/releases
- librem https://github.com/baresip/rem/releases
- libre https://github.com/baresip/re/releases

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
