### PR TITLE
styx: adapt to upstream derivation, fix build function

### DIFF
--- a/pkgs/applications/misc/styx/default.nix
+++ b/pkgs/applications/misc/styx/default.nix
@@ -1,6 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, caddy, asciidoctor
-, file, lessc, sass, multimarkdown, linkchecker
-, perlPackages, python3Packages }:
+{ lib, stdenv, fetchFromGitHub, caddy, asciidoctor, linkchecker, pkgs }:
 
 stdenv.mkDerivation rec {
   pname = "styx";
@@ -15,27 +13,18 @@ stdenv.mkDerivation rec {
 
   server = "${caddy}/bin/caddy";
   linkcheck = "${linkchecker}/bin/linkchecker";
+  nixpkgs = pkgs.path;
 
   nativeBuildInputs = [ asciidoctor ];
 
-  outputs = [ "out" "lib" "themes" ];
-
-  propagatedBuildInputs = [
-    file
-    lessc
-    sass
-    asciidoctor
-    multimarkdown
-    perlPackages.ImageExifTool
-    python3Packages.parsimonious
-  ];
+  outputs = [ "out" "themes" ];
 
   installPhase = ''
     mkdir $out
-    install -D -m 777 src/styx.sh $out/bin/styx
 
-    mkdir -p $out/share/styx-src
-    cp -r ./* $out/share/styx-src
+    install -D -m 777 src/styx.sh $out/bin/styx
+    cp src/default.nix $out/default.nix
+    cp src/styx-config.nix $out/styx-config.nix
 
     mkdir -p $out/share/doc/styx
     asciidoctor src/doc/index.adoc       -o $out/share/doc/styx/index.html
@@ -51,10 +40,11 @@ stdenv.mkDerivation rec {
 
     mkdir -p $out/share/styx/scaffold
     cp -r src/scaffold $out/share/styx
-    cp -r src/tools $out/share/styx
+    cp -r src/tools    $out/share/styx
+    cp -r src/nix      $out/share/styx
 
-    mkdir $lib
-    cp -r src/lib/* $lib
+    mkdir -p $out/lib
+    cp -r src/lib/* $out/lib
 
     mkdir $themes
     cp -r themes/* $themes


### PR DESCRIPTION
###### Description of changes

The update to version `0.7.5` in #189107 results in a working binary. When testing it with a site to build, it fails, because in this version `@nixpkgs@` got introduced in the `styx` script. Without the "nixpkgs", the build and preview function cease to work.

The derivation is now adapted to upstreams "derivation.nix" at https://github.com/styx-static/styx/blob/4a1489bb1b358647285006d6a32291ce1a54fa5c/derivation.nix

Now, site builder and preview work correctly. Due to the evaluation of `pkgs.path` the whole evaluation takes a whole lot longer locally for me..

@superherointj: Thanks for your quick review before! Could you have another look here?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
