### PR TITLE
qmplay2: rename libgme to game-music-emu

### DIFF
--- a/pkgs/applications/video/qmplay2/default.nix
+++ b/pkgs/applications/video/qmplay2/default.nix
@@ -5,10 +5,10 @@
 , cmake
 , alsa-lib
 , ffmpeg
+, game-music-emu
 , libass
 , libcddb
 , libcdio
-, libgme
 , libpulseaudio
 , libsidplayfp
 , libva
@@ -40,11 +40,11 @@ stdenv.mkDerivation rec {
   buildInputs = [
     alsa-lib
     ffmpeg
+    game-music-emu
     libXv
     libass
     libcddb
     libcdio
-    libgme
     libpulseaudio
     libsidplayfp
     libva


### PR DESCRIPTION
qmplay2: rename libgme to game-music-emu


```
error: Function called without required argument "libgme" at /home/intj/.cache/nixpkgs-review/pr-189290-2/nixpkgs/pkgs/applications/video/qmplay2/default.nix:11, did you mean "libgee", "libime" or "lib3mf"?
(use '--show-trace' to show detailed location information)
```


```
~/nixpkgs/pkgs/top-level (master) $ rg libgme
aliases.nix
720:  libgme = game-music-emu; # Added 2022-07-20
```