### PR TITLE
giara: 1.0 -> 1.0.1

### DIFF
--- a/pkgs/applications/networking/giara/default.nix
+++ b/pkgs/applications/networking/giara/default.nix
@@ -14,11 +14,11 @@
 , glib-networking
 , libadwaita
 , appstream
+, blueprint-compiler
 }:
-
 python3.pkgs.buildPythonApplication rec {
   pname = "giara";
-  version = "1.0";
+  version = "1.0.1";
 
   format = "other";
 
@@ -27,7 +27,7 @@ python3.pkgs.buildPythonApplication rec {
     owner = "World";
     repo = pname;
     rev = version;
-    hash = "sha256-xDIzgr8zYal0r0sASWqiSZANCMC52LrVmLjlnGAd2Mg=";
+    hash = "sha256-hKaniW+bbuKUrETMQGWwvC2kyudK9tCE/R69dOFzdQM=";
   };
 
   nativeBuildInputs = [
@@ -37,6 +37,7 @@ python3.pkgs.buildPythonApplication rec {
     pkg-config
     ninja
     wrapGAppsHook4
+    blueprint-compiler
   ];
 
   buildInputs = [
@@ -56,16 +57,6 @@ python3.pkgs.buildPythonApplication rec {
     pillow
     mistune
     beautifulsoup4
-  ];
-
-  patches = [
-    # Proper support for gtk4 and libadwaita
-    # @TODO: Remove when bumping the version.
-    (fetchpatch {
-      name = "giara-gtk4-libadwaita.patch";
-      url = "https://gitlab.gnome.org/World/giara/-/commit/6204427f8b8e3d8c72b669717a3f129ffae401d9.patch";
-      sha256 = "sha256-E8kbVsACPD2gkfNrzYUy0+1U7+/pIkUu4rCkX+xY0us=";
-    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This release is "[Miscellaneous improvements and fixes](https://gitlab.gnome.org/World/giara/-/compare/1.0...1.0.1?from_project_id=12731#4538c85fb32b095f8d1cdd48894703ea46293bff
)" but, notably, it fixes https://github.com/NixOS/nixpkgs/issues/168842

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

nixpkgs-review throws the following error (I'm not sure why though as the variable does exist so far as I can tell):

```
error: undefined variable 'mistune_2_0'
```

But without version 2.x of mistune, giara throws an error:

```
AttributeError: module 'mistune' has no attribute 'HTMLRenderer'
```

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
