### PR TITLE
nixos/steam: support adding additional compatibility packages

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -82,6 +82,8 @@
 
 - The module `services.calibre-server` has new options to configure the `host`, `port`, `auth.enable`, `auth.mode` and `auth.userDb` path, see [#216497](https://github.com/NixOS/nixpkgs/pull/216497/) for more details.
 
+- The `steam` module now directly supports the inclusion of additional packaged compatibility tools via `programs.steam.extraCompatPackages`.
+
 ## Nixpkgs internals {#sec-release-23.11-nixpkgs-internals}
 
 - The `qemu-vm.nix` module by default now identifies block devices via

--- a/nixos/modules/programs/steam.nix
+++ b/nixos/modules/programs/steam.nix
@@ -106,6 +106,23 @@ in {
         };
       };
     };
+
+    extraCompatPackages = mkOption {
+      type = with types; listOf package;
+      default = [];
+      defaultText = literalExpression "[]";
+      example = literalExpression ''
+        with pkgs; [
+          luxtorpeda
+          proton-ge
+        ]
+      '';
+      description = lib.mdDoc ''
+        Extra packages to be used as compatibility tools for Steam on Linux. Packages will be included
+        in the `STEAM_EXTRA_COMPAT_TOOLS_PATHS` environmental variable. For more information see
+        <https://github.com/ValveSoftware/steam-for-linux/issues/6310">.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -132,6 +149,12 @@ in {
     hardware.pulseaudio.support32Bit = config.hardware.pulseaudio.enable;
 
     hardware.steam-hardware.enable = true;
+
+    # Append the extra compatibility packages to whatever else the env variable was populated with.
+    # For more information see https://github.com/ValveSoftware/steam-for-linux/issues/6310#issuecomment-511630263
+    environment.sessionVariables = mkIf (cfg.extraCompatPackages != []) {
+      STEAM_EXTRA_COMPAT_TOOLS_PATHS = strings.makeBinPath cfg.extraCompatPackages;
+    };
 
     environment.systemPackages = [
       cfg.package


### PR DESCRIPTION
###### Description of changes

Valve allows users to use other compatibility tools with Steam aside from the versions of Proton which they ship themselves. This is especially useful for using versions of Proton, Wine (proton-ge, wine-staging) or other tools (boxtron, luxtorpeda, roberta, etc.) which you've built yourself of pulled from packages not maintained by Valve.

More details can be found here: https://github.com/ValveSoftware/steam-for-linux/issues/6310

This PR allows users to set which additional packages they want Steam to search when listing additional compatibility tools. 

**NOTE**: This is my first modules PR and could probably use some help, any feedback is appreciated. I've indicated where I had my doubts.

Please let me know if this needs to target `staging` instead of `master`.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
