### PR TITLE
pkgs/top-level: add a type for warnUndeclaredOptions

### DIFF
--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -35,6 +35,7 @@ let
 
     warnUndeclaredOptions = mkOption {
       description = "Whether to warn when <literal>config</literal> contains an unrecognized attribute.";
+      type = types.bool;
       default = false;
     };
 


### PR DESCRIPTION
Fixes https://hydra.nixos.org/build/190091926/nixlog/1