### PR TITLE
coqPackages.mkCoqDerivation: add a lib.overrideCoqDerivation function

### DIFF
--- a/pkgs/build-support/coq/extra-lib.nix
+++ b/pkgs/build-support/coq/extra-lib.nix
@@ -142,4 +142,41 @@ with builtins; with lib; recursiveUpdate lib (rec {
         if cl?case then compare cl.case var
         else all (equal true) (zipListsWith compare cl.cases var); in
     switch-if (map (cl: { cond = combine cl var; inherit (cl) out; }) clauses) default;
+
+  /* Override arguments to mkCoqDerivation for a Coq library.
+
+     This function allows you to easily override arguments to mkCoqDerivation,
+     even when they are not exposed by the Coq library directly.
+
+     Type: overrideCoqDerivation :: AttrSet -> CoqLibraryDerivation -> CoqLibraryDerivation
+
+     Example:
+
+     ```nix
+     coqPackages.lib.overrideCoqDerivation
+       {
+         defaultVersion = "9999";
+         release."9999".sha256 = "1lq8x86vd3vqqh2yq6hvyagpnhfq5wmk5pg2z0xq7b7dbbbhyfkw";
+       }
+       coqPackages.QuickChick;
+     ```
+
+     This example overrides the `defaultVersion` and `release` arguments that
+     are passed to `mkCoqDerivation` in the QuickChick derivation.
+
+     Note that there is a difference between using `.override` on a Coq
+     library vs this `overrideCoqDerivation` function. `.override` allows you
+     to modify arguments to the derivation itself, for instance by passing
+     different versions of dependencies:
+
+     ```nix
+     coqPackages.QuickCick.override { ssreflect = my-cool-ssreflect; }
+     ```
+
+     whereas `overrideCoqDerivation` allows you to override arguments to the
+     call to `mkCoqDerivation` in the Coq library.
+  */
+  overrideCoqDerivation = f: drv: (drv.override (args: {
+    mkCoqDerivation = drv_: (args.mkCoqDerivation drv_).override f;
+  }));
 })

--- a/pkgs/build-support/coq/extra-lib.nix
+++ b/pkgs/build-support/coq/extra-lib.nix
@@ -170,11 +170,22 @@ with builtins; with lib; recursiveUpdate lib (rec {
      different versions of dependencies:
 
      ```nix
-     coqPackages.QuickCick.override { ssreflect = my-cool-ssreflect; }
+     coqPackages.QuickChick.override { ssreflect = my-cool-ssreflect; }
      ```
 
      whereas `overrideCoqDerivation` allows you to override arguments to the
      call to `mkCoqDerivation` in the Coq library.
+
+     Note that all Coq libraries in Nixpkgs have a `version` argument for
+     easily using a different version.  So if all you want to do is use a
+     different version, and the derivation for the Coq library already has
+     support for the version you want, you likely only need to update the
+     `version` argument on the library derivation.  This is done with
+     `.override`:
+
+     ```nix
+     coqPackages.QuickChick.override { version = "1.4.0"; }
+     ```
   */
   overrideCoqDerivation = f: drv: (drv.override (args: {
     mkCoqDerivation = drv_: (args.mkCoqDerivation drv_).override f;

--- a/pkgs/test/coq/default.nix
+++ b/pkgs/test/coq/default.nix
@@ -1,0 +1,6 @@
+{ lib, callPackage }:
+
+lib.recurseIntoAttrs {
+  overrideCoqDerivation = callPackage ./overrideCoqDerivation { };
+}
+

--- a/pkgs/test/coq/overrideCoqDerivation/default.nix
+++ b/pkgs/test/coq/overrideCoqDerivation/default.nix
@@ -1,0 +1,40 @@
+{ lib, coq, mkCoqPackages, runCommandNoCC }:
+
+let
+
+  # This is just coq, but with dontFilter set to true. We need to set
+  # dontFilter to true here so that _all_ packages are visibile in coqPackages.
+  # There may be some versions of the top-level coq and coqPackages that don't
+  # build QuickChick, which is what we are using for this test below.
+  coqWithAllPackages = coq // { dontFilter = true; };
+
+  coqPackages = mkCoqPackages coqWithAllPackages;
+
+  # This is the main test.  This uses overrideCoqDerivation to
+  # override arguments to mkCoqDerivation.
+  #
+  # Here, we override the defaultVersion and release arguments to
+  # mkCoqDerivation.
+  overriddenQuickChick =
+    coqPackages.lib.overrideCoqDerivation
+      {
+        defaultVersion = "9999";
+        release."9999".sha256 = lib.fakeSha256;
+      }
+      coqPackages.QuickChick;
+in
+
+runCommandNoCC
+  "coq-overrideCoqDerivation-test-0.1"
+  { meta.maintainers = with lib.maintainers; [cdepillabout]; }
+  ''
+    # Confirm that the computed version number for the overridden QuickChick does
+    # actually become 9999, as set above.
+    if [ "${overriddenQuickChick.version}" -eq "9999" ]; then
+      echo "overriddenQuickChick version was successfully set to 9999"
+      touch $out
+    else
+      echo "ERROR: overriddenQuickChick version was supposed to be 9999, but was actually: ${overriddenQuickChick.version}"
+      exit 1
+    fi
+  ''

--- a/pkgs/test/coq/overrideCoqDerivation/default.nix
+++ b/pkgs/test/coq/overrideCoqDerivation/default.nix
@@ -1,4 +1,4 @@
-{ lib, coq, mkCoqPackages, runCommandNoCC }:
+{ lib, coq, mkCoqPackages, runCommand }:
 
 let
 
@@ -24,7 +24,7 @@ let
       coqPackages.QuickChick;
 in
 
-runCommandNoCC
+runCommand
   "coq-overrideCoqDerivation-test-0.1"
   { meta.maintainers = with lib.maintainers; [cdepillabout]; }
   ''

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -75,6 +75,8 @@ with pkgs;
 
   dhall = callPackage ./dhall { };
 
+  coq = callPackage ./coq {};
+
   makeWrapper = callPackage ./make-wrapper { };
   makeBinaryWrapper = callPackage ./make-binary-wrapper {
     makeBinaryWrapper = pkgs.makeBinaryWrapper.override {

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -11,7 +11,7 @@ let
 
       metaFetch = import ../build-support/coq/meta-fetch/default.nix
         {inherit lib stdenv fetchzip; };
-      mkCoqDerivation = callPackage ../build-support/coq {};
+      mkCoqDerivation = lib.makeOverridable (callPackage ../build-support/coq {});
 
       contribs = recurseIntoAttrs
         (callPackage ../development/coq-modules/contribs {});


### PR DESCRIPTION
###### Description of changes

This PR adds a `coqPackages.lib.overrideCoqDerivation` function for easily overriding arguments to `mkCoqDerivation`.

This PR also adds the beginnings of a testing architecture for the various Coq-related functions in Nixpkgs (with currently just a single test for `overrideCoqDerivation`).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
