### PR TITLE
govulncheck: init at unstable-2022-09-02

### DIFF
--- a/pkgs/tools/security/govulncheck/default.nix
+++ b/pkgs/tools/security/govulncheck/default.nix
@@ -1,0 +1,64 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "govulncheck";
+  version = "unstable-2022-09-02";
+
+  src = fetchFromGitHub {
+    owner = "golang";
+    repo = "vuln";
+    rev = "27dd78d2ca392c1738e54efe513a2ecb7bf46000";
+    sha256 = "sha256-G35y1V4W1nLZ+QGvIQwER9whBIBDFUVptrHx78orcI0=";
+  };
+
+  vendorSha256 = "sha256-9FH9nq5cEyhMxrrvfQAOWZ4aThMsU0HwlI+0W0uVHZ4=";
+
+  subPackages = [ "cmd/govulncheck" ];
+
+  preCheck = ''
+    # test all paths
+    unset subPackages
+
+    # remove test that calls checks.bash
+    # the header check and misspell gets upset at the vendor dir
+    rm all_test.go
+
+    # remove tests that generally have "inconsistent vendoring" issues
+    # - tries to builds govulncheck again
+    rm cmd/govulncheck/main_command_118_test.go
+    # - does go builds of example go files
+    rm vulncheck/binary_test.go
+    # - just have resolution issues
+    rm vulncheck/{source,vulncheck}_test.go
+  '';
+
+  ldflags = [ "-s" "-w" ];
+
+  meta = with lib; {
+    homepage = "https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck";
+    description = "The database client and tools for the Go vulnerability database, also known as vuln";
+    longDescription = ''
+      Govulncheck reports known vulnerabilities that affect Go code. It uses
+      static analysis of source code or a binary's symbol table to narrow down
+      reports to only those that could affect the application.
+
+      By default, govulncheck makes requests to the Go vulnerability database at
+      https://vuln.go.dev. Requests to the vulnerability database contain only
+      module paths, not code or other properties of your program. See
+      https://vuln.go.dev/privacy.html for more. Set the GOVULNDB environment
+      variable to specify a different database, which must implement the
+      specification at https://go.dev/security/vuln/database.
+
+      Govulncheck looks for vulnerabilities in Go programs using a specific
+      build configuration. For analyzing source code, that configuration is the
+      operating system, architecture, and Go version specified by GOOS, GOARCH,
+      and the “go” command found on the PATH. For binaries, the build
+      configuration is the one used to build the binary. Note that different
+      build configurations may have different known vulnerabilities. For
+      example, a dependency with a Windows-specific vulnerability will not be
+      reported for a Linux build.
+    '';
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ jk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -464,6 +464,8 @@ with pkgs;
 
   gojq = callPackage ../development/tools/gojq { };
 
+  govulncheck = callPackage ../tools/security/govulncheck { };
+
   gpick = callPackage ../tools/misc/gpick { };
 
   hwatch = callPackage ../tools/misc/hwatch { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Packages `govulncheck` for nixpkgs

https://go.dev/security/vuln/

https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
