### PR TITLE
novnc: use installed package files as default for `--web`

### DIFF
--- a/pkgs/applications/networking/novnc/default.nix
+++ b/pkgs/applications/networking/novnc/default.nix
@@ -11,6 +11,12 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-Z+bks7kcwj+Z3uf/t0u25DnGOM60QhSH6uuoIi59jqU=";
   };
 
+  patches = [ ./fix-paths.patch ];
+
+  postPatch = ''
+    substituteAllInPlace utils/novnc_proxy
+  '';
+
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/applications/networking/novnc/fix-paths.patch
+++ b/pkgs/applications/networking/novnc/fix-paths.patch
@@ -1,0 +1,22 @@
+diff --git a/utils/novnc_proxy b/utils/novnc_proxy
+index 0900f7e..a931763 100755
+--- a/utils/novnc_proxy
++++ b/utils/novnc_proxy
+@@ -22,7 +22,7 @@ usage() {
+     echo "                          Default: self.pem"
+     echo "    --key KEY             Path to key file, when not combined with cert"
+     echo "    --web WEB             Path to web files (e.g. vnc.html)"
+-    echo "                          Default: ./"
++    echo "                          Default: @out@/share/webapps/novnc"
+     echo "    --ssl-only            Disable non-https connections."
+     echo "                                    "
+     echo "    --record FILE         Record traffic to FILE.session.js"
+@@ -44,7 +44,7 @@ PORT="6080"
+ VNC_DEST="localhost:5900"
+ CERT=""
+ KEY=""
+-WEB=""
++WEB="@out@/share/webapps/novnc"
+ proxy_pid=""
+ SSLONLY=""
+ RECORD_ARG=""


### PR DESCRIPTION
###### Description of changes

novnc in nixpkgs right now complains: 
```
$ novnc --vnc localhost:5901
Could not find vnc.html
```
The files are installed in `${pkgs.novnc}/share/webapps/novnc`. This patches `utils/novnc_proxy` to supply this as a default for the argument to `--web`, as well as the help text.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).