### PR TITLE
smart-wallpaper: init at unstable-2022-09-01

### DIFF
--- a/pkgs/tools/X11/smart-wallpaper/default.nix
+++ b/pkgs/tools/X11/smart-wallpaper/default.nix
@@ -1,0 +1,36 @@
+{ stdenvNoCC
+, lib
+, fetchFromGitHub
+, makeWrapper
+, xdpyinfo
+, killall
+, xwinwrap
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "smart-wallpaper";
+  version = "unstable-2022-09-01";
+
+  src = fetchFromGitHub {
+    owner = "Baitinq";
+    repo = "smart-wallpaper";
+    rev = "d175695d3485fb14144c1908eb3569b20caa6ba5";
+    sha256 = "sha256-cFgvuntdKPzdQJ7xE2DIT+aNAazocIhM6BBbcQOlryU=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    install -Dm755 -t $out/bin smart-wallpaper
+    wrapProgram $out/bin/smart-wallpaper \
+      --prefix PATH : ${lib.makeBinPath [ xdpyinfo killall xwinwrap ]}
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/Baitinq/smart-wallpaper";
+    description = "A simple bash script that automatically changes your wallpaper depending on if its daytime or nighttime";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ baitinq ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9224,6 +9224,8 @@ with pkgs;
 
   nitrogen = callPackage ../tools/X11/nitrogen {};
 
+  smart-wallpaper = callPackage ../tools/X11/smart-wallpaper { };
+
   nms = callPackage ../tools/misc/nms { };
 
   nomachine-client = callPackage ../tools/admin/nomachine-client { };


### PR DESCRIPTION
###### Description of changes

Add the [smart-wallpaper](https://github.com/Baitinq/smart-wallpaper) program for automatically changing your wallpaper depending on if its daytime or nighttime (helps your eyes).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
