### PR TITLE
ferretdb: init at 0.5.2

### DIFF
--- a/pkgs/servers/nosql/ferretdb/default.nix
+++ b/pkgs/servers/nosql/ferretdb/default.nix
@@ -1,8 +1,6 @@
 { lib
 , buildGoModule
 , fetchFromGitHub
-, git
-, tree
 }:
 buildGoModule rec {
   pname = "FerretDB";

--- a/pkgs/servers/nosql/ferretdb/default.nix
+++ b/pkgs/servers/nosql/ferretdb/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, git
+, tree
+}:
+buildGoModule rec {
+  pname = "FerretDB";
+  version = "0.5.2";
+
+  src = fetchFromGitHub {
+    owner = "FerretDB";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-WSdscZ1/Dix83RE95Iv61rdaSBWx1GMi6qOIPNus+ZI=";
+  };
+
+  vendorSha256 = "sha256-fGmGE08w9w2QnBVdMZ2IKo8Zq3euJGCBVTTHNKYFY3U=";
+
+  CGO_ENABLED = 0;
+
+  subPackages = [ "cmd/ferretdb" ];
+
+  # We cannot run the `go generate` command since it requires full git history
+  # (deepClone and leaveDotGit does not seem to help)
+  preBuild = ''
+    echo ${version} > internal/util/version/gen/version.txt
+  '';
+
+  meta = with lib; {
+    description = "A truly Open Source MongoDB alternative";
+    homepage = "https://github.com/FerretDB/FerretDB";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ dit7ya ];
+  };
+}

--- a/pkgs/servers/nosql/ferretdb/default.nix
+++ b/pkgs/servers/nosql/ferretdb/default.nix
@@ -2,13 +2,14 @@
 , buildGoModule
 , fetchFromGitHub
 }:
+
 buildGoModule rec {
-  pname = "FerretDB";
+  pname = "ferretdb";
   version = "0.5.2";
 
   src = fetchFromGitHub {
     owner = "FerretDB";
-    repo = pname;
+    repo = "FerretDB";
     rev = "v${version}";
     sha256 = "sha256-WSdscZ1/Dix83RE95Iv61rdaSBWx1GMi6qOIPNus+ZI=";
   };

--- a/pkgs/servers/nosql/ferretdb/default.nix
+++ b/pkgs/servers/nosql/ferretdb/default.nix
@@ -13,17 +13,15 @@ buildGoModule rec {
     sha256 = "sha256-WSdscZ1/Dix83RE95Iv61rdaSBWx1GMi6qOIPNus+ZI=";
   };
 
+  postPatch = ''
+    echo ${version} > internal/util/version/gen/version.txt
+  '';
+
   vendorSha256 = "sha256-fGmGE08w9w2QnBVdMZ2IKo8Zq3euJGCBVTTHNKYFY3U=";
 
   CGO_ENABLED = 0;
 
   subPackages = [ "cmd/ferretdb" ];
-
-  # We cannot run the `go generate` command since it requires full git history
-  # (deepClone and leaveDotGit does not seem to help)
-  preBuild = ''
-    echo ${version} > internal/util/version/gen/version.txt
-  '';
 
   meta = with lib; {
     description = "A truly Open Source MongoDB alternative";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22489,6 +22489,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  ferretdb = callPackage ../servers/nosql/ferretdb { };
+
   felix = callPackage ../servers/felix { };
 
   felix_remoteshell = callPackage ../servers/felix/remoteshell.nix { };


### PR DESCRIPTION
###### Description of changes

FerretDB (previously MangoDB) was founded to become the de-facto open-source substitute to MongoDB. FerretDB is an open-source proxy, converting the MongoDB 5.0+ wire protocol queries to SQL - using PostgreSQL as a database engine.

https://github.com/FerretDB/FerretDB

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
