### PR TITLE
config: add allowInsecurePackages that defaults to true

### DIFF
--- a/doc/using/configuration.chapter.md
+++ b/doc/using/configuration.chapter.md
@@ -137,18 +137,27 @@ A complete list of licenses can be found in the file `lib/licenses.nix` of the n
 
 There are several ways to tweak how Nix handles a package which has been marked as insecure.
 
+-   By default insecure packages are allowed, to disable them you may add `allowInsecurePackages = false;` to your user's configuration file, like this:
+
+    ```nix
+    {
+      allowInsecurePackages = true;
+    }
+    ```
+
 -   To temporarily allow all insecure packages, you can use an environment variable for a single invocation of the nix tools:
 
     ```ShellSession
     $ export NIXPKGS_ALLOW_INSECURE=1
     ```
 
--   It is possible to permanently allow individual insecure packages, while still blocking other insecure packages by default using the `permittedInsecurePackages` configuration option in the user configuration file.
+-   It is possible to permanently allow individual insecure packages, while still blocking other insecure packages by default using the `permittedInsecurePackages` and setting ``allowInsecurePackages = false;`` configuration option in the user configuration file.
 
     The following example configuration permits the installation of the hypothetically insecure package `hello`, version `1.2.3`:
 
     ```nix
     {
+      allowInsecurePackages = false;
       permittedInsecurePackages = [
         "hello-1.2.3"
       ];
@@ -163,6 +172,7 @@ There are several ways to tweak how Nix handles a package which has been marked 
 
     ```nix
     {
+      allowInsecurePackages = false;
       allowInsecurePredicate = pkg: builtins.stringLength (lib.getName pkg) <= 5;
     }
     ```

--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -13,6 +13,16 @@
     <itemizedlist>
       <listitem>
         <para>
+          Insecure packages are now allowed by default to be able to
+          complete <literal>meta.knownVurnabilities</literal>. If you
+          want to disallow insecure packages again you can set
+          <literal>nixpkgs.config.allowInsecurePackages = false;</literal>
+          or add <literal>allowInsecurePackages = false;</literal> to
+          <literal>~/.config/nixpkgs/config.nix</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           During cross-compilation, tests are now executed if the test
           suite can be executed by the build platform. This is the case
           when doing “native” cross-compilation where the build and host

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -6,6 +6,10 @@ Support is planned until the end of June 2023, handing over to 23.05.
 
 In addition to numerous new and upgraded packages, this release has the following highlights:
 
+- Insecure packages are now allowed by default to be able to complete `meta.knownVurnabilities`.
+  If you want to disallow insecure packages again you can set `nixpkgs.config.allowInsecurePackages = false;`
+  or add `allowInsecurePackages = false;` to `~/.config/nixpkgs/config.nix`.
+
 - During cross-compilation, tests are now executed if the test suite can be executed
   by the build platform. This is the case when doing “native” cross-compilation
   where the build and host platforms are largely the same, but the nixpkgs' cross

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -87,6 +87,7 @@ let
   hasAllowedInsecure = attrs:
     !(isMarkedInsecure attrs) ||
     allowInsecurePredicate attrs ||
+    config.allowInsecurePackages ||
     builtins.getEnv "NIXPKGS_ALLOW_INSECURE" == "1";
 
 

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -76,6 +76,14 @@ let
       '';
     };
 
+    allowInsecurePackages = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether to allow packages with known security issues and vurnabilties.
+      '';
+    };
+
     allowUnfree = mkOption {
       type = types.bool;
       default = false;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
