### PR TITLE
tmcbeans: init at 1.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11231,6 +11231,12 @@
     githubId = 12312980;
     name = "Robbin C.";
   };
+  robbins = {
+    email = "nejrobbins@gmail.com";
+    github = "robbins";
+    githubId = 31457698;
+    name = "Nathanael Robbins";
+  };
   roberth = {
     email = "nixpkgs@roberthensing.nl";
     matrix = "@roberthensing:matrix.org";

--- a/pkgs/applications/editors/tmcbeans/default.nix
+++ b/pkgs/applications/editors/tmcbeans/default.nix
@@ -1,0 +1,76 @@
+{ lib
+, stdenv
+, fetchurl
+, makeWrapper
+, makeDesktopItem
+, which
+, unzip
+, libicns
+, imagemagick
+, jdk
+, copyDesktopItems
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tmcbeans";
+  version = "1.4.0";
+  src = fetchurl {
+    url = "https://download.mooc.fi/tmcbeans/installers/tmcbeans_${version}.zip";
+    hash = "sha512-kugZ7DAarbKK8RvOx7VYIpCwNhm3QVBlvqy+R7oeDDTT0LeDtHsWNIpIQSgT7t9MExfG1X9bqCqspJwYQxUG5g==";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    find -name \*.exe -exec rm -f {} \;
+
+    # Copy to installation directory
+    mkdir -pv $out/tmcbeans
+    cp -a . $out/tmcbeans
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    mkdir -pv $out/bin
+    makeWrapper $out/tmcbeans/bin/tmcbeans $out/bin/tmcbeans \
+      --prefix PATH : ${lib.makeBinPath [ jdk  which ]} \
+      --prefix JAVA_HOME : ${jdk.home} \
+      --add-flags "-J-Dawt.useSystemAAFontSettings=on" \
+      --add-flags "-J-Dswing.aatext=true"
+
+    # Extract pngs from the Apple icon image and create
+    # the missing ones from the 1024x1024 image.
+    icns2png --extract $out/tmcbeans/nb/tmcbeans.icns
+    for size in 16 24 32 48 64 128 256 512 1024; do
+      mkdir -pv $out/share/icons/hicolor/"$size"x"$size"/apps
+      if [ -e tmcbeans_"$size"x"$size"x32.png ]
+      then
+        mv tmcbeans_"$size"x"$size"x32.png $out/share/icons/hicolor/"$size"x"$size"/apps/tmcbeans.png
+      else
+        convert -resize "$size"x"$size" $out/tmcbeans/nb/tmcbeans.png $out/share/icons/hicolor/"$size"x"$size"/apps/tmcbeans.png
+      fi
+    done;
+  '';
+
+  nativeBuildInputs = [ makeWrapper unzip copyDesktopItems ];
+  buildInputs = [ libicns imagemagick ];
+
+  desktopItems = [ (makeDesktopItem {
+    name = "tmcbeans";
+    exec = "tmcbeans";
+    comment = "Apache Netbeans IDE with TMC integration";
+    desktopName = "TMCBeans";
+    genericName = "Integrated Development Environment";
+    categories = [ "Development" ];
+    icon = "tmcbeans";
+  }) ];
+
+  meta = with lib; {
+    description = "A customized version of the Netbeans IDE for Java, C, C++ and PHP with the Test My Code system installed";
+    homepage = "https://www.mooc.fi";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ robbins ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5888,6 +5888,10 @@ with pkgs;
 
   timeline = callPackage ../applications/office/timeline { };
 
+  tmcbeans = callPackage ../applications/editors/tmcbeans {
+    jdk = jdk11;
+  };
+
   tsm-client = callPackage ../tools/backup/tsm-client { };
   tsm-client-withGui = callPackage ../tools/backup/tsm-client { enableGui = true; };
 


### PR DESCRIPTION
###### Description of changes

Add TMCBeans package, a customized version of the Apache Netbeans IDE with the TestMyCode plugin installed and other misc configuration changes to Netbeans defaults. Used for courses from https://www.mooc.fi/en/.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->