### PR TITLE
nixos/nvidia: Add cuda option

### DIFF
--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -37,6 +37,22 @@ in
     ];
 
   options = {
+    hardware.nvidia.cuda.enable = lib.mkOption {
+      type = types.bool;
+      default = enabled;
+      defaultText = literalExpression ''elem "nvidia" config.services.xserver.videoDrivers'';
+      description = lib.mdDoc "Whether to enable cuda.";
+    };
+
+    hardware.nvidia.cuda.package = lib.mkOption {
+      type = types.package;
+      default = pkgs.cudaPackages.cudatoolkit;
+      defaultText = literalExpression "pkgs.cudaPackages.cudatoolkit";
+      description = lib.mdDoc ''
+        Which cuda package to use for system libraries.
+      '';
+    };
+
     hardware.nvidia.powerManagement.enable = mkOption {
       type = types.bool;
       default = false;
@@ -320,7 +336,10 @@ in
     hardware.opengl.extraPackages = [
       nvidia_x11.out
       pkgs.nvidia-vaapi-driver
+    ] ++ lib.optionals cfg.cuda.enable [
+      cfg.cuda.package
     ];
+
     hardware.opengl.extraPackages32 = [
       nvidia_x11.lib32
       pkgs.pkgsi686Linux.nvidia-vaapi-driver


### PR DESCRIPTION
###### Description of changes

Install cuda by default when people mention `serivces.xserver.videoDriver = [ "nvidia" ];`.

related: https://github.com/NixOS/nixpkgs/issues/189217

cc @FRidh @NixOS/cuda-maintainers 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
