### PR TITLE
oha: 0.5.3 -> 0.5.4

### DIFF
--- a/pkgs/tools/networking/oha/default.nix
+++ b/pkgs/tools/networking/oha/default.nix
@@ -2,21 +2,26 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "oha";
-  version = "0.5.3";
+  version = "0.5.4";
 
   src = fetchFromGitHub {
     owner = "hatoo";
     repo = pname;
     rev = "refs/tags/v${version}";
-    sha256 = "sha256-P21rANxgreXu8vA1vsFCSkh1Irs67r3s33XT1dMFD7I=";
+    sha256 = "sha256-dk9OXUt31UIZLH3E50R8iE8zJqvdT1pBu1oU25QrOro=";
   };
 
-  cargoSha256 = "sha256-l6xQbZVrWF8Uw27datqvv9B3LoPtoaCnumo0gIjKdaA=";
+  cargoSha256 = "sha256-WlAAuFz7DZ4PhlTgEXNK9sZKkS95pCrbX2AXC3c1rh8=";
 
   nativeBuildInputs = lib.optional stdenv.isLinux pkg-config;
 
   buildInputs = lib.optional stdenv.isLinux openssl
     ++ lib.optional stdenv.isDarwin Security;
+
+  # remove cargo config so it can find the linker
+  postPatch = ''
+    rm .cargo/config.toml
+  '';
 
   # tests don't work inside the sandbox
   doCheck = false;


### PR DESCRIPTION
###### Description of changes

https://github.com/hatoo/oha/compare/v0.5.3...v0.5.4
[changelog](https://github.com/hatoo/oha/blob/v0.5.4/CHANGELOG.md)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
