### PR TITLE
imtui: init at 1.0.5

### DIFF
--- a/pkgs/development/libraries/imtui/default.nix
+++ b/pkgs/development/libraries/imtui/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, imgui
+, ninja
+, withEmscripten ? false, emscripten
+, withCurl ? (!withEmscripten), curl
+, withNcurses ? (!withEmscripten), ncurses
+, static ? withEmscripten
+}:
+
+stdenv.mkDerivation rec {
+  pname = "imtui";
+  version = "1.0.5";
+
+  src = fetchFromGitHub {
+    owner = "ggerganov";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-eHQPDEfxKGLdiOi0lUUgqJcmme1XJLSPAafT223YK+U=";
+  };
+
+  nativeBuildInputs = [ cmake ninja ];
+
+  buildInputs = lib.optional withEmscripten emscripten
+    ++ lib.optional withCurl curl
+    ++ lib.optional withNcurses ncurses;
+
+  postPatch = ''
+    cp -r ${imgui}/include/imgui third-party/imgui
+  '';
+
+  cmakeFlags = [
+    "-DEMSCRIPTEN:BOOL=${if withEmscripten then "ON" else "OFF"}"
+    "-DIMTUI_SUPPORT_CURL:BOOL=${if withCurl then "ON" else "OFF"}"
+    "-DIMTUI_SUPPORT_NCURSES:BOOL=${if withNcurses then "ON" else "OFF"}"
+    "-DBUILD_SHARED_LIBS:BOOL=${if (!static) then "ON" else "OFF"}"
+    "-DIMTUI_BUILD_EXAMPLES:BOOL=OFF"
+    "-DIMTUI_INSTALL_IMGUI_HEADERS:BOOL=OFF"
+  ];
+
+  postInstall = ''
+    rm -rf $out/include/imgui
+  '';
+
+  meta = with lib; {
+    description = "Immediate mode text-based user interface library";
+    longDescription = ''
+      ImTui is an immediate mode text-based user interface library. Supports 256
+      ANSI colors and mouse/keyboard input.
+    '';
+    homepage = "https://imtui.ggerganov.com";
+    changelog = "https://github.com/ggerganov/imtui/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ azahi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18820,6 +18820,8 @@ with pkgs;
 
   imgui = callPackage ../development/libraries/imgui { };
 
+  imtui = callPackage ../development/libraries/imtui { };
+
   imlib = callPackage ../development/libraries/imlib {
     libpng = libpng12;
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
