### PR TITLE
nixos/wordpress: Fix loosing theme and plugin settings on update

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -424,6 +424,34 @@
       </listitem>
       <listitem>
         <para>
+          The WordPress module now stores themes and plugins in a
+          directory name without appending the current version. This
+          avoids loosing settings when upgrading themes and plugins as
+          some of them use the directory name to store the settings in
+          the database. This needs manual intervention in case of using
+          such a broken plugin or theme which is rare.
+        </para>
+        <programlisting language="bash">
+nix-shell -p wp-cli
+cat /etc/httpd/httpd.conf  | grep &quot;\-wordpress-&quot;
+cd /nix/store/xxx-wordpress-xxx/share/wordpress
+sudo -u wordpress wp maintenance-mode activate
+sudo -u wordpress wp maintenance-mode status
+sudo -u wordpress wp db export
+sudo -u wordpress wp db search name-version
+sudo -u wordpress wp search-replace --dry-run --verbose --precise name-version name
+# repeat without --dry-run if satisfied with results
+sudo -u wordpress wp maintenance-mode deactivate
+</programlisting>
+        <para>
+          (https://developer.wordpress.org/cli/commands/). Afterwards
+          verify that the website is working fine and no settings got
+          lost. If case of loss you can recover using the exported sql
+          dump.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <literal>k3s</literal> no longer supports docker as runtime
           due to upstream dropping support.
         </para>

--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -452,6 +452,17 @@ sudo -u wordpress wp maintenance-mode deactivate
       </listitem>
       <listitem>
         <para>
+          <literal>services.wordpress.$name.database.name</literal>
+          default value has changed from <literal>wordpress</literal> to
+          <literal>wordpress-${name}</literal>. This will break existing
+          installations if you don’t manually set
+          <literal>services.wordpress.$name.database.name</literal> back
+          to <literal>wordpress</literal> or rename the database
+          manually to the new name.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <literal>k3s</literal> no longer supports docker as runtime
           due to upstream dropping support.
         </para>

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -163,6 +163,9 @@ Use `configure.packages` instead.
   ```
   (https://developer.wordpress.org/cli/commands/). Afterwards verify that the website is working fine and no settings got lost. If case of loss you can recover using the exported sql dump.
 
+- `services.wordpress.$name.database.name` default value has changed from `wordpress` to `wordpress-${name}`.
+  This will break existing installations if you don't manually set `services.wordpress.$name.database.name` back to `wordpress` or rename the database manually to the new name.
+
 - `k3s` no longer supports docker as runtime due to upstream dropping support.
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -148,6 +148,21 @@ Available as [services.patroni](options.html#opt-services.patroni.enable).
 - (Neo)Vim can not be configured with `configure.pathogen` anymore to reduce maintainance burden.
 Use `configure.packages` instead.
 
+- The WordPress module now stores themes and plugins in a directory name without appending the current version. This avoids loosing settings when upgrading themes and plugins as some of them use the directory name to store the settings in the database. This needs manual intervention in case of using such a broken plugin or theme which is rare.
+  ```bash
+  nix-shell -p wp-cli
+  cat /etc/httpd/httpd.conf  | grep "\-wordpress-"
+  cd /nix/store/xxx-wordpress-xxx/share/wordpress
+  sudo -u wordpress wp maintenance-mode activate
+  sudo -u wordpress wp maintenance-mode status
+  sudo -u wordpress wp db export
+  sudo -u wordpress wp db search name-version
+  sudo -u wordpress wp search-replace --dry-run --verbose --precise name-version name
+  # repeat without --dry-run if satisfied with results
+  sudo -u wordpress wp maintenance-mode deactivate
+  ```
+  (https://developer.wordpress.org/cli/commands/). Afterwards verify that the website is working fine and no settings got lost. If case of loss you can recover using the exported sql dump.
+
 - `k3s` no longer supports docker as runtime due to upstream dropping support.
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/services/web-apps/wordpress.nix
+++ b/nixos/modules/services/web-apps/wordpress.nix
@@ -128,7 +128,7 @@ let
 
           name = mkOption {
             type = types.str;
-            default = "wordpress";
+            default = "wordpress-${name}";
             description = lib.mdDoc "Database name.";
           };
 
@@ -270,7 +270,7 @@ in
       ensureDatabases = mapAttrsToList (hostName: cfg: cfg.database.name) eachSite;
       ensureUsers = mapAttrsToList (hostName: cfg:
         { name = cfg.database.user;
-          ensurePermissions = { "${cfg.database.name}.*" = "ALL PRIVILEGES"; };
+          ensurePermissions = { "\\`${cfg.database.name}\\`.*" = "ALL PRIVILEGES"; };
         }
       ) eachSite;
     };

--- a/nixos/modules/services/web-apps/wordpress.nix
+++ b/nixos/modules/services/web-apps/wordpress.nix
@@ -82,7 +82,8 @@ let
           type = types.package;
           default = pkgs.wordpress;
           defaultText = literalExpression "pkgs.wordpress";
-          description = lib.mdDoc "Which WordPress package to use.";
+          example = literalExample "pkgs.wordpress-core";
+          description = lib.mdDoc "Which WordPress package to use. Use pkgs.wordpress-core for a version without the default plugins and theme.";
         };
 
         uploadsDir = mkOption {

--- a/nixos/modules/services/web-apps/wordpress.nix
+++ b/nixos/modules/services/web-apps/wordpress.nix
@@ -98,26 +98,8 @@ let
           type = types.listOf types.path;
           default = [];
           description = ''
-            List of path(s) to respective plugin(s) which are copied from the 'plugins' directory.
-            <note><para>These plugins need to be packaged before use, see example.</para></note>
-          '';
-          example = literalExpression ''
-            let
-              # Wordpress plugin 'embed-pdf-viewer' installation example
-              embedPdfViewerPlugin = pkgs.stdenv.mkDerivation {
-                name = "embed-pdf-viewer-plugin";
-                # Download the theme from the wordpress site
-                src = pkgs.fetchurl {
-                  url = "https://downloads.wordpress.org/plugin/embed-pdf-viewer.2.0.3.zip";
-                  sha256 = "1rhba5h5fjlhy8p05zf0p14c9iagfh96y91r36ni0rmk6y891lyd";
-                };
-                # We need unzip to build this package
-                nativeBuildInputs = [ pkgs.unzip ];
-                # Installing simply means copying all files to the output directory
-                installPhase = "mkdir -p $out; cp -R * $out/";
-              };
-            # And then pass this theme to the themes list like this:
-            in [ embedPdfViewerPlugin ]
+            List of path(s) to respective plugin(s) which are copied to the 'plugins' directory.
+            Using https://git.helsinki.tools/helsinki-systems/wp4nix is recommended.
           '';
         };
 
@@ -125,26 +107,8 @@ let
           type = types.listOf types.path;
           default = [];
           description = ''
-            List of path(s) to respective theme(s) which are copied from the 'theme' directory.
-            <note><para>These themes need to be packaged before use, see example.</para></note>
-          '';
-          example = literalExpression ''
-            let
-              # Let's package the responsive theme
-              responsiveTheme = pkgs.stdenv.mkDerivation {
-                name = "responsive-theme";
-                # Download the theme from the wordpress site
-                src = pkgs.fetchurl {
-                  url = "https://downloads.wordpress.org/theme/responsive.3.14.zip";
-                  sha256 = "0rjwm811f4aa4q43r77zxlpklyb85q08f9c8ns2akcarrvj5ydx3";
-                };
-                # We need unzip to build this package
-                nativeBuildInputs = [ pkgs.unzip ];
-                # Installing simply means copying all files to the output directory
-                installPhase = "mkdir -p $out; cp -R * $out/";
-              };
-            # And then pass this theme to the themes list like this:
-            in [ responsiveTheme ]
+            List of path(s) to respective theme(s) which are copied to the 'themes' directory.
+            Using https://git.helsinki.tools/helsinki-systems/wp4nix is recommended.
           '';
         };
 

--- a/nixos/modules/services/web-apps/wordpress.nix
+++ b/nixos/modules/services/web-apps/wordpress.nix
@@ -31,8 +31,8 @@ let
       # Since hard linking directories is not allowed, copying is the next best thing.
 
       # copy additional plugin(s) and theme(s)
-      ${concatMapStringsSep "\n" (theme: "cp -r ${theme} $out/share/wordpress/wp-content/themes/${theme.name}") cfg.themes}
-      ${concatMapStringsSep "\n" (plugin: "cp -r ${plugin} $out/share/wordpress/wp-content/plugins/${plugin.name}") cfg.plugins}
+      ${concatMapStringsSep "\n" (theme: "cp -r ${theme} $out/share/wordpress/wp-content/themes/${theme.passthru.wpName or theme.pname}") cfg.themes}
+      ${concatMapStringsSep "\n" (plugin: "cp -r ${plugin} $out/share/wordpress/wp-content/plugins/${plugin.passthru.wpName or plugin.pname}") cfg.plugins}
     '';
   };
 

--- a/pkgs/servers/web-apps/wordpress/default.nix
+++ b/pkgs/servers/web-apps/wordpress/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, nixosTests }:
+{ lib, stdenv, fetchurl, nixosTests, writeScript }:
 
 stdenv.mkDerivation rec {
   pname = "wordpress";
@@ -17,6 +17,16 @@ stdenv.mkDerivation rec {
   passthru.tests = {
     inherit (nixosTests) wordpress;
   };
+
+  passthru.updateScript = writeScript "update.sh" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p common-updater-scripts jq wp4nix
+
+    set -eu -o pipefail
+
+    version=$(curl --globoff "https://api.wordpress.org/core/version-check/1.7/" | jq -r '.offers[0].version')
+    update-source-version wordpress $version
+  '';
 
   meta = with lib; {
     homepage = "https://wordpress.org";

--- a/pkgs/servers/web-apps/wordpress/wordpress-core.nix
+++ b/pkgs/servers/web-apps/wordpress/wordpress-core.nix
@@ -1,0 +1,10 @@
+{ wordpress }:
+
+wordpress.overrideAttrs (oldAttrs: {
+  pname = "wordpress-core";
+
+  installPhase = oldAttrs.installPhase + ''
+    rm -r $out/share/wordpress/wp-content/plugins/*
+    rm -r $out/share/wordpress/wp-content/themes/*
+  '';
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36195,6 +36195,8 @@ with pkgs;
 
   wordpress = callPackage ../servers/web-apps/wordpress { };
 
+  wordpress-core = callPackage ../servers/web-apps/wordpress/wordpress-core.nix { };
+
   wprecon = callPackage ../tools/security/wprecon { };
 
   wraith = callPackage ../applications/networking/irc/wraith { };


### PR DESCRIPTION
###### Description of changes
Supersedes https://github.com/NixOS/nixpkgs/pull/135966

[See comment below
](https://github.com/NixOS/nixpkgs/pull/188863#issuecomment-1233532514)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
