### PR TITLE
Intellij Idea: depend on system Go debugger delve

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12032,6 +12032,16 @@
       fingerprint = "ADF4 C13D 0E36 1240 BD01  9B51 D1DE 6D7F 6936 63A5";
     }];
   };
+  silasdavis = {
+    name = "Silas Davis";
+    email = "nix@silasdavis.net";
+    matrix = "@silasdavis:one.ems.host";
+    github = "silasdavis";
+    githubId = 99715;
+    keys = [{
+      fingerprint = "B32B 47E3 1B54 4D1F 37FD  EC14 A611 84BC 079C 32DD";
+    }];
+  };
   simarra = {
     name = "simarra";
     email = "loic.martel@protonmail.com";

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -5,6 +5,7 @@
 , maven
 , autoPatchelfHook
 , libdbusmenu
+, delve
 , vmopts ? null
 }:
 
@@ -135,6 +136,15 @@ let
         maintainers = with maintainers; [ edwtjo gytis-ivaskevicius steinybot AnatolyPopov ];
         platforms = ideaPlatforms;
       };
+    }).overrideAttrs (attrs: {
+      postFixup = (attrs.postFixup or "") + lib.optionalString stdenv.isLinux ''
+        cat >> $out/$pname/bin/idea.properties << EOL
+
+        # The delve Go debugger is packaged with Goland/the Go plugin, but the binary is not correctly linked for NixOS.
+        # This instructs Idea to use the system version of delve instead.
+        dlv.path=${delve}/bin/dlv
+        EOL
+      '';
     });
 
   buildMps = { pname, version, src, license, description, wmClass, product, ... }:


### PR DESCRIPTION
Given the size of the overall Intellij Idea build and after discussion
with @Mic92 we thought it was reasonable to make idea depend on the
NixOS-packaged version of the Go debugger delve, even though it is only
needed when using the Go plugin.

This is accomplished by setting `dlv.path` (see this comment on the
Jetbrains issue tracker for reference:
https://youtrack.jetbrains.com/issue/GO-11782/Run-Targets-Debugging-in-a-remote-Docker-container-on-Apple-Silicon-fails#focus=Comments-27-5280341.0-0) which instructs intellij to use a custom `dlv` binary (i.e. not the one which is bundled with Goland or downloaded by the Plugin which requires various linking fixes.

Note: this patch leaves the existing the postFixup block from the Goland
build which patches the bundled `dlv`. For Goland the patching approach
has the modest benefits of:

1. Not showing a popup balloon popup when debugging saying 'using custom dlv...`

2. Guaranteeing Goland is given access to the exact version of delve with which
   it is bundled.

1 is a fairly minor inconvenience, and in the case of 2 I think delve is reasonably
  stable at this point so is unlikely to cause a problem.

It would be possible to use the system `dlv` for Goland and the Go
plugin if consistency is preferred.

Signed-off-by: Silas Davis <silas.davis@monax.io>

###### Description of changes

See above

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
