### PR TITLE
linuxPackages.lttng-modules: mark broken for 5.10

### DIFF
--- a/pkgs/os-specific/linux/lttng-modules/default.nix
+++ b/pkgs/os-specific/linux/lttng-modules/default.nix
@@ -57,5 +57,6 @@ stdenv.mkDerivation rec {
     license = with licenses; [ lgpl21Only gpl2Only mit ];
     platforms = platforms.linux;
     maintainers = [ maintainers.bjornfor ];
+    broken = (lib.versions.majorMinor kernel.modDirVersion) == "5.10";
   };
 }


### PR DESCRIPTION
linuxPackages.lttng-modules: mark broken for 5.10