### PR TITLE
klee: use the same LLVM version for clang

### DIFF
--- a/pkgs/applications/science/logic/klee/default.nix
+++ b/pkgs/applications/science/logic/klee/default.nix
@@ -1,9 +1,10 @@
 { lib
+, stdenv
 , callPackage
 , fetchFromGitHub
 , cmake
-, llvmPackages_11
 , clang
+, llvm
 , python3
 , zlib
 , z3
@@ -35,18 +36,14 @@
 }:
 
 let
-
   # Python used for KLEE tests.
   kleePython = python3.withPackages (ps: with ps; [ tabulate ]);
 
   # The klee-uclibc derivation.
   kleeuClibc = callPackage ./klee-uclibc.nix {
-    inherit clang llvmPackages_11 extraKleeuClibcConfig debugRuntime runtimeAsserts;
+    inherit stdenv clang llvm extraKleeuClibcConfig debugRuntime runtimeAsserts;
   };
-
-in
-clang.stdenv.mkDerivation rec {
-
+in stdenv.mkDerivation rec {
   pname = "klee";
   version = "2.3";
 
@@ -61,7 +58,7 @@ clang.stdenv.mkDerivation rec {
     cryptominisat
     gperftools
     lit # Configure phase checking for lit
-    llvmPackages_11.llvm
+    llvm
     sqlite
     stp
     z3

--- a/pkgs/applications/science/logic/klee/klee-uclibc.nix
+++ b/pkgs/applications/science/logic/klee/klee-uclibc.nix
@@ -1,10 +1,11 @@
 { lib
+, stdenv
 , fetchurl
 , fetchFromGitHub
 , which
 , linuxHeaders
 , clang
-, llvmPackages_11
+, llvm
 , python3
 , curl
 , debugRuntime ? true
@@ -23,8 +24,7 @@ let
     "RUNTIME_PREFIX" = "/";
     "DEVEL_PREFIX" = "/";
   });
-in
-clang.stdenv.mkDerivation rec {
+in stdenv.mkDerivation rec {
   pname = "klee-uclibc";
   version = "1.3";
   src = fetchFromGitHub {
@@ -37,7 +37,7 @@ clang.stdenv.mkDerivation rec {
   nativeBuildInputs = [
     clang
     curl
-    llvmPackages_11.llvm
+    llvm
     python3
     which
   ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28649,7 +28649,11 @@ with pkgs;
 
   klayout = libsForQt5.callPackage ../applications/misc/klayout { };
 
-  klee = callPackage ../applications/science/logic/klee { };
+  klee = callPackage ../applications/science/logic/klee (with llvmPackages_11; {
+    clang = clang;
+    llvm = llvm;
+    stdenv = stdenv;
+  });
 
   kmetronome = libsForQt5.callPackage ../applications/audio/kmetronome { };
 


### PR DESCRIPTION
###### Description of changes

Currently they are the same, but llvmPackages_11 is hardcoded
which is awkward to override.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).