### PR TITLE
ihp-new: init at 0.20.0

### DIFF
--- a/pkgs/development/web/ihp-new/default.nix
+++ b/pkgs/development/web/ihp-new/default.nix
@@ -1,0 +1,32 @@
+{ lib, stdenv, fetchFromGitHub, git, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  pname = "ihp-new";
+  version = "0.20.0";
+
+  src = fetchFromGitHub {
+    owner = "digitallyinduced";
+    repo = "ihp";
+    rev = "v${version}";
+    sha256 = "sha256-fvFRBnMnFGsPleVv5aPfuoP1UzjnBel0NiNULFP+GkI=";
+  };
+
+  dontConfigure = true;
+  sourceRoot = "source/ProjectGenerator";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    install -Dm755 bin/ihp-new -t $out/bin
+    wrapProgram $out/bin/ihp-new \
+      --suffix PATH ":" "${lib.makeBinPath [ git ]}";
+  '';
+
+  meta = with lib; {
+    description = "Project generator for the IHP (Integrated Haskell Platform) web framework";
+    homepage = "https://ihp.digitallyinduced.com";
+    license = licenses.mit;
+    maintainers = [ maintainers.mpscholten ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16457,6 +16457,8 @@ with pkgs;
 
   insomnia = callPackage ../development/web/insomnia { };
 
+  ihp-new = callPackage ../development/web/ihp-new { };
+
   iozone = callPackage ../development/tools/misc/iozone { };
 
   itstool = callPackage ../development/tools/misc/itstool { };


### PR DESCRIPTION
###### Description of changes

Adds the project generator for the [IHP web framework](https://ihp.digitallyinduced.com/) to nixpkgs.

Currently `ihp-new` is installed via:
```
nix-env -f https://downloads.digitallyinduced.com/ihp-new.tar.gz -i ihp-new
```

This is not very NixOS friendly, so it's better we deliver this package via nixpkgs directly.

Relates to https://github.com/digitallyinduced/ihp/issues/1507

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
