### PR TITLE
ovmfvartool: init at unstable-2021-06-16

### DIFF
--- a/pkgs/applications/virtualization/ovmfvartool/default.nix
+++ b/pkgs/applications/virtualization/ovmfvartool/default.nix
@@ -1,0 +1,33 @@
+{ lib, stdenvNoCC, fetchFromGitHub, python3 }:
+
+stdenvNoCC.mkDerivation rec {
+  name = "ovmfvartool";
+  version = "unstable-2021-06-16";
+
+  src = fetchFromGitHub {
+    owner = "hlandau";
+    repo = name;
+    rev = "c4c0c24dce1d201f95dfd69fd7fd9d51ea301377";
+    hash = "sha256-3OvYAB41apPn1c2YTKBIEITmHSUMQ0oEijY5DhZWWGo=";
+  };
+
+  postPatch = let
+    pythonPkg = python3.withPackages (p: with p; [ pyyaml ]);
+  in ''
+    # needed in build but /usr/bin/env is not available in sandbox
+    substituteInPlace ovmfvartool \
+      --replace "/usr/bin/env python3" "${pythonPkg.interpreter}"
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -m 755 ovmfvartool $out/bin/
+  '';
+
+  meta = with lib; {
+    description = "Parse and generate OVMF_VARS.fd from Yaml";
+    homepage = "https://github.com/hlandau/ovmfvartool";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ baloo raitobezarius ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23255,6 +23255,8 @@ with pkgs;
     tpmSupport = true;
   };
 
+  ovmfvartool = callPackage ../applications/virtualization/ovmfvartool { };
+
   ops = callPackage ../applications/virtualization/ops { };
 
   seabios = callPackage ../applications/virtualization/seabios { };


### PR DESCRIPTION
###### Description of changes

This brings ovmfvartool to manipulate ovmf_vars.fd files

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
