### PR TITLE
gobject-introspection: use lddtree instead of objdump as ldd wrapper

### DIFF
--- a/pkgs/development/libraries/gobject-introspection/default.nix
+++ b/pkgs/development/libraries/gobject-introspection/default.nix
@@ -103,7 +103,7 @@ stdenv.mkDerivation (finalAttrs: {
       isExecutable = true;
       src = ./wrappers/g-ir-scanner-lddwrapper.sh;
       inherit (buildPackages) bash;
-      buildobjdump = "${buildPackages.stdenv.cc.bintools}/bin/objdump";
+      buildlddtree = "${buildPackages.pax-utils}/bin/lddtree";
     }}"
     "-Dgi_cross_use_prebuilt_gi=true"
     "-Dgi_cross_binary_wrapper=${stdenv.hostPlatform.emulator buildPackages}"

--- a/pkgs/development/libraries/gobject-introspection/wrapper.nix
+++ b/pkgs/development/libraries/gobject-introspection/wrapper.nix
@@ -27,7 +27,7 @@ in
       export bash="${buildPackages.bash}"
       export emulator=${lib.escapeShellArg (stdenv.targetPlatform.emulator buildPackages)}
       export emulatorwrapper="$dev/bin/g-ir-scanner-qemuwrapper"
-      export buildobjdump="${buildPackages.stdenv.cc.bintools}/bin/objdump"
+      export buildlddtree="${buildPackages.pax-utils}/bin/lddtree"
 
       export targetgir="${lib.getDev (targetPackages.gobject-introspection-unwrapped.override argsForTarget)}"
 

--- a/pkgs/development/libraries/gobject-introspection/wrappers/g-ir-scanner-lddwrapper.sh
+++ b/pkgs/development/libraries/gobject-introspection/wrappers/g-ir-scanner-lddwrapper.sh
@@ -1,4 +1,4 @@
 #! @bash@/bin/bash
 # shellcheck shell=bash
 
-exec @buildobjdump@ -p "$@"
+exec @buildlddtree@ "$@"


### PR DESCRIPTION
the wrong path was used in gir files because the format of objdump is different from ldd so the regex in gobject-introspection doesn't work

https://gitlab.gnome.org/GNOME/gobject-introspection/-/blob/main/giscanner/shlibs.py#L42-57

  <namespace name="GLib"
             shared-library="/nix/store/pak6rr8wdnbwa1iq2ldvg8pa8zahl3r1-gobject-introspection-aarch64-unknown-linux-gnu-1.72.0/lib/libgobject-2.0.so.0,/nix/store/pak6rr8wdnbwa1iq2ldvg8pa8zahl3r1-gobject-introspection-aarch64-unknown-linux-gnu-1.72.0/lib/libglib-2.0.so.0"

objdump
gobject-introspection>   NEEDED               libgmodule-2.0.so.0
gobject-introspection>   NEEDED               libglib-2.0.so.0

ldd
gobject-introspection>  libgmodule-2.0.so.0 => /nix/store/ngm1wbwms13c2crsvrah2ypfj0b2yii5-glib-2.73.2/lib/libgmodule-2.0.so.0 (0x00007ffff7d6e000) gobject-introspection>  libglib-2.0.so.0 => /nix/store/ngm1wbwms13c2crsvrah2ypfj0b2yii5-glib-2.73.2/lib/libglib-2.0.so.0 (0x00007ffff7c32000)

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
