### PR TITLE
python3Packages.icontract: enable deal test, python3Packages.pyschemes: fix python3.10 compatibility

### DIFF
--- a/pkgs/development/python-modules/deal/default.nix
+++ b/pkgs/development/python-modules/deal/default.nix
@@ -6,16 +6,13 @@
 , astroid
 , pytestCheckHook
 , docstring-parser
-, isort
 , marshmallow
-, pytest-cov
 , sphinx
 , hypothesis
 , vaa
 , deal-solver
 , pygments
 , typeguard
-, coverage
 , urllib3
 }:
 

--- a/pkgs/development/python-modules/icontract/default.nix
+++ b/pkgs/development/python-modules/icontract/default.nix
@@ -15,6 +15,7 @@
 , astor
 , numpy
 , asyncstdlib
+, deal
 }:
 
 buildPythonPackage rec {
@@ -55,12 +56,10 @@ buildPythonPackage rec {
     astor
     numpy
     asyncstdlib
+    deal
   ];
 
   disabledTestPaths = [
-    # needs an old version of deal to comply with the tests
-    # see https://github.com/Parquery/icontract/issues/244
-    "tests_with_others/test_deal.py"
     # mypy decorator checks don't pass. For some reaseon mypy
     # doesn't check the python file provided in the test.
     "tests/test_mypy_decorators.py"

--- a/pkgs/development/python-modules/pyschemes/default.nix
+++ b/pkgs/development/python-modules/pyschemes/default.nix
@@ -1,16 +1,14 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, pythonAtLeast
 , pytestCheckHook
+, fetchpatch
 }:
 
 buildPythonPackage rec {
   pname = "pyschemes";
   version = "unstable-2017-11-08";
   format = "setuptools";
-
-  disabled = pythonAtLeast "3.10";
 
   src = fetchFromGitHub {
     owner = "spy16";
@@ -19,6 +17,14 @@ buildPythonPackage rec {
     hash = "sha256-PssucudvlE8mztwVme70+h+2hRW/ri9oV9IZayiZhdU=";
   };
 
+  patches = [
+    # Fix python 3.10 compatibility. Tracked upstream in
+    # https://github.com/spy16/pyschemes/pull/6
+    (fetchpatch {
+      url = "https://github.com/spy16/pyschemes/commit/23011128c6c22838d4fca9e00fd322a20bb566c4.patch";
+      sha256 = "sha256-vDaWxMrn2aC2wmd035EWRZ3cd/XME81z/BWG0f2T9jc=";
+    })
+  ];
   checkInputs = [
     pytestCheckHook
   ];


### PR DESCRIPTION
###### Description of changes

This PR fixes the python3.10 incompatibility of `pyschemes`. The repo hasn't been updated on 5 years but is still used. This is a rather small change and an upstream PR [has been created](https://github.com/spy16/pyschemes/pull/6).

With this, `deal` and `deal-solver` can  now be built with current python. Also the test in `icontract` can no be activated, because it has been fixed upstream and `deal` builds again.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
