### PR TITLE
Add missing deps to supertux

### DIFF
--- a/pkgs/games/supertux/default.nix
+++ b/pkgs/games/supertux/default.nix
@@ -1,6 +1,21 @@
-{ lib, stdenv, fetchurl, cmake, pkg-config, SDL2, SDL2_image , curl
-, libogg, libvorbis, libGLU, libGL, openal, boost, glew
-, libpng, freetype, glm
+{ lib
+, stdenv
+, fetchurl
+, cmake
+, pkg-config
+, SDL2
+, SDL2_image
+, curl
+, libogg
+, libvorbis
+, libGLU
+, libGL
+, openal
+, boost
+, glew
+, libpng
+, freetype
+, glm
 }:
 
 stdenv.mkDerivation rec {
@@ -14,8 +29,20 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config cmake ];
 
-  buildInputs = [ SDL2 SDL2_image curl libogg libvorbis libGLU libGL openal boost glew
-    libpng freetype glm
+  buildInputs = [
+    SDL2
+    SDL2_image
+    curl
+    libogg
+    libvorbis
+    libGLU
+    libGL
+    openal
+    boost
+    glew
+    libpng
+    freetype
+    glm
   ];
 
   cmakeFlags = [ "-DENABLE_BOOST_STATIC_LIBS=OFF" ];

--- a/pkgs/games/supertux/default.nix
+++ b/pkgs/games/supertux/default.nix
@@ -10,6 +10,9 @@
 , libvorbis
 , libGLU
 , libGL
+, libSM
+, libICE
+, libXext
 , openal
 , boost
 , glew
@@ -37,6 +40,9 @@ stdenv.mkDerivation rec {
     libvorbis
     libGLU
     libGL
+    libSM
+    libICE
+    libXext
     openal
     boost
     glew


### PR DESCRIPTION
###### Description of changes

`supertux` doesn't start with 
```
supertux2: error while loading shared libraries: libSM.so.6: cannot open shared object file: No such file or directory
```

- Added a missing dependencies
- Formatted the file modified files nixpkgs-fmt


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

CC @pSub 