### PR TITLE
swayest-workstyle: init at 1.3.0

### DIFF
--- a/pkgs/applications/window-managers/sway/swayest-workstyle/default.nix
+++ b/pkgs/applications/window-managers/sway/swayest-workstyle/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "swayest-workstyle";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "Lyr-7D1h";
+    repo = "swayest_workstyle";
+    rev = version;
+    sha256 = "sha256-LciTrYbmJV0y0H6QH88vTBXbDdDSx6FQtO4J/CFLjtY=";
+  };
+
+  cargoSha256 = "sha256-34Ij3Hd1JI6d1vhv1XomFc9SFoB/6pbS39upLk+NeQM=";
+
+  doCheck = false; # No tests
+
+  meta = with lib; {
+    description = "Map sway workspace names to icons defined depending on the windows inside of the workspace";
+    homepage = "https://github.com/Lyr-7D1h/swayest_workstyle";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ miangraham ];
+    mainProgram = "sworkstyle";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28293,6 +28293,8 @@ with pkgs;
 
   swaynag-battery = callPackage ../applications/misc/swaynag-battery {};
 
+  swayest-workstyle = callPackage ../applications/window-managers/sway/swayest-workstyle { };
+
   tiramisu = callPackage ../applications/misc/tiramisu { };
 
   rlaunch = callPackage ../applications/misc/rlaunch {


### PR DESCRIPTION
Add swayest-workstyle, a sway-enhanced workspace name iconifier.

###### Description of changes

New rust package initted at release 1.3.0 and added to sway section of all-packages. Binary tested with nixpkgs-review. I'm also using it on nixos from my nixpkgs fork without issue.

Tested:

```console
$ nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"

$ nix-shell /home/ian/.cache/nixpkgs-review/rev-cc0f5950c29950e84a06eb7e9c92aa9b313acd1c/shell.nix

(review-shell) $ ./results/swayest-workstyle/bin/sworkstyle --help
Swayest Workstyle v1.3.0
This tool will rename workspaces to the icons configured.
Config can be found in $HOME/.config/sworkstyle
...
```

How to test behavior on sway:

1. Use with `font-awesome` installed. Not a hard dependency and can be used without, but the default config outputs unicode for fa icons so these are easier to test.
1. Run `sworkstyle` from a term emu inside sway.
1. Switch to an empty workspace.
1. Run `firefox`. The name of the workspace should change from its previous text to a firefox icon.

Below is the result on my system with workspace names shown in waybar:

![image](https://user-images.githubusercontent.com/704580/187851542-5e05dfab-e7c8-4156-b6b5-5f86b730d17d.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
