### PR TITLE
p4d: init at 2022.1.2305383

### DIFF
--- a/pkgs/applications/version-management/p4d/default.nix
+++ b/pkgs/applications/version-management/p4d/default.nix
@@ -1,0 +1,52 @@
+{ stdenv
+, fetchurl
+, lib
+, autoPatchelfHook
+}:
+
+let
+  # Upstream replaces minor versions, so use cached URLs.
+  srcs = {
+    "i686-linux" = fetchurl {
+      url = "https://web.archive.org/web/20220907001049/https://ftp.perforce.com/perforce/r22.1/bin.linux26x86/helix-core-server.tgz";
+      sha256 = "e9cf27c9dd2fa6432745058a93896d151543aff712fce9f7322152d6ea88a12a";
+    };
+    "x86_64-linux" = fetchurl {
+      url = "https://web.archive.org/web/20220907001202/https://ftp.perforce.com/perforce/r22.1/bin.linux26x86_64/helix-core-server.tgz";
+      sha256 = "9c272b67574264a4f49fe846ccda24fbd4baeb282665af74b6fbccff26a43558";
+    };
+    "x86_64-darwin" = fetchurl {
+      url = "https://web.archive.org/web/20220907001334/https://ftp.perforce.com/perforce/r22.1/bin.macosx1015x86_64/helix-core-server.tgz";
+      sha256 = "2500a23fe482a303bd400f0de460b7624ad3f940fef45246004b9f956e90ea45";
+    };
+  };
+in
+stdenv.mkDerivation {
+  pname = "p4d";
+  version = "2022.1.2305383";
+
+  src =
+    assert lib.assertMsg (builtins.hasAttr stdenv.hostPlatform.system srcs) "p4d is not available for ${stdenv.hostPlatform.system}";
+    srcs.${stdenv.hostPlatform.system};
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    install -D -t $out/bin p4broker p4d p4p
+    install -D -t $out/doc/p4d -m 0644 *.txt
+  '';
+
+  meta = with lib; {
+    description = "Perforce Helix Core Server";
+    homepage = "https://www.perforce.com";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = licenses.unfree;
+    mainProgram = "p4d";
+    platforms = builtins.attrNames srcs;
+    maintainers = with maintainers; [ impl ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29701,6 +29701,7 @@ with pkgs;
   ostinato = libsForQt5.callPackage ../applications/networking/ostinato { };
 
   p4 = callPackage ../applications/version-management/p4 { };
+  p4d = callPackage ../applications/version-management/p4d { };
   p4v = libsForQt515.callPackage ../applications/version-management/p4v { };
 
   partio = callPackage ../development/libraries/partio {};


### PR DESCRIPTION
###### Description of changes

This package splits p4d, p4broker, and p4p out of the p4 package, because the actual CLI for Perforce is open-source and can be readily built from a source distribution.

The PR to update the CLI package is #190105.

Please note that I am employed by Perforce but I am not currently supporting these packages in an official capacity.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
