### PR TITLE
tcmu-runner: init at unstable-2022-02-21

### DIFF
--- a/pkgs/os-specific/linux/tcmu-runner/default.nix
+++ b/pkgs/os-specific/linux/tcmu-runner/default.nix
@@ -1,0 +1,73 @@
+{ lib
+, stdenv
+, ceph
+, cmake
+, fetchFromGitHub
+, glib
+, glusterfs
+, gperftools
+, kmod
+, libnl
+, pcre
+, pkg-config
+, util-linuxMinimal
+, zlib
+, cephSupport ? true
+, glusterSupport ? true
+, systemdSupport ? true
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tcmu-runner";
+  version = "unstable-2022-02-21";
+
+  src = fetchFromGitHub {
+    owner = "open-iscsi";
+    repo = "tcmu-runner";
+    rev = "364ae611ffdd7c8fb3d1e733563b636bf3b44ba6";
+    hash = "sha256-SxAkpOzNB7/csEVfC6ptyyxJ8lu3YnRGiZhk4DsJnBA=";
+  };
+
+  postPatch = ''
+    # fix install paths, as they are currently hardcoded
+    # see also: https://github.com/open-iscsi/tcmu-runner/issues/683
+    substituteInPlace CMakeLists.txt \
+      --replace " /etc" " \''${CMAKE_INSTALL_PREFIX}/etc" \
+      --replace " /usr/" " \''${CMAKE_INSTALL_PREFIX}/"
+    for i in *.conf_install.cmake.in; do
+      substituteInPlace "$i" \
+        --replace " \"/etc" " \"\''${CMAKE_INSTALL_PREFIX}/etc"
+    done
+    for i in *.service; do
+      substituteInPlace "$i" \
+        --replace "=/usr/bin/" "=/$out/bin/"
+    done
+    unset i
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    glib
+    gperftools # for tcmalloc
+    kmod
+    libnl
+    pcre
+    util-linuxMinimal # for libmount
+    zlib
+  ] ++ lib.optional cephSupport ceph
+    ++ lib.optional glusterSupport glusterfs;
+
+  cmakeFlags = lib.optionals systemdSupport [ "-DSUPPORT_SYSTEMD=ON" ];
+
+  meta = with lib; {
+    description = "A daemon that handles the userspace side of the LIO TCM-User backstore";
+    homepage = "https://github.com/open-iscsi/tcmu-runner";
+    maintainers = with maintainers; [ zseri ];
+    license = with licenses; [ asl20 lgpl21 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4715,6 +4715,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  tcmu-runner = callPackage ../os-specific/linux/tcmu-runner { };
+
   xlogo = callPackage ../tools/X11/xlogo { };
 
   xmlbeans = callPackage ../tools/misc/xmlbeans { };


### PR DESCRIPTION
###### Description of changes

> [LIO](http://linux-iscsi.org/wiki/Main_Page) is the [SCSI](http://en.wikipedia.org/wiki/SCSI) [target](http://en.wikipedia.org/wiki/SCSI_initiator_and_target) in the [Linux kernel](http://kernel.org/). It is entirely kernel code, and allows exported SCSI [logical units (LUNs)](http://en.wikipedia.org/wiki/Logical_unit_number) to be backed by regular files or block devices. But, if we want to get fancier with the capabilities of the device we're emulating, the kernel is not necessarily the right place. While there are userspace libraries for compression, encryption, and clustered storage solutions like [Ceph](http://ceph.com/) or [Gluster](http://www.gluster.org/), these are not accessible from the kernel.

> The TCMU userspace-passthrough backstore allows a userspace process to handle requests to a LUN. But since the kernel-user interface that TCMU provides must be fast and flexible, it is complex enough that we'd like to avoid each userspace handler having to write boilerplate code.

> **tcmu-runner** handles the messy details of the TCMU interface -- UIO, netlink, pthreads, and DBus -- and exports a more friendly C plugin module API. Modules using this API are called "TCMU handlers". Handler authors can write code just to handle the SCSI commands as desired, and can also link with whatever userspace libraries they like.

###### Things done

This just adds the package. A NixOS module should be added later to integrate this package into DBUS and systemd. (it already provides a DBUS service file, and a systemd service file (although nixos prefers to setup the systemd service file themselves))

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
