### PR TITLE
vapoursynth: fix darwin build

### DIFF
--- a/pkgs/development/libraries/vapoursynth/darwin-weak-function-flag.patch
+++ b/pkgs/development/libraries/vapoursynth/darwin-weak-function-flag.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile.am b/Makefile.am
+index c4d51382..b51f5971 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -88,7 +88,7 @@ pkginclude_HEADERS = include/VapourSynth.h \
+ 
+ pkgconfig_DATA += pc/vapoursynth.pc
+ 
+-libvapoursynth_la_LDFLAGS = -no-undefined -avoid-version $(UNDEFINEDLDFLAGS)
++libvapoursynth_la_LDFLAGS = -no-undefined -avoid-version -Wl,-U,_VSLoadPluginsNix $(UNDEFINEDLDFLAGS)
+ libvapoursynth_la_CPPFLAGS = $(PTHREAD_CFLAGS) $(ZIMG_CFLAGS) -DVS_PATH_PLUGINDIR='"$(PLUGINDIR)"'
+ libvapoursynth_la_LIBADD = $(PTHREAD_LIBS) $(ZIMG_LIBS) $(DLOPENLIB)
+ 

--- a/pkgs/development/libraries/vapoursynth/default.nix
+++ b/pkgs/development/libraries/vapoursynth/default.nix
@@ -17,6 +17,10 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./0001-Call-weak-function-to-allow-adding-preloaded-plugins.patch
+  ] ++ lib.optionals stdenv.isDarwin [
+    # For darwin/clang it's not enough to mark the function import as weak. It
+    # has to be explicitly declared that way to the linker.
+    ./darwin-weak-function-flag.patch
   ];
 
   nativeBuildInputs = [ pkg-config autoreconfHook makeWrapper ];
@@ -50,7 +54,6 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
     description = "A video processing framework with the future in mind";
     homepage    = "http://www.vapoursynth.com/";
     license     = licenses.lgpl21;

--- a/pkgs/development/libraries/vapoursynth/default.nix
+++ b/pkgs/development/libraries/vapoursynth/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
 
     withPlugins = import ./plugin-interface.nix {
       inherit lib python3 buildEnv writeText runCommandCC stdenv runCommand
-        vapoursynth makeWrapper withPlugins;
+        vapoursynth makeWrapper patchelf withPlugins;
     };
   };
 


### PR DESCRIPTION
###### Description of changes

The build is fixed, and the binary starts up, but I don't really know how to test this further.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
