### PR TITLE
jellyfin-ffmpeg: 5.1-2 -> 5.1.1-1

### DIFF
--- a/pkgs/development/libraries/jellyfin-ffmpeg/default.nix
+++ b/pkgs/development/libraries/jellyfin-ffmpeg/default.nix
@@ -2,33 +2,23 @@
 , nv-codec-headers-11
 , fetchFromGitHub
 , lib
-, fetchpatch
 }:
 
 (ffmpeg_5-full.override {
   nv-codec-headers = nv-codec-headers-11;
 }).overrideAttrs (old: rec {
   pname = "jellyfin-ffmpeg";
-  version = "5.1-2";
+  version = "5.1.1-1";
 
   src = fetchFromGitHub {
     owner = "jellyfin";
     repo = "jellyfin-ffmpeg";
     rev = "v${version}";
-    sha256 = "sha256-lw2W65mbBhiSnegxLSRqDz2WMM82ght/KB4i+5BiL4o=";
+    sha256 = "sha256-WxUADm5z6SH6Xegi2dhhien5IBY/Y/ZZaXr7MdOvpYA=";
   };
 
   configureFlags = old.configureFlags ++ [
     "--disable-ptx-compression" # https://github.com/jellyfin/jellyfin/issues/7944#issuecomment-1156880067
-  ];
-
-  patches = old.patches ++ [
-    # fixed in upstream ffmpeg 5.1.1 https://trac.ffmpeg.org/ticket/9841
-    (fetchpatch {
-      name = "rename-imf-fate-target.patch";
-      url = "https://github.com/FFmpeg/FFmpeg/commit/80d1b8938eb227f0e9efde91050836b1e9a051a9.patch";
-      sha256 = "sha256-weUbLKSQ9iRYSQ3hgXcVpo8jfKajpXK21qD1GrZYHYQ=";
-    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Description of changes

[New upstream release](https://github.com/jellyfin/jellyfin-ffmpeg/releases/tag/v5.1.1-1)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
