### PR TITLE
bcc: 0.24.0 -> 0.25.0; bpftrace: 0.15.0 -> 0.16.0

### DIFF
--- a/pkgs/os-specific/linux/bcc/default.nix
+++ b/pkgs/os-specific/linux/bcc/default.nix
@@ -7,7 +7,7 @@
 
 python.pkgs.buildPythonApplication rec {
   pname = "bcc";
-  version = "0.24.0";
+  version = "0.25.0";
 
   disabled = !stdenv.isLinux;
 
@@ -15,7 +15,7 @@ python.pkgs.buildPythonApplication rec {
     owner = "iovisor";
     repo = "bcc";
     rev = "v${version}";
-    sha256 = "sha256-5Nq6LmphiyiiIyru/P2rCCmA25cwJIWn08oK1+eM3cQ=";
+    sha256 = "sha256-05FQWBxFI8bxjm6vDCoEqqpAd4Agn84M28P3G6F3tag=";
   };
   format = "other";
 

--- a/pkgs/os-specific/linux/bpftrace/default.nix
+++ b/pkgs/os-specific/linux/bpftrace/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch
+{ lib, stdenv, fetchFromGitHub
 , cmake, pkg-config, flex, bison
 , llvmPackages, elfutils
 , libbfd, libbpf, libopcodes, bcc
@@ -9,43 +9,14 @@
 
 stdenv.mkDerivation rec {
   pname = "bpftrace";
-  version = "0.15.0";
-
-  # Cherry-picked from merged PR, remove this hook on next update
-  # https://github.com/iovisor/bpftrace/pull/2242
-  # Cannot `fetchpatch` such pure renaming diff since
-  # https://github.com/iovisor/bpftrace/commit/2df807dbae4037aa8bf0afc03f52fb3f6321c62a.patch
-  # does not contain any diff in unified format but just this instead:
-  #   ...
-  #   man/man8/{bashreadline.8 => bashreadline.bt.8}     | 0
-  #   ...
-  #   35 files changed, 0 insertions(+), 0 deletions(-)
-  #   rename man/man8/{bashreadline.8 => bashreadline.bt.8} (100%)
-  #   ...
-  # on witch `fetchpatch` fails with
-  #   error: Normalized patch '/build/patch' is empty (while the fetched file was not)!
-  #   Did you maybe fetch a HTML representation of a patch instead of a raw patch?
-  postUnpack = ''
-    rename .8 .bt.8 "$sourceRoot"/man/man8/*.8
-  '';
+  version = "0.16.0";
 
   src = fetchFromGitHub {
     owner  = "iovisor";
     repo   = "bpftrace";
     rev    = "v${version}";
-    sha256 = "sha256-9adZAKSn00W2yNwVDbVB1/O5Y+10c4EkVJGCHyd4Tgg=";
+    sha256 = "sha256-S43KS/qpzxU+Sgkcud4Cyx4yRjaT6SZzLv6R6bg5I2w=";
   };
-
-  patches = [
-    # Pull upstream fix for binutils-2.39:
-    #   https://github.com/iovisor/bpftrace/pull/2328
-    (fetchpatch {
-      name = "binutils-2.39.patch";
-      url = "https://github.com/iovisor/bpftrace/commit/3be6e708d514d3378a4fe985ab907643ecbc77ee.patch";
-      sha256 = "sha256-WWEh8ViGw8053nEG/29KeKEHV5ossWPtL/AAV/l+pnY=";
-      excludes = [ "CHANGELOG.md" ];
-    })
-  ];
 
   buildInputs = with llvmPackages;
     [ llvm libclang
@@ -64,22 +35,13 @@ stdenv.mkDerivation rec {
   cmakeFlags =
     [ "-DBUILD_TESTING=FALSE"
       "-DLIBBCC_INCLUDE_DIRS=${bcc}/include"
+      "-DINSTALL_TOOL_DOCS=off"
     ];
 
-  # nuke the example/reference output .txt files, for the included tools,
-  # stuffed inside $out. we don't need them at all.
-  # (see "Allow skipping examples" for a potential option
-  #  https://github.com/iovisor/bpftrace/pull/2256)
-  #
   # Pull BPF scripts into $PATH (next to their bcc program equivalents), but do
   # not move them to keep `${pkgs.bpftrace}/share/bpftrace/tools/...` working.
-  # (remove `chmod` once a new release "Add executable permission to tools"
-  #  https://github.com/iovisor/bpftrace/commit/77e524e6d276216ed6a6e1984cf204418db07c78)
   postInstall = ''
-    rm -rf $out/share/bpftrace/tools/doc
-
     ln -s $out/share/bpftrace/tools/*.bt $out/bin/
-    chmod +x $out/bin/*.bt
   '';
 
   outputs = [ "out" "man" ];

--- a/pkgs/os-specific/linux/oci-seccomp-bpf-hook/default.nix
+++ b/pkgs/os-specific/linux/oci-seccomp-bpf-hook/default.nix
@@ -10,12 +10,12 @@
 
 buildGoModule rec {
   pname = "oci-seccomp-bpf-hook";
-  version = "1.2.6";
+  version = "1.2.8";
   src = fetchFromGitHub {
     owner = "containers";
     repo = "oci-seccomp-bpf-hook";
     rev = "v${version}";
-    sha256 = "sha256-+HGVxPBCPIdFwzZf3lFE0MWA2xMKsHQkfDo4zyNgzpg=";
+    sha256 = "sha256-0SSiVnCWs3NLefnmZn1oCc7nwTrSzDsyjPszVBRQVH0=";
   };
   vendorSha256 = null;
 

--- a/pkgs/servers/monitoring/grafana-agent/default.nix
+++ b/pkgs/servers/monitoring/grafana-agent/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub, systemd, nixosTests, bcc }:
+{ lib, buildGoModule, fetchFromGitHub, systemd, nixosTests }:
 
 buildGoModule rec {
   pname = "grafana-agent";
@@ -27,6 +27,7 @@ buildGoModule rec {
 
   tags = [
     "nonetwork"
+    "noebpf"
     "nodocker"
   ];
 
@@ -38,8 +39,6 @@ buildGoModule rec {
   # uses go-systemd, which uses libsystemd headers
   # https://github.com/coreos/go-systemd/issues/351
   NIX_CFLAGS_COMPILE = [ "-I${lib.getDev systemd}/include" ];
-
-  buildInputs = [ bcc ];
 
   # tries to access /sys: https://github.com/grafana/agent/issues/333
   preBuild = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16751,12 +16751,14 @@ with pkgs;
   bpftools = callPackage ../os-specific/linux/bpftools { };
 
   bcc = callPackage ../os-specific/linux/bcc {
-    python = pkgs.python3;
+    python = python3;
     libbpf = libbpf_1;
+    llvmPackages = llvmPackages_14;
   };
 
   bpftrace = callPackage ../os-specific/linux/bpftrace {
-    libbpf = libbpf_1
+    libbpf = libbpf_1;
+    llvmPackages = llvmPackages_14;
   };
 
   bpm-tools = callPackage ../tools/audio/bpm-tools { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5092,6 +5092,8 @@ with pkgs;
 
   oci-cli = callPackage ../tools/admin/oci-cli { };
 
+  oci-seccomp-bpf-hook = callPackage ../os-specific/linux/oci-seccomp-bpf-hook { };
+
   ocrmypdf = with python3.pkgs; toPythonApplication ocrmypdf;
 
   ocrfeeder = callPackage ../applications/graphics/ocrfeeder { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16755,7 +16755,9 @@ with pkgs;
     libbpf = libbpf_1;
   };
 
-  bpftrace = callPackage ../os-specific/linux/bpftrace { };
+  bpftrace = callPackage ../os-specific/linux/bpftrace {
+    libbpf = libbpf_1
+  };
 
   bpm-tools = callPackage ../tools/audio/bpm-tools { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16752,6 +16752,7 @@ with pkgs;
 
   bcc = callPackage ../os-specific/linux/bcc {
     python = pkgs.python3;
+    libbpf = libbpf_1;
   };
 
   bpftrace = callPackage ../os-specific/linux/bpftrace { };

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -254,6 +254,7 @@ in {
     # Obsolete aliases (these packages do not depend on the kernel).
     inherit (pkgs) odp-dpdk pktgen; # added 2018-05
     inherit (pkgs) bcc bpftrace; # added 2021-12
+    inherit (pkgs) oci-seccomp-bpf-hook; # added 2022-11
 
     acpi_call = callPackage ../os-specific/linux/acpi-call {};
 
@@ -420,8 +421,6 @@ in {
     ndiswrapper = callPackage ../os-specific/linux/ndiswrapper { };
 
     netatop = callPackage ../os-specific/linux/netatop { };
-
-    oci-seccomp-bpf-hook = if lib.versionAtLeast kernel.version "5.4" then callPackage ../os-specific/linux/oci-seccomp-bpf-hook { } else null;
 
     perf = callPackage ../os-specific/linux/kernel/perf { };
 


### PR DESCRIPTION
###### Description of changes

upgrade to latest bcc/bpftrace (bcc upgrade breaks older bpftrace, so PR grouped together)

I've tested the tools still work with default llvm 11, but it's old so upgrading it makes more sense to have better tested code paths

I've also tested the PR with #187978 (libbpf 1.0) -- the tools work with either version of libbpf

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
