### PR TITLE
zrythm: 1.0.0-alpha.28.1.3 -> 1.0.0-beta.3.10.1

### DIFF
--- a/pkgs/applications/audio/zrythm/default.nix
+++ b/pkgs/applications/audio/zrythm/default.nix
@@ -67,13 +67,13 @@
 
 stdenv.mkDerivation rec {
   pname = "zrythm";
-  version = "1.0.0-beta.3.9.1";
+  version = "1.0.0-beta.3.10.1";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-3UfvkED2KDTZr3LTic36uVA82rS+rO+vNDpn98tpwMI=";
+    hash = "sha256-gaIHMbvwXv7/MDhdAMHFJWhoCgnArpLwLWiGdTnN6Js=";
   };
 
   # this uses meson to build, but requires cmake for dependency detection
@@ -158,6 +158,7 @@ stdenv.mkDerivation rec {
     "-Dlsp_dsp=disabled"
     "-Db_lto=false"
     "-Ddebug=true"
+    "-Dfftw3_threads_separate_type=library"
   ];
 
   NIX_LDFLAGS = ''

--- a/pkgs/applications/audio/zrythm/default.nix
+++ b/pkgs/applications/audio/zrythm/default.nix
@@ -3,14 +3,15 @@
 , fetchFromGitHub
 , SDL2
 , alsa-lib
-, libaudec
 , bash-completion
+, boost
 , breeze-icons
 , carla
 , chromaprint
 , cmake
 , curl
 , dconf
+, dbus
 , libepoxy
 , fftw
 , fftwFloat
@@ -23,10 +24,13 @@
 , help2man
 , json-glib
 , jq
+, libadwaita
+, libaudec
 , libbacktrace
 , libcyaml
 , libgtop
 , libjack2
+, libpanel
 , libpulseaudio
 , libsamplerate
 , libsndfile
@@ -48,29 +52,34 @@
 , rubberband
 , serd
 , sord
+, sox
 , sratom
 , texi2html
 , wrapGAppsHook
 , xdg-utils
 , xxHash
 , vamp-plugin-sdk
+, zix
 , zstd
-, libadwaita
 , sassc
 }:
 
 stdenv.mkDerivation rec {
   pname = "zrythm";
-  version = "1.0.0-alpha.28.1.3";
+  version = "1.0.0-beta.3.4.1";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-ERE7I6E3+RmmpnZEtcJL/1v9a37IwFauVsbJvI9gsRQ=";
+    hash = "sha256-J5yS33vShq/xQI2lNWGvskXp8fCBn0gqb4adG16Fnnw=";
   };
 
+  # this uses meson to build, but requires cmake for dependency detection
+  dontUseCmakeConfigure = true;
+
   nativeBuildInputs = [
+    cmake
     help2man
     jq
     libaudec
@@ -83,17 +92,18 @@ stdenv.mkDerivation rec {
     python3.pkgs.sphinx
     texi2html
     wrapGAppsHook
-    cmake
   ];
 
   buildInputs = [
     SDL2
     alsa-lib
     bash-completion
+    boost
     carla
     chromaprint
     curl
     dconf
+    dbus
     libepoxy
     fftw
     fftwFloat
@@ -105,10 +115,12 @@ stdenv.mkDerivation rec {
     graphviz
     guile
     json-glib
+    libadwaita
     libbacktrace
     libcyaml
     libgtop
     libjack2
+    libpanel
     libpulseaudio
     libsamplerate
     libsndfile
@@ -124,12 +136,13 @@ stdenv.mkDerivation rec {
     rubberband
     serd
     sord
+    sox
     sratom
     vamp-plugin-sdk
     xdg-utils
     xxHash
+    zix
     zstd
-    libadwaita
     sassc
   ];
 
@@ -148,6 +161,7 @@ stdenv.mkDerivation rec {
   NIX_LDFLAGS = ''
     -lfftw3_threads -lfftw3f_threads
   '';
+  GUILE_AUTO_COMPILE = 0;
 
   dontStrip = true;
 
@@ -160,7 +174,8 @@ stdenv.mkDerivation rec {
   preFixup = ''
     gappsWrapperArgs+=(
       --prefix GSETTINGS_SCHEMA_DIR : "$out/share/gsettings-schemas/${pname}-${version}/glib-2.0/schemas/"
-             )
+      --prefix XDG_DATA_DIRS : "${breeze-icons}/share"
+    )
   '';
 
   meta = with lib; {

--- a/pkgs/applications/audio/zrythm/default.nix
+++ b/pkgs/applications/audio/zrythm/default.nix
@@ -13,6 +13,7 @@
 , dconf
 , dbus
 , libepoxy
+, faust2
 , fftw
 , fftwFloat
 , flex
@@ -50,6 +51,7 @@
 , rtaudio
 , rtmidi
 , rubberband
+, sassc
 , serd
 , sord
 , sox
@@ -61,18 +63,17 @@
 , vamp-plugin-sdk
 , zix
 , zstd
-, sassc
 }:
 
 stdenv.mkDerivation rec {
   pname = "zrythm";
-  version = "1.0.0-beta.3.4.1";
+  version = "1.0.0-beta.3.9.1";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-J5yS33vShq/xQI2lNWGvskXp8fCBn0gqb4adG16Fnnw=";
+    hash = "sha256-3UfvkED2KDTZr3LTic36uVA82rS+rO+vNDpn98tpwMI=";
   };
 
   # this uses meson to build, but requires cmake for dependency detection
@@ -105,6 +106,7 @@ stdenv.mkDerivation rec {
     dconf
     dbus
     libepoxy
+    faust2
     fftw
     fftwFloat
     flex
@@ -134,6 +136,7 @@ stdenv.mkDerivation rec {
     rtaudio
     rtmidi
     rubberband
+    sassc
     serd
     sord
     sox
@@ -143,7 +146,6 @@ stdenv.mkDerivation rec {
     xxHash
     zix
     zstd
-    sassc
   ];
 
   mesonFlags = [

--- a/pkgs/development/libraries/zix/default.nix
+++ b/pkgs/development/libraries/zix/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, meson
+, ninja
+}:
+
+stdenv.mkDerivation {
+  pname = "zix";
+  version = "unstable-2022-09-08";
+
+  outputs = [ "out" "dev" ];
+
+  src = fetchFromGitLab {
+    owner = "drobilla";
+    repo = "zix";
+    # the repo doesn't have any releases yet
+    rev = "a0293511f4d82d7cb800f568ff5c0d82be5c40c7";
+    hash = "sha256-HxFIb/ux2YLVHrlgNOtxQsoQzCEPvAEG8UVXU2qN9Io=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+  ];
+
+  mesonFlags = [ "-Dbenchmarks=disabled" ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    homepage = "http://drobilla.net/software/zix";
+    description = "A lightweight C99 portability and data structure library";
+    license = licenses.isc;
+    maintainers = [ maintainers.zseri ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23002,6 +23002,8 @@ with pkgs;
 
   zita-resampler = callPackage ../development/libraries/audio/zita-resampler { };
 
+  zix = callPackage ../development/libraries/zix { };
+
   zz = callPackage ../development/compilers/zz { };
 
   zziplib = callPackage ../development/libraries/zziplib { };


### PR DESCRIPTION
###### Description of changes

https://github.com/zrythm/zrythm/compare/v1.0.0-alpha.28.1.3...v1.0.0-beta.3.9.1

This should now work as-is; it targets the staging branch not due to massive rebuilds, but because `sord` was merged into there.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

### Blockers

* #182618 for libadwaita and libpanel
* #194796 for sord
* ~~#190724 for zix~~