### PR TITLE
cloudflared: 2022.8.2 -> 2022.11.1, add tests and additional platforms

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11013,6 +11013,12 @@
       fingerprint = "D03B 218C AE77 1F77 D7F9  20D9 823A 6154 4264 08D3";
     }];
   };
+  piperswe = {
+    email = "contact@piperswe.me";
+    github = "piperswe";
+    githubId = 1830959;
+    name = "Piper McCorkle";
+  };
   pjbarnoy = {
     email = "pjbarnoy@gmail.com";
     github = "pjbarnoy";

--- a/pkgs/applications/networking/cloudflared/default.nix
+++ b/pkgs/applications/networking/cloudflared/default.nix
@@ -1,14 +1,14 @@
-{ lib, buildGoModule, fetchFromGitHub, stdenv }:
+{ lib, buildGoModule, fetchFromGitHub, stdenv, callPackage }:
 
 buildGoModule rec {
   pname = "cloudflared";
-  version = "2022.8.2";
+  version = "2022.11.1";
 
   src = fetchFromGitHub {
-    owner  = "cloudflare";
-    repo   = "cloudflared";
-    rev    = version;
-    hash   = "sha256-Kyt5d3KmLefTVVUmUUU23UV0lghzhLFCKLlmwTjN68I=";
+    owner = "cloudflare";
+    repo = "cloudflared";
+    rev = version;
+    hash = "sha256-aG63CEJfEL9r0SviZu9VzArtt3e4VuAbOMaYk9atSGo=";
   };
 
   vendorSha256 = null;
@@ -17,22 +17,56 @@ buildGoModule rec {
 
   preCheck = ''
     # Workaround for: sshgen_test.go:74: mkdir /homeless-shelter/.cloudflared: no such file or directory
-    export HOME="$(mktemp -d)";
+    export HOME="$(mktemp -d)"
 
     # Workaround for: protocol_test.go:11:
     #   lookup protocol-v2.argotunnel.com on [::1]:53: read udp [::1]:51876->[::1]:53: read: connection refused
-
     substituteInPlace "edgediscovery/protocol_test.go" \
       --replace "TestProtocolPercentage" "SkipProtocolPercentage"
+
+    # Workaround for: origin_icmp_proxy_test.go:46:
+    #   cannot create ICMPv4 proxy: socket: permission denied nor ICMPv6 proxy: socket: permission denied
+    substituteInPlace "ingress/origin_icmp_proxy_test.go" \
+      --replace "TestICMPRouterEcho" "SkipICMPRouterEcho"
+
+    # Workaround for: origin_icmp_proxy_test.go:110:
+    #   cannot create ICMPv4 proxy: socket: permission denied nor ICMPv6 proxy: socket: permission denied
+    substituteInPlace "ingress/origin_icmp_proxy_test.go" \
+      --replace "TestConcurrentRequestsToSameDst" "SkipConcurrentRequestsToSameDst"
+
+    # Workaround for: origin_icmp_proxy_test.go:242:
+    #   cannot create ICMPv4 proxy: socket: permission denied nor ICMPv6 proxy: socket: permission denied
+    substituteInPlace "ingress/origin_icmp_proxy_test.go" \
+      --replace "TestICMPRouterRejectNotEcho" "SkipICMPRouterRejectNotEcho"
+
+    # Workaround for: origin_icmp_proxy_test.go:108:
+    #   Received unexpected error: cannot create ICMPv4 proxy: Group ID 100 is not between ping group 65534 to 65534 nor ICMPv6 proxy: socket: permission denied
+    substituteInPlace "ingress/origin_icmp_proxy_test.go" \
+      --replace "TestTraceICMPRouterEcho" "SkipTraceICMPRouterEcho"
+
+    # Workaround for: icmp_posix_test.go:28: socket: permission denied
+    substituteInPlace "ingress/icmp_posix_test.go" \
+      --replace "TestFunnelIdleTimeout" "SkipFunnelIdleTimeout"
+
+    # Workaround for: icmp_posix_test.go:88: Received unexpected error: Group ID 100 is not between ping group 65534 to 65534
+    substituteInPlace "ingress/icmp_posix_test.go" \
+      --replace "TestReuseFunnel" "SkipReuseFunnel"
+
+    # Workaround for: supervisor_test.go:49:
+    #   Expected nil, but got: Could not lookup srv records on _us-v2-origintunneld._tcp.argotunnel.com: lookup _us-v2-origintunneld._tcp.argotunnel.com on [::1]:53: read udp [::1]:49342->[::1]:53: read: connection refused
+    substituteInPlace "supervisor/supervisor_test.go" \
+      --replace "Test_Initialize_Same_Protocol" "Skip_Initialize_Same_Protocol"
   '';
 
   doCheck = !stdenv.isDarwin;
 
+  passthru.tests.simple = callPackage ./tests.nix { inherit version; };
+
   meta = with lib; {
-    description = "CloudFlare Tunnel daemon (and DNS-over-HTTPS client)";
-    homepage    = "https://www.cloudflare.com/products/tunnel";
-    license     = licenses.asl20;
-    platforms   = platforms.unix;
-    maintainers = with maintainers; [ bbigras enorris thoughtpolice ];
+    description = "Cloudflare Tunnel daemon, Cloudflare Access toolkit, and DNS-over-HTTPS client";
+    homepage = "https://www.cloudflare.com/products/tunnel";
+    license = licenses.asl20;
+    platforms = platforms.unix ++ platforms.windows;
+    maintainers = with maintainers; [ bbigras enorris thoughtpolice piperswe ];
   };
 }

--- a/pkgs/applications/networking/cloudflared/tests.nix
+++ b/pkgs/applications/networking/cloudflared/tests.nix
@@ -1,0 +1,44 @@
+{ version, lib, stdenv, pkgsCross, testers, cloudflared, runCommand, wine, wine64 }:
+
+let
+  inherit (stdenv) buildPlatform;
+in
+{
+  version = testers.testVersion {
+    package = cloudflared;
+    command = "cloudflared help";
+  };
+  refuses-to-autoupdate = runCommand "cloudflared-${version}-refuses-to-autoupdate"
+    {
+      nativeBuildInputs = [ cloudflared ];
+    } ''
+    set -e
+    cloudflared update 2>&1 | tee output.txt
+    if ! grep "cloudflared was installed by nixpkgs" output.txt
+    then
+      echo "cloudflared's output didn't contain the package manager name"
+      exit 1
+    fi
+    mkdir $out
+  '';
+} // lib.optionalAttrs (buildPlatform.isLinux && (buildPlatform.isi686 || buildPlatform.isx86_64)) {
+  runs-through-wine = runCommand "cloudflared-${version}-runs-through-wine"
+    {
+      nativeBuildInputs = [ wine ];
+      exe = "${pkgsCross.mingw32.cloudflared}/bin/cloudflared.exe";
+    } ''
+    export HOME="$(mktemp -d)"
+    wine $exe help
+    mkdir $out
+  '';
+} // lib.optionalAttrs (buildPlatform.isLinux && buildPlatform.isx86_64) {
+  runs-through-wine64 = runCommand "cloudflared-${version}-runs-through-wine64"
+    {
+      nativeBuildInputs = [ wine64 ];
+      exe = "${pkgsCross.mingwW64.cloudflared}/bin/cloudflared.exe";
+    } ''
+    export HOME="$(mktemp -d)"
+    wine64 $exe help
+    mkdir $out
+  '';
+}


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updated cloudflared to 2022.11.1, added tests, tweaked and updated metadata a bit to reflect cross-compilability and new features. I added myself as a maintainer - I also maintain the Homebrew package and already have notifications set up for new versions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
  - [x] i686-w64-mingw32
    - `nix build github:piperswe/nixpkgs/cloudflared-2022.8.4#legacyPackages.x86_64-linux.cloudflared.passthru.tests.runs-through-wine`
  - [x] x86_64-w64-mingw32
    - `nix build github:piperswe/nixpkgs/cloudflared-2022.8.4#legacyPackages.x86_64-linux.cloudflared.passthru.tests.runs-through-wine64`
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
