### PR TITLE
qpdf: fix cross-compilation

### DIFF
--- a/pkgs/development/libraries/qpdf/default.nix
+++ b/pkgs/development/libraries/qpdf/default.nix
@@ -15,6 +15,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ zlib libjpeg ];
 
+  configureFlags = lib.optional (stdenv.hostPlatform != stdenv.buildPlatform)
+                     "--with-random=/dev/urandom";
+
   preCheck = ''
     patchShebangs qtest/bin/qtest-driver
   '';


### PR DESCRIPTION
Fixes NixOS#188867

###### Description of changes

If under cross compilation then supply `--with-random=/dev/urandom`. This is the same approach as done for curl.

###### Things done

- Checked native compilation  on x86-64 - no change
- Checked cross compilation `.#pkgsCross.aarch64-multiplatform.qpdf`  - works