### PR TITLE
openmm: init at 7.7.0

### DIFF
--- a/pkgs/development/libraries/science/chemistry/openmm/default.nix
+++ b/pkgs/development/libraries/science/chemistry/openmm/default.nix
@@ -1,0 +1,91 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, gfortran
+, fftwSinglePrec
+, doxygen
+, swig
+, python3Packages, enablePython ? false
+, opencl-headers, ocl-icd, enableOpencl ? false
+, clang, enableClang ? true
+, cudatoolkit, enableCuda ? false
+}:
+
+stdenv.mkDerivation rec {
+  pname = "openmm";
+  version = "7.7.0";
+
+  src = fetchFromGitHub {
+    owner = "openmm";
+    repo = pname;
+    rev = version;
+    hash = "sha256-2PYUGTMVQ5qVDeeABrwR45U3JIgo2xMXKlD6da7y3Dw=";
+  };
+
+  # "This test is stochastic and may occassionally fail". It does.
+  postPatch = ''
+    rm \
+      platforms/*/tests/Test*BrownianIntegrator.* \
+      platforms/*/tests/Test*LangevinIntegrator.* \
+      serialization/tests/TestSerializeIntegrator.cpp
+  '';
+
+  nativeBuildInputs = [ cmake gfortran swig doxygen python3Packages.python ];
+
+  buildInputs = [ fftwSinglePrec ]
+    ++ lib.optionals enableOpencl [ ocl-icd opencl-headers ]
+    ++ lib.optional enableCuda cudatoolkit;
+
+  propagatedBuildInputs = lib.optionals enablePython (with python3Packages; [
+    python
+    numpy
+    cython
+  ]);
+
+  cmakeFlags = [
+    "-DBUILD_TESTING=ON"
+    "-DOPENMM_BUILD_AMOEBA_PLUGIN=ON"
+    "-DOPENMM_BUILD_CPU_LIB=ON"
+    "-DOPENMM_BUILD_C_AND_FORTRAN_WRAPPERS=ON"
+    "-DOPENMM_BUILD_DRUDE_PLUGIN=ON"
+    "-DOPENMM_BUILD_PME_PLUGIN=ON"
+    "-DOPENMM_BUILD_RPMD_PLUGIN=ON"
+    "-DOPENMM_BUILD_SHARED_LIB=ON"
+  ] ++ lib.optionals enablePython [
+    "-DOPENMM_BUILD_PYTHON_WRAPPERS=ON"
+  ] ++ lib.optionals enableClang [
+    "-DCMAKE_C_COMPILER=${clang}/bin/clang"
+    "-DCMAKE_CXX_COMPILER=${clang}/bin/clang++"
+  ] ++ lib.optionals enableOpencl [
+    "-DOPENMM_BUILD_OPENCL_LIB=ON"
+    "-DOPENMM_BUILD_AMOEBA_OPENCL_LIB=ON"
+    "-DOPENMM_BUILD_DRUDE_OPENCL_LIB=ON"
+    "-DOPENMM_BUILD_RPMD_OPENCL_LIB=ON"
+  ] ++ lib.optionals enableCuda [
+    "-DCUDA_SDK_ROOT_DIR=${cudatoolkit}"
+    "-DOPENMM_BUILD_AMOEBA_CUDA_LIB=ON"
+    "-DOPENMM_BUILD_CUDA_LIB=ON"
+    "-DOPENMM_BUILD_DRUDE_CUDA_LIB=ON"
+    "-DOPENMM_BUILD_RPMD_CUDA_LIB=ON"
+    "-DCMAKE_LIBRARY_PATH=${cudatoolkit}/lib64/stubs"
+  ];
+
+  postInstall = lib.strings.optionalString enablePython ''
+    export OPENMM_LIB_PATH=$out/lib
+    export OPENMM_INCLUDE_PATH=$out/include
+    cd python
+    ${python3Packages.python.interpreter} setup.py build
+    ${python3Packages.python.interpreter} setup.py install --prefix=$out
+  '';
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Toolkit for molecular simulation using high performance GPU code";
+    homepage = "https://openmm.org/";
+    license = with licenses; [ gpl3Plus lgpl3Plus mit ];
+    platforms = platforms.linux;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30278,6 +30278,8 @@ with pkgs;
 
   open-policy-agent = callPackage ../development/tools/open-policy-agent { };
 
+  openmm = callPackage ../development/libraries/science/chemistry/openmm { };
+
   openshift = callPackage ../applications/networking/cluster/openshift { };
 
   opsdroid = callPackage ../applications/networking/opsdroid { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6533,6 +6533,11 @@ in {
 
   openidc-client = callPackage ../development/python-modules/openidc-client { };
 
+  openmm = toPythonModule (pkgs.openmm.override {
+    python3Packages = self;
+    enablePython = true;
+  });
+
   openpyxl = callPackage ../development/python-modules/openpyxl { };
 
   openrazer = callPackage ../development/python-modules/openrazer/pylib.nix { };


### PR DESCRIPTION
###### Description of changes

Part of the ongoing effort to upstream packages from the [NixOS-Qchem overlay](https://github.com/markuskowa/NixOS-QChem) (https://github.com/markuskowa/NixOS-QChem/issues/146). This adds the [OpenMM](https://openmm.org/) package for classical molecular dynamics.

The package works when explicitly setting `PYTHONPATH` but cannot be imported otherwise. This is also the reason why the `pythonImportsCheck` is currently commented out. I couldn't figure out what the problem is and appreciate any idea :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
