### PR TITLE
buildbot: 3.5.0 -> 3.6.0

### DIFF
--- a/pkgs/development/python-modules/buildbot/default.nix
+++ b/pkgs/development/python-modules/buildbot/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildPythonPackage, fetchpatch, fetchPypi, makeWrapper, isPy3k
+{ stdenv, lib, buildPythonPackage, fetchPypi, makeWrapper, isPy3k
 , python, twisted, jinja2, msgpack, zope_interface, sqlalchemy, alembic
 , python-dateutil, txaio, autobahn, pyjwt, pyyaml, treq, txrequests, pypugjs
 , boto3, moto, mock, lz4, setuptoolsTrial
@@ -32,11 +32,11 @@ let
 
   package = buildPythonPackage rec {
     pname = "buildbot";
-    version = "3.5.0";
+    version = "3.6.0";
 
     src = fetchPypi {
       inherit pname version;
-      sha256 = "sha256-woGHdCan5qTp00toNkWa821EgVQMrPK+OWXoqFcgIDQ=";
+      sha256 = "sha256-C8KXh+4bsf0zE8PCTwK3H/0pMP762I26quQiyHVkr2A=";
     };
 
     propagatedBuildInputs = [
@@ -78,11 +78,6 @@ let
       # This patch disables the test that tries to read /etc/os-release which
       # is not accessible in sandboxed builds.
       ./skip_test_linux_distro.patch
-      (fetchpatch{
-        url = "https://github.com/buildbot/buildbot/commit/54b8f62902122b0091319a96d0f9edd4195ab4c6.patch";
-        stripLen = 1;
-        sha256 = "sha256-OqW3ZQK0bfqPG3YlrBbrSEEKsM/XqY2NO862ZD/DgHs=";
-      })
     ];
 
     postPatch = ''

--- a/pkgs/development/python-modules/buildbot/pkg.nix
+++ b/pkgs/development/python-modules/buildbot/pkg.nix
@@ -6,7 +6,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-CYbMixfZZ1xypV0J7TW54n/fja9RGMlWiF7StJYFnqM=";
+    sha256 = "sha256-+48r7VUl7r8u3aWE0+Uwk28DMhdwz02iqq76M7MgY+k=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/buildbot/plugins.nix
+++ b/pkgs/development/python-modules/buildbot/plugins.nix
@@ -7,7 +7,7 @@
 
     src = fetchPypi {
       inherit pname version;
-      sha256 = "sha256-boa/MWi/HAhNU3/n96i0fuoQ+jT5I+dWoe1Zd7f/Yvs=";
+      sha256 = "sha256-ivdjwZYHsovZu1HQ5tc+k7ScB4OdonOcTSuMXKKeU10=";
     };
 
     # Remove unneccessary circular dependency on buildbot
@@ -34,7 +34,7 @@
 
     src = fetchPypi {
       inherit pname version;
-      sha256 = "sha256-NUDTwgkQuasOlJxNTlvfIm99LNVCrRIdBmgeJnwkSU8=";
+      sha256 = "sha256-SebskFsLZUHTi9lS9DbG8ZKQqjls+e25xvqqK7LZaMw=";
     };
 
     buildInputs = [ buildbot-pkg ];
@@ -56,7 +56,7 @@
 
     src = fetchPypi {
       inherit pname version;
-      sha256 = "sha256-EmiIDCG4iFIwFnwii8fjII7C7wsBifzeZeW7HyY04dE=";
+      sha256 = "sha256-HWhKEzjzAYJZsd31701NuHOvImwnxFM8dLvE7fqpIRM=";
     };
 
     buildInputs = [ buildbot-pkg ];
@@ -78,7 +78,7 @@
 
     src = fetchPypi {
       inherit pname version;
-      sha256 = "sha256-QcS8QJ17uzDvkynTczj05LojuIT6feGiQNCwCESbVLw=";
+      sha256 = "sha256-jGBdrVcxNpWdFT9aXO/KX/ZG/oXlWmlvpIFFSrVQ9pk=";
     };
 
     buildInputs = [ buildbot-pkg ];
@@ -100,7 +100,7 @@
 
     src = fetchPypi {
       inherit pname version;
-      sha256 = "sha256-U9ecRxpDowzjD4GsrW4FUHcbNaWeAFGKDlqMrbIoTrQ=";
+      sha256 = "sha256-8dvhVKbwTug78+14FGFyRj7AX3QpbveC4PHzc1yk03w=";
     };
 
     buildInputs = [ buildbot-pkg ];

--- a/pkgs/development/python-modules/buildbot/worker.nix
+++ b/pkgs/development/python-modules/buildbot/worker.nix
@@ -28,7 +28,7 @@ buildPythonPackage (rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-HZH3TdH5dhr3f6ev25O3SgPPNbiFGMmAp9DHwcb/2MA=";
+    sha256 = "sha256-WTvap1dx7OMim4UIZrfZVxrAWxPBwbRH6qdfO038bts=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/pytest-asyncio/default.nix
+++ b/pkgs/development/python-modules/pytest-asyncio/default.nix
@@ -54,7 +54,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Library for testing asyncio code with pytest";
     homepage = "https://github.com/pytest-dev/pytest-asyncio";
-    changelog = "https://github.com/pytest-dev/pytest-asyncio/blob/${src.rev}/CHANGELOG.rst";
+    changelog = "https://github.com/pytest-dev/pytest-asyncio/blob/v${version}/CHANGELOG.rst";
     license = licenses.asl20;
     maintainers = with maintainers; [ dotlambda ];
   };

--- a/pkgs/tools/typesetting/asciidoc/default.nix
+++ b/pkgs/tools/typesetting/asciidoc/default.nix
@@ -282,7 +282,7 @@ in python3.pkgs.buildPythonApplication rec {
       fromSource
     ] ++ lib.optional _enableDitaaFilter binaryBytecode;
     homepage = "https://asciidoc-py.github.io/";
-    changelog = "https://github.com/asciidoc-py/asciidoc-py/blob/${src.rev}/CHANGELOG.adoc";
+    changelog = "https://github.com/asciidoc-py/asciidoc-py/blob/${version}/CHANGELOG.adoc";
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
     maintainers = with maintainers; [ bjornfor dotlambda ];


### PR DESCRIPTION
###### Description of changes

Update buildbot to the latest version. 

Changelog: http://docs.buildbot.net/current/relnotes/index.html#buildbot-3-6-0-2022-08-25

Also, I fixed the changelog URLs for asciidoc and pytest-asyncio, which were causing errors when running `maintainers/scripts/update.nix` to update Buildbot.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
