### PR TITLE
lighthouse: init at 3.1.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10619,6 +10619,16 @@
     githubId = 178496;
     name = "Philipp Middendorf";
   };
+  pmw = {
+    email = "philip@mailworks.org";
+    matrix = "@philip4g:matrix.org";
+    name = "Philip White";
+    github = "philipmw";
+    githubId = 1379645;
+    keys = [{
+      fingerprint = "9AB0 6C94 C3D1 F9D0 B9D9  A832 BC54 6FB3 B16C 8B0B";
+    }];
+  };
   pmy = {
     email = "pmy@xqzp.net";
     github = "pmeiyu";

--- a/pkgs/applications/blockchains/lighthouse/default.nix
+++ b/pkgs/applications/blockchains/lighthouse/default.nix
@@ -1,0 +1,103 @@
+{ clang
+, cmake
+, fetchFromGitHub
+, fetchurl
+, lib
+, lighthouse
+, llvmPackages
+, nodePackages
+, perl
+, protobuf
+, rustPlatform
+, Security
+, stdenv
+, testers
+, unzip
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "lighthouse";
+  version = "3.1.2";
+
+  # lighthouse/common/deposit_contract/build.rs
+  depositContractSpecVersion = "0.12.1";
+  testnetDepositContractSpecVersion = "0.9.2.1";
+
+  src = fetchFromGitHub {
+    owner = "sigp";
+    repo = "lighthouse";
+    rev = "v${version}";
+    hash = "sha256-EJFg6ZjxxijxJNMwKRh0cYeqwujUV3OJgXBvBRsnbVI=";
+  };
+
+  cargoHash = "sha256-iXqRtBqvM9URQsL8qGmpr3CNX2fpbtDOaluibAX/lWo=";
+
+  buildFeatures = [ "modern" "gnosis" ];
+
+  nativeBuildInputs = [ clang cmake perl protobuf ];
+
+  buildInputs = lib.optionals stdenv.isDarwin [
+    Security
+  ];
+
+  LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+
+  depositContractSpec = fetchurl {
+    url = "https://raw.githubusercontent.com/ethereum/eth2.0-specs/v${depositContractSpecVersion}/deposit_contract/contracts/validator_registration.json";
+    hash = "sha256-ZslAe1wkmkg8Tua/AmmEfBmjqMVcGIiYHwi+WssEwa8=";
+  };
+
+  testnetDepositContractSpec = fetchurl {
+    url = "https://raw.githubusercontent.com/sigp/unsafe-eth2-deposit-contract/v${testnetDepositContractSpecVersion}/unsafe_validator_registration.json";
+    hash = "sha256-aeTeHRT3QtxBRSNMCITIWmx89vGtox2OzSff8vZ+RYY=";
+  };
+
+  LIGHTHOUSE_DEPOSIT_CONTRACT_SPEC_URL = "file://${depositContractSpec}";
+  LIGHTHOUSE_DEPOSIT_CONTRACT_TESTNET_URL = "file://${testnetDepositContractSpec}";
+
+  cargoBuildFlags = [
+    "--package lighthouse"
+  ];
+
+  __darwinAllowLocalNetworking = true;
+
+  checkFeatures = [ ];
+
+  # All of these tests require network access
+  cargoTestFlags = [
+    "--workspace"
+    "--exclude beacon_node"
+    "--exclude http_api"
+    "--exclude beacon_chain"
+    "--exclude lighthouse"
+    "--exclude lighthouse_network"
+    "--exclude slashing_protection"
+    "--exclude web3signer_tests"
+  ];
+
+  # All of these tests require network access
+  checkFlags = [
+    "--skip service::tests::tests::test_dht_persistence"
+    "--skip time::test::test_reinsertion_updates_timeout"
+  ] ++ lib.optionals (stdenv.isAarch64 && stdenv.isDarwin) [
+    "--skip subnet_service::tests::sync_committee_service::same_subscription_with_lower_until_epoch"
+    "--skip subnet_service::tests::sync_committee_service::subscribe_and_unsubscribe"
+  ];
+
+  checkInputs = [
+    nodePackages.ganache
+  ];
+
+  passthru.tests.version = testers.testVersion {
+    package = lighthouse;
+    command = "lighthouse --version";
+    version = "v${lighthouse.version}";
+  };
+
+  meta = with lib; {
+    description = "Ethereum consensus client in Rust";
+    homepage = "https://lighthouse.sigmaprime.io/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ centromere pmw ];
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -765,7 +765,6 @@ mapAliases ({
   libva1-full = throw "'libva1-full' has been renamed to/replaced by 'libva1'"; # Converted to throw 2022-02-22
   libwnck3 = libwnck;
   lightdm_gtk_greeter = lightdm-gtk-greeter; # Added 2022-08-01
-  lighthouse = throw "lighthouse has been removed: abandoned by upstream"; # Added 2022-04-24
   lighttable = throw "'lighttable' crashes (SIGSEGV) on startup, has not been updated in years and depends on deprecated GTK2"; # Added 2022-06-15
   lilyterm = throw "lilyterm has been removed from nixpkgs, because it was relying on a vte version that depended on python2"; # Added 2022-01-14
   lilyterm-git = throw "lilyterm-git has been removed from nixpkgs, because it was relying on a vte version that depended on python2"; # Added 2022-01-14

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35914,6 +35914,10 @@ with pkgs;
 
   lguf-brightness = callPackage ../misc/lguf-brightness { };
 
+  lighthouse = callPackage ../applications/blockchains/lighthouse {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   lilypond = callPackage ../misc/lilypond { guile = guile_1_8; };
 
   lilypond-unstable = callPackage ../misc/lilypond/unstable.nix { };


### PR DESCRIPTION
###### Description of changes

[Website](https://lighthouse.sigmaprime.io/).

[Documentation](https://lighthouse-book.sigmaprime.io/).

Closes #185503.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).