### PR TITLE
obs-hyperion: init at 1.0.1

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/default.nix
@@ -14,4 +14,5 @@
     obs-vkcapture32 = pkgsi686Linux.obs-studio-plugins.obs-vkcapture;
   };
   obs-backgroundremoval = callPackage ./obs-backgroundremoval.nix {};
+  obs-hyperion = callPackage ./obs-hyperion/default.nix {};
 }

--- a/pkgs/applications/video/obs-studio/plugins/obs-hyperion/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-hyperion/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, lib, fetchFromGitLab, meson, ninja, pkg-config, obs-studio, libGL
+, qtbase }:
+
+stdenv.mkDerivation rec {
+  pname = "obs-hyperion";
+  version = "1.0.1";
+
+  src = fetchFromGitLab {
+    owner = "hyperion-project";
+    repo = "hyperion-obs-plugin";
+    rev = "v${version}";
+    sha256 = "sha256-Si+TGYWpNPtUUFT+M571lCYslPyeYX92MdYV2EGgcyQ=";
+  };
+
+  nativeBuildInputs = [ meson pkg-config ninja ];
+  buildInputs = [ obs-studio libGL qtbase ];
+
+  meta = with lib; {
+    description = "OBS Studio plugin to connect to a Hyperion.ng server";
+    license = licenses.mit;
+    maintainers = with maintainers; [ algram ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
###### Description of changes
Added the `obs-hyperion` plugin.

A heads up for testers: `Hyperion.ng` itself does currently not build until a new `flatbuffers` version is released: https://github.com/hyperion-project/hyperion.ng/issues/1509

If you want to test, update `flatbuffers` to build from their `master`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
