### PR TITLE
filebot: use FHS env

### DIFF
--- a/pkgs/applications/video/filebot/default.nix
+++ b/pkgs/applications/video/filebot/default.nix
@@ -1,52 +1,62 @@
 { lib, stdenv, fetchurl, openjdk17, makeWrapper, autoPatchelfHook
-, zlib, libzen, libmediainfo, curlWithGnuTls, libmms, glib
+, buildFHSUserEnv, zlib, libzen, libmediainfo, curlWithGnuTls, libmms, glib
 }:
 
-stdenv.mkDerivation rec {
-  pname = "filebot";
-  version = "4.9.6";
+let
+  filebot = stdenv.mkDerivation rec {
+    pname = "filebot";
+    version = "4.9.6";
 
-  src = fetchurl {
-    url = "https://web.archive.org/web/20220305095926/https://get.filebot.net/filebot/FileBot_${version}/FileBot_${version}-portable.tar.xz";
-    sha256 = "sha256-3j0WmmamE9KUNwjOVZvrdFH5dS/9FHSdbLfcAsOzQOo=";
-  };
+    src = fetchurl {
+      url = "https://web.archive.org/web/20220305095926/https://get.filebot.net/filebot/FileBot_${version}/FileBot_${version}-portable.tar.xz";
+      sha256 = "sha256-3j0WmmamE9KUNwjOVZvrdFH5dS/9FHSdbLfcAsOzQOo=";
+    };
 
-  unpackPhase = "tar xvf $src";
+    unpackPhase = "tar xvf $src";
 
-  nativeBuildInputs = [ makeWrapper autoPatchelfHook ];
+    nativeBuildInputs = [ makeWrapper autoPatchelfHook ];
 
-  buildInputs = [ zlib libzen libmediainfo curlWithGnuTls libmms glib ];
+    buildInputs = [ zlib libzen libmediainfo curlWithGnuTls libmms glib ];
 
-  dontBuild = true;
-  installPhase = ''
-    mkdir -p $out/opt $out/bin
-    # Since FileBot has dependencies on relative paths between files, all required files are copied to the same location as is.
-    cp -r filebot.sh lib/ jar/ $out/opt/
-    # Filebot writes to $APP_DATA, which fails due to read-only filesystem. Using current user .local directory instead.
-    substituteInPlace $out/opt/filebot.sh \
-      --replace 'APP_DATA="$FILEBOT_HOME/data/$(id -u)"' 'APP_DATA=''${XDG_DATA_HOME:-$HOME/.local/share}/filebot/data' \
-      --replace '$FILEBOT_HOME/data/.license' '$APP_DATA/.license'
-    wrapProgram $out/opt/filebot.sh \
-      --prefix PATH : ${lib.makeBinPath [ openjdk17 ]}
-    # Expose the binary in bin to make runnable.
-    ln -s $out/opt/filebot.sh $out/bin/filebot
-  '';
-
-  meta = with lib; {
-    description = "The ultimate TV and Movie Renamer";
-    longDescription = ''
-      FileBot is the ultimate tool for organizing and renaming your Movies, TV
-      Shows and Anime as well as fetching subtitles and artwork. It's smart and
-      just works.
+    dontBuild = true;
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/opt $out/bin
+      # Since FileBot has dependencies on relative paths between files, all required files are copied to the same location as is.
+      cp -r filebot.sh lib/ jar/ $out/opt/
+      # Filebot writes to $APP_DATA, which fails due to read-only filesystem. Using current user .local directory instead.
+      substituteInPlace $out/opt/filebot.sh \
+        --replace 'APP_DATA="$FILEBOT_HOME/data/$(id -u)"' 'APP_DATA=''${XDG_DATA_HOME:-$HOME/.local/share}/filebot/data' \
+        --replace '$FILEBOT_HOME/data/.license' '$APP_DATA/.license'
+      wrapProgram $out/opt/filebot.sh \
+        --prefix PATH : ${lib.makeBinPath [ openjdk17 ]}
+      # Expose the binary in bin to make runnable.
+      ln -s $out/opt/filebot.sh $out/bin/filebot
+      runHook postInstall
     '';
-    homepage = "https://filebot.net";
-    changelog = "https://www.filebot.net/forums/viewforum.php?f=7";
-    sourceProvenance = with sourceTypes; [
-      binaryBytecode
-      binaryNativeCode
-    ];
-    license = licenses.unfreeRedistributable;
-    maintainers = with maintainers; [ gleber felschr ];
-    platforms = platforms.linux;
+
+    meta = with lib; {
+      description = "The ultimate TV and Movie Renamer";
+      longDescription = ''
+        FileBot is the ultimate tool for organizing and renaming your Movies, TV
+        Shows and Anime as well as fetching subtitles and artwork. It's smart and
+        just works.
+      '';
+      homepage = "https://filebot.net";
+      changelog = "https://www.filebot.net/forums/viewforum.php?f=7";
+      sourceProvenance = with sourceTypes; [
+        binaryBytecode
+        binaryNativeCode
+      ];
+      license = licenses.unfreeRedistributable;
+      maintainers = with maintainers; [ gleber felschr ];
+      platforms = platforms.linux;
+    };
   };
+in buildFHSUserEnv {
+  inherit (filebot) name meta;
+  runScript = "${filebot.outPath}/bin/filebot";
+  extraInstallCommands = ''
+    mv $out/bin/$name $out/bin/filebot
+  '';
 }


### PR DESCRIPTION

###### Description of changes

filebot --mode interactive executes /bin/stty, which is not present on
NixOS. Fix this by running filebot in a FHS environment with coreutils.
Closes #188828.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
