### PR TITLE
virt-top: 1.0.9 -> 1.1.1

### DIFF
--- a/pkgs/applications/virtualization/virt-top/default.nix
+++ b/pkgs/applications/virtualization/virt-top/default.nix
@@ -1,32 +1,39 @@
-{ lib, stdenv, fetchgit, fetchpatch, ocamlPackages, autoreconfHook }:
+{ lib, stdenv, fetchgit, ocamlPackages, autoreconfHook, libxml2, pkg-config, getopt }:
 
 stdenv.mkDerivation rec {
   pname = "virt-top";
-  version = "1.0.9";
+  version = "1.1.1";
 
   src = fetchgit {
     url = "git://git.annexia.org/virt-top.git";
     rev = "v${version}";
-    sha256 = "0m7pm8lzlpngsj0vjv0hg8l9ck3gvwpva7r472f8f03xpjffwiga";
+    hash = "sha256-IKIkqzx7YWki0L6D5WbwQiVWJfDFGdI2nsGgg212CcE=";
   };
 
-  patches = [
-    (fetchpatch {
-      name = "ocaml-libvirt-0.6.1.5-fix.patch";
-      url = "http://git.annexia.org/?p=virt-top.git;a=patch;h=24a461715d5bce47f63cb0097606fc336230589f";
-      sha256 = "15w7w9iggvlw8m9w8g4h08251wzb3m3zkb58glr7ifsgi3flbn61";
-    })
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    getopt
   ];
 
-  nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = with ocamlPackages; [ ocaml findlib ocaml_extlib ocaml_libvirt gettext-stub curses csv xml-light ];
+  buildInputs = with ocamlPackages; [
+    calendar
+    curses
+    findlib
+    gettext-stub
+    ocaml
+    ocaml_libvirt
+  ] ++ [ libxml2 ];
 
-  buildPhase = "make opt";
+  prePatch = ''
+    substituteInPlace ocaml-dep.sh.in --replace '#!/bin/bash' '#!${stdenv.shell}'
+    substituteInPlace ocaml-link.sh.in --replace '#!/bin/bash' '#!${stdenv.shell}'
+  '';
 
   meta = with lib; {
     description = "A top-like utility for showing stats of virtualized domains";
     homepage = "https://people.redhat.com/~rjones/virt-top/";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     maintainers = [ ];
     platforms = platforms.linux;
   };


### PR DESCRIPTION
###### Description of changes

* Upgrade virt-top from 1.0.9 to 1.1.1
  * Release notes: http://git.annexia.org/?p=virt-top.git;a=shortlog;h=refs/tags/v1.1.1
* Remove useless patch since v1.1.1
* Clean unused build inputs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
