### PR TITLE
nixos-generate-config: generate flake.nix alongside configuration.nix

### DIFF
--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -632,6 +632,18 @@ EOF
     }
 }
 
+my $flakeConfig = <<EOF;
+{
+  outputs = { self, nixpkgs }: {
+    nixosConfigurations.nixos = nixpkgs.lib.nixosSystem {
+      modules = [
+        ./configuration.nix
+      ];
+    };
+  };
+}
+EOF
+
 if ($showHardwareConfig) {
     print STDOUT $hwConfig;
 } else {
@@ -647,10 +659,13 @@ if ($showHardwareConfig) {
     mkpath($outDir, 0, 0755);
     write_file($fn, $hwConfig);
 
-    # Generate a basic configuration.nix, unless one already exists.
+    # Generate a basic configuration.nix and flake.nix, unless one already exists.
     $fn = "$outDir/configuration.nix";
-    if ($force || ! -e $fn) {
+    my $flakeFn = "$outDir/flake.nix";
+    if ($force || ! -e $fn || ! -e $flakeFn) {
         print STDERR "writing $fn...\n";
+        print STDERR "writing $flakeFn...\n";
+        write_file($flakeFn, $flakeConfig);
 
         my $bootLoaderConfig = "";
         if (-e "/sys/firmware/efi/efivars") {
@@ -693,6 +708,7 @@ EOF
         print STDERR "For more hardware-specific settings, see https://github.com/NixOS/nixos-hardware.\n"
     } else {
         print STDERR "warning: not overwriting existing $fn\n";
+        print STDERR "warning: not overwriting existing $flakeFn\n";
     }
 }
 


### PR DESCRIPTION
###### Description of changes

As part of a desire to help stabilize flakes, I've made `nixos-generate-config` create a `flake.nix` which simply imports the `configuration.nix` that is already generated as part of `nixos-generate-config`

The flake.nix looks like this

```nix
{
  outputs = { self, nixpkgs }: {
    nixosConfigurations.nixos = nixpkgs.lib.nixosSystem {
      modules = [
        ./configuration.nix
      ];
    };
  };
}
```

The `system` is already defined in `hardware-configuration.nix`, and I attempted many times to find ways to generate the `inputs` attribute set, containing `nixpkgs`. However, it seems too brittle to attempt to generate the `inputs` from `nix-instantiate --impure --eval --expr '(import <nixpkgs> {}).lib.trivial.release'`, since this can return `22.11`, which would not be a branch/release that would not exist on Github for NixOS depending on the time of running the script. So I've left the decision up to the `nix registry` to resolve, by omitting the `inputs` attribute.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
