### PR TITLE
jbig2dec: Correct license information.

### DIFF
--- a/pkgs/development/libraries/jbig2dec/default.nix
+++ b/pkgs/development/libraries/jbig2dec/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://www.jbig2dec.com/";
     description = "Decoder implementation of the JBIG2 image compression format";
-    license = lib.licenses.gpl2Plus;
+    license = lib.licenses.agpl3;
     platforms = lib.platforms.unix;
   };
 }


### PR DESCRIPTION
###### Description of changes

Update license information to correspond to information in COPYING file.

###### Things done

I don't use jbig2dec, but I'm the maintainer of the jbig2dec project.
