### PR TITLE
solana-validator 1.10.35

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -315,6 +315,12 @@
     githubId = 1174858;
     name = "Maxwell Huang-Hobbs";
   };
+  adjacentresearch = {
+     email = "nate@adjacentresearch.xyz";
+     github = "0xperp";
+     githubId = 96147421;
+     name = "0xperp";
+  };
   adnelson = {
     email = "ithinkican@gmail.com";
     github = "adnelson";

--- a/pkgs/applications/blockchains/solana-validator/default.nix
+++ b/pkgs/applications/blockchains/solana-validator/default.nix
@@ -1,0 +1,92 @@
+# largely inspired from https://github.com/saber-hq/saber-overlay/blob/master/packages/solana/solana.nix
+
+{ stdenv
+, fetchFromGitHub
+, lib
+, rustPlatform
+, IOKit
+, Security
+, AppKit
+, pkg-config
+, udev
+, zlib
+, protobuf
+, clang
+, llvm
+, pkgconfig
+, openssl
+, libclang
+, rustfmt
+, perl
+, hidapi
+, solanaPkgs ? [
+    "solana"
+    "solana-bench-tps"
+    "solana-faucet"
+    "solana-gossip"
+    "solana-install"
+    "solana-keygen"
+    "solana-ledger-tool"
+    "solana-log-analyzer"
+    "solana-net-shaper"
+    "solana-sys-tuner"
+    "solana-validator"
+    "cargo-build-bpf"
+    "cargo-test-bpf"
+    "solana-dos"
+    "solana-install-init"
+    "solana-stake-accounts"
+    "solana-test-validator"
+    "solana-tokens"
+    "solana-watchtower"
+  ] ++ [
+    # XXX: Ensure `solana-genesis` is built LAST!
+    # See https://github.com/solana-labs/solana/issues/5826
+    "solana-genesis"
+  ]
+}:
+let
+  pinData = lib.importJSON ./pin.json;
+  version = pinData.version;
+  sha256 = pinData.sha256;
+  cargoSha256 = pinData.cargoSha256;
+in
+rustPlatform.buildRustPackage rec {
+  pname = "solana-validator";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "solana-labs";
+    repo = "solana";
+    rev = "v${version}";
+    inherit sha256;
+  };
+
+  # partly inspired by https://github.com/obsidiansystems/solana-bridges/blob/develop/default.nix#L29
+  inherit cargoSha256;
+  verifyCargoDeps = true;
+
+  cargoBuildFlags = builtins.map (n: "--bin=${n}") solanaPkgs;
+
+  # weird errors. see https://github.com/NixOS/nixpkgs/issues/52447#issuecomment-852079285
+  LIBCLANG_PATH = "${libclang.lib}/lib";
+  BINDGEN_EXTRA_CLANG_ARGS =
+    "-isystem ${libclang.lib}/lib/clang/${lib.getVersion clang}/include";
+  LLVM_CONFIG_PATH = "${llvm}/bin/llvm-config";
+
+  nativeBuildInputs = [ clang llvm pkgconfig protobuf rustfmt perl ];
+  buildInputs =
+    [ openssl zlib libclang hidapi ] ++ (lib.optionals stdenv.isLinux [ udev ]);
+  strictDeps = true;
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Web-Scale Blockchain for fast, secure, scalable, decentralized apps and marketplaces. ";
+    homepage = "https://solana.com";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ adjacentresearch ];
+    platforms = platforms.unix;
+  };
+  passthru.updateScript = ./update.sh;
+}

--- a/pkgs/applications/blockchains/solana-validator/pin.json
+++ b/pkgs/applications/blockchains/solana-validator/pin.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.10.35",
+  "sha256": "sha256-y7+ogMJ5E9E/+ZaTCHWOQWG7iR+BGuVqvlNUDT++Ghc=",
+  "cargoSha256": "sha256-idlu9qkh2mrF6MxstRcvemKrtTGNY/InBnIDqRvDQPs"
+}

--- a/pkgs/applications/blockchains/solana-validator/update.sh
+++ b/pkgs/applications/blockchains/solana-validator/update.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i oil -p jq sd nix-prefetch-github ripgrep
+
+# TODO set to `verbose` or `extdebug` once implemented in oil
+shopt --set xtrace
+# we need failures inside of command subs to get the correct cargoSha256
+shopt --unset inherit_errexit
+
+const directory = $(dirname $0 | xargs realpath)
+const owner = "solana-labs"
+const repo = "solana"
+const latest_rev = $(curl -q https://api.github.com/repos/${owner}/${repo}/releases/latest | \
+  jq -r '.tag_name')
+const latest_version = $(echo $latest_rev | sd 'v' '')
+const current_version = $(jq -r '.version' $directory/pin.json)
+if ("$latest_version" === "$current_version") {
+  echo "solana is already up-to-date"
+  return 0
+} else {
+  const tarball_meta = $(nix-prefetch-github $owner $repo --rev "$latest_rev")
+  const tarball_hash = "sha256-$(echo $tarball_meta | jq -r '.sha256')"
+
+  jq ".version = \"$latest_version\" | \
+      .\"sha256\" = \"$tarball_hash\" | \
+      .\"cargoSha256\" = \"\"" $directory/pin.json | sponge $directory/pin.json
+
+  const new_cargo_sha256 = $(nix-build -A solana-testnet 2>&1 | \
+    tail -n 2 | \
+    head -n 1 | \
+    sd '\s+got:\s+' '')
+
+  jq ".cargoSha256 = \"$new_cargo_sha256\"" $directory/pin.json | sponge $directory/pin.json
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32526,6 +32526,10 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) IOKit Security AppKit;
   };
 
+  solana-validator = callPackage ../applications/blockchains/solana-validator {
+    inherit (darwin.apple_sdk.frameworks) IOKit Security AppKit;
+  };
+
   snarkos = callPackage ../applications/blockchains/snarkos {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
[Solana](https://solana.com) was added in pull #121009 along with a few other updates like #169506 (added an `update.sh` script) and #152055 (fixed a few dependencies). 

The current [solana](https://solana.com) package only provides the `cli` binary. This package adds the following binaries 
- `solana`
- `solana-bench-tps`
- `solana-faucet`
- `solana-gossip`
- `solana-install`
- `solana-keygen`
- `solana-ledger-tool`
- `solana-log-analyzer`
- `solana-net-shaper`
- `solana-sys-tuner`
- `solana-validator`
- `cargo-build-bpf`
- `cargo-test-bpf`
- `solana-dos`
- `solana-install-init`
- `solana-stake-accounts`
- `solana-test-validator`
- `solana-tokens`
- `solana-watchtower`

These packages are helpful if you would like to begin developing [solana](https://solana.com) programs, operating a validator,  RPC node, or contributing to the [solana](https://solana.com) codebase. 

Currently there is already a [solana testnet cli](https://github.com/NixOS/nixpkgs/tree/master/pkgs/applications/blockchains/solana) package from @ruuda and @happysalada. Given that the [solana](https://solana.com) codebase is large and there are many associated binaries I created a separate `solana-validator` package. I am very curious to receive feedback if this package should be separated or combined with the prior. 

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
