### PR TITLE
partialzip-rs, fetchPartial: init

### DIFF
--- a/doc/builders/fetchers.chapter.md
+++ b/doc/builders/fetchers.chapter.md
@@ -163,3 +163,8 @@ or "hg"), `domain` and `fetchSubmodules`.
 If `fetchSubmodules` is `true`, `fetchFromSourcehut` uses `fetchgit`
 or `fetchhg` with `fetchSubmodules` or `fetchSubrepos` set to `true`,
 respectively. Otherwise, the fetcher uses `fetchzip`.
+
+## `fetchPartial` {#fetchpartial}
+
+This is used when you only want to fetch a single file from a huge zip archive. It expects `url`, `file` and `sha256` as arguments.
+Note that the sever where `url` is hosted must support HTTP range requests.

--- a/pkgs/build-support/fetchpartial/default.nix
+++ b/pkgs/build-support/fetchpartial/default.nix
@@ -1,0 +1,18 @@
+{ lib, stdenvNoCC, partialzip-rs, cacert }:
+
+{ url, file, sha256 }:
+
+ stdenvNoCC.mkDerivation {
+  name = file;
+  nativeBuildInputs = [ partialzip-rs ];
+
+  buildCommand = ''
+    partialzip download ${url} ${file} "$out"
+  '';
+
+  outputHashMode = "flat";
+  outputHashAlgo = "sha256";
+  outputHash = sha256;
+
+  SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+}

--- a/pkgs/tools/networking/partialzip-rs/default.nix
+++ b/pkgs/tools/networking/partialzip-rs/default.nix
@@ -1,0 +1,23 @@
+{ lib, rustPlatform, fetchCrate, openssl, pkg-config }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "partialzip-rs";
+  version = "1.1.1";
+
+  src = fetchCrate {
+    inherit version;
+
+    crateName = "partialzip";
+    sha256 = "sha256-zQsWOwGQCvKWoZRVNU7uqqqF9X8gJKySpPYYKvKp26k=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ];
+
+  cargoHash = "sha256-wObpzJ+2kqz7iHTNlofXriuiGYjhXhIrx5vP91rTc9g=";
+
+  # Tests use the internet and therefore fail
+  doCheck = false;
+
+  meta.license = lib.licenses.mpl20;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -851,6 +851,8 @@ with pkgs;
 
   fetchgx = callPackage ../build-support/fetchgx { };
 
+  fetchPartial = callPackage ../build-support/fetchpartial { };
+
   resolveMirrorURLs = {url}: fetchurl {
     showURLs = true;
     inherit url;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1305,6 +1305,8 @@ with pkgs;
 
   ocs-url = libsForQt5.callPackage ../tools/misc/ocs-url { };
 
+  partialzip-rs = callPackage ../tools/networking/partialzip-rs { };
+
   pferd = callPackage ../tools/misc/pferd {};
 
   q = callPackage ../tools/networking/q {};


### PR DESCRIPTION
###### Description of changes
This commit adds a way to fetch parts of a zip file if a server supports range requests with `fetchPartial`.
This is done by using the `partialzip` rust crate. Note that this package has a `-rs` suffix to avoid confusion as many implementations of `partialzip` in different languages exist.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests) (Crate tests are disabled due to networking usage)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage) (1 package built)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
