### PR TITLE
nixos/paperless: use python from pkg for gunicorn

### DIFF
--- a/nixos/modules/services/misc/paperless.nix
+++ b/nixos/modules/services/misc/paperless.nix
@@ -282,7 +282,7 @@ in
       serviceConfig = defaultServiceConfig // {
         User = cfg.user;
         ExecStart = ''
-          ${pkgs.python3Packages.gunicorn}/bin/gunicorn \
+          ${pkg.python.pkgs.gunicorn}/bin/gunicorn \
             -c ${pkg}/lib/paperless-ngx/gunicorn.conf.py paperless.asgi:application
         '';
         Restart = "on-failure";


### PR DESCRIPTION
#### Copy of commit msg
This ensures that a compatible `gunicorn` is used when `pkg` is overridden.

Potentially fixes #190850 (needs backport).