### PR TITLE
juicefs: init at 1.0.0

### DIFF
--- a/pkgs/tools/filesystems/juicefs/default.nix
+++ b/pkgs/tools/filesystems/juicefs/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, stdenv
+}:
+
+buildGoModule rec {
+  pname = "juicefs";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "juicedata";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-urhm2dnWIbzt1mSFDsmqJe61E6D6FWRUG6CJPy/ExOI=";
+  };
+
+  vendorSha256 = "sha256-LvF/6YA/OVO2cyBM1c3YYhEjT26SVXcsepn+vglRKmE=";
+
+  ldflags = [ "-s" "-w" ];
+
+  doCheck = false; # requires network access
+
+  # we dont need the libjfs binary
+  postFixup = ''
+    rm $out/bin/libjfs
+  '';
+
+  meta = with lib; {
+    description = "A distributed POSIX file system built on top of Redis and S3";
+    homepage = "https://www.juicefs.com/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ dit7ya ];
+    broken = stdenv.isDarwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7811,6 +7811,8 @@ with pkgs;
 
   jmespath = callPackage ../development/tools/jmespath { };
 
+  juicefs = callPackage ../tools/filesystems/juicefs { };
+
   jmtpfs = callPackage ../tools/filesystems/jmtpfs { };
 
   jnettop = callPackage ../tools/networking/jnettop { };


### PR DESCRIPTION
###### Description of changes


Cloud file system for Developers
A POSIX, HDFS and S3 compatible distributed file system for cloud.

https://www.juicefs.com/en/
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
