### PR TITLE
buildPython*: store dist (wheel/sdist) in dist output

### DIFF
--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -115,6 +115,11 @@ in rec {
       };
     } ./python-namespaces-hook.sh) {};
 
+  pythonOutputDistHook = callPackage ({ }:
+    makeSetupHook {
+      name = "python-output-dist-hook";
+  } ./python-output-dist-hook.sh ) {};
+
   pythonRecompileBytecodeHook = callPackage ({ }:
     makeSetupHook {
       name = "python-recompile-bytecode-hook";

--- a/pkgs/development/interpreters/python/hooks/python-output-dist-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-output-dist-hook.sh
@@ -1,0 +1,10 @@
+# Setup hook for storing dist folder (wheels/sdists) in a separate output
+echo "Sourcing python-catch-conflicts-hook.sh"
+
+pythonOutputDistPhase() {
+    echo "Executing pythonOutputDistPhase"
+    mv "dist" "$dist"
+    echo "Finished executing pythonOutputDistPhase"
+}
+
+preFixupPhases+=" pythonOutputDistPhase"

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -17,6 +17,7 @@
 , pythonCatchConflictsHook
 , pythonImportsCheckHook
 , pythonNamespacesHook
+, pythonOutputDistHook
 , pythonRemoveBinBytecodeHook
 , pythonRemoveTestsDirHook
 , setuptoolsBuildHook
@@ -48,6 +49,8 @@
 
 # Enabled to detect some (native)BuildInputs mistakes
 , strictDeps ? true
+
+, outputs ? [ "out" ]
 
 # used to disable derivation, useful for specific python versions
 , disabled ? false
@@ -106,11 +109,13 @@ else
 let
   inherit (python) stdenv;
 
+  withDistOutput = lib.elem format ["pyproject" "setuptools" "flit"];
+
   name_ = name;
 
   self = toPythonModule (stdenv.mkDerivation ((builtins.removeAttrs attrs [
     "disabled" "checkPhase" "checkInputs" "doCheck" "doInstallCheck" "dontWrapPythonPrograms" "catchConflicts" "format"
-    "disabledTestPaths"
+    "disabledTestPaths" "outputs"
   ]) // {
 
     name = namePrefix + name_;
@@ -144,6 +149,8 @@ let
     ] ++ lib.optionals (python.pythonAtLeast "3.3") [
       # Optionally enforce PEP420 for python3
       pythonNamespacesHook
+    ] ++ lib.optionals withDistOutput [
+      pythonOutputDistHook
     ] ++ nativeBuildInputs;
 
     buildInputs = buildInputs ++ pythonPath;
@@ -176,6 +183,8 @@ let
 
     # Python packages built through cross-compilation are always for the host platform.
     disallowedReferences = lib.optionals (python.stdenv.hostPlatform != python.stdenv.buildPlatform) [ python.pythonForBuild ];
+
+    outputs = outputs ++ lib.optional withDistOutput "dist";
 
     meta = {
       # default to python's platforms

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -119,6 +119,7 @@ in {
     pythonCatchConflictsHook
     pythonImportsCheckHook
     pythonNamespacesHook
+    pythonOutputDistHook
     pythonRecompileBytecodeHook
     pythonRelaxDepsHook
     pythonRemoveBinBytecodeHook


### PR DESCRIPTION
Store the intermediate artifacts. In time, we should build, install and test in separate derivations as that reduces circular dependencies, avoids rebuilds when fixing tests, and makes it possible to use the wheels for creating say virtualenv's.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
