### PR TITLE
ocamlPackages.lambdapi: init at 2.2.1

### DIFF
--- a/pkgs/development/ocaml-modules/bindlib/default.nix
+++ b/pkgs/development/ocaml-modules/bindlib/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, fetchFromGitHub
+, buildDunePackage
+, earley
+, timed
+}:
+
+buildDunePackage rec {
+  pname = "bindlib";
+  version = "6.0.0";
+
+  minimalOCamlVersion = "4.07";
+
+  src = fetchFromGitHub {
+    owner = "rlepigre";
+    repo = "ocaml-${pname}";
+    rev = version;
+    hash = "sha256-058yMbz9ExvgNG/kY9tPk70XSeVRSSKVg4n4F4fmPu4=";
+  };
+
+  checkInputs = [ earley timed ];
+  doCheck = true;
+
+  meta = with lib; {
+    homepage = "https://rlepigre.github.io/ocaml-bindlib";
+    description = "Efficient binder representation in Ocaml";
+    license = licenses.gpl3;
+    changelog = "https://github.com/rlepigre/ocaml-bindlib/raw/${version}/CHANGELOG.md";
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/ocaml-modules/dedukti/default.nix
+++ b/pkgs/development/ocaml-modules/dedukti/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, fetchFromGitHub
+, buildDunePackage
+, cmdliner_1_1
+, menhir
+}:
+
+buildDunePackage rec {
+  pname = "dedukti";
+  version = "2.7";
+
+  minimalOCamlVersion = "4.08";
+
+  src = fetchFromGitHub {
+    owner = "Deducteam";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-SFxbgq2znO+OCEFzuekVquvtOEuCQanseKy+iZAeWbc=";
+  };
+
+  nativeBuildInputs = [ menhir ];
+  buildInputs = [ cmdliner_1_1 ];
+
+  doCheck = false;  # requires `tezt`
+
+  meta = with lib; {
+    homepage = "https://deducteam.github.io";
+    description = "Logical framework based on the λΠ-calculus modulo rewriting";
+    license = licenses.cecill-b;
+    changelog = "https://github.com/Deducteam/Dedukti/raw/${version}/CHANGELOG.md";
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/ocaml-modules/lambdapi/default.nix
+++ b/pkgs/development/ocaml-modules/lambdapi/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, fetchFromGitHub
+, buildDunePackage
+, alcotest
+, dedukti
+, bindlib
+, camlp-streams
+, cmdliner_1_1
+, menhir
+, pratter
+, sedlex
+, stdlib-shims
+, timed
+, why3
+, yojson
+}:
+
+buildDunePackage rec {
+  pname = "lambdapi";
+  version = "2.2.1";
+
+  minimalOCamlVersion = "4.08";
+
+  src = fetchFromGitHub {
+    owner = "Deducteam";
+    repo = pname;
+    rev = version;
+    hash = "sha256-p2ZjSfiZwkf8X4fSNJx7bAVpTFl4UBHIEANIWF7NGCs=";
+  };
+
+  nativeBuildInputs = [ menhir ];
+  propagatedBuildInputs = [
+    bindlib camlp-streams cmdliner_1_1 pratter sedlex stdlib-shims timed why3 yojson
+  ];
+
+  checkInputs = [ alcotest dedukti ];
+  doCheck = false;  # "Error: Unbound module Cmd"
+
+  meta = with lib; {
+    homepage = "https://github.com/Deducteam/lambdapi";
+    description = "Proof assistant based on the λΠ-calculus modulo rewriting";
+    license = licenses.cecill21;
+    changelog = "https://github.com/Deducteam/lambdapi/raw/${version}/CHANGES.md";
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/ocaml-modules/pratter/default.nix
+++ b/pkgs/development/ocaml-modules/pratter/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, fetchFromGitHub
+, buildDunePackage
+, camlp-streams
+, alcotest
+, qcheck
+, qcheck-alcotest
+}:
+
+buildDunePackage rec {
+  version = "2.0.0";
+  pname = "pratter";
+
+  minimalOCamlVersion = "4.08";
+
+  src = fetchFromGitHub {
+    owner = "gabrielhdt";
+    repo = "pratter";
+    rev = version;
+    hash = "sha256-QEq8Zt2pfsRT04Zd+ugGKcHdzkqYcDDUg/iAFMMDdEE=";
+  };
+
+  propagatedBuildInputs = [ camlp-streams ];
+
+  checkInputs = [ alcotest qcheck qcheck-alcotest ];
+  doCheck = true;
+
+  meta = with lib; {
+    description = "An extended Pratt parser";
+    homepage = "https://github.com/gabrielhdt/pratter";
+    license = licenses.bsd3;
+    changelog = "https://github.com/gabrielhdt/pratter/raw/${version}/CHANGELOG.md";
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/ocaml-modules/timed/default.nix
+++ b/pkgs/development/ocaml-modules/timed/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, fetchFromGitHub
+, ocaml
+, buildDunePackage
+}:
+
+buildDunePackage rec {
+  version = "1.1";
+  pname = "timed";
+
+  minimalOCamlVersion = "4.08";
+
+  src = fetchFromGitHub {
+    owner = "rlepigre";
+    repo = "ocaml-${pname}";
+    rev = version;
+    sha256 = "sha256-wUoI9j/j0IGYW2NfJHmyR2XEYfYejyoYLWnKsuWdFas=";
+  };
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Timed references for imperative state";
+    homepage = "https://github.com/rlepigre/ocaml-timed";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1175,6 +1175,8 @@ let
 
     ppxlib = callPackage ../development/ocaml-modules/ppxlib { };
 
+    pratter = callPackage ../development/ocaml-modules/pratter { };
+
     psmt2-frontend = callPackage ../development/ocaml-modules/psmt2-frontend { };
 
     psq = callPackage ../development/ocaml-modules/psq { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1221,6 +1221,8 @@ let
 
     tcpip = callPackage ../development/ocaml-modules/tcpip { };
 
+    timed = callPackage ../development/ocaml-modules/timed { };
+
     tiny_httpd = callPackage ../development/ocaml-modules/tiny_httpd { };
 
     tsort = callPackage ../development/ocaml-modules/tsort { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -284,6 +284,8 @@ let
 
     decompress =  callPackage ../development/ocaml-modules/decompress { };
 
+    dedukti =  callPackage ../development/ocaml-modules/dedukti { };
+
     diet =  callPackage ../development/ocaml-modules/diet { };
 
     digestif =  callPackage ../development/ocaml-modules/digestif { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -696,6 +696,8 @@ let
 
     ladspa = callPackage ../development/ocaml-modules/ladspa { };
 
+    lambdapi = callPackage ../development/ocaml-modules/lambdapi { };
+
     lambdasoup = callPackage ../development/ocaml-modules/lambdasoup { };
 
     lambda-term = callPackage ../development/ocaml-modules/lambda-term { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -78,6 +78,8 @@ let
 
     bigstring = callPackage ../development/ocaml-modules/bigstring { };
 
+    bindlib = callPackage ../development/ocaml-modules/bindlib { };
+
     biocaml = callPackage ../development/ocaml-modules/biocaml { };
 
     bistro = callPackage ../development/ocaml-modules/bistro { };


### PR DESCRIPTION
ocamlPackages.pratter: init at 2.0.0
ocamlPackages.dedukti: init at 2.7
ocamlPackages.bindlib: init at 6.0.0
ocamlPackages.timed: init at 1.1

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [NA] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
