### PR TITLE
Cinnamon updates 2022-09-05

### DIFF
--- a/pkgs/desktops/cinnamon/bulky/default.nix
+++ b/pkgs/desktops/cinnamon/bulky/default.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "bulky";
-  version = "2.4";
+  version = "2.5";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "bulky";
     rev = version;
-    hash = "sha256-ynPorkhT/LUkFGNRG6JLDYaQjNPm2vMzthvl0wr7J/M=";
+    hash = "sha256-WgpB/oMA3w7KO7KmkGXsl92siFGQo3Y4mLvMLTi54k8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/cinnamon/cinnamon-common/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-common/default.nix
@@ -54,13 +54,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-common";
-  version = "5.4.11";
+  version = "5.4.12";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "cinnamon";
     rev = version;
-    hash = "sha256-3uQ4t+WXauCM3jV44pSz1yqLxXwLBWv7xMvP7ug3AY0=";
+    hash = "sha256-uyQZXri3V3dKnowB97QlPWboZz1neblyvCuSacsPROg=";
   };
 
   patches = [

--- a/pkgs/desktops/cinnamon/cinnamon-control-center/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-control-center/default.nix
@@ -36,13 +36,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-control-center";
-  version = "5.4.6";
+  version = "5.4.7";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-8BDmQT/xDnpwR2YC0TGaqWPnZ61IBmVvft2Mcf6YN+A=";
+    hash = "sha256-38n1QCygkBq+wOLwui1oF6MtDWxAFWxp5U1omSVtbro=";
   };
 
   buildInputs = [

--- a/pkgs/desktops/cinnamon/muffin/default.nix
+++ b/pkgs/desktops/cinnamon/muffin/default.nix
@@ -35,7 +35,7 @@
 
 stdenv.mkDerivation rec {
   pname = "muffin";
-  version = "5.4.6";
+  version = "5.4.7";
 
   outputs = [ "out" "dev" "man" ];
 
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-xTpL+o7gFvu8VNbCb8c0Y0Z8ncqb9y2qTiXP3rHAz+M=";
+    hash = "sha256-Zx6au1FXLgK8PRmkh8jaGJ3Zh0YYFj2zmbxhgXAFgDg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/cinnamon/warpinator/default.nix
+++ b/pkgs/desktops/cinnamon/warpinator/default.nix
@@ -14,7 +14,7 @@
 
 python3.pkgs.buildPythonApplication rec  {
   pname = "warpinator";
-  version = "1.2.13";
+  version = "1.2.14";
 
   format = "other";
 
@@ -22,7 +22,7 @@ python3.pkgs.buildPythonApplication rec  {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-iLImyfUsfn+mWrgMv5NnbOvvOlJnwJG4Btx1wwlgTeM=";
+    hash = "sha256-0OmrviDti843c+nvpt7ennSrso0PD7eZOJ94JiWJT58=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/cinnamon/xapp/default.nix
+++ b/pkgs/desktops/cinnamon/xapp/default.nix
@@ -1,5 +1,4 @@
 { fetchFromGitHub
-, fetchpatch
 , glib
 , gobject-introspection
 , gtk3
@@ -23,24 +22,15 @@
 
 stdenv.mkDerivation rec {
   pname = "xapp";
-  version = "2.2.14";
+  version = "2.2.15";
 
   outputs = [ "out" "dev" ];
-
-  patches = [
-    # Add missing gio-unix-2.0 dependency, can be removed on next update
-    # https://github.com/linuxmint/xapp/pull/156
-    (fetchpatch {
-      url = "https://github.com/linuxmint/xapp/commit/052081f75d1c1212aeb6a913772723c81607bcb3.patch";
-      sha256 = "sha256-VL70Y1FIa7lQ/zKjEx0GhaU1QRu4z6Yu400/bDbgZgM=";
-    })
-  ];
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-BebsS7y/hRQSc4rYOIWJ+sSJ5fLZaCpNAE48JnviUUc=";
+    hash = "sha256-X/exXQY/v+TU8HnnquleP21tCYR9h7t43AIw4tTKVOY=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes

Previous one: #189389

Closes https://github.com/bobby285271/what-changed/issues/6

- cinnamon.bulky: 2.4 -> 2.5
- cinnamon.cinnamon-common: 5.4.11 -> 5.4.12
- cinnamon.cinnamon-control-center: 5.4.6 -> 5.4.7
- cinnamon.muffin: 5.4.6 -> 5.4.7
- cinnamon.warpinator: 1.2.13 -> 1.2.14
- cinnamon.xapps: 2.2.14 -> 2.2.15

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
