### PR TITLE
cargo-workspaces: init at 0.2.35

### DIFF
--- a/pkgs/development/tools/rust/cargo-workspaces/default.nix
+++ b/pkgs/development/tools/rust/cargo-workspaces/default.nix
@@ -1,0 +1,51 @@
+{ fetchCrate
+, lib
+, rustPlatform
+, pkg-config
+, openssl
+, zlib
+, stdenv
+, darwin
+, libssh2
+, libgit2
+, IOKit
+, Security
+, CoreFoundation
+, AppKit
+, System
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-workspaces";
+  version = "0.2.35";
+
+  src = fetchCrate {
+    inherit pname version;
+    sha256 = "sha256-MHoVeutoMaHHl1uxv52NOuvXsssqDuyfHTuyTqg9y+U=";
+  };
+
+  cargoSha256 = "sha256-wUVNsUx7JS5icjxbz3CV1lNUvuuL+gTL2QzuE+030WU=";
+  verifyCargoDeps = true;
+
+  # needed to get libssh2/libgit2 to link properly
+  LIBGIT2_SYS_USE_PKG_CONFIG = true;
+  LIBSSH2_SYS_USE_PKG_CONFIG = true;
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl zlib libssh2 libgit2 ] ++ (
+    lib.optionals stdenv.isDarwin ([ IOKit Security CoreFoundation AppKit ]
+      ++ (lib.optionals stdenv.isAarch64 [ System ]))
+  );
+
+  meta = with lib; {
+    description = "A tool for managing cargo workspaces and their crates, inspired by lerna";
+    longDescription = ''
+      A tool that optimizes the workflow around cargo workspaces with
+      git and cargo by providing utilities to version, publish, execute
+      commands and more.
+    '';
+    homepage = "https://github.com/pksunkara/cargo-workspaces";
+    license = licenses.mit;
+    maintainers = with maintainers; [ macalinao ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14478,6 +14478,9 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) CoreServices Foundation;
   };
   cargo-wipe = callPackage ../development/tools/rust/cargo-wipe { };
+  cargo-workspaces = callPackage ../development/tools/rust/cargo-workspaces {
+    inherit (darwin.apple_sdk.frameworks) IOKit Security CoreFoundation AppKit System;
+  };
   cargo-xbuild = callPackage ../development/tools/rust/cargo-xbuild { };
   cargo-generate = callPackage ../development/tools/rust/cargo-generate {
     inherit (darwin.apple_sdk.frameworks) Security;


### PR DESCRIPTION
###### Description of changes

Adds cargo-workspaces to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
