### PR TITLE
unvanquished: 0.53.1 -> 0.53.2

### DIFF
--- a/pkgs/games/unvanquished/default.nix
+++ b/pkgs/games/unvanquished/default.nix
@@ -33,7 +33,7 @@
 }:
 
 let
-  version = "0.53.1";
+  version = "0.53.2";
   binary-deps-version = "6";
 
   src = fetchFromGitHub {
@@ -41,7 +41,7 @@ let
     repo = "Unvanquished";
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "sha256-AWXuPXOhhPfdDrcyZF5o7uBnieSCGhwCzOYN8MjgTl8=";
+    sha256 = "sha256-VqMhA6GEYh/m+dzOgXS+5Jqo4x7RrQf4qIwstdTTU+E=";
   };
 
   unvanquished-binary-deps = stdenv.mkDerivation rec {
@@ -119,7 +119,7 @@ let
     pname = "unvanquished-assets";
     inherit version src;
 
-    outputHash = "sha256-+mO4HQwFfy7SeGrN4R52KOr/uNQXkHMvYir3k0l5rDo=";
+    outputHash = "sha256-MPqyqcZGc5KlkftGCspWhISBJ/h+Os29g7ZK6yWz0cQ=";
     outputHashMode = "recursive";
 
     nativeBuildInputs = [ aria2 cacert ];


### PR DESCRIPTION
###### Description of changes

https://unvanquished.net/unvanquished-0-53-2-refinements/

Known issue: map vote can stall a server of this version. Applying a patch is tricky however, as we don't build the gamelogic in nixpkgs. If you host a server which isn't running a custom mod, and you don't need to host it on a port above 32768, you may prefer to wait until the next version before upgrading.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux (no other supported platforms)
- [x] Tested basic functionality of <del>all binary files</del> graphical client only (it's a game)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
