### PR TITLE
fluent-icon-theme: init at 2022-02-28

### DIFF
--- a/pkgs/data/icons/fluent-icon-theme/default.nix
+++ b/pkgs/data/icons/fluent-icon-theme/default.nix
@@ -1,0 +1,73 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, gtk3
+, hicolor-icon-theme
+, jdupes
+, roundedIcons ? false
+, blackPanelIcons ? false
+, colorVariants ? []
+,
+}:
+let
+  pname = "Fluent-icon-theme";
+in
+lib.checkListOfEnum "${pname}: available color variants" [
+  "standard"
+  "green"
+  "grey"
+  "orange"
+  "pink"
+  "purple"
+  "red"
+  "yellow"
+  "teal"
+  "all"
+] colorVariants
+
+stdenvNoCC.mkDerivation rec {
+  inherit pname;
+  version = "2022-02-28";
+
+  src = fetchFromGitHub {
+    owner = "vinceliuice";
+    repo = pname;
+    rev = version;
+    sha256 = "UMj3qF9lhd9kM7J/3RtG3AiWlBontrowfsFOb3yr0tQ=";
+  };
+
+  nativeBuildInputs = [ gtk3 jdupes ];
+
+  buildInputs = [ hicolor-icon-theme ];
+
+  # Unnecessary & slow fixup's
+  dontPatchELF = true;
+  dontRewriteSymlinks = true;
+  dontDropIconThemeCache = true;
+
+  postPatch = ''
+    patchShebangs install.sh
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    ./install.sh --dest $out/share/icons \
+      --name Fluent \
+      ${builtins.toString colorVariants} \
+      ${lib.optionalString roundedIcons "--round"} \
+      ${lib.optionalString blackPanelIcons "--black"}
+
+    jdupes --link-soft --recurse $out/share
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Fluent icon theme for linux desktops";
+    homepage = "https://github.com/vinceliuice/Fluent-icon-theme";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ icy-thought ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25259,6 +25259,8 @@ with pkgs;
   flat-remix-gtk = callPackage ../data/themes/flat-remix-gtk { };
   flat-remix-gnome = callPackage ../data/themes/flat-remix-gnome { };
 
+  fluent-icon-theme = callPackage ../data/icons/fluent-icon-theme { };
+
   font-awesome_4 = (callPackage ../data/fonts/font-awesome { }).v4;
   font-awesome_5 = (callPackage ../data/fonts/font-awesome { }).v5;
   font-awesome_6 = (callPackage ../data/fonts/font-awesome { }).v6;


### PR DESCRIPTION
###### Description of changes
Re-submitting previous PR (from separate branch) with the intentions of adding the fluent icon-theme for the sake of providing our nix-users the ability to use and enjoy this icon theme like I did!

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
