### PR TITLE
python3Packages.markdown2: 2.4.1 -> 2.4.3, address XSS issue SNYK-PYTHON-MARKDOWN2-2606985

### DIFF
--- a/pkgs/development/python-modules/markdown2/default.nix
+++ b/pkgs/development/python-modules/markdown2/default.nix
@@ -1,4 +1,10 @@
-{ lib, buildPythonPackage, fetchFromGitHub, python, pygments }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, python
+, pygments
+}:
 
 buildPythonPackage rec {
   pname = "markdown2";
@@ -11,6 +17,14 @@ buildPythonPackage rec {
     rev = version;
     sha256 = "sha256-zNZ7/dDZbPIwcxSLvf8u5oaAgHLrZ6kk4vXNPUuZs/4=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "SNYK-PYTHON-MARKDOWN2-2606985-xss.patch";  # no CVE (yet?)
+      url = "https://github.com/trentm/python-markdown2/commit/5898fcc1090ef7cd7783fa1422cc0e53cbca9d1b.patch";
+      sha256 = "sha256-M6kKxjHVC3O0BvDeEF4swzfpFsDO/LU9IHvfjK4hznA=";
+    })
+  ];
 
   checkInputs = [ pygments ];
 

--- a/pkgs/development/python-modules/markdown2/default.nix
+++ b/pkgs/development/python-modules/markdown2/default.nix
@@ -15,7 +15,13 @@ buildPythonPackage rec {
   checkInputs = [ pygments ];
 
   checkPhase = ''
-    ${python.interpreter} ./test/test.py
+    runHook preCheck
+
+    pushd test
+    ${python.interpreter} ./test.py -- -knownfailure
+    popd  # test
+
+    runHook postCheck
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/markdown2/default.nix
+++ b/pkgs/development/python-modules/markdown2/default.nix
@@ -2,14 +2,14 @@
 
 buildPythonPackage rec {
   pname = "markdown2";
-  version = "2.4.1";
+  version = "2.4.3";
 
   # PyPI does not contain tests, so using GitHub instead.
   src = fetchFromGitHub {
     owner = "trentm";
     repo = "python-markdown2";
     rev = version;
-    sha256 = "0y7kh9jj8ys00qkfmmyqj63y21g7wn7yr715kj0j1nabs6xbp0y7";
+    sha256 = "sha256-zNZ7/dDZbPIwcxSLvf8u5oaAgHLrZ6kk4vXNPUuZs/4=";
   };
 
   checkInputs = [ pygments ];


### PR DESCRIPTION
###### Description of changes

https://security.snyk.io/vuln/SNYK-PYTHON-MARKDOWN2-2606985

Not the first time we've only got a snyk identifier for a `markdown2` security issue. Clearly they haven't found the CVE submission form. No release with the fix yet. Have tested patch with the fix omitted and the new tests do indeed fail without it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
