### PR TITLE
dolphin-emu-beta: fix darwin build

### DIFF
--- a/pkgs/applications/emulators/dolphin-emu/master.nix
+++ b/pkgs/applications/emulators/dolphin-emu/master.nix
@@ -1,12 +1,60 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, cmake
-, wrapQtAppsHook, qtbase, bluez, ffmpeg, libao, libGLU, libGL, pcre, gettext
-, libXrandr, libusb1, libpthreadstubs, libXext, libXxf86vm, libXinerama
-, libSM, libXdmcp, readline, openal, udev, libevdev, portaudio, curl, alsa-lib
-, miniupnpc, enet, mbedtls, soundtouch, sfml, xz, writeScript
-, vulkan-loader ? null, libpulseaudio ? null
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, cmake
+, wrapQtAppsHook
+, qtbase
+, bluez
+, ffmpeg
+, libao
+, libGLU
+, libGL
+, pcre
+, gettext
+, libXrandr
+, libusb1
+, libpthreadstubs
+, libXext
+, libXxf86vm
+, libXinerama
+, libSM
+, libXdmcp
+, readline
+, openal
+, udev
+, libevdev
+, portaudio
+, curl
+, alsa-lib
+, miniupnpc
+, enet
+, mbedtls
+, soundtouch
+, sfml
+, xz
+, hidapi
+, fmt_8
+, vulkan-loader
+, libpulseaudio
+, bzip2
 
-# - Inputs used for Darwin
-, CoreBluetooth, ForceFeedback, IOKit, OpenGL, libpng, hidapi }:
+  # Used in passthru
+, testers
+, dolphin-emu-beta
+, writeShellScript
+, common-updater-scripts
+, jq
+
+  # Darwin-only dependencies
+, CoreBluetooth
+, ForceFeedback
+, IOKit
+, VideoToolbox
+, OpenGL
+, libpng
+, moltenvk
+}:
 
 stdenv.mkDerivation rec {
   pname = "dolphin-emu";
@@ -20,18 +68,62 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  nativeBuildInputs = [ cmake pkg-config ]
-  ++ lib.optional stdenv.isLinux wrapQtAppsHook;
+  patches = [
+    # On x86_64-darwin CMake reportedly does not work without this in some cases.
+    # See https://github.com/NixOS/nixpkgs/pull/190373#issuecomment-1241310765
+    ./minizip-external-missing-include.patch
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    wrapQtAppsHook
+  ];
 
   buildInputs = [
-    curl ffmpeg libao libGLU libGL pcre gettext libpthreadstubs libpulseaudio
-    libXrandr libXext libXxf86vm libXinerama libSM readline openal libXdmcp
-    portaudio libusb1 libpng hidapi miniupnpc enet mbedtls soundtouch sfml xz
+    curl
+    ffmpeg
+    libao
+    libGLU
+    libGL
+    pcre
+    gettext
+    libpthreadstubs
+    libpulseaudio
+    libSM
+    readline
+    openal
+    portaudio
+    libusb1
+    libpng
+    hidapi
+    miniupnpc
+    enet
+    mbedtls
+    soundtouch
+    sfml
+    xz
     qtbase
+    fmt_8
+    bzip2
   ] ++ lib.optionals stdenv.isLinux [
-    bluez udev libevdev alsa-lib vulkan-loader
+    libXrandr
+    libXext
+    libXxf86vm
+    libXinerama
+    libXdmcp
+    bluez
+    udev
+    libevdev
+    alsa-lib
+    vulkan-loader
   ] ++ lib.optionals stdenv.isDarwin [
-    CoreBluetooth OpenGL ForceFeedback IOKit
+    CoreBluetooth
+    OpenGL
+    ForceFeedback
+    IOKit
+    VideoToolbox
+    moltenvk
   ];
 
   cmakeFlags = [
@@ -42,6 +134,12 @@ stdenv.mkDerivation rec {
     "-DDOLPHIN_WC_BRANCH=master"
   ] ++ lib.optionals stdenv.isDarwin [
     "-DOSX_USE_DEFAULT_SEARCH_PATH=True"
+    "-DUSE_BUNDLED_MOLTENVK=OFF"
+    # Bundles the application folder into a standalone executable, so we cannot devendor libraries
+    "-DSKIP_POSTPROCESS_BUNDLE=ON"
+    # Needs xcode so compilation fails with it enabled. We would want the version to be fixed anyways.
+    # Note: The updater isn't available on linux, so we dont need to disable it there.
+    "-DENABLE_AUTOUPDATE=OFF"
   ];
 
   qtWrapperArgs = lib.optionals stdenv.isLinux [
@@ -51,10 +149,10 @@ stdenv.mkDerivation rec {
     "--set QT_QPA_PLATFORM xcb"
   ];
 
-  # - Allow Dolphin to use nix-provided libraries instead of building them
   postPatch = ''
     sed -i -e 's,DISTRIBUTOR "None",DISTRIBUTOR "NixOS",g' CMakeLists.txt
   '' + lib.optionalString stdenv.isDarwin ''
+    # Allow Dolphin to use nix-provided libraries instead of submodules
     sed -i -e 's,if(NOT APPLE),if(true),g' CMakeLists.txt
     sed -i -e 's,if(LIBUSB_FOUND AND NOT APPLE),if(LIBUSB_FOUND),g' \
       CMakeLists.txt
@@ -62,26 +160,43 @@ stdenv.mkDerivation rec {
 
   postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
     install -D $src/Data/51-usb-device.rules $out/etc/udev/rules.d/51-usb-device.rules
+  '' + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # Only gets installed automatically if the standalone executable is used
+    mkdir -p $out/Applications
+    cp -r ./Binaries/Dolphin.app $out/Applications
+    ln -s $out/Applications/Dolphin.app/Contents/MacOS/Dolphin $out/bin
   '';
 
 
-  passthru.updateScript = writeScript "dolphin-update-script" ''
-    #!/usr/bin/env nix-shell
-    #!nix-shell -i bash -p curl jq common-updater-scripts
-    set -eou pipefail
-    json="$(curl -s https://dolphin-emu.org/update/latest/beta)"
-    version="$(jq -r '.shortrev' <<< "$json")"
-    rev="$(jq -r '.hash' <<< "$json")"
-    update-source-version dolphin-emu-beta "$version" --rev="$rev"
-  '';
+  passthru = {
+    tests.version = testers.testVersion {
+      package = dolphin-emu-beta;
+      command = "dolphin-emu-nogui --version";
+    };
+
+    updateScript = writeShellScript "dolphin-update-script" ''
+      set -eou pipefail
+      export PATH=${lib.makeBinPath [ curl jq common-updater-scripts ]}
+
+      json="$(curl -s https://dolphin-emu.org/update/latest/beta)"
+      version="$(jq -r '.shortrev' <<< "$json")"
+      rev="$(jq -r '.hash' <<< "$json")"
+      update-source-version dolphin-emu-beta "$version" --rev="$rev"
+    '';
+  };
 
   meta = with lib; {
     homepage = "https://dolphin-emu.org";
     description = "Gamecube/Wii/Triforce emulator for x86_64 and ARMv8";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ MP2E ashkitten xfix ];
     branch = "master";
-    broken = stdenv.isDarwin;
+    mainProgram = "Dolphin";
     platforms = platforms.unix;
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [
+      MP2E
+      ashkitten
+      xfix
+      ivar
+    ];
   };
 }

--- a/pkgs/applications/emulators/dolphin-emu/minizip-external-missing-include.patch
+++ b/pkgs/applications/emulators/dolphin-emu/minizip-external-missing-include.patch
@@ -1,0 +1,18 @@
+commit 5e0cb8066fb1653399c54e93e42375295c2562bd
+Author: Ivar Scholten <ivar.scholten@protonmail.com>
+Date:   Fri Sep 9 14:27:55 2022 +0200
+
+    Externals/minizip: add missing include to CheckFunctionExists
+
+diff --git a/Externals/minizip/CMakeLists.txt b/Externals/minizip/CMakeLists.txt
+index c3d7c5512e..f59f8b295c 100644
+--- a/Externals/minizip/CMakeLists.txt
++++ b/Externals/minizip/CMakeLists.txt
+@@ -60,6 +60,7 @@ if (HAVE_INTTYPES_H)
+   target_compile_definitions(minizip PRIVATE HAVE_INTTYPES_H)
+ endif()
+
++include(CheckFunctionExists)
+ check_function_exists(fseeko HAVE_FSEEKO)
+ if (NOT HAVE_FSEEKO)
+   target_compile_definitions(minizip PRIVATE NO_FSEEKO)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1657,7 +1657,8 @@ with pkgs;
   dolphin-emu = callPackage ../applications/emulators/dolphin-emu { };
 
   dolphin-emu-beta = qt5.callPackage ../applications/emulators/dolphin-emu/master.nix {
-    inherit (darwin.apple_sdk.frameworks) CoreBluetooth ForceFeedback IOKit OpenGL;
+    inherit (darwin.apple_sdk.frameworks) CoreBluetooth ForceFeedback IOKit OpenGL VideoToolbox;
+    inherit (darwin) moltenvk;
   };
 
   dolphin-emu-primehack = qt5.callPackage ../applications/emulators/dolphin-emu/primehack.nix {


### PR DESCRIPTION
###### Description of changes

This fixes `dolphin-emu-beta` on darwin, everything seems to work in my tests. 

Things done:
* Ran `nixpkgs-fmt` on the derivation, the inputs being more spaced out will make it easier to read future diffs.
* Disabled the auto-updater, which requires XCode to compile. We'd want our version to be fixed anyways.
* Disabled generating a standalone executable instead of a regular application bundle, this would mean we cannot devendor libraries and because of that increase closure size by a massive amount.
* Enabled `wrapQtAppsHook` on darwin, without it icons do not show up.
* Added some new darwin-only dependencies that seem to be required now. `fmt_8` was added for both platforms, the version from the submodules fails to compile on darwin and i figured devendoring would be nice on linux too.
* Added myself as a maintainer.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and “core” functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
