### PR TITLE
hunspell: 1.7.0 -> 1.7.1

### DIFF
--- a/pkgs/development/libraries/hunspell/default.nix
+++ b/pkgs/development/libraries/hunspell/default.nix
@@ -1,5 +1,12 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, ncurses, readline, autoreconfHook }:
-
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  ncurses,
+  readline,
+  autoreconfHook,
+}:
 stdenv.mkDerivation rec {
   version = "1.7.0";
   pname = "hunspell";
@@ -11,18 +18,13 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-YSJztik0QTZFNR8k8Xu1hakyE16NziDavYVkEUCbtGM=";
   };
 
-  outputs = [ "bin" "dev" "out" "man" ];
+  outputs = ["bin" "dev" "out" "man"];
 
-  buildInputs = [ ncurses readline ];
-  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ncurses readline];
+  nativeBuildInputs = [autoreconfHook];
 
   patches = [
     ./0001-Make-hunspell-look-in-XDG_DATA_DIRS-for-dictionaries.patch
-    (fetchpatch {
-      name = "CVE-2019-16707.patch";
-      url = "https://github.com/hunspell/hunspell/commit/ac938e2ecb48ab4dd21298126c7921689d60571b.patch";
-      sha256 = "0bwfksz87iy7ikx3fb54zd5ww169qfm9kl076hsch3cs8p30s8az";
-    })
   ];
 
   postPatch = ''
@@ -31,9 +33,9 @@ stdenv.mkDerivation rec {
 
   autoreconfFlags = "-vfi";
 
-  configureFlags = [ "--with-ui" "--with-readline" ];
+  configureFlags = ["--with-ui" "--with-readline"];
 
-  hardeningDisable = [ "format" ];
+  hardeningDisable = ["format"];
 
   meta = with lib; {
     homepage = "http://hunspell.sourceforge.net";
@@ -59,7 +61,7 @@ stdenv.mkDerivation rec {
         * Delphi, Java (JNA, JNI), Perl, .NET, Python, Ruby ([1], [2]), UNO.
     '';
     platforms = platforms.all;
-    license = with licenses; [ gpl2 lgpl21 mpl11 ];
-    maintainers = with lib.maintainers; [ ];
+    license = with licenses; [gpl2 lgpl21 mpl11];
+    maintainers = with lib.maintainers; [];
   };
 }


### PR DESCRIPTION

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
changelog:
https://github.com/hunspell/hunspell/releases/tag/v1.7.1

fixes CVE-2019-16707: https://nvd.nist.gov/vuln/detail/CVE-2019-16707
(this was previously patched in nixpkgs, now upstream fixed it)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
