### PR TITLE
pandoc-katex: init at 0.1.9

### DIFF
--- a/pkgs/tools/misc/pandoc-katex/default.nix
+++ b/pkgs/tools/misc/pandoc-katex/default.nix
@@ -1,0 +1,22 @@
+{ lib, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "pandoc-katex";
+  version = "0.1.9";
+
+  src = fetchFromGitHub {
+    owner = "xu-cheng";
+    repo = pname;
+    rev = version;
+    hash = "sha256-Sd+f1a3Y4XwSj5BupAH35UK6gQxzLy5jJCtc77R9wnM=";
+  };
+
+  cargoSha256 = "sha256-PVEQTzkkD6V9DqcIHznfnO1wOARSxutLApaO9dlokTQ=";
+
+  meta = with lib; {
+    description = "Pandoc filter to render math equations using KaTeX";
+    homepage = "https://github.com/xu-cheng/pandoc-katex";
+    license = with licenses; [ asl20 /* or */ mit ];
+    maintainers = with maintainers; [ minijackson pacien ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9174,6 +9174,8 @@ with pkgs;
 
   pandoc-drawio-filter = python3Packages.callPackage ../tools/misc/pandoc-drawio-filter { };
 
+  pandoc-katex = callPackage ../tools/misc/pandoc-katex { };
+
   pandoc-plantuml-filter = python3Packages.callPackage ../tools/misc/pandoc-plantuml-filter { };
 
   # pandoc-*nos is a filter suite, where pandoc-xnos has all functionality and the others are used for only specific functionality


### PR DESCRIPTION
###### Description of changes

This creates a new package for [pandoc-katex], a Pandoc filter to render math
equations using KaTeX.

[pandoc-katex]: https://github.com/xu-cheng/pandoc-katex


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


--

Cc: @minijackson
