### PR TITLE
gen6dns: init at 1.3

### DIFF
--- a/pkgs/tools/networking/gen6dns/default.nix
+++ b/pkgs/tools/networking/gen6dns/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenv, fetchurl, installShellFiles }:
 
 stdenv.mkDerivation rec {
   pname = "gen6dns";
@@ -9,8 +9,14 @@ stdenv.mkDerivation rec {
     hash = "sha256-MhYfgzbGPmrhPx89EpObrEkxaII7uz4TbWXeEGF7Xws=";
   };
 
+  nativeBuildInputs = [ installShellFiles ];
+
   preInstall = ''
     mkdir -p $out/bin
+  '';
+
+  postInstall = ''
+    installManPage gen6dns.1
   '';
 
   makeFlags = [ "INSTALL_DIR=$(out)/bin" ];

--- a/pkgs/tools/networking/gen6dns/default.nix
+++ b/pkgs/tools/networking/gen6dns/default.nix
@@ -1,0 +1,25 @@
+{ lib, stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "gen6dns";
+  version = "1.3";
+
+  src = fetchurl {
+    url = "https://www.hznet.de/tools/gen6dns-${version}.tar.gz";
+    hash = "sha256-MhYfgzbGPmrhPx89EpObrEkxaII7uz4TbWXeEGF7Xws=";
+  };
+
+  preInstall = ''
+    mkdir -p $out/bin
+  '';
+
+  makeFlags = [ "INSTALL_DIR=$(out)/bin" ];
+
+  meta = with lib; {
+    description = "Tool to generate static DNS records (AAAA and PTR) for hosts using Stateless Address Autoconfig (SLAAC)";
+    homepage = "https://www.hznet.de/tools.html#gen6dns";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ majiir ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1265,6 +1265,8 @@ with pkgs;
 
   gam = callPackage ../tools/admin/gam { };
 
+  gen6dns = callPackage ../tools/networking/gen6dns { };
+
   gfshare = callPackage ../tools/security/gfshare { };
 
   gh-cal = callPackage ../tools/misc/gh-cal {


### PR DESCRIPTION
###### Description of changes

[**gen6dns**](https://www.hznet.de/tools.html#gen6dns) is a tool to generate static DNS records (AAAA and PTR) for hosts using Stateless Address Autoconfig (SLAAC).

I found it when reading [**Idea: IPv6 Dynamic Prefix**](https://weberblog.net/idea-ipv6-dynamic-prefix/). I sure wish `bind`+`nsupdate` could do that!

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
