### PR TITLE
libspatialindex: 1.8.5 → 1.9.3

### DIFF
--- a/pkgs/development/libraries/libspatialindex/default.nix
+++ b/pkgs/development/libraries/libspatialindex/default.nix
@@ -1,20 +1,37 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libspatialindex";
-  version = "1.8.5";
+  version = "1.9.3";
 
-  src = fetchurl {
-    url = "https://download.osgeo.org/libspatialindex/spatialindex-src-${version}.tar.gz";
-    sha256 = "1vxzm7kczwnb6qdmc0hb00z8ykx11zk3sb68gc7rch4vrfi4dakw";
+  src = fetchFromGitHub {
+    owner = "libspatialindex";
+    repo = "libspatialindex";
+    rev = finalAttrs.version;
+    hash = "sha256-zsvS0IkCXyuNLCQpccKdAsFKoq0l+y66ifXlTHLNTkc=";
   };
 
-  enableParallelBuilding = true;
+  patches = [
+    # Allow building static libs
+    (fetchpatch {
+      name = "fix-static-lib-build.patch";
+      url = "https://github.com/libspatialindex/libspatialindex/commit/caee28d84685071da3ff3a4ea57ff0b6ae64fc87.patch";
+      hash = "sha256-nvTW/t9tw1ZLeycJY8nj7rQgZogxQb765Ca2b9NDvRo=";
+    })
+  ];
 
-  meta = {
+  nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [
+    "-DSIDX_BUILD_TESTS=${if finalAttrs.doCheck then "ON" else "OFF"}"
+  ];
+
+  doCheck = true;
+
+  meta = with lib; {
     description = "Extensible spatial index library in C++";
-    homepage = "http://libspatialindex.github.io/";
-    license = lib.licenses.mit;
-    platforms = lib.platforms.unix;
+    homepage = "https://libspatialindex.org";
+    license = licenses.mit;
+    platforms = platforms.unix;
   };
-}
+})


### PR DESCRIPTION
###### Description of changes
[Changelog](https://github.com/libspatialindex/libspatialindex/releases)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
