### PR TITLE
cinny-desktop: add darwin support

### DIFF
--- a/pkgs/applications/networking/instant-messengers/cinny-desktop/darwin.nix
+++ b/pkgs/applications/networking/instant-messengers/cinny-desktop/darwin.nix
@@ -1,0 +1,30 @@
+{ pname
+, version
+, src
+, meta
+, stdenvNoCC
+, undmg
+}:
+
+stdenvNoCC.mkDerivation {
+  inherit pname version src meta;
+
+  sourceRoot = "Cinny.app";
+
+  nativeBuildInputs = [
+    undmg
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{Applications/Cinny.app,bin}
+    cp -r ./* $out/Applications/Cinny.app
+    ln -s $out/Applications/Cinny.app/Contents/MacOS/Cinny $out/bin
+
+    runHook postInstall
+  '';
+}

--- a/pkgs/applications/networking/instant-messengers/cinny-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/cinny-desktop/default.nix
@@ -1,46 +1,40 @@
-{ stdenv
-, lib
-, dpkg
+{ lib
+, stdenvNoCC
+, callPackage
 , fetchurl
-, autoPatchelfHook
-, glib-networking
-, openssl
-, webkitgtk
-, wrapGAppsHook
 }:
 
-stdenv.mkDerivation rec {
-  name = "cinny-desktop";
+let
   version = "2.1.3";
 
-  src = fetchurl {
-    url = "https://github.com/cinnyapp/cinny-desktop/releases/download/v${version}/Cinny_desktop-x86_64.deb";
-    sha256 = "sha256-fUnWGnulj/515aEdd+rCy/LGLLAs2yAOOBUn9K1LhNs=";
+  mkPackage = path: src: callPackage path {
+    pname = "cinny-desktop";
+    inherit version src;
+
+    meta = with lib; {
+      description = "Yet another matrix client for desktop";
+      homepage = "https://github.com/cinnyapp/cinny-desktop";
+      mainProgram = "cinny";
+      license = licenses.mit;
+      platforms = lib.attrNames systems;
+      sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+      maintainers = with maintainers; [
+        aveltras
+        ivar
+      ];
+    };
   };
 
-  nativeBuildInputs = [
-    autoPatchelfHook
-    dpkg
-  ];
+  systems = {
+    x86_64-linux = mkPackage ./linux.nix (fetchurl {
+      url = "https://github.com/cinnyapp/cinny-desktop/releases/download/v${version}/Cinny_desktop-x86_64.deb";
+      sha256 = "sha256-fUnWGnulj/515aEdd+rCy/LGLLAs2yAOOBUn9K1LhNs=";
+    });
 
-  buildInputs = [
-    glib-networking
-    openssl
-    webkitgtk
-    wrapGAppsHook
-  ];
-
-  unpackCmd = "dpkg-deb -x $curSrc source";
-
-  installPhase = "mv usr $out";
-
-  meta = with lib; {
-    description = "Yet another matrix client for desktop";
-    homepage = "https://github.com/cinnyapp/cinny-desktop";
-    maintainers = [ maintainers.aveltras ];
-    license = licenses.mit;
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    platforms = platforms.linux;
-    mainProgram = "cinny";
+    x86_64-darwin = mkPackage ./darwin.nix (fetchurl {
+      url = "https://github.com/cinnyapp/cinny-desktop/releases/download/v${version}/Cinny_desktop-x86_64.dmg";
+      sha256 = "sha256-f9JQn5BKHluXLi89aUHuRde757Kk211w4s61tRmkNew=";
+    });
   };
-}
+in
+systems.${stdenvNoCC.hostPlatform.system} or (throw "unsupported platform ${stdenvNoCC.hostPlatform.system}")

--- a/pkgs/applications/networking/instant-messengers/cinny-desktop/linux.nix
+++ b/pkgs/applications/networking/instant-messengers/cinny-desktop/linux.nix
@@ -1,0 +1,49 @@
+{ pname
+, version
+, src
+, meta
+, stdenvNoCC
+, makeWrapper
+, autoPatchelfHook
+, wrapGAppsHook
+, dpkg
+, glib-networking
+, openssl
+, webkitgtk
+}:
+
+stdenvNoCC.mkDerivation {
+  inherit pname version src meta;
+
+  nativeBuildInputs = [
+    makeWrapper
+    wrapGAppsHook
+    autoPatchelfHook
+    dpkg
+  ];
+
+  buildInputs = [
+    glib-networking
+    openssl
+    webkitgtk
+  ];
+
+  unpackCmd = "dpkg-deb -x $src source";
+  dontConfigure = true;
+  dontBuild = true;
+  dontWrapGApps = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -r usr $out
+
+    # Environment variable fixes a blank window on nvidia:
+    # https://github.com/tauri-apps/tauri/issues/4315#issuecomment-1207755694
+    wrapProgram $out/bin/cinny \
+      --set WEBKIT_DISABLE_COMPOSITING_MODE 1 \
+      ''${gappsWrapperArgs[@]}
+
+    runHook postInstall
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3287,7 +3287,13 @@ with pkgs;
 
   cinny = callPackage ../applications/networking/instant-messengers/cinny { stdenv = stdenvNoCC; };
 
-  cinny-desktop = callPackage ../applications/networking/instant-messengers/cinny-desktop { };
+  cinny-desktop = import ../applications/networking/instant-messengers/cinny-desktop {
+    inherit
+      lib
+      stdenvNoCC
+      callPackage
+      fetchurl;
+  };
 
   ckbcomp = callPackage ../tools/X11/ckbcomp { };
 


### PR DESCRIPTION
###### Description of changes

This PR adds darwin support for cinny-desktop, a matrix client. 

Additional changes:
* Set `meta.platforms` to just `x86_64-linux` and `x86_64-darwin` as precompiled binaries are fetched for both platforms.
* Added an environment variable that fixed the window being blanked on my Linux nvidia system.
* Added myself as a maintainer.

cc @aveltras

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and “core” functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
