### PR TITLE
paperless: Allow passing extraPropagatedBuildInputs

### DIFF
--- a/pkgs/applications/office/paperless-ngx/default.nix
+++ b/pkgs/applications/office/paperless-ngx/default.nix
@@ -12,6 +12,10 @@
 , unpaper
 , liberation_ttf
 , fetchFromGitHub
+
+# Allow propagating additional dependencies through an override with
+# the packages being considered in the PYTHONPATH exposed via passthru.
+, extraPropagatedBuildInputs ? ps: []
 }:
 
 let
@@ -157,7 +161,7 @@ python.pkgs.pythonPackages.buildPythonApplication rec {
     whitenoise
     whoosh
     zope_interface
-  ];
+  ] ++ (extraPropagatedBuildInputs python.pkgs);
 
   # paperless-ngx includes the bundled django-q version. This will
   # conflict with the tests and is not needed since we overrode the


### PR DESCRIPTION
The paperless package exposes a PYTHONPATH via passthru, that is used
from its accompanying module. Using `overridePythonAttrs` it is not
possible to affect the passed PYTHONPATH to inject additional
dependencies.

My specific use case is to patch Django's settings.py with LDAP support
and propagate the `django-auth-ldap` package, which overall has a low
maintenance cost.

Tested using a slight modification to the tests:

```diff
diff --git a/nixos/tests/paperless.nix b/nixos/tests/paperless.nix
index 12883cd62c6..3da785d414e 100644
--- a/nixos/tests/paperless.nix
+++ b/nixos/tests/paperless.nix
@@ -1,4 +1,4 @@
-import ./make-test-python.nix ({ lib, ... }: {
+import ./make-test-python.nix ({ lib, pkgs, ... }: {
   name = "paperless";
   meta.maintainers = with lib.maintainers; [ erikarvstedt Flakebi ];
 
@@ -6,6 +6,9 @@ import ./make-test-python.nix ({ lib, ... }: {
     environment.systemPackages = with pkgs; [ imagemagick jq ];
     services.paperless = {
       enable = true;
+      package = pkgs.paperless-ngx.override {
+        extraPropagatedBuildInputs = ps: with ps; [ django-auth-ldap ];
+      };
       passwordFile = builtins.toFile "password" "admin";
     };
   };
@@ -15,6 +18,8 @@ import ./make-test-python.nix ({ lib, ... }: {
 
     machine.wait_for_unit("paperless-consumer.service")
 
+    machine.succeed("systemctl show -p Environment paperless-web | grep -q django-auth-ldap")
+
     with subtest("Add a document via the file system"):
         machine.succeed(
             "convert -size 400x40 xc:white -font 'DejaVu-Sans' -pointsize 20 -fill black "
```

```
machine: must succeed: systemctl show -p Environment paperless-web | grep -q django-auth-ldap
(finished: must succeed: systemctl show -p Environment paperless-web | grep -q django-auth-ldap, in 0.30 seconds)
```

I'm open to persisting this test case, but it serves no concrete purpose by itself.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
