### PR TITLE
salt: 3004.2 -> 3005

### DIFF
--- a/pkgs/tools/admin/salt/default.nix
+++ b/pkgs/tools/admin/salt/default.nix
@@ -9,11 +9,11 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "salt";
-  version = "3004.2";
+  version = "3005";
 
   src = python3.pkgs.fetchPypi {
     inherit pname version;
-    hash = "sha256-L6ZE9iANTja1WEbLNytuZ7bKD77AaX8djXPncbZl7XA=";
+    hash = "sha256-HSAMRbiARheOpW+1p1cm3GIMxeUUEQdqBN+A/1L3nNQ=";
   };
 
   propagatedBuildInputs = with python3.pkgs; [
@@ -30,10 +30,6 @@ python3.pkgs.buildPythonApplication rec {
 
   patches = [
     ./fix-libcrypto-loading.patch
-    (fetchpatch {
-      url = "https://github.com/saltstack/salt/commit/6ec8b90e402ff3fa8f27c7da70ece898592416bc.patch";
-      hash = "sha256-OQCJeG12cp2EZ0BErp6yqsqhv023923rVFDHAFUfF6c=";
-    })
   ];
 
   postPatch = ''
@@ -45,14 +41,6 @@ python3.pkgs.buildPythonApplication rec {
     # Don't require optional dependencies on Darwin, let's use
     # `extraInputs` like on any other platform
     echo -n > "requirements/darwin.txt"
-
-    # Bug in 3004.1: https://github.com/saltstack/salt/pull/61839
-    substituteInPlace "salt/utils/entrypoints.py" \
-      --replace 'if sys.version_info >= (3, 10):' 'if False:'
-
-    # Bug in 3004.1: https://github.com/saltstack/salt/issues/61865
-    substituteInPlace "salt/transport/tcp.py" \
-      --replace 'payload = self.pack_publish(package)' 'package = self.pack_publish(package)'
 
     # 3004.1: requirement of pyzmq was restricted to <22.0.0; looks like that req was incorrect
     # https://github.com/saltstack/salt/commit/070597e525bb7d56ffadede1aede325dfb1b73a4


### PR DESCRIPTION
###### Description of changes
Version 3005 got released: https://docs.saltproject.io/en/3005/topics/releases/3005.html
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
