### PR TITLE
pcre: fix on ppc(64)

### DIFF
--- a/pkgs/development/libraries/pcre/default.nix
+++ b/pkgs/development/libraries/pcre/default.nix
@@ -27,8 +27,13 @@ stdenv.mkDerivation rec {
   ]
     ++ optional (variant != null) "--enable-${variant}";
 
-  # https://bugs.exim.org/show_bug.cgi?id=2173
-  patches = [ ./stacksize-detection.patch ];
+  patches = [
+    # https://bugs.exim.org/show_bug.cgi?id=2173
+    ./stacksize-detection.patch
+
+    # https://github.com/void-linux/void-packages/commit/8e1eceec431ab3d3d6e469ad0680ce74e46f8be3
+    ./ppc-icache-flush.patch
+  ];
 
   preCheck = ''
     patchShebangs RunGrepTest

--- a/pkgs/development/libraries/pcre/ppc-icache-flush.patch
+++ b/pkgs/development/libraries/pcre/ppc-icache-flush.patch
@@ -1,0 +1,102 @@
+GCC's version of __builtin___clear_cache() is a no-op on PowerPC.
+Change to use an improved version of the existing ppc_cache_flush().
+
+--- a/sljit/sljitConfigInternal.h	2022-02-12 21:42:26.812059103 -0800
++++ b/sljit/sljitConfigInternal.h	2022-02-12 21:42:57.508834803 -0800
+@@ -284,7 +284,8 @@
+ /****************************/
+ 
+ #if (!defined SLJIT_CACHE_FLUSH && defined __has_builtin)
+-#if __has_builtin(__builtin___clear_cache)
++#if __has_builtin(__builtin___clear_cache) && \
++	!(defined SLJIT_CONFIG_PPC && SLJIT_CONFIG_PPC)
+ 
+ #define SLJIT_CACHE_FLUSH(from, to) \
+ 	__builtin___clear_cache((char*)from, (char*)to)
+--- a/sljit/sljitNativePPC_common.c	2022-02-12 21:42:26.816059204 -0800
++++ b/sljit/sljitNativePPC_common.c	2022-02-12 21:42:57.512834904 -0800
+@@ -46,6 +46,39 @@
+ #define SLJIT_PASS_ENTRY_ADDR_TO_CALL 1
+ #endif
+ 
++#ifdef __linux__
++#include <sys/auxv.h>
++
++/* Return the instruction cache line size, in bytes. */
++static SLJIT_INLINE sljit_u32 get_icache_line_size()
++{
++	static sljit_u32 icache_line_size = 0;
++	if (SLJIT_UNLIKELY(!icache_line_size)) {
++		icache_line_size = (sljit_u32) getauxval(AT_ICACHEBSIZE);
++		SLJIT_ASSERT(icache_line_size != 0);
++	}
++	return icache_line_size;
++}
++
++/* Cache and return the first hardware capabilities word. */
++static SLJIT_INLINE unsigned long get_hwcap()
++{
++	static unsigned long hwcap = 0;
++	if (SLJIT_UNLIKELY(!hwcap)) {
++		hwcap = getauxval(AT_HWCAP);
++		SLJIT_ASSERT(hwcap != 0);
++	}
++	return hwcap;
++}
++
++/* Return non-zero if this CPU has the icache snoop feature. */
++static SLJIT_INLINE unsigned long has_feature_icache_snoop()
++{
++	return (get_hwcap() & PPC_FEATURE_ICACHE_SNOOP);
++}
++
++#endif  /* __linux__ */
++
+ #if (defined SLJIT_CACHE_FLUSH_OWN_IMPL && SLJIT_CACHE_FLUSH_OWN_IMPL)
+ 
+ static void ppc_cache_flush(sljit_ins *from, sljit_ins *to)
+@@ -68,14 +101,40 @@
+ #	error "Cache flush is not implemented for PowerPC/POWER common mode."
+ #	else
+ 	/* Cache flush for PowerPC architecture. */
+-	while (from < to) {
++	/* For POWER5 and up with icache snooping, only one icbi in the range
++ 	 * is required. The sync flushes the store queue, and the icbi/isync
++	 * kills the local prefetch.
++	 */
++	if (has_feature_icache_snoop()) {
+ 		__asm__ volatile (
+-			"dcbf 0, %0\n"
+ 			"sync\n"
+ 			"icbi 0, %0\n"
+-			: : "r"(from)
++			"isync\n"
++			: : "r"(from) : "memory"
++		);
++		return;
++	}
++
++	sljit_u32 cache_line_bytes = get_icache_line_size();
++	sljit_u32 cache_line_words = cache_line_bytes / sizeof(sljit_ins);
++	uintptr_t cache_line_mask = ~(uintptr_t)(cache_line_bytes - 1);
++
++	/* Round down to start of cache line to simplify the end condition. */
++	sljit_ins* start = (sljit_ins*)((uintptr_t)(from) & cache_line_mask);
++
++	for (from = start; from < to; from += cache_line_words) {
++		__asm__ volatile (
++			"dcbf 0, %0"
++			: : "r"(from) : "memory"
++		);
++	}
++	__asm__ volatile ( "sync" );
++
++	for (from = start; from < to; from += cache_line_words) {
++		__asm__ volatile (
++			"icbi 0, %0"
++			: : "r"(from) : "memory"
+ 		);
+-		from++;
+ 	}
+ 	__asm__ volatile ( "isync" );
+ #	endif


### PR DESCRIPTION
###### Description of changes

This is a patch taken from Void Linux: https://github.com/void-linux/void-packages/blob/8e1eceec431ab3d3d6e469ad0680ce74e46f8be3/srcpkgs/pcre/patches/ppc-icache-flush.patch. I tried to `fetchpatch` it like I would on a regular package but it didn't eval, don't remember the error right now. I'll check again later.

Without this patch, the pcre test suite fails on my machine. Excuse the slightly off look, the colours on the distro I'm using don't capture correctly.

![image](https://user-images.githubusercontent.com/23431373/187914700-93513eee-2cfd-40d9-b15a-d62237439dda.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] powerpc64-linux
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
