### PR TITLE
immudb: init at 1.3.2

### DIFF
--- a/pkgs/servers/nosql/immudb/default.nix
+++ b/pkgs/servers/nosql/immudb/default.nix
@@ -1,0 +1,65 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, fetchzip
+, installShellFiles
+}:
+
+let
+  webconsoleVersion = "1.0.17";
+  webconsoleDist = fetchzip {
+    url = "https://github.com/codenotary/immudb-webconsole/releases/download/v${webconsoleVersion}/immudb-webconsole.tar.gz";
+    sha256 = "sha256-hFSvPwSRXyrSBYktTOwIRa1+aH+mX/scDYDokvZuW1s=";
+  };
+
+in
+buildGoModule rec {
+  pname = "immudb";
+  version = "1.3.2";
+
+  src = fetchFromGitHub {
+    owner = "codenotary";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-lcKjeqZeTQQMhVjnWNP3c+HanI/eenfUbpZJAo5FEkM=";
+  };
+
+  preBuild = ''
+    mkdir -p webconsole/dist
+    cp -r ${webconsoleDist}/* ./webconsole/dist
+    go generate -tags webconsole ./webconsole
+  '';
+
+  proxyVendor = true; # check if this is needed anymore when updating
+
+  vendorSha256 = "sha256-gMpkV0XqY6wh7s0lndIdCoYlvVBrMk7/lvyDVqnJ66c=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  tags = [ "webconsole" ];
+
+  ldflags = [ "-X github.com/codenotary/immudb/cmd/version.Version=${version}" ];
+
+  subPackages = [
+    "cmd/immudb"
+    "cmd/immuclient"
+    "cmd/immuadmin"
+  ];
+
+  postInstall = ''
+      mkdir -p share/completions
+      for executable in immudb immuclient immuadmin; do
+          for shell in bash fish zsh; do
+            $out/bin/$executable completion $shell > share/completions/$executable.$shell
+            installShellCompletion share/completions/$executable.$shell
+          done
+        done
+    '';
+
+  meta = with lib; {
+    description = "Immutable database based on zero trust, SQL and Key-Value, tamperproof, data change history";
+    homepage = "https://github.com/codenotary/immudb";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ dit7ya ];
+  };
+}

--- a/pkgs/servers/nosql/immudb/default.nix
+++ b/pkgs/servers/nosql/immudb/default.nix
@@ -11,7 +11,6 @@ let
     url = "https://github.com/codenotary/immudb-webconsole/releases/download/v${webconsoleVersion}/immudb-webconsole.tar.gz";
     sha256 = "sha256-hFSvPwSRXyrSBYktTOwIRa1+aH+mX/scDYDokvZuW1s=";
   };
-
 in
 buildGoModule rec {
   pname = "immudb";
@@ -47,14 +46,14 @@ buildGoModule rec {
   ];
 
   postInstall = ''
-      mkdir -p share/completions
-      for executable in immudb immuclient immuadmin; do
-          for shell in bash fish zsh; do
-            $out/bin/$executable completion $shell > share/completions/$executable.$shell
-            installShellCompletion share/completions/$executable.$shell
-          done
-        done
-    '';
+    mkdir -p share/completions
+    for executable in immudb immuclient immuadmin; do
+      for shell in bash fish zsh; do
+        $out/bin/$executable completion $shell > share/completions/$executable.$shell
+        installShellCompletion share/completions/$executable.$shell
+      done
+    done
+  '';
 
   meta = with lib; {
     description = "Immutable database based on zero trust, SQL and Key-Value, tamperproof, data change history";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23241,6 +23241,8 @@ with pkgs;
   percona-server56 = callPackage ../servers/sql/percona/5.6.x.nix { stdenv = gcc10StdenvCompat; };
   percona-server = percona-server56;
 
+  immudb = callPackage ../servers/nosql/immudb { };
+
   influxdb = callPackage ../servers/nosql/influxdb {
     # pinned due to build failure or vendoring problems. When unpinning double check with: nix-build -A $name.go-modules --rebuild
     buildGoModule = buildGo117Module;


### PR DESCRIPTION
###### Description of changes

immudb is a database with built-in cryptographic proof and verification. It tracks changes in sensitive data and the integrity of the history will be protected by the clients, without the need to trust the database. It can operate both as a key-value store, and/or as relational database (SQL).

https://github.com/codenotary/immudb

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
