### PR TITLE
hip: fix hip-config.cmake

### DIFF
--- a/pkgs/development/compilers/hip/default.nix
+++ b/pkgs/development/compilers/hip/default.nix
@@ -21,6 +21,7 @@
 , rocm-runtime
 , rocm-thunk
 , rocminfo
+, substituteAll
 , writeScript
 , writeText
 }:
@@ -36,6 +37,14 @@ let
       rev = "rocm-${version}";
       hash = "sha256-QaN666Rku2Tkio2Gm5/3RD8D5JgmCZLe0Yun1fGxa8U=";
     };
+
+    patches = [
+      (substituteAll {
+        src = ./hip-config-paths.patch;
+        inherit llvm;
+        rocm_runtime = rocm-runtime;
+      })
+    ];
 
     # - fix bash paths
     # - fix path to rocm_agent_enumerator
@@ -119,6 +128,14 @@ stdenv.mkDerivation rec {
     rocm-runtime
     rocm-thunk
     rocminfo
+  ];
+
+  patches = [
+    (substituteAll {
+      src = ./hipamd-config-paths.patch;
+      inherit llvm hip;
+      rocm_runtime = rocm-runtime;
+    })
   ];
 
   preConfigure = ''

--- a/pkgs/development/compilers/hip/hip-config-paths.patch
+++ b/pkgs/development/compilers/hip/hip-config-paths.patch
@@ -1,0 +1,36 @@
+diff --git a/hip-lang-config.cmake.in b/hip-lang-config.cmake.in
+index 1a72643a..7f35031f 100644
+--- a/hip-lang-config.cmake.in
++++ b/hip-lang-config.cmake.in
+@@ -72,8 +72,8 @@ get_filename_component(_IMPORT_PREFIX "${_DIR}/../../../" REALPATH)
+ 
+ 
+ #need _IMPORT_PREFIX to be set #FILE_REORG_BACKWARD_COMPATIBILITY
+-file(GLOB HIP_CLANG_INCLUDE_SEARCH_PATHS "${_IMPORT_PREFIX}/../llvm/lib/clang/*/include")
+-file(GLOB HIP_CLANG_INCLUDE_SEARCH_PATHS_REORG "${_IMPORT_PREFIX}/llvm/lib/clang/*/include")
++file(GLOB HIP_CLANG_INCLUDE_SEARCH_PATHS "@llvm@/lib/clang/*/include")
++file(GLOB HIP_CLANG_INCLUDE_SEARCH_PATHS_REORG "@llvm@/lib/clang/*/include")
+ find_path(HIP_CLANG_INCLUDE_PATH __clang_cuda_math.h
+     HINTS ${HIP_CLANG_INCLUDE_SEARCH_PATHS}
+           ${HIP_CLANG_INCLUDE_SEARCH_PATHS_REORG}
+@@ -88,10 +88,7 @@ endif()
+ #if HSA is not under ROCm then provide CMAKE_PREFIX_PATH=<HSA_PATH>
+ find_path(HSA_HEADER hsa/hsa.h
+   PATHS
+-    "${_IMPORT_PREFIX}/../include" #FILE_REORG_BACKWARD_COMPATIBILITY
+-    "${_IMPORT_PREFIX}/include"
+-    "${ROCM_PATH}/include"
+-    /opt/rocm/include
++    "@rocm_runtime@/include"
+ )
+ 
+ if (HSA_HEADER-NOTFOUND)
+@@ -99,7 +96,7 @@ if (HSA_HEADER-NOTFOUND)
+ endif()
+ 
+ get_filename_component(HIP_COMPILER_INSTALL_PATH ${CMAKE_HIP_COMPILER} DIRECTORY)
+-file(GLOB HIP_CLANGRT_LIB_SEARCH_PATHS "${HIP_COMPILER_INSTALL_PATH}/../lib/clang/*/lib/*")
++file(GLOB HIP_CLANGRT_LIB_SEARCH_PATHS "@llvm@/lib/clang/*/lib/*")
+ find_library(CLANGRT_BUILTINS
+     NAMES
+       clang_rt.builtins

--- a/pkgs/development/compilers/hip/hipamd-config-paths.patch
+++ b/pkgs/development/compilers/hip/hipamd-config-paths.patch
@@ -1,0 +1,47 @@
+diff --git a/hip-config.cmake.in b/hip-config.cmake.in
+index 89d1224e..120b68c6 100755
+--- a/hip-config.cmake.in
++++ b/hip-config.cmake.in
+@@ -142,7 +142,7 @@ if(HIP_COMPILER STREQUAL "clang")
+       file(TO_CMAKE_PATH "${HIP_PATH}/../lc" HIP_CLANG_ROOT)
+     endif()
+   else()
+-    set(HIP_CLANG_ROOT "${ROCM_PATH}/llvm")
++    set(HIP_CLANG_ROOT "@llvm@")
+   endif()
+   if(NOT HIP_CXX_COMPILER)
+     set(HIP_CXX_COMPILER ${CMAKE_CXX_COMPILER})
+@@ -206,10 +206,7 @@ if(NOT WIN32)
+   #if HSA is not under ROCm then provide CMAKE_PREFIX_PATH=<HSA_PATH>
+   find_path(HSA_HEADER hsa/hsa.h
+     PATHS
+-      "${_IMPORT_PREFIX}/include"
+-      #FILE_REORG_BACKWARD_COMPATIBILITY ${_IMPORT_PREFIX}/../include is for Backward compatibility
+-      "${_IMPORT_PREFIX}/../include"
+-      ${ROCM_PATH}/include
++      "@rocm_runtime@/include"
+   )
+
+   if (NOT HSA_HEADER)
+@@ -224,8 +221,8 @@ set_target_properties(hip::host PROPERTIES
+
+ if(HIP_RUNTIME MATCHES "rocclr")
+   set_target_properties(hip::amdhip64 PROPERTIES
+-    INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include;${HSA_HEADER}"
+-    INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include;${HSA_HEADER}"
++    INTERFACE_INCLUDE_DIRECTORIES "@hip@/include;${HSA_HEADER}"
++    INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "@hip@/include;${HSA_HEADER}"
+   )
+
+   get_target_property(amdhip64_type hip::amdhip64 TYPE)
+@@ -233,8 +230,8 @@ if(HIP_RUNTIME MATCHES "rocclr")
+
+   if(NOT WIN32)
+     set_target_properties(hip::device PROPERTIES
+-      INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
+-      INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
++      INTERFACE_INCLUDE_DIRECTORIES "@hip@/include"
++      INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "@hip@/include"
+     )
+   endif()
+ endif()


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR patches paths in cmake config files provided by HIP and hipamd to the proper location in the Nix store. Previously these files were trying to find headers in a way that assumes the typical ROCm installation (where everything is in /opt/rocm). This resulted in a bunch of errors when trying to compile HIP projects that are configured with cmake, like include paths that were set incorrectly or header paths that were not found.

With this patch I have been able to build rocPRIM, rocRAND, and hipCUB.

cc @lovesegfault 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
