### PR TITLE
sageWithDoc: fix documentation index

### DIFF
--- a/pkgs/applications/science/math/sage/patches/sphinx-fix-matplotlib-css-perms.patch
+++ b/pkgs/applications/science/math/sage/patches/sphinx-fix-matplotlib-css-perms.patch
@@ -1,0 +1,21 @@
+diff --git a/src/sage_docbuild/ext/multidocs.py b/src/sage_docbuild/ext/multidocs.py
+index f91c7753ca..edeb81ff2e 100644
+--- a/src/sage_docbuild/ext/multidocs.py
++++ b/src/sage_docbuild/ext/multidocs.py
+@@ -284,6 +284,16 @@ def init_subdoc(app):
+         if not app.config.multidoc_first_pass:
+             app.connect('env-updated', fetch_citation)
+ 
++            def fix_matplotlib_css_permissions(app: Sphinx, env):
++                css_file = os.path.join(app.builder.outdir, '_static', 'plot_directive.css')
++                try:
++                    os.chmod(css_file, 0o644)
++                except:
++                    pass
++
++            # executed after matplotlib's _copy_css_file
++            app.connect('build-finished', fix_matplotlib_css_permissions, priority=600)
++
+         # Monkey patch copy_static_files to make a symlink to "../"
+         def link_static_files():
+             """

--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -81,6 +81,10 @@ stdenv.mkDerivation rec {
     # Parallelize docubuild using subprocesses, fixing an isolation issue. See
     # https://groups.google.com/forum/#!topic/sage-packaging/YGOm8tkADrE
     ./patches/sphinx-docbuild-subprocesses.patch
+
+    # Docbuilding copies files from the Nix store and expects them to be writable.
+    # Remove when https://github.com/matplotlib/matplotlib/pull/23805 lands.
+    ./patches/sphinx-fix-matplotlib-css-perms.patch
   ];
 
   # Since sage unfortunately does not release bugfix releases, packagers must


### PR DESCRIPTION
###### Description of changes

Since basically forever, Sage docbuilding on Nix generates harmless errors of the following form:

```
Extension error (matplotlib.sphinxext.plot_directive):
Handler <function _copy_css_file at 0x7fd51e53c8b0> for event 'build-finished' threw an exception (exception: [Errno 13] Permission denied: '<dir>/share/doc/sage/html/en/reference/valuations/_static/plot_directive.css')
```

This happens because the matplotlib Sphinx extension copies a CSS file from the Nix store to `reference/SUBDIR/_static` using Python's `shutil.copy`, resulting in a read-only file. Because Sage docbuilding symlinks `reference/SUBDIR/_static` to `reference/_static`, the copying effectively happens multiple times, and therefore we get a "Permission denied" error for all but one of the 78 `reference/` subdirectories.

Sage builds docs in two passes for parallelism: Subdirectories are built separately, and then a second pass stitches them together by looking at some state files (`environment.pickle` in particular) created by Sphinx in each of the documentation subdirectories. Sphinx deletes these state files if the build fails, but functions registered as "build-finished" callbacks are an interesting gray area: What happens if they fail? Well, before Sphinx 5 this was ignored, but [Sphinx 5 considers this to be a build failure](https://github.com/sphinx-doc/sphinx/issues/10110) and deletes the relevant state files. Without them, Sage docbuilding can't create the documentation index.

This PR works around the issue by patching Sage's docbuilding to change plot_directive.css's permissions. I have submitted matplotlib/matplotlib#23805 to fix this properly, but since it will probably take a while to reach a release and the bug is almost Sage+Nix-specific, I'd rather get the workaround in Nixpkgs first (it fixes a user-reported problem).

Fixes #189607 (cc @aikrahguzar)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->