### PR TITLE
[release-22.05] nearcore: 1.27.0 -> 1.28.1

### DIFF
--- a/pkgs/applications/blockchains/nearcore/0001-make-near-test-contracts-optional.patch
+++ b/pkgs/applications/blockchains/nearcore/0001-make-near-test-contracts-optional.patch
@@ -1,0 +1,42 @@
+From 14635f8a87423f7682e22c4d4bc34551cfe1d10d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=B6rg=20Thalheim?= <joerg@thalheim.io>
+Date: Thu, 30 Jun 2022 07:33:44 +0000
+Subject: [PATCH] make near-test-contracts optional
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Jörg Thalheim <joerg@thalheim.io>
+---
+ Cargo.lock                    | 1 -
+ tools/state-viewer/Cargo.toml | 2 +-
+ 2 files changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index e1d8b2a83..3317587f5 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -5253,7 +5253,6 @@ dependencies = [
+  "near-primitives",
+  "near-primitives-core",
+  "near-store",
+- "near-test-contracts",
+  "nearcore",
+  "node-runtime",
+  "once_cell",
+diff --git a/tools/state-viewer/Cargo.toml b/tools/state-viewer/Cargo.toml
+index 02346bf71..51cfc4cb5 100644
+--- a/tools/state-viewer/Cargo.toml
++++ b/tools/state-viewer/Cargo.toml
+@@ -30,7 +30,7 @@ near-network = { path = "../../chain/network" }
+ near-primitives = { path = "../../core/primitives" }
+ near-primitives-core = { path = "../../core/primitives-core" }
+ near-store = { path = "../../core/store" }
+-near-test-contracts = { path = "../../runtime/near-test-contracts" }
++#near-test-contracts = { path = "../../runtime/near-test-contracts" }
+ nearcore = { path = "../../nearcore" }
+ node-runtime = { path = "../../runtime/runtime" }
+ 
+-- 
+2.36.1
+

--- a/pkgs/applications/blockchains/nearcore/default.nix
+++ b/pkgs/applications/blockchains/nearcore/default.nix
@@ -5,7 +5,7 @@
 
 rust_1_61.packages.stable.rustPlatform.buildRustPackage rec {
   pname = "nearcore";
-  version = "1.28.0";
+  version = "1.28.1";
 
   # https://github.com/near/nearcore/tags
   src = fetchFromGitHub {
@@ -14,10 +14,10 @@ rust_1_61.packages.stable.rustPlatform.buildRustPackage rec {
     # there is also a branch for this version number, so we need to be explicit
     rev = "refs/tags/${version}";
 
-    sha256 = "sha256-DRVlD74XTYgy3GeUd/7OIl2aie8nEJLmrmmkwPRkrA8=";
+    sha256 = "sha256-lAbVcmr8StAZAII++21xiBd4tRcdprefvcGzPLIjl74=";
   };
 
-  cargoSha256 = "sha256-hTqje17EdVkgqReuLnizaK3cBJuqXJXC6x5NuoKJLbs=";
+  cargoSha256 = "sha256-1aoL5fbKZ4XZ1ELVDWNDFHDL2FyNuoX/DVb0h8RWBxI=";
   cargoPatches = [ ./0001-make-near-test-contracts-optional.patch ];
 
   postPatch = ''

--- a/pkgs/applications/blockchains/nearcore/default.nix
+++ b/pkgs/applications/blockchains/nearcore/default.nix
@@ -1,10 +1,11 @@
-{ rustPlatform, lib, fetchFromGitHub
+{ rust_1_61, lib, fetchFromGitHub
 , zlib, openssl
 , pkg-config, protobuf, llvmPackages
 }:
-rustPlatform.buildRustPackage rec {
+
+rust_1_61.packages.stable.rustPlatform.buildRustPackage rec {
   pname = "nearcore";
-  version = "1.27.0";
+  version = "1.28.0";
 
   # https://github.com/near/nearcore/tags
   src = fetchFromGitHub {
@@ -12,10 +13,12 @@ rustPlatform.buildRustPackage rec {
     repo = "nearcore";
     # there is also a branch for this version number, so we need to be explicit
     rev = "refs/tags/${version}";
-    sha256 = "sha256-B9HqUa0mBSvsCPzxPt4NqpV99rV4lmQ9Q/z9lxob9oM=";
+
+    sha256 = "sha256-DRVlD74XTYgy3GeUd/7OIl2aie8nEJLmrmmkwPRkrA8=";
   };
 
-  cargoSha256 = "sha256-6GIt3J6y/O8XaHQJKRSPRgK2XbghMLif4e2Btdww9Ng=";
+  cargoSha256 = "sha256-hTqje17EdVkgqReuLnizaK3cBJuqXJXC6x5NuoKJLbs=";
+  cargoPatches = [ ./0001-make-near-test-contracts-optional.patch ];
 
   postPatch = ''
     substituteInPlace neard/build.rs \


### PR DESCRIPTION
###### Description of changes

includes: https://github.com/NixOS/nixpkgs/pull/188965

Backports of the latest version are necessary or else the client won't be able to participate in the near network.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
