### PR TITLE
zix: init at unstable-2022-09-08

### DIFF
--- a/pkgs/development/libraries/sord/default.nix
+++ b/pkgs/development/libraries/sord/default.nix
@@ -1,31 +1,42 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, python3, serd, pcre, wafHook }:
+{ lib
+, stdenv
+, doxygen
+, fetchFromGitHub
+, meson
+, ninja
+, pcre
+, pkg-config
+, python3
+, serd
+}:
 
 stdenv.mkDerivation rec {
   pname = "sord";
-  version = "unstable-2021-01-12";
+  version = "0.16.14";
 
-  # Commit picked in mitigation of #109729
   src = fetchFromGitHub {
     owner = "drobilla";
     repo = pname;
-    rev = "d2efdb2d026216449599350b55c2c85c0d3efb89";
-    sha256 = "hHTwK+K6cj9MGO77a1IXiUZtEbXZ08cLGkYZ5eMOIVA=";
-    fetchSubmodules = true;
+    rev = "v${version}";
+    hash = "sha256-S22Szpg6iXeana5t6EpbOtRstthgrJ4Z2cBrf7a9ZBk=";
   };
 
-  preConfigure = ''
-    export PKGCONFIG="$PKG_CONFIG"
-  '';
-
-  nativeBuildInputs = [ pkg-config python3 wafHook ];
+  nativeBuildInputs = [
+    doxygen
+    meson
+    ninja
+    pkg-config
+    python3
+  ];
   buildInputs = [ pcre ];
   propagatedBuildInputs = [ serd ];
-  dontAddWafCrossFlags = true;
+
+  doCheck = true;
 
   meta = with lib; {
     homepage = "http://drobilla.net/software/sord";
     description = "A lightweight C library for storing RDF data in memory";
-    license = licenses.mit;
+    license = with licenses; [ bsd0 isc ];
     maintainers = [ maintainers.goibhniu ];
     platforms = platforms.unix;
   };

--- a/pkgs/development/libraries/zix/default.nix
+++ b/pkgs/development/libraries/zix/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, meson
+, ninja
+}:
+
+stdenv.mkDerivation {
+  pname = "zix";
+  version = "unstable-2022-09-08";
+
+  outputs = [ "out" "dev" ];
+
+  src = fetchFromGitLab {
+    owner = "drobilla";
+    repo = "zix";
+    # the repo doesn't have any releases yet
+    rev = "a0293511f4d82d7cb800f568ff5c0d82be5c40c7";
+    hash = "sha256-HxFIb/ux2YLVHrlgNOtxQsoQzCEPvAEG8UVXU2qN9Io=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+  ];
+
+  mesonFlags = [ "-Dbenchmarks=disabled" ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    homepage = "http://drobilla.net/software/zix";
+    description = "A lightweight C99 portability and data structure library";
+    license = licenses.isc;
+    maintainers = [ maintainers.zseri ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21682,7 +21682,7 @@ with pkgs;
 
   sope = callPackage ../development/libraries/sope { };
 
-  sord = callPackage ../development/libraries/sord {};
+  sord = callPackage ../development/libraries/sord { };
 
   soundtouch = callPackage ../development/libraries/soundtouch {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22314,6 +22314,8 @@ with pkgs;
 
   zita-resampler = callPackage ../development/libraries/audio/zita-resampler { };
 
+  zix = callPackage ../development/libraries/zix { };
+
   zz = callPackage ../development/compilers/zz { };
 
   zziplib = callPackage ../development/libraries/zziplib { };


### PR DESCRIPTION
###### Description of changes

Split from https://github.com/NixOS/nixpkgs/pull/190218.
sord bump to prevent symbol clashes between zix and sord, and taken latest commit to avoid distro divergence regarding licenses later: https://github.com/drobilla/sord/compare/d2efdb2d026216449599350b55c2c85c0d3efb89..c1dbc93568b9280e91c9b920d09d8648e0eda44e

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage) (not doable due to hydra hang)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
