### PR TITLE
Linux Kernel update 5.19.6 date 2022-08-31

### DIFF
--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -22,12 +22,12 @@
     "5.10": {
         "patch": {
             "extra": "-hardened1",
-            "name": "linux-hardened-5.10.139-hardened1.patch",
-            "sha256": "03n49hfc1ck82gzjhxsidbcy02r08qqy7qbahd8zmrhpw6vdqfwi",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.10.139-hardened1/linux-hardened-5.10.139-hardened1.patch"
+            "name": "linux-hardened-5.10.140-hardened1.patch",
+            "sha256": "0352nh6r9p3djk07lprjpmd8q17kkqb5pi2zwrywlxrzws4wqhzh",
+            "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.10.140-hardened1/linux-hardened-5.10.140-hardened1.patch"
         },
-        "sha256": "1wdyk1w8lr5l4d038bd44rdndxjvfcva2n51h2i38jd4fp12l00w",
-        "version": "5.10.139"
+        "sha256": "00v8mdbc8ndx29grfnlf49ifikqxnl25zn0243j3bgclvfyxipx4",
+        "version": "5.10.140"
     },
     "5.15": {
         "patch": {

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -52,12 +52,12 @@
     "5.19": {
         "patch": {
             "extra": "-hardened1",
-            "name": "linux-hardened-5.19.5-hardened1.patch",
-            "sha256": "1f6zddx6mbpdn1glz32zrf13wr6j74vpk1lx56x3zllcfshds354",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.19.5-hardened1/linux-hardened-5.19.5-hardened1.patch"
+            "name": "linux-hardened-5.19.6-hardened1.patch",
+            "sha256": "1lx4li0f0j6wmh3p75hr2qa780ckybhma8s34p6xlbvxz054ncpr",
+            "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.19.6-hardened1/linux-hardened-5.19.6-hardened1.patch"
         },
-        "sha256": "1g9p4m9w9y0y1gk6vzqvsxzwqspbm10mmhd8n1mhal1yz721qgwc",
-        "version": "5.19.5"
+        "sha256": "0fm6xysg5mjfig0jils700ph83mvvkl27ix757260i31mwjgi921",
+        "version": "5.19.6"
     },
     "5.4": {
         "patch": {

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -32,12 +32,12 @@
     "5.15": {
         "patch": {
             "extra": "-hardened1",
-            "name": "linux-hardened-5.15.63-hardened1.patch",
-            "sha256": "02lgrnr8wkkrpwj6szd45dmdz4jdj2dpvpfvy8dmrl9hc870zk7k",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.15.63-hardened1/linux-hardened-5.15.63-hardened1.patch"
+            "name": "linux-hardened-5.15.64-hardened1.patch",
+            "sha256": "08hj5rx37vmw8mapzz15smpp775vrzhbfh2i0xps5qwi9majywrf",
+            "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.15.64-hardened1/linux-hardened-5.15.64-hardened1.patch"
         },
-        "sha256": "0hbkxgadz0vcslni4r46yc202wcnxblcfvkcph1017b2b8gcvlvd",
-        "version": "5.15.63"
+        "sha256": "0l6ylmxhk3lqz2zyqcbyhbfcq1p8i84g0p1d6x0q6yd3dy6d78f6",
+        "version": "5.15.64"
     },
     "5.18": {
         "patch": {

--- a/pkgs/os-specific/linux/kernel/linux-5.10.nix
+++ b/pkgs/os-specific/linux/kernel/linux-5.10.nix
@@ -3,7 +3,7 @@
 with lib;
 
 buildLinux (args // rec {
-  version = "5.10.139";
+  version = "5.10.140";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = if (modDirVersionArg == null) then concatStringsSep "." (take 3 (splitVersion "${version}.0")) else modDirVersionArg;
@@ -13,6 +13,6 @@ buildLinux (args // rec {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${version}.tar.xz";
-    sha256 = "1wdyk1w8lr5l4d038bd44rdndxjvfcva2n51h2i38jd4fp12l00w";
+    sha256 = "00v8mdbc8ndx29grfnlf49ifikqxnl25zn0243j3bgclvfyxipx4";
   };
 } // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/linux-5.15.nix
+++ b/pkgs/os-specific/linux/kernel/linux-5.15.nix
@@ -3,7 +3,7 @@
 with lib;
 
 buildLinux (args // rec {
-  version = "5.15.63";
+  version = "5.15.64";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = if (modDirVersionArg == null) then concatStringsSep "." (take 3 (splitVersion "${version}.0")) else modDirVersionArg;
@@ -13,6 +13,6 @@ buildLinux (args // rec {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${version}.tar.xz";
-    sha256 = "0hbkxgadz0vcslni4r46yc202wcnxblcfvkcph1017b2b8gcvlvd";
+    sha256 = "0l6ylmxhk3lqz2zyqcbyhbfcq1p8i84g0p1d6x0q6yd3dy6d78f6";
   };
 } // (args.argsOverride or { }))

--- a/pkgs/os-specific/linux/kernel/linux-5.19.nix
+++ b/pkgs/os-specific/linux/kernel/linux-5.19.nix
@@ -3,7 +3,7 @@
 with lib;
 
 buildLinux (args // rec {
-  version = "5.19.5";
+  version = "5.19.6";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = if (modDirVersionArg == null) then concatStringsSep "." (take 3 (splitVersion "${version}.0")) else modDirVersionArg;
@@ -13,6 +13,6 @@ buildLinux (args // rec {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${version}.tar.xz";
-    sha256 = "1g9p4m9w9y0y1gk6vzqvsxzwqspbm10mmhd8n1mhal1yz721qgwc";
+    sha256 = "0fm6xysg5mjfig0jils700ph83mvvkl27ix757260i31mwjgi921";
   };
 } // (args.argsOverride or { }))


### PR DESCRIPTION
* linux: 5.19.5 -> 5.19.6
* linux: 5.15.63 -> 5.15.64
* linux: 5.10.139 -> 5.10.140

* linux/hardened/patches/5.10: 5.10.139-hardened1 -> 5.10.140-hardened1
* linux/hardened/patches/5.15: 5.15.63-hardened1 -> 5.15.64-hardened1
* linux/hardened/patches/5.19: 5.19.5-hardened1 -> 5.19.6-hardened1

Note: I wonder what is the ideal title for this PR.