### PR TITLE
libstemmer: install and use snowball binary from buildPackages

### DIFF
--- a/pkgs/development/libraries/libstemmer/default.nix
+++ b/pkgs/development/libraries/libstemmer/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, perl }:
+{ lib, stdenv, fetchFromGitHub, perl, buildPackages }:
 
 stdenv.mkDerivation rec {
   pname = "libstemmer";
@@ -15,6 +15,9 @@ stdenv.mkDerivation rec {
 
   prePatch = ''
     patchShebangs .
+  '' + lib.optionalString (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    substituteInPlace GNUmakefile \
+      --replace './snowball' '${lib.getBin buildPackages.libstemmer}/bin/snowball'
   '';
 
   makeTarget = "libstemmer.a";
@@ -23,6 +26,7 @@ stdenv.mkDerivation rec {
     runHook preInstall
     install -Dt $out/lib libstemmer.a
     install -Dt $out/include include/libstemmer.h
+    install -Dt $out/bin {snowball,stemwords}
     runHook postInstall
   '';
 


### PR DESCRIPTION
libstemmer-aarch64-unknown-linux-gnu> ./snowball algorithms/arabic.sbl -o src_c/stem_UTF_8_arabic -eprefix arabic_UTF_8_ -r ../runtime -u
libstemmer-aarch64-unknown-linux-gnu> /nix/store/p7bpdnxqd3i5hwm92mrscf7mvxk66404-bash-5.1-p16/bin/bash: line 4: ./snowball: cannot execute binary file: Exec format error

ref: https://github.com/void-linux/void-packages/blob/4976c61b3af5ce6039caf19365c9dfb536d495f9/srcpkgs/snowball/template#L16-L21

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
