### PR TITLE
nixos/bind: add keyFiles option

### DIFF
--- a/nixos/modules/services/networking/bind.nix
+++ b/nixos/modules/services/networking/bind.nix
@@ -47,6 +47,8 @@ let
   confFile = pkgs.writeText "named.conf"
     ''
       include "/etc/bind/rndc.key";
+      ${concatMapStrings (file: "include \"${file}\"" ) cfg.keyFiles};
+
       controls {
         inet 127.0.0.1 allow {localhost;} keys {"rndc-key";};
       };
@@ -140,6 +142,19 @@ in
         description = lib.mdDoc ''
           Only use ipv4, even if the host supports ipv6.
         '';
+      };
+
+      keyFiles = mkOption {
+	      default = [ ];
+	      type = types.listOf types.path;
+	      description = lib.mdDoc ''
+          A list of files containing additional configuration
+          to be included using the include directive. This option
+          allows to include configuration like TSIG keys without
+          exposing them to the nix store readable to any process.
+          Note that using this option will also disable configuration
+          checks at build time.
+	      '';
       };
 
       forwarders = mkOption {

--- a/nixos/modules/services/networking/bind.nix
+++ b/nixos/modules/services/networking/bind.nix
@@ -145,16 +145,16 @@ in
       };
 
       keyFiles = mkOption {
-	      default = [ ];
-	      type = types.listOf types.path;
-	      description = lib.mdDoc ''
+        default = [ ];
+        type = types.listOf types.path;
+        description = lib.mdDoc ''
           A list of files containing additional configuration
           to be included using the include directive. This option
           allows to include configuration like TSIG keys without
           exposing them to the nix store readable to any process.
           Note that using this option will also disable configuration
           checks at build time.
-	      '';
+        '';
       };
 
       forwarders = mkOption {
@@ -168,7 +168,7 @@ in
 
       forward = mkOption {
         default = "first";
-        type = types.enum ["first" "only"];
+        type = types.enum [ "first" "only" ];
         description = lib.mdDoc ''
           Whether to forward 'first' (try forwarding but lookup directly if forwarding fails) or 'only'.
         '';
@@ -257,7 +257,7 @@ in
         description = "BIND daemon user";
         isSystemUser = true;
       };
-    users.groups.${bindUser} = {};
+    users.groups.${bindUser} = { };
 
     systemd.services.bind = {
       description = "BIND Domain Name Server";


### PR DESCRIPTION
This useful to include tsig keys using sops-nix or similar tools without adding those
world-readable to the nix store.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
