### PR TITLE
nixos/*: deprecate docbook option docs

### DIFF
--- a/.github/workflows/compare-manuals.sh
+++ b/.github/workflows/compare-manuals.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i bash -p html-tidy
+
+set -euo pipefail
+shopt -s inherit_errexit
+
+normalize() {
+  tidy \
+      --anchor-as-name no \
+      --coerce-endtags no \
+      --escape-scripts no \
+      --fix-backslash no \
+      --fix-style-tags no \
+      --fix-uri no \
+      --indent yes \
+      --wrap 0 \
+      < "$1" \
+      2> /dev/null
+}
+
+diff -U3 <(normalize "$1") <(normalize "$2")

--- a/.github/workflows/manual-nixos.yml
+++ b/.github/workflows/manual-nixos.yml
@@ -27,5 +27,13 @@ jobs:
           # This cache is for the nixpkgs repo checks and should not be trusted or used elsewhere.
           name: nixpkgs-ci
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-      - name: Building NixOS manual
+      - name: Building NixOS manual with DocBook options
         run: NIX_PATH=nixpkgs=$(pwd) nix-build --option restrict-eval true nixos/release.nix -A manual.x86_64-linux
+      - name: Building NixOS manual with Markdown options
+        run: |
+          export NIX_PATH=nixpkgs=$(pwd)
+          nix-build \
+            --option restrict-eval true \
+            --arg configuration '{ documentation.nixos.options.allowDocBook = false; }' \
+            nixos/release.nix \
+            -A manual.x86_64-linux

--- a/.github/workflows/manual-rendering.yml
+++ b/.github/workflows/manual-rendering.yml
@@ -1,0 +1,63 @@
+name: "Check NixOS Manual DocBook rendering against MD rendering"
+
+
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # Check every 24 hours
+    - cron:  '0 0 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  check-rendering-equivalence:
+    permissions:
+      issues: write  # for peter-evans/create-or-update-comment to create or update comment
+    if: github.repository_owner == 'NixOS'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v17
+        with:
+          # explicitly enable sandbox
+          extra_nix_config: sandbox = true
+      - uses: cachix/cachix-action@v10
+        with:
+          # This cache is for the nixpkgs repo checks and should not be trusted or used elsewhere.
+          name: nixpkgs-ci
+          signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+
+      - name: Build DocBook and MD manuals
+        run: |
+          export NIX_PATH=nixpkgs=$(pwd)
+          nix-build \
+            --option restrict-eval true \
+            -o docbook nixos/release.nix \
+            -A manual.x86_64-linux
+          nix-build \
+            --option restrict-eval true \
+            --arg configuration '{ documentation.nixos.options.allowDocBook = false; }' \
+            -o md nixos/release.nix \
+            -A manual.x86_64-linux
+
+      - name: Compare DocBook and MD manuals
+        id: check
+        run: |
+          .github/workflows/compare-manuals.sh \
+            docbook/share/doc/nixos/options.html \
+            md/share/doc/nixos/options.html
+
+      # if the manual can't be built we don't want to notify anyone.
+      # while this may temporarily hide rendering failures it will be a lot
+      # less noisy until all nixpkgs pull requests have stopped using
+      # docbook for option docs.
+      - name: Comment on failure
+        uses: peter-evans/create-or-update-comment@v2
+        if: ${{ failure() && steps.check.conclusion == 'failure' }}
+        with:
+          issue-number: 189318
+          body: |
+            Markdown and DocBook manuals do not agree.
+
+            Check https://github.com/NixOS/nixpkgs/actions/runs/${{ github.run_id }} for details.

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -284,7 +284,10 @@ rec {
   */
   literalDocBook = text:
     if ! isString text then throw "literalDocBook expects a string."
-    else { _type = "literalDocBook"; inherit text; };
+    else
+      lib.warnIf (lib.isInOldestRelease 2211)
+        "literalDocBook is deprecated, use literalMD instead"
+        { _type = "literalDocBook"; inherit text; };
 
   /* Transition marker for documentation that's already migrated to markdown
      syntax.

--- a/nixos/doc/manual/default.nix
+++ b/nixos/doc/manual/default.nix
@@ -6,6 +6,7 @@
 , extraSources ? []
 , baseOptionsJSON ? null
 , warningsAreErrors ? true
+, allowDocBook ? true
 , prefix ? ../../..
 }:
 
@@ -28,7 +29,7 @@ let
   stripAnyPrefixes = lib.flip (lib.foldr lib.removePrefix) prefixesToStrip;
 
   optionsDoc = buildPackages.nixosOptionsDoc {
-    inherit options revision baseOptionsJSON warningsAreErrors;
+    inherit options revision baseOptionsJSON warningsAreErrors allowDocBook;
     transformOptions = opt: opt // {
       # Clean up declaration sites to not refer to the NixOS source tree.
       declarations = map stripAnyPrefixes opt.declarations;

--- a/nixos/doc/manual/development/option-declarations.section.md
+++ b/nixos/doc/manual/development/option-declarations.section.md
@@ -44,26 +44,23 @@ The function `mkOption` accepts the following arguments.
 :   A textual representation of the default value to be rendered verbatim in
     the manual. Useful if the default value is a complex expression or depends
     on other values or packages.
-    Use `lib.literalExpression` for a Nix expression, `lib.literalDocBook` for
-    a plain English description in DocBook format.
+    Use `lib.literalExpression` for a Nix expression, `lib.literalMD` for
+    a plain English description in [Nixpkgs-flavored Markdown](
+    https://nixos.org/nixpkgs/manual/#sec-contributing-markup) format.
 
 `example`
 
 :   An example value that will be shown in the NixOS manual.
-    You can use `lib.literalExpression` and `lib.literalDocBook` in the same way
+    You can use `lib.literalExpression` and `lib.literalMD` in the same way
     as in `defaultText`.
 
 `description`
 
-:   A textual description of the option, in DocBook format, that will be
+:   A textual description of the option, in [Nixpkgs-flavored Markdown](
+    https://nixos.org/nixpkgs/manual/#sec-contributing-markup) format, that will be
     included in the NixOS manual. During the migration process from DocBook
-    to CommonMark the description may also be written in CommonMark, but has
-    to be wrapped in `lib.mdDoc` to differentiate it from DocBook. See
-    the nixpkgs manual for [the list of CommonMark extensions](
-    https://nixos.org/nixpkgs/manual/#sec-contributing-markup)
-    supported by NixOS documentation.
-
-    New documentation should preferably be written as CommonMark.
+    to CommonMark the description may also be written in DocBook, but this is
+    discouraged.
 
 ## Utility functions for common option patterns {#sec-option-declarations-util}
 

--- a/nixos/doc/manual/from_md/development/option-declarations.section.xml
+++ b/nixos/doc/manual/from_md/development/option-declarations.section.xml
@@ -69,8 +69,10 @@ options = {
           verbatim in the manual. Useful if the default value is a
           complex expression or depends on other values or packages. Use
           <literal>lib.literalExpression</literal> for a Nix expression,
-          <literal>lib.literalDocBook</literal> for a plain English
-          description in DocBook format.
+          <literal>lib.literalMD</literal> for a plain English
+          description in
+          <link xlink:href="https://nixos.org/nixpkgs/manual/#sec-contributing-markup">Nixpkgs-flavored
+          Markdown</link> format.
         </para>
       </listitem>
     </varlistentry>
@@ -82,7 +84,7 @@ options = {
         <para>
           An example value that will be shown in the NixOS manual. You
           can use <literal>lib.literalExpression</literal> and
-          <literal>lib.literalDocBook</literal> in the same way as in
+          <literal>lib.literalMD</literal> in the same way as in
           <literal>defaultText</literal>.
         </para>
       </listitem>
@@ -93,18 +95,12 @@ options = {
       </term>
       <listitem>
         <para>
-          A textual description of the option, in DocBook format, that
-          will be included in the NixOS manual. During the migration
-          process from DocBook to CommonMark the description may also be
-          written in CommonMark, but has to be wrapped in
-          <literal>lib.mdDoc</literal> to differentiate it from DocBook.
-          See the nixpkgs manual for
-          <link xlink:href="https://nixos.org/nixpkgs/manual/#sec-contributing-markup">the
-          list of CommonMark extensions</link> supported by NixOS
-          documentation.
-        </para>
-        <para>
-          New documentation should preferably be written as CommonMark.
+          A textual description of the option, in
+          <link xlink:href="https://nixos.org/nixpkgs/manual/#sec-contributing-markup">Nixpkgs-flavored
+          Markdown</link> format, that will be included in the NixOS
+          manual. During the migration process from DocBook to
+          CommonMark the description may also be written in DocBook, but
+          this is discouraged.
         </para>
       </listitem>
     </varlistentry>

--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -571,6 +571,25 @@
       </listitem>
       <listitem>
         <para>
+          Option descriptions, examples, and defaults writting in
+          DocBook are now deprecated. Using CommonMark is preferred and
+          will become the default in a future release.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The
+          <literal>documentation.nixos.options.allowDocBook</literal>
+          option was added to ease the transition to CommonMark option
+          documentation. Setting this option to <literal>false</literal>
+          causes an error for every option included in the manual that
+          uses DocBook documentation; it defaults to
+          <literal>true</literal> to preserve the previous behavior and
+          will be removed once the transition to CommonMark is complete.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           The udisks2 service, available at
           <literal>services.udisks2.enable</literal>, is now disabled by
           default. It will automatically be enabled through services and

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -195,6 +195,10 @@ Use `configure.packages` instead.
 
 - memtest86+ was updated from 5.00-coreboot-002 to 6.00-beta2. It is now the upstream version from https://www.memtest.org/, as coreboot's fork is no longer available.
 
+- Option descriptions, examples, and defaults writting in DocBook are now deprecated. Using CommonMark is preferred and will become the default in a future release.
+
+- The `documentation.nixos.options.allowDocBook` option was added to ease the transition to CommonMark option documentation. Setting this option to `false` causes an error for every option included in the manual that uses DocBook documentation; it defaults to `true` to preserve the previous behavior and will be removed once the transition to CommonMark is complete.
+
 - The udisks2 service, available at `services.udisks2.enable`, is now disabled by default. It will automatically be enabled through services and desktop environments as needed.
   This also means that polkit will now actually be disabled by default. The default for `security.polkit.enable` was already flipped in the previous release, but udisks2 being enabled by default re-enabled it.
 

--- a/nixos/lib/make-options-doc/default.nix
+++ b/nixos/lib/make-options-doc/default.nix
@@ -34,6 +34,10 @@
 # instead of printing warnings for eg options with missing descriptions (which may be lost
 # by nix build unless -L is given), emit errors instead and fail the build
 , warningsAreErrors ? true
+# allow docbook option docs if `true`. only markdown documentation is allowed when set to
+# `false`, and a different renderer may be used with different bugs and performance
+# characteristics but (hopefully) indistinguishable output.
+, allowDocBook ? true
 }:
 
 let
@@ -127,26 +131,23 @@ in rec {
       ];
       options = builtins.toFile "options.json"
         (builtins.unsafeDiscardStringContext (builtins.toJSON optionsNix));
+      # merge with an empty set if baseOptionsJSON is null to run markdown
+      # processing on the input options
+      baseJSON =
+        if baseOptionsJSON == null
+        then builtins.toFile "base.json" "{}"
+        else baseOptionsJSON;
     }
     ''
       # Export list of options in different format.
       dst=$out/share/doc/nixos
       mkdir -p $dst
 
-      ${
-        if baseOptionsJSON == null
-          then ''
-            # `cp $options $dst/options.json`, but with temporary
-            # markdown processing
-            python ${./mergeJSON.py} $options <(echo '{}') > $dst/options.json
-          ''
-          else ''
-            python ${./mergeJSON.py} \
-              ${lib.optionalString warningsAreErrors "--warnings-are-errors"} \
-              ${baseOptionsJSON} $options \
-              > $dst/options.json
-          ''
-      }
+      python ${./mergeJSON.py} \
+        ${lib.optionalString warningsAreErrors "--warnings-are-errors"} \
+        ${lib.optionalString (! allowDocBook) "--error-on-docbook"} \
+        $baseJSON $options \
+        > $dst/options.json
 
       brotli -9 < $dst/options.json > $dst/options.json.br
 

--- a/nixos/modules/misc/documentation.nix
+++ b/nixos/modules/misc/documentation.nix
@@ -99,7 +99,7 @@ let
               exit 1
             } >&2
         '';
-    inherit (cfg.nixos.options) warningsAreErrors;
+    inherit (cfg.nixos.options) warningsAreErrors allowDocBook;
   };
 
 
@@ -252,6 +252,23 @@ in
           Whether to split the option docs build into a cacheable and an uncacheable part.
           Splitting the build can substantially decrease the amount of time needed to build
           the manual, but some user modules may be incompatible with this splitting.
+        '';
+      };
+
+      nixos.options.allowDocBook = mkOption {
+        type = types.bool;
+        default = true;
+        description = lib.mdDoc ''
+          Whether to allow DocBook option docs. When set to `false` all option using
+          DocBook documentation will cause a manual build error; additionally a new
+          renderer may be used.
+
+          ::: {.note}
+          The `false` setting for this option is not yet fully supported. While it
+          should work fine and produce the same output as the previous toolchain
+          using DocBook it may not work in all circumstances. Whether markdown option
+          documentation is allowed is independent of this option.
+          :::
         '';
       };
 

--- a/nixos/modules/programs/rust-motd.nix
+++ b/nixos/modules/programs/rust-motd.nix
@@ -7,7 +7,7 @@ let
   format = pkgs.formats.toml { };
 in {
   options.programs.rust-motd = {
-    enable = mkEnableOption "rust-motd";
+    enable = mkEnableOption (lib.mdDoc "rust-motd");
     enableMotdInSSHD = mkOption {
       default = true;
       type = types.bool;

--- a/nixos/modules/services/continuous-integration/buildkite-agents.nix
+++ b/nixos/modules/services/continuous-integration/buildkite-agents.nix
@@ -9,7 +9,7 @@ let
     inherit name;
     value = mkOption {
       default = null;
-      inherit description;
+      description = lib.mdDoc description;
       type = types.nullOr types.lines;
     } // (if example == null then {} else { inherit example; });
   };

--- a/nixos/modules/services/desktops/espanso.nix
+++ b/nixos/modules/services/desktops/espanso.nix
@@ -6,7 +6,7 @@ in {
   meta = { maintainers = with lib.maintainers; [ numkem ]; };
 
   options = {
-    services.espanso = { enable = options.mkEnableOption "Espanso"; };
+    services.espanso = { enable = options.mkEnableOption (lib.mdDoc "Espanso"); };
   };
 
   config = mkIf cfg.enable {

--- a/nixos/modules/services/misc/sourcehut/default.nix
+++ b/nixos/modules/services/misc/sourcehut/default.nix
@@ -101,7 +101,7 @@ let
     todosrht
   ]);
   mkOptionNullOrStr = description: mkOption {
-    inherit description;
+    description = lib.mdDoc description;
     type = with types; nullOr str;
     default = null;
   };

--- a/nixos/modules/services/monitoring/prometheus/exporters/rtl_433.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/rtl_433.nix
@@ -16,7 +16,7 @@ in
           };
           "${field}" = lib.mkOption {
             type = int;
-            inherit description;
+            description = lib.mdDoc description;
           };
           location = lib.mkOption {
             type = str;

--- a/nixos/modules/services/monitoring/prometheus/exporters/v2ray.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/v2ray.nix
@@ -11,7 +11,7 @@ in
     v2rayEndpoint = mkOption {
       type = types.str;
       default = "127.0.0.1:54321";
-      description = ''
+      description = lib.mdDoc ''
         v2ray grpc api endpoint
       '';
     };

--- a/nixos/modules/services/networking/i2pd.nix
+++ b/nixos/modules/services/networking/i2pd.nix
@@ -396,12 +396,12 @@ in
       };
 
       precomputation.elgamal = mkEnableTrueOption "Precomputed ElGamal tables" // {
-        description = ''
+        description = lib.mdDoc ''
           Whenever to use precomputated tables for ElGamal.
-          <command>i2pd</command> defaults to <literal>false</literal>
+          {command}`i2pd` defaults to `false`
           to save 64M of memory (and looses some performance).
 
-          We default to <literal>true</literal> as that is what most
+          We default to `true` as that is what most
           users want anyway.
         '';
       };

--- a/nixos/modules/services/networking/keepalived/default.nix
+++ b/nixos/modules/services/networking/keepalived/default.nix
@@ -268,11 +268,11 @@ in
         type = types.nullOr types.path;
         default = null;
         example = "/run/keys/keepalived.env";
-        description = ''
+        description = lib.mdDoc ''
           Environment variables from this file will be interpolated into the
-          final config file using envsubst with this syntax: <literal>$ENVIRONMENT</literal>
-          or <literal>''${VARIABLE}</literal>.
-          The file should contain lines formatted as <literal>SECRET_VAR=SECRET_VALUE</literal>.
+          final config file using envsubst with this syntax: `$ENVIRONMENT`
+          or `''${VARIABLE}`.
+          The file should contain lines formatted as `SECRET_VAR=SECRET_VALUE`.
           This is useful to avoid putting secrets into the nix store.
         '';
       };

--- a/nixos/modules/services/networking/strongswan-swanctl/param-constructors.nix
+++ b/nixos/modules/services/networking/strongswan-swanctl/param-constructors.nix
@@ -152,7 +152,7 @@ rec {
     option = mkOption {
       type = types.attrsOf (types.submodule {options = paramsToOptions params;});
       default = {};
-      inherit description;
+      description = lib.mdDoc description;
     };
     render = postfix: attrs:
       let postfixedAttrs = mapAttrs' (name: nameValuePair "${name}-${postfix}") attrs;

--- a/nixos/modules/services/networking/wpa_supplicant.nix
+++ b/nixos/modules/services/networking/wpa_supplicant.nix
@@ -187,12 +187,12 @@ in {
       };
 
       allowAuxiliaryImperativeNetworks = mkEnableOption (lib.mdDoc "support for imperative & declarative networks") // {
-        description = ''
+        description = lib.mdDoc ''
           Whether to allow configuring networks "imperatively" (e.g. via
-          <literal>wpa_supplicant_gui</literal>) and declaratively via
-          <xref linkend="opt-networking.wireless.networks"/>.
+          `wpa_supplicant_gui`) and declaratively via
+          [](#opt-networking.wireless.networks).
 
-          Please note that this adds a custom patch to <literal>wpa_supplicant</literal>.
+          Please note that this adds a custom patch to `wpa_supplicant`.
         '';
       };
 

--- a/nixos/modules/services/web-apps/dolibarr.nix
+++ b/nixos/modules/services/web-apps/dolibarr.nix
@@ -48,12 +48,12 @@ in
 {
   # interface
   options.services.dolibarr = {
-    enable = mkEnableOption "dolibarr";
+    enable = mkEnableOption (lib.mdDoc "dolibarr");
 
     domain = mkOption {
       type = types.str;
       default = "localhost";
-      description = ''
+      description = lib.mdDoc ''
         Domain name of your server.
       '';
     };
@@ -61,35 +61,35 @@ in
     user = mkOption {
       type = types.str;
       default = "dolibarr";
-      description = ''
+      description = lib.mdDoc ''
         User account under which dolibarr runs.
 
-        <note><para>
-          If left as the default value this user will automatically be created
-          on system activation, otherwise you are responsible for
-          ensuring the user exists before the dolibarr application starts.
-        </para></note>
+        ::: {.note}
+        If left as the default value this user will automatically be created
+        on system activation, otherwise you are responsible for
+        ensuring the user exists before the dolibarr application starts.
+        :::
       '';
     };
 
     group = mkOption {
       type = types.str;
       default = "dolibarr";
-      description = ''
+      description = lib.mdDoc ''
         Group account under which dolibarr runs.
 
-        <note><para>
-          If left as the default value this group will automatically be created
-          on system activation, otherwise you are responsible for
-          ensuring the group exists before the dolibarr application starts.
-        </para></note>
+        ::: {.note}
+        If left as the default value this group will automatically be created
+        on system activation, otherwise you are responsible for
+        ensuring the group exists before the dolibarr application starts.
+        :::
       '';
     };
 
     stateDir = mkOption {
       type = types.str;
       default = "/var/lib/dolibarr";
-      description = ''
+      description = lib.mdDoc ''
         State and configuration directory dolibarr will use.
       '';
     };
@@ -98,33 +98,33 @@ in
       host = mkOption {
         type = types.str;
         default = "localhost";
-        description = "Database host address.";
+        description = lib.mdDoc "Database host address.";
       };
       port = mkOption {
         type = types.port;
         default = 3306;
-        description = "Database host port.";
+        description = lib.mdDoc "Database host port.";
       };
       name = mkOption {
         type = types.str;
         default = "dolibarr";
-        description = "Database name.";
+        description = lib.mdDoc "Database name.";
       };
       user = mkOption {
         type = types.str;
         default = "dolibarr";
-        description = "Database username.";
+        description = lib.mdDoc "Database username.";
       };
       passwordFile = mkOption {
         type = with types; nullOr path;
         default = null;
         example = "/run/keys/dolibarr-dbpassword";
-        description = "Database password file.";
+        description = lib.mdDoc "Database password file.";
       };
       createLocally = mkOption {
         type = types.bool;
         default = true;
-        description = "Create the database and database user locally.";
+        description = lib.mdDoc "Create the database and database user locally.";
       };
     };
 

--- a/nixos/modules/services/web-apps/writefreely.nix
+++ b/nixos/modules/services/web-apps/writefreely.nix
@@ -133,45 +133,45 @@ let
 in {
   options.services.writefreely = {
     enable =
-      lib.mkEnableOption "Writefreely, build a digital writing community";
+      lib.mkEnableOption (lib.mdDoc "Writefreely, build a digital writing community");
 
     package = lib.mkOption {
       type = lib.types.package;
       default = pkgs.writefreely;
       defaultText = lib.literalExpression "pkgs.writefreely";
-      description = "Writefreely package to use.";
+      description = lib.mdDoc "Writefreely package to use.";
     };
 
     stateDir = mkOption {
       type = types.path;
       default = "/var/lib/writefreely";
-      description = "The state directory where keys and data are stored.";
+      description = lib.mdDoc "The state directory where keys and data are stored.";
     };
 
     user = mkOption {
       type = types.str;
       default = "writefreely";
-      description = "User under which Writefreely is ran.";
+      description = lib.mdDoc "User under which Writefreely is ran.";
     };
 
     group = mkOption {
       type = types.str;
       default = "writefreely";
-      description = "Group under which Writefreely is ran.";
+      description = lib.mdDoc "Group under which Writefreely is ran.";
     };
 
     host = mkOption {
       type = types.str;
       default = "";
-      description = "The public host name to serve.";
+      description = lib.mdDoc "The public host name to serve.";
       example = "example.com";
     };
 
     settings = mkOption {
       default = { };
-      description = ''
-        Writefreely configuration (<filename>config.ini</filename>). Refer to
-        <link xlink:href="https://writefreely.org/docs/latest/admin/config" />
+      description = lib.mdDoc ''
+        Writefreely configuration ({file}`config.ini`). Refer to
+        <https://writefreely.org/docs/latest/admin/config>
         for details.
       '';
 
@@ -183,7 +183,7 @@ in {
             theme = mkOption {
               type = types.str;
               default = "write";
-              description = "The theme to apply.";
+              description = lib.mdDoc "The theme to apply.";
             };
           };
 
@@ -192,7 +192,7 @@ in {
               type = types.port;
               default = if cfg.nginx.enable then 18080 else 80;
               defaultText = "80";
-              description = "The port WriteFreely should listen on.";
+              description = lib.mdDoc "The port WriteFreely should listen on.";
             };
           };
         };
@@ -203,60 +203,60 @@ in {
       type = mkOption {
         type = types.enum [ "sqlite3" "mysql" ];
         default = "sqlite3";
-        description = "The database provider to use.";
+        description = lib.mdDoc "The database provider to use.";
       };
 
       name = mkOption {
         type = types.str;
         default = "writefreely";
-        description = "The name of the database to store data in.";
+        description = lib.mdDoc "The name of the database to store data in.";
       };
 
       user = mkOption {
         type = types.nullOr types.str;
         default = if cfg.database.type == "mysql" then "writefreely" else null;
         defaultText = "writefreely";
-        description = "The database user to connect as.";
+        description = lib.mdDoc "The database user to connect as.";
       };
 
       passwordFile = mkOption {
         type = types.nullOr types.path;
         default = null;
-        description = "The file to load the database password from.";
+        description = lib.mdDoc "The file to load the database password from.";
       };
 
       host = mkOption {
         type = types.str;
         default = "localhost";
-        description = "The database host to connect to.";
+        description = lib.mdDoc "The database host to connect to.";
       };
 
       port = mkOption {
         type = types.port;
         default = 3306;
-        description = "The port used when connecting to the database host.";
+        description = lib.mdDoc "The port used when connecting to the database host.";
       };
 
       tls = mkOption {
         type = types.bool;
         default = false;
         description =
-          "Whether or not TLS should be used for the database connection.";
+          lib.mdDoc "Whether or not TLS should be used for the database connection.";
       };
 
       migrate = mkOption {
         type = types.bool;
         default = true;
         description =
-          "Whether or not to automatically run migrations on startup.";
+          lib.mdDoc "Whether or not to automatically run migrations on startup.";
       };
 
       createLocally = mkOption {
         type = types.bool;
         default = false;
-        description = ''
-          When <option>services.writefreely.database.type</option> is set to
-          <code>"mysql"</code>, this option will enable the MySQL service locally.
+        description = lib.mdDoc ''
+          When {option}`services.writefreely.database.type` is set to
+          `"mysql"`, this option will enable the MySQL service locally.
         '';
       };
     };
@@ -264,15 +264,15 @@ in {
     admin = {
       name = mkOption {
         type = types.nullOr types.str;
-        description = "The name of the first admin user.";
+        description = lib.mdDoc "The name of the first admin user.";
         default = null;
       };
 
       initialPasswordFile = mkOption {
         type = types.path;
-        description = ''
+        description = lib.mdDoc ''
           Path to a file containing the initial password for the admin user.
-          If not provided, the default password will be set to <code>nixos</code>.
+          If not provided, the default password will be set to `nixos`.
         '';
         default = pkgs.writeText "default-admin-pass" "nixos";
         defaultText = "/nix/store/xxx-default-admin-pass";
@@ -284,13 +284,13 @@ in {
         type = types.bool;
         default = false;
         description =
-          "Whether or not to enable and configure nginx as a proxy for WriteFreely.";
+          lib.mdDoc "Whether or not to enable and configure nginx as a proxy for WriteFreely.";
       };
 
       forceSSL = mkOption {
         type = types.bool;
         default = false;
-        description = "Whether or not to force the use of SSL.";
+        description = lib.mdDoc "Whether or not to force the use of SSL.";
       };
     };
 
@@ -299,7 +299,7 @@ in {
         type = types.bool;
         default = false;
         description =
-          "Whether or not to automatically fetch and configure SSL certs.";
+          lib.mdDoc "Whether or not to automatically fetch and configure SSL certs.";
       };
     };
   };

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -1257,11 +1257,10 @@ let
         default = {};
         example = { Route = "fd00::/64"; };
         type = types.addCheck (types.attrsOf unitOption) check.network.sectionIPv6RoutePrefix;
-        description = ''
+        description = lib.mdDoc ''
           Each attribute in this set specifies an option in the
-          <literal>[IPv6RoutePrefix]</literal> section of the unit.  See
-          <citerefentry><refentrytitle>systemd.network</refentrytitle>
-          <manvolnum>5</manvolnum></citerefentry> for details.
+          `[IPv6RoutePrefix]` section of the unit.  See
+          {manpage}`systemd.network(5)` for details.
         '';
       };
     };
@@ -1413,10 +1412,9 @@ let
       default = [];
       example = [ { Route = "fd00::/64"; LifetimeSec = 3600; } ];
       type = with types; listOf (submodule ipv6RoutePrefixOptions);
-      description = ''
+      description = lib.mdDoc ''
         A list of ipv6RoutePrefix sections to be added to the unit.  See
-        <citerefentry><refentrytitle>systemd.network</refentrytitle>
-        <manvolnum>5</manvolnum></citerefentry> for details.
+        {manpage}`systemd.network(5)` for details.
       '';
     };
 

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -584,7 +584,7 @@ in
       example = literalExpression ''
         import pkgs.path { system = "x86_64-darwin"; }
       '';
-      description = ''
+      description = lib.mdDoc ''
         pkgs set to use for the host-specific packages of the vm runner.
         Changing this to e.g. a Darwin package set allows running NixOS VMs on Darwin.
       '';


### PR DESCRIPTION
###### Description of changes

deprecate docbook option docs and functions for creating docbook option docs. this very explicitly does not introduce warnings that could break a build to not break any systems when the 22.11 rolls around, and for 23.05 we'll want to remove docbook support for options entirely (without another warning).

a couple new module have been merged since the last conversion PR was started and a few options weren't converted even then, so we have to handle a few deprecation messages immediately as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
