### PR TITLE
packcc: init at 1.8.0

### DIFF
--- a/pkgs/development/tools/packcc/default.nix
+++ b/pkgs/development/tools/packcc/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, bats
+, uncrustify
+, testers
+, packcc
+}:
+
+stdenv.mkDerivation rec {
+  pname = "packcc";
+  version = "1.8.0";
+
+  src = fetchFromGitHub {
+    owner = "arithy";
+    repo = "packcc";
+    rev = "v${version}";
+    hash = "sha256-T7PWM5IGly6jpGt04dh5meQjrZPUTs8VEFTQEPO5RSw=";
+  };
+
+  dontConfigure = true;
+
+  preBuild = ''
+    cd build/${if stdenv.cc.isGNU then "gcc"
+               else if stdenv.cc.isClang then "clang"
+               else throw "Unsupported C compiler"}
+  '';
+
+  doCheck = true;
+
+  checkInputs = [ bats uncrustify ];
+
+  preCheck = ''
+    patchShebangs ../../tests
+
+    # Disable a failing test.
+    rm -rf ../../tests/style.d
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 release/bin/packcc $out/bin/packcc
+
+    runHook postInstall
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = packcc;
+  };
+
+  meta = with lib; {
+    description = "A parser generator for C";
+    longDescription = ''
+      PackCC is a parser generator for C. Its main features are as follows:
+      - Generates your parser in C from a grammar described in a PEG,
+      - Gives your parser great efficiency by packrat parsing,
+      - Supports direct and indirect left-recursive grammar rules.
+    '';
+    homepage = "https://github.com/arithy/packcc";
+    changelog = "https://github.com/arithy/packcc/releases/tag/${src.rev}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ azahi ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -725,6 +725,8 @@ with pkgs;
 
   owl = callPackage ../tools/networking/owl { };
 
+  packcc = callPackage ../development/tools/packcc { };
+
   packer = callPackage ../development/tools/packer { };
 
   packr = callPackage ../development/libraries/packr { };


### PR DESCRIPTION
###### Description of changes

A parser generator for C
https://github.com/arithy/packcc
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
