### PR TITLE
teleport: 9.1.2 -> 10.2.0

### DIFF
--- a/pkgs/servers/teleport/rdpclient.patch
+++ b/pkgs/servers/teleport/rdpclient.patch
@@ -1,17 +1,22 @@
 diff --git a/lib/srv/desktop/rdp/rdpclient/client.go b/lib/srv/desktop/rdp/rdpclient/client.go
-index d191c768f..71117a30d 100644
+index 4357d7aa1..7e21a0076 100644
 --- a/lib/srv/desktop/rdp/rdpclient/client.go
 +++ b/lib/srv/desktop/rdp/rdpclient/client.go
-@@ -56,10 +56,10 @@ package rdpclient
- #cgo linux,amd64 LDFLAGS: -L${SRCDIR}/../../../../../target/x86_64-unknown-linux-gnu/release
- #cgo linux,arm LDFLAGS: -L${SRCDIR}/../../../../../target/arm-unknown-linux-gnueabihf/release
- #cgo linux,arm64 LDFLAGS: -L${SRCDIR}/../../../../../target/aarch64-unknown-linux-gnu/release
+@@ -52,14 +52,9 @@ package rdpclient
+ 
+ /*
+ // Flags to include the static Rust library.
+-#cgo linux,386 LDFLAGS: -L${SRCDIR}/../../../../../target/i686-unknown-linux-gnu/release
+-#cgo linux,amd64 LDFLAGS: -L${SRCDIR}/../../../../../target/x86_64-unknown-linux-gnu/release
+-#cgo linux,arm LDFLAGS: -L${SRCDIR}/../../../../../target/arm-unknown-linux-gnueabihf/release
+-#cgo linux,arm64 LDFLAGS: -L${SRCDIR}/../../../../../target/aarch64-unknown-linux-gnu/release
 -#cgo linux LDFLAGS: -l:librdp_client.a -lpthread -ldl -lm
-+#cgo linux LDFLAGS: -l:librdp_client.a -lpthread -ldl -lm -lssl -lcrypto
- #cgo darwin,amd64 LDFLAGS: -L${SRCDIR}/../../../../../target/x86_64-apple-darwin/release
- #cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/../../../../../target/aarch64-apple-darwin/release
+-#cgo darwin,amd64 LDFLAGS: -L${SRCDIR}/../../../../../target/x86_64-apple-darwin/release
+-#cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/../../../../../target/aarch64-apple-darwin/release
 -#cgo darwin LDFLAGS: -framework CoreFoundation -framework Security -lrdp_client -lpthread -ldl -lm
-+#cgo darwin LDFLAGS: -framework CoreFoundation -framework Security -lrdp_client -lpthread -ldl -lm -lssl -lcrypto
++#cgo LDFLAGS: -L${SRCDIR}/../../../../../lib -lpthread -ldl -lm -lssl -lcrypto
++#cgo linux LDFLAGS: -l:librdp_client.a
++#cgo darwin LDFLAGS: -framework CoreFoundation -framework Security -lrdp_client
  #include <librdprs.h>
  */
  import "C"


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Bumped teleport to `10.2.0`

This is a major version bump so it'll need more review, maybe some update notes, might be some changes necessary to the module

https://github.com/gravitational/teleport/blob/master/CHANGELOG.md

https://github.com/gravitational/teleport/blob/master/CHANGELOG.md#breaking-changes

https://github.com/gravitational/teleport/compare/v9.1.2...v10.2.0


---

They removed the header from the repo so it needs to be retained and I copy it relative to the file that wants it

---

The output from rdp now doesn't include the whole target directory which was full of other mess from the build and causing a large amount of awful patching logs


before:

```
λ du -hcd 0 $(readlink -f ./result)
459M	/nix/store/fgax93lc2jmvmcghd859q5byh1n196ba-teleport-rdpclient
459M	total
```

`--check` output: `error: derivation '/nix/store/jnjd2m03d9mxgvp68jwqh9cg3yazzqz4-teleport-rdpclient.drv' may not be deterministic: output '/nix/store/fgax93lc2jmvmcghd859q5byh1n196ba-teleport-rdpclient' differs`

after:

```
λ du -hcd 0 $(readlink -f ./result)
27M	/nix/store/43fipf3s98kf11y3rqlpahbp9a4payl4-teleport-rdpclient
27M	total
```

`--check` output: all good

---

I also fully move the tsh cli to the client output and symlink rather than having two copies

Dropped the roletester since it doesn't exist anymore


I made some changes to the LDFLAGS import stuff to make it less crazy

Assuming it's additive it's a lot cleaner. If it isn't then it'll need further splitting out for linux & darwin

Built fine and nixos tests worked but it will need some proper testing

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
