### PR TITLE
pgadmin4: 6.12 -> 6.13, add email module options

### DIFF
--- a/nixos/modules/services/admin/pgadmin.nix
+++ b/nixos/modules/services/admin/pgadmin.nix
@@ -37,16 +37,65 @@ in
     };
 
     initialEmail = mkOption {
-      description = lib.mdDoc "Initial email for the pgAdmin account.";
+      description = lib.mdDoc "Initial email for the pgAdmin account";
       type = types.str;
     };
 
     initialPasswordFile = mkOption {
       description = lib.mdDoc ''
         Initial password file for the pgAdmin account.
-        NOTE: Should be string not a store path, to prevent the password from being world readable.
+        NOTE: Should be string not a store path, to prevent the password from being world readable
       '';
       type = types.path;
+    };
+
+    emailServer = {
+      enable = mkOption {
+        description = lib.mdDoc ''
+          Enable SMTP email server. This is necessary, if you want to use password recovery or change your own password
+        '';
+        type = types.bool;
+        default = false;
+      };
+      address = mkOption {
+        description = lib.mdDoc "SMTP server for email delivery";
+        type = types.str;
+        default = "localhost";
+      };
+      port = mkOption {
+        description = lib.mdDoc "SMTP server port for email delivery";
+        type = types.port;
+        default = 25;
+      };
+      useSSL = mkOption {
+        description = lib.mdDoc "SMTP server should use SSL";
+        type = types.bool;
+        default = false;
+      };
+      useTLS = mkOption {
+        description = lib.mdDoc "SMTP server should use TLS";
+        type = types.bool;
+        default = false;
+      };
+      username = mkOption {
+        description = lib.mdDoc "SMTP server username for email delivery";
+        type = types.nullOr types.str;
+        default = null;
+      };
+      sender = mkOption {
+        description = lib.mdDoc ''
+          SMTP server sender email for email delivery. Some servers require this to be a valid email address from that server
+        '';
+        type = types.str;
+        example = "noreply@example.com";
+      };
+      passwordFile = mkOption {
+        description = lib.mdDoc ''
+          Password for SMTP email account.
+          NOTE: Should be string not a store path, to prevent the password from being world readable
+        '';
+        type = types.path;
+      };
     };
 
     openFirewall = mkEnableOption (lib.mdDoc "firewall passthrough for pgadmin4");
@@ -54,10 +103,10 @@ in
     settings = mkOption {
       description = lib.mdDoc ''
         Settings for pgadmin4.
-        [Documentation](https://www.pgadmin.org/docs/pgadmin4/development/config_py.html).
+        [Documentation](https://www.pgadmin.org/docs/pgadmin4/development/config_py.html)
       '';
       type = pyType;
-      default= {};
+      default = { };
     };
   };
 
@@ -69,6 +118,13 @@ in
       SERVER_MODE = true;
     } // (optionalAttrs cfg.openFirewall {
       DEFAULT_SERVER = mkDefault "::";
+    }) // (optionalAttrs cfg.emailServer.enable {
+      MAIL_SERVER = cfg.emailServer.address;
+      MAIL_PORT = cfg.emailServer.port;
+      MAIL_USE_SSL = cfg.emailServer.useSSL;
+      MAIL_USE_TLS = cfg.emailServer.useTLS;
+      MAIL_USERNAME = cfg.emailServer.username;
+      SECURITY_EMAIL_SENDER = cfg.emailServer.sender;
     });
 
     systemd.services.pgadmin = {
@@ -115,10 +171,14 @@ in
       group = "pgadmin";
     };
 
-    users.groups.pgadmin = {};
+    users.groups.pgadmin = { };
 
     environment.etc."pgadmin/config_system.py" = {
-      text = formatPy cfg.settings;
+      text = lib.optionalString cfg.emailServer.enable ''
+        with open("${cfg.emailServer.passwordFile}") as f:
+          pw = f.read()
+        MAIL_PASSWORD = pw
+      '' + formatPy cfg.settings;
       mode = "0600";
       user = "pgadmin";
       group = "pgadmin";

--- a/nixos/tests/pgadmin4.nix
+++ b/nixos/tests/pgadmin4.nix
@@ -106,15 +106,15 @@ import ./make-test-python.nix ({ pkgs, lib, buildDeps ? [ ], pythonEnv ? [ ], ..
            && sed -i 's|driver_local.maximize_window()||' web/regression/runtests.py"
       )
 
-      # don't bother to test LDAP authentification
-      # exclude resql test due to recent postgres 14.4 update
-      # see bugreport here https://redmine.postgresql.org/issues/7527
+      # Don't bother to test LDAP or kerberos authentification
+      # For now deactivate change_password API test. Current bug report at https://redmine.postgresql.org/issues/7648
+      # Password change works from the UI, if email SMTP is configured.
       with subtest("run browser test"):
           machine.succeed(
                'cd ${pgadmin4SrcDir}/pgadmin4-${pkgs.pgadmin4.version}/web \
                && python regression/runtests.py \
                --pkg browser \
-               --exclude browser.tests.test_ldap_login.LDAPLoginTestCase,browser.tests.test_ldap_login,resql'
+               --exclude browser.tests.test_ldap_login.LDAPLoginTestCase,browser.tests.test_ldap_login,browser.tests.test_kerberos_with_mocking,browser.tests.test_change_password'
           )
 
       # fontconfig is necessary for chromium to run
@@ -126,11 +126,10 @@ import ./make-test-python.nix ({ pkgs, lib, buildDeps ? [ ], pythonEnv ? [ ], ..
                && python regression/runtests.py --pkg feature_tests'
           )
 
-      # reactivate this test again, when the postgres 14.4 test has been fixed
-      # with subtest("run resql test"):
-      #    machine.succeed(
-      #         'cd ${pgadmin4SrcDir}/pgadmin4-${pkgs.pgadmin4.version}/web \
-      #         && python regression/runtests.py --pkg resql'
-      #    )
+      with subtest("run resql test"):
+         machine.succeed(
+              'cd ${pgadmin4SrcDir}/pgadmin4-${pkgs.pgadmin4.version}/web \
+              && python regression/runtests.py --pkg resql'
+         )
     '';
   })

--- a/pkgs/tools/admin/pgadmin/update.sh
+++ b/pkgs/tools/admin/pgadmin/update.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl wget jq yarn2nix yarn common-updater-scripts
+
+set -eu -o pipefail
+
+scriptDir=$(cd "${BASH_SOURCE[0]%/*}" && pwd)
+nixpkgs=$(realpath "$scriptDir"/../../../..)
+
+newest_version="$(curl -s https://www.pgadmin.org/versions.json | jq -r .pgadmin4.version)"
+old_version=$(nix-instantiate --eval -E "(import \"$nixpkgs\" { config = {}; overlays = []; }).pgadmin4.version" | tr -d '"')
+url="https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v${newest_version}/source/pgadmin4-${newest_version}.tar.gz"
+
+if [[ $newest_version == $old_version ]]; then
+  echo "Already at latest version $newest_version"
+  exit 0
+fi
+echo "New version: $newest_version"
+
+pushd $(mktemp -d --suffix=-pgadmin4-updater)
+wget $url
+tar -xzf "pgadmin4-$newest_version.tar.gz"
+cd "pgadmin4-$newest_version/web"
+yarn2nix > yarn.nix
+cp yarn.nix yarn.lock package.json "$nixpkgs/pkgs/tools/admin/pgadmin/"
+popd
+
+update-source-version pgadmin4 "$newest_version" --print-changes


### PR DESCRIPTION
Closes #191511

###### Description of changes

Update of pgadmin to the current release. [Changelog](https://www.pgadmin.org/docs/pgadmin4/latest/release_notes_6_13.html).

With this update the tests I had to deactivate could be re-activated. Unfortunately, a new test fails now (`pgadmin.browser.tests.test_change_password.ChangePasswordTestCase`). Tracked in upstream bug report [here](https://redmine.postgresql.org/issues/7648). 

I tested the password change routine from the UI and noticed that pgadmin4 requires a working SMTP setup for password changes. This isn't new, I just haven't noticed it before. So in order to test the password change UI, I added the email options to the nixos module. Theoretically, one could also just use `services.pgadmin.settings` but then the password would be in the store.

With the options added I ran some tests and password change works as expected. The alternative to the email setup is to delete the `/varlib/pgadmin` folder and let `preStart` re-initialize pgadmin. But then all the settings are lost. 
Another alternative is to edit the `/var/lib/pgadmin/pgadmin4.db` sqlite database. 

As I said, this isn't new, but maybe noteworthy for folks who want to change their password in the future.

My VM test setup looks like:
```
services.pgadmin = {
enable = true;
initialEmail = "bruh@localhost.de";
initialPasswordFile = pkgs.writeText "pw" "bruh2012!";
emailServer = {
  enable = true;
  address = "mailserver.com";
  useSSL = true;
  port = 465;
  username = "my-username";
  sender = "my-email";
  passwordFile = pkgs.writeText "email_pw" "my-supersecret-password";
};
settings = {
  MAIL_DEBUG = true;
};
};
```

Also, I added my workflow for updating pgadmin as a script  for better reproducibility.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
- [x] Tested the new NixOS options in a VM.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
