### PR TITLE
python3Packages.remi: init at 2022.7.27

### DIFF
--- a/pkgs/development/python-modules/remi/default.nix
+++ b/pkgs/development/python-modules/remi/default.nix
@@ -1,0 +1,61 @@
+{ stdenv
+, lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, matplotlib
+, python-snap7
+, opencv4
+}:
+
+buildPythonPackage rec {
+  pname = "remi";
+  version = "2022.7.27";
+
+  src = fetchFromGitHub {
+    owner = "rawpython";
+    repo = pname;
+    rev = version;
+    hash = "sha256-VQn+Uzp6oGSit8ot0e8B0C2N41Q8+J+o91skyVN1gDA=";
+  };
+
+  preCheck = ''
+    # for some reason, REMI already deal with these using try blocks, but they fail
+    substituteInPlace test/test_widget.py \
+      --replace \
+        "from html_validator import " \
+        "from .html_validator import "
+    substituteInPlace test/test_examples_app.py \
+      --replace \
+        "from mock_server_and_request import " \
+        "from .mock_server_and_request import " \
+      --replace \
+        "from html_validator import " \
+        "from .html_validator import "
+    # Halves number of warnings
+    substituteInPlace test/test_*.py \
+      --replace \
+        "self.assertEquals(" \
+        "self.assertEqual("
+  '';
+
+  checkInputs = [
+    pytestCheckHook
+    python-snap7
+    opencv4
+    matplotlib
+  ];
+
+  pythonImportsCheck = [
+    "remi"
+    "editor"
+    "editor.widgets"
+  ];
+
+  meta = with lib; {
+    description = "Pythonic, lightweight and websocket-based webui library";
+    homepage = "https://github.com/rawpython/remi";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ pbsds ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9342,6 +9342,8 @@ in {
 
   remarshal = callPackage ../development/python-modules/remarshal { };
 
+  remi = callPackage ../development/python-modules/remi { };
+
   renault-api = callPackage ../development/python-modules/renault-api { };
 
   rencode = callPackage ../development/python-modules/rencode { };


### PR DESCRIPTION
###### Description of changes

[REMI](https://github.com/rawpython/remi) is a simple library to build dynamic websocket-driven webuis.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
