### PR TITLE
git-publish: init at 1.8.1

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-publish/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-publish/default.nix
@@ -1,0 +1,32 @@
+{ lib, stdenv, python, perl, fetchFromGitHub, installShellFiles }:
+stdenv.mkDerivation rec {
+  pname = "git-publish";
+  version = "1.8.1";
+
+  src = fetchFromGitHub {
+    owner = "stefanha";
+    repo = "git-publish";
+    rev = "v${version}";
+    sha256 = "14rz5kli6sz171cvdc46z3z0nnpd57rliwr6nn6vjjc49yyfwgl4";
+  };
+
+  nativeBuildInputs = [ perl installShellFiles ];
+  buildInputs = [ python ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm0755 git-publish $out/bin/git-publish
+    pod2man git-publish.pod > git-publish.1
+    installManPage git-publish.1
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Prepare and store patch revisions as git tags";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.lheckemann ];
+    homepage = "https://github.com/stefanha/git-publish";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2499,6 +2499,8 @@ with pkgs;
 
   git-privacy = callPackage ../development/tools/git-privacy { };
 
+  git-publish = python3Packages.callPackage ../applications/version-management/git-and-tools/git-publish { };
+
   git-repo-updater = python3Packages.callPackage ../development/tools/git-repo-updater { };
 
   git-revise = with python3Packages; toPythonApplication git-revise;


### PR DESCRIPTION
###### Description of changes

Init package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
