### PR TITLE
Strip ANSI escape sequences from gitlab-runner output

### DIFF
--- a/nixos/modules/services/continuous-integration/gitlab-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitlab-runner.nix
@@ -36,7 +36,7 @@ let
 
       # current and desired state
       NEEDED_SERVICES=$(echo ${concatStringsSep " " (attrNames hashedServices)} | tr " " "\n")
-      REGISTERED_SERVICES=$(gitlab-runner list 2>&1 | grep 'Executor' | awk '{ print $1 }')
+      REGISTERED_SERVICES=$(gitlab-runner list 2>&1 | grep 'Executor' | perl -pe 's/\x1b\[[0-9;]*[mG]//g' | awk '{ print $1 }')
 
       # difference between current and desired state
       NEW_SERVICES=$(grep -vxF -f <(echo "$REGISTERED_SERVICES") <(echo "$NEEDED_SERVICES") || true)
@@ -93,7 +93,7 @@ let
       '') hashedServices)}
 
       # unregister old services
-      for NAME in $(echo "$OLD_SERVICES")
+      for NAME in "$OLD_SERVICES"
       do
         [ ! -z "$NAME" ] && gitlab-runner unregister \
           --name "$NAME" && sleep 1


### PR DESCRIPTION
###### Description of changes

`gitlab-runner list` at version 13.12.0 unconditionally includes ANSI escape sequences with no tty detection or possibility to turn this off.

```
# setsid gitlab-runner list 2>&1 | cat | grep 'Executor' | awk '{ print $1 }' |sed -n l
runner-0_ihvs0280-gitlab-runner-nixos_539bfc1eb094\033[0;m$
runner-1_ihvs0280-gitlab-runner-nixos_60cdb010f5c2\033[0;m$
runner-2_ihvs0280-gitlab-runner-nixos_b1b1218840aa\033[0;m$
runner-3_ihvs0280-gitlab-runner-nixos_fdd4b21ca14a\033[0;m$
```

This causes errors during starting like
```
 FATAL: could not find a runner with the name 'shell-runner-1_ihvs0280-gitlab-runner-nixos_6160dad684b6'
```
preventing the actual unregistration of old runner registrations. This leads to an accumulation of registered runners over time.

The PR strips ANSI escape sequences from the output of `gitlab-runner list`

I've also removed a redundant subshell/echo combination.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Ping to the author of the original code  @misuzu 