### PR TITLE
gcs: 4.8.0 -> 4.37.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13222,6 +13222,15 @@
       fingerprint = "556A 403F B0A2 D423 F656  3424 8489 B911 F9ED 617B";
     }];
   };
+  tlater = {
+    email = "tm@tlater.net";
+    github = "TLATER";
+    githubId = 6654841;
+    name = "Tristan Daniël Maat";
+    keys = [{
+      fingerprint = "535B 6101 5823 4439 41C7  44DD 1226 4F6B BDFA BA89";
+    }];
+  };
   tljuniper = {
     email = "tljuniper1@gmail.com";
     github = "tljuniper";

--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -417,6 +417,21 @@
       </listitem>
       <listitem>
         <para>
+          <literal>pkgs.gcs</literal> no longer supports the XML-based
+          character sheet format.
+        </para>
+        <itemizedlist spacing="compact">
+          <listitem>
+            <para>
+              A tool can be downloaded from the
+              <link xlink:href="https://gurpscharactersheet.com/">gcs
+              website</link> to update old character sheets
+            </para>
+          </listitem>
+        </itemizedlist>
+      </listitem>
+      <listitem>
+        <para>
           The <literal>meta.mainProgram</literal> attribute of packages
           in <literal>wineWowPackages</literal> now defaults to
           <literal>&quot;wine64&quot;</literal>.

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -145,6 +145,11 @@ Available as [services.patroni](options.html#opt-services.patroni.enable).
   `python3.pkgs.influxgraph` packages, have been removed due to lack of upstream
   maintenance.
 
+- `pkgs.gcs` no longer supports the XML-based character sheet format.
+  - A tool can be downloaded from the [gcs
+    website](https://gurpscharactersheet.com/) to update old character
+    sheets
+
 - The `meta.mainProgram` attribute of packages in `wineWowPackages` now defaults to `"wine64"`.
 
 - (Neo)Vim can not be configured with `configure.pathogen` anymore to reduce maintainance burden.

--- a/pkgs/games/gcs/default.nix
+++ b/pkgs/games/gcs/default.nix
@@ -1,81 +1,133 @@
-{ lib, stdenv, fetchFromGitHub, runCommand
-, jdk8, ant
-, jre8, makeWrapper
+# Usage notes:
+#
+# Enable `services.gvfs` to open PDFs, or install and configure one of
+# the supported PDF viewers.
+#
+# Without this, you will get an unhelpful
+# "The BROWSE action is not supported on the current platform"
+{ lib
+, stdenv
+, fetchFromGitHub
+, jdk17
+, makeWrapper
+, wrapGAppsHook
+, copyDesktopItems
+, glib
+, gvfs
+, makeDesktopItem
 }:
+stdenv.mkDerivation rec {
+  pname = "gcs";
+  version = "v4.37.1";
 
-let
-  gcs = fetchFromGitHub {
+  src = fetchFromGitHub {
     owner = "richardwilkes";
     repo = "gcs";
-    rev = "gcs-4.8.0";
-    sha256 = "0k8am8vfwls5s2z4zj1p1aqy8gapn5vbr9zy66s5g048ch8ah1hm";
+    rev = version;
+    sha256 = "sha256-znN2tBUp0yAvM6E4eTcfmV3KmzyYlrRMLZgc/Fg9tFc=";
   };
-  appleStubs = fetchFromGitHub {
-    owner = "richardwilkes";
-    repo = "apple_stubs";
-    rev = "gcs-4.3.0";
-    sha256 = "0m1qw30b19s04hj7nch1mbvv5s698g5dr1d1r7r07ykvk1yh7zsa";
-  };
-  toolkit = fetchFromGitHub {
-    owner = "richardwilkes";
-    repo = "toolkit";
-    rev = "gcs-4.8.0";
-    sha256 = "1ciwwh0wxk3pzsj6rbggsbg3l2f741qy7yx1ca4v7vflsma84f1n";
-  };
-  library = fetchFromGitHub {
-    owner = "richardwilkes";
-    repo = "gcs_library";
-    rev = "gcs-4.8.0";
-    sha256 = "085jpp9mpv5kw00zds9sywmfq31mrlbrgahnwcjkx0z9i22amz4g";
-  };
-in stdenv.mkDerivation rec {
-  pname = "gcs";
-  version = "4.8.0";
 
-  src = runCommand "${pname}-${version}-src" { preferLocalBuild = true; } ''
-    mkdir -p $out
-    cd $out
+  nativeBuildInputs = [jdk17 makeWrapper wrapGAppsHook copyDesktopItems];
+  buildInputs = [glib gvfs];
 
-    cp -r ${gcs} gcs
-    cp -r ${appleStubs} apple_stubs
-    cp -r ${toolkit} toolkit
-    cp -r ${library} gcs_library
+  # gcs uses a bespoke bundling "script" that internally calls the
+  # built-in jpackage; while this may seem bad, it's significantly
+  # nicer to package than the gradle mess your usual Java application
+  # gets itself into.
+  #
+  # Either way, it doesn't have a configure script, but needs some
+  # patches to use things in the nix env correctly.
+  configurePhase = ''
+    patchShebangs bundle.sh
+    substituteInPlace bundle.sh --replace /bin/rm rm
   '';
 
-  nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ jdk8 jre8 ant ];
+  # Disable packaging of .deb/.rpm, just give us the raw package
+  # contents.
   buildPhase = ''
-    cd apple_stubs
-    ant
-
-    cd ../toolkit
-    ant
-
-    cd ../gcs
-    ant
-
-    cd ..
+    ./bundle.sh --unpackaged
   '';
 
-  installPhase = ''
-    mkdir -p $out/bin $out/share/java
+  installPhase = let
+    icon-install-command = size: ''
+      install -Dm 0600 \
+          out/dist/build/com.trollworks.gcs/images/app_${size}.png \
+          $out/share/icons/hicolor/${size}x${size}/apps/GCS.png
+    '';
+    icon-sizes = ["16" "32" "48" "64" "128" "256" "512" "1024"];
+    v = lib.removePrefix "v" version;
+  in ''
+    runHook preInstall
 
-    find gcs/libraries toolkit/libraries apple_stubs/ \( -name '*.jar' -and -not -name '*-src.jar' \) -exec cp '{}' $out/share/java ';'
+    install -Dm 0600 -t $out/share/java/ out/dist/modules/com.trollworks.gcs-${v}.jar
+    install -Dm 0600 ${./mime-info.xml} $out/share/mime/packages/gcs-GCS-MimeInfo.xml
 
-    makeWrapper ${jre8}/bin/java $out/bin/gcs \
-      --set GCS_LIBRARY ${library} \
-      --add-flags "-cp $out/share/java/gcs-${version}.jar com.trollworks.gcs.app.GCS"
+    ${lib.strings.concatMapStringsSep "\n" icon-install-command icon-sizes}
+
+    runHook postInstall
   '';
+
+  # Add a launcher script that wraps up gapps correctly so the file
+  # picker works.
+  preFixup = let
+    v = lib.removePrefix "v" version;
+  in ''
+    makeWrapper ${jdk17}/bin/java $out/bin/gcs \
+        ''${gappsWrapperArgs[@]} \
+        --add-flags "-jar $out/share/java/com.trollworks.gcs-${v}.jar"
+  '';
+
+  # Done as part of `makeWrapper` instead.
+  dontWrapGApps = true;
+
+  # Technically jpackage has its own set of definitions for this, but
+  # when using `--unpackaged` it never creates a .desktop file.
+  #
+  # Instead, manually extract the args from around here:
+  # https://github.com/richardwilkes/gcs/blob/v4-java/bundler/bundler/Bundler.java#L628
+  #
+  # If you're feeling motivated, feel free to write a script that
+  # implements exactly the .desktop creating part of jpackage or such.
+  desktopItems = [
+    (makeDesktopItem {
+      name = "com.trollworks.gcs";
+      desktopName = "GCS";
+      categories = ["Game" "Utility" "RolePlaying"];
+      comment = meta.description;
+      icon = "GCS";
+      exec = "gcs";
+
+      mimeTypes = [
+        "application/gcs.adm"
+        "application/gcs.adq"
+        "application/gcs.eqm"
+        "application/gcs.eqp"
+        "application/gcs.gcs"
+        "application/gcs.gct"
+        "application/gcs.not"
+        "application/gcs.skl"
+        "application/gcs.spl"
+      ];
+    })
+  ];
 
   meta = with lib; {
+    # Description differs subtly from the upstream one to conform with
+    # nixpkgs requirements.
     description = "A stand-alone, interactive, character sheet editor for the GURPS 4th Edition roleplaying game system";
     homepage = "https://gurpscharactersheet.com/";
-    sourceProvenance = with sourceTypes; [
-      fromSource
-      binaryBytecode  # source bundles dependencies as jars
-    ];
+    sourceProvenance = with sourceTypes; [fromSource];
     license = licenses.mpl20;
     platforms = platforms.all;
-    maintainers = with maintainers; [];
+    maintainers = with maintainers; [tlater];
   };
+
+  # An update script is probably superfluous for the moment, since the
+  # next release (version 5) will be moving to go, so the derivation
+  # will have to be redone by hand no matter what.
+  #
+  # Testing this as a GUI application would be valuable, but I also
+  # think that's overkill, and I'd rather not spend valuable CI time
+  # on testing a GUI app that probably only has very, very few users
+  # ;)
 }

--- a/pkgs/games/gcs/mime-info.xml
+++ b/pkgs/games/gcs/mime-info.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" ?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+  <mime-type type="application/gcs.adm">
+    <comment>GCS Advantage Modifiers Library</comment>
+    <glob pattern="*.adm"></glob>
+  </mime-type>
+  <mime-type type="application/gcs.adq">
+    <comment>GCS Advantages Library</comment>
+    <glob pattern="*.adq"></glob>
+  </mime-type>
+  <mime-type type="application/gcs.eqm">
+    <comment>GCS Equipment Modifiers Library</comment>
+    <glob pattern="*.eqm"></glob>
+  </mime-type>
+  <mime-type type="application/gcs.eqp">
+    <comment>GCS Equipment Library</comment>
+    <glob pattern="*.eqp"></glob>
+  </mime-type>
+  <mime-type type="application/gcs.gcs">
+    <comment>GURPS Character Sheet</comment>
+    <glob pattern="*.gcs"></glob>
+  </mime-type>
+  <mime-type type="application/gcs.gct">
+    <comment>GCS Character Template</comment>
+    <glob pattern="*.gct"></glob>
+  </mime-type>
+  <mime-type type="application/gcs.not">
+    <comment>GCS Notes Library</comment>
+    <glob pattern="*.not"></glob>
+  </mime-type>
+  <mime-type type="application/gcs.skl">
+    <comment>GCS Skills Library</comment>
+    <glob pattern="*.skl"></glob>
+  </mime-type>
+  <mime-type type="application/gcs.spl">
+    <comment>GCS Spells Library</comment>
+    <glob pattern="*.spl"></glob>
+  </mime-type>
+</mime-info>


### PR DESCRIPTION
###### Description of changes

This updates gcs to the most modern release. Much has changed in the intervening 29 "minor" versions: https://github.com/richardwilkes/gcs/releases

Among the changes is a switch from an XML-based format to a JSON-based format, so this is a breaking change. There is a `.deb`-packaged java tool to convert between them, which I point out in the release notes, but it of course won't work out of the box on NixOS. If I was extremely nice I'd package the conversion tool as well, and add it to `passthru` - should I?

I'm also neglecting writing a test for this - it's a GUI app, so I would have to write a full NixOS test. I'm willing to add one, but it will likely be outdated on the very next release due to the switch from Java to Go, and seems like a lot of testing overhead for a small userbase.

I'm also adding myself as a maintainer, and intend to actually update this package in the future. I assume @joachifm is ok with this?

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
