### PR TITLE
echidna: 1.7.3 -> 2.0.2

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -2144,7 +2144,6 @@ broken-packages:
   - heterogeneous-list-literals
   - hetris
   - heukarya
-  - hevm
   - HExcel
   - hexchat
   - hexif

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -738,8 +738,10 @@ self: super: builtins.intersectAttrs super {
     '';
   }) super.haskell-language-server;
 
+  # NOTE: this patch updates the hevm code to work with the latest packages that broke the build
+  # it's temporary until hevm version 0.50.0 is released - https://github.com/ethereum/hevm/milestone/1
   # tests depend on a specific version of solc
-  hevm = dontCheck (doJailbreak super.hevm);
+  hevm = dontCheck (appendPatch ./patches/hevm-update-deps.patch super.hevm);
 
   # hadolint enables static linking by default in the cabal file, so we have to explicitly disable it.
   # https://github.com/hadolint/hadolint/commit/e1305042c62d52c2af4d77cdce5d62f6a0a3ce7b

--- a/pkgs/development/haskell-modules/patches/hevm-update-deps.patch
+++ b/pkgs/development/haskell-modules/patches/hevm-update-deps.patch
@@ -1,0 +1,129 @@
+diff --git a/hevm.cabal b/hevm.cabal
+index cf36961e..3b31f595 100644
+--- a/hevm.cabal
++++ b/hevm.cabal
+@@ -71,6 +71,10 @@ library
+     -Wall -Wno-deprecations
+   extra-libraries:
+     secp256k1, ff
++  if os(darwin)
++     extra-libraries: c++
++  else
++     extra-libraries: stdc++
+   c-sources:
+     ethjet/tinykeccak.c, ethjet/ethjet.c
+   cxx-sources:
+@@ -88,7 +92,7 @@ library
+     transformers                      >= 0.5.6 && < 0.6,
+     tree-view                         >= 0.5 && < 0.6,
+     abstract-par                      >= 0.3.3 && < 0.4,
+-    aeson                             >= 1.5.6 && < 1.6,
++    aeson                             >= 2.0 && < 2.1,
+     bytestring                        >= 0.10.8 && < 0.11,
+     scientific                        >= 0.3.6 && < 0.4,
+     binary                            >= 0.8.6 && < 0.9,
+@@ -97,7 +101,7 @@ library
+     vector                            >= 0.12.1 && < 0.13,
+     ansi-wl-pprint                    >= 0.6.9 && < 0.7,
+     base16-bytestring                 >= 1.0.0 && < 2.0,
+-    brick                             >= 0.58 && < 0.63,
++    brick                             >= 0.58 && < 0.69,
+     megaparsec                        >= 9.0.0 && < 10.0,
+     mtl                               >= 2.2.2 && < 2.3,
+     directory                         >= 1.3.3 && < 1.4,
+@@ -105,13 +109,13 @@ library
+     vty                               >= 5.25.1 && < 5.34,
+     cereal                            >= 0.5.8 && < 0.6,
+     cryptonite                        >= 0.27 && <= 0.29,
+-    memory                            >= 0.14.18 && < 0.16,
++    memory                            >= 0.14.18 && < 0.20,
+     data-dword                        >= 0.3.1 && < 0.4,
+     fgl                               >= 5.7.0 && < 5.8,
+     free                              >= 5.1.3 && < 5.2,
+     haskeline                         >= 0.8.0 && < 0.9,
+     process                           >= 1.6.5 && < 1.7,
+-    lens                              >= 4.17.1 && < 4.20,
++    lens                              >= 4.17.1 && < 5.1,
+     lens-aeson                        >= 1.0.2 && < 1.2,
+     monad-par                         >= 0.3.5 && < 0.4,
+     multiset                          >= 0.3.4 && < 0.4,
+@@ -124,7 +128,6 @@ library
+     sbv                               >= 8.9,
+     semver-range                      >= 0.2.7 && < 0.3,
+     temporary                         >= 1.3 && < 1.4,
+-    text-format                       >= 0.3.2 && < 0.4,
+     witherable                        >= 0.3.5 && < 0.5,
+     wreq                              >= 0.5.3 && < 0.6,
+     regex-tdfa                        >= 1.2.3 && < 1.4,
+@@ -190,7 +193,6 @@ executable hevm
+     sbv,
+     temporary,
+     text,
+-    text-format,
+     unordered-containers,
+     vector,
+     vty
+diff --git a/src/EVM/Solidity.hs b/src/EVM/Solidity.hs
+index b7d0f36b..4e9d6892 100644
+--- a/src/EVM/Solidity.hs
++++ b/src/EVM/Solidity.hs
+@@ -70,6 +70,7 @@ import Control.Monad
+ import Control.Lens         hiding (Indexed, (.=))
+ import qualified Data.String.Here as Here
+ import Data.Aeson hiding (json)
++import qualified Data.Aeson.KeyMap as KeyMap
+ import Data.Aeson.Types
+ import Data.Aeson.Lens
+ import Data.Scientific
+@@ -714,8 +715,8 @@ astIdMap = foldMap f
+     f :: Value -> Map Int Value
+     f (Array x) = foldMap f x
+     f v@(Object x) =
+-      let t = foldMap f (HMap.elems x)
+-      in case HMap.lookup "id" x of
++      let t = foldMap f (KeyMap.elems x)
++      in case KeyMap.lookup "id" x of
+         Nothing         -> t
+         Just (Number i) -> t <> Map.singleton (round i) v
+         Just _          -> t
+diff --git a/src/EVM/SymExec.hs b/src/EVM/SymExec.hs
+index 5bbf1c03..b828098e 100644
+--- a/src/EVM/SymExec.hs
++++ b/src/EVM/SymExec.hs
+@@ -40,8 +40,8 @@ type EquivalenceResult = ProofResult ([VM], [VM]) VM ()
+
+ -- | Convenience functions for generating large symbolic byte strings
+ sbytes32, sbytes128, sbytes256, sbytes512, sbytes1024 :: Query ([SWord 8])
+-sbytes32 = toBytes <$> freshVar_ @ (WordN 256)
+-sbytes128 = toBytes <$> freshVar_ @ (WordN 1024)
++sbytes32 = toBytes <$> freshVar_ @(WordN 256)
++sbytes128 = toBytes <$> freshVar_ @(WordN 1024)
+ sbytes256 = liftA2 (++) sbytes128 sbytes128
+ sbytes512 = liftA2 (++) sbytes256 sbytes256
+ sbytes1024 = liftA2 (++) sbytes512 sbytes512
+diff --git a/src/EVM/Types.hs b/src/EVM/Types.hs
+index fdd2368d..1dc29e83 100644
+--- a/src/EVM/Types.hs
++++ b/src/EVM/Types.hs
+@@ -434,17 +434,17 @@ readN s = fromIntegral (read s :: Integer)
+ readNull :: Read a => a -> String -> a
+ readNull x = fromMaybe x . Text.Read.readMaybe
+
+-wordField :: JSON.Object -> Text -> JSON.Parser W256
++wordField :: JSON.Object -> Key -> JSON.Parser W256
+ wordField x f = ((readNull 0) . Text.unpack)
+                   <$> (x .: f)
+
+-addrField :: JSON.Object -> Text -> JSON.Parser Addr
++addrField :: JSON.Object -> Key -> JSON.Parser Addr
+ addrField x f = (read . Text.unpack) <$> (x .: f)
+
+-addrFieldMaybe :: JSON.Object -> Text -> JSON.Parser (Maybe Addr)
++addrFieldMaybe :: JSON.Object -> Key -> JSON.Parser (Maybe Addr)
+ addrFieldMaybe x f = (Text.Read.readMaybe . Text.unpack) <$> (x .: f)
+
+-dataField :: JSON.Object -> Text -> JSON.Parser ByteString
++dataField :: JSON.Object -> Key -> JSON.Parser ByteString
+ dataField x f = hexText <$> (x .: f)
+
+ toWord512 :: W256 -> Word512

--- a/pkgs/tools/security/echidna/default.nix
+++ b/pkgs/tools/security/echidna/default.nix
@@ -1,5 +1,4 @@
 { lib
-, fetchpatch
 , fetchFromGitHub
 # Haskell deps
 , mkDerivation, aeson, ansi-terminal, base, base16-bytestring, binary, brick
@@ -8,18 +7,23 @@
 , MonadRandom, mtl, optparse-applicative, process, random, stm, tasty
 , tasty-hunit, tasty-quickcheck, temporary, text, transformers , unix, unliftio
 , unliftio-core, unordered-containers, vector, vector-instances, vty
-, wl-pprint-annotated, word8, yaml , extra, ListLike, semver
+, wl-pprint-annotated, word8, yaml, extra, ListLike, semver
 }:
 mkDerivation rec {
   pname = "echidna";
-  version = "1.7.3";
+  version = "2.0.2";
 
   src = fetchFromGitHub {
     owner = "crytic";
     repo = "echidna";
     rev = "v${version}";
-    sha256 = "sha256-NkAAXYa1bbCNUO0eDM7LQbyC3//RRFAKmEHGH2Dhl/M=";
+    sha256 = "sha256-WmlQWgn4qfRmx3PdzY7wzT9AyU7Re2T1CWJ7yGjcVac=";
   };
+
+  # NOTE: echidna is behind with aeson because of hevm, this patch updates
+  # the code to work with the major aeson update that broke the build
+  # it's temporary until hevm version 0.50.0 is released - https://github.com/ethereum/hevm/milestone/1
+  patches = [ ./echidna-update-aeson.patch ];
 
   isLibrary = true;
   isExecutable = true;
@@ -51,4 +55,5 @@ mkDerivation rec {
   license = lib.licenses.agpl3Plus;
   maintainers = with lib.maintainers; [ arturcygan ];
   platforms = lib.platforms.unix;
+  mainProgram = "echidna-test";
 }

--- a/pkgs/tools/security/echidna/echidna-update-aeson.patch
+++ b/pkgs/tools/security/echidna/echidna-update-aeson.patch
@@ -1,0 +1,38 @@
+diff --git a/lib/Echidna/Config.hs b/lib/Echidna/Config.hs
+index f8d5777..3d761fe 100644
+--- a/lib/Echidna/Config.hs
++++ b/lib/Echidna/Config.hs
+@@ -13,8 +13,8 @@ import Control.Monad.State (StateT(..), runStateT)
+ import Control.Monad.Trans (lift)
+ import Data.Bool (bool)
+ import Data.Aeson
++import Data.Aeson.KeyMap (keys)
+ import Data.Has (Has(..))
+-import Data.HashMap.Strict (keys)
+ import Data.HashSet (fromList, insert, difference)
+ import Data.Maybe (fromMaybe)
+ import Data.Text (isPrefixOf)
+@@ -23,11 +23,13 @@ import EVM.Types (w256)
+ 
+ import qualified Control.Monad.Fail as M (MonadFail(..))
+ import qualified Data.ByteString as BS
++import qualified Data.Aeson.Key as Key
++import qualified Data.HashSet as HS
+ import qualified Data.List.NonEmpty as NE
+ import qualified Data.Yaml as Y
+ 
+ import Echidna.Test
+-import Echidna.Types.Campaign 
++import Echidna.Types.Campaign
+ import Echidna.Mutator.Corpus (defaultMutationConsts)
+ import Echidna.Types.Config (EConfigWithUsage(..), EConfig(..))
+ import Echidna.Types.Solidity
+@@ -52,7 +54,7 @@ instance FromJSON EConfigWithUsage where
+                   _        -> mempty
+     (c, ks) <- runStateT (parser v') $ fromList []
+     let found = fromList (keys v')
+-    return $ EConfigWithUsage c (found `difference` ks) (ks `difference` found)
++    return $ EConfigWithUsage c (HS.map Key.toText $ found `difference` ks) (HS.map Key.toText $ ks `difference` found)
+     -- this parser runs in StateT and comes equipped with the following
+     -- equivalent unary operators:
+     -- x .:? k (Parser) <==> x ..:? k (StateT)


### PR DESCRIPTION
###### Description of changes
This fixes echidna that suffered from breakage of hevm. We are working on updating hevm to move forward with dependencies but it will take some time. Until then, both hevm and echidna need little patches to update aeson that changed API with the major update.

I tried to revert aeson to the previous version but that started a rabbit hole of incompatibilities.

Fixes #182500.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
