### PR TITLE
yubikey-manager: fix build on aarch64-darwin

### DIFF
--- a/pkgs/tools/misc/yubikey-manager/default.nix
+++ b/pkgs/tools/misc/yubikey-manager/default.nix
@@ -1,4 +1,5 @@
-{ python3Packages, fetchFromGitHub, lib, yubikey-personalization, libu2f-host, libusb1, procps }:
+{ python3Packages, fetchFromGitHub, lib, yubikey-personalization, libu2f-host, libusb1, procps
+, stdenv, pyOpenSSLSupport ? !(stdenv.isDarwin && stdenv.isAarch64) }:
 
 python3Packages.buildPythonPackage rec {
   pname = "yubikey-manager";
@@ -12,25 +13,30 @@ python3Packages.buildPythonPackage rec {
     sha256 = "sha256-MwM/b1QP6pkyBjz/r6oC4sW1mKC0CKMay45a0wCktk0=";
   };
 
+  patches = lib.optionals (!pyOpenSSLSupport) [
+    ./remove-pyopenssl-tests.patch
+  ];
+
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace 'fido2 = ">=0.9, <1.0"' 'fido2 = ">*"'
     substituteInPlace "ykman/pcsc/__init__.py" \
-      --replace 'pkill' '${procps}/bin/pkill'
+      --replace 'pkill' '${if stdenv.isLinux then "${procps}" else "/usr"}/bin/pkill'
   '';
 
   nativeBuildInputs = with python3Packages; [ poetry-core ];
 
   propagatedBuildInputs =
-    with python3Packages; [
+    with python3Packages; ([
       click
       cryptography
       pyscard
       pyusb
-      pyopenssl
       six
       fido2
-    ] ++ [
+    ] ++ lib.optionals pyOpenSSLSupport [
+      pyopenssl
+    ]) ++ [
       libu2f-host
       libusb1
       yubikey-personalization

--- a/pkgs/tools/misc/yubikey-manager/remove-pyopenssl-tests.patch
+++ b/pkgs/tools/misc/yubikey-manager/remove-pyopenssl-tests.patch
@@ -1,0 +1,41 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index 65a5943..e6932e0 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -30,7 +30,6 @@ packages = [
+ python = "^3.6"
+ dataclasses = {version = "^0.8", python = "<3.7"}
+ cryptography = ">=2.1, <39"
+-pyOpenSSL = {version = ">=0.15.1", optional = true}
+ pyscard = "^1.9 || ^2.0"
+ fido2 = ">=0.9, <2.0"
+ click = "^7.0 || ^8.0"
+diff --git a/tests/test_util.py b/tests/test_util.py
+index 6ccda6c..b4460e4 100644
+--- a/tests/test_util.py
++++ b/tests/test_util.py
+@@ -8,7 +8,6 @@ from ykman.util import _parse_pkcs12_pyopenssl, _parse_pkcs12_cryptography
+ from ykman.otp import format_oath_code, generate_static_pw, time_challenge
+ from .util import open_file
+ from cryptography.hazmat.primitives.serialization import pkcs12
+-from OpenSSL import crypto
+ 
+ import unittest
+ 
+@@ -114,16 +113,6 @@ class TestUtilityFunctions(unittest.TestCase):
+         ) as rsa_2048_key_cert_encrypted_pfx:
+             self.assertTrue(is_pkcs12(rsa_2048_key_cert_encrypted_pfx.read()))
+ 
+-    def test_parse_pkcs12(self):
+-        with open_file("rsa_2048_key_cert.pfx") as rsa_2048_key_cert_pfx:
+-            data = rsa_2048_key_cert_pfx.read()
+-
+-        key1, certs1 = _parse_pkcs12_cryptography(pkcs12, data, None)
+-        key2, certs2 = _parse_pkcs12_pyopenssl(crypto, data, None)
+-        self.assertEqual(key1.private_numbers(), key2.private_numbers())
+-        self.assertEqual(1, len(certs1))
+-        self.assertEqual(certs1, certs2)
+-
+     def test_is_pem(self):
+         self.assertFalse(is_pem(b"just a byte string"))
+         self.assertFalse(is_pem(None))


### PR DESCRIPTION
###### Description of changes

... by removing the optional dependency `pyopenssl`. Also closes #166348.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
