### PR TITLE
wdomirror: fix failing build

### DIFF
--- a/pkgs/tools/wayland/wdomirror/default.nix
+++ b/pkgs/tools/wayland/wdomirror/default.nix
@@ -40,8 +40,14 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace "werror=true" "werror=false"
+  '';
+
   meta = with lib; {
     description = "Mirrors an output of a wlroots compositor to a window";
+    homepage = "https://github.com/progandy/wdomirror";
     license = licenses.mit;
     platforms = platforms.unix;
     maintainers = with maintainers; [ jpas ];


### PR DESCRIPTION
###### Description of changes

* Fix wdomirror failing build

```
[18/19] Compiling C object wdomirror.p/main.c.o
FAILED: wdomirror.p/main.c.o 
gcc -Iwdomirror.p -I. -I.. -Iprotocol -I../protocol -I/nix/store/99az9xyry9p55sagrrph44ps5gsj21gz-wayland-1.21.0-dev/include -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Werror -std=c11 -Wno-missing-braces -Wno-unused-parameter -MD -MQ wdomirror.p/main.c.o -MF wdomirror.p/main.c.o.d -o wdomirror.p/main.c.o -c ../main.c
../main.c:420:1: error: missing initializer for field 'wm_capabilities' of 'const struct xdg_toplevel_listener' [-Werror=missing-field-initializers]
  420 | };
```

A resolution is to remove the `-Werror` flag.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
