### PR TITLE
libAfterImage: fix compatibility with giflib 5

### DIFF
--- a/pkgs/development/libraries/libAfterImage/default.nix
+++ b/pkgs/development/libraries/libAfterImage/default.nix
@@ -54,6 +54,13 @@ stdenv.mkDerivation {
       # workaround '-p0' patchflags below.
       stripLen = 1;
     })
+
+    # fix https://github.com/root-project/root/issues/10990
+    (fetchpatch {
+      url = "https://github.com/root-project/root/pull/11243/commits/e177a477b0be05ef139094be1e96a99ece06350a.diff";
+      hash = "sha256-2DQmJGHmATHawl3dk9dExncVe1sXzJQyy4PPwShoLTY=";
+      stripLen = 5;
+    })
   ];
   patchFlags = [ "-p0" ];
 

--- a/pkgs/development/libraries/libAfterImage/default.nix
+++ b/pkgs/development/libraries/libAfterImage/default.nix
@@ -81,7 +81,8 @@ stdenv.mkDerivation {
     "--disable-mmx-optimization"
     "--${if static then "enable" else "disable"}-staticlibs"
     "--${if !static then "enable" else "disable"}-sharedlibs"
-  ] ++ lib.optional withX "--with-x";
+    "--${if withX then "with" else "without"}-x"
+  ];
 
   meta = with lib; {
     homepage = "http://www.afterstep.org/afterimage/";


### PR DESCRIPTION
###### Description of changes

Another attempt at fixing TEve in ROOT. Instead of #182105. This includes another minor macOS sandboxing bugfix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
