### PR TITLE
blackbox-terminal: init at 0.12.0

### DIFF
--- a/pkgs/applications/terminal-emulators/blackbox-terminal/default.nix
+++ b/pkgs/applications/terminal-emulators/blackbox-terminal/default.nix
@@ -1,0 +1,72 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, fetchurl
+, meson
+, ninja
+, pkg-config
+, vala
+, gtk4
+, vte-gtk4
+, json-glib
+, sassc
+, libadwaita
+, pcre2
+, libxml2
+, librsvg
+, callPackage
+, python3
+, gtk3
+, desktop-file-utils
+, wrapGAppsHook
+}:
+
+let
+  marble = callPackage ./marble.nix { };
+in
+stdenv.mkDerivation rec {
+  pname = "blackbox";
+  version = "0.12.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "raggesilver";
+    repo = "blackbox";
+    rev = "v${version}";
+    sha256 = "sha256-8u4qHC8+3rKDFNdg5kI48dBgAm3d6ESXN5H9aT/nIBY=";
+  };
+
+  postPatch = ''
+    patchShebangs build-aux/meson/postinstall.py
+  '';
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    vala
+    sassc
+    wrapGAppsHook
+    python3
+    gtk3 # For gtk-update-icon-cache
+    desktop-file-utils # For update-desktop-database
+  ];
+  buildInputs = [
+    gtk4
+    vte-gtk4
+    json-glib
+    marble
+    libadwaita
+    pcre2
+    libxml2
+    librsvg
+  ];
+
+  meta = with lib; {
+    description = "Beautiful GTK 4 terminal";
+    homepage = "https://gitlab.gnome.org/raggesilver/blackbox";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ chuangzhu ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/terminal-emulators/blackbox-terminal/marble.nix
+++ b/pkgs/applications/terminal-emulators/blackbox-terminal/marble.nix
@@ -1,0 +1,45 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, meson
+, ninja
+, pkg-config
+, vala
+, gobject-introspection
+, gtk4
+, gtk3
+, desktop-file-utils
+}:
+
+stdenv.mkDerivation {
+  pname = "marble";
+  version = "unstable-2022-04-20";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "raggesilver";
+    repo = "marble";
+    # Latest commit from the 'wip/gtk4' branch
+    rev = "6dcc6fefa35f0151b0549c01bd774750fe6bdef8";
+    sha256 = "sha256-0VJ9nyjWOOdLBm3ufleS/xcAS5YsSedJ2NtBjyM3uaY=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    vala
+    gtk3 # For gtk-update-icon-cache
+    desktop-file-utils # For update-desktop-database
+    gobject-introspection # For g-ir-compiler
+  ];
+  buildInputs = [ gtk4 ];
+
+  meta = with lib; {
+    description = "Raggesilver's GTK library";
+    homepage = "https://gitlab.gnome.org/raggesilver/marble";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ chuangzhu ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1788,6 +1788,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) AppKit CoreGraphics CoreServices CoreText Foundation OpenGL;
   };
 
+  blackbox-terminal = callPackage ../applications/terminal-emulators/blackbox-terminal { };
+
   contour = libsForQt5.callPackage ../applications/terminal-emulators/contour { fmt = fmt_8; };
 
   cool-retro-term = libsForQt5.callPackage ../applications/terminal-emulators/cool-retro-term { };


### PR DESCRIPTION
###### Description of changes

Solves #188062. Depends on #182618. ~~The packaging work is not perfect currently. It doesn't always launch. Most of the times it just crashes with the following error message:~~

<del>

```
**
GLib:ERROR:../glib/gvarianttypeinfo.c:186:g_variant_type_info_check: assertion failed: (0 <= index && index < 24)
Bail out! GLib:ERROR:../glib/gvarianttypeinfo.c:186:g_variant_type_info_check: assertion failed: (0 <= index && index < 24)
Aborted (core dumped)
```
</del>

![2022-09-02T17:41:17,572036917+08:00](https://user-images.githubusercontent.com/31200881/188112059-9c670d27-8f97-405d-bf47-0b5251c2eda8.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
