### PR TITLE
find-tarballs.nix: Include patches

### DIFF
--- a/maintainers/scripts/copy-tarballs.pl
+++ b/maintainers/scripts/copy-tarballs.pl
@@ -164,6 +164,7 @@ elsif (defined $expr) {
         my $algo = $fetch->{type};
         my $hash = $fetch->{hash};
         my $name = $fetch->{name};
+        my $isPatch = $fetch->{isPatch};
 
         if ($hash =~ /^([a-z0-9]+)-([A-Za-z0-9+\/=]+)$/) {
             $algo = $1;
@@ -186,6 +187,11 @@ elsif (defined $expr) {
 
         if ($url !~ /^http:/ && $url !~ /^https:/ && $url !~ /^ftp:/ && $url !~ /^mirror:/) {
             print STDERR "skipping $url (unsupported scheme)\n";
+            next;
+        }
+
+        if ($isPatch) {
+            print STDERR "skipping $url (support for patches is missing)\n";
             next;
         }
 

--- a/maintainers/scripts/find-tarballs.nix
+++ b/maintainers/scripts/find-tarballs.nix
@@ -14,7 +14,7 @@ let
     operator = const [ ];
   });
 
-  urls = map (drv: { url = head (drv.urls or [ drv.url ]); hash = drv.outputHash; isPatch = (drv?postFetch); type = drv.outputHashAlgo; name = drv.name; }) fetchurlDependencies;
+  urls = map (drv: { url = head (drv.urls or [ drv.url ]); hash = drv.outputHash; isPatch = (drv?postFetch && drv.postFetch != ""); type = drv.outputHashAlgo; name = drv.name; }) fetchurlDependencies;
 
   fetchurlDependencies =
     filter

--- a/maintainers/scripts/find-tarballs.nix
+++ b/maintainers/scripts/find-tarballs.nix
@@ -14,12 +14,12 @@ let
     operator = const [ ];
   });
 
-  urls = map (drv: { url = head (drv.urls or [ drv.url ]); hash = drv.outputHash; type = drv.outputHashAlgo; name = drv.name; }) fetchurlDependencies;
+  urls = map (drv: { url = head (drv.urls or [ drv.url ]); hash = drv.outputHash; isPatch = (drv?postFetch); type = drv.outputHashAlgo; name = drv.name; }) fetchurlDependencies;
 
   fetchurlDependencies =
     filter
       (drv: drv.outputHash or "" != "" && drv.outputHashMode or "flat" == "flat"
-          && drv.postFetch or "" == "" && (drv ? url || drv ? urls))
+          && (drv ? url || drv ? urls))
       dependencies;
 
   dependencies = map (x: x.value) (genericClosure {


### PR DESCRIPTION
###### Description of changes

I'd like to be able to download all sources files required to build a package while being offline, but also check upstream is reachable.

We can currently have `find-tarballs.nix` to obtain a list of urls / hash / name for all distfiles of a given packages, but it's skipping patches files defined with `fetchpatch`. This is so because they have a "postFetch" attribute containing a script that must be run on the downloaded file to sanitize it, the file hash corresponds to the sanitized output.

I'm proposing to include the patches files to the list and to add an attribute `isPatch` to the result which can be used to differentiate between patches and non-patches. The other commit in the PR include changes to find-tarballs.nix consumer copy-tarballs.nix by adding the code to skip patches files because this would require some work to support them.

This fixes https://github.com/NixOS/nixpkgs/issues/186831

With this change, it's now possible to download all sources for a package by iterating over the json output of find-tarballs, and using nix-instantiate to either call fetchurl or fetchpatch.

Here is a sample of Perl code I'm using
```perl
    if ($val->{isPatch}) {
        $return = `nix-instantiate '<nixpkgs>' -A fetchpatch --argstr url "$val->{url}" --argstr name "$val->{name}" --argstr sha256 "$val->{hash}"`;
        print $return;
    } else {
        $return = `nix-instantiate '<nixpkgs>' -A fetchurl --argstr url "$val->{url}" --argstr sha256 "$val->{hash}"`;
        print $return;
    }
```