### PR TITLE
paperless: move `PYTHONPATH` definition to module

### DIFF
--- a/nixos/modules/services/misc/paperless.nix
+++ b/nixos/modules/services/misc/paperless.nix
@@ -297,7 +297,7 @@ in
       };
       environment = env // {
         PATH = mkForce pkg.path;
-        PYTHONPATH = "${pkg.pythonPath}:${pkg}/lib/paperless-ngx/src";
+        PYTHONPATH = "${pkg.python.pkgs.makePythonPath pkg.propagatedBuildInputs}:${pkg}/lib/paperless-ngx/src";
       };
       # Allow the web interface to access the private /tmp directory of the server.
       # This is required to support uploading files via the web interface.

--- a/pkgs/applications/office/paperless-ngx/default.nix
+++ b/pkgs/applications/office/paperless-ngx/default.nix
@@ -207,11 +207,7 @@ python.pkgs.pythonPackages.buildPythonApplication rec {
   '';
 
   passthru = {
-    inherit python;
-    # PYTHONPATH of all dependencies used by the package
-    pythonPath = python3.pkgs.makePythonPath propagatedBuildInputs;
-    inherit path;
-
+    inherit python path;
     tests = { inherit (nixosTests) paperless; };
   };
 


### PR DESCRIPTION
#### Copy of main commit msg
`paperless-ngx.pythonPath` was incomplete due to the missing paperless-ngx source, so it had to be amended in the service.
Instead of amending it, define it entirely in the service.
                                                                                                                                    
This allows an override of `paperless-ngx.propagatedBuildInputs` to be reflected in the service's `PYTHONPATH`.

###### Things done
- [x] `nixosTests.paperless` (`x86_64-linux`)

cc @mweinelt