### PR TITLE
python310Packages.ipywidgets: 7.7.1 -> 8.0.0

### DIFF
--- a/pkgs/development/python-modules/ipywidgets/default.nix
+++ b/pkgs/development/python-modules/ipywidgets/default.nix
@@ -8,16 +8,17 @@
 , pytestCheckHook
 , traitlets
 , widgetsnbextension
+, pytz
 }:
 
 buildPythonPackage rec {
   pname = "ipywidgets";
-  version = "7.7.1";
+  version = "8.0.0";
   format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-Xy+ht6+uGvMsiAiMmCitl43pPd2jk9ftQU5VP+6T3Ks=";
+    hash = "sha256-cpXT8K2/6VR5oqMyi/Py4CfyWy4aWUSR4Fo9UZ3S5nM=";
   };
 
   propagatedBuildInputs = [
@@ -29,7 +30,10 @@ buildPythonPackage rec {
     widgetsnbextension
   ];
 
-  checkInputs = [ pytestCheckHook ];
+  checkInputs = [
+    pytestCheckHook
+    pytz
+  ];
 
   meta = {
     description = "IPython HTML widgets for Jupyter";

--- a/pkgs/development/python-modules/jupyterlab-widgets/default.nix
+++ b/pkgs/development/python-modules/jupyterlab-widgets/default.nix
@@ -4,12 +4,12 @@
 
 buildPythonPackage rec {
   pname = "jupyterlab-widgets";
-  version = "2.0.0b1";
+  version = "3.0.2";
 
   src = fetchPypi {
     pname = "jupyterlab_widgets";
     inherit version;
-    sha256 = "1xinfk3bhqmfp9ygfpi8b87h4ky8dv3sdr96035psx1jjgyyw8bi";
+    hash = "sha256-R6tUzRZaoMs7zvEjLXdHFYDNLDa74hU/xbox4mrYcyA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/widgetsnbextension/default.nix
+++ b/pkgs/development/python-modules/widgetsnbextension/default.nix
@@ -1,25 +1,23 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, notebook
 , ipywidgets
+, jupyter-packaging
 }:
 
 buildPythonPackage rec {
   pname = "widgetsnbextension";
-  version = "3.6.1";
+  version = "4.0.2";
   format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-nISuZMKJPHy+Lqr8dQUiGnlcJ9aJOEVANKxIcxmnWxA=";
+    hash = "sha256-B/DoWC+SCyQxbO8WSQ8a60mPLIddSJgFQOXF2/D/Xi0=";
   };
 
-  # setup.py claims to require notebook, but the source doesn't have any imports
-  # in it.
-  postPatch = ''
-    substituteInPlace setup.py --replace "'notebook>=4.4.1'," ""
-  '';
+  nativeBuildInputs = [
+    jupyter-packaging
+  ];
 
   propagatedBuildInputs = [ ];
 


### PR DESCRIPTION
###### Description of changes

* Upgrade python310Packages.ipywidgets from 7.7.1 to 8.0.0
* Upgrade python310Packages.jupyterlab-widgets from 2.0.0b1 to 3.0.2
* Upgrade python310Packages.widgetsnbextension from 3.6.1 to 4.0.2

See https://github.com/jupyter-widgets/ipywidgets/releases/tag/8.0.0

ipywidgets, jupyterlab-widgets, widgetsnbextension are located in the same repository: https://github.com/jupyter-widgets/ipywidgets

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
