### PR TITLE
ffmpeg: cleanup, remove old options, expose options from let in

### DIFF
--- a/pkgs/development/libraries/ffmpeg/4.nix
+++ b/pkgs/development/libraries/ffmpeg/4.nix
@@ -1,17 +1,12 @@
-{ callPackage, fetchpatch
-# Darwin frameworks
-, Cocoa, CoreMedia, VideoToolbox
-, stdenv, lib
-, ...
-}@args:
+{ callPackage, fetchpatch, ... }@args:
 
 callPackage ./generic.nix (rec {
   version = "4.4.2";
   branch = version;
   sha256 = "sha256-+YpIJSDEdQdSGpB5FNqp77wThOBZG1r8PaGKqJfeKUg=";
-  darwinFrameworks = [ Cocoa CoreMedia VideoToolbox ];
+
   patches = [
-    #  sdl2 recently changed their versioning
+    # SDL2 recently changed their versioning
     (fetchpatch {
       url = "https://git.videolan.org/?p=ffmpeg.git;a=patch;h=e5163b1d34381a3319214a902ef1df923dd2eeba";
       hash = "sha256-nLhP2+34cj5EgpnUrePZp60nYAxmbhZAEDfay4pBVk0=";

--- a/pkgs/development/libraries/ffmpeg/5.nix
+++ b/pkgs/development/libraries/ffmpeg/5.nix
@@ -1,12 +1,7 @@
-{ callPackage
-# Darwin frameworks
-, Cocoa, CoreMedia, VideoToolbox
-, ...
-}@args:
+{ callPackage, ... }@args:
 
 callPackage ./generic.nix (rec {
   version = "5.1.2";
   branch = version;
   sha256 = "sha256-OaC8yNmFSfFsVwYkZ4JGpqxzbAZs69tAn5UC6RWyLys=";
-  darwinFrameworks = [ Cocoa CoreMedia VideoToolbox ];
 } // args)

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -2,15 +2,15 @@
 , alsa-lib, bzip2, fontconfig, freetype, gnutls, libiconv, lame, libass, libogg
 , libssh, libtheora, libva, libdrm, libvorbis, libvpx, xz, soxr
 , x264, x265, xvidcore, zimg, zlib, libopus, speex, nv-codec-headers, dav1d
-, srt ? null
-, openglSupport ? false, libGLU ? null, libGL ? null
-, libmfxSupport ? false, intel-media-sdk ? null
-, libaomSupport ? false, libaom ? null
+, srt
+, openglSupport ? false, libGLU, libGL
+, libmfxSupport ? false, intel-media-sdk
+, libaomSupport ? false, libaom
 # Build options
 , runtimeCpuDetectBuild ? true # Detect CPU capabilities at runtime
 , multithreadBuild ? true # Multithreading via pthreads/win32 threads
-, sdlSupport ? !stdenv.isAarch32, SDL ? null, SDL2 ? null
-, vdpauSupport ? !stdenv.isAarch32, libvdpau ? null
+, sdlSupport ? !stdenv.isAarch32, SDL, SDL2
+, vdpauSupport ? !stdenv.isAarch32, libvdpau
 # Developer options
 , debugDeveloper ? false
 , optimizationsDeveloper ? true
@@ -69,10 +69,6 @@ let
 
   vpxSupport = reqMin "0.6" && !isAarch32;
 in
-
-assert openglSupport -> libGL != null && libGLU != null;
-assert libmfxSupport -> intel-media-sdk != null;
-assert libaomSupport -> libaom != null;
 
 stdenv.mkDerivation rec {
 

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -11,7 +11,7 @@
 # Build options
 , runtimeCpuDetectBuild ? true # Detect CPU capabilities at runtime
 , multithreadBuild ? true # Multithreading via pthreads/win32 threads
-, sdlSupport ? !stdenv.isAarch32, SDL, SDL2
+, sdlSupport ? !stdenv.isAarch32, SDL2
 , vdpauSupport ? !stdenv.isAarch32, libvdpau
 # Developer options
 , debugDeveloper ? false
@@ -138,7 +138,7 @@ stdenv.mkDerivation rec {
       (ifMinVer "4.2" (enableFeature libmfxSupport "libmfx"))
       (ifMinVer "4.2" (enableFeature libaomSupport "libaom"))
       (disDarwinOrArmFix (ifMinVer "0.9" (lib.optionalString pulseaudioSupport "--enable-libpulse")) "0.9" "--disable-libpulse")
-      (ifMinVer "2.5" (if sdlSupport && reqMin "3.2" then "--enable-sdl2" else if sdlSupport then "--enable-sdl" else null)) # autodetected before 2.5, SDL1 support removed in 3.2 for SDL2
+      (ifMinVer "2.5" (if sdlSupport && reqMin "3.2" then "--enable-sdl2" else null))
       (ifMinVer "1.2" "--enable-libsoxr")
       "--enable-libx264"
       "--enable-libxvid"
@@ -175,7 +175,7 @@ stdenv.mkDerivation rec {
     ++ optional stdenv.isLinux alsa-lib
     ++ optionals stdenv.isDarwin [ Cocoa CoreMedia VideoToolbox ]
     ++ optional vdpauSupport libvdpau
-    ++ optional sdlSupport (if reqMin "3.2" then SDL2 else SDL)
+    ++ optional sdlSupport SDL2
     ++ optional srtSupport srt
     ++ optional (reqMin "4.2") dav1d;
 

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -15,8 +15,7 @@
 , debugDeveloper ? false
 , optimizationsDeveloper ? true
 , extraWarningsDeveloper ? false
-# Darwin frameworks
-, Cocoa, darwinFrameworks ? [ Cocoa ]
+, Cocoa, CoreMedia, VideoToolbox
 # Inherit generics
 , branch, sha256, version, patches ? [], knownVulnerabilities ? []
 , doCheck ? true
@@ -185,7 +184,7 @@ stdenv.mkDerivation rec {
     ++ optional ((isLinux || isFreeBSD) && !isAarch32) libva
     ++ optional ((isLinux || isFreeBSD) && !isAarch32) libdrm
     ++ optional isLinux alsa-lib
-    ++ optionals isDarwin darwinFrameworks
+    ++ optionals isDarwin [ Cocoa CoreMedia VideoToolbox ]
     ++ optional vdpauSupport libvdpau
     ++ optional sdlSupport (if reqMin "3.2" then SDL2 else SDL)
     ++ optional (reqMin "4.2") dav1d;

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -91,7 +91,7 @@ stdenv.mkDerivation rec {
     ++ [
       "--disable-os2threads" # We don't support OS/2
       "--enable-network"
-      (ifMinVer "2.4" "--enable-pixelutils")
+      "--enable-pixelutils"
     # Executables
       "--enable-ffmpeg"
       "--disable-ffplay"
@@ -118,26 +118,26 @@ stdenv.mkDerivation rec {
       "--enable-libmp3lame"
       "--enable-iconv"
       "--enable-libtheora"
-      (ifMinVer "2.1" "--enable-libssh")
+      "--enable-libssh"
       (enableFeature vaapiSupport "vaapi")
-      (ifMinVer "3.4" (enableFeature vaapiSupport "libdrm"))
+      (enableFeature vaapiSupport "libdrm")
       (enableFeature vdpauSupport "vdpau")
       "--enable-libvorbis"
       (enableFeature vpxSupport "libvpx")
-      (ifMinVer "2.4" "--enable-lzma")
-      (ifMinVer "2.2" (enableFeature openglSupport "opengl"))
+      "--enable-lzma"
+      (enableFeature openglSupport "opengl")
       (ifMinVer "4.2" (enableFeature libmfxSupport "libmfx"))
       (ifMinVer "4.2" (enableFeature libaomSupport "libaom"))
       (lib.optionalString pulseaudioSupport "--enable-libpulse")
-      (ifMinVer "2.5" (if sdlSupport && reqMin "3.2" then "--enable-sdl2" else null))
+      (enableFeature sdlSupport "sdl2")
       "--enable-libsoxr"
       "--enable-libx264"
       "--enable-libxvid"
       "--enable-libzimg"
       "--enable-zlib"
-      (ifMinVer "2.8" "--enable-libopus")
+      "--enable-libopus"
       "--enable-libspeex"
-      (ifMinVer "2.8" "--enable-libx265")
+      "--enable-libx265"
       (ifMinVer "4.2" (enableFeature (reqMin "4.2") "libdav1d"))
     # Developer flags
       (enableFeature debugDeveloper "debug")

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -64,8 +64,7 @@ stdenv.mkDerivation rec {
   postPatch = "patchShebangs .";
   inherit patches;
 
-  outputs = [ "bin" "dev" "out" "man" ]
-    ++ optional (reqMin "1.0") "doc" ; # just dev-doc
+  outputs = [ "bin" "dev" "out" "man" "doc" ];
   setOutputFlags = false; # doesn't accept all and stores configureFlags in libs!
 
   configurePlatforms = [];
@@ -103,8 +102,8 @@ stdenv.mkDerivation rec {
       "--enable-avdevice"
       "--enable-avfilter"
       "--enable-avformat"
-      (ifMinVer "1.0" (ifVerOlder "5.0" "--enable-avresample"))
-      (ifMinVer "1.1" "--enable-avutil")
+      (ifVerOlder "5.0" "--enable-avresample")
+      "--enable-avutil"
       "--enable-postproc"
       "--enable-swresample"
       "--enable-swscale"
@@ -114,10 +113,10 @@ stdenv.mkDerivation rec {
       "--enable-libass"
       "--enable-bzlib"
       "--enable-gnutls"
-      (ifMinVer "1.0" "--enable-fontconfig")
+      "--enable-fontconfig"
       "--enable-libfreetype"
       "--enable-libmp3lame"
-      (ifMinVer "1.2" "--enable-iconv")
+      "--enable-iconv"
       "--enable-libtheora"
       (ifMinVer "2.1" "--enable-libssh")
       (enableFeature vaapiSupport "vaapi")
@@ -131,7 +130,7 @@ stdenv.mkDerivation rec {
       (ifMinVer "4.2" (enableFeature libaomSupport "libaom"))
       (lib.optionalString pulseaudioSupport "--enable-libpulse")
       (ifMinVer "2.5" (if sdlSupport && reqMin "3.2" then "--enable-sdl2" else null))
-      (ifMinVer "1.2" "--enable-libsoxr")
+      "--enable-libsoxr"
       "--enable-libx264"
       "--enable-libxvid"
       "--enable-libzimg"

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -147,7 +147,7 @@ stdenv.mkDerivation rec {
       (ifMinVer "2.8" "--enable-libopus")
       "--enable-libspeex"
       (ifMinVer "2.8" "--enable-libx265")
-      (ifMinVer "4.2" (enableFeature (dav1d != null) "libdav1d"))
+      (ifMinVer "4.2" (enableFeature (reqMin "4.2") "libdav1d"))
     # Developer flags
       (enableFeature debugDeveloper "debug")
       (enableFeature optimizationsDeveloper "optimizations")


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
