### PR TITLE
libtorch-bin: 1.10.0 -> 1.12.1

### DIFF
--- a/pkgs/development/libraries/science/math/libtorch/bin.nix
+++ b/pkgs/development/libraries/science/math/libtorch/bin.nix
@@ -17,7 +17,7 @@ let
   # this derivation. However, we should ensure on version bumps
   # that the CUDA toolkit for `passthru.tests` is still
   # up-to-date.
-  version = "1.10.0";
+  version = "1.12.1";
   device = if cudaSupport then "cuda" else "cpu";
   srcs = import ./binary-hashes.nix version;
   unavailable = throw "libtorch is not available for this platform";

--- a/pkgs/development/libraries/science/math/libtorch/binary-hashes.nix
+++ b/pkgs/development/libraries/science/math/libtorch/binary-hashes.nix
@@ -16,4 +16,21 @@ version : builtins.getAttr version {
       hash = "sha256-jPylK4j0V8SEQ8cZU+O22P7kQ28wanIB0GkBzRGyTj8=";
     };
   };
+  "1.12.1" = {
+    x86_64-darwin-cpu = {
+      name = "libtorch-macos-1.12.1.zip";
+      url = "https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.12.1.zip";
+      hash = "sha256-HSisxHs466c6XwvZEbkV/1kVNBzJOy3uVw9Bh497Vk8=";
+    };
+    x86_64-linux-cpu = {
+      name = "libtorch-cxx11-abi-shared-with-deps-1.12.1-cpu.zip";
+      url = "https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.12.1%2Bcpu.zip";
+      hash = "sha256-bHhC0WTli9vDJv56TaT6iA/d8im9zRkK1TlBuqkh4Wg=";
+    };
+    x86_64-linux-cuda = {
+      name = "libtorch-cxx11-abi-shared-with-deps-1.12.1-cu116.zip";
+      url = "https://download.pytorch.org/libtorch/cu116/libtorch-cxx11-abi-shared-with-deps-1.12.1%2Bcu116.zip";
+      hash = "sha256-YRcusDhrHYwIFOzt7vOuUlc11VyEUjIcBzjWEyi/874=";
+    };
+  };
 }


### PR DESCRIPTION
###### Description of changes

- [x] Check on `x86_64` without CUDA support.
- [x] Check on `x64_64` with CUDA support.
- [x] Figure out how to fix CUDA library dependency: if you look at PyTorch download [page](https://pytorch.org/get-started/locally/) you can mention that library is implicitly depends on `libcuda` (for example `libtorch` 1.12.1 depends on `libcuda` 11.3), but this is not specified in NIX configuration.
- [x] Figure out how to make version configurable in right way.
- [x] Fix hashes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
