### PR TITLE
gpaw: init at 22.8.0

### DIFF
--- a/pkgs/development/libraries/science/chemistry/libvdwxc/default.nix
+++ b/pkgs/development/libraries/science/chemistry/libvdwxc/default.nix
@@ -1,0 +1,52 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, gfortran
+, autoreconfHook
+, fftwMpi
+, mpi
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libvdwxc";
+  # Stable version has non-working MPI detection.
+  version = "unstable-24.02.2020";
+
+  src = fetchFromGitLab {
+    owner = "libvdwxc";
+    repo = pname;
+    rev = "92f4910c6ac88e111db2fb3a518089d0510c53b0";
+    sha256 = "1c7pjrvifncbdyngs2bv185imxbcbq64nka8gshhp8n2ns6fids6";
+  };
+
+  nativeBuildInputs = [ autoreconfHook gfortran ];
+
+  propagatedBuildInputs = [ mpi fftwMpi ];
+
+  preConfigure = ''
+    mkdir build && cd build
+
+    export PATH=$PATH:${mpi}/bin
+    configureFlagsArray+=(
+      --with-mpi=${mpi}
+      CC=mpicc
+      FC=mpif90
+      MPICC=mpicc
+      MPIFC=mpif90
+    )
+  '';
+
+  configureScript = "../configure";
+
+  hardeningDisable = [ "format" ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Portable C library of density functionals with van der Waals interactions for density functional theory";
+    license = with licenses; [ lgpl3Plus bsd3 ];
+    homepage = "https://libvdwxc.org/";
+    platforms = platforms.unix;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/development/python-modules/gpaw/SetupPath.patch
+++ b/pkgs/development/python-modules/gpaw/SetupPath.patch
@@ -1,0 +1,18 @@
+diff --git a/gpaw/__init__.py b/gpaw/__init__.py
+index b5c029e13..518c16b13 100644
+--- a/gpaw/__init__.py
++++ b/gpaw/__init__.py
+@@ -201,12 +201,7 @@ def initialize_data_paths():
+     try:
+         setup_paths[:0] = os.environ['GPAW_SETUP_PATH'].split(os.pathsep)
+     except KeyError:
+-        if len(setup_paths) == 0:
+-            if os.pathsep == ';':
+-                setup_paths[:] = [r'C:\gpaw-setups']
+-            else:
+-                setup_paths[:] = ['/usr/local/share/gpaw-setups',
+-                                  '/usr/share/gpaw-setups']
++        setup_paths[:0] = ["@gpawSetupPath@"]
+ 
+ 
+ read_rc_file()

--- a/pkgs/development/python-modules/gpaw/default.nix
+++ b/pkgs/development/python-modules/gpaw/default.nix
@@ -1,0 +1,123 @@
+{ buildPythonPackage
+, lib
+, fetchFromGitLab
+, writeTextFile
+, fetchurl
+, blas
+, lapack
+, mpi
+, scalapack
+, libxc
+, libvdwxc
+, which
+, ase
+, numpy
+, scipy
+}:
+
+assert lib.asserts.assertMsg (!blas.isILP64)
+  "A 32 bit integer implementation of BLAS is required.";
+
+assert lib.asserts.assertMsg (!lapack.isILP64)
+  "A 32 bit integer implementation of LAPACK is required.";
+
+let
+  gpawConfig = writeTextFile {
+    name = "siteconfig.py";
+    text = ''
+      # Compiler
+      compiler = 'gcc'
+      mpicompiler = '${mpi}/bin/mpicc'
+      mpilinker = '${mpi}/bin/mpicc'
+
+      # BLAS
+      libraries += ['blas']
+      library_dirs += ['${blas}/lib']
+
+      # FFTW
+      fftw = True
+      if fftw:
+        libraries += ['fftw3']
+
+      scalapack = True
+      if scalapack:
+        libraries += ['scalapack']
+
+      # LibXC
+      libxc = True
+      if libxc:
+        xc = '${libxc}/'
+        include_dirs += [xc + 'include']
+        library_dirs += [xc + 'lib/']
+        extra_link_args += ['-Wl,-rpath={xc}/lib'.format(xc=xc)]
+        if 'xc' not in libraries:
+          libraries.append('xc')
+
+      # LibVDWXC
+      libvdwxc = True
+      if libvdwxc:
+        vdwxc = '${libvdwxc}/'
+        extra_link_args += ['-Wl,-rpath=%s/lib' % vdwxc]
+        library_dirs += ['%s/lib' % vdwxc]
+        include_dirs += ['%s/include' % vdwxc]
+        libraries += ['vdwxc']
+    '';
+  };
+
+  setupVersion = "0.9.20000";
+  pawDataSets = fetchurl {
+    url = "https://wiki.fysik.dtu.dk/gpaw-files/gpaw-setups-${setupVersion}.tar.gz";
+    sha256 = "07yldxnn38gky39fxyv3rfzag9p4lb0xfpzn15wy2h9aw4mnhwbc";
+  };
+
+in buildPythonPackage rec {
+  pname = "gpaw";
+  version = "22.8.0";
+
+  src = fetchFromGitLab {
+    owner = "gpaw";
+    repo = pname;
+    rev = version;
+    hash = "sha256-Kgf8yuGua7mcGP+jVVmbE8JCsbrfzewRTRt3ihq9YX4=";
+  };
+
+  nativeBuildInputs = [ which ];
+
+  buildInputs = [ blas scalapack libxc libvdwxc ];
+
+  propagatedBuildInputs = [ ase scipy numpy mpi ];
+
+  patches = [ ./SetupPath.patch ];
+
+  postPatch = ''
+    substituteInPlace gpaw/__init__.py \
+      --subst-var-by gpawSetupPath "$out/share/gpaw/gpaw-setups-${setupVersion}"
+  '';
+
+  preConfigure = ''
+    unset CC
+    cp ${gpawConfig} siteconfig.py
+  '';
+
+  postInstall = ''
+    currDir=$(pwd)
+    mkdir -p $out/share/gpaw && cd $out/share/gpaw
+    cp ${pawDataSets} gpaw-setups.tar.gz
+    tar -xvf $out/share/gpaw/gpaw-setups.tar.gz
+    rm gpaw-setups.tar.gz
+    cd $currDir
+  '';
+
+  doCheck = false; # Requires MPI runtime to work in the sandbox
+  pythonImportsCheckHook = [ "gpaw" ];
+
+  passthru = { inherit mpi; };
+
+  meta = with lib; {
+    description = "Density functional theory and beyond within the projector-augmented wave method";
+    homepage = "https://wiki.fysik.dtu.dk/gpaw/index.html";
+    license = licenses.gpl3Only;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18036,6 +18036,7 @@ with pkgs;
   fftwSinglePrec = fftw.override { precision = "single"; };
   fftwFloat = fftwSinglePrec; # the configure option is just an alias
   fftwLongDouble = fftw.override { precision = "long-double"; };
+  fftwMpi = fftw.override { enableMpi = true; };
 
   filter-audio = callPackage ../development/libraries/filter-audio {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20226,6 +20226,8 @@ with pkgs;
 
   libvdpau = callPackage ../development/libraries/libvdpau { };
 
+  libvdwxc = callPackage ../development/libraries/science/chemistry/libvdwxc { };
+
   libmodulemd = callPackage ../development/libraries/libmodulemd { };
 
   libvdpau-va-gl = callPackage ../development/libraries/libvdpau-va-gl { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3898,6 +3898,8 @@ in {
 
   gpapi = callPackage ../development/python-modules/gpapi { };
 
+  gpaw = callPackage ../development/python-modules/gpaw { };
+
   gpiozero = callPackage ../development/python-modules/gpiozero { };
 
   gplaycli = callPackage ../development/python-modules/gplaycli { };


### PR DESCRIPTION
###### Description of changes

Part of the ongoing effort to upstream packages from the [NixOS-Qchem overlay](https://github.com/markuskowa/NixOS-QChem) (https://github.com/markuskowa/NixOS-QChem/issues/146). This adds the [GPAW](https://wiki.fysik.dtu.dk/gpaw/) package for condensed phase DFT.

The GPAW dependency LibVdwXC has also been added and requires a commit from master shortly after the latest stable release to work with GPAW.

GPAW requires an MPI-capable FFTW to work in parallel which is overriden on the fly. Not sure if this is the preferred option to do these things.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
