### PR TITLE
curl: increase coverage of tests by supplying `nghttp2` and `python3`

### DIFF
--- a/pkgs/development/libraries/nghttp2/default.nix
+++ b/pkgs/development/libraries/nghttp2/default.nix
@@ -17,7 +17,7 @@
 , enableTests ? stdenv.hostPlatform.isGnu, cunit, tzdata
 
 # downstream dependencies, for testing
-, curl
+, curlFull
 , libsoup
 }:
 
@@ -81,7 +81,8 @@ stdenv.mkDerivation rec {
   '';
 
   passthru.tests = {
-    inherit curl libsoup;
+    inherit libsoup;
+    curl = curlFull.tests.withCheck;
   };
 
   meta = with lib; {

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -26,13 +26,15 @@
 , zlibSupport ? true, zlib
 , zstdSupport ? false, zstd
 
+# for checks
+, python3
+
 # for passthru.tests
 , coeurl
 , curlpp
 , haskellPackages
 , ocamlPackages
 , phpExtensions
-, python3
 , tests
 , fetchpatch
 }:
@@ -140,6 +142,11 @@ stdenv.mkDerivation (finalAttrs: {
   # they cannot be run concurrently and are a bottleneck
   # tests are available in passthru.tests.withCheck
   doCheck = false;
+  checkInputs = [
+    python3
+    # nghttpx binary needed in PATH for http2 tests
+    nghttp2
+  ];
   preCheck = ''
     patchShebangs tests/
   '' + lib.optionalString stdenv.isDarwin ''


### PR DESCRIPTION
###### Description of changes

`nghttp2` provided to curl previously only as a library. Adding to `checkInputs` provides `nghttpx` binary via the `PATH`. Adding `python3` as a dependency shouldn't be an issue as this is only supplied when `doCheck = true`, which it usually isn't.

Once this is done, ensure `nghttp2` is using a curl build with checks enabled for its `passthru.tests`.

Keeping this draft, as until https://github.com/curl/curl/commit/ef121401d6eabed204a716f16b2776ededc75c0e makes it to a release, we get a couple of spurious test failures. Not applying that as a patch because we'd have to keep it in-repo and it's not worth becoming a permanent piece of git history.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
