### PR TITLE
Add dali99 to .mailmap 

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Daniel Løvbrøtte Olsen <me@dandellion.xyz> <daniel.olsen99@gmail.com>


### PR DESCRIPTION
This allows rewriting names and email addresses in the git commit history without rewriting history.

Documentation:
https://git-scm.com/docs/gitmailmap

I have not added any other people's authorship information, since the last time someone tried to add information like this to nixpkgs there were some concerns with privacy.