### PR TITLE
thunderbird*: 102.2.1 -> 102.2.2

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,665 +1,665 @@
 {
-  version = "102.2.1";
+  version = "102.2.2";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/af/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/af/thunderbird-102.2.2.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "d38c09e55cf1438269d80461672a615c155e975d65c8c35f5879f4236702c9eb";
+      sha256 = "81f0274a9358a25a70589923a114d92452f2f693490e93ebdf65efa955c6e36a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/ar/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/ar/thunderbird-102.2.2.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "881eb9bafcea2646ab0830cc5a7d3ed2979b0e745ddb7a018336ed7b8382e491";
+      sha256 = "27ebc77615606d1b7c3c2a2d5f9a3b1cf5343c7f17fa127467a410c02336780e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/ast/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/ast/thunderbird-102.2.2.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "17cba24fa82d4b3a16be5d44ea9be4b7bb1aff4b206841d5eb169815951a9f7f";
+      sha256 = "05cf9d371640de3421c42ea464f6de6bdb1bc4eaff6ee43bbcff82513d034776";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/be/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/be/thunderbird-102.2.2.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "271b5d606fc489918cec8d8d316f0b8cf295a296b95a1dd458dd0b7f68fe148b";
+      sha256 = "9c85da8f62f1300462c2bad9d19988c17ef7cc1bf093703b3c8d695c1049b832";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/bg/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/bg/thunderbird-102.2.2.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "1e68a8cd66f72712f74bc3735af6c0016256ebfe1c7c2e820624268ed8837350";
+      sha256 = "3235edcae2382d6198fa66ac2c03f4e01fbf0890c7dc944921abfadb38e8303d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/br/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/br/thunderbird-102.2.2.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "82ab077f9a5f43875c6c82ad7d0e17f9c0b893e0bf307574fa8506e3220c8604";
+      sha256 = "0c690d54d04b585f106d2ebf47aec2643ef730dff513ee3ef20d7d5ce884bfce";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/ca/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/ca/thunderbird-102.2.2.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "2ed8291572dbfaee211f5b9fdb97d4faa591f853815d9eaa43b704270551b02e";
+      sha256 = "814820aada02f77ac7f7bbf46488269b12f4112bd0d27820ec4cfbe9b07195e7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/cak/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/cak/thunderbird-102.2.2.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "a5e472616951c799e6dbbdfedc3e8ba497812b027ab22c909166c3e452a29d74";
+      sha256 = "12bfe570291becd5aa074be7dacba8f6b01068d9046e0c35aa0016cd7487b198";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/cs/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/cs/thunderbird-102.2.2.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "1d3d1e0355275152050a0c5d32fc0b0f6b53f336d02837ca7653416888e271b5";
+      sha256 = "dbabd84e1380447fdd7435362fcdc0daf60af718693381336195d31790cd2331";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/cy/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/cy/thunderbird-102.2.2.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "4b2f3cc7e1e81abdc52969cd08cd3586e14ea2ff574c8c3b334109dab00ccd64";
+      sha256 = "2817bb295ea0f6d180dcdaed2e5152b1e89e25eb9d12eaebae6f5d74b7e9c06a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/da/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/da/thunderbird-102.2.2.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "89613187e078a6f341ad8799cb4980cca770b2a0ccb0969740f53e5e7073f00b";
+      sha256 = "de91ba53ab1a416c5326611930c4b8031e9f7038791164e08ec9079ae49a6111";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/de/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/de/thunderbird-102.2.2.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "4b7a030cb532a94a6eb3cc1343144bb90abcb7b2fcd3df81dc126b831d0a2740";
+      sha256 = "547576de35e0e7950d0d1150167e4bba6d7802abe498c97324fd3856a0d0eb51";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/dsb/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/dsb/thunderbird-102.2.2.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "e1d05cac1f513ba573239dd677da6edb94cda9badef57b168f498b5bc218a3ee";
+      sha256 = "e64baa142d019eacf84ed9a30ca9490a7aa34cc647774f4b4be4eb9e852875da";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/el/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/el/thunderbird-102.2.2.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "d63891c05b56970021fdc455fe67d2d6f27233670e436b52522cfd012c503c74";
+      sha256 = "e04c18427b47eda0583e62ec88a07bcba8b625d47762e355bbba0b5dd81807fe";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/en-CA/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/en-CA/thunderbird-102.2.2.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "34c81ec572000433e356ec5f13dbe461ca788b19ca0af9fc34ab50d7feda9cd1";
+      sha256 = "cbb9ab2c74fa24e70be67defd94ea4777f7d4f45ba4e6f6074915dcb72756c43";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/en-GB/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/en-GB/thunderbird-102.2.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "2e9aeef97495ebe462a62cfd0d9966b66cdf0a0464a8d5d012cf3d430b4a28cb";
+      sha256 = "8b86fa495e54a99ef5bba2d6f1b507138ac85a5425e88f2e568e82501337b679";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/en-US/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/en-US/thunderbird-102.2.2.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "92883c21319411096c355569c43b6cae2cbe7770c1814a9997ea7b9746431271";
+      sha256 = "a406c23d5e7cc372d68cd5d08f3c86c611fcb63a9b78a944e3e1a048fcb6dbec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/es-AR/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/es-AR/thunderbird-102.2.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "51730734c71b67ffc865646453fec802e92852fd9ab7eb371d31d9c3e843f810";
+      sha256 = "831b31ce85bb7668befc8eed476befad689805c1ca5b2393ff433a391e2069bb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/es-ES/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/es-ES/thunderbird-102.2.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "c61667e937b15fdb22e03b7875a474e422069800780df73529b6811cdb384824";
+      sha256 = "5e942c3308489d73f3c2f3a923d5fd4e8712e0b10f5a9d4e785b743afb92ffdf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/es-MX/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/es-MX/thunderbird-102.2.2.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "7c5a404101f20fd9624c5402e8ba2c0699986739302de5739ad3304e2ea234f6";
+      sha256 = "eb0ba009a05c402c215ca04bc32ca85e130fb26feb16d8f484dd5a6780f2d0ad";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/et/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/et/thunderbird-102.2.2.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "5fb2498c2a7e1a76512ace5421bfff47a1ef336cf95f671e85188dce7c8fea78";
+      sha256 = "1020c72f7316ee97510b7f6d8cceea49753f3f00d33cf33f6246abb492eca0ca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/eu/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/eu/thunderbird-102.2.2.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "0eb3f3ca7e23e950ebafbdb6d4f4200279cc8e18a042a91ad163eb83c939c704";
+      sha256 = "2c95c74fdb3115d2ac41b5ddf5fba8da63fb0946b87d1bc77740298ca55c0b40";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/fi/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/fi/thunderbird-102.2.2.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "ae76c531ac5b826593310b2b4b2e01d877dd246379a7ae8427f6039eb5dd581f";
+      sha256 = "0407e22920c7830d9f4214a6e42cd85fbbeff2c2422c3c9c10d5ec7330f4795f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/fr/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/fr/thunderbird-102.2.2.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "3b344b3348487c393ea72012eb6fd82dd647e31cb1dd0c305dbe6aafa8438c53";
+      sha256 = "8a3da1833d1088d87ef9a73e1dcdd875b0db5aa57bba659c7423e6a9052beb9d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/fy-NL/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/fy-NL/thunderbird-102.2.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "3143c39b7e3aac2d90e6d68e2d1f782a306fdabd69641a4aa31afd02b6cd172f";
+      sha256 = "880e2585652b91265030345cb4bcf8aebbc5361a49d31edbe0a193b954df5214";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/ga-IE/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/ga-IE/thunderbird-102.2.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "db877b69e105c8d14b6ff420448712eafbaf6580a13fd415eb5112930a8633b8";
+      sha256 = "e19acf7c7e3013cb39114615ad19dbc28d62b9b538d0cdffda44f50c4e105781";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/gd/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/gd/thunderbird-102.2.2.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "3025fcddde35315267b3f0cc9d57696c5462bbe6705fb26b7a1be1eb670ca984";
+      sha256 = "c4ac7117cad296e84aece7868d8747f7d70b9a5a94f2a7b2c7eb4711790dc5c5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/gl/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/gl/thunderbird-102.2.2.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "39469544764d5607d73d3ffc0eafbcd2117072b2af6dba1a4a7ab43c3af2eb75";
+      sha256 = "b8a73f3349113154a2b330b44570138e0a715c0452058034ac33cdde1cd1d896";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/he/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/he/thunderbird-102.2.2.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "52c67f10bda950e12822207d41c6b425079d29f0d1d5654bb10b6e1d88751828";
+      sha256 = "6a26ca35bec64b24d71d50e5c2bdf2139e442768a89153169d33ce8ba6b31d2c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/hr/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/hr/thunderbird-102.2.2.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "e584a8f724d8e337743f9ad22e637089c5771c082091e221aad55b97541e0c16";
+      sha256 = "3c2010dd691155bd1f3184870905994a58f70e7911b5ab51496cfe6ae89597e6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/hsb/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/hsb/thunderbird-102.2.2.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "0304b06dd0f23ca59f85e34e3068cd9ac3275c815e2e2004358540b38cf058c9";
+      sha256 = "6adb0e04a8a3c9104f343ad6365acd2889499fbca192b80ff86652636d09a3b7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/hu/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/hu/thunderbird-102.2.2.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "ef155776003ddccfe863e920f31b45f673ef445c01556d69b6ed086561a74768";
+      sha256 = "a46951b9a21b804685024ada9f386b6d81393bc66516affe2abf996d88835f40";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/hy-AM/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/hy-AM/thunderbird-102.2.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "c65a335777b3cd9ab95b14007a9b6f10304b17c267388889a7f299ea61c44fbf";
+      sha256 = "37f04ccbe1a0ab6a2e25118aaf50186e2555f186f0d8a1b3352caa9b6158ee18";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/id/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/id/thunderbird-102.2.2.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "a407cd50ed7b4fce63b2607632a82c4e9b853b76ba522a564aae219afd0034ed";
+      sha256 = "9e754ea12d18fb9257712a95a93883685bc0afc3be1ebaec03d3aee5c2960efc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/is/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/is/thunderbird-102.2.2.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "6035248bcfde9fea269fa10ff3a87f035e3552b8cf76c10dfc86dd889cc7e958";
+      sha256 = "c046d691e9a11b59ec8dcb325ed072a47e7e447e2abe06a8e52e280879d38386";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/it/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/it/thunderbird-102.2.2.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "afeef80077a18120cff1854d54067ccbc92b30f9c0e75b41067ec1e398340eb9";
+      sha256 = "6d3e7bd4eaec2b8a88bebf883ade76be411a073f9c12ec0a9bb3c66cc9981e8b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/ja/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/ja/thunderbird-102.2.2.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "1d98a3c50d1aff70bec9ae9335708a85cf4458fbe0ff49db45a57f4d29614de4";
+      sha256 = "5400f7453a76a5c761b8c22b4f50d444bd8112c3afe3a43b0e6338cfda4fe56e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/ka/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/ka/thunderbird-102.2.2.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "5c749efe25f328be5f17ba2b2eeda41af0ce69f0f3e9cbc8bb55d58a3990d99a";
+      sha256 = "840cc16f368ebc3e6aa357ce3b41bacbafdccb510729fae8f1b76fc1c5bfb621";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/kab/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/kab/thunderbird-102.2.2.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "93b93383e4bad3b4f930bcbc35d178639a50fd7a30eaac573bc74b895955ec5a";
+      sha256 = "c67e24314357d8f2d1e857339c234dbb1813e1ba4df0e107d25f3aefefebcac2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/kk/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/kk/thunderbird-102.2.2.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "298e2c42888f29b90fdc6589b6336c5c2261a5331f5d52db89ee5b6618ec120f";
+      sha256 = "5b23cacf902762ec8f90536e3f1cb951077d674495fbfa3764707197dc413d89";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/ko/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/ko/thunderbird-102.2.2.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "75625d041a0193cfd8015174a1eaddd7315f3030258e58828df4b3521863bba8";
+      sha256 = "1c236ec1fe62e2e7969a4821aaad80a143347a5b775ea8ebb75b51c08c2acc80";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/lt/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/lt/thunderbird-102.2.2.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "c5705caf0c71efb566a0d1828ec36e940940eeee23d37b9d66246abbb28114bc";
+      sha256 = "ec59fae4f57313a4bb4ea9009369af1f12ad82e24f9013c8b34a73fc41762713";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/lv/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/lv/thunderbird-102.2.2.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "d26ea9198e8d5e9ae5f51fa2456181bd979694d7bc9bcab8f3a82c01233760d6";
+      sha256 = "99828bf55cf13781efbaac4e0e99d42b669bd9be0f78302fd69efb6270dd225f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/ms/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/ms/thunderbird-102.2.2.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "6dca09cd5f9306d102bca42d01607b63e1219324d1107447a728bab8693aeb8b";
+      sha256 = "f8f6c88e562650d9c19988ad9bb878fec1c79af5a163beff1693a203f79341c9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/nb-NO/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/nb-NO/thunderbird-102.2.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "8d2a62dd4ccade7544ecfc6a4f88bd354f70089cf161f2fe92aeb9886e6f6411";
+      sha256 = "cbdab2fcf1bfd0dcac3c1e0e988bce513d789f6bba8e1b7cc65db1cf997b36d2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/nl/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/nl/thunderbird-102.2.2.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "b82895cfc2058be4b7818ea17521deb014a17659ddb57c093cbdc26ab3e7f7cb";
+      sha256 = "d8b3e422b7aa8baf63f4f8b057c57aa824e5e0b9cf9588f0076567cc2ef70559";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/nn-NO/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/nn-NO/thunderbird-102.2.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "aea319db70387a2f075776fcf07b29e433ca16f898af70689d9cd4ed9d98d52f";
+      sha256 = "7b5eff29d874d33f07ea5e38b51fe1d0c2451b9d07ee9eea164ace136e6c86c3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/pa-IN/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/pa-IN/thunderbird-102.2.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "02c366563dd39f64ae11f9377c62434291aaedd951cea43e867a236dcd99dc2d";
+      sha256 = "ddee5093d6caccfe6f8666efc4978194302beea23396c7884c18144b077934c5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/pl/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/pl/thunderbird-102.2.2.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "5e2b8d486eacda9a8913e0ab60e2c4079d3fb89e827ca1fba871f2b6295c6cbc";
+      sha256 = "ca14c3d7061aa0c0cc65651b21d10a83f375b730ca9d372095408e729d8e31dd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/pt-BR/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/pt-BR/thunderbird-102.2.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "83339737a6ff360f1036a5b11b56f6d6648011f0c206a13da2b557aa85f4e2a0";
+      sha256 = "0d4801320dd611ef12a858e0f1da9ba1077634d73c510c7660aebcfbec423ce7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/pt-PT/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/pt-PT/thunderbird-102.2.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "4950899b2da0a706f39767199ec412e9da2b670bf15c29153244c5eb3a317731";
+      sha256 = "a54938d91562d0fcab6875395b58f18dcc51f22727a289ecdf402f1cdc48639e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/rm/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/rm/thunderbird-102.2.2.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "d9030e30196b03c341b1fd9078447d9baf7542a119617494ea73d11192f194e0";
+      sha256 = "b9df55f6fb6268bc534e0a82636af2fbbb7e046b46c6134bd50abf37254671f5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/ro/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/ro/thunderbird-102.2.2.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "d3be25f071698102abc71b50d71253326a9201ff9db3e7935afdd27d728985e1";
+      sha256 = "6c2ce54a34d5a1a6e3e29431998955793dd49157db74679951f537f61fcbac74";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/ru/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/ru/thunderbird-102.2.2.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "f9a520adaca32180b01f18fb9b8280145075248378a4a1fd273c9687733cbf42";
+      sha256 = "fac401762dd4cd9ca5870064212fbf928d63751827446a6e5ea870fdbdde4aae";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/sk/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/sk/thunderbird-102.2.2.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "4045843feb9303bc65612d1060f874d21fdf39c0abadc84c84af0017b1fcee32";
+      sha256 = "928958768474f0fe3d081be979891ca54a162fc24d7e8e27930d9035d330ffaa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/sl/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/sl/thunderbird-102.2.2.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "d914ee5a953b4ec651e634d7c2b971987ccb2ebdd130dd3ee4ab3d0cae274f59";
+      sha256 = "a34dddb780a858e61a665661d1e2384cf853b431229689d860fef3622c9d0e0f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/sq/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/sq/thunderbird-102.2.2.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "2fd3128af2a55cae9a8adc248afcc9497d602f0d36cb2cd7ff51aaca1b064487";
+      sha256 = "fcae87e539cfa1b73ee78de3ca3d23a81d6b6cdaa81e22e819b07355b7112a2b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/sr/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/sr/thunderbird-102.2.2.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "2c5ffe0a8f4d431c37cb7f39fbd145937839425232aa72e173b88fa49628ded6";
+      sha256 = "524da643994d056e0ecc1eb5d241eb4cc906e71fe0c821cec5eef78cadf695c3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/sv-SE/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/sv-SE/thunderbird-102.2.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "e98429f73e6379ebfb2bf98f9396f86025e158543e664b2b219875964dae6e1c";
+      sha256 = "40ad15ecddd5d936da810f470faba93157c0b453503a48a83f7e69d2f6f742c9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/th/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/th/thunderbird-102.2.2.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "605a86e6be2eabd0ade653f93fe62e6ae47eb80951fa9c7ab9035d13bc22e52f";
+      sha256 = "b08db7a7a5f15aa7d0257858942f861457941b27e2ae2d73f0c65876c8fa2b11";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/tr/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/tr/thunderbird-102.2.2.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "51dfa4db80dd7596c24e6a0b67e1196d59b9083de63550862fccb6672535825a";
+      sha256 = "126defec4dbab1cb25f23899542166628201ecc1d80ed566b99e427f1ce6e6cb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/uk/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/uk/thunderbird-102.2.2.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "a6fcd5719501d801ed0e9f39ac100309945e567d535e6972791ca97c509131fd";
+      sha256 = "5b9af3defc3547caba361e3ebd460a3682a09a1207bac5abee08b67cb530d710";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/uz/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/uz/thunderbird-102.2.2.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "e4666827e963fd2180babba2a117425cadff2bf47674e30225ec4f046cde1adf";
+      sha256 = "af88cbbd45ae2c168c52d0d2f19d4940a4d448e4c3b68125eb359a2c6dbffb36";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/vi/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/vi/thunderbird-102.2.2.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "67cfdc9bb1753852250aeb523f2f91ec2fdfcab910ca1e38ac61e3922f281ee9";
+      sha256 = "dd6071e000258aae9406e7750238c96101a5280989a68b955b4ad3129a62768a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/zh-CN/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/zh-CN/thunderbird-102.2.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "f2bcca607b71c567f0ba3414e668e033633f05fff7404a1cd321d165172a36b6";
+      sha256 = "da9f27ff43aa88c9e394b75b246a27639ef51f95203e955d16d3075872b43c0e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-x86_64/zh-TW/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-x86_64/zh-TW/thunderbird-102.2.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "e827be51e3af98fd484bb82d387754e5375cb7a5749bd1b8d0401632172165ed";
+      sha256 = "57006f7eb829e7a2e8f6323bd01276e065b98da51a5b40e9d52c5fe057afe224";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/af/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/af/thunderbird-102.2.2.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "42e10d674f9bc1220a1ae08f5c20551ceb9030700991681b32df137fb1fbbda6";
+      sha256 = "45b8a62bfa3a1c4c0d33a9c6332c3db769d6262740fdf63523cdac6a73c877f1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/ar/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/ar/thunderbird-102.2.2.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "d5a6370d2e20fea976165cc0d84c13832b8ded075fefdc98f21e1ab530dc8624";
+      sha256 = "aa0c2fa1e459e3c7089fc0ca35c0abd259deca9f1a2dbea9a788f41e9bb9d927";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/ast/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/ast/thunderbird-102.2.2.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "19f2ac39f04b47fb2789b0c0df8b9e0634062bcd3f117cf2cf776a39d701ec7e";
+      sha256 = "7c6d00d2d4bc270159fe383001070192612c360b19307d3f30564b251740e8e8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/be/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/be/thunderbird-102.2.2.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "4e007951f445b5c9daf36523535db459e869b50b732a8e82f64b3c0d898c512f";
+      sha256 = "1834f3bff9a9e59a350c4da3fc9accc06e7948db4be13a888b5ffbf41bd3665f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/bg/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/bg/thunderbird-102.2.2.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "6430c82f5ebc4daa2fc099d54f0aacc1d680a4c603fe69fe117490d58d9c7af3";
+      sha256 = "77e09e97aa320c88c952a99ccf1f81b64374ed96dc124268baf138e0c41b9f1a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/br/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/br/thunderbird-102.2.2.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "84568e1ec4284d1f81cf5f5627de0e19db7a32f57cb621210df27f61178961ea";
+      sha256 = "256d12149eae5a9cd171f45b8fca86c69ab2161058921019d1decbb1c4931e60";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/ca/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/ca/thunderbird-102.2.2.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "496bd038e349d2480c7ca8c05f8ec9ccd93d0e17210cf1ffe8f65c470a2db5ad";
+      sha256 = "e1311c92360ed218361341f61529b2c4abd6c90a8458fd95c9401db9d4103011";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/cak/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/cak/thunderbird-102.2.2.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "f1e811a5f1e821ecffb6d4d110f19fe55ef153992cbcf53980fd56c16552f663";
+      sha256 = "34e6a9743bfbb88d6ddb00fc8343c4da5a7849dcc913ac1e9a17e44b35666da4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/cs/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/cs/thunderbird-102.2.2.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "6ff1add590d03bb49fab16ead5b549eb32c5767998ecc955c394163ef36d8554";
+      sha256 = "c650dd57f13520963f59eb67931c6fa12c862515c31a505d026df0d5aef78342";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/cy/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/cy/thunderbird-102.2.2.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "6605ab434753eda8d9f67eb57d470616e9c3b202978d655738bdd4f478cbfd42";
+      sha256 = "56511f4b9dfe2c4525c960a2031031881049adc8b4ef3daed9f8d12cf8dd81bf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/da/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/da/thunderbird-102.2.2.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "7f60ac0c21c4894dbaacc43e74753e5dd29a768a31167eb3b0ad86c0333c247e";
+      sha256 = "fde094d4ea03acafc9804964d14c4ffe091467f4bbc0871552344aadde758345";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/de/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/de/thunderbird-102.2.2.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "9d9ee8d7d92cbfa94732d915cfd4fd86278ff08225c4099d421f48527c5b279a";
+      sha256 = "3ab1e257a58e01a107989a62854a407f9faf5ee4d1f6223221ad6fc9bd8a08ca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/dsb/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/dsb/thunderbird-102.2.2.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "37c2ea9d16be51d4cbd9eff62d0a146681d52caa63e2407e1f0d8d422b7c62de";
+      sha256 = "28fe086cad5e27a9baa68b28d9556914a385796d2420c2238f83f08c61efc982";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/el/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/el/thunderbird-102.2.2.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "e3804af2c4a34c8ec6679e7a06449d00416641d17f2d58d15e745b25cac4fb82";
+      sha256 = "94eaf766fae60a5204a8fef9306db32a32ccd670bc77fecf8f062b6f6c12096a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/en-CA/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/en-CA/thunderbird-102.2.2.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "6d2dc53467776fc068935a1181c3ec7f6c2ab9c6387ff8c12b4f689b904e9430";
+      sha256 = "01652e32486efe2a610a3649d93128ecbb4d83c2b88a9f635775e95600255d56";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/en-GB/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/en-GB/thunderbird-102.2.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "f0a2db3262832de3cf5edf4721327538af261a8eaae831337a1f1f732045f1a2";
+      sha256 = "444a6814a90f982a9b515ae34831b0a421dc3543f50492219553d3c918f03913";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/en-US/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/en-US/thunderbird-102.2.2.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "04754457bbcd3b037c27cf5c1186ab1224fc01d3b1106c76ca21d26770ff28a1";
+      sha256 = "66c7f533483337423fec636873278dc9d7af72acbee25cd4696b055006faae34";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/es-AR/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/es-AR/thunderbird-102.2.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "9fd407ef93b7c613709312350b5ba520f06c5b0d664e315ef671f85e5af50ac0";
+      sha256 = "74b59f5777a884b281f64872ce268f5a096a571e5b37158f26757725f569f4e9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/es-ES/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/es-ES/thunderbird-102.2.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "a3975e3489c8c67374a7ade117a45c85aa42c5379670204571dce0118f7aaf8f";
+      sha256 = "feea88b74e5b3576a333b4a9b867afaf4412540ba45103ade194af28013a1259";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/es-MX/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/es-MX/thunderbird-102.2.2.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "857d1f4073ffbfa81a1ad17d219ccde4f8a8b18adc6e3e2f844020be32e1c5a8";
+      sha256 = "fbf4a44defa20ee88152ad45ed2368bbf97f4d1979e7ac731ba08e7d0caf1be9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/et/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/et/thunderbird-102.2.2.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "37b5f428f5f16dc80736de0c2f23ca24003de5d4639e1500f303b1f4aa664460";
+      sha256 = "abd03a775f1295e16dbbb2c4116f5193fc73b99e39b3a0f9e7a5de9eced240c9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/eu/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/eu/thunderbird-102.2.2.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "0e4a8abe3b956d304d79218d63f64b01ef566122d00d025ef69c07f73aa87fec";
+      sha256 = "90f90a640af343f87279af424da423d927dfaf3a08d9155a9469d42a734e7bfa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/fi/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/fi/thunderbird-102.2.2.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "0a3242f6d791ab5f1be52b67d8f95ac8245bc7cf556f9dda814c2827d8f60e40";
+      sha256 = "d8fbcad40e09ad5d193d3a520ee9fec023df89e545e9aae75bface677d2b2c8a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/fr/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/fr/thunderbird-102.2.2.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "32c67c444bbe3d920aa4c30226fdbf469d5caba7a066b3d84270d0f9e0daabe5";
+      sha256 = "a78e8962cd4121e5a4a2ceb573d7b69a61ed3706163ff47c6d1c960847cb7ded";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/fy-NL/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/fy-NL/thunderbird-102.2.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "0405585c63321c44f3f459356db4bbd0cf73cccf7ae6c8684b13152e3aa3b7f3";
+      sha256 = "39f416be5d19d31c84fd8c02805a1d5fdadb665aabccaeee78ab1e53fffaa9ad";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/ga-IE/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/ga-IE/thunderbird-102.2.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "54e4e55b3339d6436591d8967de6c1cffab94da38d064df6fc0d8b85c4475d84";
+      sha256 = "d270e50e6c79f37401c080567caec4e852a3138a3f3fe095a759d1d6e118b691";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/gd/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/gd/thunderbird-102.2.2.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "46130971e0b49bb45c6895d7cf9ec890d7f95fda6479bba38cf180d36e4c4eb7";
+      sha256 = "62723dd4145b2aab4d91e3d7be6763474c23eb969407b532eb21e8e95d00c497";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/gl/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/gl/thunderbird-102.2.2.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "6e0ae14bb163b5a10c58cbdd49793e69d9d5042b0045f40be4c595781ad84c92";
+      sha256 = "933795b2c0d3ab6b56d943470f3c0b5df3b4907acbdccb9f7f70ea300e094a50";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/he/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/he/thunderbird-102.2.2.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "6d353e9ec5a72366b991854aea9163385ab902c812690c0161790c882343e5a4";
+      sha256 = "265d98ccba83b5eff448318d2208e11cbac484d0eec01f796bfee590d4473657";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/hr/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/hr/thunderbird-102.2.2.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "a05a828b434cb2677b1d3c9f317d5448db003c1373edbb84d1822182a93d3e7c";
+      sha256 = "bc120009485b1d3b91cbd87018b6e4af229d1beabb2f6aed18d498ec58cb6fdb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/hsb/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/hsb/thunderbird-102.2.2.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "4573f6938c41160f1d4c79be035f24426bc83d9440b36ca269004b729a5564e2";
+      sha256 = "8d1cf043172256f022d6ead46545b36cc366570838d6d45814b78b8484d504e7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/hu/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/hu/thunderbird-102.2.2.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "727246ee523554d64ff72611d353aead8c8b79e8f55cf187b3fb3d9f442a947e";
+      sha256 = "93c1ab56e082c2e9d579031570e496175f7fa701840a5a8c25604ecb0b333c78";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/hy-AM/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/hy-AM/thunderbird-102.2.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "467c8af9d3cfdbd18ea04214369b9d262c9d925a171a2f56548af00ec85a3611";
+      sha256 = "f141fdd4521ad0bd2c7133f8a7b87bfea09f2c82be7c72271370555f80426c8a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/id/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/id/thunderbird-102.2.2.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "4177b047863412c9ef91d8552440b7fa1f848b8675cc55b881a4cc5fdb157303";
+      sha256 = "708aa8829a18291d7e2cced2be4f161cdd2752cf6b642200159d7e4f20b496ff";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/is/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/is/thunderbird-102.2.2.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "cb8cc7838fe3c4182d887c711c636b66d017b1854a2fadbb0f6e862a54a66d40";
+      sha256 = "de55318223875e4a43a35159a1c9ee795367d8ad447f29e4bb285fcb450f3e05";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/it/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/it/thunderbird-102.2.2.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "9e9214820e407c0067cf60a3b360e8f5a608225a41708a0fd25d00fb91e46d00";
+      sha256 = "722b270098611484878e2a6cb912aababe665e781a469bbdb46818ff18e077e0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/ja/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/ja/thunderbird-102.2.2.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "ffa126f9b4a25165163df6eca65299c553b087fc2313f6dd1c7b266d41a1769f";
+      sha256 = "96f27b3877f0b23d8fd09efc5ceb6a5162d0c704abcc84ae34493e120da69cea";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/ka/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/ka/thunderbird-102.2.2.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "563eb58790172bf3a037f5828786dfb7624e3f03b81c1a57a4126f102e9572f8";
+      sha256 = "75e43501045da981ce21f3b52391379f03de3f4df731ff85bd83e2881b2adc71";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/kab/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/kab/thunderbird-102.2.2.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "c79ff5505434a23ef88c2b1aadd9e70562ad9ea77fdb379169e3495725cad1a3";
+      sha256 = "5a2861bc768fededbcf7d3fd0e9bc565be2fd5badfb18524edf762425e8da933";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/kk/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/kk/thunderbird-102.2.2.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "bfc4037fa631727d454c5b22af1e8861b436c40aa2bafda007221e5d5a813dd7";
+      sha256 = "1014bcbb12c623164871e3416bde2218326d887d527c1f76d8579b451a673d81";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/ko/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/ko/thunderbird-102.2.2.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "386921200c4b6544407994c5d1d73a3671a383f1e5b69d5f34b7a8ec727bc646";
+      sha256 = "03ed9709c1bfa2066f8ab596faf5f4b9a37174bde7da3d32448770021d1bf48f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/lt/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/lt/thunderbird-102.2.2.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "2027b59fc1a8f11dbc8ce693296a26604e9ba579e34df02e9f0c8243eda38e94";
+      sha256 = "cc06df43b59a768415d6d07051eb67892e8e849ef0ff1799ad094dbe1671a954";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/lv/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/lv/thunderbird-102.2.2.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "a5179ee6caa6847b36e9494e09d3c233beb9bb8651c586b11ce160b054e12d73";
+      sha256 = "362877abf9d52b936fdde5913655ad3e88097503415cdd38bffc35032094bd92";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/ms/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/ms/thunderbird-102.2.2.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "6d1f11d137da476fe7dbe04e7d5692c5dc81931d30e116217083ad187fdc37cc";
+      sha256 = "64224aa3c1032528e9a233e992c95be4f8fa72c27a95e8ca38803265c2dd9c41";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/nb-NO/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/nb-NO/thunderbird-102.2.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "d7a50f3f8734d249e565cbf1078627fb0e3cfa42f293574127bd2fa549652be9";
+      sha256 = "389f8bdfdbe6b6f05a6bc4154b2381aa4810787d18bb22a4f4dafd3f2f7f4e17";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/nl/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/nl/thunderbird-102.2.2.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "8962f690d105d4589df0279770b63f0b90485cb499f86e953393dd4116a87b2c";
+      sha256 = "409729a161f278ff03c5505aca4ea4894c4fb973a3ab34bad9375a8aeea898c6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/nn-NO/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/nn-NO/thunderbird-102.2.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "d0b940decdc8d77a0a6371ded16c551d8ce081134c4bb7d795adde39c5844254";
+      sha256 = "bd3712769496d416f4c3a5df2ccca46cfdfbd1ffd55346af5abb9fa7c50410ea";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/pa-IN/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/pa-IN/thunderbird-102.2.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "dd5a2d9b78085786039ca20ef88f991285ff7b59ce47857b7d81bc74faa6ec54";
+      sha256 = "47ffb31c017241cfb6cfbd9a205b159adfd21be9b079f996a5d4ba05b0cc20d2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/pl/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/pl/thunderbird-102.2.2.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "9da17d31bbacc006c2a9530d42d864ea56c9cf5b84a73d03add270bc275543b0";
+      sha256 = "ca50e4489e3a949f37b2310e7fb1d24bf24c26e7000bacd051ab77968397a882";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/pt-BR/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/pt-BR/thunderbird-102.2.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "81fee2a7ba6a2b0b8607e412324b2eebd1dc3f28194dc7de1efa5af9f1fa23a6";
+      sha256 = "3a411aa23669d0c2b9146cd64986d7e9bfda6832e3b86a8f17f08a4fcbc05ab4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/pt-PT/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/pt-PT/thunderbird-102.2.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "82e354e1642b8018c0a6f2ccc3d3d38f3a7aa39333a30d9a6ea7c6c52df6d6f5";
+      sha256 = "10613a544aff584af3da980ecf511f180b1d3cf7fe01828e2a37f593487bca6f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/rm/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/rm/thunderbird-102.2.2.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "d7fa26de70531e74931892a78a5148f95df92d29a94e7ce5aeef11168c1069ce";
+      sha256 = "60797ab2c9393806bd5ab3b4b9fb9048775fb30c58ccc436f4b21a0a39ceaf97";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/ro/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/ro/thunderbird-102.2.2.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "c4392159cabd3cf19b575d8a0598b0d52a1f9fb993234d1170240c6c6a5e4fa6";
+      sha256 = "40f11c3afad15a07f506b5b8d7dd74317b37720a398e890dd73911882ab9354e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/ru/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/ru/thunderbird-102.2.2.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "ac3d6fc7b555298ae05cb3b0fef2b6264ff11a5961f5e044664022e80bb9ae34";
+      sha256 = "10935eb98bc6d83fe9b8e5e567a9f30a00abff8b5b3e4c527ecebd7ee56ec122";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/sk/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/sk/thunderbird-102.2.2.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "41cc5938d5b64508bcc095ddfbe3eef3cde3dd88a8f145ed279bf825785fde50";
+      sha256 = "07e6c734108896e827e97671afe30aa709e701b2e64f1d1b692aee7155479cb4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/sl/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/sl/thunderbird-102.2.2.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "f8fb013b2705ce34749d1470e799d47c09b5ba94a9580a5e2d12be8b660c58c7";
+      sha256 = "b862cd06ba4a1c8a16269d2c7fda76c7b97aebf0d60ac6828cc7b3dbb51b6468";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/sq/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/sq/thunderbird-102.2.2.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "dc7407c4cb28070693b7862bc29b465a4d96c473b5b4f553d238390c694804a1";
+      sha256 = "28792eca6aa976a712c4f2c619e22c70263f7941c2c99a3aa9d83e5eb6cf00b8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/sr/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/sr/thunderbird-102.2.2.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "640731bbc689acb4874bc0f439f34213e30812bafae3ef94471945b13ae27243";
+      sha256 = "69460ea89828e4db9a93f2a005a146a503f5fd5c022665cedfbf9ee62bd826e6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/sv-SE/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/sv-SE/thunderbird-102.2.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "6d71d4ffa6393bc997566dc604992c093c24bd3a978b947704f82f03893fccfd";
+      sha256 = "08cf31fe3ad5d214278c9c79ad84defa2166d2b84917a6e7b11b7abfe113df09";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/th/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/th/thunderbird-102.2.2.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "faecaf65b8737dc63d2ea469ba1181c1e0a71c334baf29c8677730faecffb57c";
+      sha256 = "ef0c353c78ead98ffdf929912631dc3bee4087acd070dec878ce3bf9709a8f23";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/tr/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/tr/thunderbird-102.2.2.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "c6401dfca452996547b3f33dead4690f9e376313920ef7880774c8a3e556b213";
+      sha256 = "fe9e77c1739e33c5e226253a79070dd6e15d813d81cfbadca187cbeaa6fada9a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/uk/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/uk/thunderbird-102.2.2.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "05fc335e16ad0c28a59a6ba51566161f92c0053b12b0ec56409e62eaf77fa2b2";
+      sha256 = "3e12f9228479fb2361186eeee6174f4256990c829b369b4f762e75e89a7cfd12";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/uz/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/uz/thunderbird-102.2.2.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "5690ad8156e70dba56ed7664f99ac335409e88f5fc0d05be530774fdeedd20ee";
+      sha256 = "ad59e3da2b1b3f20f910e979d85e60253b07f11410dca635399681cb50d372ad";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/vi/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/vi/thunderbird-102.2.2.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "41cb6da3b59cfa31ebf28e67f93349977dcd640df5491fa451f19bc0670aa2d9";
+      sha256 = "a0342a62cd34cb6879e38717c05e272d2f45990078d0b920906ce400db3cc206";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/zh-CN/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/zh-CN/thunderbird-102.2.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "79f9f7e1620efa56ab2a8f3a1d1aea91cf82a0c12b6f0bbac01bbd5fdc6b3c63";
+      sha256 = "6506ef24bcf862da6860a166a1a14c95187518e72bbb560b114eceb9d77a7c8f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.1/linux-i686/zh-TW/thunderbird-102.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.2.2/linux-i686/zh-TW/thunderbird-102.2.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "763790430eff0c8689cb045e30920b1c0fe239a324ce739b153f8a16ccb07b25";
+      sha256 = "479d149ec221ddead41c6e6b8f3f854487ea833ff80fe6efa31061600938299e";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
@@ -39,13 +39,13 @@ rec {
   };
   thunderbird-102 = (buildMozillaMach rec {
     pname = "thunderbird";
-    version = "102.2.1";
+    version = "102.2.2";
     application = "comm/mail";
     applicationName = "Mozilla Thunderbird";
     binaryName = pname;
     src = fetchurl {
       url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
-      sha512 = "7b69cfffb5de56690cbbd97f6b627733072dee498a15adfece990f9019df8df948762ce8eb2ca2d91ef12ff56262fb1905476d8a477aed70bc71cd2f9f986ea4";
+      sha512 = "fe72ddb81d35d4a85b25a6d955a0b0f705aeda2dca0f572efca7ce94041c4ddcead6c690bda8d4bded4c43e12a15669f9608db6debec38d8b5157a914e280db5";
     };
     extraPatches = [
       # The file to be patched is different from firefox's `no-buildconfig-ffx90.patch`.


### PR DESCRIPTION
###### Description of changes

https://www.thunderbird.net/en-US/thunderbird/102.2.2/releasenotes/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
