### PR TITLE
python310Packages.vapoursynth: add a withPlugins to extend it

### DIFF
--- a/pkgs/development/libraries/vapoursynth/plugin-interface.nix
+++ b/pkgs/development/libraries/vapoursynth/plugin-interface.nix
@@ -42,6 +42,7 @@ runCommand "${vapoursynth.name}-with-plugins" {
   nativeBuildInputs = [ makeWrapper ];
   passthru = {
     inherit python3;
+    inherit (vapoursynth) src version;
     withPlugins = plugins': withPlugins (plugins ++ plugins');
   };
 } ''

--- a/pkgs/development/python-modules/vapoursynth/default.nix
+++ b/pkgs/development/python-modules/vapoursynth/default.nix
@@ -1,4 +1,4 @@
-{ vapoursynth, cython, buildPythonPackage, unittestCheckHook }:
+{ vapoursynth, cython, buildPythonPackage, unittestCheckHook, python }:
 
 buildPythonPackage {
   pname = "vapoursynth";
@@ -18,6 +18,13 @@ buildPythonPackage {
   ];
 
   unittestFlagsArray = [ "-s" "$src/test" "-p" "'*test.py'" ];
+
+  passthru = {
+    withPlugins = plugins:
+      python.pkgs.vapoursynth.override {
+        vapoursynth = vapoursynth.withPlugins plugins;
+      };
+  };
 
   inherit (vapoursynth) meta;
 }


### PR DESCRIPTION
###### Description of changes

Right now, doing

```nix
pkgs.python310Packages.vapoursynth.override {
  vapoursynth = pkgs.vapoursynth.withPlugins [ pkgs.ffms ];
}
```

would fail with`error: attribute 'version' missing`.

In addition, it adds `pythonPackages.vapoursynth.withPlugins` that achieves the same result as manually overriding vapoursynth.

###### Things done

*Note to reviewers:
Be aware that on darwin vapoursynth.withPlugins is currently failing. In fact, this feature is currently causing vapoursynth to fail compiling at all on darwin. Fixing this specific issue is out of scope of this PR.*

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
