### PR TITLE
everspace: don't use pango alias

### DIFF
--- a/pkgs/games/everspace/default.nix
+++ b/pkgs/games/everspace/default.nix
@@ -3,7 +3,7 @@
   lib, stdenv, requireFile, autoPatchelfHook, unzip,
 
   # Everspace Dependencies
-  cairo, gdk-pixbuf, gnome2, gtk2-x11, libGL, openal,
+  cairo, gdk-pixbuf, pango, gtk2-x11, libGL, openal,
 
   # Unreal Engine 4 Dependencies
   xorg
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
   buildInputs = [
     cairo
     gdk-pixbuf
-    gnome2.pango
+    pango
     gtk2-x11
     openal
     stdenv.cc.cc.lib


### PR DESCRIPTION
###### Description of changes

#188385 broke my `nixpkgs-review`s:

```
error: attribute 'pango' missing

       at /home/bt1cn/devel/nixpkgs2/pkgs/games/everspace/default.nix:32:5:

           31|     gdk-pixbuf
           32|     gnome2.pango
             |     ^
           33|     gtk2-x11
```

`gnome2.pango` is aliased to `pango`, alias references are disabled because we don't want more of those in Nixpkgs.

Can't test build because I don't have the game, but at least it evals with aliases disabled now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
