### PR TITLE
dwmbar: init at unstable-2021-12-22

### DIFF
--- a/pkgs/applications/misc/dwmbar/default.nix
+++ b/pkgs/applications/misc/dwmbar/default.nix
@@ -1,0 +1,37 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation {
+  pname = "dwmbar";
+  version = "unstable-2021-12-22";
+
+  src = fetchFromGitHub {
+    owner = "thytom";
+    repo = "dwmbar";
+    rev = "574f5703c558a56bc9c354471543511255423dc7";
+    sha256 = "sha256-IrelZpgsxq2dnsjMdh7VC5eKffEGRbDkZmZBD+tROPs=";
+  };
+
+  postPatch = ''
+    substituteInPlace dwmbar \
+      --replace 'DEFAULT_CONFIG_DIR="/usr/share/dwmbar"' "DEFAULT_CONFIG_DIR=\"$out/share/dwmbar\""
+  '';
+
+  installPhase = ''
+    install -d $out/share/dwmbar
+    cp -r modules $out/share/dwmbar/
+    install -D -t $out/share/dwmbar/ config
+    install -D -t $out/share/dwmbar/ bar.sh
+    install -Dm755 -t $out/bin/ dwmbar
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/thytom/dwmbar";
+    description = "A Modular Status Bar for dwm";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ baitinq ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26990,6 +26990,8 @@ with pkgs;
 
   dwmblocks = callPackage ../applications/misc/dwmblocks { };
 
+  dwmbar = callPackage ../applications/misc/dwmbar { };
+
   dwm-status = callPackage ../applications/window-managers/dwm/dwm-status.nix { };
 
   exploitdb = callPackage ../tools/security/exploitdb { };


### PR DESCRIPTION
###### Description of changes

Add the [dwmbar](https://github.com/thytom/dwmbar) program which is a modular status bar targeting dwm.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).