### PR TITLE
p4: 2021.2.2201121 -> 2022.1.2305383, build from source and remove unfree binaries

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -483,6 +483,16 @@
       </listitem>
       <listitem>
         <para>
+          The <literal>p4</literal> package now only includes the
+          open-source Perforce Helix Core command-line client and APIs.
+          It no longer installs the unfree Helix Core Server binaries
+          <literal>p4d</literal>, <literal>p4broker</literal>, and
+          <literal>p4p</literal>. To install the Helix Core Server
+          binaries, use the <literal>p4d</literal> package instead.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           The <literal>coq</literal> package and versioned variants
           starting at <literal>coq_8_14</literal> no longer include
           CoqIDE, which is now available through

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -160,6 +160,8 @@ Available as [services.patroni](options.html#opt-services.patroni.enable).
 - `services.hbase` has been renamed to `services.hbase-standalone`.
   For production HBase clusters, use `services.hadoop.hbase` instead.
 
+- The `p4` package now only includes the open-source Perforce Helix Core command-line client and APIs. It no longer installs the unfree Helix Core Server binaries `p4d`, `p4broker`, and `p4p`. To install the Helix Core Server binaries, use the `p4d` package instead.
+
 - The `coq` package and versioned variants starting at `coq_8_14` no
   longer include CoqIDE, which is now available through
   `coqPackages.coqide`. It is still possible to get CoqIDE as part of

--- a/pkgs/applications/version-management/p4/default.nix
+++ b/pkgs/applications/version-management/p4/default.nix
@@ -1,31 +1,115 @@
-{ stdenv, fetchurl, lib, autoPatchelfHook }:
+{ stdenv
+, fetchurl
+, fetchzip
+, lib
+, emptyDirectory
+, linkFarm
+, symlinkJoin
+, jam
+, libcxx
+, libcxxabi
+, openssl
+, xcbuild
+, CoreServices
+, Foundation
+, Security
+}:
 
+let
+  opensslStatic = openssl.override {
+    static = true;
+  };
+  androidZlibContrib =
+    let
+      src = fetchzip {
+        url = "https://android.googlesource.com/platform/external/zlib/+archive/61174f4fd262c6075f88768465f308aae95a2f04.tar.gz";
+        sha256 = "sha256-EMzKAHcEWOUugcHKH2Fj3ZaIHC9UlgO4ULKe3RvgxvI=";
+        stripRoot = false;
+      };
+    in
+    linkFarm "android-zlib-contrib" [
+      # We only want to keep the contrib directory as the other files conflict
+      # with p4's own zlib files. (For the same reason, we can't use the
+      # cone-based Git sparse checkout, either.)
+      { name = "contrib"; path = "${src}/contrib"; }
+    ];
+  libcxxUnified = symlinkJoin {
+    inherit (libcxx) name;
+    paths = [ libcxx libcxxabi ];
+  };
+in
 stdenv.mkDerivation rec {
   pname = "p4";
-  version = "2021.2.2201121";
+  version = "2022.1.2305383";
 
   src = fetchurl {
-    # actually  https://cdist2.perforce.com/perforce/r21.2/bin.linux26x86_64/helix-core-server.tgz but upstream deletes releases
-    url = "https://web.archive.org/web/20211118024943/https://cdist2.perforce.com/perforce/r21.2/bin.linux26x86_64/helix-core-server.tgz";
-    sha256 = "sha256-SrfI2ZD7KDyttCd8+fo8g4UZKljYYO/SbzqrS9tAcC8=";
+    # Upstream replaces minor versions, so use archived URL.
+    url = "https://web.archive.org/web/20220901184735id_/https://ftp.perforce.com/perforce/r22.1/bin.tools/p4source.tgz";
+    sha256 = "27ab3ddd7b178b05cf0b710e941650dac0688d294110ebafda9027732c0944c6";
   };
 
-  sourceRoot = ".";
+  nativeBuildInputs = [ jam ];
 
-  dontBuild = true;
+  buildInputs = lib.optionals stdenv.isDarwin [ CoreServices Foundation Security ];
 
-  nativeBuildInputs = [ autoPatchelfHook ];
+  outputs = [ "out" "bin" "dev" ];
 
-  installPhase = ''
-    install -D --target $out/bin p4 p4broker p4d p4p
+  hardeningDisable = lib.optionals stdenv.isDarwin [ "strictoverflow" ];
+
+  jamFlags =
+    [
+      "-sEXEC=bin.unix"
+      "-sCROSS_COMPILE=${stdenv.cc.targetPrefix}"
+      "-sMALLOC_OVERRIDE=no"
+      "-sSSLINCDIR=${lib.getDev opensslStatic}/include"
+      "-sSSLLIBDIR=${lib.getLib opensslStatic}/lib"
+    ]
+    ++ lib.optionals stdenv.cc.isClang [ "-sOSCOMP=clang" "-sCLANGVER=${stdenv.cc.cc.version}" ]
+    ++ lib.optionals stdenv.cc.isGNU [ "-sOSCOMP=gcc" "-sGCCVER=${stdenv.cc.cc.version}" ]
+    ++ lib.optionals stdenv.isLinux [ "-sOSVER=26" ]
+    ++ lib.optionals stdenv.isDarwin [
+      "-sOSVER=1013"
+      "-sMACOSX_SDK=${emptyDirectory}"
+      "-sLIBC++DIR=${libcxxUnified}/lib"
+    ];
+
+  CCFLAGS =
+    # The file contrib/optimizations/slide_hash_neon.h is missing from the
+    # upstream distribution. It comes from the Android/Chromium sources.
+    lib.optionals stdenv.isAarch64 [ "-I${androidZlibContrib}" ];
+
+  "C++FLAGS" =
+    # Avoid a compilation error that only occurs for 4-byte longs.
+    lib.optionals stdenv.isi686 [ "-Wno-narrowing" ]
+    # See the "Header dependency changes" section of
+    # https://www.gnu.org/software/gcc/gcc-11/porting_to.html for more
+    # information on why we need to include these.
+    ++ lib.optionals
+      (stdenv.cc.isClang || (stdenv.cc.isGNU && lib.versionAtLeast stdenv.cc.cc.version "11.0.0"))
+      [ "-include" "limits" "-include" "thread" ];
+
+  buildPhase = ''
+    runHook preBuild
+    jam $jamFlags -j$NIX_BUILD_CORES p4
+    jam $jamFlags -j$NIX_BUILD_CORES -sPRODUCTION=yes p4api.tar
+    runHook postBuild
   '';
 
-  meta = {
-    description = "Perforce Command-Line Client";
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $bin/bin $dev $out
+    cp bin.unix/p4 $bin/bin
+    cp -r bin.unix/p4api-${version}/include $dev
+    cp -r bin.unix/p4api-${version}/lib $out
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Perforce Helix Core command-line client and APIs";
     homepage = "https://www.perforce.com";
-    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    license = lib.licenses.unfree;
-    platforms = [ "x86_64-linux" ];
-    maintainers = with lib.maintainers; [ corngood ];
+    license = licenses.bsd2;
+    mainProgram = "p4";
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ corngood impl ];
   };
 }

--- a/pkgs/applications/version-management/p4d/default.nix
+++ b/pkgs/applications/version-management/p4d/default.nix
@@ -47,6 +47,6 @@ stdenv.mkDerivation {
     license = licenses.unfree;
     mainProgram = "p4d";
     platforms = builtins.attrNames srcs;
-    maintainers = with maintainers; [ impl ];
+    maintainers = with maintainers; [ corngood impl ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30205,7 +30205,10 @@ with pkgs;
 
   ostinato = libsForQt5.callPackage ../applications/networking/ostinato { };
 
-  p4 = callPackage ../applications/version-management/p4 { };
+  p4 = callPackage ../applications/version-management/p4 {
+    inherit (darwin.apple_sdk.frameworks) CoreServices Foundation Security;
+    openssl = openssl_1_1;
+  };
   p4d = callPackage ../applications/version-management/p4d { };
   p4v = libsForQt515.callPackage ../applications/version-management/p4v { };
 


### PR DESCRIPTION
###### Description of changes

The actual p4 command is open-source software released under the 2-clause BSD license, so we can build it here (for pretty much every architecture we support!) and include it in the cache.

This change removes the server-side commands from this package, but they are now available as part of a separate p4d package (#190100) instead. (The server package remains unfree, and to make users' lives easier its PR should probably be merged before this one.)

As an added bonus, we can also include the libraries and headers for the C/C++ API, which will allow us to package any software that uses Perforce as a library in the future.

Please note that I am employed by Perforce but I am not currently supporting these packages in an official capacity.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
