### PR TITLE
auth0-cli: init at 0.11.10

### DIFF
--- a/pkgs/tools/admin/auth0-cli/default.nix
+++ b/pkgs/tools/admin/auth0-cli/default.nix
@@ -1,0 +1,36 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "auth0-cli";
+  version = "0.11.10";
+
+  src = fetchFromGitHub {
+    owner = "auth0";
+    repo = "auth0-cli";
+    rev = "v${version}";
+    hash = "sha256-1/T2hpSNamorWFuaSBoLsGpe9I06HGew9S3yJsDLmLQ=";
+  };
+
+  vendorHash = "sha256-d9ZwK/LAZGgeagGsg3bGYnVykfQcCLUex0pe/PUCtkA=";
+
+  ldflags = [
+    "-s" "-w"
+    "-X github.com/auth0/auth0-cli/internal/buildinfo.Version=v${version}"
+  ];
+
+  preCheck = ''
+    # Feed in all tests for testing
+    # This is because subPackages above limits what is built to just what we
+    # want but also limits the tests
+    unset subPackages
+  '';
+
+  subPackages = [ "cmd/auth0" ];
+
+  meta = with lib; {
+    description = "Supercharge your developer workflow";
+    homepage = "https://auth0.github.io/auth0-cli";
+    license = licenses.mit;
+    maintainers = with maintainers; [ matthewcroughan ];
+  };
+}

--- a/pkgs/tools/admin/auth0-cli/default.nix
+++ b/pkgs/tools/admin/auth0-cli/default.nix
@@ -16,6 +16,7 @@ buildGoModule rec {
   ldflags = [
     "-s" "-w"
     "-X github.com/auth0/auth0-cli/internal/buildinfo.Version=v${version}"
+    "-X github.com/auth0/auth0-cli/internal/buildinfo.Revision=0000000"
   ];
 
   preCheck = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -272,6 +272,8 @@ with pkgs;
 
   authz0 = callPackage ../tools/security/authz0 { };
 
+  auth0-cli = callPackage ../tools/admin/auth0-cli { };
+
   atomic-operator = callPackage ../tools/security/atomic-operator { };
 
   avro-tools = callPackage ../development/tools/avro-tools { };


### PR DESCRIPTION
###### Description of changes

Adds the auth0-cli at version 0.11.10

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
