### PR TITLE
beam: dont use 'with beam' and 'with beam.interpreters'

### DIFF
--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -1,93 +1,101 @@
-{ beam, callPackage, wxGTK30, buildPackages, stdenv
+{ beam
+, callPackage
+, wxGTK30
+, buildPackages
+, stdenv
 , wxSupport ? true
 , systemdSupport ? stdenv.isLinux
 }:
 
-with beam; {
-  lib = callPackage ../development/beam-modules/lib.nix { };
+let
+  self = beam;
+in
+
+{
+  beamLib = callPackage ../development/beam-modules/lib.nix { };
 
   # R24 is the default version.
   # The main switch to change default Erlang version.
   defaultVersion = "erlangR24";
 
   # Each
-  interpreters = with beam.interpreters; {
+  interpreters = {
 
-    erlang = beam.interpreters.${defaultVersion};
-    erlang_odbc = beam.interpreters."${defaultVersion}_odbc";
-    erlang_javac = beam.interpreters."${defaultVersion}_javac";
-    erlang_odbc_javac = beam.interpreters."${defaultVersion}_odbc_javac";
+    erlang = self.interpreters.${self.defaultVersion};
+    erlang_odbc = self.interpreters."${self.defaultVersion}_odbc";
+    erlang_javac = self.interpreters."${self.defaultVersion}_javac";
+    erlang_odbc_javac = self.interpreters."${self.defaultVersion}_odbc_javac";
 
     # Standard Erlang versions, using the generic builder.
 
     # R25
-    erlangR25 = lib.callErlang ../development/interpreters/erlang/R25.nix {
+    erlangR25 = self.beamLib.callErlang ../development/interpreters/erlang/R25.nix {
       wxGTK = wxGTK30;
       parallelBuild = true;
       autoconf = buildPackages.autoconf269;
       inherit wxSupport systemdSupport;
     };
-    erlangR25_odbc = erlangR25.override { odbcSupport = true; };
-    erlangR25_javac = erlangR25.override { javacSupport = true; };
-    erlangR25_odbc_javac = erlangR25.override {
+    erlangR25_odbc = self.interpreters.erlangR25.override { odbcSupport = true; };
+    erlangR25_javac = self.interpreters.erlangR25.override { javacSupport = true; };
+    erlangR25_odbc_javac = self.interpreters.erlangR25.override {
       javacSupport = true;
       odbcSupport = true;
     };
 
     # R24
-    erlangR24 = lib.callErlang ../development/interpreters/erlang/R24.nix {
+    erlangR24 = self.beamLib.callErlang ../development/interpreters/erlang/R24.nix {
       wxGTK = wxGTK30;
       # Can be enabled since the bug has been fixed in https://github.com/erlang/otp/pull/2508
       parallelBuild = true;
       autoconf = buildPackages.autoconf269;
       inherit wxSupport systemdSupport;
     };
-    erlangR24_odbc = erlangR24.override { odbcSupport = true; };
-    erlangR24_javac = erlangR24.override { javacSupport = true; };
-    erlangR24_odbc_javac = erlangR24.override {
+    erlangR24_odbc = self.interpreters.erlangR24.override { odbcSupport = true; };
+    erlangR24_javac = self.interpreters.erlangR24.override { javacSupport = true; };
+    erlangR24_odbc_javac = self.interpreters.erlangR24.override {
       javacSupport = true;
       odbcSupport = true;
     };
 
     # R23
-    erlangR23 = lib.callErlang ../development/interpreters/erlang/R23.nix {
+    erlangR23 = self.beamLib.callErlang ../development/interpreters/erlang/R23.nix {
       wxGTK = wxGTK30;
       # Can be enabled since the bug has been fixed in https://github.com/erlang/otp/pull/2508
       parallelBuild = true;
       autoconf = buildPackages.autoconf269;
       inherit wxSupport systemdSupport;
     };
-    erlangR23_odbc = erlangR23.override { odbcSupport = true; };
-    erlangR23_javac = erlangR23.override { javacSupport = true; };
-    erlangR23_odbc_javac = erlangR23.override {
+    erlangR23_odbc = self.interpreters.erlangR23.override { odbcSupport = true; };
+    erlangR23_javac = self.interpreters.erlangR23.override { javacSupport = true; };
+    erlangR23_odbc_javac = self.interpreters.erlangR23.override {
       javacSupport = true;
       odbcSupport = true;
     };
 
     # R22
-    erlangR22 = lib.callErlang ../development/interpreters/erlang/R22.nix {
+    erlangR22 = self.beamLib.callErlang ../development/interpreters/erlang/R22.nix {
       wxGTK = wxGTK30;
       # Can be enabled since the bug has been fixed in https://github.com/erlang/otp/pull/2508
       parallelBuild = true;
       autoconf = buildPackages.autoconf269;
       inherit wxSupport systemdSupport;
     };
-    erlangR22_odbc = erlangR22.override { odbcSupport = true; };
-    erlangR22_javac = erlangR22.override { javacSupport = true; };
-    erlangR22_odbc_javac = erlangR22.override {
+    erlangR22_odbc = self.interpreters.erlangR22.override { odbcSupport = true; };
+    erlangR22_javac = self.interpreters.erlangR22.override { javacSupport = true; };
+    erlangR22_odbc_javac = self.interpreters.erlangR22.override {
       javacSupport = true;
       odbcSupport = true;
     };
 
     # R21
-    erlangR21 = lib.callErlang ../development/interpreters/erlang/R21.nix {
+    erlangR21 = self.beamLib.callErlang ../development/interpreters/erlang/R21.nix {
       wxGTK = wxGTK30;
       autoconf = buildPackages.autoconf269;
       inherit wxSupport systemdSupport;
     };
-    erlangR21_odbc = erlangR21.override { odbcSupport = true; };
-    erlangR21_javac = erlangR21.override { javacSupport = true; };
-    erlangR21_odbc_javac = erlangR21.override {
+    erlangR21_odbc = self.interpreters.erlangR21.override { odbcSupport = true; };
+    erlangR21_javac = self.interpreters.erlangR21.override { javacSupport = true; };
+    erlangR21_odbc_javac = self.interpreters.erlangR21.override {
       javacSupport = true;
       odbcSupport = true;
     };
@@ -95,10 +103,10 @@ with beam; {
     # Other Beam languages. These are built with `beam.interpreters.erlang`. To
     # access for example elixir built with different version of Erlang, use
     # `beam.packages.erlangR24.elixir`.
-    inherit (packages.erlang)
+    inherit (self.packages.erlang)
       elixir elixir_1_14 elixir_1_13 elixir_1_12 elixir_1_11 elixir_1_10 elixir_ls;
 
-    inherit (packages.erlang) lfe lfe_1_3;
+    inherit (self.packages.erlang) lfe lfe_1_3;
   };
 
   # Helper function to generate package set with a specific Erlang version.
@@ -109,12 +117,12 @@ with beam; {
   # appropriate Erlang/OTP version.
   packages = {
     # Packages built with default Erlang version.
-    erlang = packages.${defaultVersion};
+    erlang = self.packages.${self.defaultVersion};
 
-    erlangR25 = packagesWith interpreters.erlangR25;
-    erlangR24 = packagesWith interpreters.erlangR24;
-    erlangR23 = packagesWith interpreters.erlangR23;
-    erlangR22 = packagesWith interpreters.erlangR22;
-    erlangR21 = packagesWith interpreters.erlangR21;
+    erlangR25 = self.packagesWith self.interpreters.erlangR25;
+    erlangR24 = self.packagesWith self.interpreters.erlangR24;
+    erlangR23 = self.packagesWith self.interpreters.erlangR23;
+    erlangR22 = self.packagesWith self.interpreters.erlangR22;
+    erlangR21 = self.packagesWith self.interpreters.erlangR21;
   };
 }


### PR DESCRIPTION
makes it clear where attrs are coming from

in preparation for trying to splice beam-packages.nix

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
