### PR TITLE
cudatext: 1.168.0 → 1.169.2

### DIFF
--- a/pkgs/applications/editors/cudatext/default.nix
+++ b/pkgs/applications/editors/cudatext/default.nix
@@ -31,20 +31,20 @@ let
     (name: spec:
       fetchFromGitHub {
         repo = name;
-        inherit (spec) owner rev sha256;
+        inherit (spec) owner rev hash;
       }
     )
     (lib.importJSON ./deps.json);
 in
 stdenv.mkDerivation rec {
   pname = "cudatext";
-  version = "1.168.0";
+  version = "1.169.2";
 
   src = fetchFromGitHub {
     owner = "Alexey-T";
     repo = "CudaText";
     rev = version;
-    sha256 = "sha256-/06eZ79Zeq6jtcfq+lOcumBgP59bqCX/Km7k21FroSc=";
+    hash = "sha256-EQAoKft/L4sbdY8hOvyu+Cy+3I8Lt4g1KTxTlSYALac=";
   };
 
   postPatch = ''

--- a/pkgs/applications/editors/cudatext/deps.json
+++ b/pkgs/applications/editors/cudatext/deps.json
@@ -2,56 +2,56 @@
   "EncConv": {
     "owner": "Alexey-T",
     "rev": "2022.06.19",
-    "sha256": "sha256-M00rHH3dG6Vx6MEALxRNlnLLfX/rRI+rdTS7riOhgeg="
+    "hash": "sha256-M00rHH3dG6Vx6MEALxRNlnLLfX/rRI+rdTS7riOhgeg="
   },
   "ATBinHex-Lazarus": {
     "owner": "Alexey-T",
     "rev": "2022.06.14",
-    "sha256": "sha256-3QhARraYURW5uCf2f4MZfUbxdbsg9h7BlXUxKcz4jwA="
+    "hash": "sha256-3QhARraYURW5uCf2f4MZfUbxdbsg9h7BlXUxKcz4jwA="
   },
   "ATFlatControls": {
     "owner": "Alexey-T",
-    "rev": "2022.07.17",
-    "sha256": "sha256-KMGmimbtUQHa8i5wt4KLA/HotLbb/ISzdznmdqPXkNU="
+    "rev": "2022.08.28",
+    "hash": "sha256-jkVHwPQGPtLeSRy502thPIrDWzkkwvlnyGcTzjgFgIc="
   },
   "ATSynEdit": {
     "owner": "Alexey-T",
-    "rev": "2022.07.27",
-    "sha256": "sha256-SGozuk0pvp0+PwAFbGG+QMUhQ2A6mXKr31u10WIveh0="
+    "rev": "2022.08.28",
+    "hash": "sha256-U/UD3vPnIdQUe/1g/mKgs5yGirsIB/uHTjD0MOouAyI="
   },
   "ATSynEdit_Cmp": {
     "owner": "Alexey-T",
-    "rev": "2022.05.04",
-    "sha256": "sha256-6O4RijSejPogokLSBuC6pKrOpihMi/ykS06YyV64Sak="
+    "rev": "2022.08.28",
+    "hash": "sha256-/MWC4BoU/4kflvbly0phh+cfIR8rNwgWFtrXnmxk0Ks="
   },
   "EControl": {
     "owner": "Alexey-T",
-    "rev": "2022.07.20",
-    "sha256": "sha256-pCIt21m34BuDbWLn+CQwqsMQHVWHtctME63Bjx1B9hE="
+    "rev": "2022.08.22",
+    "hash": "sha256-o87V32HhFpCeSxhgkfKiL69oCcmpiReVmiNBPyv1kc4="
   },
   "ATSynEdit_Ex": {
     "owner": "Alexey-T",
     "rev": "2022.07.20",
-    "sha256": "sha256-f/BdOMcx7NTpKgaFTz4MbK3O0GcUepyMPyRdhnZImjU="
+    "hash": "sha256-f/BdOMcx7NTpKgaFTz4MbK3O0GcUepyMPyRdhnZImjU="
   },
   "Python-for-Lazarus": {
     "owner": "Alexey-T",
     "rev": "2021.10.27",
-    "sha256": "sha256-ikXdDUMJ9MxRejEVAhwUsXYVh0URVFHzEpnXuN5NGpA="
+    "hash": "sha256-ikXdDUMJ9MxRejEVAhwUsXYVh0URVFHzEpnXuN5NGpA="
   },
   "Emmet-Pascal": {
     "owner": "Alexey-T",
     "rev": "2022.01.17",
-    "sha256": "sha256-5yqxRW7xFJ4MwHjKnxYL8/HrCDLn30a1gyQRjGMx/qw="
+    "hash": "sha256-5yqxRW7xFJ4MwHjKnxYL8/HrCDLn30a1gyQRjGMx/qw="
   },
   "CudaText-lexers": {
     "owner": "Alexey-T",
     "rev": "2021.07.09",
-    "sha256": "sha256-OyC85mTMi9m5kbtx8TAK2V4voL1i+J+TFoLVwxlHiD4="
+    "hash": "sha256-OyC85mTMi9m5kbtx8TAK2V4voL1i+J+TFoLVwxlHiD4="
   },
   "bgrabitmap": {
     "owner": "bgrabitmap",
-    "rev": "v11.5",
-    "sha256": "sha256-Pevh+yhtN3oSSvbQfnO7SM6UHBVe0sSpbK8ss98XqcU="
+    "rev": "v11.5.2",
+    "hash": "sha256-aGNKkLDbGTeFgFEhuX7R2BXhnllsanJmk4k+1muiSD8="
   }
 }

--- a/pkgs/applications/editors/cudatext/update.sh
+++ b/pkgs/applications/editors/cudatext/update.sh
@@ -20,7 +20,7 @@ hash=$(nix-prefetch-url --quiet --unpack --type sha256 $url)
 sriHash=$(nix hash to-sri --type sha256 $hash)
 
 sed -i "s#version = \".*\"#version = \"$version\"#" default.nix
-sed -i "s#sha256 = \".*\"#sha256 = \"$sriHash\"#" default.nix
+sed -i "s#hash = \".*\"#hash = \"$sriHash\"#" default.nix
 
 while IFS=$'\t' read repo owner rev; do
   latest=$(curl -s https://api.github.com/repos/${owner}/${repo}/releases/latest | jq -r '.tag_name')
@@ -28,6 +28,6 @@ while IFS=$'\t' read repo owner rev; do
     url="https://github.com/${owner}/${repo}/archive/refs/tags/${latest}.tar.gz"
     hash=$(nix-prefetch-url --quiet --unpack --type sha256 $url)
     sriHash=$(nix hash to-sri --type sha256 $hash)
-    jq ".\"${repo}\".rev = \"${latest}\" | .\"${repo}\".sha256 = \"${sriHash}\"" deps.json | sponge deps.json
+    jq ".\"${repo}\".rev = \"${latest}\" | .\"${repo}\".hash = \"${sriHash}\"" deps.json | sponge deps.json
   fi
 done <<< $(jq -r 'to_entries[]|[.key,.value.owner,.value.rev]|@tsv' deps.json)


### PR DESCRIPTION
###### Description of changes
[Changelog](https://cudatext.github.io/history.txt)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
