### PR TITLE
[22.05] thunderbird*: 91 -> 102

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, buildMozillaMach, callPackage, fetchurl, fetchpatch, nixosTests }:
 
 rec {
-  thunderbird = thunderbird-91;
+  thunderbird = thunderbird-102;
   thunderbird-91 = (buildMozillaMach rec {
     pname = "thunderbird";
     version = "91.13.0";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30086,8 +30086,8 @@ with pkgs;
   thunderbird-102 = wrapThunderbird thunderbird-102-unwrapped { };
   thunderbird-102-wayland = wrapThunderbird thunderbird-102-unwrapped { forceWayland = true; };
 
-  thunderbird-bin = thunderbird-bin-91;
-  thunderbird-bin-unwrapped = thunderbird-bin-91-unwrapped;
+  thunderbird-bin = thunderbird-bin-102;
+  thunderbird-bin-unwrapped = thunderbird-bin-102-unwrapped;
 
   thunderbird-bin-102 = wrapThunderbird thunderbird-bin-102-unwrapped {
     applicationName = "thunderbird";


### PR DESCRIPTION
The upstream support of 91 branch is already ending around now,
so let's switch the default.