### PR TITLE
liblqr1: fix build on Darwin

### DIFF
--- a/pkgs/development/libraries/liblqr-1/default.nix
+++ b/pkgs/development/libraries/liblqr-1/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, glib, Carbon }:
+{ lib, stdenv, fetchFromGitHub, pkg-config, glib, Carbon, AppKit }:
 
 stdenv.mkDerivation rec {
   pname = "liblqr-1";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = lib.optionals stdenv.isDarwin [ Carbon ];
+  buildInputs = lib.optionals stdenv.isDarwin [ Carbon AppKit ];
   propagatedBuildInputs = [ glib ];
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18805,7 +18805,7 @@ with pkgs;
   libliftoff = callPackage ../development/libraries/libliftoff { };
 
   liblqr1 = callPackage ../development/libraries/liblqr-1 {
-    inherit (darwin.apple_sdk.frameworks) Carbon;
+    inherit (darwin.apple_sdk.frameworks) Carbon AppKit;
   };
 
   liblockfile = callPackage ../development/libraries/liblockfile { };


### PR DESCRIPTION
Without this patch, we sometimes get the following error when building this derivation:

```
error: builder for '/nix/store/yhfv2ng67l39z4ycs3ik733ammssm90l-liblqr-1-0.4.2.drv' failed with exit code 2;
       last 10 log lines:
       > libtool: compile:  clang -DHAVE_CONFIG_H -I. -I. -I.. -DDATADIR=\"/nix/store/illjxmhcaslif3j0nxw0mrl6217gmasg-liblqr-1-0.4.2/share/liblqr-1\" -I.. -I/nix/store/076lwg66shi066i6rksnm0y9acq1nsmn-glib-2.72.3-dev/include/glib-2.0 -I/nix/store/2vlnj2x13s88x73i16czxbx43skhi613-glib-2.72.3/lib/glib-2.0/include -I/nix/store/illjxmhcaslif3j0nxw0mrl6217gmasg-liblqr-1-0.4.2/include -fvisibility=hidden -g -O2 -Wall -c lqr_progress.c  -fno-common -DPIC -o .libs/lqr_progress.o
       > /nix/store/zhb1b88lw5qxhk50f75dgfwwh5m0cg7i-bash-5.1-p16/bin/bash ../libtool --tag=CC --mode=link clang  -g -O2 -Wall   -o liblqr-1.la -rpath /nix/store/illjxmhcaslif3j0nxw0mrl6217gmasg-liblqr-1-0.4.2/lib -version-info 3:2:3  lqr_gradient.lo lqr_rwindow.lo lqr_energy.lo lqr_cursor.lo lqr_carver.lo lqr_carver_list.lo lqr_carver_bias.lo lqr_carver_rigmask.lo lqr_vmap.lo lqr_vmap_list.lo lqr_progress.lo -L/nix/store/2vlnj2x13s88x73i16czxbx43skhi613-glib-2.72.3/lib -lglib-2.0 -lm
       > libtool: link: clang -dynamiclib -Wl,-flat_namespace -Wl,-undefined -Wl,suppress -o .libs/liblqr-1.0.dylib  .libs/lqr_gradient.o .libs/lqr_rwindow.o .libs/lqr_energy.o .libs/lqr_cursor.o .libs/lqr_carver.o .libs/lqr_carver_list.o .libs/lqr_carver_bias.o .libs/lqr_carver_rigmask.o .libs/lqr_vmap.o .libs/lqr_vmap_list.o .libs/lqr_progress.o   -L/nix/store/2vlnj2x13s88x73i16czxbx43skhi613-glib-2.72.3/lib -lglib-2.0 -lm  -O2   -install_name  /nix/store/illjxmhcaslif3j0nxw0mrl6217gmasg-liblqr-1-0.4.2/lib/liblqr-1.0.dylib -compatibility_version 4 -current_version 4.2 -Wl,-single_module
       > ld: file not found: /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit for architecture x86_64
       > clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
       > make[2]: *** [Makefile:357: liblqr-1.la] Error 1
       > make[2]: Leaving directory '/private/tmp/nix-build-liblqr-1-0.4.2.drv-0/source/lqr'
       > make[1]: *** [Makefile:332: all-recursive] Error 1
       > make[1]: Leaving directory '/private/tmp/nix-build-liblqr-1-0.4.2.drv-0/source'
       > make: *** [Makefile:242: all] Error 2
```

It is not reproducible under all circumstances, but under the conditions where it can be reproduced is stable, and adding `AppKit` as a dependency helps fixing this issue.

This has happened before, but with the Carbon framework back then with this same derivation: https://github.com/NixOS/nixpkgs/pull/135630

(cherry picked from commit 09a8c1b440a6afc4d7ddbd2d2369436a45d17b9b)

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
