### PR TITLE
Add Zoned Storage libraries + helper executables

### DIFF
--- a/pkgs/os-specific/linux/libnvme/default.nix
+++ b/pkgs/os-specific/linux/libnvme/default.nix
@@ -1,0 +1,63 @@
+{ fetchFromGitHub
+, json_c
+, lib
+, libuuid
+, meson
+, ninja
+, openssl
+, perl
+, pkg-config
+, python3
+, stdenv
+, systemd
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libnvme";
+  version = "1.1";
+
+  outputs = [ "out" "man" ];
+
+  src = fetchFromGitHub {
+    owner = "linux-nvme";
+    repo = "libnvme";
+    rev = "v${version}";
+    sha256 = "EPAPWY6/Bh8I1eLslKJAofLn0IAizmGn00Q5PJPtdRw=";
+  };
+
+  postPatch = ''
+    patchShebangs meson-vcs-tag.sh
+    chmod +x doc/kernel-doc-check
+    patchShebangs doc/kernel-doc doc/kernel-doc-check doc/list-man-pages.sh
+  '';
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    perl # for kernel-doc
+    pkg-config
+  ];
+
+  buildInputs = [
+    json_c
+    libuuid
+    openssl
+    python3
+    systemd
+  ];
+
+  mesonFlags = [
+    "-Ddocs=man"
+    "-Ddocs-build=true"
+  ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "C Library for NVM Express on Linux";
+    homepage = "https://github.com/linux-nvme/libnvme";
+    maintainers = with maintainers; [ zseri ];
+    license = with licenses; [ lgpl21Plus ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/libzbc/default.nix
+++ b/pkgs/os-specific/linux/libzbc/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, stdenv
+, autoconf-archive
+, autoreconfHook
+, fetchFromGitHub
+, gtk3
+, libtool
+, pkg-config
+, guiSupport ? false
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libzbc";
+  version = "5.12.0";
+
+  src = fetchFromGitHub {
+    owner = "westerndigitalcorporation";
+    repo = "libzbc";
+    rev = "v${version}";
+    sha256 = "qI09dkMCwMym3j1ELrFDNbNB5hW/CzwmFmZhUNDXsfI=";
+  };
+
+  nativeBuildInputs = [
+    autoconf-archive # this can be removed with the next release
+    autoreconfHook
+    libtool
+  ] ++ lib.optionals guiSupport [ pkg-config ];
+
+  buildInputs = lib.optionals guiSupport [ gtk3 ];
+
+  configureFlags = lib.optional guiSupport "--enable-gui";
+
+  meta = with lib; {
+    description = "ZBC device manipulation library";
+    homepage = "https://github.com/westerndigitalcorporation/libzbc";
+    maintainers = with maintainers; [ zseri ];
+    license = with licenses; [ bsd2 lgpl3Plus ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/libzbd/default.nix
+++ b/pkgs/os-specific/linux/libzbd/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, stdenv
+, autoconf-archive
+, autoreconfHook
+, fetchFromGitHub
+, gtk3
+, libtool
+, pkg-config
+, guiSupport ? false
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libzbd";
+  version = "2.0.3";
+
+  src = fetchFromGitHub {
+    owner = "westerndigitalcorporation";
+    repo = "libzbd";
+    rev = "v${version}";
+    sha256 = "GoCHwuR4ylyaN/FskIqKyAPe2A2O3iFVcI3UxPlqvtk=";
+  };
+
+  nativeBuildInputs = [
+    autoconf-archive # this can be removed with the next release
+    autoreconfHook
+    libtool
+  ] ++ lib.optionals guiSupport [ pkg-config ];
+
+  buildInputs = lib.optionals guiSupport [ gtk3 ];
+
+  configureFlags = lib.optional guiSupport "--enable-gui";
+
+  meta = with lib; {
+    description = "Zoned block device manipulation library and tools";
+    homepage = "https://github.com/westerndigitalcorporation/libzbd";
+    maintainers = with maintainers; [ zseri ];
+    license = with licenses; [ lgpl3Plus gpl3Plus ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4204,6 +4204,8 @@ with pkgs;
 
   libnss-mysql = callPackage ../os-specific/linux/libnss-mysql { };
 
+  libnvme = callPackage ../os-specific/linux/libnvme { };
+
   libxnd = callPackage ../development/libraries/libxnd { };
 
   libzbc = callPackage ../os-specific/linux/libzbc { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4208,6 +4208,8 @@ with pkgs;
 
   libzbc = callPackage ../os-specific/linux/libzbc { };
 
+  libzbd = callPackage ../os-specific/linux/libzbd { };
+
   lifeograph = callPackage ../applications/editors/lifeograph { };
 
   limitcpu = callPackage ../tools/misc/limitcpu { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4206,6 +4206,8 @@ with pkgs;
 
   libxnd = callPackage ../development/libraries/libxnd { };
 
+  libzbc = callPackage ../os-specific/linux/libzbc { };
+
   lifeograph = callPackage ../applications/editors/lifeograph { };
 
   limitcpu = callPackage ../tools/misc/limitcpu { };


### PR DESCRIPTION
###### Description of changes

Overview page: https://zonedstorage.io/docs/tools

https://github.com/westerndigitalcorporation/libzbc
https://github.com/westerndigitalcorporation/libzbd
https://github.com/linux-nvme/libnvme

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
