### PR TITLE
chromium: 104.0.5112.101 -> 105.0.5195.52

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -160,6 +160,11 @@ let
       ./patches/no-build-timestamps.patch
       # For bundling Widevine (DRM), might be replaceable via bundle_widevine_cdm=true in gnFlags:
       ./patches/widevine-79.patch
+    ] ++ optionals (chromiumVersionAtLeast "105") [
+      # Required to fix the build with a more recent wayland-protocols version
+      # (we currently package 1.26 in Nixpkgs while Chromium bundles 1.21):
+      # Source: https://bugs.chromium.org/p/angleproject/issues/detail?id=7582#c1
+      ./patches/angle-wayland-include-protocol.patch
     ];
 
     postPatch = ''
@@ -289,10 +294,6 @@ let
       rtc_use_pipewire = true;
       # Disable PGO because the profile data requires a newer compiler version (LLVM 14 isn't sufficient):
       chrome_pgo_phase = 0;
-    } // optionalAttrs (chromiumVersionAtLeast "105") {
-      # https://bugs.chromium.org/p/chromium/issues/detail?id=1334390:
-      use_system_libwayland = false;
-      use_system_wayland_scanner = false;
     } // optionalAttrs proprietaryCodecs {
       # enable support for the H.264 codec
       proprietary_codecs = true;

--- a/pkgs/applications/networking/browsers/chromium/patches/angle-wayland-include-protocol.patch
+++ b/pkgs/applications/networking/browsers/chromium/patches/angle-wayland-include-protocol.patch
@@ -1,0 +1,38 @@
+diff -upr a/third_party/angle/BUILD.gn b/third_party/angle/BUILD.gn
+--- a/third_party/angle/BUILD.gn	2022-08-17 19:38:11.000000000 +0000
++++ b/third_party/angle/BUILD.gn	2022-08-18 11:04:09.061751111 +0000
+@@ -489,6 +489,12 @@ config("angle_vulkan_wayland_config") {
+   if (angle_enable_vulkan && angle_use_wayland &&
+       defined(vulkan_wayland_include_dirs)) {
+     include_dirs = vulkan_wayland_include_dirs
++  } else if (angle_enable_vulkan && angle_use_wayland) {
++    include_dirs = [
++      "$wayland_gn_dir/src/src",
++      "$wayland_gn_dir/include/src",
++      "$wayland_gn_dir/include/protocol",
++    ]
+   }
+ }
+ 
+@@ -1073,6 +1079,7 @@ if (angle_use_wayland) {
+     include_dirs = [
+       "$wayland_dir/egl",
+       "$wayland_dir/src",
++      "$wayland_gn_dir/include/protocol",
+     ]
+   }
+ 
+diff -upr a/third_party/angle/src/third_party/volk/BUILD.gn b/third_party/angle/src/third_party/volk/BUILD.gn
+--- a/third_party/angle/src/third_party/volk/BUILD.gn	2022-08-17 19:38:12.000000000 +0000
++++ b/third_party/angle/src/third_party/volk/BUILD.gn	2022-08-18 11:04:36.499828006 +0000
+@@ -21,6 +21,9 @@ source_set("volk") {
+   configs += [ "$angle_root:angle_no_cfi_icall" ]
+   public_deps = [ "$angle_vulkan_headers_dir:vulkan_headers" ]
+   if (angle_use_wayland) {
+-    include_dirs = [ "$wayland_dir/src" ]
++    include_dirs = [
++      "$wayland_dir/src",
++      "$wayland_gn_dir/include/protocol",
++    ]
+   }
+ }

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -1,21 +1,21 @@
 {
   "stable": {
-    "version": "104.0.5112.101",
-    "sha256": "0nrghgngxdn9richjnxii9y94dg5zpwc3gd3vx609r4xaphibw30",
-    "sha256bin64": "1cj2mi3g5wl376wc52jgqg28h7izbsqm2gji526zkhmgb7rwq4sw",
+    "version": "105.0.5195.52",
+    "sha256": "0hkwjilzy0x28knm6nrkywnsmldhz4kgpnxka2iaghihkjzb4wfw",
+    "sha256bin64": "12wn4vrwakazdcf5wh4m7m5iws8wb30d2vsw128ynq31skmazkn4",
     "deps": {
       "gn": {
-        "version": "2022-06-08",
+        "version": "2022-07-11",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "2ecd43a10266bd091c98e6dcde507c64f6a0dad3",
-        "sha256": "1q06vsz9b4bb764wy1wy8n177z2pgpm97kq3rl1hmq185mz5fhra"
+        "rev": "9ef321772ecc161937db69acb346397e0ccc484d",
+        "sha256": "0j85kgf8c1psys6kfsq5mph8n80hcbzhr7d2blqiiysmjj0wc6ng"
       }
     },
     "chromedriver": {
-      "version": "104.0.5112.79",
-      "sha256_linux": "1naxi6pa5l9ciwzlqimcwqfjsqzyqndg1i0hp6zwh20wfvcfms3w",
-      "sha256_darwin": "0lgls8vsv31apgxjvksqaaiqj78q5v3bs0mnrxhfbw7cbhf6wxk5",
-      "sha256_darwin_aarch64": "11rjqdd65zibhb1gvdwy0slcdpvwh77mkhcj5hdg4hdlysd1a3a2"
+      "version": "105.0.5195.19",
+      "sha256_linux": "0v0dxzd6kal420xpqchyfm7q96caf19mr46lmq3pg0a374wwg9cw",
+      "sha256_darwin": "09dqqv9dnvbqw0dh99953w9l6n2wnplqrf3620apwsjg2krkbaif",
+      "sha256_darwin_aarch64": "01d8di1cmh2ai18k8ly3730vksb1yib7q7wjbk7wkd7wq33gqdcc"
     }
   },
   "beta": {


### PR DESCRIPTION
https://chromereleases.googleblog.com/2022/08/stable-channel-update-for-desktop_30.html

This update includes 24 security fixes.

CVEs:
CVE-2022-3038 CVE-2022-3039 CVE-2022-3040 CVE-2022-3041 CVE-2022-3042
CVE-2022-3043 CVE-2022-3044 CVE-2022-3045 CVE-2022-3046 CVE-2022-3047
CVE-2022-3048 CVE-2022-3049 CVE-2022-3050 CVE-2022-3051 CVE-2022-3052
CVE-2022-3053 CVE-2022-3054 CVE-2022-3055 CVE-2022-3056 CVE-2022-3057
CVE-2022-3058

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Unfortunately the build likely still fails with:
```
building
ninja: Entering directory `out/Release'
[1919/1919] LINK ./mksnapshot.stampmksnapshot.stamptamp.oKorm_v8.oKK)fault)
ninja: Entering directory `out/Release'
[3/3] LINK ./chrome_sandboxome_sandbox/sandbox.o_linux.o
ninja: Entering directory `out/Release'
[10223/51180] CC obj/third_party/fontconfig/fontconfig/fcxml.oK.oolchain/linux/unbundle:default)undle:default)ode_id.oux/unbundle:default)efault)ault)K[Kefault)[KKK[KK[Kundle:default)imization_guide_internals.mojom-webui.js
../../third_party/fontconfig/src/src/fcxml.c:3609:6: warning: ignoring return value of function declared with 'warn_unused_result' attribute [-Wunused-result]
            strerror_r (errno_, ebuf, BUFSIZ);
            ^~~~~~~~~~  ~~~~~~~~~~~~~~~~~~~~
1 warning generated.
[18950/51180] SOLINK ./libvk_swiftshader.sotls_transport_interface/dtls_transport_interface.omputils.o[K.otch.oos.oKx/unbundle:default)fault)ault)
FAILED: libvk_swiftshader.so libvk_swiftshader.so.TOC
python3 "../../build/toolchain/gcc_solink_wrapper.py" --readelf="readelf" --nm="nm"  --sofile="./libvk_swiftshader.so" --tocfile="./libvk_swiftshader.so.TOC" --output="./libvk_swiftshader.so" -- clang++ -shared -Wl,-soname="libvk_swiftshader.so" -Wl,-Bsymbolic -Wl,--version-script=../../third_party/swiftshader/src/Vulkan/vk_swiftshader.lds -fuse-ld=lld -Wl,--fatal-warnings -Wl,--build-id=sha1 -fPIC -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -Wl,--icf=all -Wl,--color-diagnostics -Wl,-mllvm,-instcombine-lower-dbg-declare=0 -flto=thin -Wl,--thinlto-jobs=all -Wl,--thinlto-cache-dir=thinlto-cache -Wl,--thinlto-cache-policy=cache_size=10\%:cache_size_bytes=40g:cache_size_files=100000 -Wl,-mllvm,-import-instr-limit=30 -fwhole-program-vtables -Wl,--no-call-graph-profile-sort -m64 -no-canonical-prefixes -Wl,-O2 -Wl,--gc-sections -rdynamic -Wl,-z,defs -Wl,--as-needed -nostdlib++ -Wl,--lto-O0 -fsanitize=cfi-vcall -fsanitize=cfi-icall -o "./libvk_swiftshader.so" @"./libvk_swiftshader.so.rsp"
ld.lld: error: unable to find library -l:libffi_pic.a
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
[18953/51180] CXX obj/third_party/vulkan-deps/vulkan-validation-layers/src/VkLayer_khronos_validation/chassis.o
ninja: build stopped: subcommand failed.
```

I've gotten too slow and haven't found a solution yet.
The main references to this problem I found so far:
- https://bugs.chromium.org/p/chromium/issues/detail?id=1334390#c14
- https://bkhome.org/news/202109/chromium-compiled-for-12-hours-before-failing.html

Unfortunately, we currently don't even seem to have a `libffi` package that provides `libffi_pic.a` in Nixpkgs.
However, the Arch Linux build doesn't seem to require `libffi` (`libffi_pic.a`).

Some Chromium source-code references:
- https://github.com/chromium/chromium/commit/188513754c7ff05e7775e6cb2621ee006ebdbf6c
- https://source.chromium.org/chromium/chromium/src/+/refs/tags/105.0.5195.52:build/config/linux/libffi/BUILD.gn
- https://source.chromium.org/chromium/chromium/src/+/main:third_party/swiftshader/src/Vulkan/BUILD.gn;drc=74c7113afb497ccb5c6be769d3c55618bde308b6

Help is really welcome as I'm not sure yet if I'll have the time and skills to resolve this soon enough.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
