### PR TITLE
buf: Patch out flakey test

### DIFF
--- a/pkgs/development/tools/buf/default.nix
+++ b/pkgs/development/tools/buf/default.nix
@@ -26,6 +26,10 @@ buildGoModule rec {
     ./skip_test_requiring_network.patch
     # Skip TestWorkspaceGit which requires .git and commits.
     ./skip_test_requiring_dotgit.patch
+    # Skips the invalid_upstream test as it is flakey. Based on upstream commit
+    # 27930caf2eb35c2592a77f59ed5afe4d9e2fb7ea.
+    # This patch may be removed on the next buf update.
+    ./skip_test_invalid_upstream_flakey.patch
   ];
 
   nativeBuildInputs = [ installShellFiles ];

--- a/pkgs/development/tools/buf/skip_test_invalid_upstream_flakey.patch
+++ b/pkgs/development/tools/buf/skip_test_invalid_upstream_flakey.patch
@@ -1,0 +1,24 @@
+diff --git a/private/bufpkg/bufstudioagent/bufstudioagent_test.go b/private/bufpkg/bufstudioagent/bufstudioagent_test.go
+index 6e010937..9cacc082 100644
+--- a/private/bufpkg/bufstudioagent/bufstudioagent_test.go
++++ b/private/bufpkg/bufstudioagent/bufstudioagent_test.go
+@@ -186,6 +186,19 @@ func testPlainPostHandlerErrors(t *testing.T, upstreamServer *httptest.Server) {
+ 	})
+ 
+ 	t.Run("invalid_upstream", func(t *testing.T) {
++		// TODO: unskip this test. This is flaky because of two reasons:
++		//
++		// 1. When a connection is closed, the underlying HTTP client does not
++		// always knows it, since the http handler implementation in go has no way
++		// of changing the connection timeout. See:
++		// https://github.com/golang/go/issues/16100
++		//
++		// 2. The expected status code is `StatusBadGateway` since the issue
++		// happened client-side (a response never came back from the server). This
++		// is not deterministic in the business logic because we're based on the
++		// connect error code that's returned. See
++		// https://linear.app/bufbuild/issue/BSR-383/flaky-test-in-bufstudioagent-testgo
++		t.SkipNow()
+ 		listener, err := net.Listen("tcp", "127.0.0.1:")
+ 		require.NoError(t, err)
+ 		go func() {


### PR DESCRIPTION
###### Description of changes

Disables the invalid_upstream test in buf 1.7. This test is flakey, and was disabled in a somewhat recent commit upstream: https://github.com/bufbuild/buf/commit/27930caf2eb35c2592a77f59ed5afe4d9e2fb7ea#diff-349ca280e5f626f278867f58285838dfa627c9eff91c2cb8e75e629ec1a0df33R201 .

This commit takes this commit, removes the unnecessary file changes, and applies it to the 1.7 source tree.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
