### PR TITLE
arch-install-scripts: 24 -> 26

### DIFF
--- a/pkgs/tools/misc/arch-install-scripts/default.nix
+++ b/pkgs/tools/misc/arch-install-scripts/default.nix
@@ -5,30 +5,42 @@
 , bash
 , coreutils
 , gawk
+, gnugrep
 , gnum4
+, makeWrapper
+, pacman
 , util-linux
+, chrootPath ? [
+    "/usr/local/sbin"
+    "/usr/local/bin"
+    "/usr/bin"
+    "/usr/bin/site_perl"
+    "/usr/bin/vendor_perl"
+    "/usr/bin/core_perl"
+  ]
 }:
 
 resholve.mkDerivation rec {
   pname = "arch-install-scripts";
-  version = "24";
+  version = "26";
 
   src = fetchFromGitHub {
     owner = "archlinux";
     repo = "arch-install-scripts";
     rev = "v${version}";
-    sha256 = "06rydiliis34lbz5fsayhbczs1xqi1a80jnhxafpjf6k3rfji6iq";
+    hash = "sha256-TRo1ANKSt3njw4HdBMUymMJDpTkL/i5/hdSqxHZnuYw=";
   };
 
   nativeBuildInputs = [ asciidoc gnum4 ];
 
-  preBuild = ''
+  postPatch = ''
     substituteInPlace ./Makefile \
       --replace "PREFIX = /usr/local" "PREFIX ?= /usr/local"
-
-    # https://github.com/archlinux/arch-install-scripts/pull/10
-    substituteInPlace ./common \
-      --replace "print '%s' \"\$1\"" "printf '%s' \"\$1\""
+    substituteInPlace ./pacstrap.in \
+      --replace "cp -a" "cp -LR --no-preserve=mode" \
+      --replace "unshare pacman" "unshare ${pacman}/bin/pacman" \
+      --replace 'gnupg "$newroot/etc/pacman.d/"' 'gnupg "$newroot/etc/pacman.d/" && chmod 700 "$newroot/etc/pacman.d/gnupg"'
+    echo "export PATH=${lib.strings.makeSearchPath "" chrootPath}:\$PATH" >> ./common
   '';
 
   installFlags = [ "PREFIX=$(out)" ];
@@ -50,7 +62,7 @@ resholve.mkDerivation rec {
       interpreter = "${bash}/bin/bash";
 
       # packages resholve should resolve executables from
-      inputs = [ coreutils gawk util-linux ];
+      inputs = [ coreutils gawk gnugrep pacman util-linux ];
 
       # TODO: no good way to resolve mount/umount in Nix builds for now
       # see https://github.com/abathur/resholve/issues/29
@@ -58,11 +70,7 @@ resholve.mkDerivation rec {
         external = [ "mount" "umount" ];
       };
 
-      # TODO: remove the execer lore override below after
-      # https://github.com/abathur/binlore/issues/1
-      execer = [
-        "cannot:${util-linux}/bin/unshare"
-      ];
+      keep = [ "$setup" "$pid_unshare" "$mount_unshare" "${pacman}/bin/pacman" ];
     };
   };
 
@@ -73,7 +81,7 @@ resholve.mkDerivation rec {
     '';
     homepage = "https://github.com/archlinux/arch-install-scripts";
     license = licenses.gpl2Only;
-    maintainers = with maintainers; [ yayayayaka ];
+    maintainers = with maintainers; [ samlukeyes123 ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Description of changes

Taking over `arch-install-scripts`.

To make `pacstrap` work, a valid `pacman.conf` should be either placed in `/etc` or passed to `pacstrap` using `-C` option.

- Closes https://github.com/NixOS/nixpkgs/pull/180031

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
