### PR TITLE
wineasio: init at 1.1.0

### DIFF
--- a/pkgs/applications/emulators/wineasio/default.nix
+++ b/pkgs/applications/emulators/wineasio/default.nix
@@ -1,0 +1,53 @@
+{ multiStdenv
+, lib
+, fetchFromGitHub
+, libjack2
+, pkg-config
+, wineWowPackages
+, pkgsi686Linux
+}:
+
+multiStdenv.mkDerivation rec {
+  pname = "wineasio";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-HEnJj9yfXe+NQuPATMpPvseFs+3TkiMLd1L+fIfQd+o=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ pkg-config wineWowPackages.stable ];
+
+  buildInputs = [ pkgsi686Linux.libjack2 libjack2 ];
+
+  dontConfigure = true;
+
+  makeFlags = [ "PREFIX=${wineWowPackages.stable}" ];
+
+  buildPhase = ''
+    runHook preBuild
+    make "''${makeFlags[@]}" 32
+    make "''${makeFlags[@]}" 64
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -D build32/wineasio.dll $out/lib/wine/i386-windows/wineasio.dll
+    install -D build32/wineasio.dll.so $out/lib/wine/i386-unix/wineasio.dll.so
+    install -D build64/wineasio.dll $out/lib/wine/x86_64-windows/wineasio.dll
+    install -D build64/wineasio.dll.so $out/lib/wine/x86_64-unix/wineasio.dll.so
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/wineasio/wineasio";
+    description = "ASIO to JACK driver for WINE";
+    license = with licenses; [ gpl2 lgpl21 ];
+    maintainers = with maintainers; [ lovesegfault ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36397,6 +36397,8 @@ with pkgs;
     wineRelease = "wayland";
   });
 
+  wineasio = callPackage ../applications/emulators/wineasio { };
+
   wishbone-tool = callPackage ../development/tools/misc/wishbone-tool { };
 
   with-shell = callPackage ../applications/misc/with-shell { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
