### PR TITLE
python3Packages.pyunpack: init at 0.3

### DIFF
--- a/pkgs/development/python-modules/pyunpack/default.nix
+++ b/pkgs/development/python-modules/pyunpack/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, easyprocess
+, entrypoint2
+, patool
+}:
+
+buildPythonPackage rec {
+  pname = "pyunpack";
+  version = "0.3";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "ponty";
+    repo = "pyunpack";
+    rev = "refs/tags/${version}";
+    hash = "sha256-1MAdiX6+u35f6S8a0ZcIIebZE8bbxTy+0TnMohJ7J6s=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyunpack/__init__.py \
+      --replace \
+       '_exepath("patool")' \
+       '"${patool}/bin/.patool-wrapped"'
+  '';
+
+  propagatedBuildInputs = [
+    easyprocess
+    entrypoint2
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pytestFlagsArray = [ "-x" ];
+
+  pythonImportsCheck = [ "pyunpack" ];
+
+  disabledTestPaths = [
+    # unfree
+    "tests/test_rar.py"
+
+    # We get "patool: error: unrecognized arguments: --password 123"
+    # The currently packaged version of patool does not support this flag.
+    # https://github.com/wummel/patool/issues/114
+    # FIXME: Re-enable these once patool is updated
+    "tests/test_rarpw.py"
+    "tests/test_zippw.py"
+  ];
+
+  meta = with lib; {
+    description = "Unpack archive files in python";
+    homepage = "https://github.com/ponty/pyunpack";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ pbsds ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8193,6 +8193,8 @@ self: super: with self; {
 
   pyuca = callPackage ../development/python-modules/pyuca { };
 
+  pyunpack = callPackage ../development/python-modules/pyunpack { };
+
   pyutil = callPackage ../development/python-modules/pyutil { };
 
   pyzbar = callPackage ../development/python-modules/pyzbar { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add pyunpack



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
