### PR TITLE
hobbits: 0.53.1 → 0.53.2

### DIFF
--- a/pkgs/tools/graphics/hobbits/default.nix
+++ b/pkgs/tools/graphics/hobbits/default.nix
@@ -1,16 +1,16 @@
 { lib, stdenv, mkDerivation, fetchFromGitHub
-, cmake, pkg-config, pffft, libpcap, libusb1, python3
+, cmake, pkg-config, pffft, libpcap, libusb1, python3, wrapQtAppsHook
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "hobbits";
-  version = "0.53.1";
+  version = "0.53.2";
 
   src = fetchFromGitHub {
     owner = "Mahlet-Inc";
-    repo = pname;
+    repo = "hobbits";
     rev = "v${version}";
-    sha256 = "sha256-dMFsv2M96+65JxTOq0CG+vm7a75GkD7N7PmbsyZ2Fog=";
+    hash = "sha256-X2DotmzqeIESkO6o39si4kEkRhLO7yBr6Djh+0s+lFc=";
   };
 
   postPatch = ''
@@ -22,7 +22,9 @@ mkDerivation rec {
 
   buildInputs = [ pffft libpcap libusb1 python3 ];
 
-  nativeBuildInputs = [ cmake pkg-config ];
+  nativeBuildInputs = [ cmake pkg-config wrapQtAppsHook ];
+
+  cmakeFlags = [ "-DUSE_SYSTEM_PFFFT=ON" ];
 
   NIX_CFLAGS_COMPILE = lib.optional stdenv.hostPlatform.isAarch64 "-Wno-error=narrowing";
 


### PR DESCRIPTION
###### Description of changes
[Changelog](https://github.com/Mahlet-Inc/hobbits/releases)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
