### PR TITLE
SDL2: 2.0.22 -> 2.24.0

### DIFF
--- a/pkgs/development/libraries/SDL2/default.nix
+++ b/pkgs/development/libraries/SDL2/default.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
     url = "https://www.libsdl.org/release/${pname}-${version}.tar.gz";
     sha256 = "sha256-keTDSxdo+S05mweOFxRIxq8Yyv2nQ5h+0gZKKJVNbZc=";
   };
-  dontDisableStatic = withStatic;
+  dontDisableStatic = if withStatic then 1 else 0;
   outputs = [ "out" "dev" ];
   outputBin = "dev"; # sdl-config
 

--- a/pkgs/development/libraries/SDL2/default.nix
+++ b/pkgs/development/libraries/SDL2/default.nix
@@ -59,11 +59,11 @@ with lib;
 
 stdenv.mkDerivation rec {
   pname = "SDL2";
-  version = "2.0.22";
+  version = "2.24.0";
 
   src = fetchurl {
     url = "https://www.libsdl.org/release/${pname}-${version}.tar.gz";
-    sha256 = "sha256-/ny/MSeILj/HJZp1oMtYViAnLFF0XThSq53YeWBpfy4=";
+    sha256 = "sha256-keTDSxdo+S05mweOFxRIxq8Yyv2nQ5h+0gZKKJVNbZc=";
   };
   dontDisableStatic = withStatic;
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/SDL2/find-headers.patch
+++ b/pkgs/development/libraries/SDL2/find-headers.patch
@@ -1,22 +1,23 @@
 diff --git a/sdl2-config.cmake.in b/sdl2-config.cmake.in
-index c570511fa..ca694f595 100644
+index db864aab9..b94e16043 100644
 --- a/sdl2-config.cmake.in
 +++ b/sdl2-config.cmake.in
-@@ -7,7 +7,8 @@ set(includedir "@includedir@")
- set(SDL2_PREFIX "${prefix}")
- set(SDL2_EXEC_PREFIX "${exec_prefix}")
- set(SDL2_LIBDIR "${libdir}")
--set(SDL2_INCLUDE_DIRS "${includedir}/SDL2")
-+set(SDL2_INCLUDE_DIRS "${includedir}/SDL2" $ENV{SDL2_PATH})
+@@ -26,7 +26,9 @@ set_and_check(SDL2_EXEC_PREFIX    "${exec_prefix}")
+ set_and_check(SDL2_BINDIR         "${bindir}")
+ set_and_check(SDL2_INCLUDE_DIR    "${includedir}/SDL2")
+ set_and_check(SDL2_LIBDIR         "${libdir}")
+-set(SDL2_INCLUDE_DIRS             "${includedir};${SDL2_INCLUDE_DIR}")
++
++set(SDL2_INCLUDE_DIRS "${includedir};${SDL2_INCLUDE_DIR}" $ENV{SDL2_PATH})
 +separate_arguments(SDL2_INCLUDE_DIRS)
- set(SDL2_LIBRARIES "-L${SDL2_LIBDIR} @SDL_RLD_FLAGS@ @SDL_LIBS@")
- string(STRIP "${SDL2_LIBRARIES}" SDL2_LIBRARIES)
  
+ set(SDL2_LIBRARIES SDL2::SDL2)
+ set(SDL2_STATIC_LIBRARIES SDL2::SDL2-static)
 diff --git a/sdl2-config.in b/sdl2-config.in
-index 5a2aed292..7c55f0a28 100644
+index f6eca7668..c0cd94590 100644
 --- a/sdl2-config.in
 +++ b/sdl2-config.in
-@@ -42,7 +42,11 @@ while test $# -gt 0; do
+@@ -46,7 +46,11 @@ while test $# -gt 0; do
        echo @SDL_VERSION@
        ;;
      --cflags)
@@ -29,6 +30,3 @@ index 5a2aed292..7c55f0a28 100644
        ;;
  @ENABLE_SHARED_TRUE@    --libs)
  @ENABLE_SHARED_TRUE@      echo -L@libdir@ @SDL_RLD_FLAGS@ @SDL_LIBS@
--- 
-2.33.1
-

--- a/pkgs/development/libraries/ffmpeg/4.nix
+++ b/pkgs/development/libraries/ffmpeg/4.nix
@@ -1,4 +1,4 @@
-{ callPackage
+{ callPackage, fetchpatch
 # Darwin frameworks
 , Cocoa, CoreMedia, VideoToolbox
 , stdenv, lib
@@ -10,4 +10,11 @@ callPackage ./generic.nix (rec {
   branch = version;
   sha256 = "sha256-+YpIJSDEdQdSGpB5FNqp77wThOBZG1r8PaGKqJfeKUg=";
   darwinFrameworks = [ Cocoa CoreMedia VideoToolbox ];
+  patches = [
+    #  sdl2 recently changed their versioning
+    (fetchpatch {
+      url = "https://git.videolan.org/?p=ffmpeg.git;a=patch;h=e5163b1d34381a3319214a902ef1df923dd2eeba";
+      hash = "sha256-nLhP2+34cj5EgpnUrePZp60nYAxmbhZAEDfay4pBVk0=";
+    })
+  ];
 } // args)


### PR DESCRIPTION
###### Description of changes

- Foremost, they changed the versioning, the patch in the version was promoted to minor. `2.0.22 == 2.22.0`;

- Full changelog in https://github.com/libsdl-org/SDL/releases/tag/release-2.24.0

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
