### PR TITLE
brotab: 1.3.0 -> 1.4.2

### DIFF
--- a/pkgs/tools/misc/brotab/default.nix
+++ b/pkgs/tools/misc/brotab/default.nix
@@ -1,14 +1,14 @@
-{ lib, fetchFromGitHub, glibcLocales, python }:
+{ lib, fetchFromGitHub, python }:
 
 python.pkgs.buildPythonApplication rec {
-  version = "1.3.0";
+  version = "1.4.2";
   pname = "brotab";
 
   src = fetchFromGitHub {
     owner = "balta2ar";
     repo = pname;
     rev = version;
-    sha256 = "1ja9qaf3rxm0chgzs5mpw973h7ibb454k9mbfbb2gl12gr9zllyw";
+    hash = "sha256-HKKjiW++FwjdorqquSCIdi1InE6KbMbFKZFYHBxzg8Q=";
   };
 
   propagatedBuildInputs = with python.pkgs; [
@@ -18,14 +18,16 @@ python.pkgs.buildPythonApplication rec {
     setuptools
   ];
 
-  checkBuildInputs = with python.pkgs; [
-    pytest
-  ];
-
-  # test_integration.py requires Chrome browser session
-  checkPhase = ''
-    ${python.interpreter} -m unittest brotab/tests/test_{brotab,utils}.py
+  postPatch = ''
+    substituteInPlace requirements/base.txt \
+      --replace "Flask==2.0.2" "Flask>=2.0.2" \
+      --replace "psutil==5.8.0" "psutil>=5.8.0" \
+      --replace "requests==2.24.0" "requests>=2.24.0"
   '';
+
+  checkInputs = with python.pkgs; [
+    pytestCheckHook
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/balta2ar/brotab";


### PR DESCRIPTION
###### Description of changes

* Upgrade brotab from 1.3.0 to 1.4.2
  * See https://github.com/balta2ar/brotab/blob/master/CHANGELOG.md

* Added some Python requirements substitutes
* Clean-up: removed unused argument

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
