### PR TITLE
valentina: 0.6.1 → 0.7.51

### DIFF
--- a/pkgs/applications/misc/valentina/default.nix
+++ b/pkgs/applications/misc/valentina/default.nix
@@ -1,65 +1,54 @@
-{ mkDerivation, lib, fetchhg
+{ lib, stdenv, fetchFromGitLab, substituteAll, installShellFiles
 , qmake, qttools
-, qtbase, qtsvg, qtxmlpatterns
-, poppler_utils
+, qtsvg, qttranslations, qtxmlpatterns
+, wrapQtAppsHook
 }:
 
-with lib;
-
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "valentina";
-  version = "0.6.1";
+  version = "0.7.51";
 
-  src = fetchhg {
-    url = "https://bitbucket.org/dismine/valentina";
+  src = fetchFromGitLab {
+    owner = "smart-pattern";
+    repo = "valentina";
     rev = "v${version}";
-    sha256 = "0dxk2av7xbsd233sr9wa1hamzb7pp8yx6p5b43rsnvnzchkqf423";
+    hash = "sha256-N9fC2tCP4TVNncatHaz5W5Mp3jOmAcEWYCl30+0myaE=";
   };
 
+  patches = (substituteAll {
+    # See https://github.com/NixOS/nixpkgs/issues/86054
+    src = ./fix-qttranslations-path.patch;
+    inherit qttranslations;
+  });
+
   postPatch = ''
-    substituteInPlace common.pri \
-      --replace '$$[QT_INSTALL_HEADERS]/QtXmlPatterns' '${getDev qtxmlpatterns}/include/QtXmlPatterns' \
-      --replace '$$[QT_INSTALL_HEADERS]/QtSvg' '${getDev qtsvg}/include/QtSvg' \
-      --replace '$$[QT_INSTALL_HEADERS]/' '${getDev qtbase}/include/' \
-      --replace '$$[QT_INSTALL_HEADERS]' '${getDev qtbase}'
-    substituteInPlace src/app/tape/tape.pro \
-      --replace '$$[QT_INSTALL_BINS]/rcc' '${getDev qtbase}/bin/rcc'
     substituteInPlace src/app/translations.pri \
-      --replace '$$[QT_INSTALL_BINS]/$$LRELEASE' '${getDev qttools}/bin/lrelease'
-    substituteInPlace src/app/valentina/mainwindowsnogui.cpp \
-      --replace 'define PDFTOPS "pdftops"' 'define PDFTOPS "${getBin poppler_utils}/bin/pdftops"'
-    substituteInPlace src/app/valentina/dialogs/dialogsavelayout.h \
-      --replace 'define PDFTOPS "pdftops"' 'define PDFTOPS "${getBin poppler_utils}/bin/pdftops"'
+      --replace '$$[QT_INSTALL_BINS]/$$LRELEASE' '${lib.getDev qttools}/bin/lrelease'
   '';
 
-  nativeBuildInputs = [ qmake qttools ];
+  nativeBuildInputs = [ qmake qttools wrapQtAppsHook installShellFiles ];
 
-  buildInputs = [ qtbase qtsvg qtxmlpatterns poppler_utils ];
+  buildInputs = [ qtsvg qtxmlpatterns ];
 
-  configurePhase = ''
-    qmake PREFIX=/ Valentina.pro -r "CONFIG += noTests noRunPath no_ccache noDebugSymbols"
-  '';
-
-  installFlags = [ "INSTALL_ROOT=$(out)" ];
+  qmakeFlags = [
+    "-r"
+    "PREFIX=${placeholder "out"}"
+    "CONFIG+=noTests"
+    "CONFIG+=noRunPath"
+    "CONFIG+=no_ccache"
+    "CONFIG+=noDebugSymbols"
+  ];
 
   postInstall = ''
-    mv $out/usr/share $out/
-    rmdir $out/usr
-
-    mkdir -p $out/share/man/man1
-    gzip -9c dist/debian/valentina.1 > $out/share/man/man1/valentina.1.gz
-    gzip -9c dist/debian/tape.1 > $out/share/man/man1/tape.1.gz
-
-    mkdir -p $out/share/mime/packages
-    cp dist/debian/valentina.sharedmimeinfo $out/share/mime/packages/valentina.xml
+    installManPage dist/debian/*.1
+    install -Dm644 dist/debian/valentina.sharedmimeinfo $out/share/mime/packages/valentina.xml
   '';
 
-  enableParallelBuilding = true;
-
-  meta = {
+  meta = with lib; {
     description = "An open source sewing pattern drafting software";
-    homepage = "https://valentinaproject.bitbucket.io/";
-    license = licenses.gpl3;
+    homepage = "https://smart-pattern.com.ua/";
+    changelog = "https://gitlab.com/smart-pattern/valentina/-/blob/v${version}/ChangeLog.txt";
+    license = licenses.gpl3Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ jfrankenau ];
   };

--- a/pkgs/applications/misc/valentina/fix-qttranslations-path.patch
+++ b/pkgs/applications/misc/valentina/fix-qttranslations-path.patch
@@ -1,0 +1,37 @@
+diff --git i/src/libs/vmisc/vabstractapplication.cpp w/src/libs/vmisc/vabstractapplication.cpp
+index b64817bab..5f9aa3518 100644
+--- i/src/libs/vmisc/vabstractapplication.cpp
++++ w/src/libs/vmisc/vabstractapplication.cpp
+@@ -221,26 +221,26 @@ void VAbstractApplication::LoadTranslation(const QString &locale)
+     ClearTranslation();
+ 
+     qtTranslator = new QTranslator(this);
+-#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
++#if defined(Q_OS_WIN)
+     qtTranslator->load("qt_" + locale, translationsPath(locale));
+ #else
+-    qtTranslator->load("qt_" + locale, QLibraryInfo::location(QLibraryInfo::TranslationsPath));
++    qtTranslator->load("qt_" + locale, QLatin1String("@qttranslations@/translations"));
+ #endif
+     installTranslator(qtTranslator);
+ 
+     qtxmlTranslator = new QTranslator(this);
+-#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
++#if defined(Q_OS_WIN)
+     qtxmlTranslator->load("qtxmlpatterns_" + locale, translationsPath(locale));
+ #else
+-    qtxmlTranslator->load("qtxmlpatterns_" + locale, QLibraryInfo::location(QLibraryInfo::TranslationsPath));
++    qtxmlTranslator->load("qtxmlpatterns_" + locale, QLatin1String("@qttranslations@/translations"));
+ #endif
+     installTranslator(qtxmlTranslator);
+ 
+     qtBaseTranslator = new QTranslator(this);
+-#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
++#if defined(Q_OS_WIN)
+     qtBaseTranslator->load("qtbase_" + locale, translationsPath(locale));
+ #else
+-    qtBaseTranslator->load("qtbase_" + locale, QLibraryInfo::location(QLibraryInfo::TranslationsPath));
++    qtBaseTranslator->load("qtbase_" + locale, QLatin1String("@qttranslations@/translations"));
+ #endif
+     installTranslator(qtBaseTranslator);
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31375,7 +31375,7 @@ with pkgs;
 
   utox = callPackage ../applications/networking/instant-messengers/utox { };
 
-  valentina = libsForQt512.callPackage ../applications/misc/valentina { };
+  valentina = libsForQt5.callPackage ../applications/misc/valentina { };
 
   vbindiff = callPackage ../applications/editors/vbindiff { };
 


### PR DESCRIPTION
###### Description of changes
[Changelog](https://gitlab.com/smart-pattern/valentina/-/blob/v0.7.51/ChangeLog.txt)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
