### PR TITLE
arkenfox-userjs: init at 105.0

### DIFF
--- a/pkgs/data/misc/arkenfox-userjs/default.nix
+++ b/pkgs/data/misc/arkenfox-userjs/default.nix
@@ -1,0 +1,29 @@
+{ lib, fetchurl, stdenvNoCC }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "arkenfox-userjs";
+  version = "105.0";
+
+  src = fetchurl {
+    url = "https://github.com/arkenfox/user.js/raw/${version}/user.js";
+    hash = "sha256-4v5VcCj5h+pLZ7wt38AoWUQgg62qPGohWwmY6yNZZ/0=";
+  };
+
+  dontUnpack = true;
+
+  installPhase = ''
+    mkdir -p $out
+    ln -s ${src} $out/user.js
+    cp ${src} $out/user.cfg
+    substituteInPlace $out/user.cfg \
+      --replace "user_pref" "defaultPref"
+  '';
+
+  meta = with lib; {
+    description = "A comprehensive user.js template for configuration and hardening";
+    homepage = "https://github.com/arkenfox/user.js";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ linsui ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25650,6 +25650,8 @@ with pkgs;
 
   arc-theme = callPackage ../data/themes/arc { };
 
+  arkenfox-userjs = callPackage ../data/misc/arkenfox-userjs { };
+
   arkpandora_ttf = callPackage ../data/fonts/arkpandora { };
 
   aurulent-sans = callPackage ../data/fonts/aurulent-sans { };


### PR DESCRIPTION
###### Description of changes
This is expected to be used in the extraPrefs in firefox so I generate a cfg file. I guess it can also be used in home-manager as user.js.

What's recommanded method to make it updated by the bot?

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
