### PR TITLE
librsvg: 2.54.4 → 2.55.1

### DIFF
--- a/nixos/tests/installed-tests/default.nix
+++ b/nixos/tests/installed-tests/default.nix
@@ -100,7 +100,6 @@ in
   gsconnect = callInstalledTest ./gsconnect.nix {};
   ibus = callInstalledTest ./ibus.nix {};
   libgdata = callInstalledTest ./libgdata.nix {};
-  librsvg = callInstalledTest ./librsvg.nix {};
   glib-testing = callInstalledTest ./glib-testing.nix {};
   libjcat = callInstalledTest ./libjcat.nix {};
   libxmlb = callInstalledTest ./libxmlb.nix {};

--- a/nixos/tests/installed-tests/librsvg.nix
+++ b/nixos/tests/installed-tests/librsvg.nix
@@ -1,9 +1,0 @@
-{ pkgs, makeInstalledTest, ... }:
-
-makeInstalledTest {
-  tested = pkgs.librsvg;
-
-  testConfig = {
-    virtualisation.memorySize = 2047;
-  };
-}

--- a/pkgs/development/libraries/librsvg/default.nix
+++ b/pkgs/development/libraries/librsvg/default.nix
@@ -30,7 +30,7 @@
 
 stdenv.mkDerivation rec {
   pname = "librsvg";
-  version = "2.55.0";
+  version = "2.55.1";
 
   outputs = [ "out" "dev" ] ++ lib.optionals withIntrospection [
     "devdoc"
@@ -38,13 +38,13 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "bmJsVk41S82MOEuQ+OTzCzA6+mweDLXMVroUkAxdtzA=";
+    sha256 = "a69IqdOlb9E7v7ufH3Z1myQLcKH6Ig/SOEdNZqkm+Yw=";
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-tvfdRGyrEkEh6sb69f0ugfzR2bgGdWa05pSyovpXAF8=";
+    hash = "sha256-nRmOB9Jo+mmB0+wXrQvoII4e0ucV7bNCDeuk6CbcPdk=";
     # TODO: move this to fetchCargoTarball
     dontConfigure = true;
   };
@@ -138,7 +138,6 @@ stdenv.mkDerivation rec {
       let
         updateSource = gnome.updateScript {
           packageName = "librsvg";
-          versionPolicy = "odd-unstable";
         };
 
         updateLockfile = {

--- a/pkgs/development/libraries/librsvg/default.nix
+++ b/pkgs/development/libraries/librsvg/default.nix
@@ -22,7 +22,6 @@
 , vala
 , withIntrospection ? stdenv.hostPlatform == stdenv.buildPlatform
 , gobject-introspection
-, nixosTests
 , _experimental-update-script-combinators
 , common-updater-scripts
 , jq
@@ -33,7 +32,7 @@ stdenv.mkDerivation rec {
   pname = "librsvg";
   version = "2.55.0";
 
-  outputs = [ "out" "dev" "installedTests" ] ++ lib.optionals withIntrospection [
+  outputs = [ "out" "dev" ] ++ lib.optionals withIntrospection [
     "devdoc"
   ];
 
@@ -93,15 +92,9 @@ stdenv.mkDerivation rec {
     # https://github.com/NixOS/nixpkgs/pull/117081#issuecomment-827782004
     (lib.enableFeature (withIntrospection && !stdenv.isDarwin) "vala")
 
-    "--enable-installed-tests"
     "--enable-always-build-tests"
   ] ++ lib.optional stdenv.isDarwin "--disable-Bsymbolic"
     ++ lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) "RUST_TARGET=${rust.toRustTarget stdenv.hostPlatform}";
-
-  makeFlags = [
-    "installed_test_metadir=${placeholder "installedTests"}/share/installed-tests/RSVG"
-    "installed_testdir=${placeholder "installedTests"}/libexec/installed-tests/RSVG"
-  ];
 
   doCheck = false; # all tests fail on libtool-generated rsvg-convert not being able to find coreutils
 
@@ -176,10 +169,6 @@ stdenv.mkDerivation rec {
         updateSource
         updateLockfile
       ];
-
-    tests = {
-      installedTests = nixosTests.installed-tests.librsvg;
-    };
   };
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

Now following the new GNOME version policy (no more odd-unstable).

https://github.com/GNOME/librsvg/compare/2.54.4...2.55.1

Cherry-picked from https://github.com/NixOS/nixpkgs/pull/182618

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
