### PR TITLE
ldmud: init at 3.6.6

### DIFF
--- a/pkgs/games/ldmud/default.nix
+++ b/pkgs/games/ldmud/default.nix
@@ -1,0 +1,100 @@
+{ lib
+, fetchFromGitHub
+, stdenv
+, autoreconfHook
+, pkg-config
+, bison
+, libiconv
+, pcre
+, libgcrypt
+, json_c
+, libxml2
+, ipv6Support ? false
+, mccpSupport ? false
+, zlib
+, mysqlSupport ? false
+, libmysqlclient
+, postgresSupport ? false
+, postgresql
+, sqliteSupport ? false
+, sqlite
+, tlsSupport ? false
+, openssl
+, pythonSupport ? false
+, python310
+, ...
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ldmud";
+  version = "3.6.6";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-2TaFt+T9B5Df6KWRQcbhY1E1D6NISb0oqLgyX47f5lI=";
+  };
+
+  sourceRoot = "${src.name}/src";
+
+  nativeBuildInputs =
+    [ autoreconfHook pkg-config bison libgcrypt pcre json_c libxml2 ]
+    ++ lib.optional mccpSupport zlib ++ lib.optional mysqlSupport libmysqlclient
+    ++ lib.optional postgresSupport postgresql
+    ++ lib.optional sqliteSupport sqlite ++ lib.optional tlsSupport openssl
+    ++ lib.optional pythonSupport python310;
+  buildInputs = lib.optionals stdenv.isDarwin [ libiconv ];
+
+  # To support systems without autoconf LD puts its configure.ac in a non-default
+  # location and uses a helper script. We skip that script and symlink the .ac
+  # file to where the autoreconfHook find it.
+  preAutoreconf = ''
+    ln -fs ./autoconf/configure.ac ./
+  '';
+
+  configureFlags = [
+    "--enable-erq=xerq"
+    "--enable-filename-spaces"
+    "--enable-use-json"
+    "--enable-use-xml=xml2"
+    (lib.enableFeature ipv6Support "use-ipv6")
+    (lib.enableFeature mccpSupport "use-mccp")
+    (lib.enableFeature mysqlSupport "use-mysql")
+    (lib.enableFeature postgresSupport "use-pgsql")
+    (lib.enableFeature sqliteSupport "use-sqlite")
+    (lib.enableFeatureAs tlsSupport "use-tls" "ssl")
+    (lib.enableFeature pythonSupport "use-python")
+  ];
+
+  preConfigure = lib.optionalString mysqlSupport ''
+    export CPPFLAGS="-I${lib.getDev libmysqlclient}/include/mysql"
+    export LDFLAGS="-L${libmysqlclient}/lib/mysql"
+  '';
+
+  installTargets = [ "install-driver" "install-utils" "install-headers" ];
+
+  postInstall = ''
+    mkdir -p "$out/share/"
+    cp -v ../COPYRIGHT $out/share/
+  '';
+
+  meta = with lib; {
+    description = "A gamedriver for LPMuds including a LPC compiler, interpreter and runtime";
+    homepage = "https://ldmud.eu";
+    changelog = "https://github.com/ldmud/ldmud/blob/${version}/HISTORY";
+    longDescription = ''
+      LDMud started as a project to clean up and modernize Amylaar's LPMud
+      gamedriver. Primary goals are full documentation, a commented source body
+      and out-of-the-box support for the major mudlibs, of which the commented
+      source body has been pretty much completed. During the course of work
+      a lot of bug fixes and improvements found their way into the driver - much
+      more than originally expected, and definitely enough to make LDMud
+      a driver in its own right.
+    '';
+    # See https://github.com/ldmud/ldmud/blob/master/COPYRIGHT
+    license = licenses.unfreeRedistributable;
+    platforms = with platforms; linux ++ darwin;
+    maintainers = with maintainers; [ cpu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33247,6 +33247,18 @@ with pkgs;
 
   koules = callPackage ../games/koules { };
 
+  ldmud = callPackage ../games/ldmud { };
+
+  ldmud-full = callPackage ../games/ldmud {
+    ipv6Support = true;
+    mccpSupport = true;
+    mysqlSupport = true;
+    postgresSupport = true;
+    sqliteSupport = true;
+    tlsSupport = true;
+    pythonSupport = true;
+  };
+
   leela-zero = libsForQt5.callPackage ../games/leela-zero { };
 
   legendary-gl = python38Packages.callPackage ../games/legendary-gl { };


### PR DESCRIPTION
###### Description of changes

LDMud is a game engine for text based multi-user dungeon games ([MUDs](https://en.wikipedia.org/wiki/MUD)), in the ["LPMud" heritage](https://en.wikipedia.org/wiki/LPMud). In essence it is a virtual machine that allows developers to implement MUD games ("mudlibs" in LD parlance) using the LPC programming language.

Its homepage is: http://www.ldmud.eu/
Source code available at: https://github.com/ldmud/ldmud

In the project's own words:
> This is 'LDMud', a gamedriver for LPMuds. (LPC compiler, interpreter
> and runtime environment.)
>
> LDMud started as a project to clean up and modernize Amylaar's LPMud
> gamedriver. Primary goals are full documentation, a commented source
> body and out-of-the-box support for the major mudlibs, of which the
> commented source body has been pretty much completed. During the course
> of work a lot of bug fixes and improvements found their way into the
> driver - much more than originally expected, and definitely enough to
> make LDMud a driver in its own right.

######  Nixpkgs Derivation Notes 

For nixpkgs the new LDMud addition is largely a standard derivation for an autoreconf/automake based project. Some small tweaks are required to get everything lined up between the Nix environment and the LDMud build system.

The new LDMud derivation is placed in `pkgs/games/ldmud/` alongside other MUD-related projects in the games category (e.g. `mudlet`, `blightmud`).

The License is set to `licenses.unfreeRedistributable` since the [upstream COPYRIGHT](https://github.com/ldmud/ldmud/blob/master/COPYRIGHT) is non-standard but does allow redistribution. The LDMud copyright grants the rights to redistribute unmodified or modified binaries or source, with the added requirement that the software not be used for monetary gain. We include the COPYRIGHT file in the built output to ensure we meet the requirements for distribution.

LDMud offers a variety of optional features, some of which require heavier dependencies (e.g. MySQL/Postgres client libraries). To support both a minimal default build equal to what one gets using the upstream build with no customization, and to also support a more useful fully featured build, the LDMud derivation is added to `all-packages.nix` twice:

1. the `ldmud` attribute builds the minimal default configuration (just the optional gcrypt and pcre options enabled, matching upstream).
2. the `ldmud-full` attribute builds LDMud with all of the optional features enabled (database support, Python support, TLS support, etc).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [X] (Package updates) Added a release notes entry if the change is major or breaking
  - [X] (Module updates) Added a release notes entry if the change is significant
  - [X] (Module addition) Added a release notes entry if adding a new NixOS module
  - [X] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
