### PR TITLE
stdenv: encode whitespace in file paths in NIX_LDFLAGS

### DIFF
--- a/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
@@ -78,8 +78,12 @@ extraAfter=()
 extraBefore=(${hardeningLDFlags[@]+"${hardeningLDFlags[@]}"})
 
 if [ -z "${NIX_LINK_TYPE_@suffixSalt@:-}" ]; then
-    extraAfter+=($(filterRpathFlags "$linkType" $NIX_LDFLAGS_@suffixSalt@))
-    extraBefore+=($(filterRpathFlags "$linkType" $NIX_LDFLAGS_BEFORE_@suffixSalt@))
+    for i in $(filterRpathFlags "$linkType" $NIX_LDFLAGS_@suffixSalt@); do
+        extraAfter+=("$(decodeWhitespaceFileURL $i)")
+    done
+    for i in $(filterRpathFlags "$linkType" $NIX_LDFLAGS_BEFORE_@suffixSalt@); do
+        extraBefore+=("$(decodeWhitespaceFileURL $i)")
+    done
 
     # By adding dynamic linker to extraBefore we allow the users set their
     # own dynamic linker as NIX_LD_FLAGS will override earlier set flags
@@ -88,7 +92,9 @@ if [ -z "${NIX_LINK_TYPE_@suffixSalt@:-}" ]; then
     fi
 fi
 
-extraAfter+=($(filterRpathFlags "$linkType" $NIX_LDFLAGS_AFTER_@suffixSalt@))
+for i in $(filterRpathFlags "$linkType" $NIX_LDFLAGS_AFTER_@suffixSalt@); do
+    extraAfter+=("$(decodeWhitespaceFileURL $i)")
+done
 
 # These flags *must not* be pulled up to -Wl, flags, so they can't go in
 # add-flags.sh. They must always be set, so must not be disabled by


### PR DESCRIPTION
### Description of changes

fix #177952

encode/decode file paths, to support whitespace in paths

targeting the `staging` branch, because this will rebuild everything

paths with whitespace are encoded like
`/tmp/yes space` &rarr; `file:/tmp/yes%20space`

so this also supports [relative paths](https://stackoverflow.com/questions/7857416/file-uri-scheme-and-relative-files) like
`a/b/yes space` &rarr; `file:a/b/yes%20space`
`./b/yes space` &rarr; `file:./b/yes%20space`

### TODO

- [ ] fix `nix develop`
  - why is `nix develop` not using the nixpkgs in workdir?
- [ ] add unit tests for the bash functions?

### Scope

fix `cc-wrapper` and `ld-wrapper`.
here, `NIX_LDFLAGS` (and friends) are transformed
to compiler arguments and linker arguments

### Out of scope

fix all `LDFLAGS`.
not realistic, because most tools cannot decode the `file:` protocol

### Discuss

should we use a different protocol than `file:`?
something like `nix_file:` or `__nix_file:`

### Related

pkgs/build-support/setup-hooks/move-lib64.sh

### Review

```sh
mkdir "/tmp/yes space"
cd "/tmp/yes space"

git clone --depth 5 https://github.com/milahu/nixpkgs -b cc-wrapper-urlencode-paths
cd nixpkgs

# rebuild the gcc toolchain
time nix-shell -E 'with import ./. {}; pkgs.mkShell {}' --run date >nix-shell.log.$(date +%F.%H-%M-%S) 2>&1 &

#nix-shell -E 'with import ./. {}; pkgs.mkShell {}' # not affected by issue 177952
nix develop --impure --expr 'with import ./. {}; pkgs.mkShell {}'

    which gcc | grep gcc-wrapper && echo ok || echo fail

    grep -Hn decodeWhitespaceFileURL $(which gcc) && echo ok || echo fail

    # FIXME
    echo $NIX_LDFLAGS
    echo $NIX_LDFLAGS | grep %20 && echo ok || echo fail

    # FIXME
    echo 'int main() { return 0; }' >test.c
    gcc -o test test.c && echo ok || echo fail

exit # nix develop
```

### Debug

`nix develop` is not using `nixpkgs` in workdir

```sh
mv ~/.cache/nix{,.bak} # hide cache
nix develop --impure --expr 'with import ./. {}; pkgs.mkShell {}' --command date
# [0.0 MiB DL] downloading 'https://api.github.com/repos/NixOS/nixpkgs/tarball/21de2b973f9fee595a7a1ac4693efff791245c34'
```

also ... `nix develop` fails in `nixpkgs`

```sh
nix develop
# error: 'file:///home/milahu/yes space/nixpkgs' is not a valid URL
```

[nix/src/libutil/url.cc](https://github.com/NixOS/nix/blob/master/src/libutil/url.cc#L54)

```cc
ParsedURL parseURL(const std::string & url)
// ...
        throw BadURL("'%s' is not a valid URL", url);
```

```sh
gdb -ex "set breakpoint pending on" -ex "b parseURL" -ex run -ex bt -ex "frame 0" -ex "info args" --args nix develop
```

problem: `No Symbol Table` &rarr; [get debug symbols](https://github.com/edolstra/dwarffs#operation)

```sh
(
mkdir nix-debug-symbols
cd nix-debug-symbols
build_id=$(nix-shell -p gcc --run 'readelf -a $(which nix) | grep "Build ID"' | awk '{print $3}')
archive_path=$(curl -s https://cache.nixos.org/debuginfo/$build_id | jq -r .archive)
wget https://cache.nixos.org/debuginfo/$archive_path
cat *.nar.xz | xz -dc | nix-store --restore out/
)
export NIX_DEBUG_INFO_DIRS=./nix-debug-symbols/out/lib/debug/
gdb -ex "set breakpoint pending on" -ex "b parseURL" -ex run -ex bt -ex "frame 0" -ex "info args" --args nix develop
```

still `No symbol table` &rarr; keep [debug symbols](https://nixos.wiki/wiki/Debug_Symbols) with `enableDebugging nix`

```sh
nix-build -E 'with import <nixpkgs> {}; enableDebugging nix'
gdb -ex "set breakpoint pending on" -ex "b parseURL" -ex run -ex bt -ex "frame 0" -ex "info args" --args ./result/bin/nix develop
# No symbol table

readelf -S ./result/bin/nix | grep -i debug
# empty -> no debug symbols -> enableDebugging has no effect
```

still `No symbol table` &rarr; keep debug symbols with `{ dontStrip = true; }`

```sh
nix-build -E 'with import <nixpkgs> {}; pkgs.nix.overrideAttrs (old: { dontStrip = true; })'
gdb -ex "set breakpoint pending on" -ex "b parseURL" -ex run -ex bt -ex "frame 0" -ex "info args" --args ./result/bin/nix develop
# No symbol table

readelf -S ./result/bin/nix | grep -i debug
# empty -> no debug symbols -> enableDebugging has no effect
```

hmm ...

### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
