### PR TITLE
nixos/lib/make-options-doc: tweak CommonMark name escaping for broader compat

### DIFF
--- a/nixos/lib/make-options-doc/generateCommonMark.py
+++ b/nixos/lib/make-options-doc/generateCommonMark.py
@@ -1,9 +1,10 @@
 import json
 import sys
+import html
 
 options = json.load(sys.stdin)
 for (name, value) in options.items():
-    print('##', name.replace('<', '\\<').replace('>', '\\>'))
+    print('##', html.escape(name))
     print(value['description'])
     print()
     if 'type' in value:


### PR DESCRIPTION
###### Description of changes

The current escaping mechanism of option names does not work with some common
markdown libraries like python-markdown: `a.\<b\>.c` is converted to HTML which
is displayed as `a.\<b>.c` (cf. [babelmark3][1]) instead of the intended `a.<b>.c`.
This PR makes the escaping more universal.

Alternatively, this could be fixed by replacing `<`/`>`/ by `&lt;`/`&gt;`, but
using proper HTML escaping felt a bit more principled.

[1]: https://babelmark.github.io

###### Testing

Compare the rendered output of `nix-build` of this file:

```nix
{ pkgs ? import ./. { } }:

let
  inherit (pkgs) lib;
  inherit (lib) types;
  testType = {
    options.a = lib.mkOption {
      description = "a";
      type = types.attrsOf (types.submodule {
        options.c = lib.mkEnableOption "c";
      });
    };
  };
  eval = lib.evalModules { modules = [ testType ]; };
  md = (pkgs.nixosOptionsDoc { inherit (eval) options; }).optionsCommonMark;
in
pkgs.runCommand "module.html" { } ''
  ${pkgs.python3Packages.markdown}/bin/markdown_py ${md} -f $out
''
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
