### PR TITLE
emacsPackages.yes-no: init at 2017-10-01

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6033,6 +6033,12 @@
       fingerprint = "A506 C38D 5CC8 47D0 DF01  134A DA8B 833B 5260 4E63";
     }];
   };
+  jcs090218 = {
+    email = "jcs090218@gmail.com";
+    github = "jcs090218";
+    githubId = 8685505;
+    name = "Jen-Chieh Shen";
+  };
   jcumming = {
     email = "jack@mudshark.org";
     github = "jcumming";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -232,6 +232,8 @@
   tree-sitter-langs = callPackage ./tree-sitter-langs { final = self; };
   tsc = callPackage ./tsc { };
 
+  yes-no = callPackage ./yes-no { };
+
   youtube-dl = callPackage ./youtube-dl { };
 
   # From old emacsPackages (pre emacsPackagesNg)

--- a/pkgs/applications/editors/emacs/elisp-packages/yes-no/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/yes-no/default.nix
@@ -1,0 +1,25 @@
+{ lib, stdenv, fetchurl }:
+
+stdenv.mkDerivation {
+  name = "yes-no";
+
+  src = fetchurl {
+    url = "https://github.com/emacsmirror/emacswiki.org/blob/185fdc34fb1e02b43759ad933d3ee5646b0e78f8/yes-no.el";
+    sha256 = "1k0nn619i82jiqm48k5nk6b8cv2rggh0i5075nhc85a2s9pwhx32";
+  };
+
+  dontUnpack = true;
+
+  installPhase = ''
+    install -d $out/share/emacs/site-lisp
+    install $src $out/share/emacs/site-lisp/yes-no.el
+  '';
+
+  meta = with lib; {
+    description = "Specify use of `y-or-n-p' or `yes-or-no-p' on a case-by-case basis";
+    homepage = "https://www.emacswiki.org/emacs/yes-no.el";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ jcs090218 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/editors/emacs/elisp-packages/yes-no/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/yes-no/default.nix
@@ -1,7 +1,8 @@
-{ lib, stdenv, fetchurl }:
+{ lib, fetchurl, trivialBuild }:
 
-stdenv.mkDerivation {
-  name = "yes-no";
+trivialBuild {
+  pname = "yes-no";
+  version = "0";
 
   src = fetchurl {
     url = "https://github.com/emacsmirror/emacswiki.org/blob/185fdc34fb1e02b43759ad933d3ee5646b0e78f8/yes-no.el";

--- a/pkgs/applications/editors/emacs/elisp-packages/yes-no/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/yes-no/default.nix
@@ -2,19 +2,12 @@
 
 trivialBuild {
   pname = "yes-no";
-  version = "0";
+  version = "2017-10-01";
 
   src = fetchurl {
-    url = "https://github.com/emacsmirror/emacswiki.org/blob/185fdc34fb1e02b43759ad933d3ee5646b0e78f8/yes-no.el";
-    sha256 = "1k0nn619i82jiqm48k5nk6b8cv2rggh0i5075nhc85a2s9pwhx32";
+    url = "https://raw.githubusercontent.com/emacsmirror/emacswiki.org/143bcaeb679a8fa8a548e92a5a9d5c2baff50d9c/yes-no.el";
+    sha256 = "03w4wfx885y89ckyd5d95n2571nmmzrll6kr0yan3ip2aw28xq3i";
   };
-
-  dontUnpack = true;
-
-  installPhase = ''
-    install -d $out/share/emacs/site-lisp
-    install $src $out/share/emacs/site-lisp/yes-no.el
-  '';
 
   meta = with lib; {
     description = "Specify use of `y-or-n-p' or `yes-or-no-p' on a case-by-case basis";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add emacs package, yes-no.el.

**Package description:** `Specify use of 'y-or-n-p' or 'yes-or-no-p' on a case-by-case basis`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
