### PR TITLE
[22.05] python3Packages.Mako: 1.2.0 -> 1.2.2

### DIFF
--- a/pkgs/development/python-modules/Mako/default.nix
+++ b/pkgs/development/python-modules/Mako/default.nix
@@ -13,6 +13,8 @@
 # tests
 , mock
 , pytestCheckHook
+, lingua
+, chameleon
 }:
 
 buildPythonPackage rec {
@@ -37,8 +39,10 @@ buildPythonPackage rec {
   };
 
   checkInputs = [
-    pytestCheckHook
+    chameleon
+    lingua
     mock
+    pytestCheckHook
   ] ++ passthru.optional-dependencies.babel;
 
   disabledTests = lib.optionals isPyPy [
@@ -49,11 +53,6 @@ buildPythonPackage rec {
     "test_stdin_success"
     # fails on pypy2.7
     "test_bytestring_passthru"
-  ];
-
-  disabledTestPaths = [
-    # lingua dependency is not packaged
-    "test/ext/test_linguaplugin.py"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/Mako/default.nix
+++ b/pkgs/development/python-modules/Mako/default.nix
@@ -19,13 +19,13 @@
 
 buildPythonPackage rec {
   pname = "Mako";
-  version = "1.2.1";
+  version = "1.2.2";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-8FSl/0dDSS8aqezEcXLLM7QrnZk8/8wUbJ3hfnF7Awc=";
+    sha256 = "sha256-NySGmzY7pjCicqX4n2jAcDUhN7j9F1dlABe34G/aFj8=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/Mako/default.nix
+++ b/pkgs/development/python-modules/Mako/default.nix
@@ -17,13 +17,13 @@
 
 buildPythonPackage rec {
   pname = "Mako";
-  version = "1.2.0";
+  version = "1.2.1";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-mnx+kiuH2zaGIQz0nV12cDOkHUAQsoTnR2gskr3dizk=";
+    sha256 = "sha256-8FSl/0dDSS8aqezEcXLLM7QrnZk8/8wUbJ3hfnF7Awc=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/lingua/default.nix
+++ b/pkgs/development/python-modules/lingua/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, flit-core
+, polib
+, click }:
+
+buildPythonPackage rec {
+  pname = "lingua";
+  version = "4.15.0";
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-DhqUZ0HbKIpANhrQT/OP4EvwgZg0uKu4TEtTX+2bpO8=";
+  };
+
+  nativeBuildInputs = [
+    flit-core
+  ];
+
+  propagatedBuildInputs = [
+    click
+    polib
+  ];
+
+  pythonImportsCheck = [ "lingua" ];
+
+  meta = with lib; {
+    description = "Translation toolset";
+    homepage = "https://github.com/wichert/lingua";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ np ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4941,6 +4941,8 @@ in {
 
   line_profiler = callPackage ../development/python-modules/line_profiler { };
 
+  lingua = callPackage ../development/python-modules/lingua { };
+
   linkify-it-py = callPackage ../development/python-modules/linkify-it-py { };
 
   linode-api = callPackage ../development/python-modules/linode-api { };


### PR DESCRIPTION
###### Description of changes
https://nvd.nist.gov/vuln/detail/CVE-2022-40023

Backport of #190559, with prerequisites added including addition of a new package, `lingua` from #182938

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
