### PR TITLE
crow-translate: 2.9.12 → 2.10.0

### DIFF
--- a/pkgs/applications/misc/crow-translate/default.nix
+++ b/pkgs/applications/misc/crow-translate/default.nix
@@ -12,15 +12,18 @@
 , qtx11extras
 , qttranslations
 , wrapQtAppsHook
+, gst_all_1
+, testers
+, crow-translate
 }:
 
 stdenv.mkDerivation rec {
   pname = "crow-translate";
-  version = "2.9.12";
+  version = "2.10.0";
 
   src = fetchzip {
     url = "https://github.com/${pname}/${pname}/releases/download/${version}/${pname}-${version}-source.tar.gz";
-    hash = "sha256-JkAykc5j5HMkK48qAm876A2zBD095CG/yR4TyXAdevM=";
+    hash = "sha256-ayEt4PI15NjlmFrDEa6Ipbn94nN9Ga7jThnIVBWPgKw=";
   };
 
   patches = [
@@ -30,6 +33,11 @@ stdenv.mkDerivation rec {
       inherit qttranslations;
     })
   ];
+
+  postPatch = ''
+    substituteInPlace data/io.crow_translate.CrowTranslate.desktop \
+      --replace "Exec=qdbus" "Exec=${lib.getBin qttools}/bin/qdbus"
+  '';
 
   nativeBuildInputs = [
     cmake
@@ -44,12 +52,20 @@ stdenv.mkDerivation rec {
     tesseract4
     qtmultimedia
     qtx11extras
-  ];
+  ] ++ (with gst_all_1; [
+    gstreamer
+    gst-plugins-base
+    gst-plugins-good
+    gst-plugins-bad
+  ]);
 
-  postInstall = ''
-    substituteInPlace $out/share/applications/io.crow_translate.CrowTranslate.desktop \
-      --replace "Exec=qdbus" "Exec=${lib.getBin qttools}/bin/qdbus"
+  preFixup = ''
+    qtWrapperArgs+=(--prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0")
   '';
+
+  passthru.tests.version = testers.testVersion {
+    package = crow-translate;
+  };
 
   meta = with lib; {
     description = "A simple and lightweight translator that allows to translate and speak text using Google, Yandex and Bing";
@@ -57,5 +73,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ sikmir ];
     platforms = platforms.linux;
+    mainProgram = "crow";
   };
 }


### PR DESCRIPTION
###### Description of changes
* [Changelog](https://github.com/crow-translate/crow-translate/releases)
* Fix audio support (https://github.com/crow-translate/crow-translate/issues/177):
test with `result/bin/crow -u "Hello world!"`
* add version test

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
