### PR TITLE
tmate: Update version

### DIFF
--- a/pkgs/servers/tmate-ssh-server/default.nix
+++ b/pkgs/servers/tmate-ssh-server/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "tmate-ssh-server";
-  version = "2.3.0";
+  version = "unstable-2021-10-17";
 
   src = fetchFromGitHub {
     owner  = "tmate-io";
     repo   = "tmate-ssh-server";
-    rev    = version;
-    sha256 = "1y77mv1k4c79glj84lzlp0s1lafr1jzf60mywr5vhy6sq47q8hwd";
+    rev    = "1f314123df2bb29cb07427ed8663a81c8d9034fd";
+    sha256 = "sha256-9/xlMvtkNWUBRYYnJx20qEgtEcjagH2NtEKZcDOM1BY=";
   };
 
   dontUseCmakeConfigure = true;
@@ -22,8 +22,7 @@ stdenv.mkDerivation rec {
     description = "tmate SSH Server";
     license     = licenses.mit;
     platforms   = platforms.unix;
-    maintainers = with maintainers; [ ];
-    knownVulnerabilities = [ "CVE-2021-44513" "CVE-2021-44512" ];
+    maintainers = with maintainers; [ ck3d ];
   };
 }
 

--- a/pkgs/tools/misc/tmate/default.nix
+++ b/pkgs/tools/misc/tmate/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "tmate";
-  version = "2.4.0";
+  version = "unstable-2022-08-07";
 
   src = fetchFromGitHub {
     owner  = "tmate-io";
     repo   = "tmate";
-    rev    = version;
-    sha256 = "0x5c31yq7ansmiy20a0qf59wagba9v3pq97mlkxrqxn4n1gcc6vi";
+    rev    = "ac919516f4f1b10ec928e20b3a5034d18f609d68";
+    sha256 = "sha256-t96gfmAMcsjkGf8pvbEx2fNx4Sj3W6oYoQswB3Dklb8=";
   };
 
   dontUseCmakeConfigure = true;
@@ -22,6 +22,6 @@ stdenv.mkDerivation rec {
     description = "Instant Terminal Sharing";
     license     = licenses.mit;
     platforms   = platforms.unix;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ ck3d ];
   };
 }


### PR DESCRIPTION
###### Description of changes

The tmate client and server has no releases since the last 3 years. CVE have been fixed in master branch, so I decided to update the packages.
Since I use these packages in my environment, I added my self as maintainer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
