### PR TITLE
handle whitespace in arrays

### DIFF
--- a/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
@@ -78,8 +78,13 @@ extraAfter=()
 extraBefore=(${hardeningLDFlags[@]+"${hardeningLDFlags[@]}"})
 
 if [ -z "${NIX_LINK_TYPE_@suffixSalt@:-}" ]; then
-    extraAfter+=($(filterRpathFlags "$linkType" $NIX_LDFLAGS_@suffixSalt@))
-    extraBefore+=($(filterRpathFlags "$linkType" $NIX_LDFLAGS_BEFORE_@suffixSalt@))
+    readArrayString _flags "$NIX_LDFLAGS_@suffixSalt@"
+    filterRpathFlagsArray _flags "$linkType"
+    extraAfter+=("${_flags[@]}")
+
+    readArrayString _flags "$NIX_LDFLAGS_BEFORE_@suffixSalt@"
+    filterRpathFlagsArray _flags "$linkType"
+    extraBefore+=("${_flags[@]}")
 
     # By adding dynamic linker to extraBefore we allow the users set their
     # own dynamic linker as NIX_LD_FLAGS will override earlier set flags

--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -139,17 +139,23 @@ if [ "$dontLink" != 1 ]; then
 
     # Add the flags that should only be passed to the compiler when
     # linking.
-    extraAfter+=($(filterRpathFlags "$linkType" $NIX_CFLAGS_LINK_@suffixSalt@))
+    readArrayString _flags "$NIX_CFLAGS_LINK_@suffixSalt@"
+    filterRpathFlagsArray _flags "$linkType"
+    extraAfter+=("${_flags[@]}")
 
     # Add the flags that should be passed to the linker (and prevent
     # `ld-wrapper' from adding NIX_LDFLAGS_@suffixSalt@ again).
-    for i in $(filterRpathFlags "$linkType" $NIX_LDFLAGS_BEFORE_@suffixSalt@); do
+    readArrayString _flags "$NIX_LDFLAGS_BEFORE_@suffixSalt@"
+    filterRpathFlagsArray _flags "$linkType"
+    for i in "${_flags[@]}"; do
         extraBefore+=("-Wl,$i")
     done
     if [[ "$linkType" == dynamic && -n "$NIX_DYNAMIC_LINKER_@suffixSalt@" ]]; then
         extraBefore+=("-Wl,-dynamic-linker=$NIX_DYNAMIC_LINKER_@suffixSalt@")
     fi
-    for i in $(filterRpathFlags "$linkType" $NIX_LDFLAGS_@suffixSalt@); do
+    readArrayString _flags "$NIX_LDFLAGS_@suffixSalt@"
+    filterRpathFlagsArray _flags "$linkType"
+    for i in "${_flags[@]}"; do
         if [ "${i:0:3}" = -L/ ]; then
             extraAfter+=("$i")
         else

--- a/pkgs/build-support/wrapper-common/utils.bash
+++ b/pkgs/build-support/wrapper-common/utils.bash
@@ -175,3 +175,10 @@ escapeString() {
 quoteString() {
     echo "${1@Q}"
 }
+
+# read array of strings from a string.
+# decode escapes and quotes, preserve whitespace in strings.
+# compatible with escapeString and quoteString.
+readArrayString() {
+    readarray -d '' "$1" < <(<<<"$2" xargs -r printf '%s\0')
+}

--- a/pkgs/build-support/wrapper-common/utils.bash
+++ b/pkgs/build-support/wrapper-common/utils.bash
@@ -144,7 +144,8 @@ checkLinkType() {
 }
 
 # When building static-pie executables we cannot have rpath
-# set. At least glibc requires rpath to be empty
+# set. At least glibc requires rpath to be empty.
+# Deprecated in favor of filterRpathFlagsArray.
 filterRpathFlags() {
     local linkType=$1 ret i
     shift
@@ -163,6 +164,23 @@ filterRpathFlags() {
         ret=("$@")
     fi
     echo "${ret[@]}"
+}
+
+# Array version of filterRpathFlags.
+# Preserve whitespace in strings.
+filterRpathFlagsArray() {
+    local linkType="$2"
+    [[ "$linkType" != "static-pie" ]] && return
+    local arrayName="$1" array i
+    typeset -n array=$arrayName
+    local L=${#array[@]}
+    for (( i=0; i<L; i++ )); do
+        [ "${array[$i]}" != '-rpath' ] && continue
+        unset -v 'array[$i]'
+        : $((i++))
+        unset -v 'array[$i]'
+    done
+    array=("${array[@]}") # fix indices in numeric array
 }
 
 # backslash-escape a string.

--- a/pkgs/build-support/wrapper-common/utils.bash
+++ b/pkgs/build-support/wrapper-common/utils.bash
@@ -169,3 +169,9 @@ filterRpathFlags() {
 escapeString() {
     printf '%q' "$1"
 }
+
+# quote a string.
+# always add quotes, also when not needed.
+quoteString() {
+    echo "${1@Q}"
+}

--- a/pkgs/build-support/wrapper-common/utils.bash
+++ b/pkgs/build-support/wrapper-common/utils.bash
@@ -164,3 +164,8 @@ filterRpathFlags() {
     fi
     echo "${ret[@]}"
 }
+
+# backslash-escape a string.
+escapeString() {
+    printf '%q' "$1"
+}

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -997,9 +997,10 @@ patchPhase() {
 
 
 fixLibtool() {
-    local search_path
-    for flag in $NIX_LDFLAGS; do
-        case $flag in
+    local search_path flags flag
+    readarray -d '' flags < <(<<<"$NIX_LDFLAGS" xargs -r printf '%s\0')
+    for flag in "${flags[@]}"; do
+        case "$flag" in
             -L*)
                 search_path+=" ${flag#-L}"
                 ;;

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -179,12 +179,12 @@ addToSearchPath() {
 # so it is defined here but tried after the hook.
 _addRpathPrefix() {
     if [ "${NIX_NO_SELF_RPATH:-0}" != 1 ]; then
-        export NIX_LDFLAGS="-rpath $1/lib ${NIX_LDFLAGS-}"
+        export NIX_LDFLAGS="-rpath $(printf '%q' "$1/lib") ${NIX_LDFLAGS-}"
         if [ -n "${NIX_LIB64_IN_SELF_RPATH:-}" ]; then
-            export NIX_LDFLAGS="-rpath $1/lib64 ${NIX_LDFLAGS-}"
+            export NIX_LDFLAGS="-rpath $(printf '%q' "$1/lib64") ${NIX_LDFLAGS-}"
         fi
         if [ -n "${NIX_LIB32_IN_SELF_RPATH:-}" ]; then
-            export NIX_LDFLAGS="-rpath $1/lib32 ${NIX_LDFLAGS-}"
+            export NIX_LDFLAGS="-rpath $(printf '%q' "$1/lib32") ${NIX_LDFLAGS-}"
         fi
     fi
 }

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1002,11 +1002,14 @@ fixLibtool() {
     for flag in "${flags[@]}"; do
         case "$flag" in
             -L*)
-                search_path+=" ${flag#-L}"
+                search_path+=" $(printf '%q' "${flag#-L}")"
                 ;;
         esac
     done
 
+    # TODO(@milahu): verify parsing of escaped strings:
+    # sys_lib_search_path='/a\ a/ /b\ b/'
+    # TODO(@milahu): escape backslashes for sed?
     sed -i "$1" \
         -e "s^eval \(sys_lib_search_path=\).*^\1'$search_path'^" \
         -e 's^eval sys_lib_.+search_path=.*^^'


### PR DESCRIPTION
#### Description of changes

fix #177952

this will rebuild everything &rarr; target is `staging` branch

before, nixpkgs supported only "simple" arrays without whitespace
examples:

```sh
# build.sh
NIX_LDFLAGS="-rpath /tmp/a -rpath /tmp/b"
```

```nix
# default.nix
{
  configureFlags = [ "--enable-a" "--enable-b" ];
}
```

... but this breaks some edge-cases
example: run `nix develop` in `/tmp/yes space` = #177952
example: pass `--name "hello world"` to `configure`

#### TODO

- [ ] re-consider urlencode #190044
- [x] fix filterRpathFlags
- [ ] fix parsing of flags
- [ ] fix configureFlags
- [ ] fix other array variables
- [ ] add tests

<details>
<summary>
TODO fix parsing of flags
</summary>

```
nixpkgs $ grep -r -e NIX_LDFLAGS -e NIX_CFLAGS pkgs/ 2>/dev/null | grep -w for
pkgs/tools/system/plan9port/default.nix:    LDFLAGS='$(for f in $NIX_LDFLAGS; do echo "-Wl,$f"; done | xargs echo)'
pkgs/build-support/build-bazel-package/default.nix:      for flag in $NIX_CFLAGS_COMPILE; do
pkgs/build-support/build-bazel-package/default.nix:      for flag in $NIX_LDFLAGS; do
pkgs/development/libraries/openal-soft/default.nix:    # removes the need for NIX_LDFLAGS.
pkgs/development/tools/build-managers/cmake/setup-hook.sh:  for flag in ${NIX_CFLAGS_COMPILE-} ${NIX_LDFLAGS-}; do
pkgs/development/compilers/nim/nixbuild.patch:+    for flag in split(getEnv("NIX_LDFLAGS")):
pkgs/applications/emulators/wine/setup-hook-darwin.sh:        echo removing @darwinSuffixSalt@-specific flags from NIX_CFLAGS_COMPILE for $mingwSalt
pkgs/applications/emulators/wine/setup-hook-darwin.sh:        echo removing @darwinSuffixSalt@-specific flags from NIX_LDFLAGS for $mingwSalt
pkgs/applications/graphics/inkscape/default.nix:  # CMake’s ARGMAX check doesn’t offer enough padding for NIX_LDFLAGS.
```

</details>

#### Scope

* fix wrappers for `nix-shell` and `nix develop`: `cc-wrapper` and `ld-wrapper`
* maybe fix configureFlags

#### Out of scope

nix store path with spaces: much pain, little gain

`pkgs/tools/system/plan9port/default.nix`

```sh
    LDFLAGS='$(for f in $NIX_LDFLAGS; do echo "-Wl,$f"; done | xargs echo)'
```

`LDFLAGS` supports simple strings only (no?)

`pkgs/development/tools/build-managers/cmake/setup-hook.sh`

```sh
  for flag in ${NIX_CFLAGS_COMPILE-} ${NIX_LDFLAGS-}; do
    # ...
      case $flag in
        -I*)
          export CMAKE_INCLUDE_PATH="${CMAKE_INCLUDE_PATH-}${CMAKE_INCLUDE_PATH:+:}${flag:2}"
          ;;
```

/home/user/src/nixpkgs/pkgs/development/compilers/nim/nixbuild.patch

```nim
    for flag in split(getEnv("NIX_LDFLAGS")):
      if flag.startsWith("-L"):
        libDirs.add(flag[2..flag.high])
```

this code is parsing compiler flags, to find include / library / framework paths.
supports simple strings only.
`NIX_LDFLAGS="-rpath a\ b"` is ignored.
`NIX_LDFLAGS="-rpath a\ -L/some/where"` could break things.
in this case, `urlencode` (#190044) is better than `escape` or `quote`

#### Review this PR

```
cd nixpkgs

git remote add milahu https://github.com/milahu/nixpkgs
git fetch milahu:handle-whitespace-in-arrays
git checkout milahu/handle-whitespace-in-arrays

# this will rebuild the gcc toolchain
time nix-shell -E 'with import ./. {}; pkgs.mkShell {}' --run date >nix-shell.log 2>&1
```

#### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
