### PR TITLE
dart: 2.17.3 -> 2.18.0

### DIFF
--- a/pkgs/development/interpreters/dart/default.nix
+++ b/pkgs/development/interpreters/dart/default.nix
@@ -2,7 +2,7 @@
 , lib
 , fetchurl
 , unzip
-, version ? "2.17.3"
+, version ? "2.18.0"
 , sources ? let
     base = "https://storage.googleapis.com/dart-archive/channels";
     x86_64 = "x64";
@@ -10,28 +10,28 @@
     aarch64 = "arm64";
     # Make sure that if the user overrides version parameter they're
     # also need to override sources, to avoid mistakes
-    version = "2.17.3";
+    version = "2.18.0";
   in
   {
     "${version}-aarch64-darwin" = fetchurl {
       url = "${base}/stable/release/${version}/sdk/dartsdk-macos-${aarch64}-release.zip";
-      sha256 = "sha256-NjkqC9DaaFGN47Qe46xUlsEx2O2bQrKhb1eJyxfr7Vg=";
+      sha256 = "sha256-wfUh6rXy8jAC0TVQJzXh4SrV2DQs9SvY8PGtNgZx+cA=";
     };
     "${version}-x86_64-darwin" = fetchurl {
       url = "${base}/stable/release/${version}/sdk/dartsdk-macos-${x86_64}-release.zip";
-      sha256 = "sha256-+6y4lOGS8VyWrZCMSgLFun0E/WOCGlHEE8J5cQiVpUY=";
+      sha256 = "sha256-zyu6r8akId/AHpBKH95wJXXu1LD9CKShWYKfppnSRx4=";
     };
     "${version}-x86_64-linux" = fetchurl {
       url = "${base}/stable/release/${version}/sdk/dartsdk-linux-${x86_64}-release.zip";
-      sha256 = "sha256-aPmgmsYaqxwTWtLmSjm/rAiJANQ5lB3uJ12OqMhUG5U=";
+      sha256 = "sha256-45HE7Y9iO5dI+JfLWF1ikFfBFB+er46bK+EYkyuhFjI=";
     };
     "${version}-i686-linux" = fetchurl {
       url = "${base}/stable/release/${version}/sdk/dartsdk-linux-${i686}-release.zip";
-      sha256 = "sha256-BFIN36OURaWIgBUiO35GkMkhCBHnqtKYPJVetdJ5cZI=";
+      sha256 = "sha256-IkSJWfAocT1l8F2igAkR+Y5PNYD5PZ0j21D8aJk9JCY=";
     };
     "${version}-aarch64-linux" = fetchurl {
       url = "${base}/stable/release/${version}/sdk/dartsdk-linux-${aarch64}-release.zip";
-      sha256 = "sha256-yZMke1raq0Mvu01LFE1aUsTEARZWMS0rAI727FHq6ts=";
+      sha256 = "sha256-Bt18brbJA/XfiyP5o197HDXMuGm+a1AZx92Thoriv78=";
     };
   }
 }:
@@ -51,7 +51,7 @@ stdenv.mkDerivation {
     mkdir -p $out
     cp -R * $out/
     echo $libPath
-  '' + lib.optionalString(stdenv.isLinux) ''
+  '' + lib.optionalString (stdenv.isLinux) ''
     find $out/bin -executable -type f -exec patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) {} \;
   '';
 


### PR DESCRIPTION
###### Description of changes
https://medium.com/dartlang/dart-2-18-f4b3101f146c

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [-] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [-] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
