### PR TITLE
imapsync: 1.727 -> 2.200

### DIFF
--- a/pkgs/tools/networking/imapsync/default.nix
+++ b/pkgs/tools/networking/imapsync/default.nix
@@ -1,16 +1,25 @@
-{lib, stdenv, makeWrapper, fetchurl, perl, openssl, perlPackages }:
+{ lib
+, fetchFromGitHub
+, makeWrapper
+, perl
+, perlPackages
+, stdenv
+}:
 
 stdenv.mkDerivation rec {
   pname = "imapsync";
-  version = "1.727";
+  version = "2.200";
 
-  src = fetchurl {
-    url = "https://releases.pagure.org/imapsync/imapsync-${version}.tgz";
-    sha256 = "1axacjw2wyaphczfw3kfmi5cl83fyr8nb207nks40fxkbs8q5dlr";
+  src = fetchFromGitHub {
+    owner = "imapsync";
+    repo = "imapsync";
+    rev = "imapsync-${version}";
+    sha256 = "sha256-EM8nT9v6ZHpEG33/ibPqvfgFoAF36nhq6Y+RUWK4vR0=";
   };
 
-  patchPhase = ''
+  postPatch = ''
     sed -i -e s@/usr@$out@ Makefile
+    substituteInPlace INSTALL.d/prerequisites_imapsync --replace "PAR::Packer" ""
   '';
 
   postInstall = ''
@@ -19,18 +28,44 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  buildInputs = with perlPackages; [ perl openssl MailIMAPClient TermReadKey
-    IOSocketSSL DigestHMAC URI FileCopyRecursive IOTee UnicodeString
-    DataUniqid JSONWebToken TestMockGuard LWP CryptOpenSSLRSA
-    LWPProtocolHttps Readonly TestPod TestMockObject ParseRecDescent
-    IOSocketInet6 NTLM
+  buildInputs = with perlPackages; [
+    Appcpanminus
+    CGI
+    CryptOpenSSLRSA
+    DataUniqid
+    DistCheckConflicts
+    EncodeIMAPUTF7
+    FileCopyRecursive
+    FileTail
+    IOSocketInet6
+    IOTee
+    JSONWebToken
+    LWP
+    MailIMAPClient
+    ModuleImplementation
+    ModuleScanDeps
+    NTLM
+    PackageStash
+    PackageStashXS
+    Readonly
+    RegexpCommon
+    SysMemInfo
+    TermReadKey
+    TestDeep
+    TestFatal
+    TestMockGuard
+    TestMockObject
+    TestPod
+    TestRequires
+    UnicodeString
+    perl
   ];
 
   meta = with lib; {
-    homepage = "http://www.linux-france.org/prj/imapsync/";
     description = "Mail folder synchronizer between IMAP servers";
-    license = licenses.gpl2Plus;
-    platforms = platforms.linux;
+    homepage = "https://imapsync.lamiral.info/";
+    license = licenses.wtfpl;
     maintainers = with maintainers; [ pSub ];
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -8307,6 +8307,20 @@ let
     };
   };
 
+  EncodeIMAPUTF7 = buildPerlPackage {
+    pname = "Encode-IMAPUTF7";
+    version = "1.05";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/P/PM/PMAKHOLM/Encode-IMAPUTF7-1.05.tar.gz";
+      hash = "sha256-RwMF3cN0g8/o08FtE3cKKAEfYAv1V6y4w+B3OZl8N+E=";
+    };
+    checkInputs = [ TestNoWarnings ];
+    meta = {
+      description = "IMAP modified UTF-7 encoding";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   EncodeJIS2K = buildPerlPackage {
     pname = "Encode-JIS2K";
     version = "0.03";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updated imapsync to the latest version and added missing Perl dependencies. Supersedes #128462.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
