### PR TITLE
flaresolverr: init at 2.2.6

### DIFF
--- a/pkgs/servers/flaresolverr/default.nix
+++ b/pkgs/servers/flaresolverr/default.nix
@@ -1,0 +1,74 @@
+{ pkgs, stdenv }:
+with pkgs;
+
+stdenv.mkDerivation rec {
+
+  pname = "flaresolverr";
+  version = "2.2.6";
+
+  src = fetchurl {
+    url = "https://github.com/FlareSolverr/FlareSolverr/releases/download/v${version}/flaresolverr-v${version}-linux-x64.zip";
+    sha256 = "sha256-ou+hKcIn3NO1/ZzyP69LOtpd1NbATNUg6KDRxCbyen4=";
+  };
+
+  nativeBuildInputs = [
+    unzip
+  ];
+
+  buildInputs = [ firefox ];
+
+  preFixup =
+    let
+      libPath = lib.makeLibraryPath [ stdenv.cc.cc ];
+    in
+    ''
+      orig_size=$(stat --printf=%s $out/bin/flaresolverr)
+      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/bin/flaresolverr
+      patchelf --set-rpath ${libPath} $out/bin/flaresolverr
+      chmod +x $out/bin/flaresolverr
+      new_size=$(stat --printf=%s $out/bin/flaresolverr)
+      ###### zeit-pkg fixing starts here.
+      # we're replacing plaintext js code that looks like
+      # PAYLOAD_POSITION = '1234                  ' | 0
+      # [...]
+      # PRELUDE_POSITION = '1234                  ' | 0
+      # ^-----20-chars-----^^------22-chars------^
+      # ^-- grep points here
+          #
+      # var_* are as described above
+      # shift_by seems to be safe so long as all patchelf adjustments occur
+      # before any locations pointed to by hardcoded offsets
+      var_skip=20
+      var_select=22
+      shift_by=$(expr $new_size - $orig_size)
+      function fix_offset {
+        # $1 = name of variable to adjust
+        location=$(grep -obUam1 "$1" $out/bin/flaresolverr | cut -d: -f1)
+        location=$(expr $location + $var_skip)
+        value=$(dd if=$out/bin/flaresolverr iflag=count_bytes,skip_bytes skip=$location \
+                   bs=1 count=$var_select status=none)
+        value=$(expr $shift_by + $value)
+        echo -n $value | dd of=$out/bin/flaresolverr bs=1 seek=$location conv=notrunc
+      }
+      fix_offset PAYLOAD_POSITION
+      fix_offset PRELUDE_POSITION
+    '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp flaresolverr $out/bin/
+    mkdir -p $out/bin/firefox
+    ln -s ${pkgs.firefox}/bin/firefox $out/bin/firefox/firefox
+  '';
+
+  dontStrip = true;
+
+  meta = with lib; {
+    description = "Proxy server to bypass Cloudflare protection";
+    homepage = "https://github.com/FlareSolverr/FlareSolverr";
+    license = licenses.mit;
+    maintainers = with maintainers; [ julienmalka ];
+  };
+
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2470,6 +2470,8 @@ with pkgs;
 
   fitnesstrax = callPackage ../applications/misc/fitnesstrax { };
 
+  flaresolverr = callPackage ../servers/flaresolverr { };
+
   flavours = callPackage ../applications/misc/flavours { };
 
   flirc = libsForQt5.callPackage ../applications/video/flirc { };


### PR DESCRIPTION
###### Description of changes
This PR adds the flaresolverr package. Flaresolverr is a proxy server to bypass Cloudflare protection, very usefull in conjonction with jackett (already packaged in nixpkgs).

Flaresolverr is here packaged using the binary shipped in Flaresolverr's releases. Facing the same issue as [here](https://github.com/vercel/pkg/issues/321), I implemented the same solution, see [here](https://github.com/NixOS/nixpkgs/pull/48193).

**Note** : If this solution is not satisfactory, it may be possible to package flaresolverr by building it from source, but as it is a node application, it would imply a more complicated packaging and an heavy node-packages file commited to the repository.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
