### PR TITLE
Fix more fetchzip fallouts

### DIFF
--- a/pkgs/data/fonts/atkinson-hyperlegible/default.nix
+++ b/pkgs/data/fonts/atkinson-hyperlegible/default.nix
@@ -12,8 +12,10 @@ in fetchFromGitHub {
   sha256 = "sha256-urSTqC3rfDRM8IMG+edwKEe7NPiTuDZph3heGHzLDks=";
 
   postFetch = ''
-    tar xf $downloadedFile --strip=1
-    install -Dm644 -t $out/share/fonts/opentype fonts/otf/*
+    install -Dm644 -t $out/share/fonts/opentype $out/fonts/otf/*
+    shopt -s extglob dotglob
+    rm -rf $out/!(share)
+    shopt -u extglob dotglob
   '';
 
   meta = with lib; {

--- a/pkgs/data/fonts/hermit/default.nix
+++ b/pkgs/data/fonts/hermit/default.nix
@@ -8,9 +8,12 @@ in fetchzip rec {
 
   url = "https://pcaro.es/d/otf-${name}.tar.gz";
 
+  stripRoot = false;
   postFetch = ''
-    tar xf $downloadedFile
-    install -m444 -Dt $out/share/fonts/opentype *.otf
+    install -m444 -Dt $out/share/fonts/opentype $out/*.otf
+    shopt -s extglob dotglob
+    rm -rf $out/!(share)
+    shopt -u extglob dotglob
   '';
   sha256 = "127hnpxicqya7v1wmzxxqafq3aj1n33i4j5ncflbw6gj5g3bizwl";
 

--- a/pkgs/data/misc/publicsuffix-list/default.nix
+++ b/pkgs/data/misc/publicsuffix-list/default.nix
@@ -11,8 +11,10 @@ in fetchFromGitHub {
   sha256 = "sha256-Q8uIXM1CMu8dlWcVoL17M1XRGu3kG7Y7jpx0oHQh+2I=";
 
   postFetch = ''
-    tar xf $downloadedFile --strip=1
-    install -Dm0444 public_suffix_list.dat tests/test_psl.txt -t $out/share/publicsuffix
+    install -Dm0444 $out/public_suffix_list.dat $out/tests/test_psl.txt -t $out/share/publicsuffix
+    shopt -s extglob dotglob
+    rm -rf $out/!(share)
+    shopt -u extglob dotglob
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes some more fallouts from #173430 without hash changes. Closes #178825.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
