### PR TITLE
workflows: fix manual-rendering.yml

### DIFF
--- a/.github/workflows/manual-rendering.yml
+++ b/.github/workflows/manual-rendering.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Compare DocBook and MD manuals
         id: check
         run: |
+          export NIX_PATH=nixpkgs=$(pwd)
           .github/workflows/compare-manuals.sh \
             docbook/share/doc/nixos/options.html \
             md/share/doc/nixos/options.html


### PR DESCRIPTION
the check command didn't set NIX_PATH, so compare-manuals.sh (which is a nix-shell script) failed.

checked that the resuting workflow runs properly on a fork that skips the cachix actions because credentials are missing there, it ran fine.