### PR TITLE
qemu: add patches for CVE-2022-0216 & CVE-2020-14394

### DIFF
--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -126,6 +126,22 @@ stdenv.mkDerivation rec {
       url = "https://gitlab.com/qemu-project/qemu/-/commit/418ade7849ce7641c0f7333718caf5091a02fd4c.patch";
       sha256 = "sha256-zQHDXedIXZBnabv4+3TA4z5mY1+KZiPmqUbhaSkGLgA=";
     })
+    # needed for CVE-2022-0216's test to pass
+    (fetchpatch {
+      name = "fuzz-tests-x86-only.patch";
+      url = "https://gitlab.com/qemu-project/qemu/-/commit/b911c30c566dee48a27bc1bfa1ee6df3a729cbbb.patch";
+      sha256 = "sha256-RXKRmZo25yZ1VuBtBA+BsY8as9kIcACqE6aEYmIm9KQ=";
+    })
+    (fetchpatch {
+      name = "CVE-2022-0216.part-1.patch";
+      url = "https://gitlab.com/qemu-project/qemu/-/commit/6c8fa961da5e60f574bb52fd3ad44b1e9e8ad4b8.patch";
+      sha256 = "sha256-0z0zVPBVXFSU8qEV0Ea2+rDxyikMyitlDM0jZOLLC6s=";
+    })
+    (fetchpatch {
+      name = "CVE-2022-0216.part-2.patch";
+      url = "https://gitlab.com/qemu-project/qemu/-/commit/4367a20cc442c56b05611b4224de9a61908f9eac.patch";
+      sha256 = "sha256-hpNu4Zjw1dIbT6Vt57cayHE1Elaltp0a/bsKlDY0Qr8=";
+    })
   ]
   ++ lib.optional nixosTestRunner ./force-uid0-on-9p.patch;
 

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -142,6 +142,11 @@ stdenv.mkDerivation rec {
       url = "https://gitlab.com/qemu-project/qemu/-/commit/4367a20cc442c56b05611b4224de9a61908f9eac.patch";
       sha256 = "sha256-hpNu4Zjw1dIbT6Vt57cayHE1Elaltp0a/bsKlDY0Qr8=";
     })
+    (fetchpatch {
+      name = "CVE-2020-14394.patch";
+      url = "https://gitlab.com/qemu-project/qemu/-/commit/effaf5a240e03020f4ae953e10b764622c3e87cc.patch";
+      sha256 = "sha256-NobsIxRC+xlyj8d/oD4mqgXAGX37pfww/PQQuKhrTzc=";
+    })
   ]
   ++ lib.optional nixosTestRunner ./force-uid0-on-9p.patch;
 


### PR DESCRIPTION
###### Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2022-0216
https://nvd.nist.gov/vuln/detail/CVE-2020-14394

CVE-2022-0216 patch comes with a test covering the issue. For this test to pass we need to apply an earlier patch which simple stops trying to run the fuzz tests for non-x86 as they were only ever really meant to apply to x86 anyway.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
