### PR TITLE
python310Packages.bcrypt: 3.2.2 -> 4.0.0

### DIFF
--- a/pkgs/development/python-modules/bcrypt/default.nix
+++ b/pkgs/development/python-modules/bcrypt/default.nix
@@ -1,37 +1,44 @@
 { lib
 , buildPythonPackage
-, setuptools
-, isPyPy
 , fetchPypi
+, libiconv
 , pythonOlder
-, cffi
 , pytestCheckHook
-, six
+, rustPlatform
+, setuptools-rust
 }:
 
 buildPythonPackage rec {
   pname = "bcrypt";
-  version = "3.2.2";
+  version = "4.0.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-QzxBDCF3BXcF2iqfLNAd0VdJOyp6wUyFk6FrPatra/s=";
+    sha256 = "sha256-xZwXD8kiX6rQTd4bph2FtBOUbozi5fX1/zDf1nKD8xk=";
   };
 
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    name = "${pname}-${version}";
+    inherit src;
+    sourceRoot = "${pname}-${version}/${cargoRoot}";
+    sha256 = "sha256-HvfRLyUhlXVuvxWrtSDKx3rMKJbjvuiMcDY6g+pYFS0=";
+  };
+
+  cargoRoot = "src/_bcrypt";
+
   nativeBuildInputs = [
-    setuptools
-  ];
+    setuptools-rust
+  ] ++ (with rustPlatform; [
+    cargoSetupHook
+    rust.cargo
+    rust.rustc
+  ]);
 
-  propagatedBuildInputs = [
-    six
-    cffi
-  ];
-
-  propagatedNativeBuildInputs = [
-    cffi
+  buildInputs = [
+    libiconv
   ];
 
   checkInputs = [

--- a/pkgs/development/python-modules/bcrypt/default.nix
+++ b/pkgs/development/python-modules/bcrypt/default.nix
@@ -6,6 +6,12 @@
 , pytestCheckHook
 , rustPlatform
 , setuptools-rust
+  # for passthru.tests
+, asyncssh
+, django_4
+, fastapi
+, paramiko
+, twisted
 }:
 
 buildPythonPackage rec {
@@ -48,6 +54,10 @@ buildPythonPackage rec {
   pythonImportsCheck = [
     "bcrypt"
   ];
+
+  passthru.tests = {
+    inherit asyncssh django_4 fastapi paramiko twisted;
+  };
 
   meta = with lib; {
     description = "Modern password hashing for your software and your servers";

--- a/pkgs/development/python-modules/paramiko/default.nix
+++ b/pkgs/development/python-modules/paramiko/default.nix
@@ -11,6 +11,7 @@
 , pynacl
 , pytest-relaxed
 , pytestCheckHook
+, six
 }:
 
 buildPythonPackage rec {
@@ -35,6 +36,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     cryptography
     pyasn1
+    six
   ] ++ passthru.optional-dependencies.ed25519; # remove on 3.0 update
 
   checkInputs = [

--- a/pkgs/development/python-modules/passlib/default.nix
+++ b/pkgs/development/python-modules/passlib/default.nix
@@ -28,9 +28,15 @@ buildPythonPackage rec {
     ++ passthru.optional-dependencies.bcrypt
     ++ passthru.optional-dependencies.totp;
 
+  disabledTests = [
+    # timming sensitive
+    "test_dummy_verify"
+  ];
+
   meta = with lib; {
     description = "A password hashing library for Python";
     homepage = "https://foss.heptapod.net/python-libs/passlib";
     license = licenses.bsdOriginal;
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
