### PR TITLE
tessen: refactor manpage installation

### DIFF
--- a/pkgs/tools/security/tessen/default.nix
+++ b/pkgs/tools/security/tessen/default.nix
@@ -7,6 +7,7 @@
 , wl-clipboard
 , pass
 , bemenu
+, scdoc
 }:
 
 stdenvNoCC.mkDerivation rec {
@@ -20,7 +21,7 @@ stdenvNoCC.mkDerivation rec {
     sha256  = "sha256-U6obXpYzIprOJ+b3QiE+eDOq1s0DYiwM55qTga9/8TE=";
   };
 
-  nativeBuildInputs = [ makeWrapper installShellFiles ];
+  nativeBuildInputs = [ makeWrapper installShellFiles scdoc ];
 
   dontBuild = true;
 
@@ -32,7 +33,9 @@ stdenvNoCC.mkDerivation rec {
   '';
 
   postInstall = ''
-    installManPage man/*
+    scdoc < man/tessen.1.scd > man/tessen.1
+    scdoc < man/tessen.5.scd > man/tessen.5
+    installManPage man/*.{1,5}
     installShellCompletion --cmd tessen \
       --bash completion/tessen.bash-completion \
       --fish completion/tessen.fish-completion


### PR DESCRIPTION
###### Description of changes

The way I created the package earlier, it seems that the manpages didn't work because I never used `scdoc` to compile the documentation. This should fix that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
