### PR TITLE
obs-studio: include plugins in wrapper again

### DIFF
--- a/pkgs/applications/video/obs-studio/wrapper.nix
+++ b/pkgs/applications/video/obs-studio/wrapper.nix
@@ -6,7 +6,7 @@ symlinkJoin {
   name = "wrapped-${obs-studio.name}";
 
   nativeBuildInputs = [ makeWrapper ];
-  paths = [ obs-studio ];
+  paths = [ obs-studio ] ++ plugins;
 
   postBuild = with lib;
     let
@@ -19,13 +19,20 @@ symlinkJoin {
         paths = plugins;
       };
 
-      wrapCommand = [
+      wrapCommandLine = [
           "wrapProgram"
           "$out/bin/obs"
           ''--set OBS_PLUGINS_PATH "${pluginsJoined}/lib/obs-plugins"''
           ''--set OBS_PLUGINS_DATA_PATH "${pluginsJoined}/share/obs/obs-plugins"''
         ] ++ pluginArguments;
-    in concatStringsSep " " wrapCommand;
+    in ''
+    ${concatStringsSep " " wrapCommandLine}
+
+    # Remove unused obs-plugins dir to not cause confusion
+    rm -r $out/share/obs/obs-plugins
+    # Leave some breadcrumbs
+    echo 'Plugins are at ${pluginsJoined}/share/obs/obs-plugins' > $out/share/obs/obs-plugins-README
+  '';
 
   inherit (obs-studio) meta;
   passthru = obs-studio.passthru // {


### PR DESCRIPTION
If the user asks for a plugin that does come with their own binaries or other
files to be included in their OBS installation, it should include those files. A
good example is obs-vkcapture which /requires/ system-wide files to have any use
whatsoever.

Plugins' paths were removed from the wrapper in step with preventing OBS from
loading plugins twice but wasn't actually required because the env variables
already point at the one and only location for plugins. The plugins' share dirs
don't get put in the system-wide share by default on NixOS but I decided to
remove the directory anyways for clarity.

Partially reverts 593d64f975e4e7d9439562d3f857d85e8be66012

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
