### PR TITLE
fusuma: 1.3.0 -> 2.4.1

### DIFF
--- a/pkgs/tools/inputmethods/fusuma/Gemfile
+++ b/pkgs/tools/inputmethods/fusuma/Gemfile
@@ -1,2 +1,2 @@
 source 'https://rubygems.org'
-gem "fusuma"
+gem 'fusuma', '2.4.1'

--- a/pkgs/tools/inputmethods/fusuma/Gemfile
+++ b/pkgs/tools/inputmethods/fusuma/Gemfile
@@ -1,2 +1,2 @@
 source 'https://rubygems.org'
-gem 'fusuma', '2.4.1'
+gem 'fusuma'

--- a/pkgs/tools/inputmethods/fusuma/Gemfile.lock
+++ b/pkgs/tools/inputmethods/fusuma/Gemfile.lock
@@ -1,13 +1,13 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    fusuma (1.3.0)
+    fusuma (2.4.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  fusuma
+  fusuma (= 2.4.1)
 
 BUNDLED WITH
    2.1.4

--- a/pkgs/tools/inputmethods/fusuma/gemset.nix
+++ b/pkgs/tools/inputmethods/fusuma/gemset.nix
@@ -4,9 +4,9 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "150jc8jyqj3w4k13lf1ihqmm2sld1yawp4jwnf43jixnc9rmzx6f";
+      sha256 = "0rq64grp98w7msjmj24hlxy1jqzqn96r81x4z09aq2v532cgqy4f";
       type = "gem";
     };
-    version = "1.3.0";
+    version = "2.4.1";
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
[Changelog](https://github.com/iberianpig/fusuma/blob/v2.4.1/CHANGELOG.md)
[Full Changelog](https://github.com/iberianpig/fusuma/compare/v1.3.0...v2.4.1)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (https://github.com/LazyGeniusMan/nixpkgs-test/actions/runs/3028417409)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
```
W, [2022-09-10T22:13:19.482670 #49317]  WARN -- : config file: /root/.config/fusuma/config.yml is NOT FOUND
I, [2022-09-10T22:13:19.482715 #49317]  INFO -- : reload config: /nix/store/arp31243gggwxx1830h6rabvyqkya4ja-ruby2.7.6-fusuma-2.4.1/lib/ruby/gems/2.7.0/gems/fusuma-2.4.1/lib/fusuma/config.yml
I, [2022-09-10T22:13:19.502891 #49317]  INFO -- : ---------------------------------------------
I, [2022-09-10T22:13:19.503143 #49317]  INFO -- : Fusuma: 2.4.1
I, [2022-09-10T22:13:19.506273 #49317]  INFO -- : libinput: 1.21.0
I, [2022-09-10T22:13:19.506321 #49317]  INFO -- : ruby 2.7.6p219
I, [2022-09-10T22:13:19.508528 #49317]  INFO -- : OS: Linux 5.19.5 #1-NixOS SMP PREEMPT_DYNAMIC Mon Aug 29 09:18:05 UTC 2022
I, [2022-09-10T22:13:19.510571 #49317]  INFO -- : Distribution: 
<<< Welcome to NixOS 22.11pre405560.2da64a81275 (\m) - \l >>>

Run 'nixos-help' for the NixOS manual.
I, [2022-09-10T22:13:19.514265 #49317]  INFO -- : Desktop session:
I, [2022-09-10T22:13:19.514303 #49317]  INFO -- : ---------------------------------------------
I, [2022-09-10T22:13:19.514319 #49317]  INFO -- : Enabled Plugins: 
I, [2022-09-10T22:13:19.514392 #49317]  INFO -- :   Fusuma::Plugin::Buffers::GestureBuffer
I, [2022-09-10T22:13:19.514405 #49317]  INFO -- :   Fusuma::Plugin::Buffers::TimerBuffer
I, [2022-09-10T22:13:19.514413 #49317]  INFO -- :   Fusuma::Plugin::Detectors::HoldDetector
I, [2022-09-10T22:13:19.514420 #49317]  INFO -- :   Fusuma::Plugin::Detectors::PinchDetector
I, [2022-09-10T22:13:19.514427 #49317]  INFO -- :   Fusuma::Plugin::Detectors::RotateDetector
I, [2022-09-10T22:13:19.514435 #49317]  INFO -- :   Fusuma::Plugin::Detectors::SwipeDetector
I, [2022-09-10T22:13:19.514446 #49317]  INFO -- :   Fusuma::Plugin::Events::Records::ContextRecord
I, [2022-09-10T22:13:19.514454 #49317]  INFO -- :   Fusuma::Plugin::Events::Records::GestureRecord
I, [2022-09-10T22:13:19.514461 #49317]  INFO -- :   Fusuma::Plugin::Events::Records::IndexRecord
I, [2022-09-10T22:13:19.514468 #49317]  INFO -- :   Fusuma::Plugin::Events::Records::TextRecord
I, [2022-09-10T22:13:19.514474 #49317]  INFO -- :   Fusuma::Plugin::Executors::CommandExecutor
I, [2022-09-10T22:13:19.514481 #49317]  INFO -- :   Fusuma::Plugin::Filters::LibinputDeviceFilter
I, [2022-09-10T22:13:19.514488 #49317]  INFO -- :   Fusuma::Plugin::Inputs::LibinputCommandInput
I, [2022-09-10T22:13:19.514495 #49317]  INFO -- :   Fusuma::Plugin::Inputs::TimerInput
I, [2022-09-10T22:13:19.514502 #49317]  INFO -- :   Fusuma::Plugin::Parsers::LibinputGestureParser
I, [2022-09-10T22:13:19.514510 #49317]  INFO -- : ---------------------------------------------
I, [2022-09-10T22:22:27.367834 #49317]  INFO -- : {:command=>"xdotool key alt+Left", :args=>{:move_x=>43.61, :move_y=>11.76, :unaccelerated_x=>26.07, :unaccelerated_y=>7.03, :zoom=>0.0, :rotate=>0.0}}
```
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Notes
This app have bunch of plugins (https://rubygems.org/gems/fusuma/reverse_dependencies). If I want to add them, Can I use this package format ? (just generate the plugin gemfile and gemset and then change the folder name and package name in `default.nix`)