### PR TITLE
swiftbar: init at 1.4.3

### DIFF
--- a/pkgs/os-specific/darwin/swiftbar/default.nix
+++ b/pkgs/os-specific/darwin/swiftbar/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, fetchzip
+, stdenvNoCC
+, makeWrapper
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "swiftbar";
+  version = "1.4.3";
+
+  src = fetchzip {
+    url = "https://github.com/swiftbar/SwiftBar/releases/download/v${version}/SwiftBar.zip";
+    sha256 = "sha256-Ut+lr1E7bMp8Uz1aL7EV0ZsfdTh9t7zUjDU/DScRpHY=";
+    stripRoot = false;
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{Applications,bin}
+    cp -r ./SwiftBar.app $out/Applications
+
+    # Symlinking doesnt work; The auto-updater will fail to start which renders the app useless
+    makeWrapper $out/Applications/SwiftBar.app/Contents/MacOS/SwiftBar $out/bin/SwiftBar
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Powerful macOS menu bar customization tool";
+    homepage = "https://swiftbar.app";
+    changelog = "https://github.com/swiftbar/SwiftBar/releases/tag/v${version}";
+    mainProgram = "SwiftBar";
+    license = licenses.mit;
+    platforms = platforms.darwin;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    maintainers = with maintainers; [ ivar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11269,6 +11269,8 @@ with pkgs;
 
   swaks = callPackage ../tools/networking/swaks { };
 
+  swiftbar = callPackage ../os-specific/darwin/swiftbar { };
+
   swiften = callPackage ../development/libraries/swiften { };
 
   squeekboard = callPackage ../applications/accessibility/squeekboard { };


### PR DESCRIPTION
###### Description of changes
This adds [swiftbar](https://swiftbar.app), a powerful macOS menu bar customization tool. It allows you to add scriptable menu bar entries which is really neat, I've been using this together with yabai to show my currently active Space's label.

I plan to add a nix-darwin/home-manager module for it as well when this PR gets merged.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and “core” functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
