### PR TITLE
tree-sitter: Update grammars

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
@@ -66,6 +66,7 @@
   tree-sitter-pug = lib.importJSON ./tree-sitter-pug.json;
   tree-sitter-python = lib.importJSON ./tree-sitter-python.json;
   tree-sitter-ql = lib.importJSON ./tree-sitter-ql.json;
+  tree-sitter-ql-dbscheme = lib.importJSON ./tree-sitter-ql-dbscheme.json;
   tree-sitter-query = lib.importJSON ./tree-sitter-query.json;
   tree-sitter-r = lib.importJSON ./tree-sitter-r.json;
   tree-sitter-regex = lib.importJSON ./tree-sitter-regex.json;

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-c-sharp",
-  "rev": "9c494a503c8e2044bfffce57f70b480c01a82f03",
-  "date": "2022-05-30T17:23:01+01:00",
-  "path": "/nix/store/h7jans0061yvwj7sph9bzp9ygx7nnqfa-tree-sitter-c-sharp",
-  "sha256": "1pjapli5a70a9308zlb3vfqamh7xybb06vqhljz4xkaagijs91yv",
+  "rev": "ad8e6980e9bf1882a324196229692febf332c4dd",
+  "date": "2022-08-22T14:15:43+01:00",
+  "path": "/nix/store/wl7r0cp4s43ivzxkd9vpvwp08xsl1cb2-tree-sitter-c-sharp",
+  "sha256": "17vn2cy23k1ms8dizyw2gz8gwfghhgd92xfvp9n4vnav9qzah09w",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-c",
-  "rev": "517bf92b2c5e8baa4241cbb8a49085ed7c3c48d4",
-  "date": "2022-07-08T09:44:02-07:00",
-  "path": "/nix/store/0nz381ay9ybngxvialwxisji9j4gwadb-tree-sitter-c",
-  "sha256": "03klq9mb9jnhjxf8lv0mk02gdp83zcyrvx1bzrqbd9jdza3ji1xl",
+  "rev": "7175a6dd5fc1cee660dce6fe23f6043d75af424a",
+  "date": "2022-08-01T15:02:51-07:00",
+  "path": "/nix/store/qhd6cw55bgmgjmi0fwd16q00yhfq612w-tree-sitter-c",
+  "sha256": "1w03r4l773ki4iq2xxsc2pqxf3pjsbybq3xq4glmnsihgylibn8v",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-clojure.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-clojure.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/sogaiu/tree-sitter-clojure",
-  "rev": "e57c569ae332ca365da623712ae1f50f84daeae2",
-  "date": "2022-06-03T17:55:54+09:00",
-  "path": "/nix/store/fx58zcfxr983yczijs6cgdfa3158bl0s-tree-sitter-clojure",
-  "sha256": "0hq8rv4s0gzbfv3qj4gsrm87baiy6k1hyfbhbbpwbrcpd8jl7gdn",
+  "rev": "087bac78c53fe1387756cd5b8e68a69b3f6d7244",
+  "date": "2022-07-19T19:21:35+09:00",
+  "path": "/nix/store/n0kwbvimmzp36y789sb5jrbarjzlwmyf-tree-sitter-clojure",
+  "sha256": "018xrralv15d7r1v63knds7cyix77ssy4jr0qdjmbakdr00r4ara",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cmake.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cmake.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/uyha/tree-sitter-cmake",
-  "rev": "599836393074e4744d78dad76b8b8eb8e1f690ff",
-  "date": "2022-07-08T12:16:35+07:00",
-  "path": "/nix/store/w6nxam1m3kq35faqcx17qmgn250fv461-tree-sitter-cmake",
-  "sha256": "02gbi24rxq4qqlxzl17vi81xjk3d3y41ig6g8w2yc6f2ihiw85na",
+  "rev": "6e51463ef3052dd3b328322c22172eda093727ad",
+  "date": "2022-08-26T09:50:26+02:00",
+  "path": "/nix/store/h7v6r9x9d552gfl8s8dwf26azvdrmsc1-tree-sitter-cmake",
+  "sha256": "14l7l6cc9pdqinff9hjda7rakzfvwk0qcbv6djl0s9f21875l4nv",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-cpp",
-  "rev": "38d8b495bd43977498f0eb122e0f9cfef8526d18",
-  "date": "2022-05-30T11:35:53-07:00",
-  "path": "/nix/store/4ndwshhwzcj9xrj8g0qnvqz7gwpd64z2-tree-sitter-cpp",
-  "sha256": "0lck8s0z0ay9aw6zljaq892xxmgx8wn3kgsin3sjf5ysyjdva3qn",
+  "rev": "f40125503642845492d87fa56ece3ed26a4ef4db",
+  "date": "2022-08-01T17:34:55-05:00",
+  "path": "/nix/store/cs7pplbqvrv3j30hl510c8qjgjx592pp-tree-sitter-cpp",
+  "sha256": "17kxbs87fqf87dh7rf56yqg1njhhmh2xw6f43bpkj7z1k2ryf5zk",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cuda.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cuda.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/thehamsta/tree-sitter-cuda",
-  "rev": "791d9f9e30958a5f951875342ec8b6f737b39533",
-  "date": "2022-05-14T13:37:18+02:00",
-  "path": "/nix/store/mwrqmqrvysf0dpb2lq6gv7d6798s90gi-tree-sitter-cuda",
-  "sha256": "0zixq97pm4rzhl14m2nb9ynndl2bf1jvkzjs25bh99qcikmdvw0i",
+  "rev": "bc48d8eaf5a145922a1bed0a69dca1342a83c12c",
+  "date": "2022-07-24T11:22:15+02:00",
+  "path": "/nix/store/xjgyflwrn6k3slzjvpy0mi1769z657li-tree-sitter-cuda",
+  "sha256": "0nd1xi5w9wjj4jbwlvwacs6b4q0syb91q06p27nc2ygs3v9wx3l7",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-dart.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-dart.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/usernobody14/tree-sitter-dart",
-  "rev": "6fc75e0478e89a6adef4903069b0035247378665",
-  "date": "2022-05-21T14:45:10-07:00",
-  "path": "/nix/store/jma7070d07rgksa29ziavrj4ian9p2h3-tree-sitter-dart",
-  "sha256": "1k2877kia3i8df368z6ynig476yr051k60zijahmd7drm740aavb",
+  "rev": "53485a8f301254e19c518aa20c80f1bcf7cf5c62",
+  "date": "2022-08-11T13:38:34-07:00",
+  "path": "/nix/store/frp77jynv64s1x0l6hix5dk12zlsf5wq-tree-sitter-dart",
+  "sha256": "1ds1hz9gkvc3dp6bz93zlb1rixzhyj8cm6xfpb7cm4a8rhajz1yl",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-dot.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-dot.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/rydesun/tree-sitter-dot",
-  "rev": "917230743aa10f45a408fea2ddb54bbbf5fbe7b7",
-  "date": "2022-03-11T21:17:49+08:00",
-  "path": "/nix/store/3xvainpyzwpbhbm30mmvvgxpgh4agljh-tree-sitter-dot",
-  "sha256": "1q2rbv16dihlmrbxlpn0x03na7xp8rdhf58vwm3lryn3nfcjckn2",
+  "rev": "9ab85550c896d8b294d9b9ca1e30698736f08cea",
+  "date": "2022-08-25T12:15:36+08:00",
+  "path": "/nix/store/p0lcm171skxdr4qbhqwl5slx76k9hap6-tree-sitter-dot",
+  "sha256": "013brrljrhgpnks1r0cdvj93l303kb68prm18gpl96pvhjfci063",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elixir.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elixir.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/elixir-lang/tree-sitter-elixir",
-  "rev": "5d0c1bfcdf8aaad225525acad930a972b319a675",
-  "date": "2022-04-28T11:17:48-05:00",
-  "path": "/nix/store/a3vks004yjn7pb80nppdyq0k18wm3myc-tree-sitter-elixir",
-  "sha256": "1iff2gk6r6qa13imizxawc4hjwwwsnvhvhafcwab2q2476gk82mz",
+  "rev": "05e3631c6a0701c1fa518b0fee7be95a2ceef5e2",
+  "date": "2022-08-04T13:28:43-05:00",
+  "path": "/nix/store/ixqcx5344qr5bzjgyl05zcp2f0gnkbz8-tree-sitter-elixir",
+  "sha256": "0qy4dgs72dyr9cv16q8na7xxkhsqjyk99xnwpgqm1sa8m0yjjyp6",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elm.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elm.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/elm-tooling/tree-sitter-elm",
-  "rev": "a9a8efad446f78db3989d7ed8517987daf510c83",
-  "date": "2022-06-07T23:23:33+02:00",
-  "path": "/nix/store/rqmldb72cml0qm7p8kpjlj064f5miprc-tree-sitter-elm",
-  "sha256": "11d9lrybhqi85lxr7gf8s4zxgbclnjiwn0w1mga3lsh9nnf50a4a",
+  "rev": "a9317711507b094b2049b42356646dd5764bca06",
+  "date": "2022-08-28T14:37:52+02:00",
+  "path": "/nix/store/cq018zk73bw5163ch7p52kkxiqd0yz0y-tree-sitter-elm",
+  "sha256": "1ml93yj9ns6pxzhk0l4hiwfp9h9s1ad3cpwdnpmbgyc0fgaqzjf9",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fish.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fish.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/ram02z/tree-sitter-fish",
-  "rev": "8a3571fc4a702b216ff918a08c9c5895df7ea06c",
-  "date": "2022-05-12T18:32:55+01:00",
-  "path": "/nix/store/vyfppzpljszmwwrk1gdg132c4nswy048-tree-sitter-fish",
-  "sha256": "1svca1agsr29ypn6pz44lwxg4b6a1k5qsm983czk3h16z5igka05",
+  "rev": "84436cf24c2b3176bfbb220922a0fdbd0141e406",
+  "date": "2022-08-21T20:31:28+01:00",
+  "path": "/nix/store/mf86jwsgjr0jdsdp88haqlqhfnpwvsh9-tree-sitter-fish",
+  "sha256": "12s3db2mg9qa8l1i4a5h59kd7kl5j83wyl5kzq7j2k56xmvq56x0",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-glsl.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-glsl.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/thehamsta/tree-sitter-glsl",
-  "rev": "57652a006b726251ae4d03862ffecbe39b1515bf",
-  "date": "2022-07-10T20:32:50+02:00",
-  "path": "/nix/store/n3rfnc7z8ps4jzgxyb9hv9kffb2alcmw-tree-sitter-glsl",
-  "sha256": "1iayzjbwfmjbak3igrgms7wpa58syy2xym6n2hpi3369v7rfgsg8",
+  "rev": "e594c182d9d55170ba01678e1fc534166a38e171",
+  "date": "2022-08-07T23:31:50-07:00",
+  "path": "/nix/store/cnfwwpml52i755k3k52r9c5sgpw57bmp-tree-sitter-glsl",
+  "sha256": "0pjy6d3fx973qf4waj80lkv03ws0sbmy4vpa9a1s72ws6y6c72in",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-haskell",
-  "rev": "cf394604ae2ec2a5e65b1afbc7dea21258ede403",
-  "date": "2022-07-02T11:46:11+02:00",
-  "path": "/nix/store/04cbp4wc4ga3d36d9xvqz2wy9bdnyapv-tree-sitter-haskell",
-  "sha256": "1kvh5gwg3c59snqhpsg23b690rnbmcya0i38mqq9n1pdmv2pzxyi",
+  "rev": "1c89468614883e951db7d4ac05a56ec864f80bc1",
+  "date": "2022-08-22T12:22:27+02:00",
+  "path": "/nix/store/20yq98my5vdv12f76hyly2cc6b1d2dz3-tree-sitter-haskell",
+  "sha256": "1m94qx0gdcv31mskjxs884153qrz1jicajxph2wlp4wdpchl7gsp",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-http.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-http.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/ntbbloodbath/tree-sitter-http",
-  "rev": "bfddd16b1cf78e0042fd1f6846a179f76a254e20",
-  "date": "2021-11-04T16:44:58-04:00",
-  "path": "/nix/store/l776a8vyhzg64pzna22hy96cia71l1sq-tree-sitter-http",
-  "sha256": "0va7lxddkpbsjpbih4dwv6i9minnl2a4lq7i6dm3fk99c71y4ghg",
+  "rev": "30a9c1789d64429a830802cde5b1760ff1064312",
+  "date": "2022-08-21T21:33:18-04:00",
+  "path": "/nix/store/0zk2zzhhx9vsp7h7gsb57db5sk20p3ji-tree-sitter-http",
+  "sha256": "0gd3dv8kr0rzhagxi729fwjzsnipyxln823a4qfqr7lzzvmb14jy",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-javascript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-javascript.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-javascript",
-  "rev": "785831303ce3d36f5dd8ada7c4c7d63518d4d2f5",
-  "date": "2022-05-30T15:49:16+02:00",
-  "path": "/nix/store/jjxv4pcbnnvsbiplhjk91lxyx5mz8l0z-tree-sitter-javascript",
-  "sha256": "0hk9zy7jykq86x0k10060f2b7xrfai551avfz0qssq3b0j2h1m3g",
+  "rev": "936d976a782e75395d9b1c8c7c7bf4ba6fe0d86b",
+  "date": "2022-08-18T14:29:19+02:00",
+  "path": "/nix/store/y3ndi84v9y3li5vnfyyp9xhb8hsgsipf-tree-sitter-javascript",
+  "sha256": "1g252s51amn9w0j6wi4jk6zic9rbw8hajqhcdycq9ma4sqpvb5dr",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-lua.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-lua.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/MunifTanjim/tree-sitter-lua",
-  "rev": "a041a547270c17f3d3aca11cb882f5c8eb88a572",
-  "date": "2022-07-07T14:08:02+06:00",
-  "path": "/nix/store/cs0rf42nnyw4w2rlzhw137iqh06dy5mh-tree-sitter-lua",
-  "sha256": "0db2wjwzzx40i38cs04w8pn0zqqv18ry4m2div0a0b2wgdhzf33f",
+  "rev": "c9ece5b2d348f917052db5a2da9bd4ecff07426c",
+  "date": "2022-07-16T17:09:45+06:00",
+  "path": "/nix/store/88rff0xq0hw7snlcf2kkvvrknnda6sgk-tree-sitter-lua",
+  "sha256": "11jhyll9w6ffd78nnr6d0y79x8r253wvxsflmq3nrhvwqvk2yarm",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-markdown.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-markdown.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/MDeiml/tree-sitter-markdown",
-  "rev": "142a5b4a1b092b64c9f5db8f11558f9dd4009a1b",
-  "date": "2022-07-04T10:48:30+02:00",
-  "path": "/nix/store/wac43pvz3wdwl2i6a8a0ik6l99c9lzmq-tree-sitter-markdown",
-  "sha256": "0q1czdv7szw9rk4h9i9xjc29s0g3m1grhsjq6rl5vm70h998fbmg",
+  "rev": "e375ba95ff9a12418f9b9e7c190f549d08b5380a",
+  "date": "2022-08-05T11:11:58+02:00",
+  "path": "/nix/store/2mga5flf52j6m8v5gglmnammklyp4qw8-tree-sitter-markdown",
+  "sha256": "0ziciy95wgw8j0dimi79dpqg7ql6m1vzkygffmqqmmvap9zfhggb",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-org-nvim.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-org-nvim.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/milisims/tree-sitter-org",
-  "rev": "bc8a040492b56754a35b3b00a3052fdb7ba12969",
-  "date": "2022-06-27T11:07:56-04:00",
-  "path": "/nix/store/6xpvk9i1250slzsh2ap3pr0fawmibngw-tree-sitter-org",
-  "sha256": "19z45bd276g4xggg2vqmr6fjwyi88xmpx1ihqq908152pq83zmv6",
+  "rev": "698bb1a34331e68f83fc24bdd1b6f97016bb30de",
+  "date": "2022-08-16T11:52:06-04:00",
+  "path": "/nix/store/bixwb7s6ax1wygp2pmg1r4czgail0kq8-tree-sitter-org",
+  "sha256": "0adzb2kw8k3w75p5f3ax9lal64k8n2fwrmrqak2z2w8jl8cgagl6",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-perl.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-perl.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/ganezdragon/tree-sitter-perl",
-  "rev": "bbf86084d9b7eb4768f3fb9fe094b3e0600057b1",
-  "date": "2022-02-26T01:42:56+05:30",
-  "path": "/nix/store/cpsi8sjl3d1v5sg2rcsw3arf7zwm4l06-tree-sitter-perl",
-  "sha256": "037kdl6kq47p35qd3p6j4560x6w24zzmjxnz2fkd28xrm0lsh9lm",
+  "rev": "ff5c3108083af6fcb7575e32a7558b8165a05bcd",
+  "date": "2022-07-18T20:23:41+05:30",
+  "path": "/nix/store/29ijys20vg6qyc2999vjiylwi9nrq3y4-tree-sitter-perl",
+  "sha256": "1zsffd55sldc1148wyjm0kh8knm4849wgwvdvwhchpzn6ji6yf8i",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-pgn.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-pgn.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/rolandwalker/tree-sitter-pgn",
-  "rev": "e26ee30850f0cb81541480cf1e2c70385bdb013a",
-  "date": "2021-08-25T17:57:38-04:00",
-  "path": "/nix/store/fj882ab2hl3qrz45zvq366na6d2gqv8v-tree-sitter-pgn",
-  "sha256": "1c4602jmq3p7p7splzip76863l1z3rgbjlbksqv0diqjxp7c42gq",
+  "rev": "4c372e9e4d69bdc57701201347afe5f6413f2367",
+  "date": "2021-09-14T07:33:59-04:00",
+  "path": "/nix/store/62pvfyg8qlybxmd8kac8fdpycsypga67-tree-sitter-pgn",
+  "sha256": "0c2iqv93fg2pl7ixa7bby0bgnfnd8djjkjcg7d9bn3y7vpswvbvi",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-php",
-  "rev": "ece74b20942a5b23acaf3622512c6d0db1491a7e",
-  "date": "2022-06-24T15:38:28-07:00",
-  "path": "/nix/store/cqqyvb0vfp0q34lf3w5jds5dq4riac9z-tree-sitter-php",
-  "sha256": "0ggx747j3hpgwqw7cjh07n866mvdcyv3mvblffbrb8b1xn3bll84",
+  "rev": "670d1eb6822d8c7ade1c71232e0bef42757b9da7",
+  "date": "2022-07-16T12:25:05+02:00",
+  "path": "/nix/store/swkym10m39vwrhvknv5x2wsx2qml6w13-tree-sitter-php",
+  "sha256": "01kkds6nac4b8xb4y4qsndg2z9y2ikr4j7brrs28aw8rzw0qlqf0",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ql-dbscheme.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ql-dbscheme.json
@@ -1,0 +1,11 @@
+{
+  "url": "https://github.com/tree-sitter/tree-sitter-ql-dbscheme",
+  "rev": "ad0c1485aa1e61b727a986d82c7fab4cd21ca723",
+  "date": "2022-07-22T15:14:16+00:00",
+  "path": "/nix/store/13yzcd1k87sfxdac4cdj8pvqv06wal6i-tree-sitter-ql-dbscheme",
+  "sha256": "0glj3j9m4wsmfgahsjzhzp34scxrwpwjqkzgj0i72rn23869xjip",
+  "fetchLFS": false,
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ql.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ql.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-ql",
-  "rev": "b2c2364e833cc9f1afa243ac367f1475330fef63",
-  "date": "2022-05-04T13:16:04-04:00",
-  "path": "/nix/store/8c01j930llm5wacj2727k8igwwyhbcz4-tree-sitter-ql",
-  "sha256": "1a4k4rmyqqcj94y57sf2h27bbkn921p1ifl2xwcqpmk6dr6n5bbr",
+  "rev": "bd087020f0d8c183080ca615d38de0ec827aeeaf",
+  "date": "2022-08-17T11:53:16+02:00",
+  "path": "/nix/store/id24yb922kcjnqx160b5hga65k9zmnkh-tree-sitter-ql",
+  "sha256": "18yv6sag794k0l7i0wxaffxhay6zgwnap5bbhi48h04q1cvas0yr",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rego.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rego.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/FallenAngel97/tree-sitter-rego",
-  "rev": "6bf5f8878bef2fb760508bff1ce0262a31925018",
-  "date": "2022-04-23T19:59:01+03:00",
-  "path": "/nix/store/gnbksy85s2z7b8c02im8liaa1d7g07my-tree-sitter-rego",
-  "sha256": "1ly2lhk4mfqmsg3pzv21ikzsxaz39bah3sgd3lcbaiqd0zzgbzks",
+  "rev": "6d70da3a998fd0081efc5d1019c71e74cc1568e9",
+  "date": "2022-08-17T15:53:32+03:00",
+  "path": "/nix/store/r23jy7qfsl6snbp0z7p5lk9x0q9ssgzs-tree-sitter-rego",
+  "sha256": "1phjhrngv818mcwvbrfpi0hrzc05cjckds5ddmndc8h7wi0db9cb",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rst.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rst.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/stsewd/tree-sitter-rst",
-  "rev": "d4b6c33ec15a4c22d0003dd37a5b20baa352b843",
-  "date": "2022-06-13T13:46:50-05:00",
-  "path": "/nix/store/scmhiai4dfc8k7nw6f0j1nmdhzv2j1ji-tree-sitter-rst",
-  "sha256": "127g78x2macl5fc1vhkfgkkd3zzj1yv9m2067j53nrivaff3jj8d",
+  "rev": "25e6328872ac3a764ba8b926aea12719741103f1",
+  "date": "2022-08-26T17:09:42-05:00",
+  "path": "/nix/store/y831a05hzw8dsajijwkahgwwcf4ima8l-tree-sitter-rst",
+  "sha256": "0f53jmpjh2kcl9srwwwb7a5k24729ig96m87qjj99myqfnzahw43",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ruby.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ruby.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-ruby",
-  "rev": "fe6a2d634da0e16b11b5aa255cc3df568a4572fd",
-  "date": "2021-03-03T16:54:30-08:00",
-  "path": "/nix/store/ragrvqj7hm98r74v5b3fljvc47gd3nhj-tree-sitter-ruby",
-  "sha256": "0m3h4928rbs300wcb6776h9r88hi32rybbhcaf6rdympl5nzi83v",
+  "rev": "ad1043283b1f9daf4aad381b6a81f18a5a27fe7e",
+  "date": "2022-08-24T18:08:57+02:00",
+  "path": "/nix/store/mkg79bscx68yirm7avhlspfwqz3snqvl-tree-sitter-ruby",
+  "sha256": "0x4j2z18gf40snhyb416s9l5a2r9jjmki8v57wqldvkm39cvhm4z",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rust.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rust.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-rust",
-  "rev": "0f14a10011ac6e56f309fb99a94829c3312b743a",
-  "date": "2022-07-11T12:34:08-04:00",
-  "path": "/nix/store/9767f79glbdja848ri2i0vii41g3z84n-tree-sitter-rust",
-  "sha256": "15js3v1kyl7h34ichy5q6zs5n0sm2b0iwgfdh34jrcgnlbvbgy52",
+  "rev": "47b061c1e1ba3a7e9c2f450363a50e87de3f7c61",
+  "date": "2022-08-18T13:07:47+02:00",
+  "path": "/nix/store/db0s8jdi3r07y0wsv7a6kkvzrfgnjqqz-tree-sitter-rust",
+  "sha256": "106406hm5aqwj6p2h70p542dgphian46rw98gj5yf82p1h0k38dz",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-surface.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-surface.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/connorlay/tree-sitter-surface",
-  "rev": "21b7676859c1187645a27ff301f76738af5dfd44",
-  "date": "2021-08-15T10:33:50-07:00",
-  "path": "/nix/store/7i1klj80jbcvwgad7nrbcs7hvn68f125-tree-sitter-surface",
-  "sha256": "122v1d2zb0w2k5h7xqgm1c42rwfrp59dzyb2lly7kxmylyazmshy",
+  "rev": "f4586b35ac8548667a9aaa4eae44456c1f43d032",
+  "date": "2022-01-18T18:13:51-08:00",
+  "path": "/nix/store/l1nzhnhw1219140vzwvillawr7m9sz22-tree-sitter-surface",
+  "sha256": "085yvq2m4dbhhn51ndhzvgfmpp3hqiwk1a39xpjy4lxgrhbyjzqn",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-svelte.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-svelte.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/Himujjal/tree-sitter-svelte",
-  "rev": "84c90ee15f851e1541c25c86e8a4338f5b4d5af2",
-  "date": "2022-04-13T11:35:15+05:30",
-  "path": "/nix/store/2miakcpw7xgg2pcwdbcg0kl2djijcfbj-tree-sitter-svelte",
-  "sha256": "0hidafgzbnksyigksab8731jdnvj1vqn7fv0jxsc1yfrwrmai6ls",
+  "rev": "52e122ae68b316d3aa960a0a422d3645ba717f42",
+  "date": "2022-07-08T23:25:40+05:30",
+  "path": "/nix/store/lqis7h7db9bq7g063l60q7361h718z56-tree-sitter-svelte",
+  "sha256": "1pbs508ly4dlppnpa5657j0zsi7fdd6azvxjk7dayxznbygnj900",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-tlaplus.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-tlaplus.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tlaplus-community/tree-sitter-tlaplus",
-  "rev": "dde405e5128c3c47ab8aa014d21b6e5296ca450f",
-  "date": "2022-02-03T12:27:54-05:00",
-  "path": "/nix/store/vwmr9wd4agmym5ryrchl470qa46j8ymr-tree-sitter-tlaplus",
-  "sha256": "06g5pbx4rydfryfxfqjq37akhqn2465xwh90r5yc5rdv0kppvbhq",
+  "rev": "deaf0e5c573ad4e2bbfc9a29abb7b6dcb572556e",
+  "date": "2022-07-26T16:48:02-04:00",
+  "path": "/nix/store/40jlhkwlrvzdg3s95w132kvs5rax8mbj-tree-sitter-tlaplus",
+  "sha256": "01nsi5403vxcc725x9rvd0ff6xfkg2lw5350i1w5998jbs9kd00g",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-typescript",
-  "rev": "49e82b1bce36d6046df911901684cd66b5345d58",
-  "date": "2022-07-06T12:52:21-07:00",
-  "path": "/nix/store/wzkgvx1sj0js8sdkm8cmip4rmsgqy3ij-tree-sitter-typescript",
-  "sha256": "1kgl0dvcjzlbpfbdf1mq9693p5j7kvcqfmxis2w30js2lmrp0wgb",
+  "rev": "082da44a5263599186dadafd2c974c19f3a73d28",
+  "date": "2022-08-25T11:07:19-07:00",
+  "path": "/nix/store/b84c7mhjj9dm3ccfwp9h2q1ac9k2axv1-tree-sitter-typescript",
+  "sha256": "0y1c4bldgmhbhll629xks5y3c9l8dq29na75y3n0hfwivrpry8rx",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-vim.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-vim.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/vigoux/tree-sitter-viml",
-  "rev": "2d75bf329e3df6e1c13f81262567b9aeb6c241d1",
-  "date": "2022-07-12T08:30:33+02:00",
-  "path": "/nix/store/l19kbw907jxk26qf5cl5w5nz17sywjf6-tree-sitter-viml",
-  "sha256": "1pc6s2pc4svk64imkc486nz8fkhkpmwamn17gvnblinsjxr8369y",
+  "rev": "d38ee3b8ea625591a0dc009d6691118517205685",
+  "date": "2022-08-27T12:10:49+02:00",
+  "path": "/nix/store/gl64rifl6x0c0g32fpzwk7kscwbzvxnk-tree-sitter-viml",
+  "sha256": "1mvmg0vssydmgkwgb4blgiwbiqiw5233l58hrqmcgfz4vg4yazr7",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/update.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/update.nix
@@ -39,6 +39,7 @@ let
     "tree-sitter-verilog"
     "tree-sitter-jsdoc"
     "tree-sitter-ql"
+    "tree-sitter-ql-dbscheme"
     "tree-sitter-embedded-template"
     "tree-sitter-tsq"
     "tree-sitter-toml"


### PR DESCRIPTION
###### Description of changes

This PR updates the grammars as instructed by https://github.com/NixOS/nixpkgs/blob/41beb4852c2ab44aceeb7ffc6aa9df61040ef613/pkgs/development/tools/parsing/tree-sitter/default.nix#L28-L32.

Since the last update, https://github.com/tree-sitter/tree-sitter-ql-dbscheme was created ub the `tree-sitter` organization. This meant that the `tree-sitter.updater.update-all-grammars` script was unable to run without error (it exited 1).

While not all grammars need to be updated, not does tree-sitter need to be updated, there was no defined procedure for updating a single dependency (eg `tree-sitter-lua`).

I sought to update `tree-sitter-lua` in order to resolve a current incompatibility.

> A description of the motivating `tree-sitter-lua` error lies below.

When opening a lua file (such as an `init.lua` for `nvim`) `tree-sitter` throws a query error when calling `tree-sitter-lua`. This issue is described partially here: https://github.com/nvim-treesitter/nvim-treesitter/issues/2295

This is the error:

```
Error detected while processing FileType Autocommands for "*":
Error executing lua callback: ...ed-0.7.2/share/nvim/runtime/lua/vim/treesitter/query.lua:172: query: error at position 23
stack traceback:
        [C]: in function '_ts_parse_query'
        ...ed-0.7.2/share/nvim/runtime/lua/vim/treesitter/query.lua:172: in function 'get_query'
        ...2/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:37: in function 'new'
        ...2/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:212: in function 'add_child'
        ...2/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:144: in function 'parse'
        ...nwrapped-0.7.2/share/nvim/runtime/lua/vim/treesitter.lua:68: in function '_create_parser'
        ...nwrapped-0.7.2/share/nvim/runtime/lua/vim/treesitter.lua:94: in function 'get_parser'
        .../start/nvim-treesitter/lua/nvim-treesitter/highlight.lua:138: in function 'start'
        .../start/nvim-treesitter/lua/nvim-treesitter/highlight.lua:144: in function 'attach'
        ...es/start/nvim-treesitter/lua/nvim-treesitter/configs.lua:477: in function 'attach_module'
        ...es/start/nvim-treesitter/lua/nvim-treesitter/configs.lua:500: in function 'reattach_module'
        ...es/start/nvim-treesitter/lua/nvim-treesitter/configs.lua:109: in function <...es/start/nvim-treesitter/lua/nvim-treesitter/configs.lua:108>
```

I noticed that the latest grammer update (da0058d4a838ce91dced2ae850e7e4f59d435937) happened before the latest release of `tree-sitter-lua` (https://github.com/MunifTanjim/tree-sitter-lua/releases/tag/v0.0.12).

After running this update and the problem has resolved.

You're able to test this problem exactly if you'd like by running:

```bash
git clone https://github.com/Hoverbear-Consulting/flake 
cd flake
nix run .#neovimConfigured packages/neovimConfigured/init.lua
```

To resolve the issue, update the `flake.nix` with the following:

```diff
--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,8 @@
   description = "Hoverbear's Flake";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    # nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:Hoverbear/nixpkgs/treesitter-update-grammars";
     nixos-wsl.url = "github:hoverbear-consulting/NixOS-WSL/master";
     nixos-wsl.inputs.nixpkgs.follows = "nixpkgs";
   };
```

Then try running:

```bash
nix run .#neovimConfigured packages/neovimConfigured/init.lua
```

For me, this fixed the issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
