### PR TITLE
ocamlPackages.notty: 0.2.2 → 0.2.3

### DIFF
--- a/pkgs/development/ocaml-modules/notty/default.nix
+++ b/pkgs/development/ocaml-modules/notty/default.nix
@@ -1,40 +1,25 @@
-{ stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild, topkg, ocb-stubblr
-, result, uucp, uuseg, uutf
-, lwt     ? null }:
+{ lib, buildDunePackage, fetchurl, cppo
+, uutf
+, lwt
+}:
 
-with lib;
+buildDunePackage rec {
+  version = "0.2.3";
+  pname = "notty";
 
-if versionOlder ocaml.version "4.05"
-|| versionAtLeast ocaml.version "4.14"
-then throw "notty is not available for OCaml ${ocaml.version}"
-else
-
-let withLwt = lwt != null; in
-
-stdenv.mkDerivation rec {
-  version = "0.2.2";
-  pname = "ocaml${ocaml.version}-notty";
+  minimalOCamlVersion = "4.08";
 
   src = fetchurl {
     url = "https://github.com/pqwy/notty/releases/download/v${version}/notty-${version}.tbz";
-    sha256 = "1y3hx8zjri3x50nyiqal5gak1sw54gw3xssrqbj7srinvkdmrz1q";
+    sha256 = "sha256-dGWfsUBz20Q4mJiRqyTyS++Bqkl9rBbZpn+aHJwgCCQ=";
   };
 
-  nativeBuildInputs = [ ocaml findlib ocamlbuild ];
-  buildInputs = [ ocb-stubblr topkg ocamlbuild ];
-  propagatedBuildInputs = [ result uucp uuseg uutf ] ++
-                          optional withLwt lwt;
+  nativeBuildInputs = [ cppo ];
 
-  strictDeps = true;
+  propagatedBuildInputs = [ lwt uutf ];
 
-  buildPhase = topkg.buildPhase
-  + " --with-lwt ${boolToString withLwt}";
-
-  inherit (topkg) installPhase;
-
-  meta = {
+  meta = with lib; {
     homepage = "https://github.com/pqwy/notty";
-    inherit (ocaml.meta) platforms;
     description = "Declarative terminal graphics for OCaml";
     license = licenses.isc;
     maintainers = with maintainers; [ sternenseemann ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28216,9 +28216,7 @@ with pkgs;
 
   indigenous-desktop = callPackage ../applications/networking/feedreaders/indigenous-desktop { };
 
-  jackline = callPackage ../applications/networking/instant-messengers/jackline {
-    ocamlPackages = ocaml-ng.ocamlPackages_4_13;
-  };
+  jackline = callPackage ../applications/networking/instant-messengers/jackline { };
 
   keylight-controller-mschneider82 = callPackage ../applications/misc/keylight-controller-mschneider82 { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3830,9 +3830,7 @@ with pkgs;
 
   fits-cloudctl = callPackage ../tools/admin/fits-cloudctl { };
 
-  flitter = callPackage ../tools/misc/flitter {
-    ocamlPackages = ocaml-ng.ocamlPackages_4_13;
-  };
+  flitter = callPackage ../tools/misc/flitter { };
 
   frangipanni = callPackage ../tools/text/frangipanni { };
 


### PR DESCRIPTION
###### Description of changes

Compatibility with recent OCaml: https://github.com/pqwy/notty/blob/v0.2.3/CHANGES.md#v023-2022-09-02

cc maintainer @sternenseemann.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
