### PR TITLE
nuget-to-nix: add support for powershellgallery.com OData API (#190202)

### DIFF
--- a/pkgs/build-support/dotnet/nuget-to-nix/default.nix
+++ b/pkgs/build-support/dotnet/nuget-to-nix/default.nix
@@ -9,6 +9,7 @@
 , jq
 , curl
 , gnugrep
+, xmlstarlet
 }:
 
 runCommandLocal "nuget-to-nix" {
@@ -17,13 +18,14 @@ runCommandLocal "nuget-to-nix" {
     inherit runtimeShell;
 
     binPath = lib.makeBinPath [
-      nix
       coreutils
+      curl
       findutils
+      gnugrep
       gnused
       jq
-      curl
-      gnugrep
+      nix
+      xmlstarlet
     ];
   };
 

--- a/pkgs/build-support/dotnet/nuget-to-nix/nuget-to-nix.sh
+++ b/pkgs/build-support/dotnet/nuget-to-nix/nuget-to-nix.sh
@@ -1,6 +1,8 @@
 #!@runtimeShell@
+# shellcheck shell=bash
 
-set -euo pipefail
+[[ ${debug:-} ]] && { PS4=':$LINENO+'; set -x; }
+set -o pipefail
 
 export PATH="@binPath@"
 
@@ -10,35 +12,59 @@ if [ $# -eq 0 ]; then
 fi
 
 pkgs=$1
-exclusions="${2:-/dev/null}"
-tmpfile=$(mktemp /tmp/nuget-to-nix.XXXXXX)
-trap "rm -f ${tmpfile}" EXIT
+exclusions=$2
+tmpfile=$(mktemp -t nuget-to-nix.XXXXXX) || exit
+trap 'rm -f "$tmpfile"' EXIT
 
-declare -A nuget_sources_cache
+# open tmpfile for stdout after making a backup of the original
+# this way we don't need to reopen the output file every time we want to echo a single line into it
+exec {orig_stdout_fd}>&1 >"$tmpfile" || exit
 
-echo "{ fetchNuGet }: ["
+# cache nuget-formatted JSON index files
+declare -A nuget_sources_cache || exit
 
-while read pkg_spec; do
-  { read pkg_name; read pkg_version; } < <(
-    # Build version part should be ignored: `3.0.0-beta2.20059.3+77df2220` -> `3.0.0-beta2.20059.3`
-    sed -nE 's/.*<id>([^<]*).*/\1/p; s/.*<version>([^<+]*).*/\1/p' "$pkg_spec")
+while IFS= read -r -d '' pkg_spec; do : pkg_spec="$pkg_spec"
+  { read -r pkg_name && read -r pkg_version; } < <(
+    xmlstarlet sel -t -m '/*[local-name()="package"]/*[local-name()="metadata"]' -v './*[local-name()="id"]' -n -v './*[local-name()="version"]' -n <"$pkg_spec"
+  ) || exit
+  [[ $pkg_name && $pkg_version ]] || { echo "ERROR: Unable to extract package name and version from $pkg_spec" >&2; exit 1; }
 
-  if grep "$pkg_name" "$exclusions" > /dev/null; then
-    continue
+  # note use of grep -Fx so we only count a complete, exact line match; otherwise we could have false substring matches or regexes that treat a name as a regex
+  if [[ $exclusions ]]; then
+    grep -qFxe "$pkg_name" "$exclusions" && continue
   fi
 
-  pkg_sha256="$(nix-hash --type sha256 --flat --base32 "$(dirname "$pkg_spec")"/*.nupkg)"
+  pkg_sha256="$(nix-hash --type sha256 --flat --base32 "${pkg_spec%/*}"/*.nupkg)" || exit
+  pkg_src="$(jq --raw-output '.source' "${pkg_spec%/*}/.nupkg.metadata")" || exit
 
-  pkg_src="$(jq --raw-output '.source' "$(dirname "$pkg_spec")/.nupkg.metadata")"
-  if [[ $pkg_src != https://api.nuget.org/* ]] && [[ ! -d $pkg_src ]]; then
-    pkg_source_url="${nuget_sources_cache[$pkg_src]:=$(curl -n --fail "$pkg_src" | jq --raw-output '.resources[] | select(."@type" == "PackageBaseAddress/3.0.0")."@id"')}"
-    pkg_url="$pkg_source_url${pkg_name,,}/${pkg_version,,}/${pkg_name,,}.${pkg_version,,}.nupkg"
-    echo "  (fetchNuGet { pname = \"$pkg_name\"; version = \"$pkg_version\"; sha256 = \"$pkg_sha256\"; url = \"$pkg_url\"; })" >> ${tmpfile}
+  if [[ -d $pkg_src ]]; then
+    # source is a local filesystem, not a a URL
+    echo "  (fetchNuGet { pname = \"$pkg_name\"; version = \"$pkg_version\"; sha256 = \"$pkg_sha256\"; })" || exit
   else
-    echo "  (fetchNuGet { pname = \"$pkg_name\"; version = \"$pkg_version\"; sha256 = \"$pkg_sha256\"; })" >> ${tmpfile}
+    case $pkg_src in
+      https://api.nuget.org/*)
+        # default repository; no explicit URL required
+        echo "  (fetchNuGet { pname = \"$pkg_name\"; version = \"$pkg_version\"; sha256 = \"$pkg_sha256\"; })" || exit
+        ;;
+      https://www.powershellgallery.com/api/v2/*)
+        # using an OData API instead of the nuget service index format
+        pkg_xml=$(curl -n --fail "https://www.powershellgallery.com/api/v2/Packages(Id='$pkg_name',Version='$pkg_version')") || exit
+        pkg_url=$(xmlstarlet sel -N a=http://www.w3.org/2005/Atom -t -m /a:entry/a:content -v ./@src -n <<<"$pkg_xml") && [[ $pkg_url ]] || exit
+        echo "  (fetchNuGet { pname = \"$pkg_name\"; version = \"$pkg_version\"; sha256 = \"$pkg_sha256\"; url = \"$pkg_url\"; })" || exit
+        ;;
+      *)
+        # unrecognized repository; assume pkg_src is a nuget service index
+        pkg_source_url="${nuget_sources_cache[$pkg_src]:=$(curl -n --fail "$pkg_src" | jq --raw-output '.resources[] | select(."@type" == "PackageBaseAddress/3.0.0")."@id"')}" || exit
+        pkg_url="$pkg_source_url${pkg_name,,}/${pkg_version,,}/${pkg_name,,}.${pkg_version,,}.nupkg"
+        echo "  (fetchNuGet { pname = \"$pkg_name\"; version = \"$pkg_version\"; sha256 = \"$pkg_sha256\"; url = \"$pkg_url\"; })" || exit
+        ;;
+    esac
   fi
-done < <(find $1 -name '*.nuspec')
+done < <(find "$pkgs" -name '*.nuspec' -print0)
 
-LC_ALL=C sort --ignore-case ${tmpfile}
+exec >&$orig_stdout_fd || exit # redirect stdout back to original destination, closing tmpfile
 
-echo "]"
+# only write the header if we got this far -- if anything failed above, no reason to print it
+echo "{ fetchNuGet }: [" || exit
+LC_ALL=C sort -s --ignore-case <"$tmpfile" || exit
+echo "]" || exit


### PR DESCRIPTION
###### Description of changes

Perform a general best-practices cleanup of `nuget-to-nix.sh`, and add support for the OData API offered at https://powershellgallery.com/

Fixes #190202.

- Support the powershellgallery.com OData API.
- Avoid using `set -e` for the reasons given in [BashFAQ #105](https://mywiki.wooledge.org/BashFAQ/105#Exercises).
- Avoid using `set -u` for the reasons given in [BashFAQ #112](https://mywiki.wooledge.org/BashFAQ/112)
- Prevent partial matches with the exclusions list from causing an exclusion to be found.
- Avoid parsing XML with sed. Use libxslt via XMLStarlet where XML parsing cannot be avoided; extract data from filenames instead of file content where it can.
- Add xmlstarlet to dependency set; sort dependencies for reduced likelihood of conflicts should additions take place in the future.
- Use `mktemp -t` to honor `TMPDIR` instead of hardcoding `/tmp`.
- Avoid expanding `tmpfile` content during EXIT trap definition to avoid shell injection via hostile TMPDIR locations.
- Avoid repeatedly reopening `tmpfile` every time a new record needs to be written to it.
- Avoid running `grep` to check for exclusions when no exclusions file is provided.
- Use `grep -q` to let grep against the exclusions file exit early when a match is found, rather than needing to process the remainder of input, and to tell it that writing output is unnecessary.
- Avoid writing header of output line until all URLs have been processed, so our stdout stays empty unless we're likely to succeed.

@IvarWithoutBones

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s) _Doesn't really apply, no compiled code_
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
