### PR TITLE
geoclue2: 2.5.7 → 2.6.0

### DIFF
--- a/pkgs/development/libraries/geoclue/add-option-for-installation-sysconfdir.patch
+++ b/pkgs/development/libraries/geoclue/add-option-for-installation-sysconfdir.patch
@@ -1,5 +1,5 @@
 diff --git a/data/meson.build b/data/meson.build
-index c189753..12c10cb 100644
+index a1fc61f..7c03882 100644
 --- a/data/meson.build
 +++ b/data/meson.build
 @@ -7,7 +7,7 @@ if get_option('enable-backend')
@@ -43,7 +43,7 @@ index 1427fbe..2623f16 100644
                               desktop_file.full_path(),
                               autostart_dir)
 diff --git a/meson.build b/meson.build
-index fde6fa3..39b7b0a 100644
+index 8aa5c31..b011879 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -12,7 +12,11 @@ gclue_api_version='2.0'
@@ -69,10 +69,10 @@ index fde6fa3..39b7b0a 100644
  conf.set10('GCLUE_USE_3G_SOURCE', get_option('3g-source'))
  conf.set10('GCLUE_USE_CDMA_SOURCE', get_option('cdma-source'))
 diff --git a/meson_options.txt b/meson_options.txt
-index 83bc60e..b726329 100644
+index 5b8c42d..945dfd5 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -34,6 +34,9 @@ option('systemd-system-unit-dir',
+@@ -40,6 +40,9 @@ option('systemd-system-unit-dir',
  option('dbus-srv-user',
         type: 'string', value: 'root',
         description: 'The user (existing) as which the service will run')

--- a/pkgs/development/libraries/geoclue/default.nix
+++ b/pkgs/development/libraries/geoclue/default.nix
@@ -27,38 +27,19 @@
 
 stdenv.mkDerivation rec {
   pname = "geoclue";
-  version = "2.5.7";
+  version = "2.6.0";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
-    owner = pname;
-    repo = pname;
+    owner = "geoclue";
+    repo = "geoclue";
     rev = version;
-    sha256 = "1mv1vs4q94bqkmgkj53jcsw1x31kczwydyy3r27a7fycgzmii1pj";
+    hash = "sha256-TbuO9wpyjtvyvqaCryaTOunR0hVVlJuqENWQQpcMcz4=";
   };
 
   patches = [
-    # Fix for falling back to GeoIP when WiFi devices are not found
-    # https://gitlab.freedesktop.org/geoclue/geoclue/-/commit/2de651b6590087a2df2defe8f3d85b3cf6b91494
-    # NOTE: this should be removed when the next version is released
-    (fetchpatch {
-      url = "https://gitlab.freedesktop.org/geoclue/geoclue/commit/2de651b6590087a2df2defe8f3d85b3cf6b91494.patch";
-      sha256 = "hv7t2Hmpv2oDXiPWA7JpYD9q+cuuk+En/lJJickvFII=";
-    })
-
-    # Make the Mozilla API key configurable
-    # https://gitlab.freedesktop.org/geoclue/geoclue/merge_requests/54 (only partially backported)
-    (fetchpatch {
-      url = "https://gitlab.freedesktop.org/geoclue/geoclue/commit/95c9ad4dc176860c85a07d0db4cb4179929bdb54.patch";
-      sha256 = "/lq/dLBJl2vf16tt7emYoTtXY6iUw+4s2XcABUHp3Kc=";
-    })
-    (fetchpatch {
-      url = "https://gitlab.freedesktop.org/geoclue/geoclue/commit/1a00809a0d89b0849a57647c878d192354247a33.patch";
-      sha256 = "6FuiukgFWg2cEKt8LlKP4E0rfSH/ZQgk6Ip1mGJpNFQ=";
-    })
-
     ./add-option-for-installation-sysconfdir.patch
   ];
 
@@ -122,6 +103,6 @@ stdenv.mkDerivation rec {
     homepage = "https://gitlab.freedesktop.org/geoclue/geoclue/wikis/home";
     maintainers = with maintainers; [ raskin ];
     platforms = with platforms; linux ++ darwin;
-    license = licenses.lgpl2;
+    license = licenses.lgpl2Plus;
   };
 }


### PR DESCRIPTION
###### Description of changes
[Changelog](https://gitlab.freedesktop.org/geoclue/geoclue/-/blob/master/NEWS)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
