### PR TITLE
zbctl: init at 8.0.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13166,6 +13166,12 @@
     }];
     name = "Karim Vergnes";
   };
+  thetallestjj = {
+    email = "me+nixpkgs@jeroen-jetten.com";
+    github = "thetallestjj";
+    githubId = 6579555;
+    name = "Jeroen Jetten";
+  };
   theuni = {
     email = "ct@flyingcircus.io";
     github = "ctheune";

--- a/pkgs/tools/admin/zbctl/default.nix
+++ b/pkgs/tools/admin/zbctl/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, stdenvNoCC
+, fetchurl
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "zbctl";
+  version = "8.0.6";
+
+  src = if stdenvNoCC.hostPlatform.system == "x86_64-darwin" then fetchurl {
+    url = "https://github.com/camunda/zeebe/releases/download/${version}/zbctl.darwin";
+    sha256 = "17hfjrcr6lmw91jq24nbw5yz61x6larmx39lyfj6pwlz0710y13p";
+  } else if stdenvNoCC.hostPlatform.system == "x86_64-linux" then fetchurl {
+    url = "https://github.com/camunda/zeebe/releases/download/${version}/zbctl";
+    sha256 = "1xng11x7wcjvc0vipdrqyn97aa4jlgcp7g9aw4d36fw0xp9p47kp";
+  } else throw "Unsupported platform ${stdenvNoCC.hostPlatform.system}";
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp $src $out/bin/zbctl
+    chmod +x $out/bin/zbctl
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "The command line interface to interact with Camunda 8 and Zeebe";
+    homepage = "https://docs.camunda.io/docs/apis-clients/cli-client/";
+    downloadPage = "https://github.com/camunda/zeebe/releases";
+    changelog = "https://github.com/camunda/zeebe/releases/tag/${version}";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = licenses.asl20;
+    platforms = [ "x86_64-darwin" "x86_64-linux" ];
+    maintainers = with maintainers; [ thetallestjj ];
+    longDescription = ''
+      A command line interface for Camunda Platform 8 designed to create and read resources inside a Zeebe broker.
+      It can be used for regular development and maintenance tasks such as:
+      * Deploying processes
+      * Creating process instances and job workers
+      * Activating, completing, or failing jobs
+      * Updating variables and retries
+      * Viewing cluster status
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12599,6 +12599,8 @@ with pkgs;
     autoreconfHook = buildPackages.autoreconfHook269;
   };
 
+  zbctl = callPackage ../tools/admin/zbctl { };
+
   zdelta = callPackage ../tools/compression/zdelta { };
 
   zed = callPackage ../development/tools/zed { };


### PR DESCRIPTION
###### Description of changes

Zbctl is an admin tool used with the Camunda 8 platform.

Homepage: https://docs.camunda.io/docs/apis-clients/cli-client/

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
