### PR TITLE
gst-plugins-bad: patch nvcodec to check opengl path

### DIFF
--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchurl
+, substituteAll
 , meson
 , ninja
 , gettext
@@ -77,6 +78,7 @@
 , mjpegtools
 , libGLU
 , libGL
+, addOpenGLRunpath
 , libintl
 , game-music-emu
 , openssl
@@ -106,6 +108,14 @@ stdenv.mkDerivation rec {
     url = "https://gstreamer.freedesktop.org/src/${pname}/${pname}-${version}.tar.xz";
     sha256 = "sha256-ehHBO1XdHSOG3ZAiGeQcv83ajh4Ko+c4GGyVB0s12k8=";
   };
+
+  patches = [
+    # Add fallback paths for nvidia userspace libraries
+    (substituteAll {
+      src = ./fix-paths.patch;
+      inherit (addOpenGLRunpath) driverLink;
+    })
+  ];
 
   nativeBuildInputs = [
     meson

--- a/pkgs/development/libraries/gstreamer/bad/fix-paths.patch
+++ b/pkgs/development/libraries/gstreamer/bad/fix-paths.patch
@@ -1,0 +1,48 @@
+diff --git a/sys/nvcodec/gstcudaloader.c b/sys/nvcodec/gstcudaloader.c
+index 4223ba1fbd..ca8bb5ceb1 100644
+--- a/sys/nvcodec/gstcudaloader.c
++++ b/sys/nvcodec/gstcudaloader.c
+@@ -135,6 +135,11 @@ gst_cuda_load_library (void)
+     return TRUE;
+ 
+   module = g_module_open (filename, G_MODULE_BIND_LAZY);
++
++  if (module == NULL) {
++    module = g_module_open("@driverLink@/lib/" CUDA_LIBNAME, G_MODULE_BIND_LAZY);
++  }
++
+   if (module == NULL) {
+     GST_WARNING ("Could not open library %s, %s", filename, g_module_error ());
+     return FALSE;
+diff --git a/sys/nvcodec/gstcuvidloader.c b/sys/nvcodec/gstcuvidloader.c
+index 3c7505ca36..eeb376fa80 100644
+--- a/sys/nvcodec/gstcuvidloader.c
++++ b/sys/nvcodec/gstcuvidloader.c
+@@ -85,6 +85,11 @@ gst_cuvid_load_library (guint api_major_ver, guint api_minor_ver)
+     return TRUE;
+ 
+   module = g_module_open (filename, G_MODULE_BIND_LAZY);
++
++  if (module == NULL) {
++    module = g_module_open ("@driverLink@/lib/" NVCUVID_LIBNAME, G_MODULE_BIND_LAZY);
++  }
++
+   if (module == NULL) {
+     GST_WARNING ("Could not open library %s, %s", filename, g_module_error ());
+     return FALSE;
+diff --git a/sys/nvcodec/gstnvenc.c b/sys/nvcodec/gstnvenc.c
+index 19637671ad..39858ccdee 100644
+--- a/sys/nvcodec/gstnvenc.c
++++ b/sys/nvcodec/gstnvenc.c
+@@ -874,6 +874,11 @@ gst_nvenc_load_library (guint * api_major_ver, guint * api_minor_ver)
+   };
+ 
+   module = g_module_open (NVENC_LIBRARY_NAME, G_MODULE_BIND_LAZY);
++
++  if (module == NULL) {
++    module = g_module_open ("@driverLink@/lib/" NVENC_LIBRARY_NAME, G_MODULE_BIND_LAZY);
++  }
++
+   if (module == NULL) {
+     GST_WARNING ("Could not open library %s, %s",
+         NVENC_LIBRARY_NAME, g_module_error ());


### PR DESCRIPTION
###### Description of changes

Fixes #189217 by loading the absolute paths for cuda userspace if normal lookup fails. Since it is a fallback it should not break non-nixos users or users overriding through `LD_LIBRARY_PATH`.

This patches `libcuda`, nvenc (`libnvidia-encode`) and nvdec (`libnvcuvid`). It does not patch `libnvrct` since that is not part of the nvidia driver. 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
