### PR TITLE
meerk40t: init at 0.8.0031

### DIFF
--- a/pkgs/applications/misc/meerk40t/default.nix
+++ b/pkgs/applications/misc/meerk40t/default.nix
@@ -1,0 +1,95 @@
+{ lib
+, fetchFromGitHub
+, python3
+, gtk3
+, wrapGAppsHook
+}:
+
+let
+  inherit (python3.pkgs) buildPythonApplication buildPythonPackage fetchPypi;
+
+  meerk40t-camera = buildPythonPackage rec {
+    pname = "meerk40t-camera";
+    version = "0.1.9";
+    format = "setuptools";
+
+    src = fetchPypi {
+      inherit pname version;
+      hash = "sha256-uGCBHdgWoorVX2XqMCg0YBweb00sQ9ZSbJe8rlGeovs=";
+    };
+
+    postPatch = ''
+      sed -i '/meerk40t/d' setup.py
+    '';
+
+    propagatedBuildInputs = with python3.pkgs; [
+      opencv4
+    ];
+
+    pythonImportsCheck = [
+      "camera"
+    ];
+
+    doCheck = false;
+
+    meta = with lib; {
+      description = "MeerK40t camera plugin";
+      license = licenses.mit;
+      homepage = "https://github.com/meerk40t/meerk40t-camera";
+      maintainers = with maintainers; [ hexa ];
+    };
+  };
+in
+buildPythonApplication rec {
+  pname = "MeerK40t";
+  version = "0.8.0031";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "meerk40t";
+    repo = pname;
+    rev = "refs/tags/${version}";
+    hash = "sha256-7Vc7Z+mxy+xRbUBeivkqVwO86ovZDo42M4G0ZD23vMk=";
+  };
+
+  nativeBuildInputs = [
+    wrapGAppsHook
+  ];
+
+  # prevent double wrapping
+  dontWrapGApps = true;
+
+  propagatedBuildInputs = with python3.pkgs; [
+    ezdxf
+    meerk40t-camera
+    opencv4
+    pillow
+    pyserial
+    pyusb
+    setuptools
+    wxPython_4_2
+  ];
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}"
+    )
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  checkInputs = with python3.pkgs; [
+    unittestCheckHook
+  ];
+
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  meta = with lib; {
+    changelog = "https://github.com/meerk40t/meerk40t/releases/tag/${version}";
+    description = "MeerK40t LaserCutter Software";
+    homepage = "https://github.com/meerk40t/meerk40t";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/development/python-modules/ezdxf/default.nix
+++ b/pkgs/development/python-modules/ezdxf/default.nix
@@ -1,22 +1,49 @@
-{ lib, buildPythonPackage, pythonOlder, fetchFromGitHub, pyparsing, pytest }:
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, pyparsing
+, typing-extensions
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
-  version = "0.12";
+  version = "0.18.1";
   pname = "ezdxf";
+  format = "setuptools";
 
   disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "mozman";
     repo = "ezdxf";
-    rev = "v${version}";
-    sha256 = "1flcq96ljk5wqrmgsb4acflqzkg7rhlaxz0j5jxky9za0mj1x6dq";
+    rev = "refs/tags/v${version}";
+    sha256 = "sha256-x1p9dWrbDtDreXdBuzOA4Za+ZC40y4xdEU7MGb9uUec=";
   };
 
-  checkInputs = [ pytest ];
-  checkPhase = "pytest tests integration_tests";
+  propagatedBuildInputs = [
+    pyparsing
+    typing-extensions
+  ];
 
-  propagatedBuildInputs = [ pyparsing ];
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # requires geomdl dependency
+    "TestNurbsPythonCorrectness"
+    "test_rational_spline_curve_points_by_nurbs_python"
+    "test_rational_spline_derivatives_by_nurbs_python"
+    "test_from_nurbs_python_curve_to_ezdxf_bspline"
+    "test_from_ezdxf_bspline_to_nurbs_python_curve_non_rational"
+    "test_from_ezdxf_bspline_to_nurbs_python_curve_rational"
+  ];
+
+  pythonImportsCheck = [
+    "ezdxf"
+    "ezdxf.addons"
+  ];
 
   meta = with lib; {
     description = "Python package to read and write DXF drawings (interface to the DXF file format)";

--- a/pkgs/development/python-modules/wxPython/4.0.nix
+++ b/pkgs/development/python-modules/wxPython/4.0.nix
@@ -20,6 +20,7 @@
 , CoreFoundation
 , pillow
 , numpy
+, six
 }:
 
 buildPythonPackage rec {
@@ -44,7 +45,11 @@ buildPythonPackage rec {
     [ wxGTK.gtk ]
   );
 
-  propagatedBuildInputs = [ pillow numpy ];
+  propagatedBuildInputs = [
+    numpy
+    pillow
+    six
+  ];
 
   DOXYGEN = "${doxygen}/bin/doxygen";
 

--- a/pkgs/development/python-modules/wxPython/4.1.nix
+++ b/pkgs/development/python-modules/wxPython/4.1.nix
@@ -13,6 +13,7 @@
 , wxGTK
 , pillow
 , numpy
+, six
 , libXinerama
 , libSM
 , libXxf86vm
@@ -70,7 +71,11 @@ buildPythonPackage rec {
     webkitgtk
   ];
 
-  propagatedBuildInputs = [ pillow numpy ];
+  propagatedBuildInputs = [
+    pillow
+    numpy
+    six
+  ];
 
   DOXYGEN = "${doxygen}/bin/doxygen";
 

--- a/pkgs/development/python-modules/wxPython/4.2-ctypes.patch
+++ b/pkgs/development/python-modules/wxPython/4.2-ctypes.patch
@@ -1,0 +1,18 @@
+diff --git a/wx/lib/wxcairo/wx_pycairo.py b/wx/lib/wxcairo/wx_pycairo.py
+index 7cfe3071..24d1120f 100644
+--- a/wx/lib/wxcairo/wx_pycairo.py
++++ b/wx/lib/wxcairo/wx_pycairo.py
+@@ -197,7 +197,12 @@ def _findCairoLib():
+ 
+ # For other DLLs we'll just use a dictionary to track them, as there
+ # probably isn't any need to use them outside of this module.
+-_dlls = dict()
++_dlls = {
++    "gdk": ctypes.CDLL("@libgdk@"),
++    "pangocairo": ctypes.CDLL("@libpangocairo@"),
++    "cairoLib": ctypes.CDLL("@libcairo@"),
++    "appsvc": ctypes.CDLL(None),
++}
+ 
+ def _findHelper(names, key, msg):
+     dll = _dlls.get(key, None)

--- a/pkgs/development/python-modules/wxPython/4.2.nix
+++ b/pkgs/development/python-modules/wxPython/4.2.nix
@@ -1,0 +1,133 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, pythonOlder
+, fetchPypi
+, substituteAll
+
+# build
+, autoPatchelfHook
+, attrdict
+, doxygen
+, pkg-config
+, python
+, sip
+, which
+
+# runtime
+, cairo
+, gst_all_1
+, gtk3
+, libGL
+, libGLU
+, libSM
+, libXinerama
+, libXtst
+, libXxf86vm
+, libglvnd
+, mesa
+, pango
+, SDL
+, webkitgtk
+, wxGTK
+, xorgproto
+
+# propagates
+, numpy
+, pillow
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "wxPython";
+  version = "4.2.0";
+  format = "other";
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-ZjzrxFCdfl0RNRiGX+J093+VQ0xdV7w4btWNZc7thsc=";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./4.2-ctypes.patch;
+      libgdk = "${gtk3.out}/lib/libgdk-3.so";
+      libpangocairo = "${pango}/lib/libpangocairo-1.0.so";
+      libcairo = "${cairo}/lib/libcairo.so";
+    })
+  ];
+
+  nativeBuildInputs = [
+    attrdict
+    pkg-config
+    SDL
+    sip
+    which
+    wxGTK
+  ] ++ lib.optionals stdenv.isLinux [
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    wxGTK
+    SDL
+  ] ++ lib.optionals stdenv.isLinux [
+    gst_all_1.gst-plugins-base
+    gst_all_1.gstreamer
+    libGL
+    libGLU
+    libSM
+    libXinerama
+    libXtst
+    libXxf86vm
+    libglvnd
+    mesa
+    webkitgtk
+    xorgproto
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+    pillow
+    six
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    export DOXYGEN=${doxygen}/bin/doxygen
+    export PATH="${wxGTK}/bin:$PATH"
+    export SDL_CONFIG="${SDL.dev}/bin/sdl-config"
+
+    ${python.interpreter} build.py -v --use_syswx dox etg sip --nodoc build_py
+
+    runHook postBuild
+  '';
+
+
+  installPhase = ''
+    runHook preInstall
+
+    ${python.interpreter} setup.py install --skip-build --prefix=$out
+    wrapPythonPrograms
+
+    runHook postInstall
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+
+    ${python.interpreter} build.py -v test
+
+    runHook postCheck
+  '';
+
+
+  meta = with lib; {
+    description = "Cross platform GUI toolkit for Python, Phoenix version";
+    homepage = "http://wxpython.org/";
+    license = licenses.wxWindows;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28701,6 +28701,8 @@ with pkgs;
 
   marker = callPackage ../applications/editors/marker { };
 
+  meerk40t = callPackage ../applications/misc/meerk40t { };
+
   musikcube = callPackage ../applications/audio/musikcube {
     inherit (darwin.apple_sdk.frameworks) Cocoa SystemConfiguration;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11899,6 +11899,13 @@ in {
     };
   };
 
+  wxPython_4_2 = callPackage ../development/python-modules/wxPython/4.2.nix {
+    wxGTK = pkgs.wxGTK32.override {
+      withWebKit = true;
+    };
+  };
+
+
   x11_hash = callPackage ../development/python-modules/x11_hash { };
 
   x256 = callPackage ../development/python-modules/x256 { };


### PR DESCRIPTION
> MeerK40t (pronounced MeerKat) is a built-from-the-ground-up MIT licensed open-source laser cutting software. It's a replacement for LaserDrw, Corel Laser, and K40 Whisperer.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
