### PR TITLE
{jam,ftjam}: set target-specific macros correctly when cross compiling

### DIFF
--- a/pkgs/development/tools/build-managers/jam/default.nix
+++ b/pkgs/development/tools/build-managers/jam/default.nix
@@ -1,13 +1,32 @@
-{ lib, stdenv, fetchurl, bison, buildPackages }:
+{ lib, stdenv, fetchurl, bison, buildPackages, pkgsBuildTarget }:
 
 let
-  mkJam = { meta ? { }, ... } @ args: stdenv.mkDerivation (args // {
+  mkJam = { pname, version, src, meta ? { } }: stdenv.mkDerivation {
+    inherit pname version src;
+
     depsBuildBuild = [ buildPackages.stdenv.cc ];
     nativeBuildInputs = [ bison ];
 
     # Jambase expects ar to have flags.
     preConfigure = ''
       export AR="$AR rc"
+    '';
+
+    # When cross-compiling, we need to set the preprocessor macros
+    # OSMAJOR/OSMINOR/OSPLAT to the values from the target platform, not the
+    # host platform. This looks a little ridiculous because the vast majority of
+    # build tools don't embed target-specific information into their binary, but
+    # in this case we behave more like a compiler than a make(1)-alike.
+    postPatch = lib.optionalString (stdenv.hostPlatform != stdenv.targetPlatform) ''
+      cat >>jam.h <<EOF
+      #undef OSMAJOR
+      #undef OSMINOR
+      #undef OSPLAT
+      $(
+        ${pkgsBuildTarget.targetPackages.stdenv.cc}/bin/${pkgsBuildTarget.targetPackages.stdenv.cc.targetPrefix}cc -E -dM jam.h \
+          | grep -E '^#define (OSMAJOR|OSMINOR|OSPLAT) '
+      )
+      EOF
     '';
 
     LOCATE_TARGET = "bin.unix";
@@ -30,59 +49,67 @@ let
 
     enableParallelBuilding = true;
 
-    meta = with lib; meta // {
+    meta = with lib; {
       license = licenses.free;
       mainProgram = "jam";
       platforms = platforms.unix;
-    };
-  });
+    } // meta;
+  };
 in
 {
   jam = let
     pname = "jam";
     version = "2.6.1";
-  in mkJam {
-    inherit pname version;
 
-    src = fetchurl {
-      url = "https://swarm.workshop.perforce.com/projects/perforce_software-jam/download/main/${pname}-${version}.tar";
-      sha256 = "19xkvkpycxfsncxvin6yqrql3x3z9ypc1j8kzls5k659q4kv5rmc";
-    };
+    base = mkJam {
+      inherit pname version;
 
-    meta = with lib; {
-      description = "Just Another Make";
-      homepage = "https://www.perforce.com/resources/documentation/jam";
-      maintainers = with maintainers; [ impl orivej ];
+      src = fetchurl {
+        url = "https://swarm.workshop.perforce.com/projects/perforce_software-jam/download/main/${pname}-${version}.tar";
+        sha256 = "19xkvkpycxfsncxvin6yqrql3x3z9ypc1j8kzls5k659q4kv5rmc";
+      };
+
+      meta = with lib; {
+        description = "Just Another Make";
+        homepage = "https://www.perforce.com/resources/documentation/jam";
+        maintainers = with maintainers; [ impl orivej ];
+      };
     };
-  };
+  in base.overrideAttrs (oldAttrs: {
+    makeFlags = (oldAttrs.makeFlags or []) ++ [
+      "CC=${buildPackages.stdenv.cc.targetPrefix}cc"
+    ];
+  });
 
   ftjam = let
     pname = "ftjam";
     version = "2.5.2";
-  in mkJam {
-    inherit pname version;
 
-    src = fetchurl {
-      url = "https://downloads.sourceforge.net/project/freetype/${pname}/${version}/${pname}-${version}.tar.bz2";
-      hash = "sha256-6JdzUAqSkS3pGOn+v/q+S2vOedaa8ZRDX04DK4ptZqM=";
+    base = mkJam {
+      inherit pname version;
+
+      src = fetchurl {
+        url = "https://downloads.sourceforge.net/project/freetype/${pname}/${version}/${pname}-${version}.tar.bz2";
+        hash = "sha256-6JdzUAqSkS3pGOn+v/q+S2vOedaa8ZRDX04DK4ptZqM=";
+      };
+
+      meta = with lib; {
+        description = "FreeType's enhanced, backwards-compatible Jam clone";
+        homepage = "https://freetype.org/jam/";
+        maintainers = with maintainers; [ AndersonTorres impl ];
+      };
     };
-
-    postPatch = ''
+  in base.overrideAttrs (oldAttrs: {
+    postPatch = (oldAttrs.postPatch or "") + ''
       substituteInPlace Jamfile --replace strip ${stdenv.cc.targetPrefix}strip
     '';
 
     # Doesn't understand how to cross compile once bootstrapped, so we'll just
     # use the Makefile for the bootstrapping portion.
     configurePlatforms = [ "build" "target" ];
-    configureFlags = [
+    configureFlags = (oldAttrs.configureFlags or []) ++ [
       "CC=${buildPackages.stdenv.cc.targetPrefix}cc"
       "--host=${stdenv.buildPlatform.config}"
     ];
-
-    meta = with lib; {
-      description = "FreeType's enhanced, backwards-compatible Jam clone";
-      homepage = "https://freetype.org/jam/";
-      maintainers = with maintainers; [ AndersonTorres impl ];
-    };
-  };
+  });
 }


### PR DESCRIPTION
###### Description of changes

Jam embeds some information about the target platform, namely the OS and architecture, directly into the binary. We need to re-evaluate the macros for the target platform when Jam is being used to cross compile. I can successfully cross-compile `p4` with this change, so I think this is hopefully the last change required here.

I'm not super pleased about having to bring `pkgsBuildTarget` into the mix, so if anyone has any better ideas, I'm all ears... :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
