### PR TITLE
fwupd: 1.8.3 → 1.8.4

### DIFF
--- a/nixos/modules/services/hardware/fwupd.nix
+++ b/nixos/modules/services/hardware/fwupd.nix
@@ -126,6 +126,8 @@ in {
     services.udev.packages = [ cfg.package ];
 
     systemd.packages = [ cfg.package ];
+
+    security.polkit.enable = true;
   };
 
   meta = {

--- a/pkgs/os-specific/linux/firmware/fwupd/add-option-for-installation-sysconfdir.patch
+++ b/pkgs/os-specific/linux/firmware/fwupd/add-option-for-installation-sysconfdir.patch
@@ -1,5 +1,16 @@
+diff --git a/data/bios-settings.d/meson.build b/data/bios-settings.d/meson.build
+index b0ff5b106..13ac380d0 100644
+--- a/data/bios-settings.d/meson.build
++++ b/data/bios-settings.d/meson.build
+@@ -1,5 +1,5 @@
+ if build_standalone and host_machine.system() == 'linux'
+ install_data('README.md',
+-  install_dir: join_paths(sysconfdir, 'fwupd', 'bios-settings.d')
++  install_dir: join_paths(sysconfdir_install, 'fwupd', 'bios-settings.d')
+ )
+ endif
 diff --git a/data/meson.build b/data/meson.build
-index d8494020d..7c896fa0d 100644
+index 3a77a7bfc..747bd1988 100644
 --- a/data/meson.build
 +++ b/data/meson.build
 @@ -26,7 +26,7 @@ endif
@@ -83,7 +94,7 @@ index 1d1698a7e..5469d00a6 100644
 +  install_dir: join_paths(sysconfdir_install, 'fwupd', 'remotes.d'),
  )
 diff --git a/meson.build b/meson.build
-index e6b717078..f8a7a7455 100644
+index e7980e965..2c66e2dc4 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -195,6 +195,12 @@ endif
@@ -100,7 +111,7 @@ index e6b717078..f8a7a7455 100644
  gio = dependency('gio-2.0', version: '>= 2.45.8')
  giounix = dependency('gio-unix-2.0', version: '>= 2.45.8', required: false)
 diff --git a/meson_options.txt b/meson_options.txt
-index 06d242371..d9e517fc0 100644
+index 6cf92e72e..2e8568292 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
 @@ -1,3 +1,4 @@
@@ -121,7 +132,7 @@ index 67bd3b9d9..ad04a91b6 100644
  )
  endif
 diff --git a/plugins/msr/meson.build b/plugins/msr/meson.build
-index 13f03ccd4..9235ebe33 100644
+index d626c3ad3..5a2f847d5 100644
 --- a/plugins/msr/meson.build
 +++ b/plugins/msr/meson.build
 @@ -10,7 +10,7 @@ install_data(['fwupd-msr.conf'],

--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -114,7 +114,7 @@ let
 
   self = stdenv.mkDerivation rec {
     pname = "fwupd";
-    version = "1.8.3";
+    version = "1.8.4";
 
     # libfwupd goes to lib
     # daemon, plug-ins and libfwupdplugin go to out
@@ -123,7 +123,7 @@ let
 
     src = fetchurl {
       url = "https://people.freedesktop.org/~hughsient/releases/fwupd-${version}.tar.xz";
-      sha256 = "sha256-ciIpd86KhmJRH/o8CIFWb2xFjsjWHSUNlGYRfWEiOOw=";
+      sha256 = "sha256-rfoHQ0zcKexBxA/vRg6Nlwlj/gx+hJ3sfzkyrbFh+IY=";
     };
 
     patches = [
@@ -322,6 +322,7 @@ let
 
     passthru = {
       filesInstalledToEtc = [
+        "fwupd/bios-settings.d/README.md"
         "fwupd/daemon.conf"
         "fwupd/remotes.d/lvfs-testing.conf"
         "fwupd/remotes.d/lvfs.conf"


### PR DESCRIPTION
###### Description of changes

https://github.com/fwupd/fwupd/releases/tag/1.8.4
https://blogs.gnome.org/hughsie/2022/08/30/new-fwupd-1-8-4-release/

Required for https://github.com/NixOS/nixpkgs/pull/182618

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
