### PR TITLE
flac: apply patch for ppc64

### DIFF
--- a/pkgs/applications/audio/flac/default.nix
+++ b/pkgs/applications/audio/flac/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fetchpatch, libogg }:
+{ lib, stdenv, fetchurl, fetchpatch, autoreconfHook, libogg }:
 
 stdenv.mkDerivation rec {
   pname = "flac";
@@ -8,6 +8,20 @@ stdenv.mkDerivation rec {
     url = "http://downloads.xiph.org/releases/flac/${pname}-${version}.tar.xz";
     sha256 = "0dz7am8kbc97a6afml1h4yp085274prg8j7csryds8m3fmz61w4g";
   };
+
+  patches = [
+    # Remove on next bump
+    (fetchpatch {
+      name = "flac-Add-POWER-AltiVec-VSX-checks.patch";
+      url = "https://github.com/xiph/flac/commit/d15bcf80a06bd5300e33d5f5c94d69fbf879f45a.patch";
+      sha256 = "sha256-Pex4zAZiP2WsHbZ3SmsDY+taN5jNLOItN2FaBa+mebM=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    # Needed for patching of configure.ac, can be removed on next bump
+    autoreconfHook
+  ];
 
   buildInputs = [ libogg ];
 


### PR DESCRIPTION
###### Description of changes

When flac detects it's compiling for POWER8/9, it wants to use some AltiVec VSX intrinsics. This check wasn't precise enough however and it also tried to use them on earlier versions of POWER.

This failure can be seen by cross-compiling with `nix-build '<unstable>' -A pkgsCross.ppc64.flac`, which fails as follows:

```
  CC       lpc_intrin_vsx.lo
lpc_intrin_vsx.c: In function 'FLAC__lpc_compute_autocorrelation_intrin_power8_vsx_lag_16':
lpc_intrin_vsx.c:94:7: warning: implicit declaration of function 'vec_vsx_ld'; did you mean 'vec_vslh'? [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wimplicit-function-declaration-Wimplicit-function-declaration8;;]
   94 |  d0 = vec_vsx_ld(0, base);
      |       ^~~~~~~~~~
      |       vec_vslh
lpc_intrin_vsx.c:94:7: warning: nested extern declaration of 'vec_vsx_ld' [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wnested-externs-Wnested-externs8;;]
lpc_intrin_vsx.c:94:7: error: incompatible types when assigning to type '__vector float' {aka '__vector(4) float'} from type 'int'
lpc_intrin_vsx.c:95:7: error: incompatible types when assigning to type '__vector float' {aka '__vector(4) float'} from type 'int'
   95 |  d1 = vec_vsx_ld(16, base);
      |       ^~~~~~~~~~
lpc_intrin_vsx.c:96:7: error: incompatible types when assigning to type '__vector float' {aka '__vector(4) float'} from type 'int'
   96 |  d2 = vec_vsx_ld(32, base);
      |       ^~~~~~~~~~
lpc_intrin_vsx.c:97:7: error: incompatible types when assigning to type '__vector float' {aka '__vector(4) float'} from type 'int'
   97 |  d3 = vec_vsx_ld(48, base);
      |       ^~~~~~~~~~
lpc_intrin_vsx.c:104:8: error: incompatible types when assigning to type '__vector float' {aka '__vector(4) float'} from type 'int'
  104 |   d4 = vec_vsx_ld(0, base);
      |        ^~~~~~~~~~
lpc_intrin_vsx.c:158:8: error: incompatible types when assigning to type '__vector float' {aka '__vector(4) float'} from type 'int'
  158 |   d0 = vec_vsx_ld(0, data+i);
      |        ^~~~~~~~~~
lpc_intrin_vsx.c:159:8: error: incompatible types when assigning to type '__vector float' {aka '__vector(4) float'} from type 'int'
  159 |   d1 = vec_vsx_ld(16, data+i);
      |        ^~~~~~~~~~
lpc_intrin_vsx.c:160:8: error: incompatible types when assigning to type '__vector float' {aka '__vector(4) float'} from type 'int'
  160 |   d2 = vec_vsx_ld(32, data+i);
      |        ^~~~~~~~~~
lpc_intrin_vsx.c:161:8: error: incompatible types when assigning to type '__vector float' {aka '__vector(4) float'} from type 'int'
  161 |   d3 = vec_vsx_ld(48, data+i);
      |        ^~~~~~~~~~
```

This fetches upstream's patch for better detection. `autoreconfHook` is needed because the patch touches `configure.ac`, so everything needs to be `autoreconf`'d.

> `4793 packages updated:`

Since this only matters to POWER, should I put these in `optionals`' so it's a no-op on all more common platforms?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] powerpc64-linux
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
