### PR TITLE
mcpp: 2.7.2 -> 2.7.2.1

### DIFF
--- a/pkgs/development/compilers/mcpp/default.nix
+++ b/pkgs/development/compilers/mcpp/default.nix
@@ -1,28 +1,26 @@
-{ lib, stdenv, fetchurl, fetchpatch }:
+{ lib
+, stdenv
+, fetchFromGitHub
+}:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "mcpp";
-  version = "2.7.2";
+  version = "2.7.2.1";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/mcpp/mcpp-${version}.tar.gz";
-    sha256 = "0r48rfghjm90pkdyr4khxg783g9v98rdx2n69xn8f6c5i0hl96rv";
+  src = fetchFromGitHub {
+    owner = "museoa";
+    repo = "mcpp";
+    rev = finalAttrs.version;
+    hash= "sha256-T4feegblOeG+NU+c+PAobf8HT8KDSfcINkRAa1hNpkY=";
   };
 
   configureFlags = [ "--enable-mcpplib" ];
 
-  patches = [
-    (fetchpatch {
-      name = "CVE-2019-14274.patch";
-      url = "https://github.com/h8liu/mcpp/commit/ea453aca2742be6ac43ba4ce0da6f938a7e5a5d8.patch";
-      sha256 = "0svkdr3w9b45v6scgzvggw9nsh6a3k7g19fqk0w3vlckwmk5ydzr";
-    })
-  ];
-
   meta = with lib; {
-    homepage = "http://mcpp.sourceforge.net/";
-    description = "A portable c preprocessor";
+    homepage = "https://github.com/museoa/mcpp";
+    description = "Matsui's C preprocessor";
     license = licenses.bsd2;
+    maintainers = with maintainers; [ AndersonTorres ];
     platforms = platforms.unix;
   };
-}
+})


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
