### PR TITLE
elixir_1_14: init at 1.14.0

### DIFF
--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -44,6 +44,11 @@ let
       # BEAM-based languages.
       elixir = elixir_1_13;
 
+      elixir_1_14 = lib'.callElixir ../interpreters/elixir/1.14.nix {
+        inherit erlang;
+        debugInfo = true;
+      };
+
       elixir_1_13 = lib'.callElixir ../interpreters/elixir/1.13.nix {
         inherit erlang;
         debugInfo = true;
@@ -60,11 +65,6 @@ let
       };
 
       elixir_1_10 = lib'.callElixir ../interpreters/elixir/1.10.nix {
-        inherit erlang;
-        debugInfo = true;
-      };
-
-      elixir_1_9 = lib'.callElixir ../interpreters/elixir/1.9.nix {
         inherit erlang;
         debugInfo = true;
       };

--- a/pkgs/development/interpreters/elixir/1.14.nix
+++ b/pkgs/development/interpreters/elixir/1.14.nix
@@ -1,0 +1,8 @@
+{ mkDerivation }:
+
+mkDerivation {
+  version = "1.14.0";
+  sha256 = "16rc4qaykddda6ax5f8zw70yhapgwraqbgx5gp3f40dvfax3d51l";
+  # https://hexdocs.pm/elixir/1.14.0/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp
+  minimumOTPVersion = "23";
+}

--- a/pkgs/development/interpreters/elixir/1.9.nix
+++ b/pkgs/development/interpreters/elixir/1.9.nix
@@ -1,9 +1,0 @@
-{ mkDerivation }:
-
-# How to obtain `sha256`:
-# nix-prefetch-url --unpack https://github.com/elixir-lang/elixir/archive/v${version}.tar.gz
-mkDerivation {
-  version = "1.9.4";
-  sha256 = "1l4318g35y4h0vi2w07ayc3jizw1xc3s7hdb47w6j3iw33y06g6b";
-  minimumOTPVersion = "20";
-}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14968,7 +14968,7 @@ with pkgs;
   inherit (beam.interpreters)
     erlang erlangR25 erlangR24 erlangR23 erlangR22 erlangR21
     erlang_odbc erlang_javac erlang_odbc_javac
-    elixir elixir_1_13 elixir_1_12 elixir_1_11 elixir_1_10 elixir_1_9
+    elixir elixir_1_14 elixir_1_13 elixir_1_12 elixir_1_11 elixir_1_10
     elixir_ls;
 
   erlang_nox = beam_nox.interpreters.erlang;

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -96,7 +96,7 @@ with beam; {
     # access for example elixir built with different version of Erlang, use
     # `beam.packages.erlangR24.elixir`.
     inherit (packages.erlang)
-      elixir elixir_1_13 elixir_1_12 elixir_1_11 elixir_1_10 elixir_1_9 elixir_ls;
+      elixir elixir_1_14 elixir_1_13 elixir_1_12 elixir_1_11 elixir_1_10 elixir_ls;
 
     inherit (packages.erlang) lfe lfe_1_3;
   };


### PR DESCRIPTION
Followed the example of #148619 since everything included still seems pertinent. However, some included packages do not build successfully on 1.14.0 yet, so I skipped the default (`elixir`) version change for purposes of this PR. Please let me know if the desired flow is instead to wait for such projects to become 1.14-compatible on their own.

###### Description of changes

https://elixir-lang.org/blog/2022/09/01/elixir-v1-14-0-released/
https://hexdocs.pm/elixir/1.14.0/changelog.html

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

Extras:

- [ ] ~Default `elixir` version 1.13 -> 1.14~
- [X] Removed unsupported 1.9 per https://hexdocs.pm/elixir/1.14.0/compatibility-and-deprecations.html

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Defaults:

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
