### PR TITLE
obs-studio-plugins.obs-vkcapture: enable 32bit support

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/default.nix
@@ -1,4 +1,4 @@
-{ callPackage, libsForQt5 }:
+{ callPackage, libsForQt5, pkgsi686Linux }:
 
 {
   obs-gstreamer = callPackage ./obs-gstreamer.nix {};
@@ -10,6 +10,8 @@
   looking-glass-obs = callPackage ./looking-glass-obs.nix {};
   obs-nvfbc = callPackage ./obs-nvfbc.nix {};
   obs-pipewire-audio-capture = callPackage ./obs-pipewire-audio-capture.nix {};
-  obs-vkcapture = callPackage ./obs-vkcapture.nix {};
+  obs-vkcapture = callPackage ./obs-vkcapture.nix {
+    obs-vkcapture32 = pkgsi686Linux.obs-studio-plugins.obs-vkcapture;
+  };
   obs-backgroundremoval = callPackage ./obs-backgroundremoval.nix {};
 }

--- a/pkgs/applications/video/obs-studio/plugins/obs-vkcapture.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-vkcapture.nix
@@ -9,6 +9,7 @@
 , vulkan-headers
 , vulkan-loader
 , libGL
+, obs-vkcapture32
 }:
 
 stdenv.mkDerivation rec {
@@ -22,8 +23,29 @@ stdenv.mkDerivation rec {
     hash = "sha256-yaN0am24p9gC+s64Rop+jQ3952UOtZund/KttnVxP48=";
   };
 
+  cmakeFlags = lib.optionals stdenv.isi686 [
+    # We don't want to build the plugin for 32bit. The library integrates with
+    # the 64bit plugin but it's necessary to be loaded into 32bit games.
+    "-DBUILD_PLUGIN=OFF"
+  ];
+
   nativeBuildInputs = [ cmake ninja ];
-  buildInputs = [ libGL libX11 obs-studio vulkan-headers vulkan-loader wayland ];
+  buildInputs = [
+    libGL
+    libX11
+    vulkan-headers
+    vulkan-loader
+    wayland
+  ]
+  ++ lib.optionals (!stdenv.isi686) [
+    obs-studio
+  ];
+
+  # Support 32bit Vulkan applications by linking in the 32bit Vulkan layer
+  postInstall = lib.optionalString (stdenv.hostPlatform.system == "x86_64-linux") ''
+    ln -s ${obs-vkcapture32}/share/vulkan/implicit_layer.d/obs_vkcapture_32.json \
+      "$out/share/vulkan/implicit_layer.d/"
+  '';
 
   meta = with lib; {
     description = "OBS Linux Vulkan/OpenGL game capture";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
