### PR TITLE
mu-repo: 1.8.1 → 1.8.2

### DIFF
--- a/pkgs/applications/misc/mu-repo/default.nix
+++ b/pkgs/applications/misc/mu-repo/default.nix
@@ -1,19 +1,23 @@
-{ lib, fetchFromGitHub, buildPythonApplication, pytestCheckHook, git }:
+{ lib, fetchFromGitHub, buildPythonApplication, pytestCheckHook, git, testers, mu-repo }:
 
 buildPythonApplication rec {
   pname = "mu-repo";
-  version = "1.8.1";
+  version = "1.8.2";
 
   src = fetchFromGitHub {
     owner = "fabioz";
-    repo = pname;
+    repo = "mu-repo";
     rev = "mu_repo_${lib.replaceStrings [ "." ] [ "_" ] version}";
-    sha256 = "0mmjdkvmdlsndi2q56ybxyz2988ppxsbbr1g54nzzkkvab2bc2na";
+    hash = "sha256-COc7hbu72eA+ikZQkz6zXtFyaa/AKhoF+Zvsr6ZVOuY=";
   };
 
   propagatedBuildInputs = [ git ];
 
   checkInputs = [ pytestCheckHook git ];
+
+  passthru.tests.version = testers.testVersion {
+    package = mu-repo;
+  };
 
   meta = with lib; {
     description = "Tool to help in dealing with multiple git repositories";
@@ -21,5 +25,6 @@ buildPythonApplication rec {
     license = licenses.gpl3;
     platforms = platforms.unix;
     maintainers = with maintainers; [ sikmir ];
+    mainProgram = "mu";
   };
 }


### PR DESCRIPTION
###### Description of changes

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
