### PR TITLE
python3Packages.dicom2nifti: 2.3.0 -> 2.4.3

### DIFF
--- a/pkgs/development/python-modules/dicom2nifti/default.nix
+++ b/pkgs/development/python-modules/dicom2nifti/default.nix
@@ -1,9 +1,9 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, isPy27
+, pythonOlder
+, pytestCheckHook
 , gdcm
-, nose
 , nibabel
 , numpy
 , pydicom
@@ -13,21 +13,30 @@
 
 buildPythonPackage rec {
   pname = "dicom2nifti";
-  version = "2.3.0";
-  disabled = isPy27;
+  version = "2.4.3";
+  disabled = pythonOlder "3.6";
 
   # no tests in PyPI dist
   src = fetchFromGitHub {
     owner = "icometrix";
     repo = pname;
     rev = version;
-    sha256 = "sha256-QSu9CGXFjDpI25Cy6QSbrwiQ2bwsVezCUxSovRLs6AI=";
+    hash = "sha256-za2+HdnUhPu3+p29JsF4iL1lyPQVmEv3fam0Yf1oeMQ=";
   };
 
-  propagatedBuildInputs = [ nibabel numpy pydicom scipy setuptools ];
+  propagatedBuildInputs = [ gdcm nibabel numpy pydicom scipy setuptools ];
 
-  checkInputs = [ nose gdcm ];
-  checkPhase = "nosetests tests";
+  # python-gdcm just builds the python interface provided by the "gdcm" package, so
+  # we should be able to replace "python-gdcm" with "gdcm" but this doesn't work
+  # (similar to https://github.com/NixOS/nixpkgs/issues/84774)
+  postPatch = ''
+    substituteInPlace setup.py --replace "python-gdcm" ""
+    substituteInPlace tests/test_generic.py --replace "from common" "from dicom2nifti.common"
+  '';
+
+  checkInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "dicom2nifti" ];
 
   meta = with lib; {
     homepage = "https://github.com/icometrix/dicom2nifti";


### PR DESCRIPTION
###### Description of changes

Routine update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [NA] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [NA] (Package updates) Added a release notes entry if the change is major or breaking
  - [NA] (Module updates) Added a release notes entry if the change is significant
  - [NA] (Module addition) Added a release notes entry if adding a new NixOS module
  - [NA] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).