### PR TITLE
common-updater-scripts: Various QoL fixes

### DIFF
--- a/pkgs/common-updater/scripts/update-source-version
+++ b/pkgs/common-updater/scripts/update-source-version
@@ -206,30 +206,28 @@ oldHashEscaped=$(echo "$oldHash" | sed -re 's|[+]|\\&|g')
 tempHashEscaped=$(echo "$tempHash" | sed -re 's|[+]|\\&|g')
 
 # Replace new version
-sed -i.bak "$nixFile" -re "$pattern"
-if cmp -s "$nixFile" "$nixFile.bak"; then
+sed -i.cmp "$nixFile" -re "$pattern"
+if cmp -s "$nixFile" "$nixFile.cmp"; then
     die "Failed to replace version '$oldVersion' to '$newVersion' in '$attr'!"
 fi
 
 # Replace new URL
 if [[ -n "$newUrl" ]]; then
-    sed -i "$nixFile" -re "s|\"$oldUrlEscaped\"|\"$newUrl\"|"
-
-    if cmp -s "$nixFile" "$nixFile.bak"; then
+    sed -i.cmp "$nixFile" -re "s|\"$oldUrlEscaped\"|\"$newUrl\"|"
+    if cmp -s "$nixFile" "$nixFile.cmp"; then
         die "Failed to replace source URL '$oldUrl' to '$newUrl' in '$attr'!"
     fi
 fi
 
-sed -i "$nixFile" -re "s|\"$oldHashEscaped\"|\"$tempHash\"|"
-if cmp -s "$nixFile" "$nixFile.bak"; then
+sed -i.cmp "$nixFile" -re "s|\"$oldHashEscaped\"|\"$tempHash\"|"
+if cmp -s "$nixFile" "$nixFile.cmp"; then
     die "Failed to replace source hash of '$attr' to a temporary hash!"
 fi
 
 # Replace new revision, if given
 if [[ -n "$newRevision" ]]; then
-    sed -i "$nixFile" -re "s|\"$oldRevision\"|\"$newRevision\"|"
-
-    if cmp -s "$nixFile" "$nixFile.bak"; then
+    sed -i.cmp "$nixFile" -re "s|\"$oldRevision\"|\"$newRevision\"|"
+    if cmp -s "$nixFile" "$nixFile.cmp"; then
         die "Failed to replace source revision '$oldRevision' to '$newRevision' in '$attr'!"
     fi
 fi
@@ -254,16 +252,15 @@ if [[ -z "$newHash" ]]; then
 fi
 
 if [[ -z "${ignoreSameHash}" && "$oldVersion" != "$newVersion" && "$oldHash" = "$newHash" ]]; then
-    mv "$nixFile.bak" "$nixFile"
     die "Both the old and new source hashes of '$attr.$sourceKey' were equivalent. Please fix the package's source URL to be dependent on '\${version}'!"
 fi
 
-sed -i "$nixFile" -re "s|\"$tempHashEscaped\"|\"$newHash\"|"
-if cmp -s "$nixFile" "$nixFile.bak"; then
+sed -i.cmp "$nixFile" -re "s|\"$tempHashEscaped\"|\"$newHash\"|"
+if cmp -s "$nixFile" "$nixFile.cmp"; then
     die "Failed to replace temporary source hash of '$attr' to the final source hash!"
 fi
 
-rm -f "$nixFile.bak"
+rm -f "$nixFile.cmp"
 rm -f "$attr.fetchlog"
 
 if [ -n "$printChanges" ]; then

--- a/pkgs/common-updater/scripts/update-source-version
+++ b/pkgs/common-updater/scripts/update-source-version
@@ -133,12 +133,6 @@ if [[ $(grep --count "$oldHash" "$nixFile") != 1 ]]; then
     die "Couldn't locate old source hash '$oldHash' (or it appeared more than once) in '$nixFile'!"
 fi
 
-oldUrl=$(nix-instantiate $systemArg --eval -E "with $importTree; builtins.elemAt ($attr.$sourceKey.drvAttrs.urls or [ $attr.$sourceKey.url ]) 0" | tr -d '"')
-
-if [[ -z "$oldUrl" ]]; then
-    die "Couldn't evaluate source url from '$attr.$sourceKey'!"
-fi
-
 oldVersion=$(nix-instantiate $systemArg --eval -E "with $importTree; $attr.${versionKey} or (builtins.parseDrvName $attr.name).version" | tr -d '"')
 
 if [[ -z "$oldVersion" ]]; then
@@ -162,7 +156,6 @@ fi
 
 # Escape regex metacharacter that are allowed in store path names
 oldVersionEscaped=$(echo "$oldVersion" | sed -re 's|[.+]|\\&|g')
-oldUrlEscaped=$(echo "$oldUrl" | sed -re 's|[${}.+]|\\&|g')
 
 if [[ $(grep --count --extended-regexp "^\s*(let\b)?\s*$versionKey\s*=\s*\"$oldVersionEscaped\"" "$nixFile") = 1 ]]; then
     pattern="/\b$versionKey\b\s*=/ s|\"$oldVersionEscaped\"|\"$newVersion\"|"
@@ -213,6 +206,14 @@ fi
 
 # Replace new URL
 if [[ -n "$newUrl" ]]; then
+    oldUrl=$(nix-instantiate $systemArg --eval -E "with $importTree; builtins.elemAt ($attr.$sourceKey.drvAttrs.urls or [ $attr.$sourceKey.url ]) 0" | tr -d '"')
+    if [[ -z "$oldUrl" ]]; then
+        die "Couldn't evaluate source url from '$attr.$sourceKey'!"
+    fi
+
+    # Escape regex metacharacter that are allowed in store path names
+    oldUrlEscaped=$(echo "$oldUrl" | sed -re 's|[${}.+]|\\&|g')
+
     sed -i.cmp "$nixFile" -re "s|\"$oldUrlEscaped\"|\"$newUrl\"|"
     if cmp -s "$nixFile" "$nixFile.cmp"; then
         die "Failed to replace source URL '$oldUrl' to '$newUrl' in '$attr'!"


### PR DESCRIPTION
###### Description of changes

- Fix replacement failure detections
- Only look for URL when replacing it

Cherry picked from https://github.com/NixOS/nixpkgs/pull/190220.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
