### PR TITLE
konf: init at 0.2.0

### DIFF
--- a/pkgs/development/tools/konf/default.nix
+++ b/pkgs/development/tools/konf/default.nix
@@ -8,9 +8,9 @@ buildGoModule rec {
   version = "0.2.0";
 
   src = fetchFromGitHub {
-    rev = "v${version}";
     owner = "SimonTheLeg";
     repo = "konf-go";
+    rev = "v${version}";
     hash = "sha256-UeuR7lsNG2Y0hdpQA5NXBUlSvYeixyKS73N95z5TZ7k=";
   };
 

--- a/pkgs/development/tools/konf/default.nix
+++ b/pkgs/development/tools/konf/default.nix
@@ -1,0 +1,24 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "konf";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    rev    = "main";
+    owner  = "SimonTheLeg";
+    repo   = "konf-go";
+    sha256 = "sha256-UeuR7lsNG2Y0hdpQA5NXBUlSvYeixyKS73N95z5TZ7k=";
+  };
+
+  vendorSha256 = "sha256-sB3j19HrTtaRqNcooqNy8vBvuzxxyGDa7MOtiGoVgN8=";
+
+  meta = with lib; {
+    description = "Lightweight and blazing fast kubeconfig manager which allows to use different kubeconfigs at the same time";
+    homepage = "https://github.com/SimonTheLeg/konf-go";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ arikgrahl ];
+  };
+}

--- a/pkgs/development/tools/konf/default.nix
+++ b/pkgs/development/tools/konf/default.nix
@@ -1,15 +1,16 @@
 { lib
 , buildGoModule
-, fetchFromGitHub }:
+, fetchFromGitHub
+}:
 
 buildGoModule rec {
   pname = "konf";
   version = "0.2.0";
 
   src = fetchFromGitHub {
-    rev    = "main";
-    owner  = "SimonTheLeg";
-    repo   = "konf-go";
+    rev = "main";
+    owner = "SimonTheLeg";
+    repo = "konf-go";
     sha256 = "sha256-UeuR7lsNG2Y0hdpQA5NXBUlSvYeixyKS73N95z5TZ7k=";
   };
 

--- a/pkgs/development/tools/konf/default.nix
+++ b/pkgs/development/tools/konf/default.nix
@@ -11,10 +11,10 @@ buildGoModule rec {
     rev = "main";
     owner = "SimonTheLeg";
     repo = "konf-go";
-    sha256 = "sha256-UeuR7lsNG2Y0hdpQA5NXBUlSvYeixyKS73N95z5TZ7k=";
+    hash = "sha256-UeuR7lsNG2Y0hdpQA5NXBUlSvYeixyKS73N95z5TZ7k=";
   };
 
-  vendorSha256 = "sha256-sB3j19HrTtaRqNcooqNy8vBvuzxxyGDa7MOtiGoVgN8=";
+  vendorHash = "sha256-sB3j19HrTtaRqNcooqNy8vBvuzxxyGDa7MOtiGoVgN8=";
 
   meta = with lib; {
     description = "Lightweight and blazing fast kubeconfig manager which allows to use different kubeconfigs at the same time";

--- a/pkgs/development/tools/konf/default.nix
+++ b/pkgs/development/tools/konf/default.nix
@@ -8,7 +8,7 @@ buildGoModule rec {
   version = "0.2.0";
 
   src = fetchFromGitHub {
-    rev = "main";
+    rev = "v${version}";
     owner = "SimonTheLeg";
     repo = "konf-go";
     hash = "sha256-UeuR7lsNG2Y0hdpQA5NXBUlSvYeixyKS73N95z5TZ7k=";

--- a/pkgs/development/tools/konf/default.nix
+++ b/pkgs/development/tools/konf/default.nix
@@ -16,6 +16,8 @@ buildGoModule rec {
 
   vendorHash = "sha256-sB3j19HrTtaRqNcooqNy8vBvuzxxyGDa7MOtiGoVgN8=";
 
+  ldflags = [ "-s" "-w" ];
+
   meta = with lib; {
     description = "Lightweight and blazing fast kubeconfig manager which allows to use different kubeconfigs at the same time";
     homepage = "https://github.com/SimonTheLeg/konf-go";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15067,6 +15067,8 @@ with pkgs;
 
   kona = callPackage ../development/interpreters/kona {};
 
+  konf = callPackage ../development/tools/konf { };
+
   lolcode = callPackage ../development/interpreters/lolcode { };
 
   love_0_10 = callPackage ../development/interpreters/love/0.10.nix { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

> konf is a lightweight kubeconfig manager. With konf you can use different kubeconfigs at the same time. And because it does not need subshells, konf is blazing fast!

-- https://github.com/SimonTheLeg/konf-go

See https://github.com/NixOS/nixpkgs/issues/190758

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
