### PR TITLE
vcmi: init at 1.0.0

### DIFF
--- a/pkgs/games/vcmi/default.nix
+++ b/pkgs/games/vcmi/default.nix
@@ -1,0 +1,97 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, SDL2
+, SDL2_image
+, SDL2_mixer
+, SDL2_ttf
+, boost
+, cmake
+, ffmpeg
+, innoextract
+, luajit
+, minizip
+, ninja
+, pkg-config
+, python3
+, qtbase
+, tbb
+, wrapQtAppsHook
+, zlib
+, testers
+, vcmi
+}:
+
+stdenv.mkDerivation rec {
+  pname = "vcmi";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "vcmi";
+    repo = "vcmi";
+    rev = version;
+    fetchSubmodules = true;
+    hash = "sha256-5PuFq6wDSj5Ye2fUjqcr/VRU0ocus6h2nn+myQTOrhU=";
+  };
+
+  postPatch = ''
+    substituteInPlace Version.cpp.in \
+      --subst-var-by GIT_SHA1 "0000000";
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    python3
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    SDL2
+    SDL2_image
+    SDL2_mixer
+    SDL2_ttf
+    boost
+    ffmpeg
+    luajit
+    minizip
+    qtbase
+    tbb
+    zlib
+  ];
+
+  cmakeFlags = [
+    "-DENABLE_TEST:BOOL=NO"
+    "-DENABLE_PCH:BOOL=NO"
+    # Make libvcmi.so discoverable in a non-standard location.
+    "-DCMAKE_INSTALL_RPATH:STRING=${placeholder "out"}/lib/vcmi"
+    # Upstream assumes relative value while Nixpkgs passes absolute.
+    # Both should be allowed: https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html
+    # Meanwhile work it around by passing a relative value.
+    "-DCMAKE_INSTALL_LIBDIR:STRING=lib"
+  ];
+
+  postFixup = ''
+    wrapProgram $out/bin/vcmibuilder \
+      --prefix PATH : "${lib.makeBinPath [ innoextract ]}"
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = vcmi;
+    command = ''
+      XDG_DATA_HOME=$PWD XDG_CACHE_HOME=$PWD XDG_CONFIG_HOME=$PWD \
+        vcmiclient --version
+    '';
+  };
+
+  meta = with lib; {
+    description = "Open-source engine for Heroes of Might and Magic III";
+    homepage = "https://vcmi.eu";
+    changelog = "https://github.com/vcmi/vcmi/blob/${src.rev}/ChangeLog";
+    license = with licenses; [ gpl2Only cc-by-sa-40 ];
+    maintainers = with maintainers; [ azahi ];
+    platforms = platforms.linux;
+    mainProgram = "vcmiclient";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11927,6 +11927,8 @@ with pkgs;
 
   vcftools = callPackage ../applications/science/biology/vcftools { };
 
+  vcmi = libsForQt5.callPackage ../games/vcmi { };
+
   vcsh = callPackage ../applications/version-management/vcsh { };
 
   vcs_query = callPackage ../tools/misc/vcs_query { };


### PR DESCRIPTION
###### Description of changes

Open-source engine for HoMM3.

https://vcmi.eu/
https://github.com/vcmi/vcmi

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
