### PR TITLE
openzwave: 1.6 -> 1.6-unstable-2022-11-17

### DIFF
--- a/pkgs/development/libraries/openzwave/default.nix
+++ b/pkgs/development/libraries/openzwave/default.nix
@@ -4,27 +4,14 @@
 
 stdenv.mkDerivation rec {
   pname = "openzwave";
-  version = "1.6";
+  version = "1.6-unstable-2022-11-17";
 
   src = fetchFromGitHub {
     owner = "OpenZWave";
     repo = "open-zwave";
-    rev = "v${version}";
-    sha256 = "0xgs4mmr0480c269wx9xkk67ikjzxkh8xcssrdx0f5xcl1lyd333";
+    rev = "3fff11d246a0d558d26110e1db6bd634a1b347c0";
+    hash = "sha256-CLK2MeoTmZ8GMKb1OAZFNLyc4C+k+REK2w+WQxZv0/E=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "fix-strncat-build-failure.patch";
-      url = "https://github.com/OpenZWave/open-zwave/commit/601e5fb16232a7984885e67fdddaf5b9c9dd8105.patch";
-      sha256 = "1n1k5arwk1dyc12xz6xl4n8yw28vghzhv27j65z1nca4zqsxgza1";
-    })
-    (fetchpatch {
-      name = "fix-text-uninitialized.patch";
-      url = "https://github.com/OpenZWave/open-zwave/commit/3b029a467e83bc7f0054e4dbba1e77e6eac7bc7f.patch";
-      sha256 = "183mrzjh1zx2b2wzkj4jisiw8br7g7bbs167afls4li0fm01d638";
-    })
-  ];
 
   outputs = [ "out" "doc" ];
 
@@ -46,6 +33,8 @@ stdenv.mkDerivation rec {
   postPatch = ''
     substituteInPlace cpp/src/Options.cpp \
       --replace /etc/openzwave $out/etc/openzwave
+    substituteInPlace cpp/build/Makefile  \
+      --replace "-Werror" "-Werror -Wno-format"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes
This change enables building of updated openzwave. 
The repository appears to be in maintenance mode (with no releases since 2019) but other tools (e.g. domoticz) depend on more recent features of this package for full functionality.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

