### PR TITLE
mympd: 8.0.4 -> 9.5.2

### DIFF
--- a/pkgs/applications/audio/mympd/default.nix
+++ b/pkgs/applications/audio/mympd/default.nix
@@ -8,28 +8,38 @@
 , lua5_3
 , libid3tag
 , flac
-, pcre
+, pcre2
+, gzip
+, perl
 }:
 
 stdenv.mkDerivation rec {
   pname = "mympd";
-  version = "8.0.4";
+  version = "9.5.2";
 
   src = fetchFromGitHub {
     owner = "jcorporation";
     repo = "myMPD";
     rev = "v${version}";
-    sha256 = "sha256-hpUoXqblhHreDZg8fDD5S4UG+ltptIbzP9LKyQ/WbX0=";
+    sha256 = "sha256-WmGaZXITvrp7ml7s7FPyp3Q3072KU/P6UombBj99fX0=";
   };
 
-  nativeBuildInputs = [ pkg-config cmake ];
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    gzip
+    perl
+  ];
+  preConfigure = ''
+    env MYMPD_BUILDDIR=$PWD/build ./build.sh createassets
+  '';
   buildInputs = [
     libmpdclient
     openssl
     lua5_3
     libid3tag
     flac
-    pcre
+    pcre2
   ];
 
   cmakeFlags = [
@@ -43,7 +53,7 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "strictoverflow" ];
 
   meta = {
-    homepage = "https://jcorporation.github.io/mympd";
+    homepage = "https://jcorporation.github.io/myMPD";
     description = "A standalone and mobile friendly web mpd client with a tiny footprint and advanced features";
     maintainers = [ lib.maintainers.doronbehar ];
     platforms = lib.platforms.linux;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
