### PR TITLE
[22.05] Prepare for backporting Chromium M105

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -289,6 +289,10 @@ let
       rtc_use_pipewire = true;
       # Disable PGO because the profile data requires a newer compiler version (LLVM 14 isn't sufficient):
       chrome_pgo_phase = 0;
+    } // optionalAttrs (chromiumVersionAtLeast "105") {
+      # https://bugs.chromium.org/p/chromium/issues/detail?id=1334390:
+      use_system_libwayland = false;
+      use_system_wayland_scanner = false;
     } // optionalAttrs proprietaryCodecs {
       # enable support for the H.264 codec
       proprietary_codecs = true;

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -3,7 +3,7 @@
 , glib, gtk3, gnome, gsettings-desktop-schemas, gn, fetchgit
 , libva, pipewire, wayland
 , gcc, nspr, nss, runCommand
-, lib
+, lib, libkrb5
 
 # package customization
 # Note: enable* flags should not require full rebuilds (i.e. only affect the wrapper)
@@ -169,13 +169,16 @@ in stdenv.mkDerivation {
 
     # needed for XDG_ICON_DIRS
     gnome.adwaita-icon-theme
+
+    # Needed for kerberos at runtime
+    libkrb5
   ];
 
   outputs = ["out" "sandbox"];
 
   buildCommand = let
     browserBinary = "${chromiumWV}/libexec/chromium/chromium";
-    libPath = lib.makeLibraryPath [ libva pipewire wayland gtk3 ];
+    libPath = lib.makeLibraryPath [ libva pipewire wayland gtk3 libkrb5 ];
 
   in with lib; ''
     mkdir -p "$out/bin"

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -184,8 +184,8 @@ in stdenv.mkDerivation {
     mkdir -p "$out/bin"
 
     makeWrapper "${browserBinary}" "$out/bin/chromium" \
-      --add-flags ${escapeShellArg commandLineArgs} \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--enable-features=UseOzonePlatform --ozone-platform=wayland}}"
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--enable-features=UseOzonePlatform --ozone-platform=wayland}}" \
+      --add-flags ${escapeShellArg commandLineArgs}
 
     ed -v -s "$out/bin/chromium" << EOF
     2i

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -32,15 +32,15 @@
     }
   },
   "dev": {
-    "version": "106.0.5216.6",
-    "sha256": "1mgdzm5iw0ml9w68wszcscw0d3l2rlsanhznyz2ll2qv412wxgci",
-    "sha256bin64": "02kj2swqfvcvn27x22i98g7r0fj4p20bqcabagigxs1bhxw56akc",
+    "version": "106.0.5231.2",
+    "sha256": "0cygann80jmc2vk83kpc7kprhw75yf7qqfi1208ksyp6m94cxnp6",
+    "sha256bin64": "1p7hq5vsmwgkyjam7blm1gxa246dg5plhk2f0vbvlnycwj54cvjm",
     "deps": {
       "gn": {
-        "version": "2022-07-11",
+        "version": "2022-08-08",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "9ef321772ecc161937db69acb346397e0ccc484d",
-        "sha256": "0j85kgf8c1psys6kfsq5mph8n80hcbzhr7d2blqiiysmjj0wc6ng"
+        "rev": "3d773bba0927e67eae8fdaee5e28b0f6203d3bee",
+        "sha256": "1pfv6iq04r5lbg5b6xa6d5vn6mzyqksmspris7cgq5lihwq825ld"
       }
     }
   },

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -32,15 +32,15 @@
     }
   },
   "dev": {
-    "version": "105.0.5148.2",
-    "sha256": "0qnkpda0chsxgfby5g38xmpkilyz2v12mrwlayfsp2iqhc7d07vz",
-    "sha256bin64": "045czwsra17iclgyzsnbbjr55lrmhzf97c2k0wwjrmd59cx4b1sa",
+    "version": "105.0.5176.3",
+    "sha256": "11zdihvy1n7d3vfl88477ppbfjd3mmkdsj4pfmfqm4mpw7zgi7fy",
+    "sha256bin64": "08rhg2am01dbb15djh7200wsg0wb48na09i706035wnnf0d8z313",
     "deps": {
       "gn": {
-        "version": "2022-06-22",
+        "version": "2022-07-11",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "29accf5ac2eadfc53e687081583b7bc1592a8839",
-        "sha256": "0z9gaw8p88yhb7fi844pvylsbgjy3ni7bnca1yx37928fjw3ppln"
+        "rev": "9ef321772ecc161937db69acb346397e0ccc484d",
+        "sha256": "0j85kgf8c1psys6kfsq5mph8n80hcbzhr7d2blqiiysmjj0wc6ng"
       }
     }
   },

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -19,15 +19,15 @@
     }
   },
   "beta": {
-    "version": "103.0.5060.53",
-    "sha256": "00di0nw6h3kb0qp2wp3ny3zsar1ayn1lyx5zr28dl1h5cwaaxjqf",
-    "sha256bin64": "01vzhhnngr6a7mm1y25ax8vhph6dl948fvkyhdhb9m4j5l4lcqj4",
+    "version": "104.0.5112.20",
+    "sha256": "0adzdk3m2l4pjlk82sqavwgxf6a5darbiwchmlrsxc58p9xxag4s",
+    "sha256bin64": "1cm5k4gpxc0dn0vdqf3qwwf36pc77va9pnci84zcpaxx0jih7l9b",
     "deps": {
       "gn": {
-        "version": "2022-05-11",
+        "version": "2022-06-08",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "578a7fe4c3c6b0bc2ae1fd2e37f14857d09895bf",
-        "sha256": "03dqfrdpf5xxl64dby3qmbwpzdq2gsa8g7xl438py3a629rgxg63"
+        "rev": "2ecd43a10266bd091c98e6dcde507c64f6a0dad3",
+        "sha256": "1q06vsz9b4bb764wy1wy8n177z2pgpm97kq3rl1hmq185mz5fhra"
       }
     }
   },

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -32,15 +32,15 @@
     }
   },
   "dev": {
-    "version": "106.0.5231.2",
-    "sha256": "0cygann80jmc2vk83kpc7kprhw75yf7qqfi1208ksyp6m94cxnp6",
-    "sha256bin64": "1p7hq5vsmwgkyjam7blm1gxa246dg5plhk2f0vbvlnycwj54cvjm",
+    "version": "106.0.5245.0",
+    "sha256": "1hpp5gcajmjf2wvgrnsrfwl879gj8w8b6asn79raqj1qf2pa7wxg",
+    "sha256bin64": "1d4v2mwpbn3h533lkh8270hmj71ag9ivh7ns03qifsqsl9jv4zdv",
     "deps": {
       "gn": {
-        "version": "2022-08-08",
+        "version": "2022-08-11",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "3d773bba0927e67eae8fdaee5e28b0f6203d3bee",
-        "sha256": "1pfv6iq04r5lbg5b6xa6d5vn6mzyqksmspris7cgq5lihwq825ld"
+        "rev": "0bcd37bd2b83f1a9ee17088037ebdfe6eab6d31a",
+        "sha256": "13zks2z65kg7fzzsysq4mswd4bhhy3h7ycdrpxfilcvixx2n2gac"
       }
     }
   },

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -32,9 +32,9 @@
     }
   },
   "dev": {
-    "version": "105.0.5195.19",
-    "sha256": "08wap1v2qjx8nzd8sbiv24vx0vdc2dhlzrlv3g4zpm2qj7l4mki7",
-    "sha256bin64": "1alj49ysqdr5w1q42ww36kxfx60df2z5jxj39lza4vxm9b8r6ij2",
+    "version": "106.0.5216.6",
+    "sha256": "1mgdzm5iw0ml9w68wszcscw0d3l2rlsanhznyz2ll2qv412wxgci",
+    "sha256bin64": "02kj2swqfvcvn27x22i98g7r0fj4p20bqcabagigxs1bhxw56akc",
     "deps": {
       "gn": {
         "version": "2022-07-11",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -32,9 +32,9 @@
     }
   },
   "dev": {
-    "version": "105.0.5191.2",
-    "sha256": "1vfgazay1h125qjiy9fnymmdskw06l8lhvllkbbpvz08zf9jfmaj",
-    "sha256bin64": "06l9ypr945dic3kj5m12dr9x098lfh208blp8gax6rxvdj8br4wh",
+    "version": "105.0.5195.10",
+    "sha256": "12spa7b8iy1ipj6f2rs6kdv6r986zdjmdkng5gk1ki1qli80gv2x",
+    "sha256bin64": "146qxhzhlmd5hvp2g1nrfk7hjdxjlrafwa1gl4msjgrdrfz3bdql",
     "deps": {
       "gn": {
         "version": "2022-07-11",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -32,9 +32,9 @@
     }
   },
   "dev": {
-    "version": "105.0.5195.10",
-    "sha256": "12spa7b8iy1ipj6f2rs6kdv6r986zdjmdkng5gk1ki1qli80gv2x",
-    "sha256bin64": "146qxhzhlmd5hvp2g1nrfk7hjdxjlrafwa1gl4msjgrdrfz3bdql",
+    "version": "105.0.5195.19",
+    "sha256": "08wap1v2qjx8nzd8sbiv24vx0vdc2dhlzrlv3g4zpm2qj7l4mki7",
+    "sha256bin64": "1alj49ysqdr5w1q42ww36kxfx60df2z5jxj39lza4vxm9b8r6ij2",
     "deps": {
       "gn": {
         "version": "2022-07-11",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -19,15 +19,15 @@
     }
   },
   "beta": {
-    "version": "104.0.5112.79",
-    "sha256": "1wxb3nl080wgg1g61g3pgzz3gaawg442iv8pxqhnayacm3qn5ilw",
-    "sha256bin64": "1vagpsnjrdjcisgg7i56l3zcgvb5sg4pkaq5li500vmgcjin8irq",
+    "version": "105.0.5195.19",
+    "sha256": "08wap1v2qjx8nzd8sbiv24vx0vdc2dhlzrlv3g4zpm2qj7l4mki7",
+    "sha256bin64": "15rhslgq77wiwiycf6m89vi3f5vry286b7kqfk0v5ibmcsf6clgf",
     "deps": {
       "gn": {
-        "version": "2022-06-08",
+        "version": "2022-07-11",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "2ecd43a10266bd091c98e6dcde507c64f6a0dad3",
-        "sha256": "1q06vsz9b4bb764wy1wy8n177z2pgpm97kq3rl1hmq185mz5fhra"
+        "rev": "9ef321772ecc161937db69acb346397e0ccc484d",
+        "sha256": "0j85kgf8c1psys6kfsq5mph8n80hcbzhr7d2blqiiysmjj0wc6ng"
       }
     }
   },

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -19,9 +19,9 @@
     }
   },
   "beta": {
-    "version": "104.0.5112.20",
-    "sha256": "0adzdk3m2l4pjlk82sqavwgxf6a5darbiwchmlrsxc58p9xxag4s",
-    "sha256bin64": "1cm5k4gpxc0dn0vdqf3qwwf36pc77va9pnci84zcpaxx0jih7l9b",
+    "version": "104.0.5112.29",
+    "sha256": "1cjqr1d2cgiwq7vlb26ilyw2r79wgyd7dkxaipmjiqyyrl4bfm6y",
+    "sha256bin64": "1vbhm3pm1jgifmg6dc4aqi7xf12dx37spifjs3flq4v2lixg5r6f",
     "deps": {
       "gn": {
         "version": "2022-06-08",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -32,9 +32,9 @@
     }
   },
   "dev": {
-    "version": "105.0.5176.3",
-    "sha256": "11zdihvy1n7d3vfl88477ppbfjd3mmkdsj4pfmfqm4mpw7zgi7fy",
-    "sha256bin64": "08rhg2am01dbb15djh7200wsg0wb48na09i706035wnnf0d8z313",
+    "version": "105.0.5191.2",
+    "sha256": "1vfgazay1h125qjiy9fnymmdskw06l8lhvllkbbpvz08zf9jfmaj",
+    "sha256bin64": "06l9ypr945dic3kj5m12dr9x098lfh208blp8gax6rxvdj8br4wh",
     "deps": {
       "gn": {
         "version": "2022-07-11",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -32,9 +32,9 @@
     }
   },
   "dev": {
-    "version": "106.0.5245.0",
-    "sha256": "1hpp5gcajmjf2wvgrnsrfwl879gj8w8b6asn79raqj1qf2pa7wxg",
-    "sha256bin64": "1d4v2mwpbn3h533lkh8270hmj71ag9ivh7ns03qifsqsl9jv4zdv",
+    "version": "106.0.5249.12",
+    "sha256": "0brqn9rs3z3fdsnzjq2mr4p5c6d5fjllhfjfg39z3zmijcmd7f5y",
+    "sha256bin64": "1giay4nfcyczzcgrrdxrizd4pkiy7hqqc4ni6jg4rnbalh72p78n",
     "deps": {
       "gn": {
         "version": "2022-08-11",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -19,9 +19,9 @@
     }
   },
   "beta": {
-    "version": "105.0.5195.37",
-    "sha256": "0ffzphr66z3g3l695b5liswpfp0577knn06mzdmwq9x1lk87cwiq",
-    "sha256bin64": "1cfkjzqwj4s5djzl2rka9kbc28i6zph0xqv1534cb68hzgwy171a",
+    "version": "105.0.5195.52",
+    "sha256": "0hkwjilzy0x28knm6nrkywnsmldhz4kgpnxka2iaghihkjzb4wfw",
+    "sha256bin64": "155w4h4py3pn337060csfia9xxbjlxvhw7s7ljb9mz6qvpijd434",
     "deps": {
       "gn": {
         "version": "2022-07-11",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -19,9 +19,9 @@
     }
   },
   "beta": {
-    "version": "105.0.5195.28",
-    "sha256": "14hy1f59ypsvqmrp0k4kv5cfcw48dizw4nkmigaxxv4bnmpwlcy1",
-    "sha256bin64": "0rgv1r94z91khzwmf1scnnsz9yqks6ygicl7bdsdbckw69njq91z",
+    "version": "105.0.5195.37",
+    "sha256": "0ffzphr66z3g3l695b5liswpfp0577knn06mzdmwq9x1lk87cwiq",
+    "sha256bin64": "1cfkjzqwj4s5djzl2rka9kbc28i6zph0xqv1534cb68hzgwy171a",
     "deps": {
       "gn": {
         "version": "2022-07-11",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -19,9 +19,9 @@
     }
   },
   "beta": {
-    "version": "104.0.5112.48",
-    "sha256": "1zk4ywphcy6nrv0yf38yhl2bcq6fk34makglx31aalf2nhhw945i",
-    "sha256bin64": "14cx0m6jak4cma62axli0l4gqzqqh4gs7gam2dfahmwxsgcdwwn7",
+    "version": "104.0.5112.57",
+    "sha256": "1fvcmnxfw65c2dgis2vwhzg671y62irzvcl609vxwxcslhwwqc4r",
+    "sha256bin64": "0nx4ca2v1bgk25yjlfgn8vgdwwplyim6a0ai1hppy4yhm9mhppk7",
     "deps": {
       "gn": {
         "version": "2022-06-08",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -19,9 +19,9 @@
     }
   },
   "beta": {
-    "version": "104.0.5112.57",
-    "sha256": "1fvcmnxfw65c2dgis2vwhzg671y62irzvcl609vxwxcslhwwqc4r",
-    "sha256bin64": "0nx4ca2v1bgk25yjlfgn8vgdwwplyim6a0ai1hppy4yhm9mhppk7",
+    "version": "104.0.5112.65",
+    "sha256": "03adyhinhmih54rsv23w0cm86ldyfsxlmqhgk36vhgylgdras81v",
+    "sha256bin64": "17rck7zvyxmlhmi4x27xhlrn6sznx75cbidhbw7bxk3z9x7qybfy",
     "deps": {
       "gn": {
         "version": "2022-06-08",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -19,9 +19,9 @@
     }
   },
   "beta": {
-    "version": "105.0.5195.19",
-    "sha256": "08wap1v2qjx8nzd8sbiv24vx0vdc2dhlzrlv3g4zpm2qj7l4mki7",
-    "sha256bin64": "15rhslgq77wiwiycf6m89vi3f5vry286b7kqfk0v5ibmcsf6clgf",
+    "version": "105.0.5195.28",
+    "sha256": "14hy1f59ypsvqmrp0k4kv5cfcw48dizw4nkmigaxxv4bnmpwlcy1",
+    "sha256bin64": "0rgv1r94z91khzwmf1scnnsz9yqks6ygicl7bdsdbckw69njq91z",
     "deps": {
       "gn": {
         "version": "2022-07-11",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -19,9 +19,9 @@
     }
   },
   "beta": {
-    "version": "104.0.5112.29",
-    "sha256": "1cjqr1d2cgiwq7vlb26ilyw2r79wgyd7dkxaipmjiqyyrl4bfm6y",
-    "sha256bin64": "1vbhm3pm1jgifmg6dc4aqi7xf12dx37spifjs3flq4v2lixg5r6f",
+    "version": "104.0.5112.39",
+    "sha256": "0xgw1n5lcqqbs0b8bpd05f1z0q2lpajg2dxangd1yfl7y16yfxv9",
+    "sha256bin64": "0abprih2sh483cqv9rqs67ha3cm9744h3gdc342lgqj3x8bmspmj",
     "deps": {
       "gn": {
         "version": "2022-06-08",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -32,9 +32,9 @@
     }
   },
   "dev": {
-    "version": "104.0.5112.12",
-    "sha256": "040xi7cwgxi1hahv8is088gma2cyz8xhsb62jfq5ahzjx2d93qp9",
-    "sha256bin64": "1av8wn3x7m9gixh8s0mv8w0hxlk80dh7y7x3fska5fjplf4x94ij",
+    "version": "104.0.5112.20",
+    "sha256": "0adzdk3m2l4pjlk82sqavwgxf6a5darbiwchmlrsxc58p9xxag4s",
+    "sha256bin64": "13p2w4wwd8ji5ydgz4x7w2q4rmn74w3z2fl999q7zaq1cra21pzd",
     "deps": {
       "gn": {
         "version": "2022-06-08",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -32,15 +32,15 @@
     }
   },
   "dev": {
-    "version": "104.0.5112.20",
-    "sha256": "0adzdk3m2l4pjlk82sqavwgxf6a5darbiwchmlrsxc58p9xxag4s",
-    "sha256bin64": "13p2w4wwd8ji5ydgz4x7w2q4rmn74w3z2fl999q7zaq1cra21pzd",
+    "version": "105.0.5148.2",
+    "sha256": "0qnkpda0chsxgfby5g38xmpkilyz2v12mrwlayfsp2iqhc7d07vz",
+    "sha256bin64": "045czwsra17iclgyzsnbbjr55lrmhzf97c2k0wwjrmd59cx4b1sa",
     "deps": {
       "gn": {
-        "version": "2022-06-08",
+        "version": "2022-06-22",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "2ecd43a10266bd091c98e6dcde507c64f6a0dad3",
-        "sha256": "1q06vsz9b4bb764wy1wy8n177z2pgpm97kq3rl1hmq185mz5fhra"
+        "rev": "29accf5ac2eadfc53e687081583b7bc1592a8839",
+        "sha256": "0z9gaw8p88yhb7fi844pvylsbgjy3ni7bnca1yx37928fjw3ppln"
       }
     }
   },

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -19,9 +19,9 @@
     }
   },
   "beta": {
-    "version": "104.0.5112.39",
-    "sha256": "0xgw1n5lcqqbs0b8bpd05f1z0q2lpajg2dxangd1yfl7y16yfxv9",
-    "sha256bin64": "0abprih2sh483cqv9rqs67ha3cm9744h3gdc342lgqj3x8bmspmj",
+    "version": "104.0.5112.48",
+    "sha256": "1zk4ywphcy6nrv0yf38yhl2bcq6fk34makglx31aalf2nhhw945i",
+    "sha256bin64": "14cx0m6jak4cma62axli0l4gqzqqh4gs7gam2dfahmwxsgcdwwn7",
     "deps": {
       "gn": {
         "version": "2022-06-08",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -19,9 +19,9 @@
     }
   },
   "beta": {
-    "version": "104.0.5112.65",
-    "sha256": "03adyhinhmih54rsv23w0cm86ldyfsxlmqhgk36vhgylgdras81v",
-    "sha256bin64": "17rck7zvyxmlhmi4x27xhlrn6sznx75cbidhbw7bxk3z9x7qybfy",
+    "version": "104.0.5112.79",
+    "sha256": "1wxb3nl080wgg1g61g3pgzz3gaawg442iv8pxqhnayacm3qn5ilw",
+    "sha256bin64": "1vagpsnjrdjcisgg7i56l3zcgvb5sg4pkaq5li500vmgcjin8irq",
     "deps": {
       "gn": {
         "version": "2022-06-08",

--- a/pkgs/applications/networking/browsers/google-chrome/default.nix
+++ b/pkgs/applications/networking/browsers/google-chrome/default.nix
@@ -147,8 +147,8 @@ in stdenv.mkDerivation {
       --prefix PATH            : "$binpath" \
       --prefix XDG_DATA_DIRS   : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH:${addOpenGLRunpath.driverLink}/share" \
       --set CHROME_WRAPPER  "google-chrome-$dist" \
-      --add-flags ${escapeShellArg commandLineArgs} \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--enable-features=UseOzonePlatform --ozone-platform=wayland}}"
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--enable-features=UseOzonePlatform --ozone-platform=wayland}}" \
+      --add-flags ${escapeShellArg commandLineArgs}
 
     for elf in $out/share/google/$appname/{chrome,chrome-sandbox,${crashpadHandlerBinary},nacl_helper}; do
       patchelf --set-rpath $rpath $elf


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This only changes the wrapper (i.e., no full Chromium rebuilds are required).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
