### PR TITLE
acgtk: 1.5.2 → 1.5.4

### DIFF
--- a/pkgs/applications/science/logic/acgtk/default.nix
+++ b/pkgs/applications/science/logic/acgtk/default.nix
@@ -1,17 +1,20 @@
-{ lib, stdenv, fetchurl, dune_2, ocamlPackages }:
+{ lib, stdenv, fetchFromGitLab, dune_2, ocamlPackages }:
 
 stdenv.mkDerivation {
 
   pname = "acgtk";
-  version = "1.5.2";
+  version = "1.5.4";
 
-  src = fetchurl {
-    url = "https://acg.loria.fr/software/acg-1.5.2-20201204.tar.gz";
-    sha256 = "09yax7dyw8kgwzlb69r9d20y7rrymzwi3bbq2dh0qdq01vjz2xwq";
+  src = fetchFromGitLab {
+    domain = "gitlab.inria.fr";
+    owner = "acg";
+    repo = "dev/acgtk";
+    rev = "8e630b6d91bad022bd1d1a075e7768034065c428";
+    sha256 = "sha256-W/BDhbng5iYuiB7desMKvRtDFdhoaxiJNvNvtbLlA6E=";
   };
 
   buildInputs = [ dune_2 ] ++ (with ocamlPackages; [
-    ocaml findlib ansiterminal cairo2 cmdliner fmt logs menhir menhirLib mtime yojson
+    ocaml findlib ansiterminal cairo2 cmdliner_1_1 fmt logs menhir menhirLib mtime sedlex yojson
   ]);
 
   buildPhase = "dune build --profile=release";


### PR DESCRIPTION
###### Description of changes

Fixes & improvements: https://gitlab.inria.fr/ACG/dev/ACGtk/-/blob/8e630b6d91bad022bd1d1a075e7768034065c428/CHANGES.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
