### PR TITLE
nixos/certbot: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -253,6 +253,7 @@
   ./security/audit.nix
   ./security/auditd.nix
   ./security/ca.nix
+  ./security/certbot.nix
   ./security/chromium-suid-sandbox.nix
   ./security/dhparams.nix
   ./security/duosec.nix

--- a/nixos/modules/security/certbot.nix
+++ b/nixos/modules/security/certbot.nix
@@ -1,0 +1,69 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.certbot;
+in {
+
+  options = {
+
+    services.certbot = {
+
+      enable = mkEnableOption "Certbot ACME client automatic certificate renewal";
+
+      acceptTerms = mkOption {
+        type = types.bool;
+        default = false;
+        description = lib.mdDoc ''
+          Accept the CA's terms of service. The default provider is Let's Encrypt,
+          you can find their ToS at <https://letsencrypt.org/repository/>.
+        '';
+      };
+
+      package = mkOption {
+        type = types.package;
+        description = mdDoc "Certbot package to use.";
+        default = pkgs.certbot;
+        defaultText = literalExpression "pkgs.certbot";
+      };
+
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+
+    assertions = [{
+      assertion = cfg.acceptTerms;
+      message = ''
+        You must accept the CA's terms of service before using
+        the ACME module by setting `security.acme.acceptTerms`
+        to `true`. For Let's Encrypt's ToS see https://letsencrypt.org/repository/
+      '';
+    }];
+
+    environment.systemPackages = [ cfg.package ];
+
+    systemd.timers.certbot = {
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnBootSec = "60m";
+        OnUnitActiveSec = "60m";
+      };
+    };
+
+    systemd.services.certbot = {
+      serviceConfig = {
+        Type = "oneshot";
+        User = "root";
+        ExecStart = "${cfg.package}/bin/certbot renew  --quiet --agree-tos";
+      };
+    };
+
+    systemd.tmpfiles.rules = ["d /etc/letsencrypt 0750 root acme"];
+
+  };
+
+}
+


### PR DESCRIPTION
###### Description of changes

Add simple module to renew certbot certificates using systemd timer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
