### PR TITLE
eartag: init at 0.2.1

### DIFF
--- a/pkgs/applications/audio/eartag/default.nix
+++ b/pkgs/applications/audio/eartag/default.nix
@@ -1,0 +1,78 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, meson
+, ninja
+, pkg-config
+, wrapGAppsHook4
+, libadwaita
+, gettext
+, glib
+, gobject-introspection
+, desktop-file-utils
+, appstream-glib
+, gtk4
+, librsvg
+, python3Packages
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "eartag";
+  version = "0.2.1";
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "knuxify";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-TlY2F2y7ZZ9f+vkYYkES5zoIGcuTWP1+rOJI62wc4SU=";
+  };
+
+  postPatch = ''
+    chmod +x ./build-aux/meson/postinstall.py
+    patchShebangs ./build-aux/meson/postinstall.py
+    substituteInPlace ./build-aux/meson/postinstall.py \
+      --replace "gtk-update-icon-cache" "gtk4-update-icon-cache"
+  '';
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    glib
+    desktop-file-utils
+    appstream-glib
+    pkg-config
+    gettext
+    gobject-introspection
+    wrapGAppsHook4
+  ] ++ lib.optional stdenv.isDarwin gtk4; # for gtk4-update-icon-cache
+
+  buildInputs = [
+    librsvg
+    libadwaita
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    pygobject3
+    eyeD3
+    pillow
+    mutagen
+    pytaglib
+    python-magic
+  ];
+
+  dontWrapGApps = true;
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/knuxify/eartag";
+    description = "Simple music tag editor";
+    # This seems to be using ICU license but we're flagging it to MIT license
+    # since ICU license is a modified version of MIT and to prevent it from
+    # being incorrectly identified as unfree software.
+    license = licenses.mit;
+    maintainers = with maintainers; [ foo-dogsquared ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2501,6 +2501,8 @@ with pkgs;
 
   droidmote = callPackage ../tools/inputmethods/droidmote { };
 
+  eartag = callPackage ../applications/audio/eartag { };
+
   ecdsautils = callPackage ../tools/security/ecdsautils { };
 
   echidna = haskell.lib.compose.justStaticExecutables (haskellPackages.callPackage (../tools/security/echidna) { });


### PR DESCRIPTION
###### Description of changes

Add [Ear Tag](https://github.com/knuxify/eartag/), a simple tag editor for your music files.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
