### PR TITLE
python3.pkgs.paperwork-backend: fix flaky test

### DIFF
--- a/pkgs/applications/office/paperwork/flaky_test.patch
+++ b/pkgs/applications/office/paperwork/flaky_test.patch
@@ -1,0 +1,12 @@
+diff --git a/paperwork-backend/tests/docimport/tests_converted.py b/paperwork-backend/tests/docimport/tests_converted.py
+index 1d1ae39b..bda63fce 100644
+--- a/paperwork-backend/tests/docimport/tests_converted.py
++++ b/paperwork-backend/tests/docimport/tests_converted.py
+@@ -102,6 +102,7 @@ class TestConvertedImport(unittest.TestCase):
+                 )
+             )
+ 
++    @unittest.skip("flaky test: https://gitlab.gnome.org/World/OpenPaperwork/paperwork/-/issues/1035#note_1493700")
+     def test_import_duplicated_docx(self):
+         with tempfile.TemporaryDirectory() as tmp_dir:
+             self.config.settings = {

--- a/pkgs/applications/office/paperwork/paperwork-backend.nix
+++ b/pkgs/applications/office/paperwork/paperwork-backend.nix
@@ -31,7 +31,14 @@ buildPythonPackage rec {
 
   sourceRoot = "source/paperwork-backend";
 
-  patchPhase = ''
+  patches = [
+    # disables a flaky test https://gitlab.gnome.org/World/OpenPaperwork/paperwork/-/issues/1035#note_1493700
+    ./flaky_test.patch
+  ];
+
+  patchFlags = [ "-p2" ];
+
+  postPatch = ''
     echo 'version = "${version}"' > src/paperwork_backend/_version.py
     chmod a+w -R ..
     patchShebangs ../tools


### PR DESCRIPTION
###### Description of changes

cc @onny 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
