### PR TITLE
buildRustPackage: allow not passing a FOD hash

### DIFF
--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -55,20 +55,9 @@ used for [SRI](https://www.w3.org/TR/SRI/) hashes. For example:
 ```
 
 Both types of hashes are permitted when contributing to nixpkgs. The
-Cargo hash is obtained by inserting a fake checksum into the
-expression and building the package once. The correct checksum can
-then be taken from the failed build. A fake hash can be used for
-`cargoSha256` as follows:
-
-```nix
-  cargoSha256 = lib.fakeSha256;
-```
-
-For `cargoHash` you can use:
-
-```nix
-  cargoHash = lib.fakeHash;
-```
+Cargo hash is obtained by building the package once without
+`cargoSha256` or `cargoHash` set. The correct checksum can then be
+taken from the failed build.
 
 Per the instructions in the [Cargo Book](https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html)
 best practices guide, Rust applications should always commit the `Cargo.lock`

--- a/pkgs/build-support/rust/build-rust-package/default.nix
+++ b/pkgs/build-support/rust/build-rust-package/default.nix
@@ -52,8 +52,6 @@
 , buildAndTestSubdir ? null
 , ... } @ args:
 
-assert cargoVendorDir == null && cargoLock == null -> !(args ? cargoSha256) && !(args ? cargoHash)
-  -> throw "cargoSha256, cargoHash, cargoVendorDir, or cargoLock must be set";
 assert buildType == "release" || buildType == "debug";
 
 let

--- a/pkgs/build-support/rust/fetch-cargo-tarball/default.nix
+++ b/pkgs/build-support/rust/fetch-cargo-tarball/default.nix
@@ -30,7 +30,9 @@ in
 let hash_ =
   if args ? hash then { outputHashAlgo = null; outputHash = args.hash; }
   else if args ? sha256 then { outputHashAlgo = "sha256"; outputHash = args.sha256; }
-  else throw "fetchCargoTarball requires a hash for ${name}";
+  # Prints 'warning: empty hash found, assuming <lib.fakeHash>', generates the FOD hash, and exits afterwards.
+  # This is useful because it allows you to generate the output hash without any boilerplate.
+  else { outputHashAlgo = "sha256"; outputHash = ""; };
 in stdenv.mkDerivation ({
   name = "${name}-vendor.tar.gz";
   nativeBuildInputs = [ cacert git cargo-vendor-normalise cargo ] ++ nativeBuildInputs;


### PR DESCRIPTION
###### Description of changes

This PR fixes a few problems I recently encountered with `buildRustPackage`:

* Previously `cargoHash`/`cargoSha256` would be required arguments, if both were unset `buildRustPackage` would throw an error and the user would have to set either to an empty string/`lib.fakeHash`. Instead we can simply start fetching the dependencies, just like for example `fetchFromGitHub` would without `sha256`. This allows you to write an expression that "prefetches" the hashes with less boilerplate, which is always nice.
* ~~Fixes `buildRustPackage` breaking either in an `nix-shell` environment or when `keepBuildTree` was used. This happened because of a dependency on `NIX_BUILD_TOP` (which is not very reliable, see https://github.com/NixOS/nixpkgs/issues/189691) that messed up paths to the cargo lockfiles.~~ Moved over to #191251.


For more information take a look at the individual commit messages.

 Tested by regenerating a few FOD hashes by commenting out `cargoSha256`.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
