### PR TITLE
fcitx5: 5.0.18 -> 5.0.19 with its plugins

### DIFF
--- a/pkgs/development/libraries/libime/default.nix
+++ b/pkgs/development/libraries/libime/default.nix
@@ -13,26 +13,26 @@ let
     url = "https://download.fcitx-im.org/data/table.tar.gz";
     sha256 = "1dw7mgbaidv3vqy0sh8dbfv8631d2zwv5mlb7npf69a1f8y0b5k1";
   };
-  arpaVer = "20220630";
+  arpaVer = "20220810";
   arpa = fetchurl {
     url = "https://download.fcitx-im.org/data/lm_sc.arpa-${arpaVer}.tar.xz";
-    sha256 = "sha256-jTsPqPoWuT0NRZDwLaBAKcJxNktZJcHJAoRcN0oqAL8=";
+    sha256 = "sha256-oRvJfSda2vGV+brIVDaK4GzbSg/h7s9Z21rlgGFdtPo=";
   };
-  dictVer = "20220706";
+  dictVer = "20220810";
   dict = fetchurl {
     url = "https://download.fcitx-im.org/data/dict-${dictVer}.tar.xz";
-    sha256 = "sha256-vNeR//eDr7QMHI6S2z+Dc0+Lk8nGriwV4eqHeLkHB3k=";
+    sha256 = "sha256-lxdS9BMYgAfo0ZFYwRuFyVXiXXsyHsInXEs69tioXSY=";
   };
 in
 stdenv.mkDerivation rec {
   pname = "libime";
-  version = "unstable-2022-07-11";
+  version = "1.0.14";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "libime";
-    rev = "1adb14eb0617ef0eb0f07ad99684f43ca8a4395c";
-    sha256 = "sha256-UldswsnkMuJh2G/EdsFl4CS7Y2RSRAb1hYeWUA2MHPw=";
+    rev = version;
+    sha256 = "sha256-O89Op2dxuhGgCxuy2GLI0waCgDreJKNQ5tTvsx/0/fk=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/tools/inputmethods/fcitx5/default.nix
+++ b/pkgs/tools/inputmethods/fcitx5/default.nix
@@ -41,17 +41,17 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "fcitx5";
-  version = "5.0.18";
+  version = "5.0.19";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = pname;
     rev = version;
-    sha256 = "sha256-ZhjNUWzi74lr8Wtf0f+VN1kc9C6q2TJ9ogXeu3NJKbI=";
+    sha256 = "sha256-hgg7Sbe5/tAWWq2to9PceBQeUdV3UWENFgvuY0qCksM=";
   };
 
   prePatch = ''
-    ln -s ${enDict} src/modules/spell/dict/$(stripHash ${enDict})
+    ln -s ${enDict} src/modules/spell/$(stripHash ${enDict})
   '';
 
   nativeBuildInputs = [

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-chinese-addons.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-chinese-addons.nix
@@ -31,13 +31,13 @@ in
 
 mkDerivation rec {
   pname = "fcitx5-chinese-addons";
-  version = "5.0.14";
+  version = "5.0.15";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = pname;
     rev = version;
-    sha256 = "sha256-ZIOPzRXW+aaVKDIBC3N04wx662r8WOa205CgTeYmudQ=";
+    sha256 = "sha256-9AGL0eAkaA2N/aE8VlgRCnW2lAl55SroBumeU5xkW5M=";
   };
 
   cmakeFlags = [

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-gtk.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-gtk.nix
@@ -26,13 +26,13 @@
 
 stdenv.mkDerivation rec {
   pname = "fcitx5-gtk";
-  version = "5.0.17";
+  version = "5.0.18";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = pname;
     rev = version;
-    sha256 = "sha256-sAPbbMoZ4NGiE7lbtcdzQQsPib6i52JwWsLe+bmTshU=";
+    sha256 = "sha256-rQ2HLiI0dIerxRV+fbHpTJy4aGmFKmGd6YckKxXmp4s=";
   };
 
   cmakeFlags = [


### PR DESCRIPTION
###### Description of changes

- https://github.com/fcitx/libime/compare/1adb14eb0617ef0eb0f07ad99684f43ca8a4395c...1.0.14
- https://github.com/fcitx/fcitx5/compare/5.0.18...5.0.19
- https://github.com/fcitx/fcitx5-chinese-addons/compare/5.0.14...5.0.15
- https://github.com/fcitx/fcitx5-gtk/compare/5.0.17...5.0.18

Closes #190234

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
