### PR TITLE
mintestWithMods: add -- Minetest bundled with mods

### DIFF
--- a/pkgs/games/minetest/minetest-with-mods.nix
+++ b/pkgs/games/minetest/minetest-with-mods.nix
@@ -6,9 +6,7 @@ flip (
 
   pkgs.makeOverridable
     (
-      { symlinkJoin
-      , makeWrapper
-      , minetest-mods
+      { minetest-mods
       , minetest
       }:
 
@@ -18,9 +16,9 @@ flip (
           ":"
           (map (mod: "${mod}/share/minetest/mods") mods);
       in
-      symlinkJoin {
+      pkgs.symlinkJoin {
         name = "minetest-with-mods";
-        buildInputs = [ makeWrapper ];
+        buildInputs = [ pkgs.makeWrapper ];
         paths = [
           minetest
         ] ++ mods;

--- a/pkgs/games/minetest/minetest-with-mods.nix
+++ b/pkgs/games/minetest/minetest-with-mods.nix
@@ -1,28 +1,33 @@
-{ symlinkJoin
-, makeWrapper
-, minetest-mods
-, minetest
-}:
-
-{
-  minetestPackage ? minetest,
-  modSelect
-}:
-
-let
-  mods = modSelect minetest-mods;
-  modPaths = builtins.concatStringsSep
-    ":"
-    (map (mod: "${mod}/share/minetest/mods") mods);
+pkgs:
+let flip = f: a: b: (f b a);
 in
-symlinkJoin {
-  name = "minetest-with-mods";
-  buildInputs = [ makeWrapper ];
-  paths = [
-    minetestPackage
-  ] ++ mods;
-  postBuild = ''
-    wrapProgram $out/bin/minetest \
-      --set MINETEST_MOD_PATH ${modPaths}
-  '';
-}
+flip (
+  modSelect:
+
+  pkgs.makeOverridable
+    (
+      { symlinkJoin
+      , makeWrapper
+      , minetest-mods
+      , minetest
+      }:
+
+      let
+        mods = modSelect minetest-mods;
+        modPaths = builtins.concatStringsSep
+          ":"
+          (map (mod: "${mod}/share/minetest/mods") mods);
+      in
+      symlinkJoin {
+        name = "minetest-with-mods";
+        buildInputs = [ makeWrapper ];
+        paths = [
+          minetest
+        ] ++ mods;
+        postBuild = ''
+          wrapProgram $out/bin/minetest \
+            --set MINETEST_MOD_PATH ${modPaths}
+        '';
+      }
+    )
+)

--- a/pkgs/games/minetest/minetest-with-mods.nix
+++ b/pkgs/games/minetest/minetest-with-mods.nix
@@ -1,0 +1,28 @@
+{ symlinkJoin
+, makeWrapper
+, minetest-mods
+, minetest
+}:
+
+{
+  minetestPackage ? minetest,
+  modSelect
+}:
+
+let
+  mods = modSelect minetest-mods;
+  modPaths = builtins.concatStringsSep
+    ":"
+    (map (mod: "${mod}/share/minetest/mods") mods);
+in
+symlinkJoin {
+  name = "minetest-with-mods";
+  buildInputs = [ makeWrapper ];
+  paths = [
+    minetestPackage
+  ] ++ mods;
+  postBuild = ''
+    wrapProgram $out/bin/minetest \
+      --set MINETEST_MOD_PATH ${modPaths}
+  '';
+}

--- a/pkgs/games/minetest/minetest-with-mods.nix
+++ b/pkgs/games/minetest/minetest-with-mods.nix
@@ -24,7 +24,7 @@ flip (
         ] ++ mods;
         postBuild = ''
           wrapProgram $out/bin/minetest \
-            --set MINETEST_MOD_PATH ${modPaths}
+            --prefix MINETEST_MOD_PATH : ${modPaths}
         '';
       }
     )

--- a/pkgs/games/minetest/mods/build-minetest-mod.nix
+++ b/pkgs/games/minetest/mods/build-minetest-mod.nix
@@ -3,7 +3,7 @@
 rec {
   buildMinetestMod =
     attrs@{
-      name ? "${attrs.pname}", 
+      name ? "${attrs.pname}",
       namePrefix ? "",
       src,
       unpackPhase ? "",

--- a/pkgs/games/minetest/mods/build-minetest-mod.nix
+++ b/pkgs/games/minetest/mods/build-minetest-mod.nix
@@ -1,0 +1,33 @@
+{stdenv}:
+
+rec {
+  buildMinetestMod =
+    attrs@{
+      name ? "${attrs.pname}", 
+      namePrefix ? "",
+      src,
+      unpackPhase ? "",
+      configurePhase ? "",
+      buildPhase ? "",
+      preInstall ? "",
+      postInstall ? "",
+      path ? ".",
+      addonInfo ? null,
+      ...
+    }:
+    stdenv.mkDerivation (attrs // {
+        name = namePrefix + name;
+        nativeBuildInputs = [];
+        inherit unpackPhase configurePhase buildPhase addonInfo preInstall postInstall;
+        installPhase = ''
+          runHook preInstall
+
+          target=$out/share/minetest/mods/${name}
+          mkdir -p $target
+          cp -r ${src}/* $target/
+
+          runHook postInstall
+          '';
+
+        });
+      }

--- a/pkgs/games/minetest/mods/default.nix
+++ b/pkgs/games/minetest/mods/default.nix
@@ -22,14 +22,6 @@ in
     };
   };
 
-  creaturesMod = buildMod {
-    pname = "creatures";
-    src = fetchGit {
-      url = "https://github.com/MirceaKitsune/minetest_mods_creatures.git";
-      rev = "adca784b964f28f7393669b3da71c99750099e7b";
-    };
-  };
-
   zombiesMod = buildMod {
     pname = "zombies";
     src = fetchGit {

--- a/pkgs/games/minetest/mods/default.nix
+++ b/pkgs/games/minetest/mods/default.nix
@@ -1,0 +1,70 @@
+{ pkgs ? import <nixpkgs> { } }:
+with pkgs;
+let buildMod = (import ./build-minetest-mod.nix { inherit stdenv; }).buildMinetestMod;
+in
+{
+
+  creaturaMod = buildMod {
+    pname = "creatura";
+    src = fetchTarball {
+      url = "https://github.com/ElCeejo/creatura/tarball/ce14c859249fa62d52fe54fcec297150ef159000";
+      sha256 = "1hxhgh5m0b0v2fv89z63ajgc48i41fv10p5il5zg43qjsqcbjlf6";
+    };
+  };
+
+  animaliaMod = buildMod {
+    pname = "animalia";
+    src = fetchFromGitHub {
+      owner = "ElCeejo";
+      repo = "animalia";
+      rev = "325dc1609ac2dc3b6d07dd4a2344380f9667c199";
+      sha256 = "0hpxws26bzx2d3vdi9555yv48lvbvyanq76jxpzrc6k5jvvhzqgp";
+    };
+  };
+
+  creaturesMod = buildMod {
+    pname = "creatures";
+    src = fetchGit {
+      url = "https://github.com/MirceaKitsune/minetest_mods_creatures.git";
+      rev = "adca784b964f28f7393669b3da71c99750099e7b";
+    };
+  };
+
+  zombiesMod = buildMod {
+    pname = "zombies";
+    src = fetchGit {
+      url = "https://github.com/minetest-mods/zombies.git";
+      rev = "0e633a5b1c7174e73c57cb2cdd676470eab9d627";
+    };
+  };
+  cityscapeMod = buildMod {
+    pname = "cityscape";
+    src = fetchGit {
+      url = "https://github.com/duane-r/cityscape.git";
+      rev = "06009a08044bc93798ed388b44d65d1ce96a8e2f";
+    };
+  };
+  whitelistMod = buildMod {
+    pname = "whitelist";
+    src = fetchGit {
+      url = "https://github.com/ShadowNinja/whitelist.git";
+      rev = "041737f01989ccdfa200e5eaa78547fd4bf12f2d";
+    };
+  };
+
+  draconisMod = buildMod {
+    pname = "draconis";
+    src = fetchTarball {
+      url = "https://github.com/ElCeejo/draconis/tarball/dca26827e70171eb7a0e7c59058b52768daa0ef6";
+      sha256 = "0mlx0qib6qyana272wn43mwhgdgyakn1n7xjqbnm1gizzf8i101i";
+    };
+  };
+
+  wieldedLightMod = buildMod {
+    pname = "wielded_light";
+    src = fetchGit {
+      url = "https://github.com/minetest-mods/wielded_light.git";
+      rev = "b5236562af9772dff8522fe2bda5b5f738e81b88";
+    };
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31878,6 +31878,14 @@ with pkgs;
 
   minetest-mods = callPackage ../games/minetest/mods { };
 
+  minetestWithMods = import ../games/minetest/minetest-with-mods.nix 
+                                {
+                                    inherit symlinkJoin;
+                                    inherit makeWrapper;
+                                    inherit minetest-mods;
+                                    inherit (pkgs) minetest;
+                                  };
+
   mnemosyne = callPackage ../games/mnemosyne {
     python = python3;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31879,11 +31879,12 @@ with pkgs;
   minetest-mods = callPackage ../games/minetest/mods { };
 
   minetestWithMods = import ../games/minetest/minetest-with-mods.nix 
+                                pkgs
                                 {
                                     inherit symlinkJoin;
                                     inherit makeWrapper;
                                     inherit minetest-mods;
-                                    inherit (pkgs) minetest;
+                                    inherit minetest;
                                   };
 
   mnemosyne = callPackage ../games/mnemosyne {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31878,7 +31878,7 @@ with pkgs;
 
   minetest-mods = callPackage ../games/minetest/mods { };
 
-  minetestWithMods = import ../games/minetest/minetest-with-mods.nix 
+  minetestWithMods = import ../games/minetest/minetest-with-mods.nix
                                 pkgs
                                 {
                                     inherit symlinkJoin;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31881,8 +31881,6 @@ with pkgs;
   minetestWithMods = import ../games/minetest/minetest-with-mods.nix
                                 pkgs
                                 {
-                                    inherit symlinkJoin;
-                                    inherit makeWrapper;
                                     inherit minetest-mods;
                                     inherit minetest;
                                   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31876,6 +31876,8 @@ with pkgs;
   minetestclient = minetestclient_5;
   minetestserver = minetestserver_5;
 
+  minetest-mods = callPackage ../games/minetest/mods { };
+
   mnemosyne = callPackage ../games/mnemosyne {
     python = python3;
   };


### PR DESCRIPTION
###### Description of changes

The PR adds a simple function `pkgs.minetestWithPackages` to bundle minetest with mods and add them to the MINETEST_MOD_PATH. The function takes the lead from functions like `ghcWithPackages`, so `minetestWithPackages (mods: [mods.whitelist])` makes the whitelist mod available in the mod path.

The mods that can be installed are bundled in the newly introduced package minetest-mods, which as yet contains only a small selection of mods that I actually use atm but would ideally be generated automatically from contentDB.

The entries in minetest-mods are generated using [pkgs/games/minetest/mods/build-minetest-mod.nix](https://github.com/NixOS/nixpkgs/compare/staging...hllizi:nixpkgs:minetest_mods_tidied?expand=1#diff-f991b24938538766f1eabb91937fdb7fd6273734c44985efb063275d459581f0), imported there as `buildMod`, which expects a set with the attributes `pname` containing the name of the mod and `src` for the source. This function is derived from the similar function for vim plugins.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
