### PR TITLE
[22.05] blightmud: 3.6.2 -> 4.0.0 

### DIFF
--- a/pkgs/games/blightmud/default.nix
+++ b/pkgs/games/blightmud/default.nix
@@ -3,16 +3,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "blightmud";
-  version = "3.5.0";
+  version = "4.0.0";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-DaICzwBew90YstV42wiY0IbvR1W4Hm8dzo3xY2qlMGQ=";
+    sha256 = "sha256-80uTwbZjXoQnfP0VWM/CnvaHyRsPA1puASJwBm3GqJk=";
   };
 
-  cargoSha256 = "sha256-BamMTPh+GN9GG4puxyTauPhjCC8heCu1wsgFaw98s9U=";
+  cargoSha256 = "sha256-uXr/5G0TH3EKqPwUKTwOguBExBEYB1D3/hr8nzOwCcM=";
 
   buildFeatures = lib.optional withTTS "tts";
 


### PR DESCRIPTION
###### Description of changes

_This is a backport of an update to Blightmud with no breaking changes, merged to master in https://github.com/NixOS/nixpkgs/pull/190388_

Updates blightmud derivation to v4.0.0. See the [upstream project](https://github.com/Blightmud/Blightmud/releases/tag/v4.0.0) for full release notes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [X] (Package updates) Added a release notes entry if the change is major or breaking
  - [X] (Module updates) Added a release notes entry if the change is significant
  - [X] (Module addition) Added a release notes entry if adding a new NixOS module
  - [X] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
