### PR TITLE
gource: 0.51 → 0.53

### DIFF
--- a/pkgs/applications/version-management/gource/default.nix
+++ b/pkgs/applications/version-management/gource/default.nix
@@ -1,23 +1,31 @@
-{ lib, stdenv, fetchurl, SDL2, ftgl, pkg-config, libpng, libjpeg, pcre
-, SDL2_image, freetype, glew, libGLU, libGL, boost, glm
+{ lib, stdenv, fetchurl, SDL2, ftgl, pkg-config, libpng, libjpeg, pcre2
+, SDL2_image, freetype, glew, libGLU, libGL, boost, glm, tinyxml
 }:
 
 stdenv.mkDerivation rec {
-  version = "0.51";
   pname = "gource";
+  version = "0.53";
 
   src = fetchurl {
     url = "https://github.com/acaudwell/Gource/releases/download/${pname}-${version}/${pname}-${version}.tar.gz";
-    sha256 = "16p7b1x4r0915w883lp374jcdqqja37fnb7m8vnsfnl2n64gi8qr";
+    hash = "sha256-PV9kwcaBL2RMMgy8mphY35e8YDb8Hl9gPKRrFbjdcjc=";
   };
+
+  postPatch = ''
+    # remove bundled library
+    rm -r src/tinyxml
+  '';
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
-    glew SDL2 ftgl libpng libjpeg pcre SDL2_image libGLU libGL
-    boost glm freetype
+    glew SDL2 ftgl libpng libjpeg pcre2 SDL2_image libGLU libGL
+    boost glm freetype tinyxml
   ];
 
-  configureFlags = [ "--with-boost-libdir=${boost.out}/lib" ];
+  configureFlags = [
+    "--with-boost-libdir=${boost.out}/lib"
+    "--with-tinyxml"
+  ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Description of changes
[Changelog](https://github.com/acaudwell/Gource/releases)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
