### PR TITLE
pywb: Init at 2.7.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1284,6 +1284,12 @@
     githubId = 29845794;
     name = "Duncan Russell";
   };
+  anpandey = {
+    email = "anpandey@protonmail.com";
+    github = "anpandey";
+    githubId = 25336974;
+    name = "Ankit Pandey";
+  };
   anpin = {
     email = "pavel@anpin.fyi";
     github = "anpin";

--- a/pkgs/development/python-modules/py3amf/default.nix
+++ b/pkgs/development/python-modules/py3amf/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, isPy3k
+, defusedxml
+}:
+
+buildPythonPackage rec {
+  pname = "Py3AMF";
+  version = "0.8.10";
+  format = "setuptools";
+
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-bawtNKCdr1NR5lTozcMCazVgpttJjBfNzIQyKzFJlSw=";
+  };
+
+  propagatedBuildInputs = [ defusedxml ];
+
+  meta = with lib; {
+    description = "AMF (Action Message Format) support for Python 3";
+    homepage = "https://github.com/StdCarrot/Py3AMF";
+    license = licenses.mit;
+    maintainers = with maintainers; [ anpandey ];
+  };
+}

--- a/pkgs/tools/misc/pywb/default.nix
+++ b/pkgs/tools/misc/pywb/default.nix
@@ -1,0 +1,92 @@
+{ lib, fetchFromGitHub, fetchPypi, python3, stdenv }:
+
+python3.pkgs.buildPythonApplication rec {
+  name = "pywb";
+  version = "2.7.4";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "webrecorder";
+    repo = "pywb";
+    rev = "v-${version}";
+    sha256 = "sha256-M44TwBzXuF33HNLB2OjmBKNDG9kt/qhGEOu589YGvsQ=";
+    # TODO: We clone the wombat submodule, but we still need to implement
+    # building wombat.
+    fetchSubmodules = true;
+  };
+
+  patches = [ ./pywb.patch ];
+
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "jinja2<3.0.0" "jinja2" \
+      --replace "redis<3.0" "redis" \
+      --replace "markupsafe<2.1.0" "markupsafe" \
+      --replace "fakeredis<1.0" "fakeredis" \
+      --replace "gevent==21.12.0" "gevent"
+  '';
+
+  propagatedBuildInputs = with python3.pkgs; [
+    brotlipy
+    chardet
+    fakeredis
+    gevent
+    jinja2
+    markupsafe
+    portalocker
+    py3amf
+    pytest
+    python-dateutil
+    pyyaml
+    redis
+    requests
+    six
+    surt
+    ua-parser
+    warcio
+    webassets
+    webencodings
+    werkzeug
+    wsgiprox
+  ];
+
+  nativeCheckInputs = with python3.pkgs; [
+    pytestCheckHook
+  ];
+
+  checkInputs = with python3.pkgs; [
+    pytest
+    mock
+    webtest
+    urllib3
+    httpbin
+    flask
+    ujson
+    lxml
+    fakeredis
+  ];
+
+  doCheck = true;
+
+  disabledTests = [
+    # 400 Bad Request.
+    "test_integration"
+    "test_live_rewriter"
+    "test_redirect_classic"
+    "test_socks"
+    "test_cert_req"
+    "test_force_https"
+    # Disabled because of fakeredis patch.
+    "test_single_redis_entry"
+    "test_single_warc_record"
+    "test_redis_pending_count"
+  ];
+
+  meta = {
+    description = "Python web archiving toolkit for creating and replaying web archives";
+    homepage = "https://github.com/webrecorder/pywb";
+    license = with lib.licenses; [ gpl3Plus agpl3Plus ];
+    maintainers = with lib.maintainers; [ anpandey ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/tools/misc/pywb/default.nix
+++ b/pkgs/tools/misc/pywb/default.nix
@@ -17,14 +17,17 @@ python3.pkgs.buildPythonApplication rec {
 
   patches = [ ./pywb.patch ];
 
-  postPatch = ''
-    substituteInPlace requirements.txt \
-      --replace "jinja2<3.0.0" "jinja2" \
-      --replace "redis<3.0" "redis" \
-      --replace "markupsafe<2.1.0" "markupsafe" \
-      --replace "fakeredis<1.0" "fakeredis" \
-      --replace "gevent==21.12.0" "gevent"
-  '';
+  nativeBuildInputs = with python3.pkgs; [
+    pythonRelaxDepsHook
+  ];
+
+  pythonRelaxDeps = [
+    "jinja2"
+    "redis"
+    "markupsafe"
+    "fakeredis"
+    "gevent"
+  ];
 
   propagatedBuildInputs = with python3.pkgs; [
     brotlipy
@@ -52,10 +55,6 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeCheckInputs = with python3.pkgs; [
     pytestCheckHook
-  ];
-
-  checkInputs = with python3.pkgs; [
-    pytest
     mock
     webtest
     urllib3

--- a/pkgs/tools/misc/pywb/pywb.patch
+++ b/pkgs/tools/misc/pywb/pywb.patch
@@ -1,0 +1,100 @@
+diff --git a/babel.ini b/babel.ini
+index 3396a587..bd3ea595 100644
+--- a/babel.ini
++++ b/babel.ini
+@@ -1,2 +1,4 @@
+ [jinja2: pywb/templates/**.html]
+-extensions=jinja2.ext.i18n,jinja2.ext.autoescape,jinja2.ext.with_
++# https://jinja.palletsprojects.com/en/3.0.x/extensions/#with-statement with is
++# now built-in.
++extensions=jinja2.ext.i18n,jinja2.ext.autoescape
+diff --git a/pywb/apps/rewriterapp.py b/pywb/apps/rewriterapp.py
+index a0292732..601bb98f 100644
+--- a/pywb/apps/rewriterapp.py
++++ b/pywb/apps/rewriterapp.py
+@@ -63,8 +63,10 @@ class RewriterApp(object):
+         self.js_proxy_rw = RewriterWithJSProxy(replay_mod=self.replay_mod)
+ 
+         if not jinja_env:
++            # https://jinja.palletsprojects.com/en/3.0.x/extensions/#with-statement
++            # with is now built in.
+             jinja_env = JinjaEnv(globals={'static_path': 'static'},
+-                                 extensions=['jinja2.ext.i18n', 'jinja2.ext.with_'])
++                                 extensions=['jinja2.ext.i18n'])
+             jinja_env.jinja_env.install_null_translations()
+ 
+         self.jinja_env = jinja_env
+diff --git a/pywb/rewrite/templateview.py b/pywb/rewrite/templateview.py
+index 7f0cbc88..39c76ee7 100644
+--- a/pywb/rewrite/templateview.py
++++ b/pywb/rewrite/templateview.py
+@@ -5,7 +5,7 @@ from pywb.utils.loaders import load
+ 
+ from six.moves.urllib.parse import urlsplit, quote
+ 
+-from jinja2 import Environment, TemplateNotFound, contextfunction, select_autoescape
++from jinja2 import Environment, TemplateNotFound, pass_context, select_autoescape
+ from jinja2 import FileSystemLoader, PackageLoader, ChoiceLoader
+ 
+ from webassets.ext.jinja2 import AssetsExtension
+@@ -139,7 +139,7 @@ class JinjaEnv(object):
+             return loc_map.get(loc)
+ 
+         def override_func(jinja_env, name):
+-            @contextfunction
++            @pass_context
+             def get_override(context, text):
+                 translate = get_translate(context)
+                 if not translate:
+@@ -158,7 +158,7 @@ class JinjaEnv(object):
+ 
+         # Special _Q() function to return %-encoded text, necessary for use
+         # with text in banner
+-        @contextfunction
++        @pass_context
+         def quote_gettext(context, text):
+             translate = get_translate(context)
+             if not translate:
+@@ -171,7 +171,7 @@ class JinjaEnv(object):
+         self.jinja_env.globals['_Q'] = quote_gettext
+         self.jinja_env.globals['default_locale'] = default_locale
+ 
+-        @contextfunction
++        @pass_context
+         def switch_locale(context, locale):
+             environ = context.get('env')
+             curr_loc = environ.get('pywb_lang', '')
+@@ -188,7 +188,7 @@ class JinjaEnv(object):
+ 
+             return app_prefix + '/' + locale + request_uri
+ 
+-        @contextfunction
++        @pass_context
+         def get_locale_prefixes(context):
+             environ = context.get('env')
+             locale_prefixes = {}
+diff --git a/pywb/warcserver/test/testutils.py b/pywb/warcserver/test/testutils.py
+index 2d6444bd..ccb96a03 100644
+--- a/pywb/warcserver/test/testutils.py
++++ b/pywb/warcserver/test/testutils.py
+@@ -5,7 +5,7 @@ import shutil
+ import yaml
+ import time
+ 
+-from fakeredis import FakeStrictRedis, DATABASES
++from fakeredis import FakeStrictRedis
+ from mock import patch
+ 
+ from pywb.warcserver.basewarcserver import BaseWarcServer
+@@ -66,7 +66,10 @@ class FakeRedisTests(object):
+         super(FakeRedisTests, cls).setup_class()
+ 
+         del PUBSUBS[:]
+-        DATABASES.clear()
++        # DATABASES is no longer used in fakeredis. In fakeredis 0.16 this was
++        # how the list of all databases was cleared. We just comment this line
++        # out and disable the tests that this causes to fail.
++        # DATABASES.clear()
+ 
+         cls.redismock = patch('redis.StrictRedis', FakeStrictRedisSharedPubSub)
+         cls.redismock.start()

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12421,6 +12421,8 @@ with pkgs;
 
   pywal = with python3Packages; toPythonApplication pywal;
 
+  pywb = callPackage ../tools/misc/pywb {};
+
   pystring = callPackage ../development/libraries/pystring { };
 
   raysession = python3Packages.callPackage ../applications/audio/raysession {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9998,6 +9998,8 @@ self: super: with self; {
 
   pyalgotrade = callPackage ../development/python-modules/pyalgotrade { };
 
+  py3amf = callPackage ../development/python-modules/py3amf { };
+
   pyamg = callPackage ../development/python-modules/pyamg { };
 
   pyaml = callPackage ../development/python-modules/pyaml { };


### PR DESCRIPTION
###### Description of changes

pywb described as a "full-featured, advanced web archiving capture and replay framework for python". More info can be found at the [webrecorder homepage](https://webrecorder.net/tools#pywb).

This is partially based on https://github.com/NixOS/nixpkgs/pull/52814, which was never merged. I've verified on x86_64 Linux that web archive playback and recording works with the following commands:

```
wb-manager init test-archive
wayback --live --record --enable-auto-fetch -a -t 8
```

and navigating to the UI at localhost:8080. I did not test any of the redis-based features.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).