### PR TITLE
tbls: init at 1.56.2

### DIFF
--- a/pkgs/tools/misc/tbls/default.nix
+++ b/pkgs/tools/misc/tbls/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, testers
+, tbls
+}:
+
+buildGoModule rec {
+  pname = "tbls";
+  version = "1.56.2";
+
+  src = fetchFromGitHub {
+    owner = "k1LoW";
+    repo = "tbls";
+    rev = "v${version}";
+    sha256 = "sha256-fJbdZlgegC54OIAbygKO5GzNh6UAuT4OZp7KK+XJhvI=";
+  };
+
+  vendorSha256 = "sha256-pmnSeQHZEtsshldfq6D/r5pMYA5ivMWkzjOq2/WseYU=";
+
+  CGO_CFLAGS = [ "-Wno-format-security" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/k1LoW/tbls.commit=unspecified"
+    "-X github.com/k1LoW/tbls.date=unspecified"
+    "-X github.com/k1LoW/tbls.version=${src.rev}"
+    "-X github.com/k1LoW/tbls/version.Version=${src.rev}"
+  ];
+
+  preCheck = ''
+    # Remove tests that require additional services.
+    rm -f \
+       datasource/datasource_test.go \
+       drivers/*/*_test.go
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = tbls;
+    command = "tbls version";
+    version = src.rev;
+  };
+
+  meta = with lib; {
+    description = "A tool to generate documentation based on a database";
+    homepage = "https://github.com/k1LoW/tbls";
+    changelog = "https://github.com/k1LoW/tbls/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ azahi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33573,6 +33573,8 @@ with pkgs;
 
   tbe = libsForQt5.callPackage ../games/the-butterfly-effect { };
 
+  tbls = callPackage ../tools/misc/tbls { };
+
   tecnoballz = callPackage ../games/tecnoballz { };
 
   teetertorture = callPackage ../games/teetertorture { };


### PR DESCRIPTION
###### Description of changes

https://github.com/k1LoW/tbls

Fixes: #189640

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
