### PR TITLE
potreeconverter: init at unstable-2022-08-04

### DIFF
--- a/pkgs/applications/graphics/potreeconverter/default.nix
+++ b/pkgs/applications/graphics/potreeconverter/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, boost
+, tbb
+, makeWrapper
+}:
+
+stdenv.mkDerivation rec {
+  pname = "PotreeConverter";
+  version = "unstable-2022-08-04";
+
+  src = fetchFromGitHub {
+    owner = "potree";
+    repo = "PotreeConverter";
+    rev = "758bbac98a662de5e57d2280675e11cc76241688";
+    sha256 = "sha256-pDdV2/edYhhBWs153hSy1evI3cXD0Xq9nrEsw3JNcH4=";
+  };
+
+  buildInputs = [
+    boost
+    tbb
+  ];
+
+  nativeBuildInputs = [
+    makeWrapper
+    cmake
+  ];
+
+  patchPhase = ''
+    substituteInPlace ./CMakeLists.txt \
+      --replace "find_package(TBB REQUIRED)" ""
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/{bin,lib}
+    mv liblaszip.so $out/lib
+    mv PotreeConverter $out/bin
+    ln -s $out/bin/PotreeConverter $out/bin/potreeconverter
+
+    # Create an empty wrapper, since PotreeConverter segfaults if called via
+    # $PATH rather than absolute path. An empty wrapper forces an absolute path
+    # on each invocation
+    wrapProgram $out/bin/PotreeConverter
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Create multi res point cloud to use with potree";
+    homepage = "https://github.com/potree/PotreeConverter";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ matthewcroughan ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1720,6 +1720,8 @@ with pkgs;
 
   portfolio-filemanager = callPackage ../applications/file-managers/portfolio-filemanager { };
 
+  potreeconverter = callPackage ../applications/graphics/potreeconverter { };
+
   ranger = callPackage ../applications/file-managers/ranger { };
 
   sfm = callPackage ../applications/file-managers/sfm { };


### PR DESCRIPTION
###### Description of changes

This is a program for processing potree pointcloud data.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
