### PR TITLE
python3Packages.django-stubs: init at 1.12.0

### DIFF
--- a/pkgs/development/python-modules/django-stubs-ext/default.nix
+++ b/pkgs/development/python-modules/django-stubs-ext/default.nix
@@ -1,0 +1,23 @@
+{ buildPythonPackage, django, fetchPypi, lib, typing-extensions }:
+
+buildPythonPackage rec {
+  pname = "django-stubs-ext";
+  version = "0.5.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-m9dBg3arALf4jW1Wvp/s6Fv6DHw0isYhFV+k16kRRvI=";
+  };
+
+  # setup.cfg tries to pull in nonexistent LICENSE.txt file
+  postPatch = "rm setup.cfg";
+
+  propagatedBuildInputs = [ django typing-extensions ];
+
+  meta = with lib; {
+    description = "Extensions and monkey-patching for django-stubs";
+    homepage = "https://github.com/typeddjango/django-stubs";
+    license = licenses.mit;
+    maintainers = with maintainers; [ elohmeier ];
+  };
+}

--- a/pkgs/development/python-modules/django-stubs/default.nix
+++ b/pkgs/development/python-modules/django-stubs/default.nix
@@ -1,0 +1,38 @@
+{ buildPythonPackage
+, django
+, django-stubs-ext
+, fetchPypi
+, lib
+, mypy
+, tomli
+, types-pytz
+, types-pyyaml
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "django-stubs";
+  version = "1.12.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-6os10NpJ97LumaeRJfGUPgM0Md0RRybWZDzDXeYZIw4=";
+  };
+
+  propagatedBuildInputs = [
+    django
+    django-stubs-ext
+    mypy
+    tomli
+    types-pytz
+    types-pyyaml
+    typing-extensions
+  ];
+
+  meta = with lib; {
+    description = "PEP-484 stubs for Django";
+    homepage = "https://github.com/typeddjango/django-stubs";
+    license = licenses.mit;
+    maintainers = with maintainers; [ elohmeier ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2616,6 +2616,8 @@ in {
 
   django-storages = callPackage ../development/python-modules/django-storages { };
 
+  django-stubs = callPackage ../development/python-modules/django-stubs { };
+
   django-stubs-ext = callPackage ../development/python-modules/django-stubs-ext { };
 
   django-tables2 = callPackage ../development/python-modules/django-tables2 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2616,6 +2616,8 @@ in {
 
   django-storages = callPackage ../development/python-modules/django-storages { };
 
+  django-stubs-ext = callPackage ../development/python-modules/django-stubs-ext { };
+
   django-tables2 = callPackage ../development/python-modules/django-tables2 { };
 
   django_tagging = callPackage ../development/python-modules/django_tagging { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This package provides typing hints for the Python Django web framework. They are useful for static analysis tools & code editor LSP integrations.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
