### PR TITLE
nvtop: 2.0.2->2.0.3

### DIFF
--- a/pkgs/tools/system/nvtop/default.nix
+++ b/pkgs/tools/system/nvtop/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , cmake
 , gtest
 , cudatoolkit
@@ -24,14 +25,22 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "nvtop" + pname-suffix;
-  version = "2.0.2";
+  version = "2.0.3";
 
   src = fetchFromGitHub {
     owner = "Syllo";
     repo = "nvtop";
     rev = version;
-    sha256 = "sha256-TlhCU7PydzHG/YMlk922mxEJ3CZw40784U0w1YawI3I=";
+    sha256 = "sha256-LhVgNU2OSM7fOUUQHYJhKhjE0fkFvYC3FIJFgu6T68Q=";
   };
+
+  #this patch should be fine to remove with next version update
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/Syllo/nvtop/commit/663a69f1c9038eabdfc3155112fb9b8d662578aa.diff";
+      sha256 = "sha256-/EJlr5b+kZnHm9UxythYreJvO+Ma+1sUI3KLBQFCCmc=";
+    })
+  ];
 
   cmakeFlags = with lib; [
     "-DCMAKE_BUILD_TYPE=Release"


### PR DESCRIPTION
###### Description of changes

Updated package to the [latest release](https://github.com/Syllo/nvtop/releases/tag/2.0.3), had to specify a specific revision because it contains a fix for building 2.0.3 in strict build environments, such as Arch and NixOS have. As usual, test of this update by someone with Nvidia gpu is welcome. Works fine with my AMD gpu.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).