### PR TITLE
kanidm: 1.1.0-alpha.8 -> 1.1.0-alpha.9

### DIFF
--- a/nixos/tests/kanidm.nix
+++ b/nixos/tests/kanidm.nix
@@ -69,7 +69,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
         server.wait_until_succeeds("curl -sf https://${serverDomain} | grep Kanidm")
         server.wait_until_succeeds("ldapsearch -H ldap://[::1]:636 -b '${ldapBaseDN}' -x '(name=test)'")
         client.wait_until_succeeds("kanidm login -D anonymous && kanidm self whoami | grep anonymous@${serverDomain}")
-        (rv, result) = server.execute("kanidmd recover_account -d quiet -c ${serverConfigFile} -n admin 2>&1 | rg -o '[A-Za-z0-9]{48}'")
+        rv, result = server.execute("kanidmd recover_account -c ${serverConfigFile} idm_admin 2>&1 | rg -o '[A-Za-z0-9]{48}'")
         assert rv == 0
       '';
   })

--- a/pkgs/servers/kanidm/default.nix
+++ b/pkgs/servers/kanidm/default.nix
@@ -17,16 +17,16 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "kanidm";
-  version = "1.1.0-alpha.8";
+  version = "1.1.0-alpha.9";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-zMtbE6Y9wXFPBqhmiTMJ3m6bLVZl+c6lRY39DWDlJNo=";
+    rev = "985462590b1c49b26a0b0ee01e24b1eb01942165";
+    hash = "sha256-JtoDuA3NCKmX+wDqav30VwrLeDALYat1iKFWpbYOO1s=";
   };
 
-  cargoSha256 = "sha256:1l7xqp457zfd9gfjp6f4lzgadfp6112jbip4irazw4084qwj0z6x";
+  cargoSha256 = "sha256-pkBkXIG2PF5YMeighQwHwhURWbJabfveyszRIdrQjcA=";
 
   KANIDM_BUILD_PROFILE = "release_nixos_${arch}";
 
@@ -56,25 +56,22 @@ rustPlatform.buildRustPackage rec {
     pam
   ];
 
-  # Failing tests, probably due to network issues
-  checkFlags = [
-    "--skip default_entries"
-    "--skip oauth2_openid_basic_flow"
-    "--skip test_server"
-    "--skip test_cache"
-  ];
+  # The UI needs to be in place before the tests are run.
+  postBuild = ''
+    # We don't compile the wasm-part form source, as there isn't a rustc for
+    # wasm32-unknown-unknown in nixpkgs yet.
+    mkdir $out
+    cp -r kanidmd_web_ui/pkg $out/ui
+  '';
 
   preFixup = ''
-    installShellCompletion --bash $releaseDir/build/completions/*.bash
-    installShellCompletion --zsh  $releaseDir/build/completions/_*
+    installShellCompletion \
+      --bash $releaseDir/build/completions/*.bash \
+      --zsh $releaseDir/build/completions/_*
 
     # PAM and NSS need fix library names
     mv $out/lib/libnss_kanidm.so $out/lib/libnss_kanidm.so.2
     mv $out/lib/libpam_kanidm.so $out/lib/pam_kanidm.so
-
-    # We don't compile the wasm-part form source, as there isn't a rustc for
-    # wasm32-unknown-unknown in nixpkgs yet.
-    cp -r kanidmd_web_ui/pkg $out/ui
   '';
 
   passthru.tests = { inherit (nixosTests) kanidm; };


### PR DESCRIPTION
https://github.com/kanidm/kanidm/releases/tag/v1.1.0-alpha.9

Uses a concrete rev, because it relies on additional commits from the
release branch that provide build fixes.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
