### PR TITLE
wren: init at 0.4.0

### DIFF
--- a/pkgs/development/compilers/wren/cli.nix
+++ b/pkgs/development/compilers/wren/cli.nix
@@ -25,9 +25,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ python3 ];
 
-  buildPhase = ''
-    make --directory projects/make
-  '';
+  makeFlags = [ "-C projects/make" ];
 
   doCheck = true;
 
@@ -40,8 +38,7 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    mkdir -p $out/bin
-    mv bin/wren_cli $out/bin/wren
+    install -Dm755 bin/wren_cli $out/bin/wren
   '';
 
   meta = with lib; {

--- a/pkgs/development/compilers/wren/cli.nix
+++ b/pkgs/development/compilers/wren/cli.nix
@@ -1,0 +1,53 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, python3
+}:
+stdenv.mkDerivation rec {
+  pname = "wren-cli";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "wren-lang";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-AUb17rV07r00SpcXAOb9PY8Ea2nxtgdZzHZdzfX5pOA=";
+  };
+
+  patches = [
+    # otherwise fails to build
+    (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/wren-lang/wren-cli/pull/136.patch";
+      sha256 = "sha256-/c1vbc769U/WeLGZiEdnALaooOHQcpTybfbxz+KQYUM=";
+    })
+  ];
+
+  buildInputs = [ python3 ];
+
+  buildPhase = ''
+    make --directory projects/make
+  '';
+
+  doCheck = true;
+
+  # NOTE: there is one test that depends on the realpath of $HOME.
+  checkPhase = ''
+    export HOME=$(mktemp -d)
+    echo "======== Testing Wren CLI ========"
+
+    python3 util/test.py
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv bin/wren_cli $out/bin/wren
+  '';
+
+  meta = with lib; {
+    description = "A command line tool for the Wren programming language";
+    homepage = "https://github.com/wren-lang/wren-cli";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dit7ya ];
+  };
+}

--- a/pkgs/development/compilers/wren/default.nix
+++ b/pkgs/development/compilers/wren/default.nix
@@ -19,9 +19,7 @@ stdenv.mkDerivation rec {
     sha256 = "0w8n5lyn3wa1nmdyci0zi249w1qbq725cr1d9xsg067irq17v8k5";
   };
 
-  buildPhase = ''
-    make --directory projects/make
-  '';
+  makeFlags = [ "-C projects/make" ];
 
   doCheck = true;
   checkPhase = ''
@@ -33,8 +31,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/lib
     cp -r lib $out
 
-    mkdir -p $out/bin
-    cp ${cli}/bin/wren $out/bin/wren
+    install -Dm755 ${cli}/bin/wren -t $out/bin
   '';
 
   buildInputs = [ python3 ];

--- a/pkgs/development/compilers/wren/default.nix
+++ b/pkgs/development/compilers/wren/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, python3
+, callPackage
+}:
+let
+  cli =
+    callPackage ./cli.nix { };
+in
+stdenv.mkDerivation rec {
+  pname = "wren";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "wren-lang";
+    repo = pname;
+    rev = version;
+    sha256 = "0w8n5lyn3wa1nmdyci0zi249w1qbq725cr1d9xsg067irq17v8k5";
+  };
+
+  buildPhase = ''
+    make --directory projects/make
+  '';
+
+  doCheck = true;
+  checkPhase = ''
+    echo "======== Testing Wren ========"
+    python3 util/test.py
+  '';
+
+  installPhase = ''
+    mkdir -p $out/lib
+    cp -r lib $out
+
+    mkdir -p $out/bin
+    cp ${cli}/bin/wren $out/bin/wren
+  '';
+
+  buildInputs = [ python3 ];
+
+  meta = with lib; {
+    description = "A small, fast, class-based concurrent scripting language";
+    homepage = "https://wren.io/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dit7ya ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21934,6 +21934,8 @@ with pkgs;
 
   wlr-protocols = callPackage ../development/libraries/wlroots/protocols.nix { };
 
+  wren = callPackage ../development/compilers/wren { };
+
   wt = wt4;
   inherit (callPackages ../development/libraries/wt {
     boost = boost175;


### PR DESCRIPTION
###### Description of changes

Wren is a small, fast, class-based concurrent scripting language #

Think Smalltalk in a Lua-sized package with a dash of Erlang and wrapped up in a familiar, modern syntax.

https://wren.io/

Packaging has been heavily adapted from the AUR package - https://aur.archlinux.org/packages/wren

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
