### PR TITLE
nextcloud23: 23.0.8 -> 23.0.9, nextcloud24: 24.0.4 -> 24.0.5

### DIFF
--- a/nixos/tests/nextcloud/with-declarative-redis-and-secrets.nix
+++ b/nixos/tests/nextcloud/with-declarative-redis-and-secrets.nix
@@ -47,9 +47,8 @@ in {
         };
       };
 
-      services.redis = {
-        enable = true;
-      };
+      services.redis.servers."nextcloud".enable = true;
+      services.redis.servers."nextcloud".port = 6379;
 
       systemd.services.nextcloud-setup= {
         requires = ["postgresql.service"];

--- a/nixos/tests/nextcloud/with-postgresql-and-redis.nix
+++ b/nixos/tests/nextcloud/with-postgresql-and-redis.nix
@@ -37,9 +37,8 @@ in {
         };
       };
 
-      services.redis = {
-        enable = true;
-      };
+      services.redis.servers."nextcloud".enable = true;
+      services.redis.servers."nextcloud".port = 6379;
 
       systemd.services.nextcloud-setup= {
         requires = ["postgresql.service"];

--- a/pkgs/servers/nextcloud/0001-Setup-remove-custom-dbuser-creation-behavior.patch
+++ b/pkgs/servers/nextcloud/0001-Setup-remove-custom-dbuser-creation-behavior.patch
@@ -1,0 +1,135 @@
+From 045f33745f863ba20acfc3fe335c575d9cd87884 Mon Sep 17 00:00:00 2001
+From: Maximilian Bosch <maximilian@mbosch.me>
+Date: Sat, 10 Sep 2022 15:18:05 +0200
+Subject: [PATCH] Setup: remove custom dbuser creation behavior
+
+Both PostgreSQL and MySQL can be authenticated against from Nextcloud by
+supplying a database password. Now, during setup the following things
+happen:
+
+* When using postgres and the db user has elevated permissions, a new
+  unprivileged db user is created and the settings `dbuser`/`dbpass` are
+  altered in `config.php`.
+
+* When using MySQL, the password is **always** regenerated since
+  24.0.5/23.0.9[1].
+
+I consider both cases problematic: the reason why people do configuration
+management is to have it as single source of truth! So, IMHO any
+application that silently alters config and thus causes deployed
+nodes to diverge from the configuration is harmful for that.
+
+I guess it was sheer luck that it worked for so long in NixOS because
+nobody has apparently used password authentication with a privileged
+user to operate Nextcloud (which is a good thing in fact).
+
+[1] https://github.com/nextcloud/server/pull/33513
+---
+ lib/private/Setup/MySQL.php      | 53 --------------------------------
+ lib/private/Setup/PostgreSQL.php | 26 ----------------
+ 2 files changed, 79 deletions(-)
+
+diff --git a/lib/private/Setup/MySQL.php b/lib/private/Setup/MySQL.php
+index 2c16cac3d2..9b2265091f 100644
+--- a/lib/private/Setup/MySQL.php
++++ b/lib/private/Setup/MySQL.php
+@@ -142,59 +142,6 @@ class MySQL extends AbstractDatabase {
+ 		$rootUser = $this->dbUser;
+ 		$rootPassword = $this->dbPassword;
+ 
+-		//create a random password so we don't need to store the admin password in the config file
+-		$saveSymbols = str_replace(['\"', '\\', '\'', '`'], '', ISecureRandom::CHAR_SYMBOLS);
+-		$password = $this->random->generate(22, ISecureRandom::CHAR_ALPHANUMERIC . $saveSymbols)
+-			. $this->random->generate(2, ISecureRandom::CHAR_UPPER)
+-			. $this->random->generate(2, ISecureRandom::CHAR_LOWER)
+-			. $this->random->generate(2, ISecureRandom::CHAR_DIGITS)
+-			. $this->random->generate(2, $saveSymbols)
+-		;
+-		$this->dbPassword = str_shuffle($password);
+-
+-		try {
+-			//user already specified in config
+-			$oldUser = $this->config->getValue('dbuser', false);
+-
+-			//we don't have a dbuser specified in config
+-			if ($this->dbUser !== $oldUser) {
+-				//add prefix to the admin username to prevent collisions
+-				$adminUser = substr('oc_' . $username, 0, 16);
+-
+-				$i = 1;
+-				while (true) {
+-					//this should be enough to check for admin rights in mysql
+-					$query = 'SELECT user FROM mysql.user WHERE user=?';
+-					$result = $connection->executeQuery($query, [$adminUser]);
+-
+-					//current dbuser has admin rights
+-					$data = $result->fetchAll();
+-					$result->closeCursor();
+-					//new dbuser does not exist
+-					if (count($data) === 0) {
+-						//use the admin login data for the new database user
+-						$this->dbUser = $adminUser;
+-						$this->createDBUser($connection);
+-
+-						break;
+-					} else {
+-						//repeat with different username
+-						$length = strlen((string)$i);
+-						$adminUser = substr('oc_' . $username, 0, 16 - $length) . $i;
+-						$i++;
+-					}
+-				}
+-			}
+-		} catch (\Exception $ex) {
+-			$this->logger->info('Can not create a new MySQL user, will continue with the provided user.', [
+-				'exception' => $ex,
+-				'app' => 'mysql.setup',
+-			]);
+-			// Restore the original credentials
+-			$this->dbUser = $rootUser;
+-			$this->dbPassword = $rootPassword;
+-		}
+-
+ 		$this->config->setValues([
+ 			'dbuser' => $this->dbUser,
+ 			'dbpassword' => $this->dbPassword,
+diff --git a/lib/private/Setup/PostgreSQL.php b/lib/private/Setup/PostgreSQL.php
+index bc24909dc3..e49e5508e1 100644
+--- a/lib/private/Setup/PostgreSQL.php
++++ b/lib/private/Setup/PostgreSQL.php
+@@ -45,32 +45,6 @@ class PostgreSQL extends AbstractDatabase {
+ 			$connection = $this->connect([
+ 				'dbname' => 'postgres'
+ 			]);
+-			//check for roles creation rights in postgresql
+-			$builder = $connection->getQueryBuilder();
+-			$builder->automaticTablePrefix(false);
+-			$query = $builder
+-				->select('rolname')
+-				->from('pg_roles')
+-				->where($builder->expr()->eq('rolcreaterole', new Literal('TRUE')))
+-				->andWhere($builder->expr()->eq('rolname', $builder->createNamedParameter($this->dbUser)));
+-
+-			try {
+-				$result = $query->execute();
+-				$canCreateRoles = $result->rowCount() > 0;
+-			} catch (DatabaseException $e) {
+-				$canCreateRoles = false;
+-			}
+-
+-			if ($canCreateRoles) {
+-				//use the admin login data for the new database user
+-
+-				//add prefix to the postgresql user name to prevent collisions
+-				$this->dbUser = 'oc_' . strtolower($username);
+-				//create a new password so we don't need to store the admin config in the config file
+-				$this->dbPassword = \OC::$server->getSecureRandom()->generate(30, ISecureRandom::CHAR_ALPHANUMERIC);
+-
+-				$this->createDBUser($connection);
+-			}
+ 
+ 			$this->config->setValues([
+ 				'dbuser' => $this->dbUser,
+-- 
+2.36.2
+

--- a/pkgs/servers/nextcloud/default.nix
+++ b/pkgs/servers/nextcloud/default.nix
@@ -46,8 +46,8 @@ in {
   '';
 
   nextcloud23 = generic {
-    version = "23.0.8";
-    sha256 = "ac3d042253399be25a2aa01c799dec75a1459b6ae453874414f6528cc2ee5061";
+    version = "23.0.9";
+    sha256 = "sha256-Ysxapp8IpRcRBC3CRM4yxoGYCuedAVURT3FhDD4jNBY=";
   };
 
   nextcloud24 = generic {

--- a/pkgs/servers/nextcloud/default.nix
+++ b/pkgs/servers/nextcloud/default.nix
@@ -51,8 +51,8 @@ in {
   };
 
   nextcloud24 = generic {
-    version = "24.0.4";
-    sha256 = "d107426f8e1c193db882a04c844f9bc7e7eeb7c21e46c46197e5154d6d6ac28e";
+    version = "24.0.5";
+    sha256 = "sha256-sieIN3zLk5Hn+eztP2mpI2Zprqqy4OpSUKc+318e8CY=";
   };
 
   # tip: get the sha with:

--- a/pkgs/servers/nextcloud/default.nix
+++ b/pkgs/servers/nextcloud/default.nix
@@ -13,6 +13,8 @@ let
       inherit sha256;
     };
 
+    patches = [ ./0001-Setup-remove-custom-dbuser-creation-behavior.patch ];
+
     passthru.tests = nixosTests.nextcloud;
 
     installPhase = ''


### PR DESCRIPTION
###### Description of changes

https://nextcloud.com/changelog/#23-0-9
https://nextcloud.com/changelog/#24-0-5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
