### PR TITLE
enyo-launcher: 2.0.2 -> 2.0.5, renamed from enyo-doom

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13885,6 +13885,12 @@
     githubId = 120451;
     name = "Urban Skudnik";
   };
+  usrfriendly = {
+      name = "Arin Lares";
+      email = "arinlares@gmail.com";
+      github = "usrfriendly";
+      githubId = 2502060;
+    };
   utdemir = {
     email = "me@utdemir.com";
     github = "utdemir";

--- a/pkgs/games/enyo-launcher/default.nix
+++ b/pkgs/games/enyo-launcher/default.nix
@@ -1,14 +1,14 @@
 { mkDerivation, lib, fetchFromGitLab, cmake, qtbase }:
 
 mkDerivation rec {
-  pname = "enyo-doom";
-  version = "2.0.2";
+  pname = "enyo-launcher";
+  version = "2.0.5";
 
   src = fetchFromGitLab {
     owner = "sdcofer70";
-    repo = "enyo-doom";
+    repo = "enyo-launcher";
     rev = version;
-    sha256 = "1s1vpwrrpb9c7r2b0k1j7dlsfasfzmi6prcwql4mxwixrl7f8ms1";
+    sha256 = "sha256-qdVP5QN2t0GK4VBWuFGrnRfgamQDZGRjwaAe6TIK604=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -16,10 +16,10 @@ mkDerivation rec {
   buildInputs = [ qtbase ];
 
   meta = {
-    homepage = "https://gitlab.com/sdcofer70/enyo-doom";
+    homepage = "https://gitlab.com/sdcofer70/enyo-launcher";
     description = "Frontend for Doom engines";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.unix;
-    maintainers = [ lib.maintainers.tadfisher ];
+    maintainers = [ lib.maintainers.usrfriendly ];
   };
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -325,6 +325,8 @@ mapAliases ({
   enblendenfuse = throw "'enblendenfuse' has been renamed to/replaced by 'enblend-enfuse'"; # Converted to throw 2022-02-22
   encryptr = throw "encryptr was removed because it reached end of life"; # Added 2022-02-06
   envdir = throw "envdir has been dropped due to the lack of maintenance from upstream since 2018"; # Added 2022-06-03
+  envelope = throw "envelope has been removed from nixpkgs, as it was unmaintained"; # Added 2021-08-05
+  enyo-doom = enyo-launcher; # Added 2022-09-09
   epoxy = libepoxy; # Added 2021-11-11
   epsxe = throw "epsxe has been removed from nixpkgs, as it was unmaintained."; # added 2021-12-15
   etcdctl = throw "'etcdctl' has been renamed to/replaced by 'etcd'"; # Converted to throw 2022-02-22

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33468,7 +33468,7 @@ with pkgs;
 
   endless-sky = callPackage ../games/endless-sky { };
 
-  enyo-doom = libsForQt5.callPackage ../games/enyo-doom { };
+  enyo-launcher = libsForQt5.callPackage ../games/enyo-launcher { };
 
   eternity = callPackage ../games/eternity-engine { };
 


### PR DESCRIPTION
###### Description of changes
This is a new package, potentially a duplicate of enyo-doom, which has been changed to "enyo-launcher" and has a different upstream repo, and three minor version releases since (from 2.02 to 2.05).
New Gitlab repo: https://gitlab.com/sdcofer70/enyo-launcher

I did not test for breaking dependent packages, as it has no dependent packages. I also only have access to x86_64-linux  on NixOS right now, so it's all I could test the build on.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- Built on platform(s)
  - [✅] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [✅ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [✅ ] Tested basic functionality of all binary files (usually in `./result/bin/`)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
