### PR TITLE
lib/modules: add `definitionsWithLocations` to evaluated options

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -720,6 +720,7 @@ rec {
         inherit (res.defsFinal') highestPrio;
         definitions = map (def: def.value) res.defsFinal;
         files = map (def: def.file) res.defsFinal;
+        definitionsWithLocations = res.defsFinal;
         inherit (res) isDefined;
         # This allows options to be correctly displayed using `${options.path.to.it}`
         __toString = _: showOption loc;


### PR DESCRIPTION
#### Copy of commit msg
This attr provides the location of each definition.

This is particularly useful for introspecting options of type `attrsOf`.
E.g., it allows finding the location of a systemd service definition by parsing `options.systemd.services.definitionsWithLocations`.

#### Discussion
I've often needed to access the location of a specific definition, for debugging or for implementing NixOS tooling.
This info is readily available and is already part of the external module interface (param `defs` in `type.merge`), so we should also add it to evaluated options.