### PR TITLE
nixos/modules/programs/dconf: redesign profiles

### DIFF
--- a/lib/dconf.nix
+++ b/lib/dconf.nix
@@ -1,0 +1,15 @@
+{ lib }:
+
+# This module contains helpers for the `programs.dconf` NixOS module
+
+rec {
+  types = {
+    tuple = "_tuple";
+  };
+
+  mkTuple = _elements: {
+    inherit _elements;
+
+    _type = types.tuple;
+  };
+}

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -42,6 +42,7 @@ let
 
     # serialization
     cli = callLibs ./cli.nix;
+    dconf = callLibs ./dconf.nix;
     generators = callLibs ./generators.nix;
 
     # misc

--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -127,6 +127,18 @@
       </listitem>
       <listitem>
         <para>
+          The <literal>programs.dconf</literal> module now supports
+          configuration using the Nix language. This allows you to
+          configure settings of apps and DEs (if they use
+          <literal>dconf</literal>) declaratively without having to use
+          <literal>extraGSettingsOverrides</literal> which has some
+          problems noted in
+          <link xlink:href="https://github.com/NixOS/nixpkgs/issues/54150">this
+          issue</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           PHP now defaults to PHP 8.1, updated from 8.0.
         </para>
       </listitem>
@@ -649,6 +661,14 @@
           because of stability and compatibility issues. Users who still
           wish to remain using GTK can do so by using
           <literal>emacs-gtk</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The option <literal>programs.dconf.packages</literal> has been
+          removed, use
+          <literal>programs.dconf.profiles.user.databases</literal>
+          instead.
         </para>
       </listitem>
       <listitem>

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -51,6 +51,11 @@ In addition to numerous new and upgraded packages, this release has the followin
   Alternatively, you can remove the `hostPlatform` line and use NixOS like you
   would in NixOS 22.05 and earlier.
 
+- The `programs.dconf` module now supports configuration using the Nix language.
+  This allows you to configure settings of apps and DEs (if they use `dconf`)
+  declaratively without having to use `extraGSettingsOverrides` which has some
+  problems noted in [this issue](https://github.com/NixOS/nixpkgs/issues/54150).
+
 - PHP now defaults to PHP 8.1, updated from 8.0.
 
 - `protonup` has been aliased to and replaced by `protonup-ng` due to upstream not maintaining it.
@@ -211,6 +216,8 @@ Available as [services.patroni](options.html#opt-services.patroni.enable).
 
 - Emacs now uses the Lucid toolkit by default instead of GTK because of stability and compatibility issues.
   Users who still wish to remain using GTK can do so by using `emacs-gtk`.
+
+- The option `programs.dconf.packages` has been removed, use `programs.dconf.profiles.user.databases` instead.
 
 - riak package removed along with `services.riak` module, due to lack of maintainer to update the package.
 

--- a/nixos/modules/i18n/input-method/ibus.nix
+++ b/nixos/modules/i18n/input-method/ibus.nix
@@ -66,7 +66,7 @@ in
     # Without dconf enabled it is impossible to use IBus
     programs.dconf.enable = true;
 
-    programs.dconf.packages = [ ibusPackage ];
+    programs.dconf.profiles.ibus.databases = [ (pkgs.dconf-utils.mkDconfDb "${ibusPackage}/etc/dconf/db/ibus.d") ];
 
     services.dbus.packages = [
       ibusPackage

--- a/nixos/modules/services/x11/display-managers/gdm.nix
+++ b/nixos/modules/services/x11/display-managers/gdm.nix
@@ -229,39 +229,13 @@ in
 
     systemd.user.services.dbus.wantedBy = [ "default.target" ];
 
-    programs.dconf.profiles.gdm =
-    let
-      customDconf = pkgs.writeTextFile {
-        name = "gdm-dconf";
-        destination = "/dconf/gdm-custom";
-        text = ''
-          ${optionalString (!cfg.gdm.autoSuspend) ''
-            [org/gnome/settings-daemon/plugins/power]
-            sleep-inactive-ac-type='nothing'
-            sleep-inactive-battery-type='nothing'
-            sleep-inactive-ac-timeout=0
-            sleep-inactive-battery-timeout=0
-          ''}
-        '';
+    programs.dconf.profiles.gdm.databases = [ "${gdm}/share/gdm/greeter-dconf-defaults" ] ++ lib.lists.optional cfg.gdm.autoSuspend {
+      org.gnome.settings-daemon.plugins.power = {
+        sleep-inactive-ac-type = "nothing";
+        sleep-inactive-battery-type = "nothing";
+        sleep-inactive-ac-timeout = 0;
+        sleep-inactive-battery-timeout = 0;
       };
-
-      customDconfDb = pkgs.stdenv.mkDerivation {
-        name = "gdm-dconf-db";
-        buildCommand = ''
-          ${pkgs.dconf}/bin/dconf compile $out ${customDconf}/dconf
-        '';
-      };
-    in pkgs.stdenv.mkDerivation {
-      name = "dconf-gdm-profile";
-      buildCommand = ''
-        # Check that the GDM profile starts with what we expect.
-        if [ $(head -n 1 ${gdm}/share/dconf/profile/gdm) != "user-db:user" ]; then
-          echo "GDM dconf profile changed, please update gdm.nix"
-          exit 1
-        fi
-        # Insert our custom DB behind it.
-        sed '2ifile-db:${customDconfDb}' ${gdm}/share/dconf/profile/gdm > $out
-      '';
     };
 
     # Use AutomaticLogin if delay is zero, because it's immediate.

--- a/pkgs/development/libraries/dconf/utils.nix
+++ b/pkgs/development/libraries/dconf/utils.nix
@@ -1,0 +1,10 @@
+{ runCommand, dconf }:
+
+{
+  # Builds a dconf database from a keyfile directory
+  mkDconfDb = dir: runCommand "dconf-db" {
+    nativeBuildInputs = [ dconf ];
+  } ''
+    dconf compile $out ${dir}
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3703,6 +3703,8 @@ with pkgs;
 
   dconf = callPackage ../development/libraries/dconf { };
 
+  dconf-utils = callPackage ../development/libraries/dconf/utils.nix { };
+
   ddate = callPackage ../tools/misc/ddate { };
 
   ddosify = callPackage ../development/tools/ddosify { };


### PR DESCRIPTION
###### Description of changes

This PR is a redesign of the NixOS dconf module and provides a way to solve the issues noted in https://github.com/NixOS/nixpkgs/issues/54150.

If merged, it presents an alternative to `extraGSettingsOverrides` that is more reliable as the user can disable overriding options with `enableUserDb = false;`. Users can store their configurations both as dconf keyfiles or as Nix expressions.

This is how the module can be used:
```nix
{
  # With keyfiles
  programs.dconf.profiles.user.databases = lib.singleton (pkgs.dconf-utils.mkDconfDb ./files/dconf);

  # With a Nix expression
  programs.dconf.profiles.user.databases = with lib.dconf; lib.singleton {
    org.gnome.shell = {
      disable-user-extensions = true;
      favorite-apps = [ "firefox.desktop" "thunderbird.desktop" ];
      welcome-dialog-last-shown-version = "999";
    };

    org.gnome.desktop.input-sources = {
      sources = [
        (mkTuple [ "xkb" "en" ])
      ];
      xkb-options = [ "terminate:ctrl_alt_bksp" ];
    };
  };
}
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
