### PR TITLE
obs-studio-plugins.obs-source-record: init at 2022-11-10

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11791,6 +11791,12 @@
     githubId = 12312980;
     name = "Robbin C.";
   };
+  robbins = {
+    email = "nejrobbins@gmail.com";
+    github = "robbins";
+    githubId = 31457698;
+    name = "Nathanael Robbins";
+  };
   roberth = {
     email = "nixpkgs@roberthensing.nl";
     matrix = "@roberthensing:matrix.org";

--- a/pkgs/applications/video/obs-studio/plugins/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/default.nix
@@ -26,6 +26,8 @@
 
   obs-pipewire-audio-capture = callPackage ./obs-pipewire-audio-capture.nix { };
 
+  obs-source-record = callPackage ./obs-source-record.nix { };
+
   obs-vkcapture = callPackage ./obs-vkcapture.nix {
     obs-vkcapture32 = pkgsi686Linux.obs-studio-plugins.obs-vkcapture;
   };

--- a/pkgs/applications/video/obs-studio/plugins/obs-source-record.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-source-record.nix
@@ -1,0 +1,34 @@
+{ lib, stdenv, fetchFromGitHub, cmake, obs-studio }:
+
+stdenv.mkDerivation rec {
+  pname = "obs-source-record";
+  version = "unstable-2022-11-10";
+
+  src = fetchFromGitHub {
+    owner = "exeldro";
+    repo = "obs-source-record";
+    rev = "4a543d3577d56a27f5f2b9aa541a466b37dafde0";
+    sha256 = "sha256-LoMgrWZ7r6lu2fisNvqrAiFvxWQQDE6lSxUHkMB/ZPY=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [
+    obs-studio
+  ];
+
+  cmakeFlags = [
+    "-DBUILD_OUT_OF_TREE=On"
+  ];
+
+  postInstall = ''
+    rm -rf $out/{data,obs-plugins}
+  '';
+
+  meta = with lib; {
+    description = "OBS Studio plugin to make sources available to record via a filter";
+    homepage = "https://github.com/exeldro/obs-source-record";
+    maintainers = with maintainers; [ robbins ];
+    license = licenses.gpl2Only;
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
###### Description of changes

Add the obs-source-record plugin which allows you to record individual sources in OBS Studio. ~~(I edited the maintainers list in another PR, I should've sent it separately b/c it's not merged yet)~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->