### PR TITLE
mongodb-6_0: init at 6.0.1

### DIFF
--- a/pkgs/servers/nosql/mongodb/6.0.nix
+++ b/pkgs/servers/nosql/mongodb/6.0.nix
@@ -1,0 +1,12 @@
+{ stdenv, callPackage, lib, sasl, boost, Security, CoreFoundation, cctools }:
+
+let
+  buildMongoDB = callPackage ./mongodb.nix {
+    inherit sasl boost Security CoreFoundation cctools;
+  };
+in
+buildMongoDB {
+  version = "6.0.1";
+  sha256 = "sha256-3LdyPHj2t7JskCJh6flCYl6qjfAbRXHsi+19L+0O2Zs=";
+  patches = [ ];
+}

--- a/pkgs/servers/nosql/mongodb/mongodb.nix
+++ b/pkgs/servers/nosql/mongodb/mongodb.nix
@@ -1,5 +1,23 @@
-{ lib, stdenv, fetchurl, sconsPackages, boost, gperftools, pcre-cpp, snappy, zlib, libyamlcpp
-, sasl, openssl, libpcap, python3, curl, Security, CoreFoundation, cctools, xz }:
+{ lib
+, stdenv
+, fetchurl
+, sconsPackages
+, boost
+, gperftools
+, pcre-cpp
+, snappy
+, zlib
+, libyamlcpp
+, sasl
+, openssl
+, libpcap
+, python3
+, curl
+, Security
+, CoreFoundation
+, cctools
+, xz
+}:
 
 # Note:
 # The command line tools are written in Go as part of a different package (mongodb-tools)
@@ -11,17 +29,33 @@ with lib;
 }:
 
 let
-  variants = if versionAtLeast version "4.2"
-    then rec { python = scons.python.withPackages (ps: with ps; [ pyyaml cheetah3 psutil setuptools ]);
-            scons = sconsPackages.scons_3_1_2.override { python = python3; }; # 4.2 < mongodb <= 5.0.x needs scons 3.x built with python3
-            mozjsVersion = "60";
-            mozjsReplace = "defined(HAVE___SINCOS)";
-          }
-    else rec { python = scons.python.withPackages (ps: with ps; [ pyyaml typing cheetah ]);
-            scons = sconsPackages.scons_3_1_2;
-            mozjsVersion = "45";
-            mozjsReplace = "defined(HAVE_SINCOS)";
-          };
+  variants =
+    if versionAtLeast version "4.2" then rec {
+      python = scons.python.withPackages (ps: with ps; [
+        pyyaml
+        cheetah3
+        psutil
+        setuptools
+      ]);
+
+      # 4.2 < mongodb <= 5.0.x needs scons 3.x built with python3
+      scons = sconsPackages.scons_3_1_2.override { python = python3; };
+
+      mozjsVersion = "60";
+      mozjsReplace = "defined(HAVE___SINCOS)";
+
+    } else rec {
+      python = scons.python.withPackages (ps: with ps; [
+        pyyaml
+        typing
+        cheetah
+      ]);
+
+      scons = sconsPackages.scons_3_1_2;
+      mozjsVersion = "45";
+      mozjsReplace = "defined(HAVE_SINCOS)";
+   };
+
   system-libraries = [
     "boost"
     "pcre"

--- a/pkgs/servers/nosql/mongodb/mongodb.nix
+++ b/pkgs/servers/nosql/mongodb/mongodb.nix
@@ -20,7 +20,8 @@
 }:
 
 # Note:
-# The command line tools are written in Go as part of a different package (mongodb-tools)
+#   The command line administrative tools are part of other packages:
+#   see pkgs.mongodb-tools and pkgs.mongosh.
 
 with lib;
 

--- a/pkgs/servers/nosql/mongodb/mongodb.nix
+++ b/pkgs/servers/nosql/mongodb/mongodb.nix
@@ -31,7 +31,23 @@ with lib;
 
 let
   variants =
-    if versionAtLeast version "4.2" then rec {
+    if versionAtLeast version "6.0" then rec {
+      python = scons.python.withPackages (ps: with ps; [
+        pyyaml
+        cheetah3
+        psutil
+        setuptools
+        packaging
+        pymongo
+      ]);
+
+      # 4.2 < mongodb <= 6.0.x needs scons 3.x built with python3
+      scons = sconsPackages.scons_3_1_2.override { python = python3; };
+
+      mozjsVersion = "60";
+      mozjsReplace = "defined(HAVE___SINCOS)";
+
+    } else if versionAtLeast version "4.2" then rec {
       python = scons.python.withPackages (ps: with ps; [
         pyyaml
         cheetah3
@@ -164,7 +180,10 @@ in stdenv.mkDerivation rec {
     runHook postInstallCheck
   '';
 
-  installTargets = if (versionAtLeast version "4.4") then "install-core" else "install";
+  installTargets =
+    if (versionAtLeast version "6.0") then "install-devcore"
+    else if (versionAtLeast version "4.4") then "install-core"
+    else "install";
 
   prefixKey = if (versionAtLeast version "4.4") then "DESTDIR=" else "--prefix=";
 

--- a/pkgs/servers/nosql/mongodb/mongodb.nix
+++ b/pkgs/servers/nosql/mongodb/mongodb.nix
@@ -197,6 +197,9 @@ in stdenv.mkDerivation rec {
     inherit license;
 
     maintainers = with maintainers; [ bluescreen303 offline cstrahan ];
-    platforms = subtractLists systems.doubles.i686 systems.doubles.unix;
+    platforms = subtractLists systems.doubles.i686 (
+      if (versionAtLeast version "6.0") then systems.doubles.linux
+      else systems.doubles.unix
+    );
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23287,6 +23287,13 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
   };
 
+  mongodb-6_0 = callPackage ../servers/nosql/mongodb/6.0.nix {
+    sasl = cyrus_sasl;
+    boost = boost178.override { enableShared = false; };
+    inherit (darwin) cctools;
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
+  };
+
   nginx-sso = callPackage ../servers/nginx-sso { };
 
   percona-server56 = callPackage ../servers/sql/percona/5.6.x.nix { stdenv = gcc10StdenvCompat; };


### PR DESCRIPTION
###### Description of changes

This packages MongoDB 6.0.
See individual commits.

CC maintainers: @bluescreen303 @offlinehacker @cstrahan

GitHub: closes #190297

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
