### PR TITLE
Python cleanups found while reviewing #188984

### DIFF
--- a/pkgs/development/python-modules/qiskit-machine-learning/default.nix
+++ b/pkgs/development/python-modules/qiskit-machine-learning/default.nix
@@ -11,8 +11,6 @@
 , qiskit-terra
 , scikit-learn
 , sparse
-  # Optional inputs
-, withTorch ? true
 , torch
   # Check Inputs
 , pytestCheckHook
@@ -38,10 +36,11 @@ buildPythonPackage rec {
     fastdtw
     numpy
     psutil
+    torch
     qiskit-terra
     scikit-learn
     sparse
-  ] ++ lib.optional withTorch torch;
+  ];
 
   doCheck = false;  # TODO: enable. Tests fail on unstable due to some multithreading issue?
   checkInputs = [

--- a/pkgs/development/python-modules/rising/default.nix
+++ b/pkgs/development/python-modules/rising/default.nix
@@ -3,7 +3,6 @@
 , isPy27
 , fetchFromGitHub
 , pytestCheckHook
-, pytest-cov
 , dill
 , numpy
 , torch
@@ -25,7 +24,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ numpy torch threadpoolctl tqdm ];
-  checkInputs = [ dill pytest-cov pytestCheckHook ];
+  checkInputs = [ dill pytestCheckHook ];
 
   disabledTests = [ "test_affine" ];  # deprecated division operator '/'
 

--- a/pkgs/development/python-modules/torchgpipe/default.nix
+++ b/pkgs/development/python-modules/torchgpipe/default.nix
@@ -1,8 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, isPy27
-, pytest-runner
+, pythonOlder
 , pytestCheckHook
 , torch
 }:
@@ -11,7 +10,7 @@ buildPythonPackage rec {
   pname = "torchgpipe";
   version = "0.0.7";
 
-  disabled = isPy27;
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "kakaobrain";
@@ -20,9 +19,14 @@ buildPythonPackage rec {
     sha256 = "0ki0njhmz1i3pkpr3y6h6ac7p5qh1kih06mknc2s18mfw34f2l55";
   };
 
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "'pytest-runner'" ""
+  '';
+
   propagatedBuildInputs = [ torch ];
 
-  checkInputs = [ pytest-runner pytestCheckHook ];
+  checkInputs = [ pytestCheckHook ];
   disabledTests = [
     "test_inplace_on_requires_grad"
     "test_input_requiring_grad"


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
