### PR TITLE
grb unstable init, vul 2020-02-15 -> 2022-07-02

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15186,13 +15186,18 @@
     }];
   };
   cafkafk = {
-    email = "cafkafk@cafkafk.com";
+    email = "christina@cafkafk.com";
     matrix = "@cafkafk:matrix.cafkafk.com";
     name = "Christina Sørensen";
     github = "cafkafk";
     githubId = 89321978;
-    keys = [{
-      fingerprint = "7B9E E848 D074 AE03 7A0C  651A 8ED4 DEF7 375A 30C8";
-    }];
+    keys = [
+      {
+        fingerprint = "7B9E E848 D074 AE03 7A0C  651A 8ED4 DEF7 375A 30C8";
+      }
+      {
+        fingerprint = "208A 2A66 8A2F CDE7 B5D3 8F64 CDDC 792F 6552 51ED";
+      }
+    ];
   };
 }

--- a/pkgs/applications/misc/grb/default.nix
+++ b/pkgs/applications/misc/grb/default.nix
@@ -1,0 +1,24 @@
+{ lib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "grb";
+  version = "unstable-2022-07-02";
+
+  src = fetchFromGitHub {
+    owner = "LukeSmithxyz";
+    repo = pname;
+    rev = "35a5353ab147b930c39e1ccd369791cc4c27f0df";
+    sha256 = "sha256-hQ21DXnkBJVCgGXQKDR+DjaDC3RXS2pNmSLDoHvHA4E=";
+  };
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
+
+  meta = with lib; {
+    description = "A cli-accessible Greek Bible with the Septuagint, SBL and Apocrypha";
+    homepage = "https://github.com/LukeSmithxyz/grb";
+    license = licenses.publicDomain;
+    maintainers = [ maintainers.cafkafk ];
+  };
+}

--- a/pkgs/applications/misc/kjv/default.nix
+++ b/pkgs/applications/misc/kjv/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation {
     description = "The Bible, King James Version";
     homepage = "https://github.com/bontibon/kjv";
     license = licenses.unlicense;
-    maintainers = with maintainers; [ jtobin ];
+    maintainers = with maintainers; [ jtobin cafkafk ];
     mainProgram = "kjv";
   };
 }

--- a/pkgs/applications/misc/vul/default.nix
+++ b/pkgs/applications/misc/vul/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "vul";
-  version = "unstable-2020-02-15";
+  version = "unstable-2022-07-02";
 
   src = fetchFromGitHub {
     owner = "LukeSmithxyz";
     repo = pname;
-    rev = "f6ebd8f6b6fb8a111e7b59470d6748fcbe71c559";
-    sha256 = "aUl4f82sGOWkEvTDNILDszj5hztDRvYpHVovFl4oOCc=";
+    rev = "97efaedb79c9de62b6a19b04649fd8c00b85973f";
+    sha256 = "sha256-NwRUx7WVvexrCdPtckq4Szf5ISy7NVBHX8uAsRtbE+0=";
   };
 
   makeFlags = [
@@ -19,6 +19,6 @@ stdenv.mkDerivation rec {
     description = "Latin Vulgate Bible on the Command Line";
     homepage = "https://github.com/LukeSmithxyz/vul";
     license = licenses.publicDomain;
-    maintainers = [ maintainers.j0hax ];
+    maintainers = [ maintainers.j0hax maintainers.cafkafk ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2726,6 +2726,8 @@ with pkgs;
 
   goku = callPackage ../os-specific/darwin/goku { };
 
+  grb = callPackage ../applications/misc/grb { };
+
   kerf   = kerf_1; /* kerf2 is WIP */
   kerf_1 = callPackage ../development/interpreters/kerf {
     stdenv = clangStdenv;


### PR DESCRIPTION




###### Description of changes
- init grb unstable at 2022-07-02
- update vul 2020-02-15 -> 2022-07-02
- add self as maintainer for both and kjv

grb, vul, and kjv are essentially the same package, so it makes
sense to handle them in unison.

###### For maintainers
These packages could all easily go in a shared directory as
they are very closely related.

Before that, it would make sense to make kjv reflect upstream instead
of the fork it currently reflects (e.g. create a version
for the fork and for the original) before doing this.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
