### PR TITLE
everspace: add desktop file

### DIFF
--- a/pkgs/games/everspace/default.nix
+++ b/pkgs/games/everspace/default.nix
@@ -1,6 +1,6 @@
 {
   # Packaging Dependencies
-  lib, stdenv, requireFile, autoPatchelfHook, unzip,
+  lib, stdenv, requireFile, autoPatchelfHook, unzip, copyDesktopItems, makeDesktopItem,
 
   # Everspace Dependencies
   cairo, gdk-pixbuf, pango, gtk2-x11, libGL, openal,
@@ -11,7 +11,7 @@
 
 # Known issues:
 # - Video playback (upon starting a new game) does not work (screen is black)
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "everspace";
   version = "1.3.5.3655";
 
@@ -23,6 +23,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [
     autoPatchelfHook
+    copyDesktopItems
     unzip
   ];
 
@@ -89,8 +90,23 @@ stdenv.mkDerivation {
     mkdir -p "$out/bin"
     ln -s "$out/opt/everspace/game/RSG/Binaries/Linux/RSG-Linux-Shipping" "$out/bin/everspace"
 
+    mkdir -p "$out/share/pixmaps"
+    ln -s "$out/opt/everspace/support/icon.png" "$out/share/pixmaps/everspace-gog.png"
+
     runHook postInstall
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      type = "Application";
+      name = "everspace-gog";
+      desktopName = "EVERSPACE™";
+      comment = meta.description;
+      exec = "everspace";
+      icon = "everspace-gog";
+      categories = [ "Game" ];
+    })
+  ];
 
   meta = with lib; {
     description = "Action-focused single-player space shooter with roguelike elements";


### PR DESCRIPTION
###### Description of changes

Adds a desktop file for the game. I forgot this in my original PR: #188385.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
