### PR TITLE
move-cli: init at unstable-2022-08-28

### DIFF
--- a/pkgs/development/tools/move/move-cli/default.nix
+++ b/pkgs/development/tools/move/move-cli/default.nix
@@ -16,10 +16,18 @@
 , icu
 , boogie
 , dotnet-sdk
+, callPackage
+, wrapWithMoveProverDeps
 }:
 
 let
+  # Tests only pass on Z3 4.11.
   z3 = z3_4_11;
+  # `dotnet-sdk` only works on 64-bit systems, so we can't run
+  # the Move prover on `i686`.
+  # Exclude Move prover tests until z3 4.11 is on Nixpkgs
+  installProver = !stdenv.isi686;
+
   common = { buildFeatures ? [ ] }:
     let
       # Default to not running tests.
@@ -27,84 +35,84 @@ let
       # expected outputs were generated with no features. (16 byte addresses)
       # We should run tests on `move-cli` with no features enabled.
       doCheck = (builtins.length buildFeatures) == 0;
-      # `dotnet-sdk` only works on 64-bit systems, so we can't run
-      # the Move prover on `i686`.
-      # Exclude Move prover tests until z3 4.11 is on Nixpkgs
-      installProver = !stdenv.isi686;
-    in
-    rustPlatform.buildRustPackage rec {
-      inherit buildFeatures doCheck;
+      package = rustPlatform.buildRustPackage rec {
+        inherit buildFeatures doCheck;
 
-      pname = "move";
-      version = "unstable-2022-08-28";
-      src = fetchFromGitHub {
-        owner = "move-language";
-        repo = "move";
-        rev = "bc57bf2df7aee3f639ec670af5c6ff5341d89a9d";
-        sha256 = "sha256-4BCwDTfdH8TTeF+zJyea3WsoU0YGgGSS1B3FxEZ6Ulk=";
-      };
+        pname = "move";
+        version = "unstable-2022-08-28";
+        src = fetchFromGitHub {
+          owner = "move-language";
+          repo = "move";
+          rev = "bc57bf2df7aee3f639ec670af5c6ff5341d89a9d";
+          sha256 = "sha256-4BCwDTfdH8TTeF+zJyea3WsoU0YGgGSS1B3FxEZ6Ulk=";
+        };
 
-      cargoSha256 = "sha256-BTbChMtwSD5GIHLXUaEMlk3PMMh7jgR9yWk2W4J4El8=";
+        cargoSha256 = "sha256-BTbChMtwSD5GIHLXUaEMlk3PMMh7jgR9yWk2W4J4El8=";
 
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [ openssl zlib git ] ++ (lib.optionals stdenv.isDarwin ([
-        IOKit
-        Security
-        CoreFoundation
-        AppKit
-      ] ++ (lib.optionals stdenv.isAarch64 [ System ])))
-        ++ (lib.optionals installProver [
-        z3
-        icu
-        boogie
-        dotnet-sdk
-      ]);
+        nativeBuildInputs = [ pkg-config ];
+        buildInputs = [ openssl zlib git ] ++ (lib.optionals stdenv.isDarwin ([
+          IOKit
+          Security
+          CoreFoundation
+          AppKit
+        ] ++ (lib.optionals stdenv.isAarch64 [ System ])))
+          ++ (lib.optionals installProver [
+          z3
+          icu
+          boogie
+          dotnet-sdk
+        ]);
 
-      # Set $MOVE_HOME to $TMPDIR to prevent tests from writing to the home directory.
-      preCheck = ''
-        export MOVE_HOME=$TMPDIR
-        ${lib.optionalString installProver ''
-          export BOOGIE_EXE=${boogie}/bin/boogie
-          export Z3_EXE=${z3}/bin/z3
-          export DOTNET_ROOT=${dotnet-sdk}
-          export LD_LIBRARY_PATH=${icu}/lib
-        ''}
-      '';
-
-      # We want to check with `--profile ci`, so we use `--debug` here to get rid of the
-      # `--release` flag.
-      checkType = "debug";
-      cargoTestFlags = [
-        "--workspace"
-        "--profile"
-        "ci"
-        # Ignore Solidity tests since they require a specific version of Solc.
-        "--exclude"
-        "evm-exec-utils"
-        "--exclude"
-        "move-to-yul"
-      ] ++ (lib.optionals (!installProver) [
-        "--exclude"
-        "move-prover"
-      ]);
-      cargoCheckFlags = lib.optionals (!installProver) [
-        "--skip"
-        "prove"
-      ];
-
-      meta = with lib; {
-        description = "CLI frontend for the Move compiler and VM";
-        longDescription = ''
-          Move is a programming language for writing safe smart contracts originally
-          developed at Facebook to power the Diem blockchain. Move is designed to be
-          a platform-agnostic language to enable common libraries, tooling, and
-          developer communities across diverse blockchains with vastly different
-          data and execution models.
+        # Set $MOVE_HOME to $TMPDIR to prevent tests from writing to the home directory.
+        preCheck = ''
+          export MOVE_HOME=$TMPDIR
+          ${lib.optionalString installProver ''
+            export BOOGIE_EXE=${boogie}/bin/boogie
+            export Z3_EXE=${z3}/bin/z3
+            export DOTNET_ROOT=${dotnet-sdk}
+            export LD_LIBRARY_PATH=${icu}/lib
+          ''}
         '';
-        homepage = "https://github.com/move-language/move";
-        license = licenses.asl20;
-        maintainers = with maintainers; [ macalinao ];
+
+        # We want to check with `--profile ci`, so we use `--debug` here to get rid of the
+        # `--release` flag.
+        checkType = "debug";
+        cargoTestFlags = [
+          "--workspace"
+          "--profile"
+          "ci"
+          # Ignore Solidity tests since they require a specific version of Solc.
+          "--exclude"
+          "evm-exec-utils"
+          "--exclude"
+          "move-to-yul"
+        ] ++ (lib.optionals (!installProver) [
+          "--exclude"
+          "move-prover"
+        ]);
+        cargoCheckFlags = lib.optionals (!installProver) [
+          "--skip"
+          "prove"
+        ];
+
+        meta = with lib; {
+          description = "CLI frontend for the Move compiler and VM";
+          longDescription = ''
+            Move is a programming language for writing safe smart contracts originally
+            developed at Facebook to power the Diem blockchain. Move is designed to be
+            a platform-agnostic language to enable common libraries, tooling, and
+            developer communities across diverse blockchains with vastly different
+            data and execution models.
+          '';
+          homepage = "https://github.com/move-language/move";
+          license = licenses.asl20;
+          maintainers = with maintainers; [ macalinao ];
+        };
       };
+    in
+    wrapWithMoveProverDeps {
+      inherit package;
+      bin = "move";
     };
 in
 rec {

--- a/pkgs/development/tools/move/move-cli/default.nix
+++ b/pkgs/development/tools/move/move-cli/default.nix
@@ -12,13 +12,14 @@
 , AppKit
 , System
   # Prover dependencies
-, z3
+, z3_4_11
 , icu
 , boogie
 , dotnet-sdk
 }:
 
 let
+  z3 = z3_4_11;
   common = { buildFeatures ? [ ] }:
     let
       # Default to not running tests.
@@ -29,8 +30,7 @@ let
       # `dotnet-sdk` only works on 64-bit systems, so we can't run
       # the Move prover on `i686`.
       # Exclude Move prover tests until z3 4.11 is on Nixpkgs
-      # installProver = !stdenv.isi686;
-      installProver = false;
+      installProver = !stdenv.isi686;
     in
     rustPlatform.buildRustPackage rec {
       inherit buildFeatures doCheck;
@@ -45,7 +45,6 @@ let
       };
 
       cargoSha256 = "sha256-BTbChMtwSD5GIHLXUaEMlk3PMMh7jgR9yWk2W4J4El8=";
-      verifyCargoDeps = true;
 
       nativeBuildInputs = [ pkg-config ];
       buildInputs = [ openssl zlib git ] ++ (lib.optionals stdenv.isDarwin ([

--- a/pkgs/development/tools/move/move-cli/default.nix
+++ b/pkgs/development/tools/move/move-cli/default.nix
@@ -1,0 +1,119 @@
+{ fetchFromGitHub
+, lib
+, rustPlatform
+, pkg-config
+, openssl
+, zlib
+, stdenv
+, git
+, IOKit
+, Security
+, CoreFoundation
+, AppKit
+, System
+  # Prover dependencies
+, z3
+, icu
+, boogie
+, dotnet-sdk
+}:
+
+let
+  common = { buildFeatures ? [ ] }:
+    let
+      # Default to not running tests.
+      # Tests do not pass with the `address20` or `address32` features enabled, since
+      # expected outputs were generated with no features. (16 byte addresses)
+      # We should run tests on `move-cli` with no features enabled.
+      doCheck = (builtins.length buildFeatures) == 0;
+      # `dotnet-sdk` only works on 64-bit systems, so we can't run
+      # the Move prover on `i686`.
+      # Exclude Move prover tests until z3 4.11 is on Nixpkgs
+      # installProver = !stdenv.isi686;
+      installProver = false;
+    in
+    rustPlatform.buildRustPackage rec {
+      inherit buildFeatures doCheck;
+
+      pname = "move";
+      version = "unstable-2022-08-28";
+      src = fetchFromGitHub {
+        owner = "move-language";
+        repo = "move";
+        rev = "bc57bf2df7aee3f639ec670af5c6ff5341d89a9d";
+        sha256 = "sha256-4BCwDTfdH8TTeF+zJyea3WsoU0YGgGSS1B3FxEZ6Ulk=";
+      };
+
+      cargoSha256 = "sha256-BTbChMtwSD5GIHLXUaEMlk3PMMh7jgR9yWk2W4J4El8=";
+      verifyCargoDeps = true;
+
+      nativeBuildInputs = [ pkg-config ];
+      buildInputs = [ openssl zlib git ] ++ (lib.optionals stdenv.isDarwin ([
+        IOKit
+        Security
+        CoreFoundation
+        AppKit
+      ] ++ (lib.optionals stdenv.isAarch64 [ System ])))
+        ++ (lib.optionals installProver [
+        z3
+        icu
+        boogie
+        dotnet-sdk
+      ]);
+
+      # Set $MOVE_HOME to $TMPDIR to prevent tests from writing to the home directory.
+      preCheck = ''
+        export MOVE_HOME=$TMPDIR
+        ${lib.optionalString installProver ''
+          export BOOGIE_EXE=${boogie}/bin/boogie
+          export Z3_EXE=${z3}/bin/z3
+          export DOTNET_ROOT=${dotnet-sdk}
+          export LD_LIBRARY_PATH=${icu}/lib
+        ''}
+      '';
+
+      # We want to check with `--profile ci`, so we use `--debug` here to get rid of the
+      # `--release` flag.
+      checkType = "debug";
+      cargoTestFlags = [
+        "--workspace"
+        "--profile"
+        "ci"
+        # Ignore Solidity tests since they require a specific version of Solc.
+        "--exclude"
+        "evm-exec-utils"
+        "--exclude"
+        "move-to-yul"
+      ] ++ (lib.optionals (!installProver) [
+        "--exclude"
+        "move-prover"
+      ]);
+      cargoCheckFlags = lib.optionals (!installProver) [
+        "--skip"
+        "prove"
+      ];
+
+      meta = with lib; {
+        description = "CLI frontend for the Move compiler and VM";
+        longDescription = ''
+          Move is a programming language for writing safe smart contracts originally
+          developed at Facebook to power the Diem blockchain. Move is designed to be
+          a platform-agnostic language to enable common libraries, tooling, and
+          developer communities across diverse blockchains with vastly different
+          data and execution models.
+        '';
+        homepage = "https://github.com/move-language/move";
+        license = licenses.asl20;
+        maintainers = with maintainers; [ macalinao ];
+      };
+    };
+in
+rec {
+  move-cli = common { };
+  move-cli-address20 = common {
+    buildFeatures = [ "address20" ];
+  };
+  move-cli-address32 = common {
+    buildFeatures = [ "address32" ];
+  };
+}

--- a/pkgs/development/tools/move/move-cli/default.nix
+++ b/pkgs/development/tools/move/move-cli/default.nix
@@ -25,7 +25,6 @@ let
   z3 = z3_4_11;
   # `dotnet-sdk` only works on 64-bit systems, so we can't run
   # the Move prover on `i686`.
-  # Exclude Move prover tests until z3 4.11 is on Nixpkgs
   installProver = !stdenv.isi686;
 
   common = { buildFeatures ? [ ] }:

--- a/pkgs/development/tools/move/wrapWithMoveProverDeps.nix
+++ b/pkgs/development/tools/move/wrapWithMoveProverDeps.nix
@@ -1,0 +1,43 @@
+# This file returns a function for wrapping a package with the Move prover
+# dependencies injected into the environment.
+# This would generally be used by any downstream consumer of the Move CLI common repository,
+# e.g. Aptos or Sui.
+{ stdenv
+, z3_4_11
+, icu
+, boogie
+, dotnet-sdk
+, symlinkJoin
+, makeWrapper
+}:
+
+let
+  z3 = z3_4_11;
+in
+{ package
+, bin
+}:
+
+let
+  installProver = !stdenv.isi686;
+in
+if installProver then
+  symlinkJoin
+  {
+    name = "${package.name}-${bin}-with-move-prover-deps";
+    paths = [
+      package
+      z3
+      icu
+      boogie
+      dotnet-sdk
+    ];
+    buildInputs = [ makeWrapper ];
+    postBuild = ''
+      wrapProgram $out/bin/${bin} \
+        --set Z3_EXE ${z3}/bin/z3 \
+        --set DOTNET_ROOT ${dotnet-sdk} \
+        --set LD_LIBRARY_PATH ${icu}/lib \
+        --set BOOGIE_EXE ${boogie}/bin/boogie
+    '';
+  } else package

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24550,6 +24550,7 @@ with pkgs;
 
   moq = callPackage ../development/tools/moq { };
 
+  wrapWithMoveProverDeps = callPackage ../development/tools/move/wrapWithMoveProverDeps.nix { };
   inherit (callPackages ../development/tools/move/move-cli {
     inherit (darwin.apple_sdk.frameworks) IOKit Security CoreFoundation AppKit System;
   }) move-cli move-cli-address20 move-cli-address32;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24550,6 +24550,10 @@ with pkgs;
 
   moq = callPackage ../development/tools/moq { };
 
+  inherit (callPackages ../development/tools/move/move-cli {
+    inherit (darwin.apple_sdk.frameworks) IOKit Security CoreFoundation AppKit System;
+  }) move-cli move-cli-address20 move-cli-address32;
+
   quicktemplate = callPackage ../development/tools/quicktemplate { };
 
   linux_logo = callPackage ../tools/misc/linux-logo { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24550,7 +24550,7 @@ with pkgs;
 
   moq = callPackage ../development/tools/moq { };
 
-  wrapWithMoveProverDeps = callPackage ../development/tools/move/wrapWithMoveProverDeps.nix { };
+  move-wrapWithMoveProverDeps = callPackage ../development/tools/move/wrapWithMoveProverDeps.nix { };
   inherit (callPackages ../development/tools/move/move-cli {
     inherit (darwin.apple_sdk.frameworks) IOKit Security CoreFoundation AppKit System;
   }) move-cli move-cli-address20 move-cli-address32;


### PR DESCRIPTION
###### Description of changes

Adds the Move CLI.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
