### PR TITLE
thunderbird*: 102.2.1 -> 102.2.2

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,665 +1,665 @@
 {
-  version = "102.2.0";
+  version = "102.2.1";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/af/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/af/thunderbird-102.2.1.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "e0d5a533c7455301f00dcd31c3d9ce6eeaf257f42afec1ed2414c130db426152";
+      sha256 = "d38c09e55cf1438269d80461672a615c155e975d65c8c35f5879f4236702c9eb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/ar/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/ar/thunderbird-102.2.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "325ae46353ea013325af5c42430fe5dbf2643e385f339627425dfc6086d973d2";
+      sha256 = "881eb9bafcea2646ab0830cc5a7d3ed2979b0e745ddb7a018336ed7b8382e491";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/ast/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/ast/thunderbird-102.2.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "012006fa85f1f6f45c257206ef83a94b802061e4a6e1367a3a86114ba985347e";
+      sha256 = "17cba24fa82d4b3a16be5d44ea9be4b7bb1aff4b206841d5eb169815951a9f7f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/be/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/be/thunderbird-102.2.1.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "a1febd1083e17e3476e40c1026793fb56c308dca199f8eff1f930118957222b5";
+      sha256 = "271b5d606fc489918cec8d8d316f0b8cf295a296b95a1dd458dd0b7f68fe148b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/bg/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/bg/thunderbird-102.2.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "54ef16d94ac2f95039dbbe03240dd401651234cfa65ed9cd128f7b78a5170809";
+      sha256 = "1e68a8cd66f72712f74bc3735af6c0016256ebfe1c7c2e820624268ed8837350";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/br/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/br/thunderbird-102.2.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "296c837719db56356f2b23b06b2e0114a6c213d338e014b468bba0de6eda1165";
+      sha256 = "82ab077f9a5f43875c6c82ad7d0e17f9c0b893e0bf307574fa8506e3220c8604";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/ca/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/ca/thunderbird-102.2.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "3193ed376a1a1634b81c868d4a48cb5a4c73f8549dbda62319e3d591cbe77f8e";
+      sha256 = "2ed8291572dbfaee211f5b9fdb97d4faa591f853815d9eaa43b704270551b02e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/cak/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/cak/thunderbird-102.2.1.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "182074172b1b0481978c6201eab49875006c9a9feb1fdcbcf5a74594afd3f4c0";
+      sha256 = "a5e472616951c799e6dbbdfedc3e8ba497812b027ab22c909166c3e452a29d74";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/cs/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/cs/thunderbird-102.2.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "75186fecd4c0b248653808342fb0fcb1a4fbd1d19ef1b8cbed5d547bb74fdffd";
+      sha256 = "1d3d1e0355275152050a0c5d32fc0b0f6b53f336d02837ca7653416888e271b5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/cy/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/cy/thunderbird-102.2.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "ac340fb179bf03226298d5a9b963c66aeec4b0a8d0a584fb5147dfa07afcb4b8";
+      sha256 = "4b2f3cc7e1e81abdc52969cd08cd3586e14ea2ff574c8c3b334109dab00ccd64";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/da/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/da/thunderbird-102.2.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "2743548ce40a7d4732eead3dc6003c4b71e020489ca73582c7e8da7c3d542399";
+      sha256 = "89613187e078a6f341ad8799cb4980cca770b2a0ccb0969740f53e5e7073f00b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/de/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/de/thunderbird-102.2.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "41629ea31959a2aa7db06908e27cc8ca73d2dd80069c6dd1bc8ddf3b8454ccb2";
+      sha256 = "4b7a030cb532a94a6eb3cc1343144bb90abcb7b2fcd3df81dc126b831d0a2740";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/dsb/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/dsb/thunderbird-102.2.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "c7e38f67ef8350694cb77a6a5ec289870205f172d52b6d7d2b57089d9123d6b4";
+      sha256 = "e1d05cac1f513ba573239dd677da6edb94cda9badef57b168f498b5bc218a3ee";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/el/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/el/thunderbird-102.2.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "7e5048dcd204524e516c7a2f2cf8179f389ae02ed683779a5df47e810d983f71";
+      sha256 = "d63891c05b56970021fdc455fe67d2d6f27233670e436b52522cfd012c503c74";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/en-CA/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/en-CA/thunderbird-102.2.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "dbf9d22ddc1d65e7d47c2d7cb1706c157be82367af46714592f72a6568702cf7";
+      sha256 = "34c81ec572000433e356ec5f13dbe461ca788b19ca0af9fc34ab50d7feda9cd1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/en-GB/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/en-GB/thunderbird-102.2.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "bad92cabd1c7f2886bed381b95e42a5b90a2c00a7590112df6d63dfaed191f09";
+      sha256 = "2e9aeef97495ebe462a62cfd0d9966b66cdf0a0464a8d5d012cf3d430b4a28cb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/en-US/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/en-US/thunderbird-102.2.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "fc46eed51f11b09a22d048a2e294bab3759ed17047ad049b295ac06124ac26d6";
+      sha256 = "92883c21319411096c355569c43b6cae2cbe7770c1814a9997ea7b9746431271";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/es-AR/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/es-AR/thunderbird-102.2.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "9904a857ea7d64917ab9a408ec3c15c61a6110f3bc0edc33f792229e9d462da9";
+      sha256 = "51730734c71b67ffc865646453fec802e92852fd9ab7eb371d31d9c3e843f810";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/es-ES/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/es-ES/thunderbird-102.2.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "aba7bc43a22b4dc72fc86abc567b688b088bc0aff6bd98fc4d56c4befdc86d68";
+      sha256 = "c61667e937b15fdb22e03b7875a474e422069800780df73529b6811cdb384824";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/es-MX/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/es-MX/thunderbird-102.2.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "07757eca4947cb99cb9fb5588659b2da053d96eb9a71b836a30c25c8d78b22f0";
+      sha256 = "7c5a404101f20fd9624c5402e8ba2c0699986739302de5739ad3304e2ea234f6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/et/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/et/thunderbird-102.2.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "5118f9c33520e3eac6b3179b63b6d22082784272df52c96e29240360a2db927d";
+      sha256 = "5fb2498c2a7e1a76512ace5421bfff47a1ef336cf95f671e85188dce7c8fea78";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/eu/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/eu/thunderbird-102.2.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "e1dd14890a17abe0a35f89b9ab020184b4e74436218db87f020d0650bd1e6d6b";
+      sha256 = "0eb3f3ca7e23e950ebafbdb6d4f4200279cc8e18a042a91ad163eb83c939c704";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/fi/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/fi/thunderbird-102.2.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "cece483ceff36920c39172647759a482d9f62d1f5b62dbcb4f8ad45cddc2f5d6";
+      sha256 = "ae76c531ac5b826593310b2b4b2e01d877dd246379a7ae8427f6039eb5dd581f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/fr/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/fr/thunderbird-102.2.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "ad6d12bfe74549582d8e155bb4cdd036657c324a5d4d1e34cae24fe227d976b0";
+      sha256 = "3b344b3348487c393ea72012eb6fd82dd647e31cb1dd0c305dbe6aafa8438c53";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/fy-NL/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/fy-NL/thunderbird-102.2.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "eb736ed3354635decf682cb1c85f25d160383e0385146825ad2fdfc9523eb99b";
+      sha256 = "3143c39b7e3aac2d90e6d68e2d1f782a306fdabd69641a4aa31afd02b6cd172f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/ga-IE/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/ga-IE/thunderbird-102.2.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "adf6b52fec4df57e8c53f5209ffb90d2241a17c9d950a108be42b68b7809e849";
+      sha256 = "db877b69e105c8d14b6ff420448712eafbaf6580a13fd415eb5112930a8633b8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/gd/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/gd/thunderbird-102.2.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "6a5d219878914a9b17fef0a18d2f7ab9ca8e44fa05a33af8155117b3a892b222";
+      sha256 = "3025fcddde35315267b3f0cc9d57696c5462bbe6705fb26b7a1be1eb670ca984";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/gl/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/gl/thunderbird-102.2.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "ad32a71cadb1f3abeec0f397d825d839ce268249c7d8737699e86fa4c6db6648";
+      sha256 = "39469544764d5607d73d3ffc0eafbcd2117072b2af6dba1a4a7ab43c3af2eb75";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/he/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/he/thunderbird-102.2.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "984652267caed5007b30db4ef72e8b4d5addb84e431b36c9e590ed572e7f6dac";
+      sha256 = "52c67f10bda950e12822207d41c6b425079d29f0d1d5654bb10b6e1d88751828";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/hr/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/hr/thunderbird-102.2.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "10fc94bf9c86a7b93c90e97380694991515d68565f772c6b65fdb3c29b6b366c";
+      sha256 = "e584a8f724d8e337743f9ad22e637089c5771c082091e221aad55b97541e0c16";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/hsb/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/hsb/thunderbird-102.2.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "421f91a2ad1e4d591223a36df583860a789fc5068af65eb17ec9789306582169";
+      sha256 = "0304b06dd0f23ca59f85e34e3068cd9ac3275c815e2e2004358540b38cf058c9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/hu/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/hu/thunderbird-102.2.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "59bd60b855e74d6a22f30a2f5e1621d7831da9187fb5f87096dd751234a940ab";
+      sha256 = "ef155776003ddccfe863e920f31b45f673ef445c01556d69b6ed086561a74768";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/hy-AM/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/hy-AM/thunderbird-102.2.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "b22473ac123ece7b191198ab989b7e4f8ee3bf1683851c67f42c342a6d16b735";
+      sha256 = "c65a335777b3cd9ab95b14007a9b6f10304b17c267388889a7f299ea61c44fbf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/id/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/id/thunderbird-102.2.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "435bbcfe33fc787646eda7307af038c2ed5958db147c7249d6be231df69b548f";
+      sha256 = "a407cd50ed7b4fce63b2607632a82c4e9b853b76ba522a564aae219afd0034ed";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/is/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/is/thunderbird-102.2.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "d650362838f0b764c90bda391f2727abd5360a6ae9449b8f8adb08cfc7c13c10";
+      sha256 = "6035248bcfde9fea269fa10ff3a87f035e3552b8cf76c10dfc86dd889cc7e958";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/it/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/it/thunderbird-102.2.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "1b5d6c9624b5e230880a0a6839319b317d19ebeb9ee5b73d9d515273b1e3185f";
+      sha256 = "afeef80077a18120cff1854d54067ccbc92b30f9c0e75b41067ec1e398340eb9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/ja/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/ja/thunderbird-102.2.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "587b6e71ad34e3f2a6ffb9c0b73397cbb0a237607fc2f984da4ce5123f1ac20c";
+      sha256 = "1d98a3c50d1aff70bec9ae9335708a85cf4458fbe0ff49db45a57f4d29614de4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/ka/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/ka/thunderbird-102.2.1.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "7af13df4fa3d598d89b615c059a2aba8667211c84b169f86275ff248c69c42c1";
+      sha256 = "5c749efe25f328be5f17ba2b2eeda41af0ce69f0f3e9cbc8bb55d58a3990d99a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/kab/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/kab/thunderbird-102.2.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "2109b2f25965043b95778b9109371997c380366d7db1a4b6983c19cdd845145b";
+      sha256 = "93b93383e4bad3b4f930bcbc35d178639a50fd7a30eaac573bc74b895955ec5a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/kk/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/kk/thunderbird-102.2.1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "4d5571386687c77d108ebd36ba3e2d8ce77dda77f838f78f7f3dfdb7f9be2979";
+      sha256 = "298e2c42888f29b90fdc6589b6336c5c2261a5331f5d52db89ee5b6618ec120f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/ko/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/ko/thunderbird-102.2.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "9622dfed1f9456bc8619e065d5ec73165f0a6a3a67373804e9a5b2160e53d00f";
+      sha256 = "75625d041a0193cfd8015174a1eaddd7315f3030258e58828df4b3521863bba8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/lt/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/lt/thunderbird-102.2.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "9354e778336ea6fcc6d5fb62b67feaf13891a40331d3c52615207ca8698715bd";
+      sha256 = "c5705caf0c71efb566a0d1828ec36e940940eeee23d37b9d66246abbb28114bc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/lv/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/lv/thunderbird-102.2.1.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "428caff991e4e683c1584fbf352ee4853c9a615b85b1eeed48e2924bd7322940";
+      sha256 = "d26ea9198e8d5e9ae5f51fa2456181bd979694d7bc9bcab8f3a82c01233760d6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/ms/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/ms/thunderbird-102.2.1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "a2c8de445f99d2d2bfc11a1c3e0dd152e435f57b98dbacdc89116d87ab09af70";
+      sha256 = "6dca09cd5f9306d102bca42d01607b63e1219324d1107447a728bab8693aeb8b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/nb-NO/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/nb-NO/thunderbird-102.2.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "1d6f5d729f22a7e70034b40f8b9d2e1dbdc19f13847e3a9d188c438b2241d5dd";
+      sha256 = "8d2a62dd4ccade7544ecfc6a4f88bd354f70089cf161f2fe92aeb9886e6f6411";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/nl/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/nl/thunderbird-102.2.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "2ca1bb47a95aa26de1c7d38f73327b0761ed4be71a06cf3ebbc3a4f6e1fdc19c";
+      sha256 = "b82895cfc2058be4b7818ea17521deb014a17659ddb57c093cbdc26ab3e7f7cb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/nn-NO/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/nn-NO/thunderbird-102.2.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "87ea920192587f9d266bc894903614ededf2e331186dde5b8e034292776ea7e8";
+      sha256 = "aea319db70387a2f075776fcf07b29e433ca16f898af70689d9cd4ed9d98d52f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/pa-IN/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/pa-IN/thunderbird-102.2.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "4173330ea979aa3af5c904a6b061f5b2446b33d0eb86b69768361a200a5c6bf7";
+      sha256 = "02c366563dd39f64ae11f9377c62434291aaedd951cea43e867a236dcd99dc2d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/pl/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/pl/thunderbird-102.2.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "23a4864083d98587ee47e75fb3f7680bc0f6eac5108223530ea07d7919a90a7c";
+      sha256 = "5e2b8d486eacda9a8913e0ab60e2c4079d3fb89e827ca1fba871f2b6295c6cbc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/pt-BR/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/pt-BR/thunderbird-102.2.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "2d018b23e00810517e2d6ab50977e09f9c2c8cdbf78b49040b047e76e2722266";
+      sha256 = "83339737a6ff360f1036a5b11b56f6d6648011f0c206a13da2b557aa85f4e2a0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/pt-PT/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/pt-PT/thunderbird-102.2.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "80e1f64d4697d7729162b0c63f4540eb9e5b98da162ab4ec0a9841dad7e76b8a";
+      sha256 = "4950899b2da0a706f39767199ec412e9da2b670bf15c29153244c5eb3a317731";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/rm/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/rm/thunderbird-102.2.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "4fc642c5a681d8fd84500452a895172b376b76e0935f7126ac4d1c773003505c";
+      sha256 = "d9030e30196b03c341b1fd9078447d9baf7542a119617494ea73d11192f194e0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/ro/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/ro/thunderbird-102.2.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "fd333ad0cbe09a6a598f79921548382579cc032ac5ffecf4756da8694ba9ec28";
+      sha256 = "d3be25f071698102abc71b50d71253326a9201ff9db3e7935afdd27d728985e1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/ru/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/ru/thunderbird-102.2.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "4e1858e7baf59ebd38994a21c12d5a490324146d89b493177ab79f9088a69bb3";
+      sha256 = "f9a520adaca32180b01f18fb9b8280145075248378a4a1fd273c9687733cbf42";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/sk/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/sk/thunderbird-102.2.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "68fdfcf95a5bd2836622e5863c83529f15037c4676467c9e436aab3c2031a037";
+      sha256 = "4045843feb9303bc65612d1060f874d21fdf39c0abadc84c84af0017b1fcee32";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/sl/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/sl/thunderbird-102.2.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "c42bcc5ab3e6ca4a354eb5de7ce5e9560c096a45064329abbd85b0095e9c61ce";
+      sha256 = "d914ee5a953b4ec651e634d7c2b971987ccb2ebdd130dd3ee4ab3d0cae274f59";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/sq/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/sq/thunderbird-102.2.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "d352d21bbf1e915c23ed675a1efac5ee9ed7b9b43e90aff571d6846766fb9dd1";
+      sha256 = "2fd3128af2a55cae9a8adc248afcc9497d602f0d36cb2cd7ff51aaca1b064487";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/sr/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/sr/thunderbird-102.2.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "f20c4dd96f77e0e804be47265bfb354c0c4930dbcb5593d59471981d437f1ffb";
+      sha256 = "2c5ffe0a8f4d431c37cb7f39fbd145937839425232aa72e173b88fa49628ded6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/sv-SE/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/sv-SE/thunderbird-102.2.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "af90aea4186067856dce2b8d3a81de1ad8a28c4ddd789e871be5453e13a668b1";
+      sha256 = "e98429f73e6379ebfb2bf98f9396f86025e158543e664b2b219875964dae6e1c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/th/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/th/thunderbird-102.2.1.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "763ee3216755967f5a8f27a1083ac4c0c0ca245de6682b946f43130f64194beb";
+      sha256 = "605a86e6be2eabd0ade653f93fe62e6ae47eb80951fa9c7ab9035d13bc22e52f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/tr/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/tr/thunderbird-102.2.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "d70bb634e0e0634ea78dcedb12ed6fa0135662dd98fab804b51ecf20c9367c4a";
+      sha256 = "51dfa4db80dd7596c24e6a0b67e1196d59b9083de63550862fccb6672535825a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/uk/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/uk/thunderbird-102.2.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "6884e6518b12a7d8cd9f0755244ba9faa72457c200e10c6aa16df4351368c563";
+      sha256 = "a6fcd5719501d801ed0e9f39ac100309945e567d535e6972791ca97c509131fd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/uz/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/uz/thunderbird-102.2.1.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "f4268739d0c85450bf7fdb9c0bc10882c683a890f739b75bd8778f749c2dc529";
+      sha256 = "e4666827e963fd2180babba2a117425cadff2bf47674e30225ec4f046cde1adf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/vi/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/vi/thunderbird-102.2.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "4c2345b6b8faed2af549015d09f2679ca604f1d0edafb0522d11a822186483da";
+      sha256 = "67cfdc9bb1753852250aeb523f2f91ec2fdfcab910ca1e38ac61e3922f281ee9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/zh-CN/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/zh-CN/thunderbird-102.2.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "e7475977ca163db56081a2c017fca98120d014ddff7ce1f23993161430a0a889";
+      sha256 = "f2bcca607b71c567f0ba3414e668e033633f05fff7404a1cd321d165172a36b6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-x86_64/zh-TW/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/zh-TW/thunderbird-102.2.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "5e67c1039028037274f9f2a85d8fbd88a0ba7339132ffbf52fa2632fdd0b3ef0";
+      sha256 = "e827be51e3af98fd484bb82d387754e5375cb7a5749bd1b8d0401632172165ed";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/af/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/af/thunderbird-102.2.1.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "e1395eac1c8048376e90ad10012063d29c7b8413d65f3bd4862d7b3481227c36";
+      sha256 = "42e10d674f9bc1220a1ae08f5c20551ceb9030700991681b32df137fb1fbbda6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/ar/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/ar/thunderbird-102.2.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "0da531cd5c650d41bc04994ae1b2a917a663a69afbf802bc9774efcff6ddc826";
+      sha256 = "d5a6370d2e20fea976165cc0d84c13832b8ded075fefdc98f21e1ab530dc8624";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/ast/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/ast/thunderbird-102.2.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "090a6c78576aa8376313edd7324820391832860fd9b91c861a0c08f4c2658715";
+      sha256 = "19f2ac39f04b47fb2789b0c0df8b9e0634062bcd3f117cf2cf776a39d701ec7e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/be/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/be/thunderbird-102.2.1.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "991ab842e66834aed3f0f841c3eb59262ff67e925706de4ef61b03967dfc8507";
+      sha256 = "4e007951f445b5c9daf36523535db459e869b50b732a8e82f64b3c0d898c512f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/bg/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/bg/thunderbird-102.2.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "11bcccdb1a7d1b0cee6e46c8645013be8f0372656ebe0e9f4d042950fd77976e";
+      sha256 = "6430c82f5ebc4daa2fc099d54f0aacc1d680a4c603fe69fe117490d58d9c7af3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/br/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/br/thunderbird-102.2.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "0c612c2261997e4def626ce1be51d4ffa405e7ff17ccf31b1abd2e4bf2870540";
+      sha256 = "84568e1ec4284d1f81cf5f5627de0e19db7a32f57cb621210df27f61178961ea";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/ca/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/ca/thunderbird-102.2.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "de9db187169c39ad823c0bb2154384ff698d04badc65e4cbd928e1f215d186e3";
+      sha256 = "496bd038e349d2480c7ca8c05f8ec9ccd93d0e17210cf1ffe8f65c470a2db5ad";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/cak/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/cak/thunderbird-102.2.1.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "89972257154dc19f08c64bba98f383b67e99712af17df918da0ac047be0ab610";
+      sha256 = "f1e811a5f1e821ecffb6d4d110f19fe55ef153992cbcf53980fd56c16552f663";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/cs/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/cs/thunderbird-102.2.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "cabce94fec815a9da981ec915cd56662bfaedc881ff9cb8f8247ae4baaa7477b";
+      sha256 = "6ff1add590d03bb49fab16ead5b549eb32c5767998ecc955c394163ef36d8554";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/cy/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/cy/thunderbird-102.2.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "beb124d16c8fab044d2e33a1d51885a32efeacd489804fdb97f0bc3136d8cdd2";
+      sha256 = "6605ab434753eda8d9f67eb57d470616e9c3b202978d655738bdd4f478cbfd42";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/da/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/da/thunderbird-102.2.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "6792f973b1580fac934ef8848e3ae63dd19f66d874f917d97bb2dc2f157a66a6";
+      sha256 = "7f60ac0c21c4894dbaacc43e74753e5dd29a768a31167eb3b0ad86c0333c247e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/de/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/de/thunderbird-102.2.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "042a2bed47a37c073b3c07ff8afdaea8c76820d41b7ffc443aee4e991e6c877b";
+      sha256 = "9d9ee8d7d92cbfa94732d915cfd4fd86278ff08225c4099d421f48527c5b279a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/dsb/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/dsb/thunderbird-102.2.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "af8b5805f40003de0d44cb136ceaf1e050ac267e5d07b9adee7c74e8e2b5e2e5";
+      sha256 = "37c2ea9d16be51d4cbd9eff62d0a146681d52caa63e2407e1f0d8d422b7c62de";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/el/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/el/thunderbird-102.2.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "42106c5e72dd43d7c370a0809ed3f46409708aec5278d44ce0326d610b56a585";
+      sha256 = "e3804af2c4a34c8ec6679e7a06449d00416641d17f2d58d15e745b25cac4fb82";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/en-CA/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/en-CA/thunderbird-102.2.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "3accbf4e9bdb3f91412ef681fa6f051b0ef157a8011757ccc04d33d825a25676";
+      sha256 = "6d2dc53467776fc068935a1181c3ec7f6c2ab9c6387ff8c12b4f689b904e9430";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/en-GB/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/en-GB/thunderbird-102.2.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "31a419251f58e31317ffb9354a958ebe45c7397b1d4fa4a6359b2b5e73c7eeaf";
+      sha256 = "f0a2db3262832de3cf5edf4721327538af261a8eaae831337a1f1f732045f1a2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/en-US/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/en-US/thunderbird-102.2.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "c64e332a907769297ea4fa9261b643b95c061ff71931cba448394811ba5e8009";
+      sha256 = "04754457bbcd3b037c27cf5c1186ab1224fc01d3b1106c76ca21d26770ff28a1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/es-AR/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/es-AR/thunderbird-102.2.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "bef709b48546e812dee7705db58f6fa0b0668c01e82e2a121439553517d0a42e";
+      sha256 = "9fd407ef93b7c613709312350b5ba520f06c5b0d664e315ef671f85e5af50ac0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/es-ES/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/es-ES/thunderbird-102.2.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "24c59cb2779215e468bd1ec1329accc4e4bb276748cf94798aaf87a8240286be";
+      sha256 = "a3975e3489c8c67374a7ade117a45c85aa42c5379670204571dce0118f7aaf8f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/es-MX/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/es-MX/thunderbird-102.2.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "8de5de1c701f8894839fa286b3fdd67fc5e188b1b8d1681186e6e11b8e862096";
+      sha256 = "857d1f4073ffbfa81a1ad17d219ccde4f8a8b18adc6e3e2f844020be32e1c5a8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/et/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/et/thunderbird-102.2.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "4af58f8787ca36a49d7659fed575c18b05d7c54ceb5383911b917c00f45c5311";
+      sha256 = "37b5f428f5f16dc80736de0c2f23ca24003de5d4639e1500f303b1f4aa664460";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/eu/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/eu/thunderbird-102.2.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "89a3b35a85077d7ba5e85aa7b6fe24c6726a82bc9d5fc794f6b47af543c14e1a";
+      sha256 = "0e4a8abe3b956d304d79218d63f64b01ef566122d00d025ef69c07f73aa87fec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/fi/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/fi/thunderbird-102.2.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "04065018c7dc5a686e2aec5c5b46e583695d1d5cbbfc6dcbe4042e004532c05f";
+      sha256 = "0a3242f6d791ab5f1be52b67d8f95ac8245bc7cf556f9dda814c2827d8f60e40";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/fr/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/fr/thunderbird-102.2.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "13293388059f55f039e9326dbd6f303e06b9f0ab3acc307a577334be2c98d900";
+      sha256 = "32c67c444bbe3d920aa4c30226fdbf469d5caba7a066b3d84270d0f9e0daabe5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/fy-NL/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/fy-NL/thunderbird-102.2.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "1a20599ae1eed1a15db7773bb8493c9b2c6d8462c26def64704a4a3c2bd66d89";
+      sha256 = "0405585c63321c44f3f459356db4bbd0cf73cccf7ae6c8684b13152e3aa3b7f3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/ga-IE/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/ga-IE/thunderbird-102.2.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "1cdd88f46f2a1a100124a9409f50b6a860504bae94b5c4d3032320ec8d9b12be";
+      sha256 = "54e4e55b3339d6436591d8967de6c1cffab94da38d064df6fc0d8b85c4475d84";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/gd/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/gd/thunderbird-102.2.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "fa0e81fc06902fdb977d5fcd0fba76b462e80e507f7ad740f59523e4cda499fc";
+      sha256 = "46130971e0b49bb45c6895d7cf9ec890d7f95fda6479bba38cf180d36e4c4eb7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/gl/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/gl/thunderbird-102.2.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "eb7f9c93a58f341c5e6f48527a1c8fd68a5018e4d3a79410aeaa7ac2c92a6081";
+      sha256 = "6e0ae14bb163b5a10c58cbdd49793e69d9d5042b0045f40be4c595781ad84c92";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/he/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/he/thunderbird-102.2.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "88c9fc856f27559b2e87b4c5aaa6be4afa049d1f415bb5f2f8d82828de12d47c";
+      sha256 = "6d353e9ec5a72366b991854aea9163385ab902c812690c0161790c882343e5a4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/hr/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/hr/thunderbird-102.2.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "ee1d57da19764898fda8867442ae3600d2e9c34a19db1eb9f61dd757802e15ab";
+      sha256 = "a05a828b434cb2677b1d3c9f317d5448db003c1373edbb84d1822182a93d3e7c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/hsb/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/hsb/thunderbird-102.2.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "afee806f7cf3f31b9711be299ae9ce85a71fd896fcffaf1e2b7373fa5d8fd4d5";
+      sha256 = "4573f6938c41160f1d4c79be035f24426bc83d9440b36ca269004b729a5564e2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/hu/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/hu/thunderbird-102.2.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "ce3c7e6117646c3f47cff9fa86cfdaad2eab2a4b2e447a00e58c031931fc22f3";
+      sha256 = "727246ee523554d64ff72611d353aead8c8b79e8f55cf187b3fb3d9f442a947e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/hy-AM/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/hy-AM/thunderbird-102.2.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "2b1e51d05939e5fa5940d2b13b6d88cca27036bf5b16c4269bd07f9296befdf0";
+      sha256 = "467c8af9d3cfdbd18ea04214369b9d262c9d925a171a2f56548af00ec85a3611";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/id/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/id/thunderbird-102.2.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "f0924b16cb34d52abd11b12023fd16de3655d19a6e2396dc213245beefae0812";
+      sha256 = "4177b047863412c9ef91d8552440b7fa1f848b8675cc55b881a4cc5fdb157303";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/is/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/is/thunderbird-102.2.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "00d302b3e8e7061b4953c716af844a04df0fee265a320eb8ddb10af8885746f0";
+      sha256 = "cb8cc7838fe3c4182d887c711c636b66d017b1854a2fadbb0f6e862a54a66d40";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/it/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/it/thunderbird-102.2.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "8c57f5ced863464faa061b12bca9b7ebc21e1e2d0c65e3399565cd7efdd98a38";
+      sha256 = "9e9214820e407c0067cf60a3b360e8f5a608225a41708a0fd25d00fb91e46d00";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/ja/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/ja/thunderbird-102.2.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "e4c9d5ced11c04791323f9a6f2ec7972e37b59a5de8b9cb80601acee2b084c31";
+      sha256 = "ffa126f9b4a25165163df6eca65299c553b087fc2313f6dd1c7b266d41a1769f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/ka/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/ka/thunderbird-102.2.1.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "6f141c07c58f04aa1a321c0c7b141b4b4b816e5930a9d399e3adadd9a0250a2d";
+      sha256 = "563eb58790172bf3a037f5828786dfb7624e3f03b81c1a57a4126f102e9572f8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/kab/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/kab/thunderbird-102.2.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "0549fe744c9d65656b333053061eaab75a2feceea8442c5a6968d0c9b6f50df3";
+      sha256 = "c79ff5505434a23ef88c2b1aadd9e70562ad9ea77fdb379169e3495725cad1a3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/kk/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/kk/thunderbird-102.2.1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "ba5cce04a893d45788e3e350f1f0860aa13af28f789e9119fd7ac769a54ee52b";
+      sha256 = "bfc4037fa631727d454c5b22af1e8861b436c40aa2bafda007221e5d5a813dd7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/ko/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/ko/thunderbird-102.2.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "5bd950922fca96ea24a33c1796912f347cd5d1868c0064e1881813dc01b65f55";
+      sha256 = "386921200c4b6544407994c5d1d73a3671a383f1e5b69d5f34b7a8ec727bc646";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/lt/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/lt/thunderbird-102.2.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "78050a52770641145c0e3dfed35e83e2b384ff2b7bb271458fd5444e2077f5af";
+      sha256 = "2027b59fc1a8f11dbc8ce693296a26604e9ba579e34df02e9f0c8243eda38e94";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/lv/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/lv/thunderbird-102.2.1.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "746cb7995683cbc64a93bd5562eb537f1449b0f4b7c4818e786f4083c190eff0";
+      sha256 = "a5179ee6caa6847b36e9494e09d3c233beb9bb8651c586b11ce160b054e12d73";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/ms/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/ms/thunderbird-102.2.1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "4c6927646e16ae85fc4522d784886c377ab11b6d0c016899af0a41f54b611e59";
+      sha256 = "6d1f11d137da476fe7dbe04e7d5692c5dc81931d30e116217083ad187fdc37cc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/nb-NO/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/nb-NO/thunderbird-102.2.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "df8a53f2e992e7113e53f42aa854ed71bbe9cde213e337eb87a051c92ce038f2";
+      sha256 = "d7a50f3f8734d249e565cbf1078627fb0e3cfa42f293574127bd2fa549652be9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/nl/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/nl/thunderbird-102.2.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "4e3b4060d0672cec8ddd0f0f7fc5f472c74ef4dbe2fa3f321ec1a2d83f5da5b1";
+      sha256 = "8962f690d105d4589df0279770b63f0b90485cb499f86e953393dd4116a87b2c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/nn-NO/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/nn-NO/thunderbird-102.2.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "bdee6b2564fbe0c27f8f73b12f0d098c880d9620aaab4a0ac4a45843c3d3cb31";
+      sha256 = "d0b940decdc8d77a0a6371ded16c551d8ce081134c4bb7d795adde39c5844254";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/pa-IN/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/pa-IN/thunderbird-102.2.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "d1b4977be649dc8ce14e2d1718a7e4848e2b779ab590a73d9ab9cbb93f367fe8";
+      sha256 = "dd5a2d9b78085786039ca20ef88f991285ff7b59ce47857b7d81bc74faa6ec54";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/pl/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/pl/thunderbird-102.2.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "d525db6addbce4a8184b41979762f059f1ab320689dccf2d05ebbe21605bc5a4";
+      sha256 = "9da17d31bbacc006c2a9530d42d864ea56c9cf5b84a73d03add270bc275543b0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/pt-BR/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/pt-BR/thunderbird-102.2.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "2fb7e81228bf937da77e9c6f3b31d6fc997963747d9c350f49061bde7a45bb8f";
+      sha256 = "81fee2a7ba6a2b0b8607e412324b2eebd1dc3f28194dc7de1efa5af9f1fa23a6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/pt-PT/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/pt-PT/thunderbird-102.2.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "5668d31d58bf0e127b1469a8e06751ba19cfcda76cd1cc98d02018de4165bc76";
+      sha256 = "82e354e1642b8018c0a6f2ccc3d3d38f3a7aa39333a30d9a6ea7c6c52df6d6f5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/rm/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/rm/thunderbird-102.2.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "904d413f3a07ef047d125a5a9395b87ef5a7babddab14ca813581861450531e4";
+      sha256 = "d7fa26de70531e74931892a78a5148f95df92d29a94e7ce5aeef11168c1069ce";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/ro/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/ro/thunderbird-102.2.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "e19bb49a4a542028d8457d00dce350644843795350787aa6f08c95bc74437113";
+      sha256 = "c4392159cabd3cf19b575d8a0598b0d52a1f9fb993234d1170240c6c6a5e4fa6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/ru/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/ru/thunderbird-102.2.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "95ba91fba53940a4966a6a7cb844498e2923b4b0ca7cf51c6e2b41f30f91b3f6";
+      sha256 = "ac3d6fc7b555298ae05cb3b0fef2b6264ff11a5961f5e044664022e80bb9ae34";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/sk/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/sk/thunderbird-102.2.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "ea321124434fac1d6ba5266d2e8b4abd1038e5447a6bc0cd44542eff4bdc4ce2";
+      sha256 = "41cc5938d5b64508bcc095ddfbe3eef3cde3dd88a8f145ed279bf825785fde50";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/sl/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/sl/thunderbird-102.2.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "6921a1590a1369eadd5f064aa5cf395fc162dde32ff0b61dc55d49a9e67807d0";
+      sha256 = "f8fb013b2705ce34749d1470e799d47c09b5ba94a9580a5e2d12be8b660c58c7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/sq/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/sq/thunderbird-102.2.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "c91a7703064f9c17c1e95b25cb4f669f95efe54b174e530bc2776d870c5225cc";
+      sha256 = "dc7407c4cb28070693b7862bc29b465a4d96c473b5b4f553d238390c694804a1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/sr/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/sr/thunderbird-102.2.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "ad7d6a645e7ee883f1ae0cad11f4be146f97953d93e0deaefb6e890734a95cbb";
+      sha256 = "640731bbc689acb4874bc0f439f34213e30812bafae3ef94471945b13ae27243";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/sv-SE/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/sv-SE/thunderbird-102.2.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "a9571d48f8cd48bc7a28fd8f6e1159ed808f316ac8e3e4a5bfaf6ce34f79fef5";
+      sha256 = "6d71d4ffa6393bc997566dc604992c093c24bd3a978b947704f82f03893fccfd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/th/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/th/thunderbird-102.2.1.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "ff826f5422e47661edda7c6a9cf6ece9118134bcd5db44a77e64baf36d42d03a";
+      sha256 = "faecaf65b8737dc63d2ea469ba1181c1e0a71c334baf29c8677730faecffb57c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/tr/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/tr/thunderbird-102.2.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "4b2195603362dca61f2134055642a803362fd778df64bc3cc886233387b0dacb";
+      sha256 = "c6401dfca452996547b3f33dead4690f9e376313920ef7880774c8a3e556b213";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/uk/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/uk/thunderbird-102.2.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "ebe0d31a0eaa084d2c34a09951bc3be9dcbdc0b70e4c445a604da10972c9dac1";
+      sha256 = "05fc335e16ad0c28a59a6ba51566161f92c0053b12b0ec56409e62eaf77fa2b2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/uz/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/uz/thunderbird-102.2.1.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "4b4333b4f3fd335cc8dd46b2c180cee40ab259f94d4b1d483b8e065efe5ff05c";
+      sha256 = "5690ad8156e70dba56ed7664f99ac335409e88f5fc0d05be530774fdeedd20ee";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/vi/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/vi/thunderbird-102.2.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "ea5916ae8265ddc6f25305f902de24bec8cd4bbe81f8710689fd53e2c0833894";
+      sha256 = "41cb6da3b59cfa31ebf28e67f93349977dcd640df5491fa451f19bc0670aa2d9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/zh-CN/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/zh-CN/thunderbird-102.2.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "2e159880fcc061eae67c7a166a6deef10e9d277f00e19fbf9ee00ad46e63cb3a";
+      sha256 = "79f9f7e1620efa56ab2a8f3a1d1aea91cf82a0c12b6f0bbac01bbd5fdc6b3c63";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.0/linux-i686/zh-TW/thunderbird-102.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/zh-TW/thunderbird-102.2.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "26d10a147f3dc0f40a83a1c7a9ea84862a36c85f4a5ff4c36578814ed7f8ebbb";
+      sha256 = "763790430eff0c8689cb045e30920b1c0fe239a324ce739b153f8a16ccb07b25";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
@@ -39,13 +39,13 @@ rec {
   };
   thunderbird-102 = (buildMozillaMach rec {
     pname = "thunderbird";
-    version = "102.2.0";
+    version = "102.2.1";
     application = "comm/mail";
     applicationName = "Mozilla Thunderbird";
     binaryName = pname;
     src = fetchurl {
       url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
-      sha512 = "a9ca311e3c55c8703aaecfe30f8a8040a16acc445530f7462baeaaf941f7221e60b66b0894ea0b3c0eb83ccc882706674cfa319ae93557405946ffffb1f6b5dc";
+      sha512 = "7b69cfffb5de56690cbbd97f6b627733072dee498a15adfece990f9019df8df948762ce8eb2ca2d91ef12ff56262fb1905476d8a477aed70bc71cd2f9f986ea4";
     };
     extraPatches = [
       # The file to be patched is different from firefox's `no-buildconfig-ffx90.patch`.


### PR DESCRIPTION
https://www.thunderbird.net/en-US/thunderbird/102.2.1/releasenotes/
https://www.mozilla.org/en-US/security/advisories/mfsa2022-38/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
