### PR TITLE
libcdr: 0.1.6 → 0.1.7, fix cross-compilation

### DIFF
--- a/pkgs/development/libraries/libcdr/default.nix
+++ b/pkgs/development/libraries/libcdr/default.nix
@@ -2,22 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "libcdr";
-  version = "0.1.6";
+  version = "0.1.7";
 
   src = fetchurl {
     url = "https://dev-www.libreoffice.org/src/${pname}-${version}.tar.xz";
-    sha256 = "0qgqlw6i25zfq1gf7f6r5hrhawlrgh92sg238kjpf2839aq01k81";
+    hash = "sha256-VmYknWE0ZrmqHph+pBCcBDZYZuknfYD2zZZj6GuOzdQ=";
   };
 
-  patches = [
-    # Fix build with icu 68
-    # Remove in next release
-    (fetchpatch {
-      name = "libcdr-fix-icu-68";
-      url = "https://cgit.freedesktop.org/libreoffice/libcdr/patch/?id=bf3e7f3bbc414d4341cf1420c99293debf1bd894";
-      sha256 = "0cgra10p8ibgwn8y5q31jrpan317qj0ribzjs4jq0bwavjq92w2k";
-    })
-  ];
+  strictDeps = true;
 
   buildInputs = [ libwpg libwpd lcms librevenge icu boost cppunit ];
 

--- a/pkgs/development/libraries/libgsf/default.nix
+++ b/pkgs/development/libraries/libgsf/default.nix
@@ -1,6 +1,8 @@
-{ fetchurl
+{ fetchFromGitLab
 , lib
 , stdenv
+, autoreconfHook
+, gtk-doc
 , pkg-config
 , intltool
 , gettext
@@ -21,12 +23,26 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "bmwg0HeDOQadWDwNY3WdKX6BfqENDYl+u+ll8W4ujlI=";
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "GNOME";
+    repo = "libgsf";
+    rev = "LIBGSF_${lib.replaceStrings ["."] ["_"] version}";
+    hash = "sha256-6RP2DJWcDQ8dkKtcPxAkRsS7jSvvLoDNZHXiDJwR8Eg=";
   };
 
+  postPatch = ''
+    # Fix cross-compilation
+    substituteInPlace configure.ac \
+      --replace "AC_PATH_PROG(PKG_CONFIG, pkg-config, no)" \
+                "PKG_PROG_PKG_CONFIG"
+  '';
+
+  strictDeps = true;
+
   nativeBuildInputs = [
+    autoreconfHook
+    gtk-doc
     pkg-config
     intltool
     libintl


### PR DESCRIPTION
###### Description of changes
* [Changelog](https://git.libreoffice.org/libcdr/+log)
* fix cross-compilation (via libgsf):
```
libgsf-aarch64-unknown-linux-gnu> checking pkg-config is at least version 0.9.0... ./configure: line 15213: no: command not found
```
(Setting `export PKG_CONFIG=${stdenv.cc.targetPrefix}pkg-config}` in `preConfigure` doesn't work.)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
