### PR TITLE
quickstack: init at unstable-2021-01-26

### DIFF
--- a/pkgs/development/tools/quickstack/default.nix
+++ b/pkgs/development/tools/quickstack/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, lib, fetchFromGitHub, fetchpatch, cmake, pkg-config, libiberty, libelf, binutils-unwrapped, zlib }:
+stdenv.mkDerivation {
+  pname = "quickstack";
+  version = "unstable-2021-01-26";
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [ libiberty libelf binutils-unwrapped zlib ];
+
+  src = fetchFromGitHub {
+    owner = "yoshinorim";
+    repo = "quickstack";
+    rev = "b853629a55fb7494b40c3bc52c743b428c73e39e";
+    sha256 = "1jzl37rmipk8n9s5sl8xrp1bhxgc0607qcpn74px0dli2xm9cvb2";
+  };
+
+  patches = [
+    (fetchpatch {
+      # Submitted upstream: https://github.com/yoshinorim/quickstack/pull/14
+      name = "find-deps-better.patch";
+      url = "https://github.com/lheckemann/quickstack/commit/c6bc165e6ea3c03af8769f216f9f437d9021257b.patch";
+      sha256 = "sha256-uCG75XAQQLcnye9S/MeIP77xhIVFOrF5MIni0941LVs=";
+    })
+  ];
+
+  meta = {
+    description = "Tool for low-overhead stack traces";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.lheckemann ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10191,6 +10191,8 @@ with pkgs;
 
   quickbms = pkgsi686Linux.callPackage ../tools/archivers/quickbms { };
 
+  quickstack = pkgs.callPackage ../development/tools/quickstack { };
+
   q-text-as-data = callPackage ../tools/misc/q-text-as-data { };
 
   qalculate-gtk = callPackage ../applications/science/math/qalculate-gtk { };


### PR DESCRIPTION
###### Description of changes

Draft, since I'm not sure I'll be using this enough to be able to maintain it, in hopes that anyone else who wants it can start from here and not from scratch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
