### PR TITLE
[22.05] element-{web,desktop}: 1.11.0 -> 1.11.4, fix CVE-2022-36059 & CVE-2022-36060

### DIFF
--- a/pkgs/applications/networking/instant-messengers/element/element-desktop-package.json
+++ b/pkgs/applications/networking/instant-messengers/element/element-desktop-package.json
@@ -2,7 +2,7 @@
   "name": "element-desktop",
   "productName": "Element",
   "main": "lib/electron-main.js",
-  "version": "1.11.0",
+  "version": "1.11.4",
   "description": "A feature-rich client for Matrix.org",
   "author": "Element",
   "repository": {
@@ -42,7 +42,7 @@
   "dependencies": {
     "auto-launch": "^5.0.5",
     "counterpart": "^0.18.6",
-    "electron-store": "^6.0.1",
+    "electron-store": "^8.0.2",
     "electron-window-state": "^5.0.3",
     "minimist": "^1.2.6",
     "png-to-ico": "^2.1.1",
@@ -62,7 +62,7 @@
     "asar": "^2.0.1",
     "chokidar": "^3.5.2",
     "detect-libc": "^1.0.3",
-    "electron": "^19",
+    "electron": "^20",
     "electron-builder": "22.11.4",
     "electron-builder-squirrel-windows": "22.11.4",
     "electron-devtools-installer": "^3.1.1",
@@ -87,6 +87,9 @@
   "hakDependencies": {
     "matrix-seshat": "^2.3.3",
     "keytar": "^7.9.0"
+  },
+  "resolutions": {
+    "@types/node": "16.11.38"
   },
   "build": {
     "appId": "im.riot.app",
@@ -119,10 +122,14 @@
       "darkModeSupport": true
     },
     "win": {
-      "target": {
-        "target": "squirrel"
-      },
+      "target": [
+        "squirrel",
+        "msi"
+      ],
       "sign": "scripts/electron_winSign"
+    },
+    "msi": {
+      "perMachine": true
     },
     "directories": {
       "output": "dist"

--- a/pkgs/applications/networking/instant-messengers/element/element-desktop.nix
+++ b/pkgs/applications/networking/instant-messengers/element/element-desktop.nix
@@ -39,6 +39,8 @@ mkYarnPackage rec {
     sha256 = pinData.desktopYarnHash;
   };
 
+  packageResolutions = (builtins.fromJSON (builtins.readFile ./element-desktop-package.json)).resolutions;
+
   nativeBuildInputs = [ makeWrapper ] ++ lib.optionals stdenv.isDarwin [ desktopToDarwinBundle ];
 
   inherit seshat;

--- a/pkgs/applications/networking/instant-messengers/element/pin.json
+++ b/pkgs/applications/networking/instant-messengers/element/pin.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.11.0",
-  "desktopSrcHash": "WYXPsiR3hKj+cPvs5bLzZ301vLISp3ANLf/GgBBMYqM=",
-  "desktopYarnHash": "0v60ak06g87i3q5rqgxy3v3whk3njj0v1ml9rfdab1mbzrj6209c",
-  "webHash": "0lczkrdd37qj13j4vvl4k2cxf7drs0q9c2clb7zgaxalxkdrv483"
+  "version": "1.11.4",
+  "desktopSrcHash": "lIyx1gpPkuOGzHTbkHKNiGsVKEkKUIz/8sj/KZ9XK9o=",
+  "desktopYarnHash": "0m0zzq2wbk7h7anjmj586089j2qgsd5cj99rmi2hmsmssq63fmwk",
+  "webHash": "0ilvnlnh300l9f3y89k3dxipa7gqsh3aq6h76v843nq2y292w43a"
 }


### PR DESCRIPTION
###### Description of changes
Backport of https://github.com/NixOS/nixpkgs/pull/189150, https://github.com/NixOS/nixpkgs/pull/186133.

cc @zseri @yu-re-ka @sumnerevans 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
