### PR TITLE
nerd-font-patcher: 2.1.0 -> 2.2.2

### DIFF
--- a/pkgs/applications/misc/nerd-font-patcher/default.nix
+++ b/pkgs/applications/misc/nerd-font-patcher/default.nix
@@ -2,7 +2,7 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "nerd-font-patcher";
-  version = "2.1.0";
+  version = "2.2.2";
 
   # This uses a sparse checkout because the repo is >2GB without it
   src = fetchFromGitHub {
@@ -13,7 +13,7 @@ python3Packages.buildPythonApplication rec {
       font-patcher
       /src/glyphs
     '';
-    sha256 = "sha256-06dn6M2wCFO/uBHDR7VZHNHIybT4h/VGD9nHc4G0EKA=";
+    sha256 = "sha256-boZUd1PM8puc9BTgOwCJpkfk6VMdXLsIyp+fQmW/ZqI=";
   };
 
   propagatedBuildInputs = with python3Packages; [ fontforge ];
@@ -22,15 +22,15 @@ python3Packages.buildPythonApplication rec {
 
   postPatch = ''
     sed -i font-patcher \
-      -e 's,__dir__ + "/src,"'$out'/share/${pname},'
+      -e 's,__dir__ + "/src,"'$out'/share/nerd-font-patcher,'
   '';
 
   dontBuild = true;
 
   installPhase = ''
-    mkdir -p $out/bin $out/share/${pname}
-    install -Dm755 font-patcher $out/bin/${pname}
-    cp -ra src/glyphs $out/share/${pname}
+    mkdir -p $out/bin $out/share/nerd-font-patcher
+    install -Dm755 font-patcher $out/bin/nerd-font-patcher
+    cp -ra src/glyphs $out/share/nerd-font-patcher
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
