### PR TITLE
nixos/doc: fix acme dns-01 example

### DIFF
--- a/nixos/modules/security/acme/doc.xml
+++ b/nixos/modules/security/acme/doc.xml
@@ -237,8 +237,8 @@ services.bind = {
 
 <programlisting>
 systemd.services.dns-rfc2136-conf = {
-  requiredBy = ["acme-example.com.service", "bind.service"];
-  before = ["acme-example.com.service", "bind.service"];
+  requiredBy = ["acme-example.com.service" "bind.service"];
+  before = ["acme-example.com.service" "bind.service"];
   unitConfig = {
     ConditionPathExists = "!/var/lib/secrets/dnskeys.conf";
   };
@@ -249,18 +249,19 @@ systemd.services.dns-rfc2136-conf = {
   path = [ pkgs.bind ];
   script = ''
     mkdir -p /var/lib/secrets
+    chmod 755 /var/lib/secrets
     tsig-keygen rfc2136key.example.com &gt; /var/lib/secrets/dnskeys.conf
     chown named:root /var/lib/secrets/dnskeys.conf
     chmod 400 /var/lib/secrets/dnskeys.conf
 
-    # Copy the secret value from the dnskeys.conf, and put it in
-    # RFC2136_TSIG_SECRET below
+    # extract secret value from the dnskeys.conf
+    while read x y; do if [ "$x" = "secret" ]; then secret="''${y:1:''${#y}-3}"; fi; done &lt; /var/lib/secrets/dnskeys.conf
 
     cat &gt; /var/lib/secrets/certs.secret &lt;&lt; EOF
     RFC2136_NAMESERVER='127.0.0.1:53'
     RFC2136_TSIG_ALGORITHM='hmac-sha256.'
     RFC2136_TSIG_KEY='rfc2136key.example.com'
-    RFC2136_TSIG_SECRET='your secret key'
+    RFC2136_TSIG_SECRET='$secret'
     EOF
     chmod 400 /var/lib/secrets/certs.secret
   '';


### PR DESCRIPTION
Summary: fix errors with example code in the manual that shows how to set up DNS-01 verification via the acme protocol, e.g. for those who want to get wildcard certificates from Let's Encrypt.

Fix syntax error in nix arrays (there should not be commas.)

Fix permissions on /var/lib/secrets so it can be read by bind daemon. Without this fix bind won't start.

Add the missing feature: put the generated secret into certs.secret

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
