### PR TITLE
libbluray: backport bugfix

### DIFF
--- a/pkgs/development/libraries/libbluray/default.nix
+++ b/pkgs/development/libraries/libbluray/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, pkg-config, fontconfig, autoreconfHook, DiskArbitration
+{ lib, stdenv, fetchurl, fetchpatch, pkg-config, fontconfig, autoreconfHook, DiskArbitration
 , withJava ? false, jdk, ant
 , withAACS ? false, libaacs
 , withBDplus ? false, libbdplus
@@ -20,6 +20,16 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./BDJ-JARFILE-path.patch
+    (fetchpatch {
+      name = "Initial-support-for-Java-18.patch";
+      url = "https://code.videolan.org/videolan/libbluray/-/commit/3187c3080096e107f0a27eed1843232b58342577.patch";
+      hash = "sha256-2TSciAoPzELkgmFGB38h1RgynOCJueyCL8hIADxAPHo=";
+    })
+    (fetchpatch {
+      name = "bd-j-BDJSecurityManager-Change-setSecurityManager-de.patch";
+      url = "https://code.videolan.org/videolan/libbluray/-/commit/9a2d23d049760ef9cc9661ff90011a84d90368f1.patch";
+      hash = "sha256-xCc2h5ocXCqnpVMPQaybT2Ncs2YOzifQ0mlCCUhYlc8=";
+    })
   ];
 
   nativeBuildInputs = [ pkg-config autoreconfHook ]


### PR DESCRIPTION
###### Description of changes

This backports a bugfix that fixes a bunch of blurays. Another patch was backported too as the bugfix was based on the previous patch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
