### PR TITLE
mov-cli: init at unstable-2022-06-30

### DIFF
--- a/pkgs/applications/video/mov-cli/default.nix
+++ b/pkgs/applications/video/mov-cli/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, python3
+, fetchFromGitHub
+}:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "mov-cli";
+  version = "unstable-2022-06-30";
+
+  src = fetchFromGitHub {
+    owner = "mov-cli";
+    repo = "mov-cli";
+    rev = "b89e807e8ffc830b0b18c8e98712441c03774b8e";
+    sha256 = "sha256-D+OeXcLdkbG4ASbPQYIWf7J1CRZ9jH3UXxfTL4WleY0=";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [ setuptools httpx click beautifulsoup4 colorama ];
+
+  postPatch = ''
+    substituteInPlace setup.py --replace "bs4" "beautifulsoup4"
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/mov-cli/mov-cli";
+    description = "A cli tool to browse and watch movies";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ baitinq ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -230,6 +230,8 @@ with pkgs;
     python3 = python39;
   };
 
+  mov-cli = callPackage ../applications/video/mov-cli { };
+
   ani-cli = callPackage ../applications/video/ani-cli { };
 
   anime-downloader = callPackage ../applications/video/anime-downloader { };


### PR DESCRIPTION
###### Description of changes

Add the [mov-cli](https://github.com/mov-cli/mov-cli) program for browsing and watching movies via the terminal.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
