### PR TITLE
paperless: use `imagemagickBig`

### DIFF
--- a/pkgs/applications/office/paperless-ngx/default.nix
+++ b/pkgs/applications/office/paperless-ngx/default.nix
@@ -3,7 +3,7 @@
 , nixosTests
 , python3
 , ghostscript
-, imagemagick
+, imagemagickBig
 , jbig2enc
 , optipng
 , pngquant
@@ -51,7 +51,7 @@ let
 
   path = lib.makeBinPath [
     ghostscript
-    imagemagick
+    imagemagickBig
     jbig2enc
     optipng
     pngquant

--- a/pkgs/applications/office/paperless-ngx/default.nix
+++ b/pkgs/applications/office/paperless-ngx/default.nix
@@ -49,7 +49,16 @@ let
     };
   };
 
-  path = lib.makeBinPath [ ghostscript imagemagick jbig2enc optipng pngquant qpdf tesseract4 unpaper ];
+  path = lib.makeBinPath [
+    ghostscript
+    imagemagick
+    jbig2enc
+    optipng
+    pngquant
+    qpdf
+    tesseract4
+    unpaper
+  ];
 in
 python.pkgs.pythonPackages.buildPythonApplication rec {
   pname = "paperless-ngx";


### PR DESCRIPTION
#### Copy of commit msg
`imagemagickBig` has `gs` support. This fixes a warning during thumbnail generation (`convert: no images defined`).
The type of thumbnails that are generated is unchanged.