### PR TITLE
styx: 0.7.2 -> 0.7.5

### DIFF
--- a/pkgs/applications/misc/styx/default.nix
+++ b/pkgs/applications/misc/styx/default.nix
@@ -1,16 +1,16 @@
 { lib, stdenv, fetchFromGitHub, caddy, asciidoctor
 , file, lessc, sass, multimarkdown, linkchecker
-, perlPackages, python27 }:
+, perlPackages, python3Packages }:
 
 stdenv.mkDerivation rec {
   pname = "styx";
-  version = "0.7.2";
+  version = "0.7.5";
 
   src = fetchFromGitHub {
     owner  = "styx-static";
     repo   = "styx";
-    rev    = "0f0a878156eac416620a177cc030fa9f2f69b1b8";
-    sha256 = "0ig456j1s17w4zhhcmkrskpy6n7061v5f2isa3qhipmn0gwb91af";
+    rev    = "v${version}";
+    hash = "sha256-f6iA/nHpKnm3BALoQq8SzdcSzJLCFSferEf69SpgD2Y=";
   };
 
   server = "${caddy}/bin/caddy";
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     asciidoctor
     multimarkdown
     perlPackages.ImageExifTool
-    (python27.withPackages (ps: [ ps.parsimonious ]))
+    python3Packages.parsimonious
   ];
 
   installPhase = ''


### PR DESCRIPTION
###### Description of changes

Styx fails to build on current master with the following error:
```
error: parsimonious-0.9.0 not supported for interpreter python2.7
(use '--show-trace' to show detailed location information)
```

Since parsimonious can run with python3 I updated the styx derivation. If there was a specific reason to include python27, please let me know.

Besides, I updated styx to the current version.

@ericsagnes as maintainer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
