### PR TITLE
iwgtk: 0.4.0 -> 0.8.0

### DIFF
--- a/pkgs/tools/networking/iwgtk/default.nix
+++ b/pkgs/tools/networking/iwgtk/default.nix
@@ -1,21 +1,38 @@
-{ fetchFromGitHub, gtk3, lib, pkg-config, stdenv }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, pkg-config
+, scdoc
+, wrapGAppsHook
+, gtk4
+, qrencode
+}:
 
 stdenv.mkDerivation rec {
   pname = "iwgtk";
-  version = "0.4";
+  version = "0.8";
 
   src = fetchFromGitHub {
     owner = "j-lentz";
     repo = pname;
     rev = "v${version}";
-    sha256 = "129h7vq9b1r9a5c79hk8d06bj8lgzrnhq55x54hqri9c471jjh0s";
+    sha256 = "sha256-89rzDxalZtQkwAKS6hKPVY87kOWPySwDeZrPs2rGs/k=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  # patch systemd service to pass necessary environments and use absolute paths
+  patches = [ ./systemd-service.patch ];
 
-  buildInputs = [ gtk3 ];
+  nativeBuildInputs = [ meson ninja pkg-config scdoc wrapGAppsHook ];
 
-  makeFlags = [ "prefix=$(out)" ];
+  buildInputs = [ gtk4 qrencode ];
+
+  postInstall = ''
+    mv $out/share/lib/systemd $out/share
+    rmdir $out/share/lib
+    substituteInPlace $out/share/systemd/user/iwgtk.service --subst-var out
+  '';
 
   meta = with lib; {
     description = "Lightweight, graphical wifi management utility for Linux";

--- a/pkgs/tools/networking/iwgtk/systemd-service.patch
+++ b/pkgs/tools/networking/iwgtk/systemd-service.patch
@@ -1,0 +1,12 @@
+--- a/misc/iwgtk.service
++++ b/misc/iwgtk.service
+@@ -6,7 +6,8 @@ PartOf=graphical-session.target
+ After=graphical-session.target
+ 
+ [Service]
+-ExecStart=iwgtk -i
++ExecStart=@out@/bin/iwgtk -i
++PassEnvironment=DISPLAY XAUTHORITY
+ Restart=on-failure
+ 
+ [Install]


### PR DESCRIPTION
###### Description of changes

Closes #177666 

https://github.com/J-Lentz/iwgtk/compare/v0.4...v0.8
[changelog](https://github.com/J-Lentz/iwgtk/blob/v0.8/CHANGELOG)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
