### PR TITLE
zld: 1.3.3 -> 1.3.4

### DIFF
--- a/pkgs/development/tools/zld/default.nix
+++ b/pkgs/development/tools/zld/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   pname = "zld";
-  version = "1.3.3";
+  version = "1.3.4";
   src = fetchzip {
     url = "https://github.com/michaeleisel/zld/releases/download/${version}/zld.zip";
-    sha256 = "0qb4l7a4vhpnzkgzhw0jivz40jr5gdhqfyynhbkhn7ryh5s52d1p";
+    sha256 = "1rzdcrky0dl9n7niv39a5gc7q7rwl8jv6h77nvm6gwdymkjf2973";
   };
 
   installPhase = ''


### PR DESCRIPTION
###### Description of changes

Update to zld from 1.3.3 to 1.3.4. This version includes a fix to an issue where, during Rust builds, executable produced would crash with code signing issue (work around of Apple codesigning issue)

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
