### PR TITLE
ocamlPackages.plotkicadsch: init at 0.9

### DIFF
--- a/pkgs/development/ocaml-modules/git/unix.nix
+++ b/pkgs/development/ocaml-modules/git/unix.nix
@@ -26,7 +26,7 @@ buildDunePackage {
     astring cohttp-lwt-unix decompress
     domain-name ipaddr mtime mirage-flow
     cstruct ptime mimic ca-certs-nss
-    tls tls-mirage
+    tls tls-mirage git
   ];
   checkInputs = [
     alcotest alcotest-lwt base64 ke

--- a/pkgs/development/ocaml-modules/kicadsch/default.nix
+++ b/pkgs/development/ocaml-modules/kicadsch/default.nix
@@ -1,0 +1,23 @@
+{ lib
+, buildDunePackage
+, fetchurl
+}:
+
+buildDunePackage rec {
+  pname = "kicadsch";
+  version = "0.9.0";
+
+  minimalOCamlVersion = "4.07";
+
+  src = fetchurl {
+    url = "https://github.com/jnavila/plotkicadsch/releases/download/v${version}/plotkicadsch-${version}.tbz";
+    sha256 = "sha256-B+vnEPyd3SUzviTdNoyvYk0p7Hrg/XTJm8KxsY8A4jQ=";
+  };
+
+  meta = with lib; {
+    description = "OCaml library for exporting Kicad Sch files to SVG pictures";
+    homepage = "https://github.com/jnavila/plotkicadsch";
+    license = licenses.isc;
+    maintainers = with maintainers; [ leungbk ];
+  };
+}

--- a/pkgs/development/ocaml-modules/plotkicadsch/default.nix
+++ b/pkgs/development/ocaml-modules/plotkicadsch/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, buildDunePackage
+, fetchFromGitHub
+, substituteAll
+, base64
+, cmdliner
+, digestif
+, git-unix
+, kicadsch
+, lwt
+, lwt_ppx
+, sha
+, tyxml
+, coreutils
+, imagemagick
+}:
+
+buildDunePackage rec {
+  pname = "plotkicadsch";
+
+  inherit (kicadsch) src version;
+
+  minimalOCamlVersion = "4.09";
+
+  patches = [
+    (substituteAll {
+      src = ./fix-paths.patch;
+      inherit coreutils imagemagick;
+    })
+  ];
+
+  buildInputs = [
+    base64
+    cmdliner
+    digestif
+    git-unix
+    kicadsch
+    lwt
+    lwt_ppx
+    sha
+    tyxml
+  ];
+
+  meta = with lib; {
+    description = "A tool to export Kicad Sch files to SVG pictures";
+    homepage = "https://github.com/jnavila/plotkicadsch";
+    license = licenses.isc;
+    maintainers = with maintainers; [ leungbk ];
+  };
+}

--- a/pkgs/development/ocaml-modules/plotkicadsch/fix-paths.patch
+++ b/pkgs/development/ocaml-modules/plotkicadsch/fix-paths.patch
@@ -1,0 +1,26 @@
+diff --git a/plotkicadsch/src/git-imgdiff b/plotkicadsch/src/git-imgdiff
+index cbddecb..8d21a8a 100755
+--- a/plotkicadsch/src/git-imgdiff
++++ b/plotkicadsch/src/git-imgdiff
+@@ -1,4 +1,4 @@
+ #!/bin/bash
+ PIPE=$(mktemp -u)
+-(! compare -metric RMSE $2 $1 png:${PIPE} 2> /dev/null) &&  (montage -geometry +4+4 $2 $PIPE $1 png:- | display -title "$1" -)
++(! @imagemagick@/bin/compare -metric RMSE $2 $1 png:${PIPE} 2> /dev/null) &&  (@imagemagick@/bin/montage -geometry +4+4 $2 $PIPE $1 png:- | @imagemagick@/bin/display -title "$1" -)
+ rm $PIPE
+diff --git a/plotkicadsch/src/sysAbst.ml b/plotkicadsch/src/sysAbst.ml
+index c3c7b52..15db6d4 100644
+--- a/plotkicadsch/src/sysAbst.ml
++++ b/plotkicadsch/src/sysAbst.ml
+@@ -30,7 +30,7 @@ let detect_os () : os =
+   if Sys.win32 then Windows
+   else if Sys.cygwin then Cygwin
+   else
+-    let ((in_ch, _, _) as uname) = UnixLabels.open_process_full "uname" ~env:[| |] in
++    let ((in_ch, _, _) as uname) = UnixLabels.open_process_full "@coreutils@/bin/uname" ~env:[| |] in
+     let os = input_line in_ch in
+     ignore (UnixLabels.close_process_full uname) ;
+     match os with
+-- 
+2.37.1
+

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -664,6 +664,8 @@ let
 
     ke = callPackage ../development/ocaml-modules/ke { };
 
+    kicadsch = callPackage ../development/ocaml-modules/kicadsch { };
+
     lablgl = callPackage ../development/ocaml-modules/lablgl { };
 
     lablgtk3 = callPackage ../development/ocaml-modules/lablgtk3 { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1147,6 +1147,10 @@ let
 
     piqi-ocaml = callPackage ../development/ocaml-modules/piqi-ocaml { };
 
+    plotkicadsch = callPackage ../development/ocaml-modules/plotkicadsch {
+      inherit (pkgs) coreutils imagemagick;
+    };
+
     posix-base = callPackage ../development/ocaml-modules/posix/base.nix { };
 
     posix-socket = callPackage ../development/ocaml-modules/posix/socket.nix { };


### PR DESCRIPTION
###### Description of changes

Also added ocamlPackages.git to the propagatedBuildInputs of ocamlPackages.git-unix to allow plotkicadsch to build properly.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->