### PR TITLE
xpra: Also add module paths to xorg-uinput.conf

### DIFF
--- a/pkgs/tools/X11/xpra/default.nix
+++ b/pkgs/tools/X11/xpra/default.nix
@@ -189,6 +189,7 @@ in buildPythonApplication rec {
   postInstall = ''
     # append module paths to xorg.conf
     cat ${xorgModulePaths} >> $out/etc/xpra/xorg.conf
+    cat ${xorgModulePaths} >> $out/etc/xpra/xorg-uinput.conf
 
     # make application icon visible to desktop environemnts
     icon_dir="$out/share/icons/hicolor/64x64/apps"


### PR DESCRIPTION
We also need to inject the xorg module paths there otherwise it'd fail to load the "dummy" module. If uinput is used, xpra will [silently replace `xorg.conf` with `xorg-uinput.conf`](https://github.com/Xpra-org/xpra/blob/337d861d28af03d112d5bd88817a8293c1e0fce0/xpra/x11/vfb_util.py#L231-L235) in the xorg/xvfb command line before launching it.

Longer explanation:

```
(++) Using config file: "/nix/store/nydjmsg0hjyd8hhh5kasn3h8lwa01jfy-xpra-4.3.3/etc/xpra/xorg-uinput.conf"
[snip]
[31m2022-09-11 17:16:05,750  full command: /nix/store/6yzcxxdbaabw9mnz67mji2ib1zafp7fk-xorg-server-1.20.14/bin/Xorg -noreset -novtswitch -nolisten tcp +extension GLX +extension RANDR +extension RENDER -auth $XAUTHORITY -logfile ${XPRA_SESSION_DIR}/Xorg.log -configdir "${XPRA_SESSION_DIR}/xorg.conf.d/$PID" -config "${XORG_CONFIG_PREFIX}/nix/store/nydjmsg0hjyd8hhh5kasn3h8lwa01jfy-xpra-4.3.3/etc/xpra/xorg.conf"[0m
[3
```

If we look at the "full command" it supposedly executed, there is no trace of `xorg-uinput.conf` to be found. Turns out the full command is a big lie because xpra [silently replaces `xorg.conf` with `xorg-uinput.conf`](https://github.com/Xpra-org/xpra/blob/337d861d28af03d112d5bd88817a8293c1e0fce0/xpra/x11/vfb_util.py#L231-L235) before running the command if uinput is used.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
