### PR TITLE
classicube: init at 1.3.2

### DIFF
--- a/pkgs/games/classicube/default.nix
+++ b/pkgs/games/classicube/default.nix
@@ -1,0 +1,93 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+  # native build dependencies
+, dos2unix
+, makeWrapper
+  # build dependencies
+, SDL2
+, libGL
+, curl
+, openal
+  # runtime dependencies
+, liberation_ttf
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ClassiCube";
+  version = "1.3.2";
+
+  src = fetchFromGitHub {
+    owner = "UnknownShadow200";
+    repo = "ClassiCube";
+    rev = version;
+    sha256 = "6a0f7b03ef3a7f74cf42ffa5b88ab1a7b7beb4d864871a1b700465343ae74bb6";
+  };
+
+  nativeBuildInputs = [ dos2unix makeWrapper ];
+
+  prePatch = ''
+    # The ClassiCube sources have DOS-style newlines
+    # which causes problems with diff/patch.
+    dos2unix 'src/Platform_Posix.c' 'src/Core.h'
+  '';
+
+  patches = [
+    # Fix hardcoded font paths
+    ./font-location.patch
+    # ClassiCube doesn't compile with its X11 backend
+    # because of issues with libXi.
+    ./use-sdl.patch
+    # For some reason, the Makefile doesn't link
+    # with libcurl and openal when ClassiCube requires them.
+    # Also links with SDL2 instead of libX11 and libXi.
+    ./fix-linking.patch
+  ];
+
+  font_path = "${liberation_ttf}/share/fonts/truetype";
+
+  enableParallelBuilding = true;
+
+  postPatch = ''
+    # ClassiCube hardcodes locations of fonts.
+    # This changes the hardcoded location
+    # to the path of liberation_ttf instead
+    substituteInPlace src/Platform_Posix.c \
+      --replace '%NIXPKGS_FONT_PATH%' "${font_path}"
+  '' + lib.optionalString enableParallelBuilding ''
+    # ClassiCube's Makefile hardcodes JOBS=1 for some reason,
+    # even though it works perfectly well multi-threaded.
+    substituteInPlace src/Makefile \
+      --replace 'JOBS=1' "JOBS=$NIX_BUILD_CORES"
+  '';
+
+  buildInputs = [ SDL2 libGL curl openal liberation_ttf ];
+
+  buildPhase = ''
+    cd 'src'
+    make
+    cd -
+  '';
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    cp 'src/ClassiCube' "$out/bin"
+    # ClassiCube puts downloaded resources
+    # next to the location of the executable by default.
+    # This doesn't work with Nix
+    # as the location of the executable is read-only.
+    # We wrap the program to make it put its resources
+    # in ~/.local/share instead.
+    wrapProgram "$out/bin/ClassiCube" \
+      --run 'mkdir -p "$HOME/.local/share/ClassiCube"' \
+      --add-flags '-d"$HOME/.local/share/ClassiCube"'
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.classicube.net/";
+    description = "A lightweight, custom Minecraft Classic/ClassiCube client with optional additions written from scratch in C";
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ _360ied ];
+  };
+}

--- a/pkgs/games/classicube/default.nix
+++ b/pkgs/games/classicube/default.nix
@@ -1,15 +1,12 @@
 { lib
 , stdenv
 , fetchFromGitHub
-  # native build dependencies
 , dos2unix
 , makeWrapper
-  # build dependencies
 , SDL2
 , libGL
 , curl
 , openal
-  # runtime dependencies
 , liberation_ttf
 }:
 

--- a/pkgs/games/classicube/default.nix
+++ b/pkgs/games/classicube/default.nix
@@ -59,11 +59,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ SDL2 libGL curl openal liberation_ttf ];
 
-  buildPhase = ''
-    cd 'src'
-    make
-    cd -
-  '';
+  preBuild = "cd src";
+
+  postBuild = "cd -";
 
   installPhase = ''
     mkdir -p "$out/bin"

--- a/pkgs/games/classicube/default.nix
+++ b/pkgs/games/classicube/default.nix
@@ -51,7 +51,6 @@ stdenv.mkDerivation rec {
     # to the path of liberation_ttf instead
     substituteInPlace src/Platform_Posix.c \
       --replace '%NIXPKGS_FONT_PATH%' "${font_path}"
-  '' + lib.optionalString enableParallelBuilding ''
     # ClassiCube's Makefile hardcodes JOBS=1 for some reason,
     # even though it works perfectly well multi-threaded.
     substituteInPlace src/Makefile \

--- a/pkgs/games/classicube/fix-linking.patch
+++ b/pkgs/games/classicube/fix-linking.patch
@@ -1,0 +1,13 @@
+diff --git a/src/Makefile b/src/Makefile
+index 83188ce..3439cdb 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -40,7 +40,7 @@ LIBS=-mwindows -lws2_32 -lwininet -lwinmm -limagehlp -lcrypt32 -ld3d9
+ endif
+ 
+ ifeq ($(PLAT),linux)
+-LIBS=-lX11 -lXi -lpthread -lGL -lm -ldl
++LIBS=-lSDL2 -lpthread -lGL -lm -ldl -lcurl -lopenal
+ endif
+ 
+ ifeq ($(PLAT),sunos)

--- a/pkgs/games/classicube/font-location.patch
+++ b/pkgs/games/classicube/font-location.patch
@@ -1,0 +1,16 @@
+diff --git a/src/Platform_Posix.c b/src/Platform_Posix.c
+index bca992d..3540afa 100644
+--- a/src/Platform_Posix.c
++++ b/src/Platform_Posix.c
+@@ -440,9 +440,8 @@ void Platform_LoadSysFonts(void) {
+ 		String_FromConst("/Library/Fonts")
+ 	};
+ #else
+-	static const cc_string dirs[2] = {
+-		String_FromConst("/usr/share/fonts"),
+-		String_FromConst("/usr/local/share/fonts")
++	static const cc_string dirs[1] = {
++		String_FromConst("%NIXPKGS_FONT_PATH%")
+ 	};
+ #endif
+ 	for (i = 0; i < Array_Elems(dirs); i++) {

--- a/pkgs/games/classicube/use-sdl.patch
+++ b/pkgs/games/classicube/use-sdl.patch
@@ -1,0 +1,13 @@
+diff --git a/src/Core.h b/src/Core.h
+index e94a39e..96527d0 100644
+--- a/src/Core.h
++++ b/src/Core.h
+@@ -170,7 +170,7 @@ Thus it is **NOT SAFE** to allocate a string on the stack. */
+ #define CC_BUILD_LINUX
+ #define CC_BUILD_POSIX
+ #define CC_BUILD_GL
+-#define CC_BUILD_X11
++#define CC_BUILD_SDL
+ #define CC_BUILD_CURL
+ #define CC_BUILD_OPENAL
+ #if defined CC_BUILD_RPI

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -358,6 +358,8 @@ with pkgs;
 
   chrysalis = callPackage ../applications/misc/chrysalis { };
 
+  classicube = callPackage ../games/classicube { };
+
   clj-kondo = callPackage ../development/tools/clj-kondo { };
 
   cloak = callPackage ../applications/misc/cloak {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

ClassiCube is a lightweight, custom Minecraft Classic/Classicube client with optional additions written from scratch in C.

Homepage: https://www.classicube.net/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
