### PR TITLE
tageditor: 3.3.10 -> 3.7.5

### DIFF
--- a/pkgs/applications/audio/tageditor/default.nix
+++ b/pkgs/applications/audio/tageditor/default.nix
@@ -1,9 +1,8 @@
 { stdenv
-, pkgs
+, lib
 , fetchFromGitHub
 , pkg-config
 , cmake
-
 , cpp-utilities
 , qtutilities
 , mp4v2
@@ -18,13 +17,13 @@
 
 stdenv.mkDerivation rec {
   pname = "tageditor";
-  version = "3.3.10";
+  version = "3.7.5";
 
   src = fetchFromGitHub {
     owner = "martchus";
-    repo = "tageditor";
+    repo = pname;
     rev = "v${version}";
-    sha256 = "16cmq7dyalcwc8gx1y9acngw5imjh8ydp4prxy7qpzk4fj3kpsak";
+    hash = "sha256-/0zzzOEkzNr1aIpPFdflFaM/0HTs3TlIRxau3Yt+Hog=";
   };
 
   nativeBuildInputs = [
@@ -32,10 +31,10 @@ stdenv.mkDerivation rec {
     cmake
     wrapQtAppsHook
   ];
+
   buildInputs = [
     mp4v2
     libid3tag
-    pkg-config
     qtbase
     qttools
     qtx11extras
@@ -45,7 +44,7 @@ stdenv.mkDerivation rec {
     tagparser
   ];
 
-  meta = with pkgs.lib; {
+  meta = with lib; {
     homepage = "https://github.com/Martchus/tageditor";
     description = "A tag editor with Qt GUI and command-line interface supporting MP4/M4A/AAC (iTunes), ID3, Vorbis, Opus, FLAC and Matroska";
     license = licenses.gpl2;
@@ -53,4 +52,3 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
   };
 }
-

--- a/pkgs/development/libraries/qtutilities/default.nix
+++ b/pkgs/development/libraries/qtutilities/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "qtutilities";
-  version = "6.7.0";
+  version = "6.8.0";
 
   src = fetchFromGitHub {
     owner = "Martchus";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-RjVmrdUHDBelwagWD5Mx+S3tdFO7I0+8RmFR7hwoe8o=";
+    hash = "sha256-I8VvVGlz6rQLWd7Fq0q58VFFj+EHGiwkayam2Cj3aJQ=";
   };
 
   buildInputs = [ qtbase cpp-utilities ];

--- a/pkgs/development/libraries/tagparser/default.nix
+++ b/pkgs/development/libraries/tagparser/default.nix
@@ -1,20 +1,21 @@
 { stdenv
-, pkgs
+, lib
 , fetchFromGitHub
 , cmake
 , cpp-utilities
 , zlib
+, isocodes
 }:
 
 stdenv.mkDerivation rec {
   pname = "tagparser";
-  version = "9.4.0";
+  version = "11.5.0";
 
   src = fetchFromGitHub {
     owner = "Martchus";
     repo = "tagparser";
     rev = "v${version}";
-    sha256 = "097dq9di19d3mvnlrav3fm78gzjni5babswyv10xnrxfhnf14f6x";
+    hash = "sha256-qgopl32cFQFQTYu9WBOzPeU69J8K49SREX7X0Pw7Als=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -23,7 +24,11 @@ stdenv.mkDerivation rec {
     cpp-utilities zlib
   ];
 
-  meta = with pkgs.lib; {
+  cmakeFlags = [
+    "-DLANGUAGE_FILE_ISO_639_2=${isocodes}/share/iso-codes/json/iso_639-2.json"
+  ];
+
+  meta = with lib; {
     homepage = "https://github.com/Martchus/tagparser";
     description = "C++ library for reading and writing MP4/M4A/AAC (iTunes), ID3, Vorbis, Opus, FLAC and Matroska tags";
     license = licenses.gpl2;


### PR DESCRIPTION
###### Description of changes

https://github.com/Martchus/tageditor/releases

https://github.com/Martchus/tagparser/releases

https://github.com/Martchus/qtutilities/releases

#172844 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
