### PR TITLE
hex: init at 0.4.2

### DIFF
--- a/pkgs/tools/misc/hex/default.nix
+++ b/pkgs/tools/misc/hex/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, testers
+, hex
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "hex";
+  version = "0.4.2";
+
+  src = fetchFromGitHub {
+    owner = "sitkevij";
+    repo = "hex";
+    rev = "v${version}";
+    hash = "sha256-mxKjiciejnOTbSkCzOWdAtysRAnEv4JgntPS1qM9og8=";
+  };
+
+  cargoHash = "sha256-kGe6XN03V+ILnlAcT0E8BvrYMa7ub05STFsFY6X5Gkk=";
+
+  passthru.tests.version = testers.testVersion {
+    package = hex;
+    version = "hx ${version}";
+  };
+
+  meta = with lib; {
+    description = "Futuristic take on hexdump, made in Rust";
+    homepage = "https://github.com/sitkevij/hex";
+    changelog = "https://github.com/sitkevij/hex/releases/tag/v${version}";
+    mainProgram = "hx";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ivar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7445,6 +7445,8 @@ with pkgs;
 
   hevea = callPackage ../tools/typesetting/hevea { };
 
+  hex = callPackage ../tools/misc/hex { };
+
   hexd = callPackage ../tools/misc/hexd { };
   pixd = callPackage ../tools/misc/pixd { };
 


### PR DESCRIPTION
###### Description of changes
This adds [hex](https://github.com/sitkevij/hex), an futuristic take on hexdump, made in Rust.

Fixes #190768

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and “core” functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
