### PR TITLE
wofi-emoji: fix no emoji data

### DIFF
--- a/pkgs/applications/misc/wofi-emoji/default.nix
+++ b/pkgs/applications/misc/wofi-emoji/default.nix
@@ -7,7 +7,7 @@ let emojiJSON = fetchurl {
 in
 stdenv.mkDerivation rec {
   pname = "wofi-emoji";
-  version = "unstable-2022-08-19";
+  version = "unstable-2022-09-03";
 
   src = fetchFromGitHub {
     owner = "dln";
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace build.sh \
-      --replace 'curl ${emojiJSON.url}' 'cat emoji-en-US.json'
+      --replace 'curl ${emojiJSON.url}' 'cat ${emojiJSON}'
   '';
 
   buildPhase = ''


### PR DESCRIPTION
###### Description of changes
As it was, the postPatch phase didn't correctly patch the emoji data into the wofi-emoji script, because the emoji-en-US.json wasn't in the build directory. Now the postPatch phase uses the absolute path to said file in the nix store.


###### Things done

- Built on platform(s)
  - [ X ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ X ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ X ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
