### PR TITLE
maple-font: init at 5.5

### DIFF
--- a/pkgs/data/fonts/maple-font/default.nix
+++ b/pkgs/data/fonts/maple-font/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, stdenv
+, unzip
+, fetchurl
+}:
+
+let
+  maple-font = { pname, version, sha256, desc }: stdenv.mkDerivation
+    rec{
+
+      inherit pname version desc;
+      src = fetchurl {
+        url = "https://github.com/subframe7536/Maple-font/releases/download/v${version}/${pname}.zip";
+        inherit sha256;
+      };
+
+      # Work around the "unpacker appears to have produced no directories"
+      # case that happens when the archive doesn't have a subdirectory.
+      setSourceRoot = "sourceRoot=`pwd`";
+      nativeBuildInputs = [ unzip ];
+      installPhase = ''
+        find . -name '*.ttf'    -exec install -Dt $out/share/fonts/truetype {} \;
+      '';
+
+      meta = with lib; {
+        homepage = "https://github.com/subframe7536/Maple-font";
+        description = ''
+          Open source ${desc} font with round corner and ligatures for IDE and command line
+        '';
+        license = licenses.ofl;
+        platforms = platforms.all;
+        maintainers = with maintainers; [ oluceps ];
+      };
+
+    };
+in
+{
+  Mono-v5 = maple-font {
+    pname = "MapleMono";
+    version = "5.5";
+    sha256 = "sha256-xkZ9NefjWHPjWNW8LGM8CgT2Zrg4j1evvx1K56sUzR8=";
+    desc = "monospace";
+  };
+  Mono-NF-v5 = maple-font {
+    pname = "MapleMono-NF";
+    version = "5.5";
+    sha256 = "sha256-cPVGuH1CSfnRvQ4ehBvOVno7CT6Popc1Nnpcn5uJoQY=";
+    desc = "Nerd Font";
+  };
+
+}
+
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4241,6 +4241,9 @@ with pkgs;
 
   mapcidr = callPackage ../tools/misc/mapcidr { };
 
+  maple-mono = (callPackage ../data/fonts/maple-font { }).Mono-v5;
+  maple-mono-NF = (callPackage ../data/fonts/maple-font { }).Mono-NF-v5;
+
   marl = callPackage ../development/libraries/marl {};
 
   marlin-calc = callPackage ../tools/misc/marlin-calc {};


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
