### PR TITLE
python3Packages.apsw: 3.38.5-r1 -> 3.39.2.1

### DIFF
--- a/pkgs/development/python-modules/apsw/default.nix
+++ b/pkgs/development/python-modules/apsw/default.nix
@@ -5,11 +5,12 @@
 , sqlite
 , isPyPy
 , python
+, fetchpatch
 }:
 
 buildPythonPackage rec {
   pname = "apsw";
-  version = "3.38.5-r1";
+  version = "3.39.2.1";
   format = "setuptools";
 
   disabled = isPyPy;
@@ -18,11 +19,20 @@ buildPythonPackage rec {
     owner = "rogerbinns";
     repo = "apsw";
     rev = "refs/tags/${version}";
-    hash = "sha256-pPviSrONGgWZUREMENPt34bpHggR00Kl6DrB40JWm+w=";
+    hash = "sha256-W1uQFya/IQUBAPAjwdCJ1K5LVc4spcYj0dN2YP2vtN0=";
   };
 
   buildInputs = [
     sqlite
+  ];
+
+  patches = [
+    # ongoing issue: https://github.com/rogerbinns/apsw/issues/363
+    # apsw needs to know the compile flags of sqlite to match features
+    (fetchpatch {
+      url = "https://github.com/rogerbinns/apsw/commit/e92f019ff785d8e52d381dc541d3f4f8236fb356.patch";
+      hash = "sha256-Zdy0ukfWkak9lTdU5WMNzWNp7uDROJgXLcfvQdfm2Oo=";
+    })
   ];
 
   # Project uses custom test setup to exclude some tests by default, so using pytest


### PR DESCRIPTION
###### Description of changes

Update of `apsw`. 

[Changelog](https://github.com/rogerbinns/apsw/releases/tag/3.39.2.1)

This includes a fix to a failing test. Root issue is discussed upstream [here](https://github.com/rogerbinns/apsw/issues/363) and patch for the failing test was submitted [here](https://github.com/rogerbinns/apsw/commit/e92f019ff785d8e52d381dc541d3f4f8236fb356). 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
