### PR TITLE
cppreference-doc: init at 2022.07.30

### DIFF
--- a/pkgs/development/misc/cppreference-doc/default.nix
+++ b/pkgs/development/misc/cppreference-doc/default.nix
@@ -1,0 +1,31 @@
+{ lib, fetchzip }:
+
+let
+  pname = "cppreference-doc";
+  version = "2022.07.30";
+  ver = builtins.replaceStrings ["."] [""] version;
+
+in fetchzip {
+  name = pname + "-" + version;
+
+  url = "https://github.com/PeterFeicht/${pname}/releases/download/v${ver}/html-book-${ver}.tar.xz";
+  sha256 = "sha256-gsYNpdxbWnmwcC9IJV1g+e0/s4Hoo5ig1MGoYPIHspw=";
+
+  stripRoot = false;
+
+  postFetch = ''
+    rm $out/cppreference-doxygen-local.tag.xml $out/cppreference-doxygen-web.tag.xml
+    mkdir -p $out/share/cppreference/doc
+    mv $out/reference $out/share/cppreference/doc/html
+  '';
+
+  passthru = { inherit pname version; };
+
+  meta = with lib; {
+    description = "C++ standard library reference";
+    homepage = "https://en.cppreference.com";
+    license = licenses.cc-by-sa-30;
+    maintainers = with maintainers; [ panicgh ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15360,6 +15360,8 @@ with pkgs;
 
   avr8burnomat = callPackage ../development/misc/avr8-burn-omat { };
 
+  cppreference-doc = callPackage ../development/misc/cppreference-doc { };
+
   sourceFromHead = callPackage ../build-support/source-from-head-fun.nix {};
 
   jruby = callPackage ../development/interpreters/jruby { };


### PR DESCRIPTION
###### Description of changes

Adds an offline version of https://en.cppreference.com.

When installed to a user profile, the user can for example set a browser bookmark to file:///home/USER/.nix-profile/share/cppreference/doc/html/en/index.html and have fast and privacy preserving access to the C/C++ documentation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
