### PR TITLE
[22.05] emacs: use withPgtk option more

### DIFF
--- a/pkgs/applications/editors/emacs/generic.nix
+++ b/pkgs/applications/editors/emacs/generic.nix
@@ -136,7 +136,7 @@ let emacs = stdenv.mkDerivation (lib.optionalAttrs nativeComp {
     ++ lib.optionals (stdenv.isLinux && withX) [ m17n_lib libotf ]
     ++ lib.optional (withX && withGTK2) gtk2-x11
     ++ lib.optional (withX && withGTK3) gtk3-x11
-    ++ lib.optional withGTK3 gsettings-desktop-schemas
+    ++ lib.optional (!stdenv.isDarwin && withGTK3) gsettings-desktop-schemas
     ++ lib.optional withPgtk gtk3
     ++ lib.optional (withX && withMotif) motif
     ++ lib.optional withSQLite3 sqlite

--- a/pkgs/applications/editors/emacs/generic.nix
+++ b/pkgs/applications/editors/emacs/generic.nix
@@ -15,7 +15,7 @@
 , libgccjit, targetPlatform, makeWrapper # native-comp params
 , fetchFromSavannah
 , systemd ? null
-, withX ? !stdenv.isDarwin
+, withX ? !stdenv.isDarwin && !withPgtk
 , withNS ? stdenv.isDarwin
 , withGTK2 ? false, gtk2-x11 ? null
 , withGTK3 ? true, gtk3-x11 ? null, gsettings-desktop-schemas ? null
@@ -29,7 +29,7 @@
 , nativeComp ? false
 , withAthena ? false
 , withToolkitScrollBars ? true
-, withPgtk ? false
+, withPgtk ? false, gtk3 ? null
 , withXinput2 ? withX && lib.versionAtLeast version "29"
 , withImageMagick ? lib.versionOlder version "27" && (withX || withNS)
 , toolkit ? (
@@ -45,9 +45,10 @@ assert stdenv.isDarwin -> libXaw != null;       # fails to link otherwise
 assert withNS -> !withX;
 assert withNS -> stdenv.isDarwin;
 assert (withGTK2 && !withNS) -> withX;
-assert (withGTK3 && !withNS) -> withX;
-assert withGTK2 -> !withGTK3 && gtk2-x11 != null;
-assert withGTK3 -> !withGTK2 && gtk3-x11 != null;
+assert (withGTK3 && !withNS) -> withX || withPgtk;
+assert withGTK2 -> !withGTK3 && gtk2-x11 != null && !withPgtk;
+assert withGTK3 -> !withGTK2 && ((gtk3-x11 != null) || withPgtk);
+assert withPgtk -> withGTK3 && !withX && gtk3 != null;
 assert withXwidgets -> withGTK3 && webkitgtk != null;
 
 
@@ -134,7 +135,9 @@ let emacs = stdenv.mkDerivation (lib.optionalAttrs nativeComp {
     ++ lib.optionals withImageMagick [ imagemagick ]
     ++ lib.optionals (stdenv.isLinux && withX) [ m17n_lib libotf ]
     ++ lib.optional (withX && withGTK2) gtk2-x11
-    ++ lib.optionals (withX && withGTK3) [ gtk3-x11 gsettings-desktop-schemas ]
+    ++ lib.optional (withX && withGTK3) gtk3-x11
+    ++ lib.optional withGTK3 gsettings-desktop-schemas
+    ++ lib.optional withPgtk gtk3
     ++ lib.optional (withX && withMotif) motif
     ++ lib.optional withSQLite3 sqlite
     ++ lib.optional withWebP libwebp


### PR DESCRIPTION
###### Description of changes

Backport of https://github.com/NixOS/nixpkgs/pull/189929

Cherry-picked from commit 6d0e82f11aeaef74f8f9adcf18c1c77df8c8e2c6

There was a conflict; in this cherry-picked version of the commit, `withGTK3` now has its default value of `true` unchanged, whereas in the commit on `master` branch, `withGTK3` had its previous value of `false` changed to `withPgtk`. I think this is a reasonable resolution to the conflict, but let me know if you believe otherwise.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->