### PR TITLE
drawing: 1.0.0 -> 1.0.1

### DIFF
--- a/pkgs/applications/graphics/drawing/default.nix
+++ b/pkgs/applications/graphics/drawing/default.nix
@@ -1,6 +1,5 @@
 { lib
 , fetchFromGitHub
-, fetchpatch
 , meson
 , ninja
 , pkg-config
@@ -19,7 +18,7 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "drawing";
-  version = "1.0.0";
+  version = "1.0.1";
 
   format = "other";
 
@@ -27,18 +26,8 @@ python3.pkgs.buildPythonApplication rec {
     owner = "maoschanz";
     repo = pname;
     rev = version;
-    sha256 = "sha256-qNaljtuA5E/QaLJ9QILPRQCqOvKmX4ZGq/0z5unA8KA=";
+    sha256 = "sha256-9nosriI3Kdf1M5/TYFWn1jtQTqNKhBcFh7q3E4Uoq4s=";
   };
-
-  patches = [
-    # Fix build with meson 0.61, can be removed on next update.
-    # https://github.com/NixOS/nixpkgs/issues/167584
-    (fetchpatch {
-      url = "https://github.com/maoschanz/drawing/commit/6dd271089af76b69322500778e3ad6615a117dcc.patch";
-      sha256 = "sha256-4pKWm3LYstVxZ4+gGsZDfM4K+7WBY8EYjylzc/CQZmo=";
-      includes = [ "data/meson.build" "help/meson.build" ];
-    })
-  ];
 
   nativeBuildInputs = [
     appstream-glib


### PR DESCRIPTION
###### Description of changes

https://github.com/maoschanz/drawing/compare/1.0.0...1.0.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


