### PR TITLE
rmfakecloud: build the web ui

### DIFF
--- a/pkgs/servers/rmfakecloud/default.nix
+++ b/pkgs/servers/rmfakecloud/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, buildGoModule }:
+{ lib, fetchFromGitHub, buildGoModule, callPackage, enableWebui ? true }:
 
 buildGoModule rec {
   pname = "rmfakecloud";
@@ -13,8 +13,12 @@ buildGoModule rec {
 
   vendorSha256 = "sha256-NwDaPpjkQogXE37RGS3zEALlp3NuXP9RW//vbwM6y0A=";
 
-  postPatch = ''
-    # skip including the JS SPA, which is difficult to build
+  ui = callPackage ./webui.nix { inherit version src; };
+
+  postPatch = if enableWebui then ''
+    mkdir -p ui/build
+    cp -r ${ui}/* ui/build
+  '' else ''
     sed -i '/go:/d' ui/assets.go
   '';
 

--- a/pkgs/servers/rmfakecloud/webui.nix
+++ b/pkgs/servers/rmfakecloud/webui.nix
@@ -1,0 +1,37 @@
+{ version, src, stdenv, lib, fetchFromGitHub, fetchYarnDeps, fixup_yarn_lock, yarn, nodejs }:
+
+stdenv.mkDerivation rec {
+  inherit version src;
+
+  pname = "rmfakecloud-webui";
+
+  yarnOfflineCache = fetchYarnDeps {
+    yarnLock = "${src}/ui/yarn.lock";
+    sha256 = "sha256-lKA3W7gXT2Dnux+sIXCluG5HxkGQgHPnCjgV/a4pjY0=";
+  };
+
+  nativeBuildInputs = [ fixup_yarn_lock yarn nodejs ];
+
+  buildPhase = ''
+    export HOME=$(mktemp -d)
+    cd ui
+    fixup_yarn_lock yarn.lock
+    yarn config --offline set yarn-offline-mirror ${yarnOfflineCache}
+    yarn install --offline --frozen-lockfile --ignore-engines --ignore-scripts --no-progress
+    patchShebangs node_modules
+    export PATH=$PWD/node_modules/.bin:$PATH
+    ./node_modules/.bin/react-scripts build
+    mkdir -p $out
+    cd ..
+  '';
+
+  installPhase = ''
+    cp -r ui/build/* $out
+  '';
+
+  meta = with lib; {
+    description = "Only the webui files for rmfakecloud";
+    homepage = "https://ddvk.github.io/rmfakecloud/";
+    license = licenses.agpl3Only;
+  };
+}


### PR DESCRIPTION
###### Description of changes

Previously rmfakecloud was built without the web ui making it show 404 when attempting to use it. Build it similar to how other projects using yarn are built. 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
