### PR TITLE
python3Packages.nvidia-ml-py: init 11.515.48

### DIFF
--- a/pkgs/development/python-modules/nvidia-ml-py/0001-locate-libnvidia-ml.so.1-on-NixOS.patch
+++ b/pkgs/development/python-modules/nvidia-ml-py/0001-locate-libnvidia-ml.so.1-on-NixOS.patch
@@ -1,0 +1,17 @@
+diff --git a/pynvml.py b/pynvml.py
+index 9a424de..669afe0 100644
+--- a/pynvml.py
++++ b/pynvml.py
+@@ -1676,7 +1676,11 @@ def _LoadNvmlLibrary():
+                             nvmlLib = CDLL(os.path.join(os.getenv("ProgramFiles", "C:/Program Files"), "NVIDIA Corporation/NVSMI/nvml.dll"))
+                     else:
+                         # assume linux
+-                        nvmlLib = CDLL("libnvidia-ml.so.1")
++                        try:
++                            nvmlLib = CDLL("libnvidia-ml.so.1")
++                        except OSError:
++                            # Assume NixOS
++                            nvmlLib = CDLL("/run/opengl-driver/lib/libnvidia-ml.so.1")
+                 except OSError as ose:
+                     _nvmlCheckReturn(NVML_ERROR_LIBRARY_NOT_FOUND)
+                 if (nvmlLib == None):

--- a/pkgs/development/python-modules/nvidia-ml-py/default.nix
+++ b/pkgs/development/python-modules/nvidia-ml-py/default.nix
@@ -14,14 +14,14 @@ buildPythonPackage rec {
     hash = "sha256-iNLQu9c8Q3B+FXMObRTtxqE3B/siJIlIlCH6T0rX+sY=";
   };
 
+  patches = [
+    ./0001-locate-libnvidia-ml.so.1-on-NixOS.patch
+  ];
+
   # no tests
   doCheck = false;
 
   pythonImportsCheck = [ "pynvml" ];
-
-  patches = [
-    ./0001-locate-libnvidia-ml.so.1-on-NixOS.patch
-  ];
 
   meta = {
     description = "Python Bindings for the NVIDIA Management Library";

--- a/pkgs/development/python-modules/nvidia-ml-py/default.nix
+++ b/pkgs/development/python-modules/nvidia-ml-py/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+}:
+
+buildPythonPackage rec {
+  pname = "nvidia-ml-py";
+  version = "11.515.48";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "tar.gz";
+    hash = "sha256-iNLQu9c8Q3B+FXMObRTtxqE3B/siJIlIlCH6T0rX+sY=";
+  };
+
+  # no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "pynvml" ];
+
+  patches = [
+    ./0001-locate-libnvidia-ml.so.1-on-NixOS.patch
+  ];
+
+  meta = {
+    description = "Python Bindings for the NVIDIA Management Library";
+    homepage = "https://pypi.org/project/nvidia-ml-py";
+    license = lib.licenses.bsd3;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6289,6 +6289,8 @@ in {
 
   nvchecker = callPackage ../development/python-modules/nvchecker { };
 
+  nvidia-ml-py = callPackage ../development/python-modules/nvidia-ml-py { };
+
   nxt-python = callPackage ../development/python-modules/nxt-python { };
 
   python-nvd3 = callPackage ../development/python-modules/python-nvd3 { };


### PR DESCRIPTION
###### Description of changes

Adding the `nvidia-ml-py` bindings for the NVIDIA Management Library.
This is a requirement for [nvitop](https://github.com/XuehaiPan/nvitop#installation) which I would like to package next.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).