### PR TITLE
gitolite: fix reference to /bin

### DIFF
--- a/pkgs/applications/version-management/gitolite/default.nix
+++ b/pkgs/applications/version-management/gitolite/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, git, lib, makeWrapper, nettools, perl, perlPackages, nixosTests }:
+{ stdenv, coreutils, fetchFromGitHub, git, lib, makeWrapper, nettools, perl, perlPackages, nixosTests }:
 
 stdenv.mkDerivation rec {
   pname = "gitolite";
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
       --replace /usr/bin/perl "${perl}/bin/perl"
     substituteInPlace src/lib/Gitolite/Setup.pm \
       --replace hostname "${nettools}/bin/hostname"
+    substituteInPlace src/commands/sskm \
+      --replace /bin/rm "${coreutils}/bin/rm"
   '';
 
   postFixup = ''


### PR DESCRIPTION
###### Description of changes

sskm command cannot clean up temp directory

###### Things done

patch a "/bin/rm" reference

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
 to the relevant packages
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
