### PR TITLE
k3s: 1.23.6+k3s1 -> 1.23.10+k3s1

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/default.nix
@@ -46,27 +46,27 @@ with lib;
 # Those pieces of software we entirely ignore upstream's handling of, and just
 # make sure they're in the path if desired.
 let
-  k3sVersion = "1.23.6+k3s1";     # k3s git tag
-  k3sCommit = "418c3fa858b69b12b9cefbcff0526f666a6236b9"; # k3s git commit at the above version
-  k3sRepoSha256 = "0fmw491dn5mpi058mr7sij51i5m4qg2grx30cnl3h2v4s0sdkx2i";
-  k3sVendorSha256 = "sha256-iHg5ySMaiSWXs98YGmxPwdZr4zdBIFma12dNEuf30Hs=";
+  k3sVersion = "1.23.10+k3s1";     # k3s git tag
+  k3sCommit = "826b9498df9578509e8c4b6906071592a6295159"; # k3s git commit at the above version
+  k3sRepoSha256 = "sha256-0O3KuEJ5TUhyfsZbgGpud5METzP85W7iilswc4kd1lU=";
+  k3sVendorSha256 = "sha256-0qPC6HfbziRl27rGbXverUtQKpZIuQihwWPqY9LjfQQ=";
 
-  # taken from ./manifests/traefik.yaml, extracted from '.spec.chart' https://github.com/k3s-io/k3s/blob/v1.23.3%2Bk3s1/scripts/download#L9
+  # taken from ./manifests/traefik.yaml, extracted from '.spec.chart' https://github.com/k3s-io/k3s/blob/v1.23.10%2Bk3s1/scripts/download#L9
   # The 'patch' and 'minor' versions are currently hardcoded as single digits only, so ignore the trailing two digits. Weird, I know.
   traefikChartVersion = "10.19.3";
   traefikChartSha256 = "04zg5li957svgscdmkzmzjkwljaljyav68rzxmhakkwgav6q9058";
 
-  # taken from ./scripts/version.sh VERSION_ROOT https://github.com/k3s-io/k3s/blob/v1.23.3%2Bk3s1/scripts/version.sh#L47
+  # taken from ./scripts/version.sh VERSION_ROOT https://github.com/k3s-io/k3s/blob/v1.23.10%2Bk3s1/scripts/version.sh#L49
   k3sRootVersion = "0.11.0";
   k3sRootSha256 = "016n56vi09xkvjph7wgzb2m86mhd5x65fs4d11pmh20hl249r620";
 
-  # taken from ./scripts/version.sh VERSION_CNIPLUGINS https://github.com/k3s-io/k3s/blob/v1.23.3%2Bk3s1/scripts/version.sh#L45
-  k3sCNIVersion = "1.0.1-k3s1";
+  # taken from ./scripts/version.sh VERSION_CNIPLUGINS https://github.com/k3s-io/k3s/blob/v1.23.10%2Bk3s1/scripts/version.sh#L47
+  k3sCNIVersion = "1.1.1-k3s1";
   k3sCNISha256 = "11ihlzzdnqf9p21y0a4ckpbxac016nm7746dcykhj26ym9zxyv92";
 
   # taken from go.mod, the 'github.com/containerd/containerd' line
   # run `grep github.com/containerd/containerd go.mod | head -n1 | awk '{print $4}'`
-  containerdVersion = "1.5.11-k3s2";
+  containerdVersion = "1.5.13-k3s1";
   containerdSha256 = "16132snvrg8r0vwm6c0lz0q6fx686s2ix53nm3aka9a83xs75vf2";
 
   # run `grep github.com/kubernetes-sigs/cri-tools go.mod | head -n1 | awk '{print $4}'` in the k3s repo at the tag
@@ -185,12 +185,13 @@ let
     postInstall = ''
       mv $out/bin/server $out/bin/k3s
       pushd $out
-      # taken verbatim from https://github.com/k3s-io/k3s/blob/v1.23.3%2Bk3s1/scripts/build#L105-L113
+      # taken verbatim from https://github.com/k3s-io/k3s/blob/v1.23.10%2Bk3s1/scripts/build#L115-L123
       ln -s k3s ./bin/k3s-agent
       ln -s k3s ./bin/k3s-server
       ln -s k3s ./bin/k3s-etcd-snapshot
       ln -s k3s ./bin/k3s-secrets-encrypt
       ln -s k3s ./bin/k3s-certificate
+      ln -s k3s ./bin/k3s-completion
       ln -s k3s ./bin/kubectl
       ln -s k3s ./bin/crictl
       ln -s k3s ./bin/ctr


### PR DESCRIPTION
Proposing directly to release-22.05 because master already is on 1.24.x.

@moduon MT-1075

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I found no changelog, so this is the evolution of k3s in these releases:

- https://github.com/k3s-io/k3s/releases/tag/v1.23.4%2Bk3s1
- https://github.com/k3s-io/k3s/releases/tag/v1.23.5%2Bk3s1
- https://github.com/k3s-io/k3s/releases/tag/v1.23.6%2Bk3s1
- https://github.com/k3s-io/k3s/releases/tag/v1.23.7%2Bk3s1
- https://github.com/k3s-io/k3s/releases/tag/v1.23.8%2Bk3s1
- https://github.com/k3s-io/k3s/releases/tag/v1.23.8%2Bk3s2
- https://github.com/k3s-io/k3s/releases/tag/v1.23.9%2Bk3s1
- https://github.com/k3s-io/k3s/releases/tag/v1.23.10%2Bk3s1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
