### PR TITLE
python39Packages.jupyterlab_server: fix failing build, python310Packages.jupyterlab_server: 2.15.0 -> 2.15.1

### DIFF
--- a/pkgs/development/python-modules/jupyterlab_server/default.nix
+++ b/pkgs/development/python-modules/jupyterlab_server/default.nix
@@ -1,5 +1,4 @@
-{ stdenv
-, lib
+{ lib
 , buildPythonPackage
 , fetchPypi
 , hatchling
@@ -14,7 +13,7 @@
 , pytest-timeout
 , pytest-tornasync
 , ruamel-yaml
-, strict-rfc3339
+, importlib-metadata
 }:
 
 buildPythonPackage rec {
@@ -28,19 +27,17 @@ buildPythonPackage rec {
     sha256 = "sha256-qRxRXg55caj3w8mDS3SIV/faxQL5NgS/KDmHmR/Zh+8=";
   };
 
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace "--cov jupyterlab_server --cov-report term-missing --cov-report term:skip-covered" ""
-
-    # translation tests try to install additional packages into read only paths
-    rm -r tests/translations/
-  '';
-
   nativeBuildInputs = [
     hatchling
   ];
 
-  propagatedBuildInputs = [ requests jsonschema json5 babel jupyter_server ];
+  propagatedBuildInputs = [
+    requests
+    jsonschema
+    json5
+    babel
+    jupyter_server
+  ] ++ lib.optional (pythonOlder "3.10") importlib-metadata;
 
   checkInputs = [
     openapi-core
@@ -50,19 +47,25 @@ buildPythonPackage rec {
     ruamel-yaml
   ];
 
+  postPatch = ''
+    # translation tests try to install additional packages into read only paths
+    rm -r tests/translations/
+  '';
+
   preCheck = ''
     export HOME=$(mktemp -d)
   '';
 
   pytestFlagsArray = [
-    # DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
+    # DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12.
+    # Use setuptools or check PEP 632 for potential alternatives.
     "-W ignore::DeprecationWarning"
   ];
 
   __darwinAllowLocalNetworking = true;
 
   meta = with lib; {
-    description = "JupyterLab Server";
+    description = "A set of server components for JupyterLab and JupyterLab like applications";
     homepage = "https://jupyter.org";
     license = licenses.bsdOriginal;
     maintainers = [ maintainers.costrouc ];

--- a/pkgs/development/python-modules/jupyterlab_server/default.nix
+++ b/pkgs/development/python-modules/jupyterlab_server/default.nix
@@ -18,13 +18,13 @@
 
 buildPythonPackage rec {
   pname = "jupyterlab_server";
-  version = "2.15.0";
+  version = "2.15.1";
   format = "pyproject";
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-qRxRXg55caj3w8mDS3SIV/faxQL5NgS/KDmHmR/Zh+8=";
+    sha256 = "sha256-MFMTlw4THFkM93u2uMp+mFkbwwQRHo0QO8kdIS6UeW8=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes

* Fix failing build of python39Packages.jupyterlab_server with Python 3.9 due to a missing importlib-metadata propagated build input.

```console
> ERROR: Could not find a version that satisfies the requirement importlib-metadata>=3.6; python_version < "3.10" (from jupyterlab-server) (from versions: none)
> ERROR: No matching distribution found for importlib-metadata>=3.6; python_version < "3.10"
```


* Upgrade python310Packages.jupyterlab_server from 2.15.0 to 2.15.1
* Clean unused arguments, stale substitute and attribute ordering

Detected during python310Packages.json5 upgrade: https://github.com/NixOS/nixpkgs/pull/188601

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
