### PR TITLE
python3Packages.svgwrite: 1.4.1 → 1.4.3

### DIFF
--- a/pkgs/development/python-modules/svgwrite/default.nix
+++ b/pkgs/development/python-modules/svgwrite/default.nix
@@ -2,31 +2,29 @@
 , buildPythonPackage
 , fetchFromGitHub
 , pythonOlder
-, pytest
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "svgwrite";
-  version = "1.4.1";
+  version = "1.4.3";
 
   src = fetchFromGitHub {
     owner = "mozman";
     repo = "svgwrite";
     rev = "v${version}";
-    sha256 = "sha256-d//ZUFb5yj51uD1fb6yJJROaQ2MLyfA3Pa84TblqLNk=";
+    sha256 = "sha256-uOsrDhE9AwWU7GIrCVuL3uXTPqtrh8sofvo2C5t+25I=";
   };
 
   # svgwrite requires Python 3.6 or newer
   disabled = pythonOlder "3.6";
 
-  checkInputs = [
-    pytest
-  ];
+  checkInputs = [ pytestCheckHook ];
 
-  # embed_google_web_font test tried to pull font from internet
-  checkPhase = ''
-    pytest -k "not test_embed_google_web_font"
-  '';
+  disabledTests = [
+    # embed_google_web_font test tried to pull font from internet
+    "test_embed_google_web_font"
+  ];
 
   meta = with lib; {
     description = "A Python library to create SVG drawings";


### PR DESCRIPTION
###### Description of changes
[Changelog](https://github.com/mozman/svgwrite/blob/master/NEWS.rst)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
