### PR TITLE
qmk: 1.1.0 -> 1.1.1

### DIFF
--- a/pkgs/tools/misc/qmk/default.nix
+++ b/pkgs/tools/misc/qmk/default.nix
@@ -5,16 +5,17 @@
 , dfu-programmer
 , dfu-util
 , gcc-arm-embedded
+, gnumake
 , teensy-loader-cli
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "qmk";
-  version = "1.1.0";
+  version = "1.1.1";
 
   src = python3.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "sha256-dxV3yeaOt/4IlpurNq60IHE6UlBi3OUqBu2kDajNpeE=";
+    sha256 = "sha256-3QKOCevNYfi9+MuCkp36/A4AfZelo4A7RYGbRkF3Mmk=";
   };
 
   nativeBuildInputs = with python3.pkgs; [
@@ -27,12 +28,13 @@ python3.pkgs.buildPythonApplication rec {
     appdirs
     argcomplete
     colorama
-    qmk-dotty-dict
+    dotty-dict
     hid
     hjson
     jsonschema
     milc
     pygments
+    pyserial
     pyusb
     pillow
   ] ++ [ # Binaries need to be in the path so this is in propagatedBuildInputs
@@ -41,6 +43,7 @@ python3.pkgs.buildPythonApplication rec {
     dfu-util
     teensy-loader-cli
     gcc-arm-embedded
+    gnumake
     pkgsCross.avr.buildPackages.binutils
     pkgsCross.avr.buildPackages.binutils.bintools
     pkgsCross.avr.buildPackages.gcc8


### PR DESCRIPTION
###### Description of changes

While flashing my Corne keyboard QMK prompted me to install `pyserial`
and `make` packages. I have added them to propagatedBuildInputs.

Edit: Updated version to 1.1.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
