### PR TITLE
bundler: 2.3.20 -> 2.3.21

### DIFF
--- a/pkgs/development/ruby-modules/bundler/default.nix
+++ b/pkgs/development/ruby-modules/bundler/default.nix
@@ -1,4 +1,4 @@
-{ buildRubyGem, ruby, writeScript }:
+{ lib, buildRubyGem, ruby, writeScript }:
 
 buildRubyGem rec {
   inherit ruby;
@@ -21,4 +21,11 @@ buildRubyGem rec {
   postFixup = ''
     sed -i -e "s/activate_bin_path/bin_path/g" $out/bin/bundle
   '';
+
+  meta = with lib; {
+    description = "Manage your Ruby application's gem dependencies";
+    homepage = "https://bundler.io";
+    license = licenses.mit;
+    maintainers = with maintainers; [anthonyroussel];
+  };
 }

--- a/pkgs/development/ruby-modules/bundler/default.nix
+++ b/pkgs/development/ruby-modules/bundler/default.nix
@@ -4,8 +4,8 @@ buildRubyGem rec {
   inherit ruby;
   name = "${gemName}-${version}";
   gemName = "bundler";
-  version = "2.3.20";
-  source.sha256 = "sha256-gJJ3vHzrJo6XpHS1iwLb77jd9ZB39GGLcOJQSrgaBHw=";
+  version = "2.3.21";
+  source.sha256 = "sha256-+u3H/8Fno8U7ZMRj2me1DVvkOAR2HeWmjdo0TCG/0d4=";
   dontPatchShebangs = true;
 
   passthru.updateScript = writeScript "gem-update-script" ''

--- a/pkgs/development/ruby-modules/bundler/default.nix
+++ b/pkgs/development/ruby-modules/bundler/default.nix
@@ -1,4 +1,4 @@
-{ buildRubyGem, ruby }:
+{ buildRubyGem, ruby, writeScript }:
 
 buildRubyGem rec {
   inherit ruby;
@@ -7,6 +7,16 @@ buildRubyGem rec {
   version = "2.3.20";
   source.sha256 = "sha256-gJJ3vHzrJo6XpHS1iwLb77jd9ZB39GGLcOJQSrgaBHw=";
   dontPatchShebangs = true;
+
+  passthru.updateScript = writeScript "gem-update-script" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p curl common-updater-scripts jq
+
+    set -eu -o pipefail
+
+    latest_version=$(curl -s https://rubygems.org/api/v1/gems/${gemName}.json | jq --raw-output .version)
+    update-source-version ${gemName} "$latest_version"
+  '';
 
   postFixup = ''
     sed -i -e "s/activate_bin_path/bin_path/g" $out/bin/bundle


### PR DESCRIPTION
###### Description of changes

* Upgrade bundler from 2.3.20 to 2.3.21
* Add passthru.updateScript to automatically update bundler
* Add missing meta information
* Add anthonyroussel to maintainers
  * There is no maintainers on this package
  * I use bundler really often, so I propose to add myself as a maintainer of the package

See release notes: https://github.com/rubygems/rubygems/blob/master/bundler/CHANGELOG.md#2321-august-24-2022

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
