### PR TITLE
binutils-unwrapped: install gcc LTO plugin

### DIFF
--- a/pkgs/build-support/bintools-wrapper/gnu-binutils-ar-wrapper.sh
+++ b/pkgs/build-support/bintools-wrapper/gnu-binutils-ar-wrapper.sh
@@ -2,4 +2,4 @@
 # shellcheck shell=bash
 
 @gnu_binutils_inject_plugin@
-exec @prog@ --enable-deterministic-archives "$@"
+exec @prog@ "$@"

--- a/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
@@ -249,6 +249,7 @@ if (( "${NIX_DEBUG:-0}" >= 1 )); then
 fi
 
 PATH="$path_backup"
+@gnu_binutils_inject_plugin@
 # Old bash workaround, see above.
 @prog@ \
     ${extraBefore+"${extraBefore[@]}"} \

--- a/pkgs/development/tools/misc/binutils/BFD_PLUGINS_DIR.patch
+++ b/pkgs/development/tools/misc/binutils/BFD_PLUGINS_DIR.patch
@@ -1,0 +1,24 @@
+--- a/bfd/plugin.c
++++ b/bfd/plugin.c
+@@ -490,9 +490,18 @@ build_plugin_list (bfd *abfd)
+   /* The intent was to search ${libdir}/bfd-plugins for plugins, but
+      unfortunately the original implementation wasn't precisely that
+      when configuring binutils using --libdir.  Search in the proper
+-     path first, then the old one for backwards compatibility.  */
+-  static const char *path[]
+-    = { LIBDIR "/bfd-plugins", BINDIR "/../lib/bfd-plugins" };
++     path first, then the old one for backwards compatibility.
++
++     On top of that user is allowed to extend default search path with
++     BFD_PLUGINS_DIR environment variable. It's useful for cases when
++     modifying system directories is not feasible.
++   */
++  const char *path[] =
++    {
++      getenv ("BFD_PLUGINS_DIR"),
++      LIBDIR "/bfd-plugins",
++      BINDIR "/../lib/bfd-plugins",
++    };
+   struct stat last_st;
+   unsigned int i;
+ 

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -50,8 +50,6 @@ let
   #INFO: The targetPrefix prepended to binary names to allow multiple binuntils
   # on the PATH to both be usable.
   targetPrefix = lib.optionalString (targetPlatform != hostPlatform) "${targetPlatform.config}-";
-
-  gcc_lto_plugin_path = "${stdenv.cc.cc}/libexec/gcc/${stdenv.targetPlatform.config}/${stdenv.cc.cc.version or "UNKNOWN"}/liblto_plugin.so";
 in
 
 stdenv.mkDerivation {
@@ -205,19 +203,6 @@ stdenv.mkDerivation {
   doInstallCheck = (buildPlatform == hostPlatform) && (hostPlatform == targetPlatform);
 
   enableParallelBuilding = true;
-
-  # Install linker plugin to make 'ar', 'ld' and friends auto-load
-  # linker plugin to handle LTO bytecode without explicit --plugin
-  # parameter.
-  #
-  # We can install the link only if our compiler's host and target
-  # match binutils' host and target.
-  postInstall = lib.optionalString (   stdenv.cc.stdenv.hostPlatform == stdenv.hostPlatform
-                                    && stdenv.cc.stdenv.targetPlatform == stdenv.targetPlatform) ''
-    if [ -e ${gcc_lto_plugin_path} ]; then
-      ln -s ${gcc_lto_plugin_path} $out/lib/bfd-plugins/
-    fi
-  '';
 
   passthru = {
     inherit targetPrefix;

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -87,6 +87,9 @@ stdenv.mkDerivation {
     #    https://sourceware.org/PR29450
     # Remove once 2.40 releases.
     ./gas-dwarf-zero-PR29451.patch
+
+    # Add an extra path to look up gcc LTO plugin. Used by binutils wrapper.
+    ./BFD_PLUGINS_DIR.patch
   ]
   ++ lib.optional targetPlatform.isiOS ./support-ios.patch
   # This patch was suggested by Nick Clifton to fix

--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -172,10 +172,6 @@ in with pkgs; rec {
           cp ${bootBinutils.out}/bin/$i $out/bin
         done
         cp -r '${lib.getLib binutils.bintools}'/lib/* "$out/lib/"
-        chmod -R u+w $out/lib
-        # remove link to gcc's lto plugin in binutils. Does not exist
-        # for cross-gcc.
-        rm -f "$out/lib/bfd-plugins/liblto_plugin.so"
 
         chmod -R u+w $out
 

--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -172,6 +172,10 @@ in with pkgs; rec {
           cp ${bootBinutils.out}/bin/$i $out/bin
         done
         cp -r '${lib.getLib binutils.bintools}'/lib/* "$out/lib/"
+        chmod -R u+w $out/lib
+        # remove link to gcc's lto plugin in binutils. Does not exist
+        # for cross-gcc.
+        rm -f "$out/lib/bfd-plugins/liblto_plugin.so"
 
         chmod -R u+w $out
 


### PR DESCRIPTION
Reviewers' note: I did a very hacky condition of gcc and binutils compatibility. I think it's slightly incorrect for cross case. Please have a close look at it.

Before the change binutils was not able to handle LTO bytecode without
explicit plugin being passed:

    $ touch a.c && gcc -flto -fPIC -c a.c -o a.o && ar cr a.a a.o
    ar: a.o: plugin needed to handle lto object

After the change binutils can now handle LTO bytecode and build valid
indices:

    $ touch a.c && gcc -flto -fPIC -c a.c -o a.o && ar cr a.a a.o
    <ok>

The change fixes LTO build of sway:

    $ nix build --impure --expr 'with import ./. {}; sway-unwrapped.overrideAttrs (oa: { NIX_CFLAGS_COMPILE = "-flto=auto"; NIX_CFLAGS_LINK = "-flto=auto"; })

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
