### PR TITLE
replibyte: init at 0.9.7

### DIFF
--- a/pkgs/development/tools/database/replibyte/default.nix
+++ b/pkgs/development/tools/database/replibyte/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, stdenv
+, rustPlatform
+, fetchFromGitHub
+, fetchpatch
+, pkg-config
+, openssl
+, Security
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "replibyte";
+  version = "0.9.7";
+
+  src = fetchFromGitHub {
+    owner = "Qovery";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "02bdz0464d6gbkgbvn67sgn6cc6p6pjqacblh8nimy0r8b13x2ki";
+  };
+
+  # Lockfile was updated in a commit after the release
+  cargoPatches = [
+    (fetchpatch {
+      url = "https://github.com/Qovery/Replibyte/commit/15f122cc83fff03ae410be705779ab964fa7b375.patch";
+      sha256 = "sha256-v95V4pl/2WN2do2SLVTJIO+5J7esqhC2BZaGBEtDhe0=";
+    })
+  ];
+
+  cargoSha256 = "sha256-Y9CXpJTY/uszAVAbafa2+FumWKWFGaOLhK1FY+Nc+EU=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ Security ];
+
+  cargoBuildFlags = [ "--all-features" ];
+
+  doCheck = false; # requires multiple dbs to be installed
+
+  meta = with lib; {
+    description = "Seed your development database with real data";
+    homepage = "https://github.com/Qovery/replibyte";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ dit7ya ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14272,6 +14272,10 @@ with pkgs;
 
   rasm = callPackage ../development/compilers/rasm { };
 
+  replibyte = callPackage ../development/tools/database/replibyte {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   rgbds = callPackage ../development/compilers/rgbds { };
 
   rgxg = callPackage ../tools/text/rgxg { };


### PR DESCRIPTION
###### Description of changes

Resolves #186300.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
