### PR TITLE
[22.05] apacheHttpdPackages.mod_wsgi: add patch for CVE-2022-2255

### DIFF
--- a/pkgs/servers/http/apache-modules/mod_wsgi/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_wsgi/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, apacheHttpd, python, ncurses }:
+{ lib, stdenv, fetchFromGitHub, apacheHttpd, python, ncurses, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "mod_wsgi";
@@ -11,9 +11,17 @@ stdenv.mkDerivation rec {
     hash = "sha256-gaWA6m4ENYtm88hCaoqrcIooA0TBI7Kj6fU6pPShoo4=";
   };
 
+  patches = [
+    (fetchpatch {
+      name = "CVE-2022-2255.patch";
+      url = "https://github.com/GrahamDumpleton/mod_wsgi/commit/af3c0c2736bc0b0b01fa0f0aad3c904b7fa9c751.patch";
+      sha256 = "sha256-5gW0E/Ojm/T6aZLuw6BdYwfWN4wHAD7/zz1qjs8DbE4=";
+    })
+  ];
+
   buildInputs = [ apacheHttpd python ncurses ];
 
-  patchPhase = ''
+  postPatch = ''
     sed -r -i -e "s|^LIBEXECDIR=.*$|LIBEXECDIR=$out/modules|" \
       ${if stdenv.isDarwin then "-e 's|/usr/bin/lipo|lipo|'" else ""} \
       configure


### PR DESCRIPTION
###### Description of changes
https://nvd.nist.gov/vuln/detail/CVE-2022-2255

Unstable already taken care of with a 4.9.3 bump.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
