### PR TITLE
fcitx5-mozc: package ut dictionary

### DIFF
--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-mozc.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-mozc.nix
@@ -107,7 +107,7 @@ in clangStdenv.mkDerivation rec {
     description = "Fcitx5 Module of A Japanese Input Method for Chromium OS, Windows, Mac and Linux (the Open Source Edition of Google Japanese Input)";
     homepage = "https://github.com/fcitx/mozc";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ berberman ];
+    maintainers = with maintainers; [ berberman govanify ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-mozc.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-mozc.nix
@@ -3,6 +3,10 @@
 , jsoncpp, gtest, which, gtk2, unzip, abseil-cpp, breakpad }:
 let
   inherit (python3Packages) python gyp six;
+  utdic = fetchurl {
+    url = "https://osdn.net/downloads/users/39/39056/mozcdic-ut-20220904.tar.bz2";
+    sha256 = "sha256-pmLBCcw2Zsirzl1PjYkviRIZoyfUz5rpESeABDxuhtU=";
+  };
   japanese_usage_dictionary = fetchFromGitHub {
     owner = "hiroyuki-komatsu";
     repo = "japanese-usage-dictionary";
@@ -47,6 +51,9 @@ in clangStdenv.mkDerivation rec {
   postUnpack = ''
     unzip ${x-ken-all} -d $sourceRoot/src/
     unzip ${jigyosyo} -d $sourceRoot/src/
+    mkdir $TMPDIR/unpack
+    tar xf ${utdic} -C $TMPDIR/unpack
+    cat $TMPDIR/unpack/mozcdic-ut-20220904/mozcdic-ut-20220904.txt >> $sourceRoot/src/data/dictionary_oss/dictionary00.txt
 
     rmdir $sourceRoot/src/third_party/breakpad/
     ln -s ${breakpad} $sourceRoot/src/third_party/breakpad


### PR DESCRIPTION
###### Description of changes

This adds the [UT dictionnary](http://linuxplayers.g1.xrea.com/mozc-ut.html) to fcitx5-mozc, on top of the current usage dictionaries we have.
mozc's internal dictionary is lackluster at best and as we already package by default dictionaries, might as well make sane defaults. [See here for additional context](https://wiki.archlinux.org/title/Mozc#The_UT_Dictionary) .
This fixes https://github.com/NixOS/nixpkgs/issues/142250 .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
