### PR TITLE
datadog-agent: suppress datadog-agent loading errors

### DIFF
--- a/pkgs/tools/networking/dd-agent/datadog-agent.nix
+++ b/pkgs/tools/networking/dd-agent/datadog-agent.nix
@@ -93,7 +93,8 @@ in buildGoModule rec {
   # into standard paths.
   postInstall = ''
     mkdir -p $out/${python.sitePackages} $out/share/datadog-agent
-    cp -R $src/cmd/agent/dist/conf.d $out/share/datadog-agent
+    cp -R --no-preserve=mode $src/cmd/agent/dist/conf.d $out/share/datadog-agent
+    rm -rf $out/share/datadog-agent/conf.d/{apm.yaml.default,process_agent.yaml.default,winproc.d}
     cp -R $src/cmd/agent/dist/{checks,utils,config.py} $out/${python.sitePackages}
 
     cp -R $src/pkg/status/templates $out/share/datadog-agent


### PR DESCRIPTION
Loading Errors for apm, process-agent and winproc.d appear on the datadog agent.

Here is an excerpt from the results of the `agent status` command:

```
=========
Collector
=========

  Running Checks
  ==============

    cpu
    ---
      Instance ID: cpu [OK]
      Configuration Source: file:/nix/store/i1vci7bbfn6m3vp9i5h9p4dnvrwp5i1l-datadog-agent-7.35.1/share/datadog-agent/conf.d/cpu.d/conf.yaml.default
      Total Runs: 4,748
      Metric Samples: Last Run: 9, Total: 42,725
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 0, Total: 0
      Average Execution Time : 0s
      Last Execution Date : 2022-09-05 03:33:29 UTC (1662348809000)
      Last Successful Execution Date : 2022-09-05 03:33:29 UTC (1662348809000)


    disk
    ----
      Instance ID: disk [OK]
      Configuration Source: file:/etc/datadog-agent/conf.d/disk.d/conf.yaml
      Total Runs: 4,749
      Metric Samples: Last Run: 60, Total: 285,612
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 0, Total: 0
      Average Execution Time : 0s
      Last Execution Date : 2022-09-05 03:33:30 UTC (1662348810000)
      Last Successful Execution Date : 2022-09-05 03:33:30 UTC (1662348810000)


    file_handle
    -----------
      Instance ID: file_handle [OK]
      Configuration Source: file:/nix/store/i1vci7bbfn6m3vp9i5h9p4dnvrwp5i1l-datadog-agent-7.35.1/share/datadog-agent/conf.d/file_handle.d/conf.yaml.default
      Total Runs: 4,749
      Metric Samples: Last Run: 5, Total: 23,745
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 0, Total: 0
      Average Execution Time : 0s
      Last Execution Date : 2022-09-05 03:33:36 UTC (1662348816000)
      Last Successful Execution Date : 2022-09-05 03:33:36 UTC (1662348816000)


    io
    --
      Instance ID: io [OK]
      Configuration Source: file:/nix/store/i1vci7bbfn6m3vp9i5h9p4dnvrwp5i1l-datadog-agent-7.35.1/share/datadog-agent/conf.d/io.d/conf.yaml.default
      Total Runs: 4,748
      Metric Samples: Last Run: 41, Total: 194,641
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 0, Total: 0
      Average Execution Time : 0s
      Last Execution Date : 2022-09-05 03:33:28 UTC (1662348808000)
      Last Successful Execution Date : 2022-09-05 03:33:28 UTC (1662348808000)


    load
    ----
      Instance ID: load [OK]
      Configuration Source: file:/nix/store/i1vci7bbfn6m3vp9i5h9p4dnvrwp5i1l-datadog-agent-7.35.1/share/datadog-agent/conf.d/load.d/conf.yaml.default
      Total Runs: 4,749
      Metric Samples: Last Run: 6, Total: 28,494
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 0, Total: 0
      Average Execution Time : 0s
      Last Execution Date : 2022-09-05 03:33:35 UTC (1662348815000)
      Last Successful Execution Date : 2022-09-05 03:33:35 UTC (1662348815000)


    memory
    ------
      Instance ID: memory [OK]
      Configuration Source: file:/nix/store/i1vci7bbfn6m3vp9i5h9p4dnvrwp5i1l-datadog-agent-7.35.1/share/datadog-agent/conf.d/memory.d/conf.yaml.default
      Total Runs: 4,748
      Metric Samples: Last Run: 20, Total: 94,960
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 0, Total: 0
      Average Execution Time : 0s
      Last Execution Date : 2022-09-05 03:33:27 UTC (1662348807000)
      Last Successful Execution Date : 2022-09-05 03:33:27 UTC (1662348807000)


    network
    -------
      Instance ID: network [OK]
      Configuration Source: file:/etc/datadog-agent/conf.d/network.d/conf.yaml
      Total Runs: 4,749
      Metric Samples: Last Run: 36, Total: 170,964
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 0, Total: 0
      Average Execution Time : 0s
      Last Execution Date : 2022-09-05 03:33:37 UTC (1662348817000)
      Last Successful Execution Date : 2022-09-05 03:33:37 UTC (1662348817000)


    ntp
    ---
      Instance ID: ntp:d884b5186b651429 [OK]
      Configuration Source: file:/nix/store/i1vci7bbfn6m3vp9i5h9p4dnvrwp5i1l-datadog-agent-7.35.1/share/datadog-agent/conf.d/ntp.d/conf.yaml.default
      Total Runs: 80
      Metric Samples: Last Run: 1, Total: 80
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 1, Total: 80
      Average Execution Time : 0s
      Last Execution Date : 2022-09-05 03:31:30 UTC (1662348690000)
      Last Successful Execution Date : 2022-09-05 03:31:30 UTC (1662348690000)


    uptime
    ------
      Instance ID: uptime [OK]
      Configuration Source: file:/nix/store/i1vci7bbfn6m3vp9i5h9p4dnvrwp5i1l-datadog-agent-7.35.1/share/datadog-agent/conf.d/uptime.d/conf.yaml.default
      Total Runs: 4,749
      Metric Samples: Last Run: 1, Total: 4,749
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 0, Total: 0
      Average Execution Time : 0s
      Last Execution Date : 2022-09-05 03:33:34 UTC (1662348814000)
      Last Successful Execution Date : 2022-09-05 03:33:34 UTC (1662348814000)

  Loading Errors
  ==============
    apm
    ---
      Core Check Loader:
        Check apm not found in Catalog

    process_agent
    -------------
      Core Check Loader:
        Check process_agent not found in Catalog

    winproc
    -------
      Core Check Loader:
        Check winproc not found in Catalog
```

The datadog web console displays the following figure:

![Infrastructure-List-Datadog](https://user-images.githubusercontent.com/1421516/188356063-b38b96c0-8f75-4b51-a4d6-a1d3468d5923.png)


###### Description of changes

To suppress these errors, I have removed these default configurations that were copied in the postInstall phase.

- $out/share/datadog-agent/conf.d/apm.yaml.default
- $out/share/datadog-agent/conf.d/process_agent.yaml.default
- $out/share/datadog-agent/conf.d/winproc.d

References:　https://github.com/DataDog/datadog-agent/issues/12172

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
