### PR TITLE
pkgsMusl.cargo: fix build

### DIFF
--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -145,6 +145,18 @@ in stdenv.mkDerivation rec {
 
     # Useful debugging parameter
     # export VERBOSE=1
+  '' + lib.optionalString (stdenv.targetPlatform.isMusl && !stdenv.targetPlatform.isStatic) ''
+    # Upstream rustc still assumes that musl = static[1].  The fix for
+    # this is to disable crt-static by default for non-static musl
+    # targets.
+    #
+    # Even though Cargo will build build.rs files for the build platform,
+    # cross-compiling _from_ musl appears to work fine, so we only need
+    # to do this when rustc's target platform is dynamically linked musl.
+    #
+    # [1]: https://github.com/rust-lang/compiler-team/issues/422
+    substituteInPlace compiler/rustc_target/src/spec/linux_musl_base.rs \
+        --replace "base.crt_static_default = true" "base.crt_static_default = false"
   '' + lib.optionalString (stdenv.isDarwin && stdenv.isx86_64) ''
     # See https://github.com/jemalloc/jemalloc/issues/1997
     # Using a value of 48 should work on both emulated and native x86_64-darwin.


### PR DESCRIPTION
###### Description of changes

**At long last**, this finally fixes the build of even quite complex Rust packages with `pkgsMusl`.

Upstream rustc still assumes that musl = static.  The fix for this is to disable crt-static by default for musl targets.

For every package apart from Cargo, we can fix this by just patching rustc to not have crt-static by default.  But Cargo is built with the upstream bootstrap binary for rustc, which we can't easily patch. This means we need to find another way to make sure crt-static is not used during the build of pkgsMusl.cargo.

By default, Cargo doesn't apply Rust flags when building build.rs if `--target` is passed.  The only good fix for this is to use the unstable `-Zhost-config` Cargo feature, which allows us to specify flags that should be passed to rustc when building for the (in Nixpkgs parlance) build system (e.g. for build.rs scripts).

Unfortunately, Cargo does not support e.g. a `[host.'cfg(target_env = "musl")']` key (it only supports it for "target"), so we have to patch this conditionally to avoid it messing with non-Musl targets.

I haven't taken most of @yu-re-ka's patches from https://github.com/NixOS/nixpkgs/pull/186466, just because they weren't strictly necessary to get them to work.  They're probably still worth looking at.

I've tested `fd`, `pkgsMusl.fd`, and `pkgsStatic.fd`.  I checked that the static one is still static, and that the `pkgsMusl` one is dynamically linked.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
