### PR TITLE
firefox{,-bin}-unwrapped: 104.0.1 -> 104.0.2; firefox-{beta,devedition}-bin-unwrapped: 105.0b4 -> 105.0b7

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
@@ -1,985 +1,985 @@
 {
-  version = "105.0b4";
+  version = "105.0b7";
   sources = [
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/ach/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/ach/firefox-105.0b7.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "fc1b328460f12bb0a8825d04edf951decd6d09156016fb163df3ec67ed0f1cbd";
+      sha256 = "13a62be6911a5f87861881bed801072236737b5759e65b357ae299cc96ff1aa7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/af/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/af/firefox-105.0b7.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "6750bbda950f16d4ca3d164b14a705b9ec2749d8c4eb2c329911248c8f844644";
+      sha256 = "f0099ffc0dc4d9af4fb188f435b97c400c58a500c655474fa5fadc5d4dffbcc1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/an/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/an/firefox-105.0b7.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "6a7a307bff37f04f2d6eadb536121ce573910031738ef05842d500ed9e38228d";
+      sha256 = "21e9e063cd0b632e3d9705b5a80c5fa9a89e5b7434c3e8734a790e2acef43442";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/ar/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/ar/firefox-105.0b7.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "6f2f90812ea4bc0fb6b28ac040dd7111d5d62b1f4e54651a4e2b6032ba4fee0c";
+      sha256 = "a73196b20aa377a2cb59c703461688fdbd536e972fbacb1a8b2b07373710d7d4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/ast/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/ast/firefox-105.0b7.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "ac02d448971702ce733d22cbbe30d52d411886de94958aa285b8a3b9c989115d";
+      sha256 = "2e49bd2d24c2b82a1ed32e4bc80185c26757a5c3d25adf9a4b14812ef9f2e470";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/az/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/az/firefox-105.0b7.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "a64cd95047addb4bfb89ff0189ab47dde5937d41a95f6ee84a900e37291d5119";
+      sha256 = "b0e234f6ca1857a6cacd6216788d0ab9ad6423f84d7bdc925c3548e1ffd75c0a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/be/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/be/firefox-105.0b7.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "c78580fbc236cb3655646573014e144f00c7dfcf8ba526022a9e56a92f81db43";
+      sha256 = "5ae874edf139a8de1ed3979a95ec5504a1edc0061ad16948fc50ba9cd589c3ac";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/bg/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/bg/firefox-105.0b7.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "c435b581f9d3894a6b849498eb89914c349bb17a8ce00487f384ed170fbed5b9";
+      sha256 = "570e978f4004e83765869f48bb6323928060cd66d7a83730ac41bb313980bfa8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/bn/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/bn/firefox-105.0b7.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "68246aed580525cbc21c91fb8400074e98992e3c9cc3eeb90a87801128c09823";
+      sha256 = "d2b249993c01207c7632e03ac650c65be2beeecaeefeae0a959e3f4469bd03d3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/br/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/br/firefox-105.0b7.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "ede92a9f21f352195a1e2eb3f8951f5eec989825373b19499f81e58440d771dc";
+      sha256 = "94cb7a8497fd00db19c72ecb3c6abb3346ad880dee69ab5a554f7551aae74497";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/bs/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/bs/firefox-105.0b7.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "16d8c06a95a639ee4fb04083ba212ca1e6d596d5c4fa55f3f68e2e6d4bbb861e";
+      sha256 = "e6fe304c7715bf7d9ebed33b04be48c05bb92b9a8a379a6f13d8741c2e1a0463";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/ca-valencia/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/ca-valencia/firefox-105.0b7.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "d354b53aee4734a8882882834f7e7faeb89ee94c8b65ce75c4f891cac3bc08a5";
+      sha256 = "cb2a906394c5578b152fbab4c6d2b108c7f22134f1bfd464cf352e35f352931b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/ca/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/ca/firefox-105.0b7.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "a93e48cb20989fc7eab58ebaab24847a10022f9601db04650d8a5e5e44869643";
+      sha256 = "28660bafe17c4caae2557e34197df4d2a4f15d752eb2544ee85d4e8a91a2d4d2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/cak/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/cak/firefox-105.0b7.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "b9c5b6f2b206c980a8c21ad9e2afc1755e1abf299ad28a571085b4d7e68c5d4f";
+      sha256 = "6eca76304180c2a3eec62abb8aef1fb493190e7398920d43ed07fe8ad2b71c84";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/cs/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/cs/firefox-105.0b7.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "4c663807c65fe5f36c03a2f74898bab87639c63db8c5a11a4584657e5b36f904";
+      sha256 = "e05b6161a38d7510ba9e043790622ab93cfae10c6daa41eccae09cee91dab747";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/cy/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/cy/firefox-105.0b7.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "efacdc4e0993f2a0f66b806334f14501b9c1895eb5daab3b746b078f8f99b65a";
+      sha256 = "365d1cb65216955dc6154a7fb55d647e542444308336fe220b27f93f2296095d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/da/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/da/firefox-105.0b7.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "6859a2c981ac9e6fb303f797e54771c927473d63fd91810c200f9224e2367884";
+      sha256 = "2502ce36a6fc6caefa6c61313e47c0ac7a7e4592122b0dc9c61cc5a71d843c70";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/de/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/de/firefox-105.0b7.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "c24b3b706b817141d1f278de1de575b1f859dd473ff5db2445d746f75cb16a3f";
+      sha256 = "a3ca68ccaf196819e7486cbe3428bdc31dcf7a76304d5c49999954679f4ff773";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/dsb/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/dsb/firefox-105.0b7.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "f8f7c2a3e5dc196f26d4db5d2678956a77ac64b0be58bdf6f0bb519494fc8a8f";
+      sha256 = "acf1f01a5c22276311e168a4220944cc246a900ad86ac90cfe52900888920962";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/el/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/el/firefox-105.0b7.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "a569b1bb237a1a76abe00dc4c433783c66dd2513d6c5a457157ce600222978ea";
+      sha256 = "7388edcd56f5ad294b15831e61f4a0e9a77672f4adeaf58bc785efcc55166d5d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/en-CA/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/en-CA/firefox-105.0b7.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "a0833c0a9c211afd4a1799794456d53188cb1a07268c63ba36d3ff5ea1a28f8e";
+      sha256 = "b7da929c9f3f7b7a00c106628c9519217970b49cecd283ed0e302a3aced794e3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/en-GB/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/en-GB/firefox-105.0b7.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "d183379acd5c6a803057efece0edf3757634039bdf414bde930937742924c02a";
+      sha256 = "af49484d4d24e254af371a011866950e59ba8312283dcab7f20081ec6f2afc66";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/en-US/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/en-US/firefox-105.0b7.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "5c00e37a1a66a00997ffb0e17f1669371a4cf3fc793bf0e6c84db697c1fd3977";
+      sha256 = "813a0564e1fed3b63e7e29ab420d0939463e503ef33ddf3d80f07168e52847c6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/eo/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/eo/firefox-105.0b7.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "bd52e0a1b39100bd399a9493faf5fd557caa25a57474230ae9c652fdd09992e9";
+      sha256 = "d3fe7f293788d4e366b7ab770d0555b5934023975375e2175bde5b56d4d27470";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/es-AR/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/es-AR/firefox-105.0b7.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "c9ffd34877e452b0c22d6816ad47838da9c7fd984cf44702454d6766150ae4d9";
+      sha256 = "f5c46350b90bd37c3b4e45b234f700ab83e89c4e11915d5f65868fbf22fbaa16";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/es-CL/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/es-CL/firefox-105.0b7.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "b52c0ed6b21e469bbfbbcd38c75e797247661aafea68c5fd310b91d556e8a7c4";
+      sha256 = "f66a7f164df38afac62c2840eacb4a77090d7ee46f01822cbbf532f393d64f70";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/es-ES/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/es-ES/firefox-105.0b7.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "28d444a54a2d711d21ff271d4ee5ec5f219db65e06f7484e6e54e7a1bf057c34";
+      sha256 = "1530d720bceee238ddbd678ce8178b82bc39ff4dd6d46040025a95a24a62b468";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/es-MX/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/es-MX/firefox-105.0b7.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "999ba11319a0ec7b328a2b7eeb267bc8b485e08ab7e9005560649954d3484ccf";
+      sha256 = "5fde90a6bd7f6e5a5cbce269f38cd440d2b313f2ecfe419bac300576bff3bfb6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/et/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/et/firefox-105.0b7.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "938f67632f9f72a836576399880086ea73ee812cd26df4f97735d2cfba01cd1e";
+      sha256 = "2d8ecf0cce7f336eb72f2c437a366ff22af388e8e24e5879e5e16899126c5c1f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/eu/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/eu/firefox-105.0b7.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "b41e8dbdb34b635e23729188d74f18e4a8cbb8868930b77b9d99bd89411f1c04";
+      sha256 = "3af8b10bba6bda9ccc82fbf151e96344855b0eeb6eaca0e51861ad31447ee36b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/fa/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/fa/firefox-105.0b7.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "acb40b7488d1a72b0fc2732ab865b781189653b53ba0e1a94aaee703ec90ac30";
+      sha256 = "ec4afce2b55e518ca2cdd4eb7c5e2b71dfcd129b6d414320874b65a6c010bd25";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/ff/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/ff/firefox-105.0b7.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "7d9c15bc4f4e96088baee1fc5a20855d87981fc694dcad2dd957438f7e9503a3";
+      sha256 = "b4b939a65a7f0a14b43625bb9d62a5f88b9743e6ac8cb1f440fd10932a2b0f7a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/fi/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/fi/firefox-105.0b7.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "4f66228638eece139029eccbc5365d330b866b3a92eca7afd20871a2eae50e9c";
+      sha256 = "61ee094a94103dad37800754c8632fed5b432807c971191f0974b4fc6fe67551";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/fr/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/fr/firefox-105.0b7.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "9a71c8784779d8eb47af8703c2bad11494a7969e117c5ed1876345ea93e45219";
+      sha256 = "711eb85209495aa1429d8224954273e2f1dc93f5d225405a7ff33ee98d15466f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/fy-NL/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/fy-NL/firefox-105.0b7.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "1f8aa6041bdd99f9330b3e8c7ccc5f890c72d7906fd1b49ae0a115417aa20042";
+      sha256 = "8797b779508074eacd09a568e48a274446cf1a71fd0e4cce2d8b1381f7401bf1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/ga-IE/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/ga-IE/firefox-105.0b7.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "7e00b07cc70ea3eb0075a9b6e2458a4ccf1fa354f9fb0f47281b575ab5d8ed19";
+      sha256 = "a9bc5f839f186a12eaa99bb58282bad228ecfab68f22bd072a53a4af0381735d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/gd/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/gd/firefox-105.0b7.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "46ed6a12bb62dea71eb3d3608f6a0e13dfe1fdc60abfc4363e67d79b30e0c27e";
+      sha256 = "16f8c5e3a91c353d9d7cc54ae92ae18cb850dc708571ee681556d9843da7017e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/gl/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/gl/firefox-105.0b7.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "837a222455918425f90b6142c4d2d755b2578b0bd3baff172a06fdbed765a5bd";
+      sha256 = "1dd1a06cb8c4ab0e9a9ec12a77b32a12cde88224717f32bde706bdf685549188";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/gn/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/gn/firefox-105.0b7.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "fe670b45f6acdcb6fc2d057ae95a6f4be27d8ff5fdcb473567b969099d0c95b6";
+      sha256 = "85f832fb117683efcdc27577d8fc3c4b395bcd29cc11c1462f2b9aa18c9387fc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/gu-IN/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/gu-IN/firefox-105.0b7.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "9d50cf9014e407ede6160888746c09f0db235ab9d2449daf67e91f5eae62d689";
+      sha256 = "b250875a640b26f09e6e02f3a126a8e5bbfe42af113925ce9b365724bf57a97e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/he/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/he/firefox-105.0b7.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "338a5224ee1270296b3f17e064be60cce9ebe902024f21330da76a15258d52d2";
+      sha256 = "ad279ae9378bc95184ae8d35917783ebc882d17c51e115f5e5135dc5ef28c512";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/hi-IN/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/hi-IN/firefox-105.0b7.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "5de9f01616ed1bcd0d733b6c132bea954d27b2517c1d7fac686c28312b999f2e";
+      sha256 = "3bfe69b2a62eea5bfe9aa42ab40a336fde4d18078386e6007a34e00b09a01f30";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/hr/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/hr/firefox-105.0b7.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "2dc85be4b18a60489e22ef2f03e927e10e05c2d27c5238993f0733226e4d379b";
+      sha256 = "6f5d0cad0eb51286c65410b50690490f01b9a6a482b3193b3b84134a104722fb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/hsb/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/hsb/firefox-105.0b7.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "6ef80cfd62b09f90ab4c9ae3f60bc8255f66e0babb15691471103c09521f8802";
+      sha256 = "7057e09b13062dddd253ef0e3a1092d9c5927c5535af9347cdd3a7d2fe32ceb0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/hu/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/hu/firefox-105.0b7.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "a375af98158f4f67483dac58ce86445022b2e8c06b4a3bbc6151b7c7c067597b";
+      sha256 = "da70d69bd720783457c958f660e9d43690844479e40feac890c25fef88483e11";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/hy-AM/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/hy-AM/firefox-105.0b7.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "5d26b9c59be468a03522e9d09b45de7a4675095b80af31a1068c663b2b4d3d7c";
+      sha256 = "709d92a8bb38e1848486c778a6caa65eb62c03ddd569047163d6d379b9659a59";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/ia/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/ia/firefox-105.0b7.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "15329bdb8a037ed9d349d4df5c1ae41a1372de9a4d9a4022f2819f69e9c33508";
+      sha256 = "8956636f5e9a73845ce2a2a985a3400fdf6756bb067b718c1d0f973344ea0594";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/id/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/id/firefox-105.0b7.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "3000c43344cb4cb23c5ca7a913fddd928da55af520f9f9f31d22a9665fde8282";
+      sha256 = "d843bda421ab18a1b9d4d6d0a1ff84b11997a9410947b8cabc6824d12ff92cb9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/is/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/is/firefox-105.0b7.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "29cde348b1e6ddb10a99b5f41ce2c150cf7055b669e2a6554a9bc914bd4a606f";
+      sha256 = "0e39f998588c62b8c0ed585c455d7d2fe7cb7c345130c350542c2332a300768f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/it/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/it/firefox-105.0b7.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "3644b7fda921ed404a4b534713c35dee5fd0852ad07affaa02b56d089e155a16";
+      sha256 = "399171eca9f00f2fd6de9f7b2ba70f44edb6671ee0f2ce78ee5fc4bd53f91897";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/ja/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/ja/firefox-105.0b7.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "f129ae934b6168a4e66b92156bc22856ddf384066d05e8bcff9acf45b4aa9d28";
+      sha256 = "63377f004554553566cab432567691f5c05cac98ab828790d2b31e6170d6351a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/ka/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/ka/firefox-105.0b7.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "89c3800e43cbf964038d6318cefa8fb29735dfdfe053a1853ee402ad191b893e";
+      sha256 = "afaa721bc9de934dfcbc877039524f1182c6b1a490c74040cd9a88f80d384caa";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/kab/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/kab/firefox-105.0b7.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "2b5a71b1d930eeb643540747e75a7e86da9f237c3360083a0695f2f81ea5dae9";
+      sha256 = "f1fb49fc3cad44e0f36a4b93d8865ca86153574fed56986b5a38e8ae286d643b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/kk/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/kk/firefox-105.0b7.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "05592c38ddc519a7aa0852547db390a338be263ae19e954951f581c1a9e0dd6e";
+      sha256 = "11c45debdfa934576bd018bed468d68ed5cd1ba23aa53225bb59e447358f7017";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/km/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/km/firefox-105.0b7.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "f689a206670ccd4b783c0a8d8462a0931b963167c6dbefa42c0d8c149716cc57";
+      sha256 = "673e3a75bd899b452487ebbb2cc11e1e4ba479ca523ec2dc70ef02f21775e6c6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/kn/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/kn/firefox-105.0b7.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "e3a800a36fbd038128ca2f4b7cd31fc0ac4c7fb4f6f661e041630afe0cf22388";
+      sha256 = "e2b7245903fa77dc298c403c0d1f0ced0b73817a225fc9b75edf69619405983b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/ko/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/ko/firefox-105.0b7.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "0925a0b7e9ed1c7fcae5e05b1507c133133a9a7c2955849d29c5bbf85d26bde4";
+      sha256 = "d6034ee93743430908351525beb537aba7fac33728175b2dbaa3b4a2711ddaa1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/lij/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/lij/firefox-105.0b7.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "3a011dec1722396048a06caa651ef5a7345f04192fb24f8a603933f7538a163e";
+      sha256 = "37ef77fcf09d9183d2739e4f1e996bde7ba06801c4fb76958a9c37a1561c1b08";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/lt/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/lt/firefox-105.0b7.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "0bf04523fc5eb5694c73899e9546e87b9c675cb6ca3126aee455b8dad292e420";
+      sha256 = "ef18f0531d27870a9ac21d0561c7b003802c485b003894869bc6c6de6fea6944";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/lv/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/lv/firefox-105.0b7.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "57416a071ae13d479934c64ebe3252198ffd1942d38e0d55465664b50d1ea16c";
+      sha256 = "875a15f3ac5b591bc053113ce75729bb418c8ffaa7b887cc1693857a729c927e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/mk/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/mk/firefox-105.0b7.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "06bbe39910e8772d3a05315dd602d09931091af0b6a87411a332cb3d43ee83a8";
+      sha256 = "48720e781a01b1e3303acdbcf67b4c900412a4926ba56ba2d083ecda766d832e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/mr/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/mr/firefox-105.0b7.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "9f72146eb92a8bc5c1f0d41c8a856052b1c6c8e80496d17d00e3d682f2202ac4";
+      sha256 = "a9ca850bb1587ec2a04f02bc1bb084955ebfa62b4420eb70a6b8c84b05f94967";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/ms/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/ms/firefox-105.0b7.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "a905bfea8146d6a57cf3338c263393e41a86037bc63d78b53830d3323f8a9fe5";
+      sha256 = "86afbfdbd242f529023cbf8b9fdac1b855fc785bc5a2b76f487dc128ed9c3d2c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/my/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/my/firefox-105.0b7.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "c30afce9527a8f585aa3fc6695d2f65e9680d152500044efdf78301627fa91b7";
+      sha256 = "fbbef1a89617248e39994c3b15ec28a7e63363203f918f474333a27886715659";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/nb-NO/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/nb-NO/firefox-105.0b7.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "da86e78ffcfa8d5cb582af53f823574643f7da3496372f84786e5b32e991cf93";
+      sha256 = "08dc174142f0504e5c861801c94e9edb7212f75b1ddd2618a0bf10974a339858";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/ne-NP/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/ne-NP/firefox-105.0b7.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "c0aa4784bc06e3af004d78b720c283d440e587ab96e617849aa99c9f57fe53d7";
+      sha256 = "1fcfd03fa7ef6a166ffb3b5b604f2269df080f1a7a667adee4f0fc3cff46fdbf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/nl/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/nl/firefox-105.0b7.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "e44e1b8ccdf0b870aa652105389fdd2f0bf34ffb92b91dfb522f134cb2b37c43";
+      sha256 = "d01013367ba10d4b277699400ffd42472251fa4cfee1d19ab832157d7768950c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/nn-NO/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/nn-NO/firefox-105.0b7.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "af7aa64c5709dd4234dd9083803a22f4cd7ae2d668ac2e74912f57a4b18b2cf7";
+      sha256 = "604df0b9375f10076a16c0534f389f7df1f231787baf6920faea9e377b50961a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/oc/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/oc/firefox-105.0b7.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "ed77eea45fb2853901fb3719f470177b48c69ab8c874ef51092c13591f579a87";
+      sha256 = "54b267142a7610874b8035fd7a1515930cbcfdd87dcf728267a2612b6ea3fa05";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/pa-IN/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/pa-IN/firefox-105.0b7.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "49a2fb89019508fcf8023f781e02cdf1d3724074704b5b373d2623f28c1cb543";
+      sha256 = "79ad16af9b1db8cffebc90e5fe1ae3ad5cd15d525ec6a9207ad6c549c8feb06d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/pl/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/pl/firefox-105.0b7.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "00f55a894cc64ba19151aa648765724a71bf7d325d30923ae8c0cb0a608d6677";
+      sha256 = "d8c7b8e41f31e1f0ab5b0529e812f0b4ee00dfa16cf059229e2f4a8f59206751";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/pt-BR/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/pt-BR/firefox-105.0b7.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "2943035d7098b4f76165776d193e190a4296489ebf2b9e7b8d595a5a48646c82";
+      sha256 = "2966d0d3ba90d7a8d6f547de9f637f2529f6c30641f2f31db2f91e64de5f60a2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/pt-PT/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/pt-PT/firefox-105.0b7.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "45cd00455c28b8d0e25eead3d1acc94ee69e992a67380888cd6c6ca24e3cddd1";
+      sha256 = "86b2f6b2466af8fe7168789ef13c01679803c999413a8bafb912f499cf9ce560";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/rm/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/rm/firefox-105.0b7.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "4679df642263ea46127f5a68724053f511526e63c7e8b45e723f8df80449b332";
+      sha256 = "1e15cfd326277cf7b2a7df294a7c3ebed482554b73b1cfde79894d6f24e75c47";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/ro/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/ro/firefox-105.0b7.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "0cd6e690bb9d9d4b98586ab31f55c6c439fb65aef217665da9dd986f8b0ed3b5";
+      sha256 = "5885ad7d401bb22132778ed7110998d32851c301ca2cd681ca4c8832f47e51f3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/ru/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/ru/firefox-105.0b7.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "eb62f203f1f918602845d6408009434d41289bc0850d5dcedca20d45c5528c05";
+      sha256 = "ff82a49bff9ed006aa5cbb4de32b9b0f03ecfc9df959fcc0081b44a65c275d8a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/sco/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/sco/firefox-105.0b7.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "734676f07cffe71515cfe58cbfb9eebb4dbd9e277c95e18d5a6cf204e6498150";
+      sha256 = "1dccd958bba50ccdde880236937144541c69ae04d68d148d8ea0676cf1bb3146";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/si/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/si/firefox-105.0b7.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "ca7d35d0e5e6e9b7cd7a781d9f0e390f4d0a8d73a7264b93763cdde0778eb2d7";
+      sha256 = "f80b0ff36ee4e950b07118aba76a936f4be31b6f165eb0a7c5f6a6311f85cec6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/sk/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/sk/firefox-105.0b7.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "d552053c91dff557d2fe9e74c4161bfc6c70e67767fd6d103fc4c0391fe97c97";
+      sha256 = "c4d3802ba892f91ccbe08cf4b78ba11ec85729b69d788ccd9b05f03be2c00ff4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/sl/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/sl/firefox-105.0b7.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "5629962c8561c7f17c0744524c60cfc098b24b19a14e87595bc841032f95c8f9";
+      sha256 = "ba6b0a38beb958fc1c04b72c29abb7573651952915490e40362d1da340254b13";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/son/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/son/firefox-105.0b7.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "4b8dc06eb44e2d674066d81e20a2c4ba690581d37d1a3cc3c7d230a33abcaff8";
+      sha256 = "620e33ad569ddb08a908b35893479f61e028d6f24436ae275181cf5fb9cdce31";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/sq/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/sq/firefox-105.0b7.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "077554b371195c0681be44e1cb023f793c6cf20d6987d129ed4b702632d2c22f";
+      sha256 = "c60ffab78ad65dc2d601ca7d1d18fe300b08a1c462ed9bae7110bcf60e302630";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/sr/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/sr/firefox-105.0b7.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "0b88c35685fd14e6803fcf6e57594bd1146f2522617546d37ea27e833b4a9d75";
+      sha256 = "4648afe034e724b7c29a2f25dc915643667c96c797729553fd9ebf9cbc70ff30";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/sv-SE/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/sv-SE/firefox-105.0b7.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "05969c20da144ed99323fd9ccc6ad68d7c59f9d7ab11516d114b0b39fc7342a3";
+      sha256 = "a5cd48036e92fd8beccd7888b1eef0c4674d700cffc23fe068f1f5b9ad50aa18";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/szl/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/szl/firefox-105.0b7.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "ed8b4e74b35d428abb1f7f7fead53fadc6b1b2b6c86c36ed2c2a98c6743ae71f";
+      sha256 = "984c228cae4f8e258a927efea71fc8004c1d8105fbd16e0650146ee4b3aec96a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/ta/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/ta/firefox-105.0b7.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "445fbcb39a03252af9ba55d170080655ebad1c3650ad1cb6ca922e8e6782efd6";
+      sha256 = "bf3ac91735ec4d1774f3b0b9b4888c6adb4c96803ca2cd1540cd54c709fdd3be";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/te/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/te/firefox-105.0b7.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "6eeb0e40fc1f17ebc80eefe62be0c546f5e8cc520dda222bf228557fc00fba7c";
+      sha256 = "d5254b2d5e28c4eb29046d3877c22fb5e3fea3f20140ddacc9a768045ead90de";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/th/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/th/firefox-105.0b7.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "14d58b87fcbffa36ce10bfddfe57d9bead1081cc4cf80f2885df794673571886";
+      sha256 = "a70e7001a2c930dce2a3dfbd90bec64fa28b26ef4d44a45d8c610fb51488f28d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/tl/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/tl/firefox-105.0b7.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "ed0646e23df70da7f167bc324bb28341b84230477fd7e6b4174c86100cadbfc5";
+      sha256 = "916a7d3e75497c399e11bf9da97b29ab4255f8d299ac38fdbf2e2dd9c15f4a72";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/tr/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/tr/firefox-105.0b7.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "f36acfaaf7b6fc681e10505bdd22174bf93b67f6521f481c55c7f1ed7dbbb067";
+      sha256 = "f9e4030e563e4f48230854a1938f79799187c88bfed83201d0cc4e2652479160";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/trs/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/trs/firefox-105.0b7.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "e5d523c9838371609673ec85aec4499064a14ddefa9217fc8f7e2e135e12b1cc";
+      sha256 = "1b94d24b358639f95a27270e9c6277a2b4842849fdd85c8c8f866818f0330fd4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/uk/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/uk/firefox-105.0b7.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "1abd672be68ea7196b85498a07f804c9ca5f4a4e18be4ebfd0f7e31bad9569fd";
+      sha256 = "a44b8311d8ffddf09658e8832568296a1316bf1a40a1d1972cbf0c02e964de7e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/ur/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/ur/firefox-105.0b7.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "9e9db7fb5162cbabd9d9139cfcd65993b28004e85bfb5080067e2f9b8f909c28";
+      sha256 = "aa093d955810a55959a7a87e46a2b2eac4669a953e3799d3f438fdf0e08a1c43";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/uz/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/uz/firefox-105.0b7.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "4a1236aa8926070e3ac450792350991938e6b70d14bbf17c2868f4b324ba3e2f";
+      sha256 = "2a8b7ce3dcfaaff5afa167cb1477f4aefc8bdb1f7bed2214d8cddc683b6f4776";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/vi/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/vi/firefox-105.0b7.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "a6a5a928036e5bdd53f88f1310f2229b3b3ef19ad81ce0cf9a9c26d246d10884";
+      sha256 = "4ace0bf9b421158fe8b621980283b4ef8c9635cb6b1c382c5e289677b2ae24ba";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/xh/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/xh/firefox-105.0b7.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "8b1eb387d2a83e9c0ea9c23fc705419cfe8e8fa2bdb3ce394d36f950ef77ae9a";
+      sha256 = "b8bd277d9dce3286db6b5d88639089835521234040862546ffe207285a9bea79";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/zh-CN/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/zh-CN/firefox-105.0b7.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "4f47f349479296e9387dbc38ceea26c5ebd87c04c45c5affc008f05bd322be61";
+      sha256 = "1f32136c672590d07f63624737d89801e99a827ddbe9362afdb7363d16a86768";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-x86_64/zh-TW/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-x86_64/zh-TW/firefox-105.0b7.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "7d0816d8711bca9714d368253284acd9d6cb7a07ca6c745a9ae8002b60fe520b";
+      sha256 = "c8fdccccdf233b22adf983f8e4e37f42cb25ea120a37c1152d63b19a6c0dfc3b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/ach/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/ach/firefox-105.0b7.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "c767794e9986cc20d23c1038f214d487ef23d39a08fd340ccba11c3eb6867c47";
+      sha256 = "8a79163406319fdbbdaef5726eee9b51a9b2db90a82628d036964e5e96134a95";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/af/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/af/firefox-105.0b7.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "da5c6dee55493aacf0e68af76b6d7933233dc8e61e7167526345c6d14b5eea6c";
+      sha256 = "dd30ef9f04909242712cf048e2e5482443d2ac6e7ec25a98207fe7a50466e03c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/an/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/an/firefox-105.0b7.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "7fb34063fdafe8b25441d6a81792bcb857c47674f0d1cc8de8a5236c17310646";
+      sha256 = "91e82a3426c9b318fd2a9624bfc5518753ec47784a9dd084b23bce808c37fbd3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/ar/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/ar/firefox-105.0b7.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "028c17e84d8dfb186bfc518bfc3bf786c2399403b1dd71cb8b51b7d317eafac6";
+      sha256 = "645f8e8e101e5ccfbdab9618b9488d0fc5f3295f42ae09e851ac3ec4b2e15a24";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/ast/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/ast/firefox-105.0b7.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "e6dcf44fa349dcbe1b0d5e19618789c5a14afdda53700d9adf246f48611e96c1";
+      sha256 = "12dcc595a5d0c0e4ee553113c2cb25d0d9849b460528227346a003582793fd7a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/az/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/az/firefox-105.0b7.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "7ead3e3438e0bdc354929f781816f9860d14019a2ad5b9f9c4c21285ec3ecc60";
+      sha256 = "cc01fc756e452c8ed5eeba3f181588edad0f596556c25d2814bcda051e62bc56";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/be/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/be/firefox-105.0b7.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "b48a5333f1af27f678a4bd1055477b4cf326f853bccc679a5a1acd5e339e8ef2";
+      sha256 = "1fe85390fdf39aa78da80c79b368c8512343987499d61f99f7ddee436c27042c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/bg/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/bg/firefox-105.0b7.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "3fd08b08ef6747fd757ef807eeb661a2740b53b09b11f744a8772564ca9aac57";
+      sha256 = "2e43d97831cc333cc3ab727e9071bb9ec9c3505c3e41fefa5870506e3a6abbf3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/bn/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/bn/firefox-105.0b7.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "179d7b29f6f2448a6beddf1b5731eaf9f1b15654e2dc14344e2ea09bce62c272";
+      sha256 = "b722e41397db4714d50f2c19c2b65c0387db927c5c059dffd63d838495904f6a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/br/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/br/firefox-105.0b7.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "ac30cca6daf986bc39d062dfc17b57c7b2fcabf864dc29390014766fbc1fb74d";
+      sha256 = "6524622c7c0bb66f62862023af201afb75a7a626c868827f9faed10d228360eb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/bs/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/bs/firefox-105.0b7.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "2e002a119eb6e600145049429a789b907b76bb2cf3fe89225d8fde0fd0a65ac1";
+      sha256 = "b06d698767ea11303efe7b21f29a6930d015813cdc962c981329c840946f7ae6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/ca-valencia/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/ca-valencia/firefox-105.0b7.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "f073bb982430c8877fd614cdac8b907b5c10be1c3b10a86b5e90b37a2ca7d739";
+      sha256 = "54b73cf334f79c723d9038afee3c4440d9f4e852ad482bb63510320472afc6eb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/ca/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/ca/firefox-105.0b7.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "b7cfa0ebb87116a41b4fb54843e139b5f16018e6f1e770773bea74c6ff8ff292";
+      sha256 = "d9fa450f3abd89f9ae6eb5fae8ee050df2c82fb73b50b31bef8254f9394ff404";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/cak/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/cak/firefox-105.0b7.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "fcdef5fb64d64c41d74105c4effff7bd215520f8f2b11e0b70fdf6a4ae787233";
+      sha256 = "8cf2a58a84b19954631b0f95b47e5bdd1d647711d64237afdb6a4cb3eac29073";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/cs/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/cs/firefox-105.0b7.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "547f150b668a849987c90f6972fb0faa6bf8c38d62d3a4defb53084c8ac6be46";
+      sha256 = "8e154ef48fcb2c178904e80133b932c776deb54387672e00a9a2ef9e47f7d074";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/cy/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/cy/firefox-105.0b7.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "20be6b4385547f0a54235fb7feb8e89e07762c12f12e0dae4df1690ec0390af6";
+      sha256 = "8da8c8a21d247b08ad38229750ff7ca62c3262249e7d90c5ce07d47e6184c519";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/da/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/da/firefox-105.0b7.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "42b748e74095677c7ec80fb8c8994fe89b10913f8565fbe3f3437dcf65b6001a";
+      sha256 = "1f8d6b3cdca8f96ce4492b5fc764c5e36f50f11c63284d7963603d40051a4017";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/de/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/de/firefox-105.0b7.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "187852236ad5aaa222990beb46bb9ff8d49ffbe389dbeffb597753f8e45ef9ca";
+      sha256 = "cfee445a533dc5e01e3db63318e4959af1748192ea72b6dfdb86c3804b83a84f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/dsb/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/dsb/firefox-105.0b7.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "460a94cc0210d71addd0ddf00105c8ddb2aa9d2cc484cec7c29fb516372473ac";
+      sha256 = "a2736e67ff9547ecb6837eef11668ff1eb2905b673a0efb224dee6f06f411fb1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/el/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/el/firefox-105.0b7.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "941905124b1f70f4ef7af17374063a1f1f82abf2173a32a49ed09cf9f43eaa3b";
+      sha256 = "197b6df04f42212663386822b2f2d22b88262ef06839e9d58ba204410142deba";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/en-CA/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/en-CA/firefox-105.0b7.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "f214a9e1ac2b34b507c22eb19afb158b60bc28bd00523a8fb1bcfc94f7e1f0cc";
+      sha256 = "5c7dcc47da6d2cbf0f95a7c07e33732af6d95a5f5a2f5c2918bf5e470f9abddb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/en-GB/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/en-GB/firefox-105.0b7.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "2815c568df0b5f75306eb86f9ba73fb65f836db2180c80cc9612fe9766325b81";
+      sha256 = "cc8ed9c353bcd702b8c1d8568994cb46c2564af2d5b18972c083061dea530668";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/en-US/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/en-US/firefox-105.0b7.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "e99d2dd51ccfb12a81bd3c5b7d1f6b5e93162bb4ad0328dadb8ea4a47a0f7062";
+      sha256 = "d7691688423e9980be334ee597b83956bed93ca3ec681ec3a776232b3de799a1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/eo/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/eo/firefox-105.0b7.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "4c03a7b7931aa210b7c16728b2d30042a2562cee6a1e337bfc6aace3d7f45215";
+      sha256 = "7ef482769080f3cd5bfd044764af9800737e17f285a66ecf5c01e4786211e0a4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/es-AR/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/es-AR/firefox-105.0b7.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "53d692134721977045d23cb9d5fea97098338b4bff7c0f76b6dd1d363bcea4ef";
+      sha256 = "7bf3e1ba9dad95fc339d8a4a3bbdcfa28d672399e1b10baee6880d9ea89c81c2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/es-CL/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/es-CL/firefox-105.0b7.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "c8ab9bc7a40aeecf602ffbbc00f04050a940bd8e59efde04920774513538b2ba";
+      sha256 = "e4e31c38221213f379c83f93755c7465afa8dd8b7a30ead56c99edd6d9fcc1ce";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/es-ES/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/es-ES/firefox-105.0b7.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "749b87f68f03afde1e30569d141a1a7718e1e374cb20fac00b89ad42bdae932c";
+      sha256 = "4c5b106a1683c69bce4534ac4facd87a89cc551218bf9aacf84ead1411a4286d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/es-MX/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/es-MX/firefox-105.0b7.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "c908eba75aab9fe7ba297155198441cbaf1ba990fc79013e1cbae13d6e0e874f";
+      sha256 = "4dc95bd04e33760d979787340cd14370cc06bf9b2cac6cd66ed8a75e42276b30";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/et/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/et/firefox-105.0b7.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "42a525c9f19bc947ed52afaca888f8239ece5cd519b964e62e00f0310b3a159b";
+      sha256 = "864a21c72777aed316a13b5a7a7d6f3214c66376417e9c4338ab415e4f175814";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/eu/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/eu/firefox-105.0b7.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "fb5ee665865701b49108075fb87d0e4dae5ed9767e74c533aa7ed0bfb3127771";
+      sha256 = "ca54b8cb3e4fc3dc1314ce77e5eca86f1e31286352cb379ab43c1fea7e4229c3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/fa/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/fa/firefox-105.0b7.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "d5c6d934ea9b70d1761012c93d8c40df20c863c49a7291f7b2a4bd545d88e58d";
+      sha256 = "429db01b9dd0169050ee14bcf4ef79013dea13b6679c15e9158b1ed47a3b3620";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/ff/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/ff/firefox-105.0b7.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "46dbc7bbe5bf8823a929b8528b0e8dbd1bd21ad35b955c6c332722ded9561864";
+      sha256 = "176790d8f9b70cf81274676e2019fcd2cf25fdf8c22a23e42e53e8852c18084f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/fi/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/fi/firefox-105.0b7.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "8550a63802252270ee3d9f4a50fa608704c56ba99f1a89324f17ff7fe5d140a7";
+      sha256 = "b57bb43585d2037a411d8f5be52800faa480f636372b86b8238484055bd5e449";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/fr/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/fr/firefox-105.0b7.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "bd388b66bf5a60df588ce4e658bf0b69f80d8e58eb669369c5d836e790def1fe";
+      sha256 = "e18817bd6ba798f743a083c7be8de83a716a919ed800640b78021b4baf3a5d52";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/fy-NL/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/fy-NL/firefox-105.0b7.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "7e342e203e62e36e60e0704468409650507de8633a3d4d4e09dabb46e779b5d6";
+      sha256 = "3f730a5a65eb4bdb97965a37f87aef37f1a00a8209cfd1f6a2bbd97836b2c4cf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/ga-IE/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/ga-IE/firefox-105.0b7.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "6129c72a648314faa82eddc0e247ef605761d7547937900725f6785da9f47bba";
+      sha256 = "b3c26a42d9bfd6b106ecf5edcf28288defe080adca3f9834d33000a7779262b2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/gd/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/gd/firefox-105.0b7.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "9fb39f9f90357a48331c66dd060ae6b01021526f7f07e9bf70ae5b15ac19bc0e";
+      sha256 = "03bc483a77990c7abd9145e2d38dba8a61fd5bc256d5baed332b82948cd75511";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/gl/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/gl/firefox-105.0b7.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "d3d96ae9aa53ae8dd48add2022751db633fe03053f3721d8eeb09ab3edb41224";
+      sha256 = "e5a699d8287babf72c091443c52af0c11662e995c07419c3ac57020eafbe7465";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/gn/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/gn/firefox-105.0b7.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "c9150894db643a4051059385fabc71d1d5d33a20c42f43285140f2358d9391ba";
+      sha256 = "8443c87731f3c0cce14f2089181df277500cce1b74b11d56de66774cb7c4272b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/gu-IN/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/gu-IN/firefox-105.0b7.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "a6c7ddc3dce46c4e12f4832cde7f4375dd75e4f8e53df40dd4c3a117e338b39e";
+      sha256 = "a354865fade4730606241d7ce6e26e9b0552b3127ed0ab480e83fa160c02a455";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/he/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/he/firefox-105.0b7.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "f3ee92e80fca0cb0326d967443323ffd326839f2bbfd39976830f49d11a883a3";
+      sha256 = "ee828206a0de497eb296951e3d6f34b7ae1312299a4cdea872594cc0d0d4081f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/hi-IN/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/hi-IN/firefox-105.0b7.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "51bd3dc16570737ac59d1de8fb3b82412cfc8e044fca0649c2bf04c734d95fba";
+      sha256 = "3215bbaf6d715fef020466d4f747695f66208351cc1b040af44b0596465e723c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/hr/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/hr/firefox-105.0b7.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "81311a51dfb6d107f420af7086511f5ae3e0427a246b384faf25e7b3345e7e3a";
+      sha256 = "7e412b19745b586ce46a509833c5a65033e35706728034ee612ee7c2430fb06c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/hsb/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/hsb/firefox-105.0b7.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "26bc5999cf16db2bd4291308bb79a5a5219301dbcbfa959de395f9bdd435fc2e";
+      sha256 = "a5faf9ecffcd0084d5b2951ab735e2b76b6dff19585b0ad632806493659ba2dd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/hu/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/hu/firefox-105.0b7.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "ab24c9fe7a18d64a431a31aefa97dd1353a2147874ca5edff276a812d4d56927";
+      sha256 = "29dbb8f19c6856323a1d6085f55c40e9f7d2ce15acb9b9ce50e4f4b8c1519da9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/hy-AM/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/hy-AM/firefox-105.0b7.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "3f9328be047cf83bbab5fa0194e8a306f807067663a20bbe70b789e6d7fb9f36";
+      sha256 = "e604a92e6b100edc085d6da7a2df58f9ecaeba2c1e776a2285245ca61867da8f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/ia/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/ia/firefox-105.0b7.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "670a30d73eccc21a28b72a259ccd7b68156df96900b2aa302b9b908ec08c6eeb";
+      sha256 = "d7b63d055c83501b772423b7d6aa8c15997602e3db6efac9530b2a84b47008c2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/id/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/id/firefox-105.0b7.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "7e709253057535b0ee3bf0e965ddd75742995cf484f765eb89e5b83f7ce6c535";
+      sha256 = "0154283f68d3cd5ff3739d61f238f9814ab187c1fb7654e4116fd69b8877b251";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/is/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/is/firefox-105.0b7.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "cc35d4efb18ea5eb49581823d1d38f80dadcc0c4baecbdfc3a1fc3d321d6a982";
+      sha256 = "8a726cc353c2474a3f0ab45580cf5ac65e6905521af0b0bb9493eedd707d4c97";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/it/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/it/firefox-105.0b7.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "129e10dcf807be40a15ebffdb3f60b8504313f7e9b2a652feae3c811952a340a";
+      sha256 = "9d7f56ef7547f6b6dd7c9e4fc483ecb93d9c185c842e90b8fb1227c1ba2bc99e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/ja/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/ja/firefox-105.0b7.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "ecb957e2a06b22b2d613d69b41583c309c7392d9a914896dafd94cd4be760b27";
+      sha256 = "10505e1acfc1e67f67971cd779b414dc0db3fae85b80402cea5d727b21596dd2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/ka/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/ka/firefox-105.0b7.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "5a45215eaf6a6d08dbf2a60a01b5568950adb6b1aa4d53168d8b9746140e2466";
+      sha256 = "c7e69e19221d5ca83a6ed290597e4e5913f742556552692e803c9af92fb9fcfe";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/kab/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/kab/firefox-105.0b7.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "627639219e8d55eec4ed3bbe4bb423737fe71d92cbf582d05236949ddc6766fa";
+      sha256 = "828c84f727177e72d712db0a6530b6cc963b7e4d2b4341ee8d0521d66c4d6c24";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/kk/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/kk/firefox-105.0b7.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "623b3bb504923ea1f679fb320ad63b7ebf6d57b8a3238dc40c101f7ff8dcd93f";
+      sha256 = "3ffad382088f692beb29f6cce6549555f53caeea9f4b8f4d63f4305d5b11308b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/km/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/km/firefox-105.0b7.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "ceb15c2e1505ef24e5dd8fde4f9cb6d0e56397defb5d41a30645ad774fb93b5f";
+      sha256 = "3c0bc5779d894b9473071ef9e92c03caf6d7f28f7340ac8bf7bcc3cd03b4f082";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/kn/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/kn/firefox-105.0b7.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "4000b614006c9f87c8e6d6aa25bbac9af9c24214ac799b4b579adbccdefba45f";
+      sha256 = "1825fd0001d3bb425fbbe47769911624c4f067ba92e3183556d153577ce37dbf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/ko/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/ko/firefox-105.0b7.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "76a0d32667325e2b3ab00cc85ef7b3c8460b954c865f51019affdc96ec97587d";
+      sha256 = "edb36c21d31682bb5858937a56496f2bba0d5249b55cb8cced4cfe8f70c8f01f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/lij/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/lij/firefox-105.0b7.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "5e0b9335ebd118d5dae94258e37d4d093f25ccb6509d77f20abfc2c3b80c5a71";
+      sha256 = "26f5b03382dfeedf1ead9831946147a3e60d44c03acf017bd5425cef06c812ac";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/lt/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/lt/firefox-105.0b7.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "9ffd85855204fabe654c4a2673db478b08027092c5883294673a374327085c99";
+      sha256 = "24c08596879ba8a5e7cd3b2b8a044e349a5a067feb0ed00a7545e41c2ea5360c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/lv/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/lv/firefox-105.0b7.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "c97d1628a91e8336921733262901c609ca462baad4e01ecd7d28712d5fdc5ef0";
+      sha256 = "9f5bd67bb40ee418ba7b4b98b33b0a1b54a9f934b0d221ec1c142939edaa9d90";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/mk/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/mk/firefox-105.0b7.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "5435ed668d3dc2292d5e68715c0ce19262e328044a7ec67c387938b31d3d05d0";
+      sha256 = "a0f662e5c8adfa5d63b99c0acaa19655fef74f09d0f0102e9e4a244d9cd7ebfc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/mr/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/mr/firefox-105.0b7.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "9e20a34c88c72c1f2f830b6830c14a4c1f2db4f8c5063292176f0a9f4fb28ce4";
+      sha256 = "f6f4a7e00d3603467c0cffdaf7d655d37ec867b26234da2518f508d574a4a92f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/ms/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/ms/firefox-105.0b7.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "81e5fb499b8d380c141963262829f0d7f043cab5f80bcd3381a22d1cf70e088a";
+      sha256 = "76a9e7df0a6d7c097e6ea43103024c8245c74ff01900f3bb0042dddd6fe30546";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/my/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/my/firefox-105.0b7.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "7df0ac77a1f948e6a44c99565193d4e5b74b28a39380b25a5aa1043e97cb5e49";
+      sha256 = "707d9b7389cb13d4a353241285be6fb249fa3dbbced60c9ddcea806d7cc6d82c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/nb-NO/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/nb-NO/firefox-105.0b7.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "14b17fa54d1a33c8162b1f5ef9c00d266069ee84a3402c51afa65ab91e783b10";
+      sha256 = "0b4c9e37989f9946c45d29d605428ad1fd5dae2901eb1e001801af968c54a553";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/ne-NP/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/ne-NP/firefox-105.0b7.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "fc06d470f4070d3fff135d0a3dd2ca464a3846eef8f3774c51e1905c0b2eb8c5";
+      sha256 = "54870358a207b77ad06d74b97d3d0f02ad72d6ad03176a94ddc52a0ac68f59a1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/nl/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/nl/firefox-105.0b7.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "e623adbc47745a6a1388e20c11482f68573d4a44ab95275ab3934e84e9428bae";
+      sha256 = "4980f4d5d022c9374a1c64bd1e3d6a00e16996d357c5c2e5c3976dce295bbb6f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/nn-NO/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/nn-NO/firefox-105.0b7.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "d0ff8a50854e3debb97c9c7dc73fc99f659e85a08eac917d52866d79d4b3e393";
+      sha256 = "4022e90a4d90db67f9d9a9668cc447ca9d56ba6d550dd4afa5b6bfd420307200";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/oc/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/oc/firefox-105.0b7.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "bbbe7b10ac0e7904364314f9382d6331cd77b2b37838e316376eb9df9ea013cf";
+      sha256 = "46f616ae6c48f0d3cb49c01f50eecf11166f32d677c4e6ec1d7d28fe6340c035";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/pa-IN/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/pa-IN/firefox-105.0b7.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "c8b9062f72bb541571158a04038657a13c15d7e344f789f4d8af94ce9624ee36";
+      sha256 = "e07c3639c91bea102044aca96f60d5d58faf2d49dd0eefae88d04bdc5081c71f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/pl/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/pl/firefox-105.0b7.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "2709903cb56bda2f3e5dba0ac49f99238471f1fde15a3898a84a8a47154128df";
+      sha256 = "8b5458468374cd6567581d3c915bef7be22d535402f6d9b1853229a2877a58a4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/pt-BR/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/pt-BR/firefox-105.0b7.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "28550c7294ec55d5b3ec79dbbac3f452f6f092bf21cbfcc120ce9d92d090ae23";
+      sha256 = "996648fb5c185952ed441997ac689c4d8da2dc064306b3aff1c32405da8e85c9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/pt-PT/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/pt-PT/firefox-105.0b7.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "4b93a7077624e3f3fb41c96d30d128762c539067c4f8b964cb2cbd8cc92663a1";
+      sha256 = "b92ca1f134e09d0587a64b87010058fa30ab3a49035c41f07f704c0a40da2670";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/rm/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/rm/firefox-105.0b7.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "0e968e910d21891bb3904663cfecb51b5de0d8f830958b36ef618289f9f62773";
+      sha256 = "c487f6b873c3075f94247affa4dd27b630d5544664c1cda405b6b60fd30f4068";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/ro/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/ro/firefox-105.0b7.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "6ac4bd6cb07cc517bd8a321d4d08ae0752934b56317b7deee93c75482ec051f1";
+      sha256 = "07e0cfa7f8ccbb31bd0b7723d35f64316cbdbe0f676e6f9ca907238ff20a979c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/ru/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/ru/firefox-105.0b7.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "2db391678d197b710e81315b4ccbd196170d870802110d252caab1d59f7349b1";
+      sha256 = "0b19de137527fcc99f45e516b5ed34d044f7dded24f3fa1f7546d4744d7cef44";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/sco/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/sco/firefox-105.0b7.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "660199a409d85280512e7673a17e41a97c0e501db646f7a80fe29ab9319f4b18";
+      sha256 = "c7e5ab469c7cda3af0dcdaabc50e15a7acad613eac4212a7d1d50af6b8cffede";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/si/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/si/firefox-105.0b7.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "df6d08444b32946cab5a79a7c8baa8a54c25b306e8f599dc90cd1f40557531b7";
+      sha256 = "3ecf4f710a9858b203331b845a9ef4a0a8c0d156cfa4828da19a7b4c0dd1c636";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/sk/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/sk/firefox-105.0b7.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "55e2a3e70a14db5f05ea53b503ad1844027cbce963c5df9bfd18cf1ad9cada91";
+      sha256 = "058eed9e796918659be9385ee12d1988436140de55569a4c5d6e27bf1d1bb925";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/sl/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/sl/firefox-105.0b7.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "8539728ab0bb61facb3406878785ed7206f4e8fb647eeeb70c1d97d63c0d7692";
+      sha256 = "b31053632a69d89634d9e6b22f842b2b205ce2930ca740081044ca18bddb84ba";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/son/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/son/firefox-105.0b7.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "e87b177c2f39aa7e43199d336743cf7a3e60e288778b225e0716e61683bbe6ac";
+      sha256 = "0ef828ca1e35cb1eb2d9026a9661fa042f4ab45e17c0f8b4cd4525f1d9deca47";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/sq/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/sq/firefox-105.0b7.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "b74e2df90cb6158ccd528a94f4e3f2feda4262a3c3fce8bb165b85823e7eca7f";
+      sha256 = "7a77233f388062d298dd414f51d16c162cd34a0c9200835f8327acd3cbb49195";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/sr/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/sr/firefox-105.0b7.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "5ad05b4928aa5a88fb5821702e1e88f4531e85aab1f99f4ab2dd46396f0f8ef5";
+      sha256 = "2c37d2f0ffc5bcac7c418925835d2d99c2038a4394d8c687547d3a6da9a67d99";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/sv-SE/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/sv-SE/firefox-105.0b7.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "838fe74cc7b7fc79d121b5359ef9d099a785a0562940fdca1a02e08b4afcf327";
+      sha256 = "0c57588c2e263b2e0388594784ef5a99aee25ca9af5d5f1aade62e90f15dbfe8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/szl/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/szl/firefox-105.0b7.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "6bf11a1bd71b3171d1916078d489405fe822b9366a931156aee5ac7c46186753";
+      sha256 = "94440f21c940eb0919cb0f4eaee0a1e78c84fa07814c1f430a37fc66ea8283d5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/ta/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/ta/firefox-105.0b7.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "162087213dd6628bfe546618fb4b0cd2dc7170ed9507f3e2a2f9833731327a1d";
+      sha256 = "f02e8ef3a2980e4efff329f352c569fe57f06c55260d9d84e879ededc9fa525d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/te/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/te/firefox-105.0b7.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "2807be16c6419e4111e585b52a34c948ab3cc5873444ba155cc0336a584f53d8";
+      sha256 = "f425dbe7c83e16a5b40d04272d88dee50418ab9f12121c8f3ddd123bd963e97e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/th/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/th/firefox-105.0b7.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "e3a443c09f2ebe397554fbc910956c079de6b4345071756734a5f748722c7a4b";
+      sha256 = "ce5cb99e2078e8e8071904c5555978556fabe3e81c52197c95a97a4fd7af8781";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/tl/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/tl/firefox-105.0b7.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "75dfbf0ecb2d64a0959ce3909e8ee4dd46cf483634ec81a5772dd7b74022cf46";
+      sha256 = "92826687ce1dda746598a25bdfdd19558c15619b3adfff17d50fb06c81c4a093";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/tr/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/tr/firefox-105.0b7.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "c80863a4411db9cc893a97b4bb1e5e1c150c18177e309534152f42d2785b746b";
+      sha256 = "0191dc0d436017946a049e9b58cf286751a3a68b3609774dd4f472798753df6a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/trs/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/trs/firefox-105.0b7.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "b53405c1316833e79c4401f1dd382e70a12ba5543d5813a016774958c620649d";
+      sha256 = "48dd0d4d2069c6903c09225c4cdcf554a71f159dc949300eb61ecc4f7f2e5206";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/uk/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/uk/firefox-105.0b7.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "4f07d43eaa16460eaeed370257527a48b04a7b3d2dc0a40ab8bb013d8d291028";
+      sha256 = "46c5195e8620e89359d4ec3ef4459762998741157024083104244c2e2b0fb555";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/ur/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/ur/firefox-105.0b7.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "092528797f577e986d8542bd4a6b698e7c9561a22c02435d3acc128a72c4b09d";
+      sha256 = "8ff1c85efc895de8b77ebb45fa70533c7c42cb14435b93630a5b61e21f5990f6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/uz/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/uz/firefox-105.0b7.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "e3bc907bd0edcf667df73448f40924be8cd54195d26b23472a0a819141de3f9f";
+      sha256 = "eab0e07f9ca884635f2cb5af22633a62e323856306a055f94117f5d4c97d7739";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/vi/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/vi/firefox-105.0b7.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "71a2cf4843e0a1e04dfc8448331ab847edfee153b583a0e8c7c63771ce8d15d5";
+      sha256 = "6fd296c409afcd4393ec882d33ac42dcc3d504556f77ee66d3b1a2da3a8954cc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/xh/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/xh/firefox-105.0b7.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "b7eeec581af2ae770380b78449cc19774dfa897e1cc845078d73258f67bd52aa";
+      sha256 = "c979fc5936f031087d7e5ef34c7469a3304846164aca3d53c6d2a47b2cb191c0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/zh-CN/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/zh-CN/firefox-105.0b7.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "364454910726556f534390e1f2db4b1983808b3b4801154597adf4ab2a49bcf2";
+      sha256 = "0d0fe599a723622827d09dab13ca90c6be5806a50e0af58eeae2556259ca5622";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b4/linux-i686/zh-TW/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b7/linux-i686/zh-TW/firefox-105.0b7.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "0346667d226f74dbbb15b42ce0e7408f1c3d5c9773ae12f99126d1ec0f30fe11";
+      sha256 = "864380014676d51e54ca79dc35d9d78ccf885ac671150bf3e31c2ad63d6f94c0";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
@@ -1,985 +1,985 @@
 {
-  version = "105.0b4";
+  version = "105.0b7";
   sources = [
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/ach/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/ach/firefox-105.0b7.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "a03cb9c1272b467728effbbb9fc836e8b81a6af53d8a22455706b546f49de452";
+      sha256 = "f9ed5881dd2d9f4e830a8b41b74c97f753e90815f26ff9cf84ada35ce82e756b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/af/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/af/firefox-105.0b7.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "30aaeb8e2236f9053702bf1fb722fa4fc0122c68851d7371ec087b8e4fb4c905";
+      sha256 = "ba43220df73912f340b4b7906d528a9eeb5fff97beb2f98561c7ff1bb0523ff7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/an/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/an/firefox-105.0b7.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "fa7d5d71e7d6d196e08dc4421ff8766ac4ea4091b84986b3fb1541e118665fd7";
+      sha256 = "0bcd4d4c3a9aa12929a360e2cebe75ba39561c3a5e0bf035daea917a50cef483";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/ar/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/ar/firefox-105.0b7.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "04703a211f24378893ad2dbb3b15573dc466360758a3211cb735de9495461210";
+      sha256 = "885eb5fafa64d128623c237fc9e512a6a939e5db30e36e2074d9116ef3902bb2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/ast/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/ast/firefox-105.0b7.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "d08e3a4d8def85371b180116fb9fb3f034847cfa1c9d62a51c7e9fc9ff280d89";
+      sha256 = "2db2eada936647e9c0e3ea7015cc68f0efc4853fb699ace541665409c44098aa";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/az/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/az/firefox-105.0b7.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "f2b5b3cbc7385d4a09d14fa9ceea2275092d3fd5b4bc34ef2220c4706c237e80";
+      sha256 = "c1df6ddcc0f04520a25248b9166565569a77e84e5421ab331a150b704abcf947";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/be/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/be/firefox-105.0b7.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "15574d7e968636efbd74b8e4355dc336a6713024816d678456d3f97f03685647";
+      sha256 = "a40cfcb8f4c7a86c306d757f20acb555523d1780cd4b355a07cb5b395486d6c9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/bg/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/bg/firefox-105.0b7.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "e5899a4d96dffc141bdc21a1b1b0ea89b71415b587c0f9bd6588a56fc937b3a5";
+      sha256 = "366a6cb972117fc0fb0246c969b299df160fe8342d751774a6846abe4d833e2d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/bn/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/bn/firefox-105.0b7.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "554e2eeb1099e94a991f0730cdc8f92bc426eb973fab4eb9de6537c1e0c32101";
+      sha256 = "f5f7aeaf73ee7bda731f89c48cbd725180421208314797f15249ddcff7935890";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/br/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/br/firefox-105.0b7.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "65456e0cd00ef1407f5ff6d8684f932c9d97ed6766a322e538ba64dd514e99db";
+      sha256 = "d795103d86c8b23096f48f51008ce1df592d543b801141e3da8b2ec90d5ed760";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/bs/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/bs/firefox-105.0b7.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "bfc33cd99f5950691123a01dc1e3807d45eed4c2d1aa4cdebeda71a5281c7baa";
+      sha256 = "0c2928e31be0f601f48c560eca2ad32c95127b5775febbe1b6c590989f49deff";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/ca-valencia/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/ca-valencia/firefox-105.0b7.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "1e4486af8c3dcb08394db6ecff575354c4728fb7293939e95043ff86918d928c";
+      sha256 = "f3c99892e9357da2191b2c408fb6ea72cf2386907eda18c1eff8a00eccb5c73d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/ca/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/ca/firefox-105.0b7.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "9e85c6a56091eb67d8f39593dcfb212fc979b7c326c8f8107837cca8bc011080";
+      sha256 = "c8f84af5c19422b73a34e1342cd93cac28bfa10acc7f7dcbc06222f75693f95e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/cak/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/cak/firefox-105.0b7.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "dcdf6bc00b3620e591051463d0bea90d2dd36b7b074c8b870b77fc85f5a8f9a4";
+      sha256 = "9838b5224d7e161bfea451124e19f4f8a28f96106cf1dccbc5e42a87bc86846c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/cs/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/cs/firefox-105.0b7.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "ce6a83929d2a53d51e47fe250e48c4cbb396a3a505373fcea94a8ec5f6011676";
+      sha256 = "327b12321f68c9343a0ea4d3adc10313a363e43398cdd1659e842b681ba7f8fd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/cy/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/cy/firefox-105.0b7.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "db00ce4a2432319e01838ed370c4e4e2ffe8c7ab483266e5e5f6dce12ce55864";
+      sha256 = "11d4f2a1653f1433b990a762df574c7ffb4f5a53153c0568f7ac23603a3cfa4f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/da/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/da/firefox-105.0b7.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "d9c167f7458bb59c5b1c2953566adabfd76d21205f49634cd7904e18a34f7b5f";
+      sha256 = "ef6b515fca5e076a461aa3976333b622d47082433985ee251bd8332c01bf9f53";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/de/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/de/firefox-105.0b7.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "a7710dc4e3796e7490a5059a6baa0f9abd88777bd34fe424df03cc4a61909688";
+      sha256 = "dc041053c2dcb548dbdfdf6ba76ae38c175b5cb6f6176f483d9e9efb55677871";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/dsb/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/dsb/firefox-105.0b7.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "5ebc91b805126fcd634f49af3a5524645d4453802c952d0012d3b8e67c457adf";
+      sha256 = "ed042c438d72e8a829861061f10c2673e5c22313c0353d368e95ad11e7c18c0e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/el/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/el/firefox-105.0b7.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "b29457d294ce16af339915997cbf7a36a13142e28420376e819dc32a3e23bf6f";
+      sha256 = "ecc1354b763f8c7abbd9a66ff70f8afe3a4270833d0f8f362a2f22a6813db4af";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/en-CA/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/en-CA/firefox-105.0b7.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "698d536a237e15ae8e674386af11f219dd761af62cb127bfcdddb21a584db9e7";
+      sha256 = "28b46a62d0023c115b202ae6706c1180f9a078cedf7026c04822c48fd2d9a905";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/en-GB/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/en-GB/firefox-105.0b7.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "cac48184af7e8c0faca88b80d7463bca23d973e9fafd4029229c84a2548525be";
+      sha256 = "a295f0995de373c2475a61a38805ab112489097bb1a227b9320bdfebd1e8ffb3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/en-US/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/en-US/firefox-105.0b7.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "eae8c5f2c646166602799b41b9058d010f85711c85b638a7c1157b956cc22422";
+      sha256 = "c6e5578ebb31521edccdbda4469b6af06701aa37c168017e00ac28c9f5871e95";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/eo/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/eo/firefox-105.0b7.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "ce248e3b878e3b0957827a57f68e7c1a201b84c107c6a171caa34f41f3e37877";
+      sha256 = "e4396046f3d8f8f4c4100869f6ed7e806ea39ae0d19649d419d8c6148ac8dd64";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/es-AR/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/es-AR/firefox-105.0b7.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "724e580299822f5657708d906da2b278847105e1dc4043e724146092f508f039";
+      sha256 = "d6c2c0a18ec5cf9cf6a4ec1b099dd494ead653053f5796fc043d676e3e41b696";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/es-CL/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/es-CL/firefox-105.0b7.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "0619d485159835e7d5c71a75f27e86034398c483035b63e66cd1d8f427239704";
+      sha256 = "d2681a37c03c5b16a79427ddab4853eb1913d58820e6a1aec6e61e68376a3399";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/es-ES/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/es-ES/firefox-105.0b7.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "4cf51a5452d1902335c8782a914272d4f731dd5d1f670ceefc312e128b8ca78f";
+      sha256 = "a8b7b4339d544fce843953e2cfb6b8d9ef9c13af412eb8cba5d349881ee5d879";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/es-MX/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/es-MX/firefox-105.0b7.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "eccdd06641310c10617412f0d176e851547574ed888192008a73ecfcda8002a8";
+      sha256 = "a63511b03dd4f4d42835b8c31df2e0185c5f5ca965c911095773bc5936e9d75e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/et/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/et/firefox-105.0b7.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "fc06a8b667ccd9447cd6e3884373cd0c5e60470a9dc6a97b17007f7334908341";
+      sha256 = "973e3af967aea805fd2a8d3d9b8a39fec5b41ed27cc85400a1f094466b929ce3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/eu/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/eu/firefox-105.0b7.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "4eb1e383ad39267c97b055a655d6d068d8b14437b9cd991206e06300a3245e16";
+      sha256 = "938a441056aea6370ff4469d3177c0becb1854dcc61897e005af4198d0220993";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/fa/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/fa/firefox-105.0b7.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "d898e5c0d11737e9bb95524b351a384aacb8fc5bb8056fc1714829303ce14588";
+      sha256 = "113c442b04f02637881eca2023948101bd19f34476397176fda2963c177e7808";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/ff/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/ff/firefox-105.0b7.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "cdbcc45b849db770e045e38bd03961be85190cf98862ef9d59d379c5519e3d11";
+      sha256 = "4606ba39899dfe2bcdc03d2867541d20a3d350e242e53895830a927cdf34897a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/fi/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/fi/firefox-105.0b7.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "4c8fa002f2d2744dd01835f95b9ac4e83c2dbd6c135d1fa4f71d83d418ac8445";
+      sha256 = "b3451c3b34f3307593ea65f061ef69d402a1ad5a1ae5606e6f3e104feca99850";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/fr/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/fr/firefox-105.0b7.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "7c9e5f58fefb084a447b7f4eb66f2dabe823c7f89c758688f047628f399bf717";
+      sha256 = "4d70d97bf7c9395f14177dcdb4641a6d2ed7c12156ce98baae768bb47c321b67";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/fy-NL/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/fy-NL/firefox-105.0b7.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "f55608e30f5a43b51b53994bd1bc8ceaee4eafbc2730247f6a6af752820402fa";
+      sha256 = "2ecd33855a8eee051f578c8d13c0762074985dba5384f88a67b251528e14885b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/ga-IE/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/ga-IE/firefox-105.0b7.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "f7fce57d6fee28991ad1a3ebec38bbf3a78b6ed66c9a6ebf34a280a5f274fd19";
+      sha256 = "d413155c768b783b1cbb04c514b52fb573fcac490ca8440cce58c295d0306c33";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/gd/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/gd/firefox-105.0b7.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "1137d3a7b4f270821912bd8cc8114125189d14eb42c5f9f65ace0f22a065b870";
+      sha256 = "df287de7167addf9081f1d69f50f1ff6e67c70c93fc600ef1ae201e808a88073";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/gl/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/gl/firefox-105.0b7.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "6f7d194dbc68e1f2cb5e5e4460f8ba6824592fc50244dc478237cf2733fba497";
+      sha256 = "4a36292799dc25444f6f08205e210dac923d24a9eaeefd5d136eec8456f82fd4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/gn/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/gn/firefox-105.0b7.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "b6c1e6f15dd70f0359f308a297d64a1609d661e8d23319946071d6003ff6e191";
+      sha256 = "f6029ae4595c31ee753f72412c400cbcc98207b290e72647cb1b66abd8020f28";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/gu-IN/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/gu-IN/firefox-105.0b7.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "46f059e8efe95ff546404f8f2e70ce99125db928354e0230b221b9becb2fb5db";
+      sha256 = "2448c1681a9ba7522756d31608e6ca74ad8816ce335be0716e5e26d9dee44fcc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/he/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/he/firefox-105.0b7.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "79b9d9a0934b611d324d49b56437203c32de6b02fc852d111bec39db34b9f623";
+      sha256 = "e857b093da44ff11576879df759c55f5b1b3f87f1e18f5636a3d688cd1fc8876";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/hi-IN/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/hi-IN/firefox-105.0b7.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "3f31f6b8f2a3bfff198afcb4f3c86e2360eff6e783f7009f4a311d530239dbc4";
+      sha256 = "ac8454216677cf05eb815ca1611a47d2be33f0fe72b2ba721dd472395608fbe0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/hr/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/hr/firefox-105.0b7.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "9b6d8c05eb52a6e4748bf003a3e3365f3b359e55d8b2b782b726ccd45b0b8261";
+      sha256 = "65c7702502fa59bc261aebd3af8246f40072ad2dfbc605f5c254ff2a51bf108e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/hsb/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/hsb/firefox-105.0b7.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "405bb71c53a86422ae0e13e713e933731982a23720b4775a71dcf2dc855eb883";
+      sha256 = "9715966ba1f6b9fe691473c88fdfec93a3e544da0486db61149d6b69efa119ae";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/hu/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/hu/firefox-105.0b7.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "0f3597fbf6311010de09ab730dee286db7478d9a8ae56044b869550a67f52a99";
+      sha256 = "a92f2ead63d16f2dc52e9b1d76546fc1ce2e70318dd3d92fc3e65e36effb0021";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/hy-AM/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/hy-AM/firefox-105.0b7.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "07fe5a07700123da801179e5061e90ee9fa1a25b504af3dcde31ea605aa63b26";
+      sha256 = "d2936ea9570d6122817369b0938ebdd406c845dbbfae3282b338d622333e07b4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/ia/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/ia/firefox-105.0b7.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "f2e7e0d481d309b64c0c75fb784bb069e123d7dca22af2ad6bdc302877097ac6";
+      sha256 = "ac823c4d9ae2f74ac4fa9e3fd3d902c52e8a87987ec5aef803404eae83edfbee";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/id/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/id/firefox-105.0b7.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "afc17a4c43eb7fc757a40f224c30b963996b418d798689ccba52b2a49ef42f7a";
+      sha256 = "edc7cc55f03e93fee4cd1ea4e9284fadd2451de8405ebfe1cd36bad3ce037916";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/is/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/is/firefox-105.0b7.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "b6be8816f13042e42465952bc14ae46fad81efcec5163792155cca74c6383b9a";
+      sha256 = "2a9b2c8d6ad77c04566f7ad38db00d16da61a51d003d60d875088cd3393eca72";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/it/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/it/firefox-105.0b7.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "9b5598a7684ff646041973dec7cb1d500239d814a7728d03afa05b1cc1b3fb32";
+      sha256 = "7e0cf4f4feae193364ca90c3d60e17a173344d3476f67acc333408fcc3eb26eb";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/ja/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/ja/firefox-105.0b7.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "eebfe843296b9e989d6651319f6f48fafd45b0e4b44af1a8feea78a3eb0c17a1";
+      sha256 = "d82753524dc2587e6e229fbe37c7298ed6aa103b98a5d1379f9b81f7d3e88ce4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/ka/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/ka/firefox-105.0b7.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "8d44b801338d88f86f75e9077d1d01dc284450cd7d6908d19f91b4a19012a0e3";
+      sha256 = "4fd1a1bc2091055d32728206276bf0a8765ffdd726cd110bf1145e5673a2031e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/kab/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/kab/firefox-105.0b7.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "65f5e180963559f229e85d899ab78b00811acf0ad934d71d1f92ab214c3ce4a2";
+      sha256 = "34dd78e993071cb4cff51729106e487feb9ae4d919eb15e1fe1c14bdcfea66b6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/kk/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/kk/firefox-105.0b7.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "83a248fefdd32a96ae35e22d742aafb16c94a855c6536323dbc2c5c6aaf825c8";
+      sha256 = "e06a7f0ccaa879d26e10a5dd3407cb7755026e97f323af72a727252f85371bd8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/km/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/km/firefox-105.0b7.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "d65a3282c6625f968681f586037b428d48016c84ce2bee713e8466b0e26d7cb3";
+      sha256 = "6b8084cb087652b70bae48ecc4827896847b68b04424438acb6e8d29965ce2bb";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/kn/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/kn/firefox-105.0b7.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "a78dc608ba90858e9294cd1eb2ce6a25ca4bacf52e851880a5532a843f024067";
+      sha256 = "625efa6dc65aff58290ada4e08fd8098c7992001bbb05ebff6670fed2ddbc27c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/ko/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/ko/firefox-105.0b7.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "9c31e9084935d818be99c7878b0810d2d20e943cf0d70ca04ca25976aab5909d";
+      sha256 = "8cd46c7e6354303298b1f1199498bdc4f312f2ed9b09fd6b76405eea1658ec6d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/lij/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/lij/firefox-105.0b7.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "d737257ed8c9af7b538c328ed3729343afe56e452cf250adcc55cfd3ba9c52a9";
+      sha256 = "01077366b93a1e4f24656c01fc3d914c553296ee45564426e4b35f4bf9373d7c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/lt/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/lt/firefox-105.0b7.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "bb37dc334d711cdbab36f453c6a38ce47b79394197977ad22afa2c831b8134a6";
+      sha256 = "710ac8ccd6e21d46d238b1f606e7b18b0eeb1c4abca6b73e5d80788b29ff5d8a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/lv/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/lv/firefox-105.0b7.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "f94388a8558e2b7de1a904ea35c78cfdca9bda40774b4ce50bbb6b0dd1057465";
+      sha256 = "580c8a2dcf69f6e6e3274e00f61639e08b8216766ce753e4e360b0abd9227db0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/mk/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/mk/firefox-105.0b7.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "48ddf6a414dcdb31a35ee3e9acca32bf1979d68406047229262dd883faf1c312";
+      sha256 = "478f083fa99a14fdbb054bf582c9fd8924bc673af38a06e939b2003dfc816a38";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/mr/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/mr/firefox-105.0b7.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "3eb45f70c0666775785c23804df3373dcf1a466f10b388a90c606d90eb62958d";
+      sha256 = "d98b910ec7c21db26402e2f7c1c59ebda3390d83b26498db0421ee72078fe7bd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/ms/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/ms/firefox-105.0b7.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "c40fec5a578cad7713fffaf9f97a9f35d2e5bc5147b954a94183ccc26764138e";
+      sha256 = "77e4081b3e25e36a342375404d4073f8711191a9914da6d00db527e28bdf5569";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/my/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/my/firefox-105.0b7.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "870ed8509bbdd39d9741b33312d5d2b03071c0b878692c558c28c7db8eeafd2e";
+      sha256 = "a7c4bf65867fd804785d80e70f5ac02c37640d655796ef3707e24c30f03e2293";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/nb-NO/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/nb-NO/firefox-105.0b7.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "1ee32b991fadb6c403f7c008e893d6d6fb6e4f1960ee879648de60c5bc3eccd6";
+      sha256 = "6da93fcbf48b9f36ae42ebd4490a855e3ebb1b4d33c1e8845e16db01e26548bd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/ne-NP/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/ne-NP/firefox-105.0b7.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "18ee918f8f63da0d69088f154f536e6b26dbd7e76790fa1c52e2cbae7145a030";
+      sha256 = "710a987cbf6d0f5e78175fa205ecb859ace0c6b2a33acba9d19099dcf328fefe";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/nl/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/nl/firefox-105.0b7.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "b657a0497eb309b44c4413f195bd5bbdb590c8e83aa15a390cddc952accbcc86";
+      sha256 = "f4d0527e98f2f12be7f492061049fb01f48bd835d0458ccc3d192fc9a3180cc7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/nn-NO/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/nn-NO/firefox-105.0b7.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "ca650ae3899a88f96ff49c098ddd9a9dbcf8fb0d2336fc25abb60e76594eb76d";
+      sha256 = "bb1cd05d17d81d4ff61110381fc03a0d395abba654633d4015fac6173f547c83";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/oc/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/oc/firefox-105.0b7.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "0f637a5a9d759314a49af6c2f43e7430171e127b568e8b23eb515de5104bc78b";
+      sha256 = "961b793144730bafd42e9a6312e1f92f14d4741a59b283de827750cd4f4df30f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/pa-IN/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/pa-IN/firefox-105.0b7.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "6956e514426bb5cce22f9d4de878e7347f4ae145c2c77e8fe5e4513d9ce53446";
+      sha256 = "839ac627365973e2bf82799fb03e063e68a3828fd8c7d306737a3558f4e764af";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/pl/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/pl/firefox-105.0b7.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "e069c13fdd346da8fc5558bd776389e0d4650bea519d59e6097462159cfe4b67";
+      sha256 = "3df949572daa3c063cdd65f5ba4e112c5147266944dec27387d4318b32be8950";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/pt-BR/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/pt-BR/firefox-105.0b7.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "eecc441ca8a535a6a2223823d73d00f0dba4004717fc7eb41621c598223247b8";
+      sha256 = "373af13073e4652c98b0d5f0bf0ad56dc8f64e7b90c536a0c951a004fd9e6696";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/pt-PT/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/pt-PT/firefox-105.0b7.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "eeb3690e517d1cc9bca609ebb5e8ae3f5e3318aac8472f2a0d522880ab2fa19b";
+      sha256 = "3d145c2aee5341a3dc3442f7749bdb201be618fb5c31c22ef00d2a315d0eced9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/rm/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/rm/firefox-105.0b7.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "8e8bbb07d14fd0453458a673a7c5f028f4164ba39379a1b6bb4a10e21c2bd7a2";
+      sha256 = "c8c99d0e7389819817ef4d794330e1441662244603bbf801cd42daf25c2cb6c0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/ro/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/ro/firefox-105.0b7.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "fb53c3558dfcec3be0794bb02dfe78bc75b1e8418b601f2d1a05fc2acdf64d95";
+      sha256 = "aba252578bea2e80f133f873d2e4ebbd307b26ae02c609da86e98feba6f2e47f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/ru/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/ru/firefox-105.0b7.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "5d4afb5f05ea2e859cee27bf9f14247f5e21e9c9d47c6cc9985a3e786bdc4680";
+      sha256 = "21900e3fd6d622d1c05cd2245fa685e12bf3be424f61cbbd30e781afaed6a29e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/sco/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/sco/firefox-105.0b7.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "227c3be4692b306ff090476a98879c4e11740d1df65b6ec40a88623e61062b4a";
+      sha256 = "97db95bdbf28748c3901cb05734bb3db0b11b010372309240f361515fae14fe3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/si/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/si/firefox-105.0b7.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "77e273eadc4d72d2f0e6ffb99f7148b2ebac85fb8b76dd277b0b8d7a17ed05c2";
+      sha256 = "87dd101705962b873ba777ec8d363d0e9397df051424d0708133ea77b98fadbe";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/sk/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/sk/firefox-105.0b7.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "5761f183fca4031f3402713b731fba702008cb91386db3908a2962d905de2249";
+      sha256 = "ed7337f9a71028c8d99b7c165e1c52806e06df3e0c3044af02e60becd04f7c66";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/sl/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/sl/firefox-105.0b7.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "06a48bb8116ef34e7e1760b767ff7a7834ce9a30da7ac1318ca0f03721c4841c";
+      sha256 = "ae6f9c04a02bc618d26efde7f9b76857bff29acffa6f82d43776e93066ef9ea7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/son/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/son/firefox-105.0b7.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "48a04c9f6185c4d2873f137be581555a179386c909617f416db1056923df22f3";
+      sha256 = "934608cedd43c3473024f711fd2419754aa326d2a210a7da410774fb13361d9f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/sq/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/sq/firefox-105.0b7.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "755c8aea04de8007cbcf51e5d042fd1aa8162753e995336759d084941092460d";
+      sha256 = "03d384c17887d09b3a43fdcb901ae5c1adcb64b1a9a6f99d6747afd7e9a1c24a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/sr/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/sr/firefox-105.0b7.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "c81f590ab33e087c5a57459d5fd4dfbc7aeec71b8e8d443773779ed3839b7148";
+      sha256 = "5ad33b9402e664cf25a706bc8dcfd3440cbe792d6cc71cfcfeceeca13b50e00e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/sv-SE/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/sv-SE/firefox-105.0b7.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "74c46ad5eec2e1a887d185afebd8af7ff661f6338f22700de24934c0cbcef07d";
+      sha256 = "115fed66d7ee716c3d11f15c883a8aaff8d0a5ce06914462ff9bbfaccead8fe9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/szl/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/szl/firefox-105.0b7.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "5992687eb7df4ed98e7d698ffceae482c558602d0f865a66cb114442140e6d1b";
+      sha256 = "2bdffdf500aa796ed0f6b6bec1497048014f33d5cb01ba508b9b430db9f9c7ac";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/ta/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/ta/firefox-105.0b7.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "3f88f6e52e401ccd1cbed97af9272cd1b4f760d4f4ac29fccf709f387cb2a3b2";
+      sha256 = "beffb0eb6ccf06a65688df4b6d19766d9bcd4c74d966da29878ab9ef83e25002";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/te/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/te/firefox-105.0b7.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "8acf20cbdc25fdadbb3ff5c0be6340b32cd3d3958fffca13bb9dc48177c24632";
+      sha256 = "91f722acb621485b01ecbf55a2e06f43651ba263ed8d1a1808bf9d1f335c9fc0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/th/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/th/firefox-105.0b7.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "032ef9f5166d54ef89cce3421144d77bcd91ec5fe200ce99e61656a0e3ae9f90";
+      sha256 = "a867fcdbb125a8cc8f1f02897653dcc2eacd3f72a9d09e86d40803884f4acafe";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/tl/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/tl/firefox-105.0b7.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "399be09656eaa7a2b384b28aab74df8b60e593b3c0fae1426142e149bdb1904d";
+      sha256 = "337f90742745bde608f6678218d4ddaedfe6ab8922acf714426aa99211863c03";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/tr/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/tr/firefox-105.0b7.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "05bb2a27de4ad1444350945007228659e5f4c4ac080a6b58ac2eadd253fc632e";
+      sha256 = "93f9c96e904cb24fe12b8dd497d3bb2e093c998863bb259be1e8bcfab87896f4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/trs/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/trs/firefox-105.0b7.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "31e4a7c21e8d6c2ac6c6aabcf129640674749573d52ffc44c6e85d9b0cd8939d";
+      sha256 = "e6e67dd5067f16bcd7b5b12a0008b72c2e190517de1c1486413f0bb16640d7fd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/uk/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/uk/firefox-105.0b7.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "701c489397cb5604f99f10bb07524ac9dfdf2db2d01b0852e5cbff9f77c8ea2e";
+      sha256 = "109aeeb507610fd8bbd653ed5848ded31311b997a22ced8c9dc31e0f9d0f9223";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/ur/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/ur/firefox-105.0b7.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "2beaddd9d554fa17329f324bc88d5448fecabc2678b5094b4b3c98e5d46e191a";
+      sha256 = "c5eede5051c2f7610bf1038d0e4f267f2a90e20a77c61baef466146e85e1a64f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/uz/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/uz/firefox-105.0b7.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "670a7625d9a049d043a5c98237d66d56da6aab7d39f2eaf7342a07b54f15e479";
+      sha256 = "f35b5dbe015aa06428e9af8732c018cd1e70517dcf768e62cc0eb8a1afe44820";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/vi/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/vi/firefox-105.0b7.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "e3d6300e0b64c507ef687eda272b930d37617f422fdbe956995df6f182d122de";
+      sha256 = "37919b430d561957004d6ac7cd3d1221cdaead20a0fc8d3686991b31f3a85412";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/xh/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/xh/firefox-105.0b7.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "47b58663edfd010e1da6c0c8209bfc724fbd31b1e9cc24e058cf7cb7947b67ba";
+      sha256 = "5e1e2d4d0254eb03b678038b1530c31aa17e04dace1b8239289cb8417655f9f5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/zh-CN/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/zh-CN/firefox-105.0b7.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "c480608fc0da33e006fde80fa773db41b26d85814f0af3b78b6796d0608212b4";
+      sha256 = "cada9ee5aee542fb5029aa63e6a4af74a668e6b13838f519194d9f39cea61c12";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-x86_64/zh-TW/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-x86_64/zh-TW/firefox-105.0b7.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "a652e2e1f7eda96c43a428e1e3a0dfc896725211710a031f006d12b830d4b8ab";
+      sha256 = "1d6a4fb24ea63c74a0da94c85a976f04abfa019142d638e7a9bc646d398dfba6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/ach/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/ach/firefox-105.0b7.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "fb4b13970d487a74d14f5765f963ddb5a99d4a6e7a891a03579e2db8c8239dc4";
+      sha256 = "a2f7e8a0e3848828a3ed510af13e15c5210ac70874bc503d57104f1d16724ddd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/af/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/af/firefox-105.0b7.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "fb55667c8e69bc3eb3cb09bd97f69a16a9d9b48909bd360897b7d204db5baffa";
+      sha256 = "5aa746b98ca4b33a51d49e54ac33869d8b724586961bcf6495f082432fdf94ee";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/an/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/an/firefox-105.0b7.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "ed502d939479bfb6c42e65745e91ca455ed8aa19e52190ff47af74f122640e7c";
+      sha256 = "9fa4b05cfd3ac618035c7df2b51bcf4a577dd07c108ea62141cccfe4731c9f35";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/ar/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/ar/firefox-105.0b7.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "6a42a16803d813edda005216c2d3eaca3b2ce3e4e854d6daf30708ce7a4aae3a";
+      sha256 = "2c693e4fbe4ca432dbe03e06e0f703f24125ca38a6e963f1058c47931304ad86";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/ast/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/ast/firefox-105.0b7.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "794b555c353224bd6cb084f47b06a714d1d7696d178de4e81a9654bf3b848005";
+      sha256 = "6a43fbf9c6005e9d35bfa3fc312a0bd3a88c0fa542231a03d670c99ff6548baa";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/az/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/az/firefox-105.0b7.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "aa534f14ce3724794661a7fd169a686f832e5b1ec13064884dd6bd9a1378ec20";
+      sha256 = "b9cead726243f90d5c8f6ad833b4dd2022995d7db069ec3e9a58cffdebb5c3e2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/be/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/be/firefox-105.0b7.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "88f2baa29f4e973e4843855b51b2b577608874bf38106af0c61f473427e1877a";
+      sha256 = "0b407632149bd7100737c73adf6a3d595d01bb175fcf80719b540bc466b34c15";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/bg/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/bg/firefox-105.0b7.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "4f36299f6b70efb66052256ce1b92abb5158c0ae66661c480b7150b5ce551585";
+      sha256 = "bf97dc547cd2538ac9582d361975d60b75fe0f6003941e5136dba52cabf3bd2b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/bn/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/bn/firefox-105.0b7.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "8e30239f2a0c3563877ddce236d4e58357c7f87f6eacbe104de84790d83f6f23";
+      sha256 = "5cb3c12b64823bbc517ab535b2db6cfce3b070b79700cfef4d06c3a427b27495";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/br/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/br/firefox-105.0b7.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "dc58ab4f1388294d5ca302c05df2fdab12b6c28d90f3e9e58bae295bac086d43";
+      sha256 = "682425ea3fe485d34fac300b9dbcd5ff77979fc9d12a0bb2bf1f287416d23d2b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/bs/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/bs/firefox-105.0b7.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "7374072bcd8713f532a853691e72481dbdd9570b3b9c07f89091289f8078891a";
+      sha256 = "bf8b139967fed32e6be5d4288305bcbf1b1c77bc759a564124cc7c0d3d8100e3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/ca-valencia/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/ca-valencia/firefox-105.0b7.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "b8970521f87d0ccaa9f44fe4531ae7a4c278720733ca3a1d3327baa289d8fa91";
+      sha256 = "d271254652594cf73c5cc36f09ca807fbb4aca36e5aa74551844fcaae94c2381";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/ca/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/ca/firefox-105.0b7.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "0761cdae6c6ef40b503b3edf08153a2da71edaa6b4999bcfe3dc6bb24024597e";
+      sha256 = "497442365d89e42b3a24e328e94e3ee07e7f9b23b0c618c4528576a6581335fd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/cak/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/cak/firefox-105.0b7.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "a0fa7f979055b9d3d94bdf7b7c9bc9251a341d6a9ad808a8c93fb92271ff4d1f";
+      sha256 = "89f34815231e418aec4f68cbc03ba6951fbbe7d2165f7b7efdbddf63c3033264";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/cs/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/cs/firefox-105.0b7.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "6559fb5da198df6330204b02c18842344c4493e22a1766990ac2d5ff50a73d32";
+      sha256 = "7e32abaf3f6f5b7fad8f8a08182c3c24236210c3faae56231a0044ba8a27d85d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/cy/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/cy/firefox-105.0b7.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "c246734ee63f09f198f4bc2765caf9de1cd7eb72176e3f32a13fc82696bb3a3a";
+      sha256 = "d6b649f50dd992bfaf11beda5b00a86c28e8dd732ab502ba667764e25ac09f74";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/da/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/da/firefox-105.0b7.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "5298e1942d2200aba50837a367d344535280b96fbf1e6daa9e8f0bd58795b5d2";
+      sha256 = "5459c4aabe9b90932574528d061bb0eb9a0413841d3d14b9d526d258c7ccfce0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/de/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/de/firefox-105.0b7.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "de7903b51d4df1ed1f66d09af5d3604d5e5bf58d835bf56ceeaf9f054c4ef010";
+      sha256 = "baa6c20b93b0ab77ab126eeb34a53a72cbcec76c77e6d041a477a4fbe7c942cf";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/dsb/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/dsb/firefox-105.0b7.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "d4370a10fe3d9f7155f656684c8c246787483c97070f4e99a8a815eb7d4eba85";
+      sha256 = "05ec702144102b1f675ff9139d523cec8ce3cb9fcd733d73e7e79376091414ea";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/el/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/el/firefox-105.0b7.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "c0a1b8d7c549cf819ffc0381f8543eee7b15e10547275cca0f3f1fbd00a34836";
+      sha256 = "73d97a30d7f47e8a9946fd3d242e87e98501e37af522d25bd56bf39122dd007a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/en-CA/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/en-CA/firefox-105.0b7.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "e5a4ddfe8109066f91163c6ffe01720b724c27fc12f2cf4a647e362f11ad7521";
+      sha256 = "c8f1af4787b1c73c0cbaa56b8faafbd78e592732ad7d3799c4530e0a90912db2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/en-GB/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/en-GB/firefox-105.0b7.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "0763738ec48957bc2d12efd374d0f129d4cae7900fb47acb22dfe33fe5e8e967";
+      sha256 = "f20cdd02d0f73d36473a796878407518260a917ec6634c8dabaf54014f1a9852";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/en-US/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/en-US/firefox-105.0b7.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "49fa3d1183f6fdc4ce7442258e078f06ad80fd730ece261c18efd8f6a9506bf7";
+      sha256 = "cd508890eaff2b3e4d2c5e37cff778d2e11138ba374665ab01fb243bf3aaa328";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/eo/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/eo/firefox-105.0b7.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "4179d753248a1bb38d90b03eb35e5333d3cbd83234d32293ab6fb97eebafe1e9";
+      sha256 = "eab4e8e697f41d11b6aeb8379731e8ccf834e95757d133c92067d8c78bf3697e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/es-AR/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/es-AR/firefox-105.0b7.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "9d7e1338031cb030563992a8007cd54de6061b56ef11e60f7e4fb2dfdb543fab";
+      sha256 = "c983374044ae5b28826f37703f3d60abfbc25008d7fc74153fd04c6343db2d87";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/es-CL/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/es-CL/firefox-105.0b7.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "39c56f2f0f55f55a72ebbee0ad50a90ca9ab89bd7492ae0738b8ceb8ffd45afb";
+      sha256 = "2b976c15006af15910e008eea6377f5825973f018be7b908281d324b848d4bb3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/es-ES/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/es-ES/firefox-105.0b7.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "c0146ea6c8dcfecb4d0d853caf8da8bbab6a23f7b0f05952b84e94791a48dcc6";
+      sha256 = "00d09aa82eaca9f0c01860df1ebbf8a5a8663ae86b69e21317f766a4f0bb03a6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/es-MX/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/es-MX/firefox-105.0b7.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "c17e8e950c04af0bdcbfff288124ba3bde14057df1d15389fea4dc165f996524";
+      sha256 = "3bb47f8e19f8df778a530dffde2adc35ada2a1d60d74e28c69be8e0e8cab5e2d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/et/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/et/firefox-105.0b7.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "c3f41a16ccb6d1e39f66c4a975cb6a30e7776e60ce2d078d723fa2068eb21148";
+      sha256 = "e676f2c1f9af6f5077a32de2b37b1c17c3a7e0d18f61a62a0f7bb6ad9cb79b84";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/eu/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/eu/firefox-105.0b7.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "ed7dd0278ea69840aad84ac4deb04271a4b882a7abfa001b5236175f2c4398cd";
+      sha256 = "2a7b3b21fcdbec93587e8f7085485967c850ff46c6a951b9ebc40057ad435b61";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/fa/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/fa/firefox-105.0b7.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "2142e9376c5beb3f5e4a5e5d0de3b0bf595f76b2317e640c45c5f377785728a0";
+      sha256 = "55cf1be2f8ec26d677a46ea5f5c944006be36430882a4f3312e484bbf6e2faae";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/ff/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/ff/firefox-105.0b7.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "73d661a0c578c3159eb0be0cbdf518527c099bd9a2738f9c75eeb7cc1fa64c9c";
+      sha256 = "8d77b6a35ac85de269002bbb9599b7ff49b0f1beb1c4cd40818ddc86f2ec7366";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/fi/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/fi/firefox-105.0b7.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "4732926ab0238c34e7453c314bc978a53a2e64ee5af6d1247d197367369721bb";
+      sha256 = "36d9c6adf9afa99c8d53b15a3c01ce3f50a1d34b72d99286dbfea289c3675887";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/fr/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/fr/firefox-105.0b7.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "049a8fd01dde5e136db08dcdcb447f03fdafbf454d54bfc8ad996bc49e3ecb07";
+      sha256 = "35fa4217954a9ce2a9f37fc16e2b46151c81487cf3bed3e34940a3a4a96920a0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/fy-NL/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/fy-NL/firefox-105.0b7.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "102914de1d63b52b59e6efb0d1493d4bf8571b128d55074f757ff4174a79369e";
+      sha256 = "1318cdb9a9e59e4644c72dcbbbfb9fb9188b31cd40bf1e8eebf9e4c1cbf49322";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/ga-IE/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/ga-IE/firefox-105.0b7.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "b17d37992ef8ad0ac57fe227626d34bcd664c9e46a36b21816b978bf373bf441";
+      sha256 = "31bee4fc77fe4d2d4bc54fcf650820dd1775f529c1a0be6780b5348961d30621";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/gd/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/gd/firefox-105.0b7.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "2a624249fc35195fe79b6ecad664df4f7ab510ece592040120285b269981e5d9";
+      sha256 = "d45f87a654e9ff0d626817cb0c6332203523885d27fb20aefa1f1fea6a8a9a5b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/gl/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/gl/firefox-105.0b7.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "50ee86add433eb20f3c33a347d4a2598bbf74de02e129bb4cbd9accc860e7044";
+      sha256 = "696fa24a4481a8e96e4efb79708141968cacfd6dc289f53481ddea81d2248f56";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/gn/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/gn/firefox-105.0b7.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "5c6998d3a4fdcc24bedc84b0dc9c116911c75cf99f0b7e5166333d51ea988841";
+      sha256 = "ad307064e2e702a11d47cbcd3a2f55ceb8a5064ee359acb37c10c9ecbba6efdd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/gu-IN/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/gu-IN/firefox-105.0b7.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "12f3b0b0a5b2463959e4a7cb43279287ad5443057b31a8c9f78e85618f20cdf9";
+      sha256 = "6921cd481e8ca808a18d75789e54b18c0b095a345d08bcfe219e5c67b5d24ae3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/he/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/he/firefox-105.0b7.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "5dd7331299df4ec87c7196e600c1d9b3ae3d38d6050239599d9d7c7b99841cf5";
+      sha256 = "8008601d3162cd2a7cbda4d7bb8e2cdd5b524f3425dfcebca9f92193ad4b4e0f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/hi-IN/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/hi-IN/firefox-105.0b7.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "aafd078d55ce7104c3336eafc56f9d9d48ebc47190cd959a8b5e55544d05be65";
+      sha256 = "262e4564e5b7a37335fb0b38bb00c54974d49dc86104fe7cd473ad3734f85b7e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/hr/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/hr/firefox-105.0b7.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "b6eabc1a3463111d7fba1a76ee8fd5b634b2ea7635ea1c1118fbb73b8771caf4";
+      sha256 = "35f38bfb4d10e6f133e6ab6eb32a2ff7e8f7ca6569928d51206da5f9cca49c4c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/hsb/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/hsb/firefox-105.0b7.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "7aea7b81a04e4628b2a08dfc4245e29f3a590099934b38c02cd8dab990799695";
+      sha256 = "fc258e8bc246772424c6cde450b26f9f920e5501f393955eec0b37017cbd7fd2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/hu/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/hu/firefox-105.0b7.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "1f1c52f40aab391f8ba001944da88d69b94a32e33c9a7789b778a49c2feea334";
+      sha256 = "0531dfc535700f9cb4078c21b3188e1dfb54c4d53b6a2105611af833614cb4c8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/hy-AM/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/hy-AM/firefox-105.0b7.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "3a9920ff3dc3faf51c39b28422648bf952782a49dc681d0e78cd19f8ed24432f";
+      sha256 = "1d30d63d45745891945dc091265d076677da43515844d9379f67201938660ee0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/ia/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/ia/firefox-105.0b7.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "db86e72d30f002a402af520764a0fdec8fbf0ac0a54e70ae15cfcb34ee8bce5a";
+      sha256 = "787095ca8863b370060b36775bb0f60727d0678105d948b26e1bc6417b23e45e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/id/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/id/firefox-105.0b7.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "379b5f7ae14ed65c6375fd0f5c16cb17a4d14acf5d3d72eb2eb5eae884bae38b";
+      sha256 = "43ebdc78511195ab8eabc0bf60ddc61c2ac8834793ef3d9293ca0d928ebc6000";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/is/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/is/firefox-105.0b7.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "a42389c4b42697fb2e802262ecef3d8b0b9fa5b54ece61971c15f91d76b2606c";
+      sha256 = "88ba10f1e07605f23a7144bd2dc93c78c3a002cd7f5b66ad0fd0548b3fee3e75";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/it/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/it/firefox-105.0b7.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "1b0a8beec03ab224515b7c3b3e4cee9f05a5dd79eca317d6c2019e07402b66b6";
+      sha256 = "a934d08a697f1a309ac34edb08314a134c24f242cb9dc26cef5d4d017afea043";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/ja/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/ja/firefox-105.0b7.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "d78cbfb28cd5fcd091b78693954aae57eb3eda65776e7f11d2ef504b4ead3435";
+      sha256 = "8e14b8ddeedc9e7d08d6b90c40877c670870be834a084f91a282dfdd281d4a94";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/ka/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/ka/firefox-105.0b7.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "be932f3cc4a286552746a6e24ea6ba7cc84cd7d9d686e42a85744d787bc444dd";
+      sha256 = "6f7a1151d112f8173cc9479e7ab68abf5d36b819c3f9f827737b6185e68c5e37";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/kab/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/kab/firefox-105.0b7.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "4da770aa41aebf2f6782f4213da840ebfe7f6a69c1a0b2b3727862c83dece74b";
+      sha256 = "1c4252f04cdb7b96596a5895b12bcbe88718a0302648fb2703ab47846c4620fc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/kk/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/kk/firefox-105.0b7.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "510164c5a49b3eb4f184b6daf2ba6664a500c3a732c4867e701919bf1e42b5e6";
+      sha256 = "db2acaefbeba6a983367c4e58107e1b599920d8b4b04078f631295b6806fba84";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/km/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/km/firefox-105.0b7.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "0215e67e67c60ea578a03952512ef4148f4f21b7a9f7153c3e00293e01f478a0";
+      sha256 = "30a57951732fd40f4fbbb79621a983bba0905b2369fb4758eebb10c7cbc2efc2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/kn/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/kn/firefox-105.0b7.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "28de45afd296876a1f2e06d6980e8a668baa67466fb35ce41834d0487e289e9a";
+      sha256 = "9ec40c1a7cdbcb222d4bf9ab33b5dd7c605d71731da83dd3b714e1b1330c96cb";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/ko/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/ko/firefox-105.0b7.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "47216724727245234ae46943b7dc6651b735a393d88586d18eabd8adad98ad03";
+      sha256 = "3135cabd301635ec831225b0c6529e03850cbfc4e33cbee6918ff2ae993e8b77";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/lij/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/lij/firefox-105.0b7.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "409c1975329acd4589a8c0cca1f5e57eab3c613ac6b780dd01669a400de6e7e8";
+      sha256 = "e83ea8a205d4ae071d86eb35c161ca6325090438fd25722399b39d789fb167fa";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/lt/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/lt/firefox-105.0b7.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "bb8831bbf615d8038ef254e8d74b83b230e7c3de7ea4f3b42391e8e954d59450";
+      sha256 = "14099fadcca1da120520a66aeac0393be3d5f0540d7ae160637b5fdfccedd7a2";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/lv/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/lv/firefox-105.0b7.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "9845b7f697a0b75e10100c008c221c2b535a110dd8c352145c5d714ce1f32ae7";
+      sha256 = "9fc56d60a0a8d3564c09a080e643c6491903375382fcc654e687b49c6693f42b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/mk/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/mk/firefox-105.0b7.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "390194fee06bb0b8b409e939551feb86df013f98d7814ca0ef3da25369c11de6";
+      sha256 = "6b5dbf714e0abfd4090c561404c51dfecc99b51829dd783d6ea780441cda904a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/mr/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/mr/firefox-105.0b7.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "ddb1182675be8d278828018e6c2eaa62f1582bd3735f611e5d593933a9ece105";
+      sha256 = "79876e4150eb622a9e569df9601ce7d6da3fab6e76d47422b1a434742fb0f369";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/ms/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/ms/firefox-105.0b7.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "9b85d1737a56890524f89a5639e6a636971a650222c300dd7f31f968a9f93fb2";
+      sha256 = "afa057f21cfdff7ab671267e29e1744e0cf06e59ec2b328b2544a014b5c88d05";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/my/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/my/firefox-105.0b7.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "ae8303f9bc4b269be315b623d8b8006a624daa17e19fffd58dd9cd4c08b7b8fe";
+      sha256 = "c3aafe8cb3914105e10765846488604598e0190d49099c4863d16a5417356d36";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/nb-NO/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/nb-NO/firefox-105.0b7.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "244b5dfcccfd8dafd46c16ce7de786bb4b1669574ccc61448fee11be3e5ec42b";
+      sha256 = "c709bbf8932a43432f6fd39ed19c68ec25b1219ebdecaa440cb8fa4cc76478ac";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/ne-NP/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/ne-NP/firefox-105.0b7.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "2cf3d148c2c9cafe83a201b46346ff093f3ab9113b893fae5736c11d24cce641";
+      sha256 = "3e37642d18b297612da0d1629c5df03345dff8d7fa9f38ddec1586444968268f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/nl/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/nl/firefox-105.0b7.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "bd75e8177833134c9402428c3453dbe49a0ffcb6a451db625c8eafdb3ea1b21b";
+      sha256 = "31f9129bb427e9a63c005b5fe25b9ec4814d5ba6a21923f2ce0172064c20139a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/nn-NO/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/nn-NO/firefox-105.0b7.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "2607abceaa172a73fb9157c649ccb728557680bfa2701a32dad9f04b76a50aaf";
+      sha256 = "b87aff06a8040d3508b0ea7aec139c2b2d16720399b8b0f9b9987ab8d2733706";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/oc/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/oc/firefox-105.0b7.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "2034fbcf5b35e937e74098b446f2b03bb8a595e0ff3bc98c33236b0de294e3e2";
+      sha256 = "881a947a26b907f747248bf81eabc1298dc0c9f5913751bea0fa3afc8bd072a7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/pa-IN/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/pa-IN/firefox-105.0b7.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "798c2889c94ec08f950819fd620cddcaefd5a8d9e4b983d255373a3b037b94af";
+      sha256 = "37694990ac36aef8207ef66cca1c757f38a40ea5660799544a4f381308f772bf";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/pl/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/pl/firefox-105.0b7.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "e96e883271b07091c7a0cc0df633ec47c5c80c289553395a3a3545749842e4e0";
+      sha256 = "5629e4f6d8f12f7d98db3b06cfdd69a937bdf8ce555cad9ab197da8a85e0c14d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/pt-BR/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/pt-BR/firefox-105.0b7.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "b53110eb38993ee28561e232f8e2e4b4ad88470c36c9f5e63cc2dfac5d2fce86";
+      sha256 = "292929f4526a8dd23f40e676ac761d58854412108e553bcf7a66758959dcbc1b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/pt-PT/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/pt-PT/firefox-105.0b7.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "df093a7332f949d596f7a4ef072c92a7603897022eeda134940ae6bd5f41068b";
+      sha256 = "a334545a7fe60a2dd31fc37895efb596ab0f8e1d50283766bb0ee0071a023b3b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/rm/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/rm/firefox-105.0b7.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "b403de5008438826bdd5c1584bd50ddb7afb1479e8f997d960fba3ef83c8678c";
+      sha256 = "fcbea8590253f884b2c825638ee5db715906b3fb0d2af068e9871e2ab2fa2028";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/ro/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/ro/firefox-105.0b7.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "e2969109f9185f0adfd446dbe26e607f0d94f119dd18db318ba04b852ebdc365";
+      sha256 = "a2fe0ce1eae6fd5ccf430f2f27e26fe243192fc8b3bb06ce594f9b7137d8da06";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/ru/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/ru/firefox-105.0b7.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "1d6d1b4c55bacb5883d974c6fc16c51ad6bc579eb0995d45c30faf7622066c0f";
+      sha256 = "0545c86d65800a197d260c901dd9adbe5c4314a92de3d6585d28bfa7424b961a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/sco/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/sco/firefox-105.0b7.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "976c1d3d6c4161d00046f1e795b738f914e48e8967fa22ea8de090f5baac7d6a";
+      sha256 = "3088a34a74231eefc0211f74970c25c09a065e714475ead7530d4169449defc1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/si/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/si/firefox-105.0b7.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "5d73f70dfcdb52aed6fcd873f4db589da7f08b9b71dcb24941f14a1a0442deb7";
+      sha256 = "176375a83ab1be2f151ddb6fae353c799edf2b113feaf414068f092f5eff6d43";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/sk/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/sk/firefox-105.0b7.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "5938b2871a706692f323b021bfd1527a0ff4bd0ff726c234835962455f2d66eb";
+      sha256 = "1f77696dc438d781ca97cfa80cbd973bba504637ddc3a191b4170302e423f364";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/sl/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/sl/firefox-105.0b7.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "caf563693b02e83d013723a63c45b2606af60d7ff7f6cda9fd28eb4094923996";
+      sha256 = "c4177e0f975834d06f4c9274d77bbff52e1ed69c37d59c30441d39aeb906eef1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/son/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/son/firefox-105.0b7.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "b885fa5f5c8f47b7cbb0472a1438e4ead10de1ea9867091d8ce5dd1aa6ddbe60";
+      sha256 = "44ff8d9c65de4f4d3b5b680cba96714cd628bd91344e51bd608a497699b0278e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/sq/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/sq/firefox-105.0b7.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "2c480a2a925d2649b6a7da52d5d5a3213c81361ef1e287fd5dfde000aa73d139";
+      sha256 = "425144d84ed4de63af3a55237be87e189c1a92ba337dd836ce039d151bbe2787";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/sr/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/sr/firefox-105.0b7.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "055f7d29c4eb74caef455c277639c5d0d44f2f9ab7907a5fba7d8ae0c747d031";
+      sha256 = "084791fddf4941105966715019f015f236f44be2a50611934d8a16fe9188c2b7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/sv-SE/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/sv-SE/firefox-105.0b7.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "246a62abf165ada5da7ffbf72162621aed38186914189fd903fcdf7a7f40a395";
+      sha256 = "f0acc7ff6bc0fec65810a9dc6361c9e1722690c6785c294405f8fae30732e372";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/szl/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/szl/firefox-105.0b7.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "a44152566fce0f382178665333ceab934c4ad6bd044d15b3c23a4783769865ab";
+      sha256 = "5930bc5b76e923a57818b22baafd4ea5834d2b6023cfe652d3347db2d10a57d6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/ta/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/ta/firefox-105.0b7.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "c97127659428cd5a3cfc7a0738d7ded0a4cd901c2d4f701eb697907eacb295d9";
+      sha256 = "62d4cf46230a5cce86a4aa1d4291f9b926e77f42833d61dd13006c32990378a6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/te/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/te/firefox-105.0b7.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "5744187ad0ff0f99eda48bde943d86b05dea2897f8f89a051eab5952040e5f52";
+      sha256 = "1c7038c601f97bfabbd0042b87c45f83f521a79a8de220c68e81529bf2b9bfd6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/th/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/th/firefox-105.0b7.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "d5683959baf8dc35806b490b0590b723837a572a02d7e706903a1525f84cfcb1";
+      sha256 = "be6127c6ccd2b9059a74924712d343f2d516cbab7f657510d7db093eb3a6ef09";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/tl/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/tl/firefox-105.0b7.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "59c0cd4805d21766e5693abbcbb15b23ee46f1ae6fddfc4c2a00bd771b700f46";
+      sha256 = "3ea16c0492259bf92411a9f36f4de158b855a3b2e6a1f17e1f83b35823b355fc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/tr/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/tr/firefox-105.0b7.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "9da23f725c95d59c6de4bc11873d041567b06d3c012d2e63c0f215a0455c0ab1";
+      sha256 = "c941241f543bb715e2d4e6b5702fbefdbd366ec65bd78fab33271aae9a8d0754";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/trs/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/trs/firefox-105.0b7.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "73c1f35fbba69962b0deda97e0b5e7319c11aaa0ec6eeed1de3ed9bacf8883b2";
+      sha256 = "ff9f3ba492eadb4ec0d5da885eeb5a01138eb8edab94c6fc52302635675ef91b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/uk/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/uk/firefox-105.0b7.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "33e599d89f3a835e330feaf4fe06513c38cb09e820fd25fd5c20c02b22ec5d45";
+      sha256 = "1d969e756dec62b43c39acb3f9f3dc08d2f54b8c2427ee7397c987199806ffc5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/ur/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/ur/firefox-105.0b7.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "e6bc8fa55cbde39a851362bf2cc281c0514a0be798bd30cf9c7c0633945d70a9";
+      sha256 = "08d78f19dbcdb382e7bc2c97f1ad8be9b251756d285bd091872c6659c459e6b3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/uz/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/uz/firefox-105.0b7.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "9b94ded2a2fad5460bc8e28f568ccaff699af0256c5a09aa5871d6af2f6d0b3b";
+      sha256 = "ecf37ec50b90c146c3325fc79eaec6468e79d2abd3c2b39e5395c31d1bff4a4a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/vi/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/vi/firefox-105.0b7.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "2aec0174bd473d515532e2a73fabf1abe3daf082d352595b2bbf081081b75112";
+      sha256 = "9564e9bedd47a03e37de3aca042cd1f76725b014e22d66ad22f478b801ed2306";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/xh/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/xh/firefox-105.0b7.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "76faac0eebcc5df1f35a674607a8da2dae9ea0463b9e8a113edbe6a8eaa73795";
+      sha256 = "25864ec3def2d389be9e40e1ed4c482d0cceaa9021577cf5028853a61423f8ff";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/zh-CN/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/zh-CN/firefox-105.0b7.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "9861c44c528304ab8c3973aa74004d20ca618018a472f29f5b8b1b156fdf5d82";
+      sha256 = "4ba390d58f3380ea89b7a7caf493b246ea4c1568f67da56f2950c33eb879026e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b4/linux-i686/zh-TW/firefox-105.0b4.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b7/linux-i686/zh-TW/firefox-105.0b7.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "a6aa8bd72c3aea7f4713ba5dd60b52be393cd0135d1e8d19e6500381faeb5c11";
+      sha256 = "e0f5a12bd06bbd3cfc68642dd3d780b2999a7afe4fb0a887e722315eb0f0b7a1";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,985 +1,985 @@
 {
-  version = "104.0.1";
+  version = "104.0.2";
   sources = [
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/ach/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/ach/firefox-104.0.2.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "8053fd82fdbf10c47d0dccb28b492ded8387c18cc546b56864b7266452881efc";
+      sha256 = "e750e21e02d92c5ede06acadf197b2e31e2f13d75f028ee64672a401153b89d4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/af/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/af/firefox-104.0.2.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "382be22b80aff8903ed94cad22f39cb84c56d3e7e5fb3272e69343853dee424b";
+      sha256 = "e15950d3270a7d7a90482cb1a30e32fc05679e41b9801bf4cca62d5619c25ae4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/an/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/an/firefox-104.0.2.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "9ebde79395fb45fab6865f971c5baa6f98f4f797a1a109c75ddc223ae33c2d9b";
+      sha256 = "9b7f38e1b871b5d7b51445276c5caf6a6fd6b395872a556e553095cecd3429cf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/ar/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/ar/firefox-104.0.2.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "2ffdb1653d9dff2f74f8aa5c3b607a96cd4a6a15b0bb67169415e121fe821af4";
+      sha256 = "3fd55b68280f31815dd55413672d02d19cde7d6f50692fc7ec164fd939020c34";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/ast/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/ast/firefox-104.0.2.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "4c7ec12021fe09fb5f71ef545c8cb55bb40fcc8ec6217442abecd8fe0c08909d";
+      sha256 = "962e9969642e0b071724cf6639351315d41b913c4d27105cee759704beb22d03";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/az/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/az/firefox-104.0.2.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "b607e5ac6146bb4ae0af09694677a3fb636c95cc14097c99955cfb9ed40c1564";
+      sha256 = "9e8d619eb5e277ea8f744920dc579a3c62df565ac85f8e3327fb05a04e0274e2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/be/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/be/firefox-104.0.2.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "c852946e12af33843ec8e4b93af8f57845670a96aaebdf407bbf82143448f9ca";
+      sha256 = "35aa5baeb6b1f87f6ff85a9da63020baf7ab0823c1eeda3805aa1c3007a93022";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/bg/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/bg/firefox-104.0.2.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "b31b58bc5c03770a6034abe742d1da2b72f2f643e1f39f0a8007546bf70458a7";
+      sha256 = "a89454de140579dc00d65255d7eb288a4f30c2eb380ca73c939daefa6370b0f2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/bn/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/bn/firefox-104.0.2.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "630db4cf43182db59ed857a8a189af7f91b30f0cf63af817b0a37787f3ffc455";
+      sha256 = "c230ecd7ef964c496e0d48d7b631a39611f8b08693da2871a0ef4e1930cfdb00";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/br/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/br/firefox-104.0.2.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "bd1eb815a8d1774bab437bb7eb97f8738cb014bd61ab352c6f8fa0ade1cce2f5";
+      sha256 = "433ba1f1ffcc66c16cf2019ee0673f7cbe7fc985998c75a692c5ff3a17a22fac";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/bs/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/bs/firefox-104.0.2.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "c5fab1a5ccf14c1c614010bf870bbe6749a9a1093db759096911bfbb0b9353f1";
+      sha256 = "eecb73f5e26094ac1d3583b1e5a4d369a2a0d48a8cfe5763a4cc60fb399583d7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/ca-valencia/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/ca-valencia/firefox-104.0.2.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "43ba166d09d5342b112e743c643ef22794c116cf5e8626034b1aaa1d0f2515b0";
+      sha256 = "1c014382839ff91c828d2cf6baec31f2ac07a23437260151d3af94798fec17ba";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/ca/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/ca/firefox-104.0.2.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "30346e3d55fa6a5f4cc3160cc79244ac728edd8baa0c0db73b160f2c0dc455ad";
+      sha256 = "6d80cf5e25731534c10d065cb7e735927114e827f60c7aa29c783b1e9edd482f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/cak/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/cak/firefox-104.0.2.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "3964470185dcb92e7ba8f64af11fd1d9acd2c588453eee178d427358be71f2b6";
+      sha256 = "0e3d03c656a5d6e2562891b1493056b4e682ced83d09d7249d6964298d05028c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/cs/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/cs/firefox-104.0.2.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "3c6fd07a95c005cf054184aea537a244a98e648d427b2b83c13d6653deb532c2";
+      sha256 = "23e144a0bf66874b6666d9fb5a3609df29cdd3edc63cec9a7ddbe1fd7ec3607d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/cy/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/cy/firefox-104.0.2.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "8b3c0b8986d2f301be92371108adb5b2a495a2ffd81b5ac2926de472182d29a7";
+      sha256 = "83fbeca73052d25c4b0369797fad1692eeabab185a2f14e23d0dabb867a1eaf8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/da/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/da/firefox-104.0.2.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "d664a0ab257ef74cf267d75a0091815eda69db8ac1adab8e6c0c4874c0b8a805";
+      sha256 = "bcd5fb746149f9a83e7088505c32d590bd7e32d1b37d51d750d99a1dddd2d327";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/de/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/de/firefox-104.0.2.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "d7793ac5e781b8dbb3b181d47fede04dfa03fba2617de5c046add1f76d8a435b";
+      sha256 = "87f84b820f45be9c14ddf98d98e00f48fc2d755b166dcf927cde6538bd17125a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/dsb/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/dsb/firefox-104.0.2.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "3158f5453113fb3c043d855cd1d402e73a271de891fed2f856e97e98357d6de3";
+      sha256 = "f87d0f58bc041a0160266bf3233cfa3b87627ac46f45fcf27c6a0f0e59da549f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/el/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/el/firefox-104.0.2.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "f87f44385cac7c104841ba68ab5c1667c6f64fd4d46dac1fad49a7e1aeb794a3";
+      sha256 = "ab436b7706dfebe82bf0d3c869d0994b4eda6486c19a67bd9ce95ccdffb366cc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/en-CA/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/en-CA/firefox-104.0.2.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "f01336722ea92296698dd17d7fe41d8ce454cf2a2cd16b6be78802d6bff5231d";
+      sha256 = "372fe8a4e75d37584d426fccbbdf491065aeb80d621d547a5e6294777a8d8140";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/en-GB/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/en-GB/firefox-104.0.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "74307e52a3bbfb62ded038acfa8444b0015742f40b3726ffddc04fb42dbe810d";
+      sha256 = "fbb634e10f111e94482a65d97ca6b1b5430d16d6baa756434e1220815ef3f212";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/en-US/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/en-US/firefox-104.0.2.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "0a1f8431f6787069526d076892b1f61efad9bc6a115f15fc2e87c5b6c2e19b4a";
+      sha256 = "89830b1a083ce589927e5807c632deb0a4d20d582b8bad558d2d63b731893420";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/eo/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/eo/firefox-104.0.2.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "3210cabe69bfeca81dc7185642a7c12e53f64cd99864ac6d0add8ddcee84c340";
+      sha256 = "160fedf11b9bca3cd74bbda0196cbcb3fff76bf4a73623fc86b3d99e330c4df3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/es-AR/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/es-AR/firefox-104.0.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "140bb0d005a20eca9020bc450b620b2449f1aa8bbc09478a8411d1ffe6c4d7a0";
+      sha256 = "38b5d10a88605c80027029f0a5559ede4a23cbabaf02e54ef5e731607c043c36";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/es-CL/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/es-CL/firefox-104.0.2.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "ac55acedff1f2b3380b119a2dd128a1ff7517e09b6a163bcf148e53701d65222";
+      sha256 = "ac9e8268015d509325485298dbbc7628db87fe9f0b4a2fb4651eac53e05bc0bd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/es-ES/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/es-ES/firefox-104.0.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "bfb557f6de6aa3a71166c5367fcda251400b47311b3813edd674f5f9baebb4c4";
+      sha256 = "3de05312a59163a255ef880a8a771aea75200be94b11aa561d4ee52491d15ce2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/es-MX/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/es-MX/firefox-104.0.2.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "090fd44ccd3a236a211aa9590652b0f884613416e1922f9c94a7ef12542bcf64";
+      sha256 = "6a94a906ac9bebce459f618a045358a52dccb3c30f07ed8eef90073ecd1eeb02";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/et/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/et/firefox-104.0.2.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "d4fb34459d5cf0fa3aa8e636cd751e35c3fdf34c1538f363821c21dcae09724c";
+      sha256 = "be6909c0f097043a37c47ffa58c2ed84a60c55f7bbc214e8c9b590cabbf85e8c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/eu/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/eu/firefox-104.0.2.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "f6392454e120c4a06e8d54fa09596029942cca2b1242dfdaff014e14a9996288";
+      sha256 = "6c3951d07e9880b55083cefebd1c596c692ef55e3f769e69c3e7dff8c0051065";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/fa/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/fa/firefox-104.0.2.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "0298f238a10652342b936c66ad68345c75bc6e4e27f246c68f066289cc23c4cb";
+      sha256 = "c47b1ea6f2d38a9e6068ca2904a5420ebc55b88917f65b40f351090f6765cb60";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/ff/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/ff/firefox-104.0.2.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "9a0dbdcebccbeac6b6cab6e64ce1df6d7166f00015d9ba1f3f764eb55eb6ceee";
+      sha256 = "629eca1b5f93d8bf357afc7633695bec4fa7b65696695158b91dc5617d63c252";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/fi/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/fi/firefox-104.0.2.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "a8191c56e89b11c29ba9fdaa4cd1952bff3f65047becabd7a7b4114a9399e7b4";
+      sha256 = "624471974a275d26dbb9d4196805749544b196a7740b073c5f2259ef553a2518";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/fr/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/fr/firefox-104.0.2.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "2e4659ee305f640904803c1c83bb7288dabf6a42de3cd44fe79b413930c2b34c";
+      sha256 = "ce92be8564377527bc9b6008dadb8c954a0051502543805203d96e9638e6095b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/fy-NL/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/fy-NL/firefox-104.0.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "ba3677007fdc5f2e0830f71810ffe448331cb7e184d782aa3790659b1a700728";
+      sha256 = "2e1caf244b97f3bf0d2f0af5771031d515165b1c65d88beabfe962a78dc194f9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/ga-IE/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/ga-IE/firefox-104.0.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "b16ac3c99fee0db84a4a69586fe96e3d0c1fe14e90db46b5c6bbb2a70ba9f5ae";
+      sha256 = "9fdd1482b000d26db2a8b9e26f7e7d0d7914d276879c87f8bfea2046951f5c75";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/gd/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/gd/firefox-104.0.2.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "8d04179cff2df6b1b35b4fe23f595e3b5bea021a725858f5f02c7453ce4f79d5";
+      sha256 = "d389f42c995c0ad83600d1541d59617fe796eebee84afe583a6c45fc42a9a26b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/gl/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/gl/firefox-104.0.2.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "39b385c78ebdd835c401633c216861324c6321f714faea9cb8eeb4d4128bb098";
+      sha256 = "735adab6eebc7ea2ec870817ac671b8c550dbe8b4d5cff6e66b89940a7655bfd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/gn/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/gn/firefox-104.0.2.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "c836b01a176960fac100be980fdc87baf9588a306e4fc0557d52662fcc333117";
+      sha256 = "a3b3e0b424366ebd7c3984a7fbf1b9f0b1039ccfd44b9760498464b0503312e8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/gu-IN/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/gu-IN/firefox-104.0.2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "cacadecaf6f7ef548dd2d2eef47623ed9d259f12429bf6cbd74530dcef251553";
+      sha256 = "4b2c4db1a56d80b5d19d02b3a907c2a6b218267834f05f8703acf4bb1f730df9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/he/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/he/firefox-104.0.2.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "61205c7362d271322e85be1c955f353db7c7df089f699337914410830a830761";
+      sha256 = "55548e660271ff8fc8f01932d68ce7e90cacb30a5624953dddb7c75ee4baa181";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/hi-IN/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/hi-IN/firefox-104.0.2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "a9de6ad9d77f7c7471d1da29b556c96ddd5cc30e14ca863e035be340d33eb4ef";
+      sha256 = "3db29f8f7f338f22137be850b8478513e2eac351be7c04b373f4c2185b34f568";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/hr/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/hr/firefox-104.0.2.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "92590ac81c158296e2815800a6afe1b5c901aa76d074de96e41ec05157b019bc";
+      sha256 = "4f14b4d280c49b1c9af12006ab5f440a28bb69d53223a45f109a5c13ac2afa2c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/hsb/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/hsb/firefox-104.0.2.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "230b96917334265ad235983e4c31f44ad88454dae15aab35eea03328949058bd";
+      sha256 = "4ef97dafc237de15a69ecc32d545c2d1620fd17e83e8f622164a3614b492f550";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/hu/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/hu/firefox-104.0.2.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "3074006d1d25023a8472665df8df9f2b9b756167f6a34dfb9678bbd532a2cf8b";
+      sha256 = "a7f8a5f5a2e7c0eb4ac28cd8c1449407e92a632be8f55783f24c182daf1ab67e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/hy-AM/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/hy-AM/firefox-104.0.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "55a4d2cb3363c07162b3851cef449111c36d029d274e1e82bc851d9e1acc4c2c";
+      sha256 = "345d1cc6d643b56fc1c4ebb2b004573e261eef45b33a3f88d7b6fc4e08b82593";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/ia/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/ia/firefox-104.0.2.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "7388fc216e9a20886a9259328ec31b9cbe704664fa1074511da97b017bb90f45";
+      sha256 = "e645a171d8fe01b72de1b627a681c50c39916f4c3cf3c68786ddbf3bd2bdf76a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/id/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/id/firefox-104.0.2.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "a4bb7b6bd9418f469da9da6261bf730881b9552897c47bff9302f7656cb8de66";
+      sha256 = "f2a8ff93cfe5708ecc87e3b3408d3edf98b7810c29f0092864728ca11bb9cbb4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/is/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/is/firefox-104.0.2.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "d68f99bf6c3c8b1f55e90918b447142c23c19176cabf160adda6a8ed72b2bbca";
+      sha256 = "bd528e9786b861847d82cf356930379f5887243ce55f55e3dfb7d0056c2b8c6f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/it/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/it/firefox-104.0.2.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "32c76eb0facdaf6a122dd435d0bf439fb67263d8d2d59e38cce43a42b102076a";
+      sha256 = "f4bc03cb34b89fd1bd89453183dfa39a316ac58be91548b4789c508b7eec4c4a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/ja/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/ja/firefox-104.0.2.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "2cb74bda7dd887cddba48518e7365c0f78b9bcbe779b3d42b9e302c2bc7272f7";
+      sha256 = "61727753443caadfb0e6a137f3cc3d4db79226cf94a60977234abb866da2a1e0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/ka/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/ka/firefox-104.0.2.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "aff885827a0012629b9a08675253e56d66119e565f39a79bedbef939912d70a0";
+      sha256 = "ba239d15f98db5ad462add00e12c242c8e700c728a3da6207a2929c08530fb5c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/kab/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/kab/firefox-104.0.2.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "d44a7266a6bf05adf879f9f96148e86912aaf06af6c9e1b21898ce4d137c0912";
+      sha256 = "1bfd28981caf4043570e235b86982c185b99c70280ed7d5bd7fba5e12f8eec09";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/kk/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/kk/firefox-104.0.2.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "c43f1c6d64d95f2b21a1471d70de463addd253f99ff6ce3c7ad31bfbcedfd2b6";
+      sha256 = "c02feff1802efdb4e3f54ae35e1f2fcfa435d3df6f47d0c7a71414e981e94b65";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/km/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/km/firefox-104.0.2.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "bf8e176a88a90021c093d5864869dbcace1d1e485eac36f10284e90b82e0c6cc";
+      sha256 = "91fffa21cb137da35863d273b2bb920a65c038b03db7dcba01606e09c9a4a0ff";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/kn/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/kn/firefox-104.0.2.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "6ab211aba16ace1febf04a1b505296bc60cd4d7f30ffa879b603130dce28f697";
+      sha256 = "5e8493e8b8030257695dca64c40b6a95ae1a4f1049384d79cf105f82f78b0adc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/ko/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/ko/firefox-104.0.2.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "b7aaf899456dafb2e9d17bfd7b2d004ce86cb8dd7ddce952b43306c757786da7";
+      sha256 = "34d34c2cc0cfbe1c3a9d0d9f8e634973adb9d33235c9268727f0e04f8ac1c818";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/lij/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/lij/firefox-104.0.2.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "19ab919dea3a8f2c9cd9da77b13cff2bc23e3b69c1fbc0ae95fff237f45116de";
+      sha256 = "b5fe5d6a6936369127af07cb8e0699f5ef9a87bd91c92a0e441fa3c9d02946b6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/lt/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/lt/firefox-104.0.2.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "0e68f7d9f968babecbeb575fd230b33697b11d38af9c1869d7106834704bd968";
+      sha256 = "2a0a3ec28fcf9847b011ec19620b012e7b3fb47ef46d4c073c23132a0f410813";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/lv/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/lv/firefox-104.0.2.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "34e5191fb9e9a7b7c50008f0f2f52e55a0be6a514d4d00b3c19a78eb1f00ee75";
+      sha256 = "a0f30b8590fb40e4c848a92d614a9bc48fb08bd8544b6ac7491b6c7966ea1a44";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/mk/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/mk/firefox-104.0.2.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "76a7e405c9a3fc41c4195091e825385d886da7a0d738c8efd363a558c6ef77b6";
+      sha256 = "fcdb6a1a8d17050a35491790fea04ef32fa9c792c0bf54688caef7421dc76457";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/mr/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/mr/firefox-104.0.2.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "6470d228fdbae2c730c7b54d3fc9653b582b7684eb44442327fbadc77f8ee47a";
+      sha256 = "2aa8eb8cb5bf7bf538f8ba2a335e8c8022941e026ff1cebf850fd3fd35e12577";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/ms/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/ms/firefox-104.0.2.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "af22b32264a687130d20561f7bcb00550c007060e8efd81c8d0b0bbc0836b324";
+      sha256 = "3cde6f353d84ad1e8d53889a08fd3b3ae4f3b683c899bfaff4a4e8c41640c9f6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/my/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/my/firefox-104.0.2.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "379aeb87c66c4c7fe88da0715966c6e7b826b333843f8c02a66a43d7f080cdee";
+      sha256 = "43e07c493c5d666bbbf0cc5c459f65c837a6ad79812507f9eca348cc7137900b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/nb-NO/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/nb-NO/firefox-104.0.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "185e4dcfab9a600904ede81cc17c1a91f09e95accb1cf8074b59a5b42ffb8542";
+      sha256 = "a69acf463d5ebd23e9707fad6f12dc2ba84430f05bbc9e2f3209812f5e9f58b2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/ne-NP/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/ne-NP/firefox-104.0.2.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "4702ac7a3ba62b0036c2d2db0a9698a16859e02e2a5c249dd2fb33dff7ac7818";
+      sha256 = "dd7ccbd686fe18ab6d4fe22b56e26c930287fef450cfc2a2ebdeca6488ffcd8d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/nl/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/nl/firefox-104.0.2.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "97f684f9f32487607482a1c4fded5a6ae051f576675fa50d770baf353338a14e";
+      sha256 = "1fa0b65fe5f5410ab8395fb3ce7a33250f9ccb7bfcefef27ba8e6c1e4660a81d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/nn-NO/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/nn-NO/firefox-104.0.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "601d776b31fbf41abf76481189593811d22c9aa707ff0c6f4affcfca0e1213b7";
+      sha256 = "c63e095bba9244325b48b7d09327107ccb44ab25abfdfc27fbd63cac43dc2354";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/oc/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/oc/firefox-104.0.2.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "795329484f06760657d1ad61b559e504bd91f70971a673980377e81ab79db1ad";
+      sha256 = "e7f3d8f6c889b5c32ff39c99bb5f832badc0a7630e9630539583554cd0105711";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/pa-IN/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/pa-IN/firefox-104.0.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "54e4b8e6d6b433c598cb5c51c51bf225cec19c6978861141c7e97bf72b168591";
+      sha256 = "d589d9315a9b1c0e07039e588dab1433aaf9fd8a32124bac33a2d28f086d0a58";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/pl/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/pl/firefox-104.0.2.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "006433743dbe81fbb75d2d481c366abf0c69b511e21b991e87e642141ea30284";
+      sha256 = "fd0e4b836b119e0ba91bd43f527d070b10593efc7af169cc03076126163a4c23";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/pt-BR/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/pt-BR/firefox-104.0.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "838abd102b00dee004259e00ee7e568d5747d72ce3e953f9603a68c520c174c0";
+      sha256 = "2642981983ce1edd2bc6f11c8a086f047bea743b57a8e3b601a481f3b3acac83";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/pt-PT/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/pt-PT/firefox-104.0.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "50981b2ba562f9e6b43d11e5b83b033618ead8f2904c3d42bad6175ec82b1f45";
+      sha256 = "b89c9c4a68c9c3d160e2028e79c2b459bd7dae48b748751095b16da2dbb6bdfc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/rm/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/rm/firefox-104.0.2.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "3b50507b270c20eddae825f3f74028589d884fa712f14522613256ed99ae37aa";
+      sha256 = "04173834eae36e9c5be2c100b8e9e428bb6134eb03d89a4b57154003739f60a5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/ro/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/ro/firefox-104.0.2.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "bf6c6d1a98a406973780e631fd1e2d3061dcc85576dbc442d24de33fbb789cde";
+      sha256 = "2bd6a05cb02c128960a0901907bf4f8f0ac08d5468174e6f711e9aaa4ba812ec";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/ru/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/ru/firefox-104.0.2.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "d46b3f9a7f8b3de37af6cd3e410f059f258b823bbb9ab0dc78d123b643a8e04d";
+      sha256 = "557b55077665a1765fd552b109ad3e86a14ce9a8d82dcc6da981310d5d841891";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/sco/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/sco/firefox-104.0.2.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "1be16b7651cb2d5d42d0e18bdbdb5282f9f6cdaf56edbe39719552cc781a1e3b";
+      sha256 = "11447bd049c8e6f4025b4bd91b554f4f00bd43cbfb6df11e41b3b259ef577e8f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/si/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/si/firefox-104.0.2.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "8a7b7786d56c696f7daf450e8ec472545e1fa2fb51597b1fd4bed20fcfa75ce4";
+      sha256 = "5f5d10b67bb8d7e4e9e54aacdde8f6baeee22f7ec9063dc44dcb3a74b9cdc280";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/sk/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/sk/firefox-104.0.2.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "473605f1340d8075a3e6a775730a8d6bf4df275ac6f658f4bc5ad5fefcc9a1eb";
+      sha256 = "ac955cab23b768570e98ca209b9ef1d7fcd5ad38088629b6c02dfcd9df98d2d5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/sl/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/sl/firefox-104.0.2.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "87e7d25a27a75a96b8bc4714a1c32bee2567428d51b70dd1a4b042be3fca444a";
+      sha256 = "cbd4aadaf69b126b9812b86602869d70a0f1d44a8cc7bcfcf3bd860bbd708aa1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/son/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/son/firefox-104.0.2.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "a300d54ddc9381ebcd305b12b39a89b862d5b7c44a253df307dd39d3e990332b";
+      sha256 = "22d6cb57073eca472ab1888fbeaf918a2b582a4d43009099827c7b16c78fcb78";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/sq/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/sq/firefox-104.0.2.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "626ea07f08439683842da69a66f365e25270f8037e8309bb59e5ad29a0209550";
+      sha256 = "ddb92620fb72faed0531d15f5e6c409fa45a871da52c2a94379ddff86398233b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/sr/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/sr/firefox-104.0.2.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "bbbbbd24452dce9521e429c8a2219d281324048592ec238c58b0e32d89a6a0b8";
+      sha256 = "97d3445014649654d0a53a8a8787bc1d230c754c8e82f6565d28204cee6eb7ec";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/sv-SE/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/sv-SE/firefox-104.0.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "0b71f626373c89420ca75dbeb87cb81d92b1554e347c45bd2e0f1ef0480086a5";
+      sha256 = "56b67c574d9c6dd61d0d90815d44a389db87c7797f589ba783eb0e267bfcff39";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/szl/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/szl/firefox-104.0.2.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "171734e604d2427d109ca62fdc147e95412dcddf5b103ce53959b38011b55db6";
+      sha256 = "b01855404d1954ac2e7ca32de795664487b3140a3abb6eb39f9e7c4517a3e847";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/ta/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/ta/firefox-104.0.2.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "565feccc8d44f80b2535c8457e8fe7955bf870851e9bf5ce01945072be361529";
+      sha256 = "b753c8cf0b0f8986c128e723504d60af2546eb9e1230282f5d2df904986a460f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/te/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/te/firefox-104.0.2.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "a40de9b858e3a72e2763def4bdfbf2bf728968d4dc1af1c8ff98fdfdd9957d9c";
+      sha256 = "fc5261411de2ea175bbc334444f013ee48f81b5275ee236da2cb45cd7f72a07c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/th/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/th/firefox-104.0.2.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "209a2ecaf06491acfcfd12f2484a2e0bb4d4cd28e717c3cd463d7a82b1b890be";
+      sha256 = "bd6c33ebc54eafedac5693e66a994fd3d0926c1d032d92bb304b795a56e65bb4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/tl/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/tl/firefox-104.0.2.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "1315d19fd1aedf3c2fe4575e338642e613f5aadcc934e4aa394b46508ba8e7d3";
+      sha256 = "fc22328a44622a85a25da5da2d6de4f671552cc00a187bb79b39f86376df83e0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/tr/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/tr/firefox-104.0.2.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "43bc5ae743762dbd1e6a5f4ca741af0d5a249fd44c5c44d460dccd299ee16b33";
+      sha256 = "cae0a63fa1eb6bbfab6eb1757afa084935355ea3789d2188b1f965328b3095c6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/trs/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/trs/firefox-104.0.2.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "b891de426ce99550b4e2811b9f3afa60f51386c37c2561fd11cfcd9ded4ea255";
+      sha256 = "9c214a98cba98de1f19658d37a40a68aee742afc4cf00fb641da9bc536f96efd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/uk/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/uk/firefox-104.0.2.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "274a0294fb9b87651d32d112a3b800a8f54cbcea5b3771a6f16a78166f2431d9";
+      sha256 = "4db6f9fac2fd5ae72b0eff4bd74d61f9f3be736bff949d9d845be8e187ed7af3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/ur/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/ur/firefox-104.0.2.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "0a6221f13bd4e064490b1ff893971f841d88dde5a0627d5cfda677a73a70f056";
+      sha256 = "25d06c4179f123cc9113e4c4044f5b31e5cca98af56385fd3c64eb23cf26bd6a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/uz/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/uz/firefox-104.0.2.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "461ef5aa63c27314c9ce18915aebfae83a79605f6631c552a16ffcf2cd39a179";
+      sha256 = "36a0917b3b2894fd097b085fac92aa9581523e5e221a4cfbd2e1aaf0eb4cedce";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/vi/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/vi/firefox-104.0.2.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "8f225b81c0e3f370f032fa70ee5b1b8a7b411f7044de946e038d120341213695";
+      sha256 = "eec707d1188c1f34d2e36d4f8beb55d3025aeac88a1bba962855e9228ee4eb24";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/xh/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/xh/firefox-104.0.2.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "f5ee5df9ae04fdb6c0a7682c0bbeb9a7680c0709cdeefdfd2e436fc78c65751e";
+      sha256 = "fa22632decc106b9533f0a45a2b7c006aa3a9b7c7c8ed3dce21e336cb05412e0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/zh-CN/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/zh-CN/firefox-104.0.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "e55359627f9d9c40c6b82371b1513903827b5090e8b8ac7ce377792f86dc51cc";
+      sha256 = "6354d6fc61d550b7002ca14af8ba23f39cfd6228a9e3ee416cd3c4a7f50ae70a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-x86_64/zh-TW/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-x86_64/zh-TW/firefox-104.0.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "fa36cd618329d7d7d52ff3ec516bf14609c0a64116b5c176d93f4ed76f29228a";
+      sha256 = "15d008da0371397f6065609e35cf8fe3a5ededa4a49d73793a67b7dfeff84744";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/ach/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/ach/firefox-104.0.2.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "a31c9d83642f07ca2184b5f5d9cef6e61f2868b8b7476b4af2736e54ad873917";
+      sha256 = "80b52bb7921d5774eb967bc64291b3416fc57c1039d111ed0d70b6f791397bc6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/af/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/af/firefox-104.0.2.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "7a52546bc92b712b59dd4863f9c068bf45778f338b10f36eef5a166d468fdc7e";
+      sha256 = "dc9cde444ea2a4382fddc5ef0890d69147696224866e92f598ed53aa7ff689b3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/an/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/an/firefox-104.0.2.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "694f21ac00a61e03a0fa62d2071b50666af9eb97e02d6d5a2a27475965d72fa3";
+      sha256 = "dc611ee301c1d7054e676ed880595bd209f1d7d1ffa75beaa4ba3071ab913dbb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/ar/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/ar/firefox-104.0.2.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "4365c922c78b0358e067addadb0b80abe96a446dd0508bba9e493224619d9598";
+      sha256 = "ced68c11ca588e46b65e6152d888f897302fe0751fe03d9a74154af7799da99c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/ast/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/ast/firefox-104.0.2.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "0391c040c9a5a14f1bd28a1428dc6a0d338e19b219c68c15bb66d044891dc5d3";
+      sha256 = "27d7ba793e4cd8f5ba7a1a3b87d88b95b428f60dccf7ba760965ae959dfc1726";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/az/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/az/firefox-104.0.2.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "d3163732b7b3153c4cbb03938a1d434912f6a0430e95a6d0a84b4715ee1ba06d";
+      sha256 = "c82e1ec94e81b7ccf7e71ab6affdf178cff9fa096d505334ae7de0a68a1f331b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/be/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/be/firefox-104.0.2.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "b9426c3c7f7cf1982a5f841528181ec278c38109197887b1f19db2ecad806a31";
+      sha256 = "0656e05c254983660921cece1fdc90e1d2331762b5e5c6812b155d1fc39c382f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/bg/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/bg/firefox-104.0.2.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "45f8df1cfdd487bc57d5f35c610db4f63d1913cd7842317250cb96f6b88fa84b";
+      sha256 = "3a7adafa1c2f905b1fb0bf13b06e5bb96d69eca8a560e6c95bacd6746c63aec0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/bn/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/bn/firefox-104.0.2.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "623cc1e5b9a5e9adf8720a54611c77a6716f61c4393bce24a9880bc00807ebb0";
+      sha256 = "42f6e9ec380cd0c965f8b4c9359ad6a1a0241b6193fdc4c51bc59ad01832d22a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/br/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/br/firefox-104.0.2.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "75f70f142355ed33e0b29f4d923f86d70d52b3315e2f5e8222dc830868ac9699";
+      sha256 = "6fd4ef5a0d7a93f7616b6d0d5582145d9026e26dc9e0b8019c1c6c043254225b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/bs/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/bs/firefox-104.0.2.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "481720b31fe9e43e89a6dcadedf891600eaae846f6ac254510c1023fc0bf7602";
+      sha256 = "4b72ed0432f8f5850eb21bc5e48968a9cb6fab00be13be64b8dd81b124c5d689";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/ca-valencia/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/ca-valencia/firefox-104.0.2.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "c77daa0a6eda1bd7a3302aff89fc5cc742f82ca590d8b50c3eb4d5f8912c4d38";
+      sha256 = "9d2b519e39499fdedb8bb701f6aa656e7a1ff45c9c47f10ba59d419f300edbd1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/ca/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/ca/firefox-104.0.2.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "340f4856c85821bceb8507d2fe4d41bc7af2a86f47c5e4b3d2883cdcd84e23d3";
+      sha256 = "2248f0b61091e549ef59174000a84d4996915674db36086925a2ca2575c57010";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/cak/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/cak/firefox-104.0.2.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "0189a40abcd38fca21209b2d9df45c2ce4d0bbd1e58398a6990c99991b31809a";
+      sha256 = "bbb31dd39ae935a1c80884ab0f36ad24643cd4d9980cdcce95fa5f41b14b072a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/cs/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/cs/firefox-104.0.2.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "a43ed9268c3dc51eeca3f86f0f7b1d5dd4b6653b453888e7f8a02e7da764adaf";
+      sha256 = "b1be942e5dcea324e82245e7370cb198a7541e13bca6df93d0b9365da1409f43";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/cy/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/cy/firefox-104.0.2.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "b13e05d11884c99c6d1de9ae40debb6ea5c127b3e04570a58cdd16e64dcbaba4";
+      sha256 = "e4138344d8029ea6b96e36cc28b45aed7c4713386f75d60c9a9d6a2f704c8017";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/da/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/da/firefox-104.0.2.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "9e921067152df52d659f0db49141a5279f7ca820587fd9c67b111a9d8d27b4fd";
+      sha256 = "2217f5ef88d72c2cd380bf338caeada54f1f2fe7b41bb52a6823cacb0b31e1be";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/de/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/de/firefox-104.0.2.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "505d066c5e2d98c588ee16134424eab9e29b596f36079abef16fa13d2bd57a9a";
+      sha256 = "e34a6310d1186255e47d2c774cc327f9167b890eb8d7dfc814d1d8716e0b71e4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/dsb/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/dsb/firefox-104.0.2.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "01ce83767a2dd06c9f0b3ebd0fc84f86b269b12e8c5cf27e19fba377dbf19b7b";
+      sha256 = "41161204e3ca96c1376bcd207d11761fe28ab24235aa2abd8727bb2172be0d29";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/el/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/el/firefox-104.0.2.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "dfef402bea95a99bc142742f6814427f0d9ae69171a25b70e42a0b8ad805a964";
+      sha256 = "325eb9fcb25883e9ee2307a0c52273e3b8eaa7b8b7e99e7b34be5bc865e2451f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/en-CA/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/en-CA/firefox-104.0.2.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "ea86e7f299f7bc4007d3911aff35515071597815d421081aed0b7f70d4037998";
+      sha256 = "b7b2608de5445c5c26477daa7933be07b168ea1101eb9fb01c5bd2b504d9ff23";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/en-GB/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/en-GB/firefox-104.0.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "fba537f5929f2c672e342648b60bd0b483a358ace54c702423f8b5ac6b7350d4";
+      sha256 = "9491c5453825ada4b0cf45a908b2788b29b3f7dff71d44b17a2ac2be67f7248e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/en-US/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/en-US/firefox-104.0.2.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "4245963fa4a308e39e33adf561a2dbba544ee4ccb664166a1a0bd3d4866c80e7";
+      sha256 = "010fe1a264424dbce895fbde5c612484096b0c1958fda6af18004f06360f42c0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/eo/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/eo/firefox-104.0.2.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "10a4dc233087fc6f7d254361c254f4690a2723511b10c7d0809288b8930b20cd";
+      sha256 = "d210ede62d2a499d2d8a728a1012f39011b5b3da26c3d76578c24689ff249080";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/es-AR/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/es-AR/firefox-104.0.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "fd1ca98759dc662accdff786767d0e743fe373f1b07383e60e6bd346901a20fc";
+      sha256 = "98a93ba8568de1984667e91b47c8e599db98fe84f8266179d022c2e0c7041e5b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/es-CL/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/es-CL/firefox-104.0.2.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "9f647c6b6a4922759e19c9f7b97114072a6a61ae77cbf28f393de55a45fdd160";
+      sha256 = "155bb4237c38d913c468ebff4c97d93580610352f3cd1ab0194b6c712a91a1bb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/es-ES/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/es-ES/firefox-104.0.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "83f53ea66a76f9a00bb9b6baed846898ce778d8a0587af88d8ce7f233dc22fa8";
+      sha256 = "517d91a75338712f064ba6e32de08ca5731221b285609e972d350d9bccfab83a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/es-MX/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/es-MX/firefox-104.0.2.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "62228d4fd9dd396746b197cf7eaba8089cb1693e725bf4fbfae6897e89a6d308";
+      sha256 = "d1d8db1960d84cde6b471075f45cc69eba5f01fd473653a19ea0077a6157e4d5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/et/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/et/firefox-104.0.2.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "1a63924adf21db0cc80fbe3cc145667f236ce30486db0dd6923784d39285f1ad";
+      sha256 = "80a16b63deea88bd982a0291fd30ef805d71a5bc9491d089d175482a344bb423";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/eu/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/eu/firefox-104.0.2.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "02d07cdcf16faf4f639fe7c7549a3e8bc94b69a9152b6655a05f8f95105685fa";
+      sha256 = "525215517774eea3c69af35f787e1b5a22182a54f852ea896007810f98469a0d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/fa/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/fa/firefox-104.0.2.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "e1dfa550cb458db803a4d8af7bac5b1379b14b1d1c002d03ae6d4cc246a2b14d";
+      sha256 = "d66756cf467ac6b418468a67f00fa74c275f0e60c12d0b0750be90717018a1c7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/ff/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/ff/firefox-104.0.2.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "2f3c7b080a45b4aeac2a65be70c3f96591766acb3e8fc100c0e72f543631e755";
+      sha256 = "186789c2fafd2091a27d778d77142810b47583f9ff70b55ebab44c01a84ef71c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/fi/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/fi/firefox-104.0.2.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "2c618c81d2cb07b81ca0330359fc684365093080345c67f6c0369cfdbe657cef";
+      sha256 = "19da3c94f704c9ef0d0c311fa999488c34dbd6e80e1537be938ac671b5c88afb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/fr/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/fr/firefox-104.0.2.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "2a6e0d96bafb5684aac73729e75fcce8e25aa356c6970afdc49ef9088a8e0827";
+      sha256 = "34210abdd4426f3fae552c66a24f9ec47a62c2caf31c6e461fcc628f12a0ae32";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/fy-NL/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/fy-NL/firefox-104.0.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "55bad815f4450dac06b5a87ff1a9a5bd88d614a17ad32247d3c793bcc6c1199f";
+      sha256 = "f010fe685469665a06c825539dbb1ad9869b7637e6615afe1ea2b73975bfd7ca";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/ga-IE/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/ga-IE/firefox-104.0.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "ba760d34d5bba3894af6f49c0718d7873052be0ace2638194d72a1a530dda5dc";
+      sha256 = "52e749ea69e3b8b3532bb42ed97bb4c6f068630cef906823e1a4384cc7a3821b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/gd/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/gd/firefox-104.0.2.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "4c5e01c0f9fb008242f63ca269501fe705f1493f3be7669af41cf77367590819";
+      sha256 = "2fec3c5feb400dac5cf50cf2dcdcd0ad1055fb309e3c6df9a570f69475a96e25";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/gl/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/gl/firefox-104.0.2.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "3d752fdbe4079ef095837b16d6827373221340ccfb990448cb34f311718cadde";
+      sha256 = "567d6158b3d034177bb6d834027503d296f19c51ded4a728d10f41f4312be616";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/gn/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/gn/firefox-104.0.2.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "78c2813a0d78e7d8c7cc06e00f295b2624c36539065306ce422a630e962ea7c1";
+      sha256 = "f7a6f4601a8d22a0d0abb3ae531b0aecc7d93c39e134b9b4710a7da3b39e712c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/gu-IN/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/gu-IN/firefox-104.0.2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "245063e3c3db7724cbd6c2c8f40554ab8414cc17893d9762a148811ec173915f";
+      sha256 = "1d9e0dd08d3cac979799b0ed5ddb36064a194dad19fa691df9b9839c2d66a820";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/he/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/he/firefox-104.0.2.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "316bd30577b34684fbae8baf8e38ee74545670704d738eab96380486f6be6731";
+      sha256 = "554d20610f4da37bd7e5a741dab279b4d2cf049c260648950a27af7da2631031";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/hi-IN/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/hi-IN/firefox-104.0.2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "1f0779f17acca8166e92cca11a38006e5d931cb8c9b5d0f88b4436be91a355ea";
+      sha256 = "e66c7af75fcd766f7dfbd220d29cfb1ff835222499ff567b20f0d7f429937947";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/hr/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/hr/firefox-104.0.2.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "70ce9afb3e8c9e2239ded6d9ad737c3624bd7f66dcce74949084a519bc4a093e";
+      sha256 = "8853c55f7e822a93b26be08814ec972dd5ff22ae4451189bc370e79541048163";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/hsb/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/hsb/firefox-104.0.2.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "f8c65415c6cfcfea767341ea1807e5d8734a575f230ec1693fb7f7c25ffef346";
+      sha256 = "6fa56ffd044ccf9d7144ac93219d0c8278408a60de9a23f5e73384e112b28a32";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/hu/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/hu/firefox-104.0.2.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "6a39fc6c310d375403fe1e7d9a24d36d19e9a0f92a87b5ca7d3344c408c0f492";
+      sha256 = "22dfe001c214b0a80bd6540ba3d8e72d2b939b23a3858588e68723cbf80c33bc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/hy-AM/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/hy-AM/firefox-104.0.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "e3c2dfb22aae397d52ba20db8d31208920f066d939f88574afdbc44ad73aaca3";
+      sha256 = "f8e214d41410854cb406e191c3863b6e7f4f7caa738f9161a9696d8b6c0f4252";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/ia/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/ia/firefox-104.0.2.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "4c70aa33a75a07234cf19fc9b3501b4108796c28b87a37ebfcf38271c2533570";
+      sha256 = "5055120cd0d5c509954412d098238e1cb753e1488a3e0365861ca6552976a1d8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/id/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/id/firefox-104.0.2.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "74180cd700e6ca7519fe0dee181a17d238fb30ca88c43ecb2ef1a0c70ff64a2d";
+      sha256 = "165132adbc0332273ffcf7818a7b4466cd986e3c53215ac7526c2678a598573a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/is/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/is/firefox-104.0.2.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "983eee43a3cf1e2625f01e4e28e8cbbb147a965c2b906f9a7967d2c5f3647b4c";
+      sha256 = "a2611d61d3741b81b12ddc9869f8dbfe87f565a7fa4afaba42a471fb8ef66d6e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/it/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/it/firefox-104.0.2.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "f6fa77b440fb5c3f82620de27bb28eea15c73cfa686313fc45bfc98624b0a6f0";
+      sha256 = "e30b8f2f3b92551adeab81750b8ea2dd5f7e5aec86edbb0f23cd10f14548bce2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/ja/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/ja/firefox-104.0.2.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "e679ed95282b09186e863da2397ff0d8938326a59569bf20a5825a8aa0937d83";
+      sha256 = "86aad03a64c1cd57ce314fac2094b6c063ef9e5162a94bb1de7330e8473c2d84";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/ka/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/ka/firefox-104.0.2.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "9927f37998c04bed685e3a8c727f7d88345a56a270406f39b77b32cef4ed47c3";
+      sha256 = "0db19b144bb1d3355b57b2b86258fe371cb571b653da33577388aaf3f4f763f2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/kab/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/kab/firefox-104.0.2.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "a95c1d431a8bb78dc747243593fa95f39772b31072a19a7be4276c139106c54b";
+      sha256 = "92bb6a41d403b7ec3c625a991d811e226f104c7e455e12b2c05aabcd6d646ef7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/kk/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/kk/firefox-104.0.2.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "7bad95e09ed494fd42d23259429d6ee295b9d2356c9c830f2ba90c59c2c85f54";
+      sha256 = "5017ad7b7cb70d7ebcccfe970ace772525f2d0a05432d771eda07c84c2c63659";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/km/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/km/firefox-104.0.2.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "e836436450ac9f2fbe6769d56959aa68f97e0609bce79080d75f9cbd55c45c30";
+      sha256 = "04c5e486e7bbc38d5233bb78656a2cacda391ef6c9142490274981a48c1d5efe";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/kn/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/kn/firefox-104.0.2.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "3ba796425b7f9cfdd3b05fe9d51d4d8baa5661d13df879c9a5fffa10c03e0962";
+      sha256 = "678cbc40d44235ac911160ac6b5a71aa2de958f1f98e8fdc1a7caf4560719aa5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/ko/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/ko/firefox-104.0.2.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "482e295ca68907eeb29415179a01020b6773c1e732987abf1e9dfee8bed6ad69";
+      sha256 = "5c9450fdc8a3b6c55b11ab074db207cf3b19abf5756f4cde05d5807871dece93";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/lij/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/lij/firefox-104.0.2.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "ce82d2e860031838403355374c3f174f8adaefb94ceda4c00f7779aeeb49f449";
+      sha256 = "8a9319259383c8c3a262f396f248a513e527487bb71423982aa0cda343af282b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/lt/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/lt/firefox-104.0.2.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "9f1c00041dad5f12525049ed060f7edf4b1ebcce7f5bc92a51f3cbf0e8ffe16f";
+      sha256 = "e8cea75877838fdf24791b9ddd02445fc1d627c41b3d0cf3820d1f68304aab69";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/lv/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/lv/firefox-104.0.2.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "2ce6543e40f0a31b805883420cb031f908cc8ffa61ab87887f10e8510e22a6d8";
+      sha256 = "2eaab147964996d132a7217a86fd315a9c3e06716fb3b461019e31585a87e1e1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/mk/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/mk/firefox-104.0.2.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "a87c1435397031f82eb95c6cf53e77b3b78da4a83fb22163313c4d44b064d83d";
+      sha256 = "8bdea99a3670ea42081ff0ad2a7c43a40810e96f5548182f7a13d7e729427868";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/mr/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/mr/firefox-104.0.2.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "52a9f79922e2749b437c96e36572c66393587af0827ef878f051cf781815be9b";
+      sha256 = "1b3b2563ae2ea1cbf5a0eccc644362e2012fd4fa827237660e2d4e914c3b665d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/ms/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/ms/firefox-104.0.2.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "44d191afe6eb8bb1ae0a1c42e9364fc9e2df872de785afaa28febe2f10be2841";
+      sha256 = "fa848d1f8bf20cee0015e3b669d7d9d114971395ac3e46e9bf6ec76ffa41085f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/my/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/my/firefox-104.0.2.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "41e6b78e79442a5c188244ca6913e2efba6b80a06a4dc73551122aaca53c87dd";
+      sha256 = "f9f22295cfebb814f08f12cb67242d8d57e0e567ac354a7c3907848744988030";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/nb-NO/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/nb-NO/firefox-104.0.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "c87e32da5fcfca3a615c0596e4e7bc063880d09acabf57eba572ff935da4e6cd";
+      sha256 = "9f1a774c7aa1d68d0a85a2fd45d77a6265a98ff2cfddaba31430824706b0844d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/ne-NP/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/ne-NP/firefox-104.0.2.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "3b83084f12069db42eeed1f10db3d6a510424cb83b6294e8660a27768208782a";
+      sha256 = "d4fd464af41e3f7f698161672d2cd64114776b2472c6507ac210623bf9ff7660";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/nl/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/nl/firefox-104.0.2.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "3b24d5185687b0c9d157f7df95c09873558924eef6e30163093d33617b608a79";
+      sha256 = "d0c9e3efeae39edb3fe5f94bda5a081c50490d1fb7375180f03de820796a31ad";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/nn-NO/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/nn-NO/firefox-104.0.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "81ccd7bbab199bd6c52e2a9ff652da99ce4784839357393fd9fc5c988b585678";
+      sha256 = "d46b4c653513cc43b025d8636ed797da39e1cc1e73996726c9f172b36d8f233e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/oc/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/oc/firefox-104.0.2.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "76a2dc01da8496b2f3c2ae556ed000303f5fd972048d33caf44b97a033876ce3";
+      sha256 = "e8311f1e98e51aac0cce67934875a435de409640d85e3ec71d6246c58585c69d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/pa-IN/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/pa-IN/firefox-104.0.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "79a1f58cdae0e9de01d50beab77b10daaf5c74e1a423b01c9ee66c93a8a1e6dd";
+      sha256 = "1e3e89c94a6eaa922115b30d14ac9b220f156ae5058d95dd236b82445c619180";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/pl/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/pl/firefox-104.0.2.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "8ffb844968823350d2a1919baf116647f696ce1575af2b97da2e4c3808a49d96";
+      sha256 = "cb627ae6ff19def4a423758eb37de1f3893f2346657e44a84e8797aaa93930a5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/pt-BR/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/pt-BR/firefox-104.0.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "dffbea9f54ec05fa4a4a603e4af62d964caa263840e57a62b07182f1a853feed";
+      sha256 = "2db6d59778c2220e9962342c96cd7f12a6b91d63f6b3256e7db3ab438b732727";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/pt-PT/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/pt-PT/firefox-104.0.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "c0a1f34075bfcbd449e2b4e26ceb6338615aaa51fbcae8849298cfb5c96941de";
+      sha256 = "0776065b673cf7b85021173f2bf976db23040194a593f1023132b11ef9969314";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/rm/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/rm/firefox-104.0.2.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "9172cb23f05219ddfb98999c5199e3259c661def5d9eff9cbc923baf8e10e666";
+      sha256 = "ad0994056d9fe0fb7867a812f671ae389014a91aa7b7227dec1a90d1d7a04a98";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/ro/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/ro/firefox-104.0.2.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "17622e7aa33c99ce0fc79471b2ea16991b4b8b8c9f7ac44a75c46229405b3545";
+      sha256 = "1c90f5cd272ba0f83a0a7d17d28d576a5be1c99c36a8791a0b30e056c3ac9be4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/ru/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/ru/firefox-104.0.2.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "16a7eef2d5154cdfe8671db7f0ec499db724bcff853c1394ad5b131cde13d267";
+      sha256 = "11b0b1044197f79c5b16b8fd58e4b9e42b7993efe52b940ddae81fd2050f71d2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/sco/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/sco/firefox-104.0.2.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "29e634801b4c1575dc8f5dbe9f8f747288fceadf9a48624787575e15fc7eaf0f";
+      sha256 = "8b12b04e952d7e3883aa855c29622be23e0590add03f9b0f7d70d4c17b8c4a48";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/si/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/si/firefox-104.0.2.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "ec25bd63d35cafc135b1134a8d475b6c17ea51a45822be89dd559c5e1ef4401f";
+      sha256 = "378d43a49ce5f350e964b2448d8b2a38c3a03d827a97b417913a439771fce843";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/sk/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/sk/firefox-104.0.2.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "244d3fb7b64a4f331f58d4677e5d7d2196518e18656038b8b81ce35da27a0890";
+      sha256 = "163a169a922cf3df37a568ddf7d38d5fd476fe52b5add2c849adfec2d80360e1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/sl/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/sl/firefox-104.0.2.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "077aba96432bdc1207246aa85d61cc217da5cf0503b62d376b0a660543584596";
+      sha256 = "26ed27f60f7241be5debbb64aa3529465a8c614934d5ba5f165d874d10e268c5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/son/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/son/firefox-104.0.2.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "e8486edc54f2acbca987f70d4938c4c357e608d606aac27f0d5d79961fd31dc0";
+      sha256 = "1d6f0259e6b17fdf5cee19236c95b1b98be3fee4881086f5aef6910e9c1394e3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/sq/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/sq/firefox-104.0.2.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "bf8160049ba4221996b40e52ffadb8fe3deff4104398280b6f3346d84c13fd8d";
+      sha256 = "a03ef3eb35ce6465877481611c3dafc41f02a5c513c47366068409a144366b20";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/sr/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/sr/firefox-104.0.2.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "e28bce795d6ac963b85bb1364a6f6ca2fceee9a62a8663c8dae7e08a81ae0ae6";
+      sha256 = "db21117be2df950e93e792ef556f83e48742d06506840f208e36bdb1227227b2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/sv-SE/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/sv-SE/firefox-104.0.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "46c402853c5f85d6167d3a27a5a3f5f107ac63e88cc96c41ef9fe480004c8c87";
+      sha256 = "cc590eb7559412e7b2a29ba85a2d7b880e5f22c298ff6a2444eed6eadd69c99e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/szl/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/szl/firefox-104.0.2.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "8af1852af64114a28c897e7259588274abad7887b0100b4db0c0f8f8386905e6";
+      sha256 = "aa0d8959b50c90c12939a2c3448a6a10aed87ec0420f135c991210f723c4d291";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/ta/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/ta/firefox-104.0.2.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "f755e7001c87b46236e8d5be3fb04c9ee1c92cda8b9ab7951487d171b96a9e88";
+      sha256 = "fbcc892cebe80dd45efe739745959b63783f014636f99bb90757ac8aaf55be84";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/te/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/te/firefox-104.0.2.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "f829424c90f074574bc46a39254dc2fa35cef0942bf999b5d76f231b621fa7a4";
+      sha256 = "b071e61789659bfad44b0d0dc97773a1f6fc09ed5871e45d6f201c9ab62b6cda";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/th/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/th/firefox-104.0.2.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "1a580020a10346eac69b53055417dc7b856e4534a430d7b035d5c5502185c790";
+      sha256 = "5959990c6aabaae85fa9a9c892bcf77ffdf56f26a72be4205eeaffc813e75808";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/tl/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/tl/firefox-104.0.2.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "4338bf3ef4731b1659280b73db0f045eef621cabd88c5b20023f90f93dee0323";
+      sha256 = "d8a47e0827c6c07ba1b7b86c49ee425d514cfa5838ecce86141fbc7ef587f788";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/tr/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/tr/firefox-104.0.2.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "9520fe8fd49df6210eea6d44e86adb23287341b6238ca604b14d583619bd977a";
+      sha256 = "62d3bf567fb20e1805c224b9f53859a1485c8b1859a64115d465d8c8009bb0a9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/trs/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/trs/firefox-104.0.2.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "fd3b1647ce1f3506f789776f09c34a1421f47ef526f2a6551e556dcf38c11c9e";
+      sha256 = "aecf6d70f79259fc1ebdb37edc5399e20cda023f5632c63e19a48c7b682b7c48";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/uk/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/uk/firefox-104.0.2.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "510956569849567ecd63eed4c8a29b8f0c5b79f1ec982787493e57b06e55abab";
+      sha256 = "913f25f2c57b8cac385aef661192ac323da5326eb0a7b7767086a108aec2c564";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/ur/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/ur/firefox-104.0.2.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "d5f15c2b1a3937cdbc73e5017605233d5d99f7a4bbd00e68518aee64b14d8374";
+      sha256 = "987bde5d66f4227070026bf190f015ef27e136c9d986bd39cf43954e83fbab2a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/uz/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/uz/firefox-104.0.2.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "c1539642cea700089ade88c560fd506f982458a65fd71156928cac4744b1f7cf";
+      sha256 = "2369ac2be59f81f611ab04a5b66015d2aed790894ce3f19e6d7c02873f39a9d4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/vi/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/vi/firefox-104.0.2.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "63bdb9f476491f2d16545f9dfddf5c96d6d8544662f9edfc4ada4133be9bb38c";
+      sha256 = "7cf554375250b1f60ab98c312ac3d4bed60794ed56db9a6b1c4e2a711f81efeb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/xh/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/xh/firefox-104.0.2.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "de394a6b8c1cfcc03820b88e711eb1e19b67059bf194b408dbddc49fbb5e6272";
+      sha256 = "441317cab501e4655caf7c38877aceb3a3cb9f620a442f370beda00bd01723bb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/zh-CN/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/zh-CN/firefox-104.0.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "8a16d657b66b144e8fcebf6f4063ee5a8af45835f30ed153ac0c1e9134600ccc";
+      sha256 = "6310f600d8df3760f62c9438565e446229b9035b5b2691848e5a1e7f887c50a5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.1/linux-i686/zh-TW/firefox-104.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/104.0.2/linux-i686/zh-TW/firefox-104.0.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "ce7f31676846267e671a72ce162efe8f631ccde0225bd83786131b4ae51855ac";
+      sha256 = "0839fd52b9738ab75c2227d0c2d3ca802c11e12e499f9b77788a0b0126654947";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -3,10 +3,10 @@
 rec {
   firefox = buildMozillaMach rec {
     pname = "firefox";
-    version = "104.0.1";
+    version = "104.0.2";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "ad80fccfde34a201fc4b596c2a0a1d959abc132946dde0865b6da624a07fd9c57381bc268c394a17f295e0e183d122b2cf5c5126e8a0bc99684affaa6212e246";
+      sha512 = "bf0d972add11566f5ef6402a22abd82122945de9fa9aab6ed7bb7e41d0843d41948a6d95c0769b0b704c066c8ff6e3f3bf26fcf288c64cd3b3f09a13d4dd467d";
     };
 
     meta = {


### PR DESCRIPTION
https://www.mozilla.org/en-US/firefox/104.0.2/releasenotes/

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
