### PR TITLE
binutils: restore `nm` autodetection on darwin

### DIFF
--- a/pkgs/development/tools/misc/binutils/0001-Revert-libtool.m4-fix-nm-BSD-flag-detection.patch
+++ b/pkgs/development/tools/misc/binutils/0001-Revert-libtool.m4-fix-nm-BSD-flag-detection.patch
@@ -1,0 +1,137 @@
+From beca4a2c25ee86e4020f8b8bddc4d8e0ed3430b3 Mon Sep 17 00:00:00 2001
+From: Andrew Childs <andrew.childs@bibo.com.ph>
+Date: Tue, 22 Feb 2022 11:28:04 +0900
+Subject: [PATCH] Revert "libtool.m4: fix nm BSD flag detection"
+
+This reverts commit bef9ef8ca0f941d743c77cc55b5fe7985990b2a7.
+---
+ ChangeLog  |  9 ------
+ libtool.m4 | 88 ++++++++++++++++++++++++++----------------------------
+ 2 files changed, 43 insertions(+), 54 deletions(-)
+
+diff --git a/ChangeLog b/ChangeLog
+index 18e8b6835da..c12f07403c3 100644
+--- a/ChangeLog
++++ b/ChangeLog
+@@ -375,15 +375,6 @@
+ 
+ 	* src-release.sh (GDB_SUPPPORT_DIRS): Add libbacktrace.
+ 
+-2021-09-27  Nick Alcock  <nick.alcock@oracle.com>
+-
+-	PR libctf/27967
+-	* libtool.m4 (LT_PATH_NM): Try BSDization flags with a user-provided
+-	NM, if there is one.  Run nm on itself, not on /dev/null, to avoid
+-	errors from nms that refuse to work on non-regular files.  Remove
+-	other workarounds for this problem.  Strip out blank lines from the
+-	nm output.
+-
+ 2021-09-27  Nick Alcock  <nick.alcock@oracle.com>
+ 
+ 	PR libctf/27967
+diff --git a/libtool.m4 b/libtool.m4
+index a216bb14e99..7a711249304 100644
+--- a/libtool.m4
++++ b/libtool.m4
+@@ -3200,55 +3200,53 @@ _LT_DECL([], [file_magic_cmd], [1],
+ 
+ # LT_PATH_NM
+ # ----------
+-# find the pathname to a BSD- or MS-compatible name lister, and any flags
+-# needed to make it compatible
++# find the pathname to a BSD- or MS-compatible name lister
+ AC_DEFUN([LT_PATH_NM],
+ [AC_REQUIRE([AC_PROG_CC])dnl
+ AC_CACHE_CHECK([for BSD- or MS-compatible name lister (nm)], lt_cv_path_NM,
+ [if test -n "$NM"; then
+-   # Let the user override the nm to test.
+-   lt_nm_to_check="$NM"
+- else
+-   lt_nm_to_check="${ac_tool_prefix}nm"
+-   if test -n "$ac_tool_prefix" && test "$build" = "$host"; then
+-     lt_nm_to_check="$lt_nm_to_check nm"
+-   fi
+- fi
+- for lt_tmp_nm in $lt_nm_to_check; do
+-   lt_save_ifs="$IFS"; IFS=$PATH_SEPARATOR
+-   for ac_dir in $PATH /usr/ccs/bin/elf /usr/ccs/bin /usr/ucb /bin; do
+-     IFS="$lt_save_ifs"
+-     test -z "$ac_dir" && ac_dir=.
+-     case "$lt_tmp_nm" in
+-     */*|*\\*) tmp_nm="$lt_tmp_nm";;
+-     *) tmp_nm="$ac_dir/$lt_tmp_nm";;
+-     esac
+-     if test -f "$tmp_nm" || test -f "$tmp_nm$ac_exeext" ; then
+-       # Check to see if the nm accepts a BSD-compat flag.
+-       # Adding the `sed 1q' prevents false positives on HP-UX, which says:
+-       #   nm: unknown option "B" ignored
+-       case `"$tmp_nm" -B "$tmp_nm" 2>&1 | grep -v '^ *$' | sed '1q'` in
+-       *$tmp_nm*) lt_cv_path_NM="$tmp_nm -B"
+-	 break
+-	 ;;
+-       *)
+-	 case `"$tmp_nm" -p "$tmp_nm" 2>&1 | grep -v '^ *$' | sed '1q'` in
+-	 *$tmp_nm*)
+-	   lt_cv_path_NM="$tmp_nm -p"
+-	   break
+-	   ;;
+-	 *)
+-	   lt_cv_path_NM=${lt_cv_path_NM="$tmp_nm"} # keep the first match, but
+-	   continue # so that we can try to find one that supports BSD flags
+-	   ;;
+-	 esac
+-	 ;;
+-       esac
+-     fi
+-   done
+-   IFS="$lt_save_ifs"
+- done
+- : ${lt_cv_path_NM=no}])
++  # Let the user override the test.
++  lt_cv_path_NM="$NM"
++else
++  lt_nm_to_check="${ac_tool_prefix}nm"
++  if test -n "$ac_tool_prefix" && test "$build" = "$host"; then
++    lt_nm_to_check="$lt_nm_to_check nm"
++  fi
++  for lt_tmp_nm in $lt_nm_to_check; do
++    lt_save_ifs="$IFS"; IFS=$PATH_SEPARATOR
++    for ac_dir in $PATH /usr/ccs/bin/elf /usr/ccs/bin /usr/ucb /bin; do
++      IFS="$lt_save_ifs"
++      test -z "$ac_dir" && ac_dir=.
++      tmp_nm="$ac_dir/$lt_tmp_nm"
++      if test -f "$tmp_nm" || test -f "$tmp_nm$ac_exeext" ; then
++	# Check to see if the nm accepts a BSD-compat flag.
++	# Adding the `sed 1q' prevents false positives on HP-UX, which says:
++	#   nm: unknown option "B" ignored
++	# Tru64's nm complains that /dev/null is an invalid object file
++	case `"$tmp_nm" -B /dev/null 2>&1 | sed '1q'` in
++	*/dev/null* | *'Invalid file or object type'*)
++	  lt_cv_path_NM="$tmp_nm -B"
++	  break
++	  ;;
++	*)
++	  case `"$tmp_nm" -p /dev/null 2>&1 | sed '1q'` in
++	  */dev/null*)
++	    lt_cv_path_NM="$tmp_nm -p"
++	    break
++	    ;;
++	  *)
++	    lt_cv_path_NM=${lt_cv_path_NM="$tmp_nm"} # keep the first match, but
++	    continue # so that we can try to find one that supports BSD flags
++	    ;;
++	  esac
++	  ;;
++	esac
++      fi
++    done
++    IFS="$lt_save_ifs"
++  done
++  : ${lt_cv_path_NM=no}
++fi])
+ if test "$lt_cv_path_NM" != "no"; then
+   NM="$lt_cv_path_NM"
+ else
+-- 
+2.34.1
+

--- a/pkgs/development/tools/misc/binutils/0001-Revert-libtool.m4-fix-the-NM-nm-over-here-B-option-w.patch
+++ b/pkgs/development/tools/misc/binutils/0001-Revert-libtool.m4-fix-the-NM-nm-over-here-B-option-w.patch
@@ -1,0 +1,42 @@
+This reverts upstream commit caf606c90d55305967b9253447dda93d2f1835ab
+until https://sourceware.org/PR29547 is fixed.
+
+--- a/libtool.m4
++++ b/libtool.m4
+@@ -3214,31 +3214,25 @@ AC_CACHE_CHECK([for BSD- or MS-compatible name lister (nm)], lt_cv_path_NM,
+      lt_nm_to_check="$lt_nm_to_check nm"
+    fi
+  fi
+- for lt_tmp_nm in "$lt_nm_to_check"; do
++ for lt_tmp_nm in $lt_nm_to_check; do
+    lt_save_ifs="$IFS"; IFS=$PATH_SEPARATOR
+    for ac_dir in $PATH /usr/ccs/bin/elf /usr/ccs/bin /usr/ucb /bin; do
+      IFS="$lt_save_ifs"
+      test -z "$ac_dir" && ac_dir=.
+-     # Strip out any user-provided options from the nm to test twice,
+-     # the first time to test to see if nm (rather than its options) has
+-     # an explicit path, the second time to yield a file which can be
+-     # nm'ed itself.
+-     tmp_nm_path="`$ECHO "$lt_tmp_nm" | sed 's, -.*$,,'`"
+-     case "$tmp_nm_path" in
++     case "$lt_tmp_nm" in
+      */*|*\\*) tmp_nm="$lt_tmp_nm";;
+      *) tmp_nm="$ac_dir/$lt_tmp_nm";;
+      esac
+-     tmp_nm_to_nm="`$ECHO "$tmp_nm" | sed 's, -.*$,,'`"
+-     if test -f "$tmp_nm_to_nm" || test -f "$tmp_nm_to_nm$ac_exeext" ; then
++     if test -f "$tmp_nm" || test -f "$tmp_nm$ac_exeext" ; then
+        # Check to see if the nm accepts a BSD-compat flag.
+        # Adding the `sed 1q' prevents false positives on HP-UX, which says:
+        #   nm: unknown option "B" ignored
+-       case `"$tmp_nm" -B "$tmp_nm_to_nm" 2>&1 | grep -v '^ *$' | sed '1q'` in
++       case `"$tmp_nm" -B "$tmp_nm" 2>&1 | grep -v '^ *$' | sed '1q'` in
+        *$tmp_nm*) lt_cv_path_NM="$tmp_nm -B"
+ 	 break
+ 	 ;;
+        *)
+-	 case `"$tmp_nm" -p "$tmp_nm_to_nm" 2>&1 | grep -v '^ *$' | sed '1q'` in
++	 case `"$tmp_nm" -p "$tmp_nm" 2>&1 | grep -v '^ *$' | sed '1q'` in
+ 	 *$tmp_nm*)
+ 	   lt_cv_path_NM="$tmp_nm -p"
+ 	   break

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -68,6 +68,12 @@ stdenv.mkDerivation {
     # Make binutils output deterministic by default.
     ./deterministic.patch
 
+
+    # Breaks nm BSD flag detection, heeds an upstream fix:
+    #   https://sourceware.org/PR29547
+    ./0001-Revert-libtool.m4-fix-the-NM-nm-over-here-B-option-w.patch
+    ./0001-Revert-libtool.m4-fix-nm-BSD-flag-detection.patch
+
     # Required for newer macos versions
     ./0001-libtool.m4-update-macos-version-detection-block.patch
 


### PR DESCRIPTION
The change restores the patch `nixpkgs` kept for `binutils-2.38`.
On top of that we revert the second `binutils-2.39`-specific commit
that attempted to fix it.

We can drop both reverts once https://sourceware.org/PR29547 is fixed.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
