### PR TITLE
p4v: 2021.3.2186916 -> 2022.2.2336701, fix ELF patching, add macOS support

### DIFF
--- a/pkgs/applications/version-management/p4v/darwin.nix
+++ b/pkgs/applications/version-management/p4v/darwin.nix
@@ -1,0 +1,24 @@
+{ stdenv, undmg }:
+
+{ pname, version, src, meta }:
+stdenv.mkDerivation {
+  inherit pname version src meta;
+
+  nativeBuildInputs = [ undmg ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    mkdir -p $out/Applications $out/bin
+
+    # Install Qt applications.
+    for f in p4admin.app p4merge.app p4v.app; do
+      mv $f $out/Applications
+    done
+
+    # Install p4vc separately (it's a tiny shell script).
+    mv p4vc $out/bin
+    substituteInPlace $out/bin/p4vc \
+      --replace /Applications $out/Applications
+  '';
+}

--- a/pkgs/applications/version-management/p4v/default.nix
+++ b/pkgs/applications/version-management/p4v/default.nix
@@ -28,11 +28,11 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "p4v";
-  version = "2021.3.2186916";
+  version = "2022.2.2336701";
 
   src = fetchurl {
-    url = "http://web.archive.org/web/20211118024745/https://cdist2.perforce.com/perforce/r21.3/bin.linux26x86_64/p4v.tgz";
-    sha256 = "1zldg21xq4srww9pcfbv3p8320ghjnh333pz5r70z1gwbq4vf3jq";
+    url = "https://web.archive.org/web/20220902181457/https://ftp.perforce.com/perforce/r22.2/bin.linux26x86_64/p4v.tgz";
+    sha256 = "8fdade4aafe25f568a61cfd80823aa90599c2a404b7c6b4a0862c84b07a9f8d2";
   };
 
   dontBuild = true;

--- a/pkgs/applications/version-management/p4v/default.nix
+++ b/pkgs/applications/version-management/p4v/default.nix
@@ -27,59 +27,81 @@
 , xcbutilwm
 }:
 
-stdenv.mkDerivation {
+let
   pname = "p4v";
   version = "2022.2.2336701";
 
-  src = fetchurl {
-    url = "https://web.archive.org/web/20220902181457/https://ftp.perforce.com/perforce/r22.2/bin.linux26x86_64/p4v.tgz";
-    sha256 = "8fdade4aafe25f568a61cfd80823aa90599c2a404b7c6b4a0862c84b07a9f8d2";
+  unwrapped = stdenv.mkDerivation {
+    pname = "${pname}-unwrapped";
+    inherit version;
+
+    src = fetchurl {
+      url = "https://web.archive.org/web/20220902181457/https://ftp.perforce.com/perforce/r22.2/bin.linux26x86_64/p4v.tgz";
+      sha256 = "8fdade4aafe25f568a61cfd80823aa90599c2a404b7c6b4a0862c84b07a9f8d2";
+    };
+
+    nativeBuildInputs = [ autoPatchelfHook ];
+    buildInputs = [
+      cups
+      dbus
+      fontconfig
+      gccForLibs
+      libX11
+      libXcomposite
+      libXcursor
+      libXdamage
+      libXext
+      libXi
+      libXrandr
+      libXrender
+      libXtst
+      libinput
+      libxcb
+      libxkbcommon
+      nss
+      qttools
+      qtwebengine
+      xcbutilimage
+      xcbutilkeysyms
+      xcbutilrenderutil
+      xcbutilwm
+    ];
+
+    dontBuild = true;
+
+    # Don't wrap the Qt apps; upstream has its own wrapper scripts.
+    dontWrapQtApps = true;
+
+    installPhase = ''
+      mkdir -p $out
+      cp -r bin lib $out
+      addAutoPatchelfSearchPath $out/lib
+    '';
+
+    meta = {
+      description = "Perforce Helix Visual Client";
+      homepage = "https://www.perforce.com";
+      sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+      license = lib.licenses.unfreeRedistributable;
+      platforms = [ "x86_64-linux" ];
+      maintainers = with lib.maintainers; [ impl nathyong nioncode ];
+    };
   };
+in
+stdenv.mkDerivation {
+  inherit pname version;
 
-  nativeBuildInputs = [ autoPatchelfHook ];
-  buildInputs = [
-    cups
-    dbus
-    fontconfig
-    gccForLibs
-    libX11
-    libXcomposite
-    libXcursor
-    libXdamage
-    libXext
-    libXi
-    libXrandr
-    libXrender
-    libXtst
-    libinput
-    libxcb
-    libxkbcommon
-    nss
-    qttools
-    qtwebengine
-    xcbutilimage
-    xcbutilkeysyms
-    xcbutilrenderutil
-    xcbutilwm
-  ];
-
-  dontBuild = true;
-
-  # Don't wrap the Qt apps; upstream has its own wrapper scripts.
-  dontWrapQtApps = true;
-
-  installPhase = ''
-    mkdir -p $out
-    cp -r bin lib $out
-    addAutoPatchelfSearchPath $out/lib
+  # Build a "clean" version of the package so that we don't add extra ".bin" or
+  # configuration files to users' PATHs. We can't easily put the unwrapped
+  # package files in libexec (where they belong, probably) because the upstream
+  # wrapper scripts have the bin directory hardcoded.
+  buildCommand = ''
+    mkdir -p $out/bin
+    for f in p4admin p4merge p4v p4vc; do
+      ln -s ${unwrapped}/bin/$f $out/bin
+    done
   '';
+  preferLocalBuild = true;
 
-  meta = {
-    description = "Perforce Helix Visual Client";
-    homepage = "https://www.perforce.com";
-    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    license = lib.licenses.unfreeRedistributable;
-    platforms = [ "x86_64-linux" ];
-    maintainers = with lib.maintainers; [ impl nathyong nioncode ];
-  };
+  inherit (unwrapped) meta passthru;
 }

--- a/pkgs/applications/version-management/p4v/default.nix
+++ b/pkgs/applications/version-management/p4v/default.nix
@@ -1,32 +1,33 @@
 { stdenv
 , fetchurl
 , lib
-, qtbase
+, autoPatchelfHook
+, cups
+, dbus
+, fontconfig
+, gccForLibs
+, libX11
+, libXcomposite
+, libXcursor
+, libXdamage
+, libXext
+, libXi
+, libXrandr
+, libXrender
+, libXtst
+, libinput
+, libxcb
+, libxkbcommon
+, nss
+, qttools
 , qtwebengine
-, qtdeclarative
-, qtwebchannel
-, syntax-highlighting
-, openssl
-, xkeyboard_config
-, patchelfUnstable
-, wrapQtAppsHook
-, writeText
+, xcbutilimage
+, xcbutilkeysyms
+, xcbutilrenderutil
+, xcbutilwm
 }:
-let
-  # This abomination exists because p4v calls CRYPTO_set_mem_functions and
-  # expects it to succeed. The function will fail if CRYPTO_malloc has already
-  # been called, which happens at init time via qtwebengine -> ... -> libssh. I
-  # suspect it was meant to work with a version of Qt where openssl is
-  # statically linked or some other library is used.
-  crypto-hack = writeText "crypto-hack.c" ''
-      #include <stddef.h>
-      int CRYPTO_set_mem_functions(
-            void *(*m)(size_t, const char *, int),
-            void *(*r)(void *, size_t, const char *, int),
-            void (*f)(void *, const char *, int)) { return 1; }
-    '';
 
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "p4v";
   version = "2022.2.2336701";
 
@@ -35,50 +36,50 @@ in stdenv.mkDerivation rec {
     sha256 = "8fdade4aafe25f568a61cfd80823aa90599c2a404b7c6b4a0862c84b07a9f8d2";
   };
 
-  dontBuild = true;
-  nativeBuildInputs = [ patchelfUnstable wrapQtAppsHook ];
-
-  ldLibraryPath = lib.makeLibraryPath [
-      stdenv.cc.cc.lib
-      qtbase
-      qtwebengine
-      qtdeclarative
-      qtwebchannel
-      syntax-highlighting
-      openssl
+  nativeBuildInputs = [ autoPatchelfHook ];
+  buildInputs = [
+    cups
+    dbus
+    fontconfig
+    gccForLibs
+    libX11
+    libXcomposite
+    libXcursor
+    libXdamage
+    libXext
+    libXi
+    libXrandr
+    libXrender
+    libXtst
+    libinput
+    libxcb
+    libxkbcommon
+    nss
+    qttools
+    qtwebengine
+    xcbutilimage
+    xcbutilkeysyms
+    xcbutilrenderutil
+    xcbutilwm
   ];
 
-  dontWrapQtApps = true;
-  installPhase = ''
-    mkdir $out
-    cp -r bin $out
-    mkdir -p $out/lib
-    cp -r lib/P4VResources $out/lib
-    $CC -fPIC -shared -o $out/lib/libcrypto-hack.so ${crypto-hack}
+  dontBuild = true;
 
-    for f in $out/bin/*.bin ; do
-      patchelf --set-rpath $ldLibraryPath --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $f
-      # combining this with above breaks rpath (patchelf bug?)
-      patchelf --add-needed libstdc++.so \
-               --add-needed $out/lib/libcrypto-hack.so \
-               --clear-symbol-version _ZNSt20bad_array_new_lengthD1Ev \
-               --clear-symbol-version _ZTVSt20bad_array_new_length \
-               --clear-symbol-version _ZTISt20bad_array_new_length \
-               --clear-symbol-version _ZdlPvm \
-               $f
-      wrapQtApp $f \
-        --suffix QT_XKB_CONFIG_ROOT : ${xkeyboard_config}/share/X11/xkb
-    done
+  # Don't wrap the Qt apps; upstream has its own wrapper scripts.
+  dontWrapQtApps = true;
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r bin lib $out
+    addAutoPatchelfSearchPath $out/lib
   '';
 
-  dontFixup = true;
-
   meta = {
-    description = "Perforce Visual Client";
+    description = "Perforce Helix Visual Client";
     homepage = "https://www.perforce.com";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfreeRedistributable;
     platforms = [ "x86_64-linux" ];
-    maintainers = with lib.maintainers; [ nathyong nioncode ];
+    maintainers = with lib.maintainers; [ impl nathyong nioncode ];
   };
 }

--- a/pkgs/applications/version-management/p4v/linux.nix
+++ b/pkgs/applications/version-management/p4v/linux.nix
@@ -1,0 +1,89 @@
+{ stdenv
+, autoPatchelfHook
+, cups
+, dbus
+, fontconfig
+, gccForLibs
+, libX11
+, libXcomposite
+, libXcursor
+, libXdamage
+, libXext
+, libXi
+, libXrandr
+, libXrender
+, libXtst
+, libinput
+, libxcb
+, libxkbcommon
+, nss
+, qttools
+, qtwebengine
+, xcbutilimage
+, xcbutilkeysyms
+, xcbutilrenderutil
+, xcbutilwm
+}:
+
+{ pname, version, src, meta }:
+let
+  unwrapped = stdenv.mkDerivation {
+    pname = "${pname}-unwrapped";
+    inherit version src meta;
+
+    nativeBuildInputs = [ autoPatchelfHook ];
+    buildInputs = [
+      cups
+      dbus
+      fontconfig
+      gccForLibs
+      libX11
+      libXcomposite
+      libXcursor
+      libXdamage
+      libXext
+      libXi
+      libXrandr
+      libXrender
+      libXtst
+      libinput
+      libxcb
+      libxkbcommon
+      nss
+      qttools
+      qtwebengine
+      xcbutilimage
+      xcbutilkeysyms
+      xcbutilrenderutil
+      xcbutilwm
+    ];
+
+    dontBuild = true;
+
+    # Don't wrap the Qt apps; upstream has its own wrapper scripts.
+    dontWrapQtApps = true;
+
+    installPhase = ''
+      mkdir -p $out
+      cp -r bin lib $out
+      addAutoPatchelfSearchPath $out/lib
+    '';
+  };
+in
+stdenv.mkDerivation {
+  inherit pname version;
+
+  # Build a "clean" version of the package so that we don't add extra ".bin" or
+  # configuration files to users' PATHs. We can't easily put the unwrapped
+  # package files in libexec (where they belong, probably) because the upstream
+  # wrapper scripts have the bin directory hardcoded.
+  buildCommand = ''
+    mkdir -p $out/bin
+    for f in p4admin p4merge p4v p4vc; do
+      ln -s ${unwrapped}/bin/$f $out/bin
+    done
+  '';
+  preferLocalBuild = true;
+
+  inherit (unwrapped) meta passthru;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30207,7 +30207,7 @@ with pkgs;
 
   p4 = callPackage ../applications/version-management/p4 { };
   p4d = callPackage ../applications/version-management/p4d { };
-  p4v = libsForQt515.callPackage ../applications/version-management/p4v { };
+  p4v = callPackage ../applications/version-management/p4v { };
 
   partio = callPackage ../development/libraries/partio {};
 


### PR DESCRIPTION
###### Description of changes

The plugins and DVCS support (using an upstream-redistributed p4d binary) weren't working properly with the manual ELF patching being done in this package, so I rewrote it to use `autoPatchelfHook` instead. I created a small wrapper to avoid polluting the bin directory as suggested in #110168. I also upgraded it to the latest upstream version and added a macOS version.

Please note that I am employed by Perforce but I am not currently supporting these packages in an official capacity.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
