### PR TITLE
cyberchef: init at 9.46.0

### DIFF
--- a/pkgs/tools/misc/cyberchef/default.nix
+++ b/pkgs/tools/misc/cyberchef/default.nix
@@ -1,0 +1,26 @@
+{ lib, fetchzip, stdenv }:
+
+stdenv.mkDerivation rec {
+  pname = "cyberchef";
+  version = "9.46.0";
+
+  src = fetchzip {
+    url = "https://github.com/gchq/CyberChef/releases/download/v${version}/CyberChef_v${version}.zip";
+    sha256 = "sha256-4IqXp7fYgXwIuciUklrQoRD2XagatdhQ3l6ghjgTCR8=";
+    stripRoot = false;
+  };
+
+  installPhase = ''
+    mkdir -p "$out/share/cyberchef"
+    mv "CyberChef_v${version}.html" index.html
+    mv * "$out/share/cyberchef"
+  '';
+
+  meta = with lib; {
+    description = "The Cyber Swiss Army Knife for encryption, encoding, compression and data analysis.";
+    homepage = "https://gchq.github.io/CyberChef";
+    maintainers = with maintainers; [ sebastianblunt ];
+    license = licenses.asl20;
+  };
+
+}

--- a/pkgs/tools/misc/cyberchef/default.nix
+++ b/pkgs/tools/misc/cyberchef/default.nix
@@ -22,5 +22,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ sebastianblunt ];
     license = licenses.asl20;
   };
-
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2177,6 +2177,8 @@ with pkgs;
 
   crystfel-headless = callPackage ../applications/science/physics/crystfel { withGui = false; };
 
+  cyberchef = callPackage ../tools/misc/cyberchef { };
+
   cw = callPackage ../tools/admin/cw { };
 
   ec2-api-tools = callPackage ../tools/virtualization/ec2-api-tools { };


### PR DESCRIPTION
###### Description of changes

Init latest version of [cyberchef](https://github.com/gchq/CyberChef). The output consists of static files put into share/cyberchef, allowing you to run cyberchef from a local copy instead of the online version that includes tracking.

This is an alternative implementation to #168222, this version just pulls the built copy of cyberchef, thus avoiding node2nix.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
