### PR TITLE
freenukum: 0.3.5 -> 0.4.0

### DIFF
--- a/pkgs/games/freenukum/default.nix
+++ b/pkgs/games/freenukum/default.nix
@@ -6,6 +6,7 @@
 , dejavu_fonts
 , SDL2
 , SDL2_ttf
+, SDL2_image
 }:
 let
   pname = "freenukum";
@@ -24,16 +25,17 @@ let
 in
 rustPlatform.buildRustPackage rec {
   inherit pname;
-  version = "0.3.5";
+  version = "0.4.0";
 
   src = fetchFromGitLab {
+    domain = "salsa.debian.org";
     owner = "silwol";
-    repo = pname;
+    repo = "freenukum";
     rev = "v${version}";
-    sha256 = "0yqfzh0c8fqk92q9kmidy15dc5li0ak1gbn3v7p3xw5fkrzf99gy";
+    sha256 = "sha256-Tk9n2gPwyPin6JZ4RSO8d/+xVpEz4rF8C2eGKwrAXU0=";
   };
 
-  cargoSha256 = "1nss5zbdvxkr1mfb6vi6yjxcih99w836kvfr4r3n5dvzlkvga2vf";
+  cargoSha256 = "sha256-8RfiObWDqZJg+sjjDBk+sRoS5CiECIdNPH79T+O8e8M=";
 
   nativeBuildInputs = [
     installShellFiles
@@ -42,6 +44,7 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [
     SDL2
     SDL2_ttf
+    SDL2_image
   ];
 
   postPatch = ''
@@ -55,13 +58,15 @@ rustPlatform.buildRustPackage rec {
       ${dejavu_fonts}/share/fonts/truetype/DejaVuSans.ttf \
       $out/share/fonts/truetype/dejavu/DejaVuSans.ttf
     mkdir -p $out/share/doc/freenukum
-    install -Dm644 README.md CHANGELOG.md COPYING $out/share/doc/freenukum/
+    install -Dm644 README.md CHANGELOG.md $out/share/doc/freenukum/
     installManPage doc/freenukum.6
     install -Dm644 "${desktopItem}/share/applications/"* -t $out/share/applications/
   '';
 
   meta = with lib; {
     description = "Clone of the original Duke Nukum 1 Jump'n Run game";
+    homepage = "https://salsa.debian.org/silwol/freenukum";
+    changelog = "https://salsa.debian.org/silwol/freenukum/-/blob/v${version}/CHANGELOG.md";
     license = licenses.agpl3Plus;
     maintainers = with maintainers; [ _0x4A6F ];
     broken = stdenv.isDarwin;


### PR DESCRIPTION
###### Description of changes

Closes #189617

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
