### PR TITLE
evolution-data-server: generate GSettings patch as part of update script

### DIFF
--- a/pkgs/common-updater/combinators.nix
+++ b/pkgs/common-updater/combinators.nix
@@ -1,0 +1,128 @@
+{ lib
+}:
+
+/*
+  This is a set of tools to manipulate update scripts as recognized by update.nix.
+  It is still very experimental with **instability** almost guaranteed so any use
+  outside Nixpkgs is discouraged.
+
+  update.nix currently accepts the following type:
+
+  type UpdateScript
+    // Simple path to script to execute script
+    = FilePath
+    // Path to execute plus arguments to pass it
+    | [ (FilePath | String) ]
+    // Advanced attribue set (experimental)
+    | {
+      // Script to execute (same as basic update script above)
+      command : (FilePath | [ (FilePath | String) ])
+      // Features that the script supports
+      // - commit: (experimental) returns commit message in stdout
+      supportedFeatures : ?[ "commit" ]
+      // Override attribute path detected by update.nix
+      attrPath : ?String
+    }
+*/
+
+let
+  /*
+    type ShellArg = String | { __rawShell : String }
+  */
+
+  /*
+    Quotes all arguments to be safely passed to the Bourne shell.
+
+    escapeShellArgs' : [ShellArg] -> String
+  */
+  escapeShellArgs' = lib.concatMapStringsSep " " (arg: if arg ? __rawShell then arg.__rawShell else lib.escapeShellArg arg);
+
+  /*
+    processArg : { maxArgIndex : Int, args : [ShellArg], paths : [FilePath] } → (String|FilePath) → { maxArgIndex : Int, args : [ShellArg], paths : [FilePath] }
+    Helper reducer function for building a command arguments where file paths are replaced with argv[x] reference.
+  */
+  processArg =
+    { maxArgIndex, args, paths }:
+    arg:
+    if builtins.isPath arg then {
+      args = args ++ [ { __rawShell = "\"\$${builtins.toString maxArgIndex}\""; } ];
+      maxArgIndex = maxArgIndex + 1;
+      paths = paths ++ [ arg ];
+    } else {
+      args = args ++ [ arg ];
+      inherit maxArgIndex paths;
+    };
+  /*
+    extractPaths : Int → [ (String|FilePath) ] → { maxArgIndex : Int, args : [ShellArg], paths : [FilePath] }
+    Helper function that extracts file paths from command arguments and replaces them with argv[x] references.
+  */
+  extractPaths = maxArgIndex: command: builtins.foldl' processArg { inherit maxArgIndex; args = [ ]; paths = [ ]; } command;
+  /*
+    processCommand : { maxArgIndex : Int, commands : [[ShellArg]], paths : [FilePath] } → [ (String|FilePath) ] → { maxArgIndex : Int, commands : [[ShellArg]], paths : [FilePath] }
+    Helper reducer function for extracting file paths from individual commands.
+  */
+  processCommand =
+    { maxArgIndex, commands, paths }:
+    command:
+    let
+      new = extractPaths maxArgIndex command;
+    in
+    {
+      commands = commands ++ [ new.args ];
+      paths = paths ++ new.paths;
+      maxArgIndex = new.maxArgIndex;
+    };
+  /*
+    extractCommands : Int → [[ (String|FilePath) ]] → { maxArgIndex : Int, commands : [[ShellArg]], paths : [FilePath] }
+    Helper function for extracting file paths from a list of commands and replacing them with argv[x] references.
+  */
+  extractCommands = maxArgIndex: commands: builtins.foldl' processCommand { inherit maxArgIndex; commands = [ ]; paths = [ ]; } commands;
+
+  /*
+    commandsToShellInvocation : [[ (String|FilePath) ]] → [ (String|FilePath) ]
+    Converts a list of commands into a single command by turning them into a shell script and passing them to `sh -c`.
+  */
+  commandsToShellInvocation = commands:
+    let
+      extracted = extractCommands 0 commands;
+    in
+    [
+      "sh"
+      "-c"
+      (lib.concatMapStringsSep ";" escapeShellArgs' extracted.commands)
+      # We need paths as separate arguments so that update.nix can ensure they refer to the local directory
+      # rather than a store path.
+    ] ++ extracted.paths;
+in
+rec {
+  /*
+    normalize : UpdateScript → UpdateScript
+    EXPERIMENTAL! Converts a basic update script to the experimental attribute set form.
+  */
+  normalize = updateScript: {
+    command = lib.toList (updateScript.command or updateScript);
+    supportedFeatures = updateScript.supportedFeatures or [ ];
+  } // lib.optionalAttrs (updateScript ? attrPath) {
+    inherit (updateScript) attrPath;
+  };
+
+  /*
+    sequence : [UpdateScript] → UpdateScript
+    EXPERIMENTAL! Combines multiple update scripts to run in sequence.
+  */
+  sequence =
+    scripts:
+
+    let
+      scriptsNormalized = builtins.map normalize scripts;
+    in
+    let
+      scripts = scriptsNormalized;
+      validateFeatures = ({ supportedFeatures, ... }: supportedFeatures == [ ]);
+    in
+
+    assert lib.assertMsg (lib.all validateFeatures scripts) "Combining update scripts with features enabled is currently unsupported.";
+    assert lib.assertMsg (builtins.length (lib.unique (builtins.map ({ attrPath ? null, ... }: attrPath) scripts)) == 1) "Combining update scripts with different attr paths is currently unsupported.";
+
+    commandsToShellInvocation (builtins.map ({ command, ... }: command) scripts);
+}

--- a/pkgs/desktops/gnome/core/evolution-data-server/default.nix
+++ b/pkgs/desktops/gnome/core/evolution-data-server/default.nix
@@ -2,8 +2,12 @@
 , lib
 , fetchurl
 , substituteAll
+, runCommand
+, git
+, coccinelle
 , pkg-config
 , gnome
+, update-script-combinators
 , python3
 , gobject-introspection
 , gettext
@@ -63,7 +67,7 @@ stdenv.mkDerivation rec {
 
   prePatch = ''
     substitute ${./hardcode-gsettings.patch} hardcode-gsettings.patch \
-      --subst-var-by ESD_GSETTINGS_PATH ${glib.makeSchemaPath "$out" "${pname}-${version}"} \
+      --subst-var-by EDS_GSETTINGS_PATH ${glib.makeSchemaPath "$out" "${pname}-${version}"} \
       --subst-var-by GDS_GSETTINGS_PATH ${glib.getSchemaPath gsettings-desktop-schemas}
     patches="$patches $PWD/hardcode-gsettings.patch"
   '';
@@ -125,10 +129,41 @@ stdenv.mkDerivation rec {
   ];
 
   passthru = {
-    updateScript = gnome.updateScript {
-      packageName = "evolution-data-server";
-      versionPolicy = "odd-unstable";
-    };
+    # In order for GNOME not to depend on OCaml through Coccinelle,
+    # we materialize the SmPL patch into a unified diff-style patch.
+    hardcodeGsettingsPatch =
+      runCommand
+        "hardcode-gsettings.patch"
+        {
+          inherit src;
+          nativeBuildInputs = [
+            git
+            coccinelle
+            python3 # For patch script
+          ];
+        }
+        ''
+          unpackPhase
+          cd "''${sourceRoot:-.}"
+          git init
+          git add -A
+          spatch --sp-file "${./hardcode-gsettings.cocci}" --dir . --in-place
+          git diff > "$out"
+        '';
+
+    updateScript =
+      let
+        updateSource = gnome.updateScript {
+          packageName = "evolution-data-server";
+          versionPolicy = "odd-unstable";
+        };
+
+        updateGsettingsPatch = update-script-combinators.copyAttrOutputToFile "evolution-data-server.hardcodeGsettingsPatch" ./hardcode-gsettings.patch;
+      in
+      update-script-combinators.sequence [
+        updateSource
+        updateGsettingsPatch
+      ];
   };
 
   meta = with lib; {

--- a/pkgs/desktops/gnome/core/evolution-data-server/hardcode-gsettings.cocci
+++ b/pkgs/desktops/gnome/core/evolution-data-server/hardcode-gsettings.cocci
@@ -1,0 +1,76 @@
+/**
+ * Since Nix does not have a standard location like /usr/share,
+ * where GSettings system could look for schemas, we need to point the software to a correct location somehow.
+ * For executables, we handle this using wrappers but this is not an option for libraries like e-d-s.
+ * Instead, we hardcode the schema path when creating the settings.
+ */
+
+@initialize:python@
+@@
+
+cpp_constants = {}
+
+def register_cpp_constant(const_name, val):
+    cpp_constants[const_name] = val.strip()
+
+def resolve_cpp_constant(const_name):
+    return cpp_constants.get(const_name, const_name)
+
+e_s_d_schema_constants = [
+    # The following are actually part of e-d-s, despite the name.
+    # We rename the old ambiguos constant name in ./prepare-for-gsettings-patching.patch
+    "\"org.gnome.Evolution.DefaultSources\"",
+    "\"org.gnome.evolution.shell.network-config\"",
+]
+
+g_d_s_schema_constants = [
+    "\"org.gnome.system.proxy\"",
+]
+
+def get_schema_directory(schema_path):
+    # Sometimes the schema id is referenced using C preprocessor #define constant in the same file
+    # let’s try to resolve it first.
+    schema_path = resolve_cpp_constant(schema_path.strip())
+    if schema_path.startswith("\"org.gnome.evolution-data-server") or schema_path in e_s_d_schema_constants:
+        return "\"@EDS_GSETTINGS_PATH@\""
+    elif schema_path in g_d_s_schema_constants:
+        return "\"@GDS_GSETTINGS_PATH@\""
+    raise Exception(f"Unknown schema path {schema_path}")
+
+
+@find_cpp_constants@
+identifier const_name;
+expression val;
+@@
+
+#define const_name val
+
+@script:python record_cpp_constants depends on find_cpp_constants@
+const_name << find_cpp_constants.const_name;
+val << find_cpp_constants.val;
+@@
+
+register_cpp_constant(const_name, val)
+
+
+@depends on ever record_cpp_constants || never record_cpp_constants@
+// We want to run after #define constants have been collected but even if there are no #defines.
+expression SCHEMA_PATH;
+expression settings;
+// Coccinelle does not like autocleanup macros in + sections,
+// let’s use fresh id with concatenation to produce the code as a string.
+fresh identifier schema_source_decl = "g_autoptr(GSettingsSchemaSource) " ## "schema_source";
+fresh identifier schema_decl = "g_autoptr(GSettingsSchema) " ## "schema";
+fresh identifier SCHEMA_DIRECTORY = script:python(SCHEMA_PATH) { get_schema_directory(SCHEMA_PATH) };
+@@
+-settings = g_settings_new(SCHEMA_PATH);
++{
++	schema_source_decl;
++	schema_decl;
++	schema_source = g_settings_schema_source_new_from_directory(SCHEMA_DIRECTORY,
++	                                                            g_settings_schema_source_get_default(),
++	                                                            TRUE,
++	                                                            NULL);
++	schema = g_settings_schema_source_lookup(schema_source, SCHEMA_PATH, FALSE);
++	settings = g_settings_new_full(schema, NULL, NULL);
++}

--- a/pkgs/desktops/gnome/core/evolution-data-server/hardcode-gsettings.patch
+++ b/pkgs/desktops/gnome/core/evolution-data-server/hardcode-gsettings.patch
@@ -1,16 +1,16 @@
 diff --git a/src/addressbook/libebook/e-book-client.c b/src/addressbook/libebook/e-book-client.c
-index 2c0557c3c..5955aa55e 100644
+index 7888e69..c3b695c 100644
 --- a/src/addressbook/libebook/e-book-client.c
 +++ b/src/addressbook/libebook/e-book-client.c
-@@ -1989,7 +1989,20 @@ e_book_client_get_self (ESourceRegistry *registry,
+@@ -1983,7 +1983,18 @@ e_book_client_get_self (ESourceRegistry *registry,
  
  	*out_client = book_client;
  
 -	settings = g_settings_new (SELF_UID_PATH_ID);
 +	{
-+		GSettingsSchemaSource *schema_source;
-+		GSettingsSchema *schema;
-+		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++		g_autoptr(GSettingsSchemaSource) schema_source;
++		g_autoptr(GSettingsSchema) schema;
++		schema_source = g_settings_schema_source_new_from_directory("@EDS_GSETTINGS_PATH@",
 +									    g_settings_schema_source_get_default(),
 +									    TRUE,
 +									    NULL);
@@ -18,21 +18,19 @@ index 2c0557c3c..5955aa55e 100644
 +							 SELF_UID_PATH_ID,
 +							 FALSE);
 +		settings = g_settings_new_full(schema, NULL, NULL);
-+		g_settings_schema_source_unref(schema_source);
-+		g_settings_schema_unref(schema);
 +	}
  	uid = g_settings_get_string (settings, SELF_UID_KEY);
  	g_object_unref (settings);
  
-@@ -2057,7 +2070,20 @@ e_book_client_set_self (EBookClient *client,
+@@ -2051,7 +2062,18 @@ e_book_client_set_self (EBookClient *client,
  	g_return_val_if_fail (
  		e_contact_get_const (contact, E_CONTACT_UID) != NULL, FALSE);
  
 -	settings = g_settings_new (SELF_UID_PATH_ID);
 +	{
-+		GSettingsSchemaSource *schema_source;
-+		GSettingsSchema *schema;
-+		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++		g_autoptr(GSettingsSchemaSource) schema_source;
++		g_autoptr(GSettingsSchema) schema;
++		schema_source = g_settings_schema_source_new_from_directory("@EDS_GSETTINGS_PATH@",
 +									    g_settings_schema_source_get_default(),
 +									    TRUE,
 +									    NULL);
@@ -40,22 +38,20 @@ index 2c0557c3c..5955aa55e 100644
 +							 SELF_UID_PATH_ID,
 +							 FALSE);
 +		settings = g_settings_new_full(schema, NULL, NULL);
-+		g_settings_schema_source_unref(schema_source);
-+		g_settings_schema_unref(schema);
 +	}
  	g_settings_set_string (
  		settings, SELF_UID_KEY,
  		e_contact_get_const (contact, E_CONTACT_UID));
-@@ -2093,8 +2119,20 @@ e_book_client_is_self (EContact *contact)
+@@ -2087,8 +2109,18 @@ e_book_client_is_self (EContact *contact)
  	 * unfortunately the API doesn't allow that.
  	 */
  	g_mutex_lock (&mutex);
 -	if (!settings)
 -		settings = g_settings_new (SELF_UID_PATH_ID);
 +	if (!settings) {
-+		GSettingsSchemaSource *schema_source;
-+		GSettingsSchema *schema;
-+		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++		g_autoptr(GSettingsSchemaSource) schema_source;
++		g_autoptr(GSettingsSchema) schema;
++		schema_source = g_settings_schema_source_new_from_directory("@EDS_GSETTINGS_PATH@",
 +									    g_settings_schema_source_get_default(),
 +									    TRUE,
 +									    NULL);
@@ -63,25 +59,23 @@ index 2c0557c3c..5955aa55e 100644
 +							 SELF_UID_PATH_ID,
 +							 FALSE);
 +		settings = g_settings_new_full(schema, NULL, NULL);
-+		g_settings_schema_source_unref(schema_source);
-+		g_settings_schema_unref(schema);
 +	}
  	uid = g_settings_get_string (settings, SELF_UID_KEY);
  	g_mutex_unlock (&mutex);
  
 diff --git a/src/addressbook/libebook/e-book.c b/src/addressbook/libebook/e-book.c
-index 3396b57c0..ac6420b2e 100644
+index 8dfff6d..cd88392 100644
 --- a/src/addressbook/libebook/e-book.c
 +++ b/src/addressbook/libebook/e-book.c
-@@ -2594,7 +2594,20 @@ e_book_get_self (ESourceRegistry *registry,
+@@ -2587,7 +2587,18 @@ e_book_get_self (ESourceRegistry *registry,
  		return FALSE;
  	}
  
 -	settings = g_settings_new (SELF_UID_PATH_ID);
 +	{
-+		GSettingsSchemaSource *schema_source;
-+		GSettingsSchema *schema;
-+		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++		g_autoptr(GSettingsSchemaSource) schema_source;
++		g_autoptr(GSettingsSchema) schema;
++		schema_source = g_settings_schema_source_new_from_directory("@EDS_GSETTINGS_PATH@",
 +									    g_settings_schema_source_get_default(),
 +									    TRUE,
 +									    NULL);
@@ -89,21 +83,19 @@ index 3396b57c0..ac6420b2e 100644
 +							 SELF_UID_PATH_ID,
 +							 FALSE);
 +		settings = g_settings_new_full(schema, NULL, NULL);
-+		g_settings_schema_source_unref(schema_source);
-+		g_settings_schema_unref(schema);
 +	}
  	uid = g_settings_get_string (settings, SELF_UID_KEY);
  	g_object_unref (settings);
  
-@@ -2649,7 +2662,20 @@ e_book_set_self (EBook *book,
+@@ -2642,7 +2653,18 @@ e_book_set_self (EBook *book,
  	g_return_val_if_fail (E_IS_BOOK (book), FALSE);
  	g_return_val_if_fail (E_IS_CONTACT (contact), FALSE);
  
 -	settings = g_settings_new (SELF_UID_PATH_ID);
 +	{
-+		GSettingsSchemaSource *schema_source;
-+		GSettingsSchema *schema;
-+		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++		g_autoptr(GSettingsSchemaSource) schema_source;
++		g_autoptr(GSettingsSchema) schema;
++		schema_source = g_settings_schema_source_new_from_directory("@EDS_GSETTINGS_PATH@",
 +									    g_settings_schema_source_get_default(),
 +									    TRUE,
 +									    NULL);
@@ -111,21 +103,19 @@ index 3396b57c0..ac6420b2e 100644
 +							 SELF_UID_PATH_ID,
 +							 FALSE);
 +		settings = g_settings_new_full(schema, NULL, NULL);
-+		g_settings_schema_source_unref(schema_source);
-+		g_settings_schema_unref(schema);
 +	}
  	g_settings_set_string (
  		settings, SELF_UID_KEY,
  		e_contact_get_const (contact, E_CONTACT_UID));
-@@ -2677,7 +2703,20 @@ e_book_is_self (EContact *contact)
+@@ -2670,7 +2692,18 @@ e_book_is_self (EContact *contact)
  
  	g_return_val_if_fail (E_IS_CONTACT (contact), FALSE);
  
 -	settings = g_settings_new (SELF_UID_PATH_ID);
 +	{
-+		GSettingsSchemaSource *schema_source;
-+		GSettingsSchema *schema;
-+		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++		g_autoptr(GSettingsSchemaSource) schema_source;
++		g_autoptr(GSettingsSchema) schema;
++		schema_source = g_settings_schema_source_new_from_directory("@EDS_GSETTINGS_PATH@",
 +									    g_settings_schema_source_get_default(),
 +									    TRUE,
 +									    NULL);
@@ -133,25 +123,23 @@ index 3396b57c0..ac6420b2e 100644
 +							 SELF_UID_PATH_ID,
 +							 FALSE);
 +		settings = g_settings_new_full(schema, NULL, NULL);
-+		g_settings_schema_source_unref(schema_source);
-+		g_settings_schema_unref(schema);
 +	}
  	uid = g_settings_get_string (settings, SELF_UID_KEY);
  	g_object_unref (settings);
  
 diff --git a/src/calendar/backends/contacts/e-cal-backend-contacts.c b/src/calendar/backends/contacts/e-cal-backend-contacts.c
-index de1716941..e83b104f1 100644
+index e696861..52af238 100644
 --- a/src/calendar/backends/contacts/e-cal-backend-contacts.c
 +++ b/src/calendar/backends/contacts/e-cal-backend-contacts.c
-@@ -1397,7 +1397,20 @@ e_cal_backend_contacts_init (ECalBackendContacts *cbc)
+@@ -1387,7 +1387,18 @@ e_cal_backend_contacts_init (ECalBackendContacts *cbc)
  		(GDestroyNotify) g_free,
  		(GDestroyNotify) contact_record_free);
  
 -	cbc->priv->settings = g_settings_new ("org.gnome.evolution-data-server.calendar");
 +	{
-+		GSettingsSchemaSource *schema_source;
-+		GSettingsSchema *schema;
-+		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++		g_autoptr(GSettingsSchemaSource) schema_source;
++		g_autoptr(GSettingsSchema) schema;
++		schema_source = g_settings_schema_source_new_from_directory("@EDS_GSETTINGS_PATH@",
 +									    g_settings_schema_source_get_default(),
 +									    TRUE,
 +									    NULL);
@@ -159,25 +147,23 @@ index de1716941..e83b104f1 100644
 +							 "org.gnome.evolution-data-server.calendar",
 +							 FALSE);
 +		cbc->priv->settings = g_settings_new_full(schema, NULL, NULL);
-+		g_settings_schema_source_unref(schema_source);
-+		g_settings_schema_unref(schema);
 +	}
  	cbc->priv->notifyid = 0;
  	cbc->priv->update_alarms_id = 0;
  	cbc->priv->alarm_enabled = FALSE;
 diff --git a/src/calendar/libecal/e-reminder-watcher.c b/src/calendar/libecal/e-reminder-watcher.c
-index b08a7f301..a49fe39c5 100644
+index a24ede2..5d2a032 100644
 --- a/src/calendar/libecal/e-reminder-watcher.c
 +++ b/src/calendar/libecal/e-reminder-watcher.c
-@@ -2202,7 +2202,21 @@ e_reminder_watcher_init (EReminderWatcher *watcher)
+@@ -2477,7 +2477,19 @@ e_reminder_watcher_init (EReminderWatcher *watcher)
  
- 	watcher->priv = G_TYPE_INSTANCE_GET_PRIVATE (watcher, E_TYPE_REMINDER_WATCHER, EReminderWatcherPrivate);
+ 	watcher->priv = e_reminder_watcher_get_instance_private (watcher);
  	watcher->priv->cancellable = g_cancellable_new ();
 -	watcher->priv->settings = g_settings_new ("org.gnome.evolution-data-server.calendar");
 +	{
-+		GSettingsSchemaSource *schema_source;
-+		GSettingsSchema *schema;
-+		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++		g_autoptr(GSettingsSchemaSource) schema_source;
++		g_autoptr(GSettingsSchema) schema;
++		schema_source = g_settings_schema_source_new_from_directory("@EDS_GSETTINGS_PATH@",
 +									    g_settings_schema_source_get_default(),
 +									    TRUE,
 +									    NULL);
@@ -186,25 +172,23 @@ index b08a7f301..a49fe39c5 100644
 +							 FALSE);
 +		watcher->priv->settings = g_settings_new_full(schema, NULL,
 +							      NULL);
-+		g_settings_schema_source_unref(schema_source);
-+		g_settings_schema_unref(schema);
 +	}
  	watcher->priv->scheduled = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, e_reminder_watcher_free_rd_slist);
- 	watcher->priv->default_zone = icaltimezone_copy (zone);
+ 	watcher->priv->default_zone = e_cal_util_copy_timezone (zone);
  	watcher->priv->timers_enabled = TRUE;
 diff --git a/src/camel/camel-cipher-context.c b/src/camel/camel-cipher-context.c
-index dcdc3eed0..fd2e428c2 100644
+index 8013ba7..ba74769 100644
 --- a/src/camel/camel-cipher-context.c
 +++ b/src/camel/camel-cipher-context.c
-@@ -1635,7 +1635,20 @@ camel_cipher_can_load_photos (void)
+@@ -1625,7 +1625,18 @@ camel_cipher_can_load_photos (void)
  	GSettings *settings;
  	gboolean load_photos;
  
 -	settings = g_settings_new ("org.gnome.evolution-data-server");
 +	{
-+		GSettingsSchemaSource *schema_source;
-+		GSettingsSchema *schema;
-+		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++		g_autoptr(GSettingsSchemaSource) schema_source;
++		g_autoptr(GSettingsSchema) schema;
++		schema_source = g_settings_schema_source_new_from_directory("@EDS_GSETTINGS_PATH@",
 +									    g_settings_schema_source_get_default(),
 +									    TRUE,
 +									    NULL);
@@ -212,25 +196,23 @@ index dcdc3eed0..fd2e428c2 100644
 +							 "org.gnome.evolution-data-server",
 +							 FALSE);
 +		settings = g_settings_new_full(schema, NULL, NULL);
-+		g_settings_schema_source_unref(schema_source);
-+		g_settings_schema_unref(schema);
 +	}
  	load_photos = g_settings_get_boolean (settings, "camel-cipher-load-photos");
  	g_clear_object (&settings);
  
 diff --git a/src/camel/camel-gpg-context.c b/src/camel/camel-gpg-context.c
-index 1b3362886..f0811b292 100644
+index 685d3ab..521d91f 100644
 --- a/src/camel/camel-gpg-context.c
 +++ b/src/camel/camel-gpg-context.c
-@@ -573,7 +573,20 @@ gpg_ctx_get_executable_name (void)
+@@ -571,7 +571,18 @@ gpg_ctx_get_executable_name (void)
  		GSettings *settings;
  		gchar *path;
  
 -		settings = g_settings_new ("org.gnome.evolution-data-server");
 +		{
-+			GSettingsSchemaSource *schema_source;
-+			GSettingsSchema *schema;
-+			schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++			g_autoptr(GSettingsSchemaSource) schema_source;
++			g_autoptr(GSettingsSchema) schema;
++			schema_source = g_settings_schema_source_new_from_directory("@EDS_GSETTINGS_PATH@",
 +										    g_settings_schema_source_get_default(),
 +										    TRUE,
 +										    NULL);
@@ -238,25 +220,72 @@ index 1b3362886..f0811b292 100644
 +								 "org.gnome.evolution-data-server",
 +								 FALSE);
 +			settings = g_settings_new_full(schema, NULL, NULL);
-+			g_settings_schema_source_unref(schema_source);
-+			g_settings_schema_unref(schema);
 +		}
  		path = g_settings_get_string (settings, "camel-gpg-binary");
  		g_clear_object (&settings);
  
+diff --git a/src/camel/camel-utils.c b/src/camel/camel-utils.c
+index e61160c..d17871a 100644
+--- a/src/camel/camel-utils.c
++++ b/src/camel/camel-utils.c
+@@ -362,7 +362,19 @@ void
+ _camel_utils_initialize (void)
+ {
+ 	G_LOCK (mi_user_headers);
+-	mi_user_headers_settings = g_settings_new ("org.gnome.evolution-data-server");
++	{
++		g_autoptr(GSettingsSchemaSource) schema_source;
++		g_autoptr(GSettingsSchema) schema;
++		schema_source = g_settings_schema_source_new_from_directory("@EDS_GSETTINGS_PATH@",
++									    g_settings_schema_source_get_default(),
++									    TRUE,
++									    NULL);
++		schema = g_settings_schema_source_lookup(schema_source,
++							 "org.gnome.evolution-data-server",
++							 FALSE);
++		mi_user_headers_settings = g_settings_new_full(schema, NULL,
++							       NULL);
++	}
+ 	g_signal_connect (mi_user_headers_settings, "changed::camel-message-info-user-headers",
+ 		G_CALLBACK (mi_user_headers_settings_changed_cb), NULL);
+ 	G_UNLOCK (mi_user_headers);
+diff --git a/src/camel/providers/smtp/camel-smtp-transport.c b/src/camel/providers/smtp/camel-smtp-transport.c
+index f535ad6..30130b9 100644
+--- a/src/camel/providers/smtp/camel-smtp-transport.c
++++ b/src/camel/providers/smtp/camel-smtp-transport.c
+@@ -1458,7 +1458,18 @@ smtp_helo (CamelSmtpTransport *transport,
+ 		transport->authtypes = NULL;
+ 	}
+ 
+-	settings = g_settings_new ("org.gnome.evolution-data-server");
++	{
++		g_autoptr(GSettingsSchemaSource) schema_source;
++		g_autoptr(GSettingsSchema) schema;
++		schema_source = g_settings_schema_source_new_from_directory("@EDS_GSETTINGS_PATH@",
++									    g_settings_schema_source_get_default(),
++									    TRUE,
++									    NULL);
++		schema = g_settings_schema_source_lookup(schema_source,
++							 "org.gnome.evolution-data-server",
++							 FALSE);
++		settings = g_settings_new_full(schema, NULL, NULL);
++	}
+ 	name = g_settings_get_string (settings, "camel-smtp-helo-argument");
+ 	g_clear_object (&settings);
+ 
 diff --git a/src/libedataserver/e-network-monitor.c b/src/libedataserver/e-network-monitor.c
-index e0d8b87d6..3a4d5a359 100644
+index 188f276..7c4db94 100644
 --- a/src/libedataserver/e-network-monitor.c
 +++ b/src/libedataserver/e-network-monitor.c
-@@ -255,7 +255,20 @@ e_network_monitor_constructed (GObject *object)
+@@ -256,7 +256,18 @@ e_network_monitor_constructed (GObject *object)
  	/* Chain up to parent's method. */
  	G_OBJECT_CLASS (e_network_monitor_parent_class)->constructed (object);
  
 -	settings = g_settings_new ("org.gnome.evolution-data-server");
 +	{
-+		GSettingsSchemaSource *schema_source;
-+		GSettingsSchema *schema;
-+		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++		g_autoptr(GSettingsSchemaSource) schema_source;
++		g_autoptr(GSettingsSchema) schema;
++		schema_source = g_settings_schema_source_new_from_directory("@EDS_GSETTINGS_PATH@",
 +									    g_settings_schema_source_get_default(),
 +									    TRUE,
 +									    NULL);
@@ -264,25 +293,23 @@ index e0d8b87d6..3a4d5a359 100644
 +							 "org.gnome.evolution-data-server",
 +							 FALSE);
 +		settings = g_settings_new_full(schema, NULL, NULL);
-+		g_settings_schema_source_unref(schema_source);
-+		g_settings_schema_unref(schema);
 +	}
  	g_settings_bind (
  		settings, "network-monitor-gio-name",
  		object, "gio-name",
 diff --git a/src/libedataserver/e-oauth2-service-google.c b/src/libedataserver/e-oauth2-service-google.c
-index f0c6f2cbf..0053e3ce6 100644
+index f9d9056..115d344 100644
 --- a/src/libedataserver/e-oauth2-service-google.c
 +++ b/src/libedataserver/e-oauth2-service-google.c
-@@ -69,7 +69,20 @@ eos_google_read_settings (EOAuth2Service *service,
+@@ -70,7 +70,18 @@ eos_google_read_settings (EOAuth2Service *service,
  	if (!value) {
  		GSettings *settings;
  
 -		settings = g_settings_new ("org.gnome.evolution-data-server");
 +		{
-+			GSettingsSchemaSource *schema_source;
-+			GSettingsSchema *schema;
-+			schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++			g_autoptr(GSettingsSchemaSource) schema_source;
++			g_autoptr(GSettingsSchema) schema;
++			schema_source = g_settings_schema_source_new_from_directory("@EDS_GSETTINGS_PATH@",
 +										    g_settings_schema_source_get_default(),
 +										    TRUE,
 +										    NULL);
@@ -290,25 +317,23 @@ index f0c6f2cbf..0053e3ce6 100644
 +								 "org.gnome.evolution-data-server",
 +								 FALSE);
 +			settings = g_settings_new_full(schema, NULL, NULL);
-+			g_settings_schema_source_unref(schema_source);
-+			g_settings_schema_unref(schema);
 +		}
  		value = g_settings_get_string (settings, key_name);
  		g_object_unref (settings);
  
 diff --git a/src/libedataserver/e-oauth2-service-outlook.c b/src/libedataserver/e-oauth2-service-outlook.c
-index 687c10d3b..684583c35 100644
+index 687c10d..ac1deae 100644
 --- a/src/libedataserver/e-oauth2-service-outlook.c
 +++ b/src/libedataserver/e-oauth2-service-outlook.c
-@@ -70,7 +70,20 @@ eos_outlook_read_settings (EOAuth2Service *service,
+@@ -70,7 +70,18 @@ eos_outlook_read_settings (EOAuth2Service *service,
  	if (!value) {
  		GSettings *settings;
  
 -		settings = g_settings_new ("org.gnome.evolution-data-server");
 +		{
-+			GSettingsSchemaSource *schema_source;
-+			GSettingsSchema *schema;
-+			schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++			g_autoptr(GSettingsSchemaSource) schema_source;
++			g_autoptr(GSettingsSchema) schema;
++			schema_source = g_settings_schema_source_new_from_directory("@EDS_GSETTINGS_PATH@",
 +										    g_settings_schema_source_get_default(),
 +										    TRUE,
 +										    NULL);
@@ -316,25 +341,47 @@ index 687c10d3b..684583c35 100644
 +								 "org.gnome.evolution-data-server",
 +								 FALSE);
 +			settings = g_settings_new_full(schema, NULL, NULL);
-+			g_settings_schema_source_unref(schema_source);
-+			g_settings_schema_unref(schema);
++		}
+ 		value = g_settings_get_string (settings, key_name);
+ 		g_object_unref (settings);
+ 
+diff --git a/src/libedataserver/e-oauth2-service-yahoo.c b/src/libedataserver/e-oauth2-service-yahoo.c
+index 329a38c..f541393 100644
+--- a/src/libedataserver/e-oauth2-service-yahoo.c
++++ b/src/libedataserver/e-oauth2-service-yahoo.c
+@@ -66,7 +66,18 @@ eos_yahoo_read_settings (EOAuth2Service *service,
+ 	if (!value) {
+ 		GSettings *settings;
+ 
+-		settings = g_settings_new ("org.gnome.evolution-data-server");
++		{
++			g_autoptr(GSettingsSchemaSource) schema_source;
++			g_autoptr(GSettingsSchema) schema;
++			schema_source = g_settings_schema_source_new_from_directory("@EDS_GSETTINGS_PATH@",
++										    g_settings_schema_source_get_default(),
++										    TRUE,
++										    NULL);
++			schema = g_settings_schema_source_lookup(schema_source,
++								 "org.gnome.evolution-data-server",
++								 FALSE);
++			settings = g_settings_new_full(schema, NULL, NULL);
 +		}
  		value = g_settings_get_string (settings, key_name);
  		g_object_unref (settings);
  
 diff --git a/src/libedataserver/e-oauth2-service.c b/src/libedataserver/e-oauth2-service.c
-index 682673c16..436f52d5f 100644
+index 979095b..ecac6bb 100644
 --- a/src/libedataserver/e-oauth2-service.c
 +++ b/src/libedataserver/e-oauth2-service.c
-@@ -95,7 +95,20 @@ eos_default_guess_can_process (EOAuth2Service *service,
+@@ -89,7 +89,18 @@ eos_default_guess_can_process (EOAuth2Service *service,
  	name_len = strlen (name);
  	hostname_len = strlen (hostname);
  
 -	settings = g_settings_new ("org.gnome.evolution-data-server");
 +	{
-+		GSettingsSchemaSource *schema_source;
-+		GSettingsSchema *schema;
-+		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++		g_autoptr(GSettingsSchemaSource) schema_source;
++		g_autoptr(GSettingsSchema) schema;
++		schema_source = g_settings_schema_source_new_from_directory("@EDS_GSETTINGS_PATH@",
 +									    g_settings_schema_source_get_default(),
 +									    TRUE,
 +									    NULL);
@@ -342,26 +389,24 @@ index 682673c16..436f52d5f 100644
 +							 "org.gnome.evolution-data-server",
 +							 FALSE);
 +		settings = g_settings_new_full(schema, NULL, NULL);
-+		g_settings_schema_source_unref(schema_source);
-+		g_settings_schema_unref(schema);
 +	}
  	values = g_settings_get_strv (settings, "oauth2-services-hint");
  	g_object_unref (settings);
  
 diff --git a/src/libedataserver/e-proxy.c b/src/libedataserver/e-proxy.c
-index 883379a60..989353494 100644
+index bcd07f9..17db26c 100644
 --- a/src/libedataserver/e-proxy.c
 +++ b/src/libedataserver/e-proxy.c
-@@ -969,8 +969,37 @@ e_proxy_init (EProxy *proxy)
+@@ -957,8 +957,33 @@ e_proxy_init (EProxy *proxy)
  
  	proxy->priv->type = PROXY_TYPE_SYSTEM;
  
 -	proxy->priv->evolution_proxy_settings = g_settings_new ("org.gnome.evolution.shell.network-config");
 -	proxy->priv->proxy_settings = g_settings_new ("org.gnome.system.proxy");
 +	{
-+		GSettingsSchemaSource *schema_source;
-+		GSettingsSchema *schema;
-+		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++		g_autoptr(GSettingsSchemaSource) schema_source;
++		g_autoptr(GSettingsSchema) schema;
++		schema_source = g_settings_schema_source_new_from_directory("@EDS_GSETTINGS_PATH@",
 +									    g_settings_schema_source_get_default(),
 +									    TRUE,
 +									    NULL);
@@ -371,12 +416,10 @@ index 883379a60..989353494 100644
 +		proxy->priv->evolution_proxy_settings = g_settings_new_full(schema,
 +									    NULL,
 +									    NULL);
-+		g_settings_schema_source_unref(schema_source);
-+		g_settings_schema_unref(schema);
 +	}
 +	{
-+		GSettingsSchemaSource *schema_source;
-+		GSettingsSchema *schema;
++		g_autoptr(GSettingsSchemaSource) schema_source;
++		g_autoptr(GSettingsSchema) schema;
 +		schema_source = g_settings_schema_source_new_from_directory("@GDS_GSETTINGS_PATH@",
 +									    g_settings_schema_source_get_default(),
 +									    TRUE,
@@ -386,25 +429,23 @@ index 883379a60..989353494 100644
 +							 FALSE);
 +		proxy->priv->proxy_settings = g_settings_new_full(schema,
 +								  NULL, NULL);
-+		g_settings_schema_source_unref(schema_source);
-+		g_settings_schema_unref(schema);
 +	}
  	proxy->priv->proxy_http_settings = g_settings_get_child (proxy->priv->proxy_settings, "http");
  	proxy->priv->proxy_https_settings = g_settings_get_child (proxy->priv->proxy_settings, "https");
  	proxy->priv->proxy_socks_settings = g_settings_get_child (proxy->priv->proxy_settings, "socks");
 diff --git a/src/libedataserver/e-source-registry.c b/src/libedataserver/e-source-registry.c
-index a5a30a3e1..5fbdf8190 100644
+index 837e940..4bbd00d 100644
 --- a/src/libedataserver/e-source-registry.c
 +++ b/src/libedataserver/e-source-registry.c
-@@ -1749,7 +1749,21 @@ e_source_registry_init (ESourceRegistry *registry)
+@@ -1769,7 +1769,19 @@ e_source_registry_init (ESourceRegistry *registry)
  
  	g_mutex_init (&registry->priv->sources_lock);
  
 -	registry->priv->settings = g_settings_new (GSETTINGS_SCHEMA);
 +	{
-+		GSettingsSchemaSource *schema_source;
-+		GSettingsSchema *schema;
-+		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++		g_autoptr(GSettingsSchemaSource) schema_source;
++		g_autoptr(GSettingsSchema) schema;
++		schema_source = g_settings_schema_source_new_from_directory("@EDS_GSETTINGS_PATH@",
 +									    g_settings_schema_source_get_default(),
 +									    TRUE,
 +									    NULL);
@@ -413,25 +454,23 @@ index a5a30a3e1..5fbdf8190 100644
 +							 FALSE);
 +		registry->priv->settings = g_settings_new_full(schema, NULL,
 +							       NULL);
-+		g_settings_schema_source_unref(schema_source);
-+		g_settings_schema_unref(schema);
 +	}
  
  	g_signal_connect (
  		registry->priv->settings, "changed",
 diff --git a/src/libedataserverui/e-reminders-widget.c b/src/libedataserverui/e-reminders-widget.c
-index f89cd4a5c..06cca9b5f 100644
+index d18474d..418ccc2 100644
 --- a/src/libedataserverui/e-reminders-widget.c
 +++ b/src/libedataserverui/e-reminders-widget.c
-@@ -1650,7 +1650,21 @@ static void
+@@ -1874,7 +1874,19 @@ static void
  e_reminders_widget_init (ERemindersWidget *reminders)
  {
  	reminders->priv = e_reminders_widget_get_instance_private (reminders);
 -	reminders->priv->settings = g_settings_new ("org.gnome.evolution-data-server.calendar");
 +	{
-+		GSettingsSchemaSource *schema_source;
-+		GSettingsSchema *schema;
-+		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++		g_autoptr(GSettingsSchemaSource) schema_source;
++		g_autoptr(GSettingsSchema) schema;
++		schema_source = g_settings_schema_source_new_from_directory("@EDS_GSETTINGS_PATH@",
 +									    g_settings_schema_source_get_default(),
 +									    TRUE,
 +									    NULL);
@@ -440,25 +479,23 @@ index f89cd4a5c..06cca9b5f 100644
 +							 FALSE);
 +		reminders->priv->settings = g_settings_new_full(schema, NULL,
 +								NULL);
-+		g_settings_schema_source_unref(schema_source);
-+		g_settings_schema_unref(schema);
 +	}
  	reminders->priv->cancellable = g_cancellable_new ();
  	reminders->priv->is_empty = TRUE;
  	reminders->priv->is_mapped = FALSE;
 diff --git a/src/services/evolution-source-registry/evolution-source-registry-autoconfig.c b/src/services/evolution-source-registry/evolution-source-registry-autoconfig.c
-index 6f03053d6..dffc186c7 100644
+index 6f03053..127c92e 100644
 --- a/src/services/evolution-source-registry/evolution-source-registry-autoconfig.c
 +++ b/src/services/evolution-source-registry/evolution-source-registry-autoconfig.c
-@@ -706,7 +706,20 @@ evolution_source_registry_merge_autoconfig_sources (ESourceRegistryServer *serve
+@@ -706,7 +706,18 @@ evolution_source_registry_merge_autoconfig_sources (ESourceRegistryServer *serve
  	gchar *autoconfig_directory;
  	gint ii;
  
 -	settings = g_settings_new ("org.gnome.evolution-data-server");
 +	{
-+		GSettingsSchemaSource *schema_source;
-+		GSettingsSchema *schema;
-+		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++		g_autoptr(GSettingsSchemaSource) schema_source;
++		g_autoptr(GSettingsSchema) schema;
++		schema_source = g_settings_schema_source_new_from_directory("@EDS_GSETTINGS_PATH@",
 +									    g_settings_schema_source_get_default(),
 +									    TRUE,
 +									    NULL);
@@ -466,25 +503,23 @@ index 6f03053d6..dffc186c7 100644
 +							 "org.gnome.evolution-data-server",
 +							 FALSE);
 +		settings = g_settings_new_full(schema, NULL, NULL);
-+		g_settings_schema_source_unref(schema_source);
-+		g_settings_schema_unref(schema);
 +	}
  
  	autoconfig_sources = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, e_autoconfig_free_merge_source_data);
  
 diff --git a/src/services/evolution-source-registry/evolution-source-registry-migrate-proxies.c b/src/services/evolution-source-registry/evolution-source-registry-migrate-proxies.c
-index d531cb9e2..c5b1c761c 100644
+index d531cb9..3d8807c 100644
 --- a/src/services/evolution-source-registry/evolution-source-registry-migrate-proxies.c
 +++ b/src/services/evolution-source-registry/evolution-source-registry-migrate-proxies.c
-@@ -61,7 +61,20 @@ evolution_source_registry_migrate_proxies (ESourceRegistryServer *server)
+@@ -61,7 +61,18 @@ evolution_source_registry_migrate_proxies (ESourceRegistryServer *server)
  	extension_name = E_SOURCE_EXTENSION_PROXY;
  	extension = e_source_get_extension (source, extension_name);
  
 -	settings = g_settings_new (NETWORK_CONFIG_SCHEMA_ID);
 +	{
-+		GSettingsSchemaSource *schema_source;
-+		GSettingsSchema *schema;
-+		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++		g_autoptr(GSettingsSchemaSource) schema_source;
++		g_autoptr(GSettingsSchema) schema;
++		schema_source = g_settings_schema_source_new_from_directory("@EDS_GSETTINGS_PATH@",
 +									    g_settings_schema_source_get_default(),
 +									    TRUE,
 +									    NULL);
@@ -492,25 +527,23 @@ index d531cb9e2..c5b1c761c 100644
 +								 NETWORK_CONFIG_SCHEMA_ID,
 +								 FALSE);
 +			settings = g_settings_new_full(schema, NULL, NULL);
-+			g_settings_schema_source_unref(schema_source);
-+			g_settings_schema_unref(schema);
 +	}
  
  	switch (g_settings_get_int (settings, "proxy-type")) {
  		case 1:
 diff --git a/src/services/evolution-source-registry/evolution-source-registry.c b/src/services/evolution-source-registry/evolution-source-registry.c
-index 1c0a11382..3e144845e 100644
+index 1c0a113..d26b059 100644
 --- a/src/services/evolution-source-registry/evolution-source-registry.c
 +++ b/src/services/evolution-source-registry/evolution-source-registry.c
-@@ -181,7 +181,20 @@ main (gint argc,
+@@ -181,7 +181,18 @@ main (gint argc,
  
  reload:
  
 -	settings = g_settings_new ("org.gnome.evolution-data-server");
 +	{
-+		GSettingsSchemaSource *schema_source;
-+		GSettingsSchema *schema;
-+		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++		g_autoptr(GSettingsSchemaSource) schema_source;
++		g_autoptr(GSettingsSchema) schema;
++		schema_source = g_settings_schema_source_new_from_directory("@EDS_GSETTINGS_PATH@",
 +									    g_settings_schema_source_get_default(),
 +									    TRUE,
 +									    NULL);
@@ -518,8 +551,6 @@ index 1c0a11382..3e144845e 100644
 +							 "org.gnome.evolution-data-server",
 +							 FALSE);
 +		settings = g_settings_new_full(schema, NULL, NULL);
-+		g_settings_schema_source_unref(schema_source);
-+		g_settings_schema_unref(schema);
 +	}
  
  	if (!opt_disable_migration && !g_settings_get_boolean (settings, "migrated")) {

--- a/pkgs/development/tools/misc/coccinelle/default.nix
+++ b/pkgs/development/tools/misc/coccinelle/default.nix
@@ -25,6 +25,41 @@ stdenv.mkDerivation rec {
       url = "https://github.com/coccinelle/coccinelle/commit/540888ff426e0b1f7907b63ce26e712d1fc172cc.patch";
       sha256 = "sha256-W8RNIWDAC3lQ5bG+gD50r7x919JIcZRpt3QSOSMWpW4=";
     })
+
+    # Fix attaching code before declarations.
+    # https://github.com/coccinelle/coccinelle/issues/282
+    (fetchpatch {
+      url = "https://github.com/coccinelle/coccinelle/commit/cd33db143416d820f547bf5869482cfcfc0ea9d0.patch";
+      sha256 = "q7wbxbB9Ob0fSJwCjRtDPO3Xg4RO9yrQZG9G0/LGunI=";
+    })
+
+    # Fix attaching declaration metavariables.
+    # https://github.com/coccinelle/coccinelle/issues/281
+    (fetchpatch {
+      url = "https://github.com/coccinelle/coccinelle/commit/df71c5c0fe2a73c7358f73f45a550b57a7e30d85.patch";
+      sha256 = "qrYfligJnXP7J5G/hfzyaKg9aFn74VExtc/Rs/DI2gc=";
+    })
+
+    # Support GLib’s autocleanup macros.
+    # https://github.com/coccinelle/coccinelle/issues/275
+    (fetchpatch {
+      url = "https://github.com/coccinelle/coccinelle/commit/6d5602aca8775c3c5c503939c3dcf0637649d09b.patch";
+      sha256 = "NACf8joOOvN32H/sIfI+oqiT3289zXXQVVfXbRfbIe8=";
+    })
+
+    # Exit with non-zero status on failure.
+    (fetchpatch {
+      url = "https://github.com/coccinelle/coccinelle/commit/6c0a855af14d41864e1e522b93dc39646a3b83c7.patch";
+      sha256 = "6yfK8arB0GDW7o4cXsv0Y9TMvqgGf3/P1ebXrFFUC80=";
+    })
+    (fetchpatch {
+      url = "https://github.com/coccinelle/coccinelle/commit/5448bb2bd03491ffec356bf7bd6ddcdbf4d36bc9.patch";
+      sha256 = "fyyxw2BNZUpyLBieIhOKeWbLFGP1tjULH70w/hU+jKw=";
+    })
+    (fetchpatch {
+      url = "https://github.com/coccinelle/coccinelle/commit/b8b1937657765e991195a10fcd7b8f7a300fc60b.patch";
+      sha256 = "ergWJF6BKrhmJhx1aiVYDHztgjaQvaJ5iZRAmC9i22s=";
+    })
   ];
 
   nativeBuildInputs = with ocamlPackages; [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -124,6 +124,8 @@ with pkgs;
 
   genericUpdater = callPackage ../common-updater/generic-updater.nix { };
 
+  update-script-combinators = callPackage ../common-updater/combinators.nix { };
+
   gitUpdater = callPackage ../common-updater/git-updater.nix { };
 
   httpTwoLevelsUpdater = callPackage ../common-updater/http-two-levels-updater.nix { };


### PR DESCRIPTION
###### Description of changes

This should avoid it getting out of sync again.

Introduce some helper functions to make the generation cleaner.

cc @symphorien

Cherry-picked from https://github.com/NixOS/nixpkgs/pull/182618 and made it more robust and slightly cleaner by factoring it out some.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
