### PR TITLE
Handle melpa new fetchers (sourcehut, codeberg)

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/update-melpa.el
+++ b/pkgs/applications/editors/emacs/elisp-packages/update-melpa.el
@@ -103,6 +103,10 @@ return Promise to resolve in that process."
                                                   (url-hexify-string repo)
                                                   "/repository/archive.tar.gz?ref="
                                                   commit)))
+            ("sourcehut" (list "nix-prefetch-url"
+                               "--unpack" (concat "https://git.sr.ht/~" repo "/archive/" commit ".tar.gz")))
+            ("codeberg" (list "nix-prefetch-url"
+                              "--unpack" (concat "https://codeberg.org/" repo "/archive/" commit ".tar.gz")))
             ("bitbucket" (list "nix-prefetch-hg"
                                (concat "https://bitbucket.com/" repo) commit))
             ("hg"        (list "nix-prefetch-hg"


### PR DESCRIPTION
Melpa introduced two new fetchers sourcehut in melpa/melpa@a3645b0 and codeberg in melpa/melpa@962f7c8, this change broke melpa update script.

Cc: emacs maintainers @lovek323 @jwiegley @adisbladis
