### PR TITLE
services.nix-daemon: refactor into mkRemoteBuilderDesc

### DIFF
--- a/lib/tests/nix-daemon.nix
+++ b/lib/tests/nix-daemon.nix
@@ -1,0 +1,52 @@
+# to run these tests:
+# nix-instantiate --eval --strict lib/tests/nix-daemon.nix
+let
+  lib = import ../default.nix;
+
+  buildMachine1 = {
+    hostName = "localhost";
+    sshKey = "/home/groot/.ssh/id_rsa";
+    system = "x86_64-linux";
+    maxJobs = 2;
+    speedFactor = 2;
+    supportedFeatures = [
+      "big-parallel"
+      "kvm"
+    ];
+  };
+
+  nixConfModule =
+    { config, ... }:
+    {
+      buildMachine = buildMachine1;
+    };
+
+  finalConfig =
+    (lib.modules.evalModules {
+      modules = [
+        nixConfModule
+        (
+          { config, ... }:
+          {
+            options = {
+              buildMachine = lib.mkOption {
+                description = lib.mdDoc ''PlaceHolder'';
+                type = lib.types.submoduleWith {
+                  modules = [ ../../nixos/modules/config/nix-remote-builder.nix ];
+                  specialArgs = {
+                    nixVersion = "2.32";
+                  };
+                };
+              };
+            };
+          }
+        )
+      ];
+    }).config;
+in
+lib.runTests {
+  testNixRemoteBuilderUri = {
+    expr = finalConfig.buildMachine.rendered;
+    expected = "ssh://localhost x86_64-linux /home/groot/.ssh/id_rsa 2 2 big-parallel,kvm - -";
+  };
+}

--- a/nixos/modules/config/nix-remote-build.nix
+++ b/nixos/modules/config/nix-remote-build.nix
@@ -10,197 +10,24 @@
 let
   inherit (lib)
     any
-    concatMapStrings
     concatStringsSep
     filter
-    getVersion
     mkIf
-    mkMerge
     mkOption
-    optional
-    optionalString
     types
-    versionAtLeast
     ;
 
   cfg = config.nix;
-
-  nixPackage = cfg.package.out;
-
-  isNixAtLeast = versionAtLeast (getVersion nixPackage);
-
-  buildMachinesText = concatMapStrings (
-    machine:
-    (concatStringsSep " " (
-      [
-        "${optionalString (machine.protocol != null) "${machine.protocol}://"}${
-          optionalString (machine.sshUser != null) "${machine.sshUser}@"
-        }${machine.hostName}"
-        (
-          if machine.system != null then
-            machine.system
-          else if machine.systems != [ ] then
-            concatStringsSep "," machine.systems
-          else
-            "-"
-        )
-        (if machine.sshKey != null then machine.sshKey else "-")
-        (toString machine.maxJobs)
-        (toString machine.speedFactor)
-        (
-          let
-            res = (machine.supportedFeatures ++ machine.mandatoryFeatures);
-          in
-          if (res == [ ]) then "-" else (concatStringsSep "," res)
-        )
-        (
-          let
-            res = machine.mandatoryFeatures;
-          in
-          if (res == [ ]) then "-" else (concatStringsSep "," machine.mandatoryFeatures)
-        )
-      ]
-      ++ optional (isNixAtLeast "2.4pre") (
-        if machine.publicHostKey != null then machine.publicHostKey else "-"
-      )
-    ))
-    + "\n"
-  ) cfg.buildMachines;
-
 in
 {
   options = {
     nix = {
       buildMachines = mkOption {
-        type = types.listOf (
-          types.submodule {
-            options = {
-              hostName = mkOption {
-                type = types.str;
-                example = "nixbuilder.example.org";
-                description = ''
-                  The hostname of the build machine.
-                '';
-              };
-              protocol = mkOption {
-                type = types.enum [
-                  null
-                  "ssh"
-                  "ssh-ng"
-                ];
-                default = "ssh";
-                example = "ssh-ng";
-                description = ''
-                  The protocol used for communicating with the build machine.
-                  Use `ssh-ng` if your remote builder and your
-                  local Nix version support that improved protocol.
-
-                  Use `null` when trying to change the special localhost builder
-                  without a protocol which is for example used by hydra.
-                '';
-              };
-              system = mkOption {
-                type = types.nullOr types.str;
-                default = null;
-                example = "x86_64-linux";
-                description = ''
-                  The system type the build machine can execute derivations on.
-                  Either this attribute or {var}`systems` must be
-                  present, where {var}`system` takes precedence if
-                  both are set.
-                '';
-              };
-              systems = mkOption {
-                type = types.listOf types.str;
-                default = [ ];
-                example = [
-                  "x86_64-linux"
-                  "aarch64-linux"
-                ];
-                description = ''
-                  The system types the build machine can execute derivations on.
-                  Either this attribute or {var}`system` must be
-                  present, where {var}`system` takes precedence if
-                  both are set.
-                '';
-              };
-              sshUser = mkOption {
-                type = types.nullOr types.str;
-                default = null;
-                example = "builder";
-                description = ''
-                  The username to log in as on the remote host. This user must be
-                  able to log in and run nix commands non-interactively. It must
-                  also be privileged to build derivations, so must be included in
-                  {option}`nix.settings.trusted-users`.
-                '';
-              };
-              sshKey = mkOption {
-                type = types.nullOr types.str;
-                default = null;
-                example = "/root/.ssh/id_buildhost_builduser";
-                description = ''
-                  The path to the SSH private key with which to authenticate on
-                  the build machine. The private key must not have a passphrase.
-                  If null, the building user (root on NixOS machines) must have an
-                  appropriate ssh configuration to log in non-interactively.
-
-                  Note that for security reasons, this path must point to a file
-                  in the local filesystem, *not* to the nix store.
-                '';
-              };
-              maxJobs = mkOption {
-                type = types.int;
-                default = 1;
-                description = ''
-                  The number of concurrent jobs the build machine supports. The
-                  build machine will enforce its own limits, but this allows hydra
-                  to schedule better since there is no work-stealing between build
-                  machines.
-                '';
-              };
-              speedFactor = mkOption {
-                type = types.int;
-                default = 1;
-                description = ''
-                  The relative speed of this builder. This is an arbitrary integer
-                  that indicates the speed of this builder, relative to other
-                  builders. Higher is faster.
-                '';
-              };
-              mandatoryFeatures = mkOption {
-                type = types.listOf types.str;
-                default = [ ];
-                example = [ "big-parallel" ];
-                description = ''
-                  A list of features mandatory for this builder. The builder will
-                  be ignored for derivations that don't require all features in
-                  this list. All mandatory features are automatically included in
-                  {var}`supportedFeatures`.
-                '';
-              };
-              supportedFeatures = mkOption {
-                type = types.listOf types.str;
-                default = [ ];
-                example = [
-                  "kvm"
-                  "big-parallel"
-                ];
-                description = ''
-                  A list of features supported by this builder. The builder will
-                  be ignored for derivations that require features not in this
-                  list.
-                '';
-              };
-              publicHostKey = mkOption {
-                type = types.nullOr types.str;
-                default = null;
-                description = ''
-                  The (base64-encoded) public host key of this builder. The field
-                  is calculated via {command}`base64 -w0 /etc/ssh/ssh_host_type_key.pub`.
-                  If null, SSH will use its regular known-hosts file when connecting.
-                '';
-              };
+        type = lib.types.listOf (
+          lib.types.submoduleWith {
+            modules = [ ./nix-remote-builder.nix ];
+            specialArgs = {
+              nixVersion = lib.getVersion cfg.package;
             };
           }
         );
@@ -247,7 +74,7 @@ in
 
     # List of machines for distributed Nix builds
     environment.etc."nix/machines" = mkIf (cfg.buildMachines != [ ]) {
-      text = buildMachinesText;
+      text = lib.concatMapStringsSep "\n" (bm: bm.rendered) cfg.buildMachines;
     };
 
     # Legacy configuration conversion.

--- a/nixos/modules/config/nix-remote-builder.nix
+++ b/nixos/modules/config/nix-remote-builder.nix
@@ -1,0 +1,182 @@
+{
+  config,
+  lib,
+  nixVersion,
+  ...
+}:
+with lib;
+let
+  isNixAtLeast = lib.versionAtLeast nixVersion;
+
+  mkRemoteBuilderDesc =
+    machine:
+    concatStringsSep " " (
+      [
+        "${optionalString (machine.protocol != null) "${machine.protocol}://"}${
+          optionalString (machine.sshUser != null) "${machine.sshUser}@"
+        }${machine.hostName}"
+        (
+          if machine.system != null then
+            machine.system
+          else if machine.systems != [ ] then
+            concatStringsSep "," machine.systems
+          else
+            "-"
+        )
+        (if machine.sshKey != null then machine.sshKey else "-")
+        (toString machine.maxJobs)
+        (toString machine.speedFactor)
+        (
+          let
+            res = (machine.supportedFeatures ++ machine.mandatoryFeatures);
+          in
+          if (res == [ ]) then "-" else (concatStringsSep "," res)
+        )
+        (
+          let
+            res = machine.mandatoryFeatures;
+          in
+          if (res == [ ]) then "-" else (concatStringsSep "," machine.mandatoryFeatures)
+        )
+      ]
+      ++ optional (isNixAtLeast "2.4pre") (
+        if machine.publicHostKey != null then machine.publicHostKey else "-"
+      )
+    );
+in
+{
+  options = {
+    hostName = lib.mkOption {
+      type = types.str;
+      example = "nixbuilder.example.org";
+      description = ''
+        The hostname of the build machine.
+      '';
+    };
+    protocol = lib.mkOption {
+      type = types.enum [
+        null
+        "ssh"
+        "ssh-ng"
+      ];
+      default = "ssh";
+      example = "ssh-ng";
+      description = ''
+        The protocol used for communicating with the build machine.
+        Use `ssh-ng` if your remote builder and your
+        local Nix version support that improved protocol.
+
+        Use `null` when trying to change the special localhost builder
+        without a protocol which is for example used by hydra.
+      '';
+    };
+    system = lib.mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "x86_64-linux";
+      description = ''
+        The system type the build machine can execute derivations on.
+        Either this attribute or {var}`systems` must be
+        present, where {var}`system` takes precedence if
+        both are set.
+      '';
+    };
+    systems = lib.mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      description = ''
+        The system types the build machine can execute derivations on.
+        Either this attribute or {var}`system` must be
+        present, where {var}`system` takes precedence if
+        both are set.
+      '';
+    };
+    sshUser = lib.mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "builder";
+      description = ''
+        The username to log in as on the remote host. This user must be
+        able to log in and run nix commands non-interactively. It must
+        also be privileged to build derivations, so must be included in
+        {option}`nix.settings.trusted-users`.
+      '';
+    };
+    sshKey = lib.mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "/root/.ssh/id_buildhost_builduser";
+      description = ''
+        The path to the SSH private key with which to authenticate on
+        the build machine. The private key must not have a passphrase.
+        If null, the building user (root on NixOS machines) must have an
+        appropriate ssh configuration to log in non-interactively.
+
+        Note that for security reasons, this path must point to a file
+        in the local filesystem, *not* to the nix store.
+      '';
+    };
+    maxJobs = lib.mkOption {
+      type = types.int;
+      default = 1;
+      description = ''
+        The number of concurrent jobs the build machine supports. The
+        build machine will enforce its own limits, but this allows hydra
+        to schedule better since there is no work-stealing between build
+        machines.
+      '';
+    };
+    speedFactor = lib.mkOption {
+      type = types.int;
+      default = 1;
+      description = ''
+        The relative speed of this builder. This is an arbitrary integer
+        that indicates the speed of this builder, relative to other
+        builders. Higher is faster.
+      '';
+    };
+    mandatoryFeatures = lib.mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "big-parallel" ];
+      description = ''
+        A list of features mandatory for this builder. The builder will
+        be ignored for derivations that don't require all features in
+        this list. All mandatory features are automatically included in
+        {var}`supportedFeatures`.
+      '';
+    };
+    supportedFeatures = lib.mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [
+        "kvm"
+        "big-parallel"
+      ];
+      description = ''
+        A list of features supported by this builder. The builder will
+        be ignored for derivations that require features not in this
+        list.
+      '';
+    };
+    publicHostKey = lib.mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        The (base64-encoded) public host key of this builder. The field
+        is calculated via {command}`base64 -w0 /etc/ssh/ssh_host_type_key.pub`.
+        If null, SSH will use its regular known-hosts file when connecting.
+      '';
+    };
+    rendered = mkOption {
+      internal = true;
+      readOnly = true;
+      type = types.str;
+      default = mkRemoteBuilderDesc config;
+    };
+  };
+}


### PR DESCRIPTION
I like to specify my builders on the go (for various reasons, there are many factors that decide where I build), in my shell.
what I do is I export in my shell
RUNNER1="xxxx"
RUNNER2="yyyyy"
then I can run any nix command and append a --option buiilders "$RUNNER1" (any combination of the $RUNNER). 


which are generated from "mkRemoteBuilderDesc" that I've copy/pasted in my flake.
I would like to expose mkRemoteBuilderDesc somehow but not sure how to
do so. In some file in lib/ ?

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
