### PR TITLE
novnc: correctly install and point to `websockify`

### DIFF
--- a/pkgs/applications/networking/novnc/default.nix
+++ b/pkgs/applications/networking/novnc/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub }:
+{ lib, python3, stdenv, substituteAll, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
   pname = "novnc";
@@ -11,7 +11,12 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-Z+bks7kcwj+Z3uf/t0u25DnGOM60QhSH6uuoIi59jqU=";
   };
 
-  patches = [ ./fix-paths.patch ];
+  patches = with python3.pkgs; [
+    (substituteAll {
+      src = ./websockify.patch;
+      inherit websockify;
+    })
+  ] ++ [ ./fix-paths.patch ];
 
   postPatch = ''
     substituteAllInPlace utils/novnc_proxy

--- a/pkgs/applications/networking/novnc/websockify.patch
+++ b/pkgs/applications/networking/novnc/websockify.patch
@@ -1,0 +1,13 @@
+diff --git a/utils/novnc_proxy b/utils/novnc_proxy
+index 0365c1e..7eba2db 100755
+--- a/utils/novnc_proxy
++++ b/utils/novnc_proxy
+@@ -167,7 +167,7 @@ if [[ -d ${HERE}/websockify ]]; then
+ 
+     echo "Using local websockify at $WEBSOCKIFY"
+ else
+-    WEBSOCKIFY_FROMSYSTEM=$(which websockify 2>/dev/null)
++    WEBSOCKIFY_FROMSYSTEM="@websockify@/bin/websockify"
+     WEBSOCKIFY_FROMSNAP=${HERE}/../usr/bin/python2-websockify
+     [ -f $WEBSOCKIFY_FROMSYSTEM ] && WEBSOCKIFY=$WEBSOCKIFY_FROMSYSTEM
+     [ -f $WEBSOCKIFY_FROMSNAP ] && WEBSOCKIFY=$WEBSOCKIFY_FROMSNAP


### PR DESCRIPTION
`utils/novnc_proxy` tries to download and run the `websockify` package in the directory where the script is located, which doesn't work because the nix store is read-only. This patches the script to point to nix-installed `websockify`.

As it's logically a separate change I separated this and ##188897 into separate PRs. I'll need to rebase this once #188897 is submitted.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
