### PR TITLE
elf2uf2-rs: unstable-2021-12-12 -> 1.3.7

### DIFF
--- a/pkgs/development/embedded/elf2uf2-rs/default.nix
+++ b/pkgs/development/embedded/elf2uf2-rs/default.nix
@@ -1,14 +1,12 @@
-{ lib, stdenv, rustPlatform, fetchFromGitHub, pkg-config, udev }:
+{ lib, stdenv, rustPlatform, fetchCrate, pkg-config, udev }:
 
 rustPlatform.buildRustPackage rec {
   pname = "elf2uf2-rs";
-  version = "unstable-2021-12-12";
+  version = "1.3.7";
 
-  src = fetchFromGitHub {
-    owner = "JoNil";
-    repo = pname;
-    rev = "91ae98873ed01971ab1543b98266a5ad2ec09210";
-    sha256 = "sha256-DGrT+YdDLdTYy5SWcQ+DNbpifGjrF8UTXyEeE/ug564=";
+  src = fetchCrate {
+    inherit pname version;
+    sha256 = "sha256-2ZilZIYXCNrKJlkHBsz/2/pMtF+UDfjDlt53ylcwgus=";
   };
 
   nativeBuildInputs = [
@@ -19,7 +17,7 @@ rustPlatform.buildRustPackage rec {
     udev
   ];
 
-  cargoSha256 = "sha256-5ui1+987xICP2wUSHy4YzKskn52W51Pi4DbEh+GbSPE=";
+  cargoSha256 = "sha256-+3Rqlzkrw9XfM3PelGNbnRGaWQLbzVJ7iJgvGgVt5FE=";
 
   meta = with lib; {
     description = "Convert ELF files to UF2 for USB Flashing Bootloaders";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

There is no changelog or release notes for this package.

diff (small): https://github.com/JoNil/elf2uf2-rs/compare/91ae98873ed01971ab1543b98266a5ad2ec09210..b861f6b3c9540bcb27e88ec496e09763e590dc76

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - N/A x86_64-darwin
  - N/A aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
