### PR TITLE
linux: Enable HARDENED_USERCOPY

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -481,6 +481,7 @@ let
       DEBUG_LIST                       = yes;
       # Detect writes to read-only module pages
       DEBUG_SET_MODULE_RONX            = whenOlder "4.11" (option yes);
+      HARDENED_USERCOPY                = yes;
       RANDOMIZE_BASE                   = option yes;
       STRICT_DEVMEM                    = mkDefault yes; # Filter access to /dev/mem
       IO_STRICT_DEVMEM                 = mkDefault yes;


### PR DESCRIPTION
Enabled in [Arch][1], [Debian][2], [Fedora][3] (no others checked). Recommended by [Kernel Self Protection Project][4]. Originally [reported to have no noticeable performance impact][5].

[1]: https://github.com/archlinux/svntogit-packages/blob/66d72ee54afc604391b618fc3eecc43f29e479e8/trunk/config#L10252
[2]: https://salsa.debian.org/kernel-team/linux/-/blob/07731f5956cf29876a7abc13f4ecbdf4d9459592/debian/config/config#L7710
[3]: https://src.fedoraproject.org/rpms/kernel/blob/6d6ad72f0ccfe72146f2876f90fe609548caa349/f/kernel-x86_64-fedora.config#_2202
[4]: https://kernsec.org/wiki/index.php/Kernel_Self_Protection_Project/Recommended_Settings
[5]: https://lwn.net/Articles/695991/

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

Tested by running, atop nixos-unstable:

```
nix build -j1 ".#"linux_{4_14,5_18}{,_hardened} ".#"linux_5_19
nix-build -j1 -A linux_4_14.tests -A linux_4_14_hardened.tests -A linux_5_18.tests -A linux_5_18_hardened.tests -A linux_5_19.tests
```

Only built oldest and newest Kernels to save time and under the assumption that in-between Kernels have the same support as long as the oldest and newest do.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
