### PR TITLE
doc: specify that `longDescription` should be Markdown

### DIFF
--- a/doc/stdenv/meta.chapter.md
+++ b/doc/stdenv/meta.chapter.md
@@ -80,7 +80,7 @@ Right: `"A library for decoding PNG images"`
 
 ### `longDescription` {#var-meta-longDescription}
 
-An arbitrarily long description of the package.
+An arbitrarily long description of the package in [CommonMark](https://commonmark.org) Markdown.
 
 ### `branch` {#var-meta-branch}
 


### PR DESCRIPTION
See https://github.com/NixOS/nixos-search/issues/525 for context.

In the spirit of [RFC 72](https://github.com/NixOS/rfcs/blob/master/rfcs/0072-commonmark-docs.md), document that `longDescription` is in Markdown format (should this be CommonMark?).

This is purely a documentation change because I don't think there are currently any consumers of `longDescription` that rely on it being a particular format besides plain text.

Producers, on the other hand, [seem](https://github.com/NixOS/nixpkgs/pull/45534/files) [to](https://github.com/NixOS/nixpkgs/pull/164508/files) have been using the Markdown convention, if any.