### PR TITLE
linux: Disable DRM_LEGACY, NOUVEAU_LEGACY_CTX_SUPPORT

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -270,6 +270,9 @@ let
     };
 
     video = {
+      DRM_LEGACY = no;
+      NOUVEAU_LEGACY_CTX_SUPPORT = whenAtLeast "5.2" no;
+
       # Allow specifying custom EDID on the kernel command line
       DRM_LOAD_EDID_FIRMWARE = yes;
       VGA_SWITCHEROO         = yes; # Hybrid graphics support


### PR DESCRIPTION
###### Description of changes

This currently gets enabled as generate-config.pl will enable all the drivers below it as modules.

Is “not set” in [Arch][1], [Debian][2], [Fedora][3]. See also [summary of setting from various distros in April 2020][4].

Recommended disabled by [CLIP OS][5] and per current [Kernel config description][6]:

> bool "Enable legacy drivers (DANGEROUS)"
> Enable legacy DRI1 drivers. Those drivers expose unsafe and dangerous
> APIs to user-space, which can be used to circumvent access
> restrictions and other security measures. For backwards compatibility
> those drivers are still available, but their use is highly
> inadvisable and might harm your system.
>
> You are recommended to use the safe modeset-only drivers instead, and
> perform 3D emulation in user-space.
>
> Unless you have strong reasons to go rogue, say "N".

Also disable NOUVEAU_LEGACY_CTX_SUPPORT, as this does `select DRM_LEGACY`. Per Kernel config docs:

>There was a version of the nouveau DDX that relied on legacy
> ctx ioctls not erroring out. But that was back in time a long
> ways, so offer a way to disable it now. For uapi compat with
> old nouveau ddx this should be on by default, but modern distros
> should consider turning it off.

and the [commit][7]:

> These driver functions contain several bugs and security holes. This
> change makes these functions optional can be turned on by a setting,
> they are turned off by default for modeset driver with the exception of
> the nouvea driver that may require them with an old version of libdrm.

Referenced earlier commit elaborates that

> libdrm_nouveau before 2.4.33 used contexts

Since nixpkgs here has a much newer version (2.4.33 is from March 2012), should not be a concern.

NOUVEAU_LEGACY_CTX_SUPPORT is also “not set” in the linked Arch, Debian, & Fedora configs.

[1]: https://github.com/archlinux/svntogit-packages/blob/66d72ee54afc604391b618fc3eecc43f29e479e8/trunk/config#L6637
[2]: https://salsa.debian.org/kernel-team/linux/-/blob/07731f5956cf29876a7abc13f4ecbdf4d9459592/debian/config/config#L713
[3]: https://src.fedoraproject.org/rpms/kernel/blob/rawhide/f/kernel-x86_64-fedora.config#_1528
[4]: https://github.com/a13xp0p0v/kconfig-hardened-check/issues/38#issuecomment-608639217
[5]: https://docs.clip-os.org/clipos/kernel.html#configuration
[6]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/gpu/drm/Kconfig#n421
[7]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=b30a43ac7132cdda833ac4b13dd1ebd35ace14b7

###### Things done

Tested by running, atop nixos-unstable:

```
nix build ".#"linux_{4_14,4_19,5_10,5_15,5_18}{,_hardened}.configfile ".#"linux_{4_9,5_19}.configfile
nix build -j1 ".#"linux_{4_14,5_18}{,_hardened} ".#"linux_5_19
nix-build -j1 -A linux_4_14.tests -A linux_4_14_hardened.tests -A linux_5_18.tests -A linux_5_18_hardened.tests -A linux_5_19.tests
```

I have not tested running the Kernel with Nouveau in-use, as currently do not have the hardware setup (Nvidia GPU) to do so. Again, though, per upstream commit messages and the current configuration in other distros, no problems expected.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
