### PR TITLE
mpd: fix cross compilation

### DIFF
--- a/pkgs/development/libraries/libid3tag/default.nix
+++ b/pkgs/development/libraries/libid3tag/default.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, fetchurl, zlib, gperf}:
+{ lib, stdenv, fetchurl, zlib, gperf_3_0 }:
 
 stdenv.mkDerivation rec {
   pname = "libid3tag";
@@ -12,7 +12,11 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" ];
   setOutputFlags = false;
 
-  propagatedBuildInputs = [ zlib gperf ];
+  strictDeps = true;
+
+  nativeBuildInputs = [ gperf_3_0 ];
+
+  buildInputs = [ zlib ];
 
   patches = [
     ./debian-patches.patch

--- a/pkgs/servers/mpd/default.nix
+++ b/pkgs/servers/mpd/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, glib, systemd, boost, fmt
+{ lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, glib, systemd, boost, fmt, buildPackages
 # Darwin inputs
 , AudioToolbox, AudioUnit
 # Inputs
@@ -144,6 +144,8 @@ let
         pkg-config
       ]
         ++ concatAttrVals features_ nativeFeatureDependencies;
+
+      depsBuildBuild = [ buildPackages.stdenv.cc ];
 
       postPatch = lib.optionalString (stdenv.isDarwin && lib.versionOlder stdenv.targetPlatform.darwinSdkVersion "12.0") ''
         substituteInPlace src/output/plugins/OSXOutputPlugin.cxx \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19740,9 +19740,7 @@ with pkgs;
   # On non-GNU systems we need GNU Gettext for libintl.
   libintl = if stdenv.hostPlatform.libc != "glibc" then gettext else null;
 
-  libid3tag = callPackage ../development/libraries/libid3tag {
-    gperf = gperf_3_0;
-  };
+  libid3tag = callPackage ../development/libraries/libid3tag { };
 
   libidn = callPackage ../development/libraries/libidn { };
 


### PR DESCRIPTION
###### Description of changes

```
mpd-aarch64-unknown-linux-gnu> /nix/store/vs2wgwqjchj436r2djj35n75gf4x3ib8-aarch64-unknown-linux-gnu-binutils-2.38/bin/aarch64-unknown-linux-gnu-ld: /nix/store/8qki5s206x5h0aapcbbc1s7csy0b511h-libid3tag-aarch64-unknown-linux-gnu-0.15.1b/lib/libid3tag.so: undefined reference to `id3_compat_lookup'
mpd-aarch64-unknown-linux-gnu> /nix/store/vs2wgwqjchj436r2djj35n75gf4x3ib8-aarch64-unknown-linux-gnu-binutils-2.38/bin/aarch64-unknown-linux-gnu-ld: /nix/store/8qki5s206x5h0aapcbbc1s7csy0b511h-libid3tag-aarch64-unknown-linux-gnu-0.15.1b/lib/libid3tag.so: undefined reference to `id3_compat_fixup'
mpd-aarch64-unknown-linux-gnu> collect2: error: ld returned 1 exit status
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
