### PR TITLE
wasmer: enable LLVM and singlepass compilers on supported environments

### DIFF
--- a/pkgs/development/interpreters/wasmer/default.nix
+++ b/pkgs/development/interpreters/wasmer/default.nix
@@ -1,10 +1,18 @@
 { stdenv
 , lib
 , rustPlatform
+, libffi
+, libxml2
+, ncurses
+, zlib
 , fetchFromGitHub
 , cmake
+, llvmPackages_12 # See version specified in https://github.com/wasmerio/wasmer/tree/master/lib/compiler-llvm#requirements
 , llvmPackages
 , pkg-config
+# See matrix https://github.com/wasmerio/wasmer/blob/master/Makefile#L22
+, withLlvmCompiler ? ((stdenv.isDarwin || stdenv.isLinux) && stdenv.isx86_64)
+, withSinglepassCompiler ? ((stdenv.isDarwin || stdenv.isLinux) && stdenv.isx86_64)
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -21,11 +29,14 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "sha256-tswsbijNN5UcSZovVmy66yehcEOpQDGMdRgR/1mkuE8=";
 
-  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [] ++ lib.optionals withLlvmCompiler [ libffi libxml2 ncurses zlib ];
+  nativeBuildInputs = [ cmake pkg-config ] ++ lib.optionals withLlvmCompiler [ llvmPackages_12.llvm ];
 
   # cranelift+jit works everywhere, see:
   # https://github.com/wasmerio/wasmer/blob/master/Makefile#L22
-  buildFeatures = [ "cranelift" "jit" ];
+  buildFeatures = [ "cranelift" "jit" ]
+    ++ lib.optionals withLlvmCompiler [ "llvm" ]
+    ++ lib.optionals withSinglepassCompiler [ "singlepass" ];
   cargoBuildFlags = [
     # must target manifest and desired output bin, otherwise output is empty
     "--manifest-path" "lib/cli/Cargo.toml"
@@ -36,6 +47,7 @@ rustPlatform.buildRustPackage rec {
   # error: Package `wasmer-workspace v2.3.0 (/build/source)` does not have the feature `test-jit`
   checkFeatures = [ "test-cranelift" ];
 
+  # Using llvmPackages_12 makes the test wast::spec::unreachable::cranelift::universal fail on aarch64
   LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

More information about those compilers can be found here:
https://github.com/wasmerio/wasmer/tree/2.3.0/lib/compiler-singlepass
https://github.com/wasmerio/wasmer/tree/2.3.0/lib/compiler-llvm
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
