### PR TITLE
usql: 0.12.0 -> 0.12.13

### DIFF
--- a/pkgs/applications/misc/usql/default.nix
+++ b/pkgs/applications/misc/usql/default.nix
@@ -7,18 +7,27 @@
 
 buildGoModule rec {
   pname = "usql";
-  version = "0.12.0";
+  version = "0.12.13";
 
   src = fetchFromGitHub {
     owner = "xo";
     repo = "usql";
     rev = "v${version}";
-    sha256 = "sha256-OOu3zWK/ccmaEVriXKl7SZUJLLYaJB3tgF+eR9p+TmM=";
+    hash = "sha256-F/eOD7/w8HjJBeiXagaf4yBLZcZVuy93rfVFeSESlZo=";
   };
 
-  vendorSha256 = "sha256-9XyG0Fu3idxGG01MoBr5BMoQSz+dyZFEXRNvvb+XWjA=";
+  vendorHash = "sha256-7rMCqTfUs89AX0VP689BmKsuvLJWU5ANJVki+JMVf7g=";
 
   buildInputs = [ unixODBC icu ];
+
+  # Exclude broken impala driver
+  # The driver breaks too often and is not used.
+  #
+  # See https://github.com/xo/usql/pull/347
+  #
+  excludedPackages = [
+    "impala"
+  ];
 
   # These tags and flags are copied from build-release.sh
   tags = [

--- a/pkgs/applications/misc/usql/default.nix
+++ b/pkgs/applications/misc/usql/default.nix
@@ -57,7 +57,6 @@ buildGoModule rec {
     homepage = "https://github.com/xo/usql";
     license = licenses.mit;
     maintainers = with maintainers; [ georgyo anthonyroussel ];
-    # usql does not build on ARM.
-    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+    platforms = with platforms; linux ++ darwin;
   };
 }

--- a/pkgs/applications/misc/usql/default.nix
+++ b/pkgs/applications/misc/usql/default.nix
@@ -56,9 +56,8 @@ buildGoModule rec {
     description = "Universal command-line interface for SQL databases";
     homepage = "https://github.com/xo/usql";
     license = licenses.mit;
-    maintainers = with maintainers; [ georgyo ];
+    maintainers = with maintainers; [ georgyo anthonyroussel ];
     # usql does not build on ARM.
     platforms = [ "x86_64-linux" "x86_64-darwin" ];
   };
-
 }


### PR DESCRIPTION
###### Description of changes

* Upgrade usql from 0.12.0 to 0.12.13
  * Release notes: https://github.com/xo/usql/compare/v0.12.0...v0.12.13

* Build usql on aarch64-darwin + aarch64-linux
* Added myself to maintainers (I use usql very often)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
