### PR TITLE
shapeshifter-dispatcher: init at 3.0.1

### DIFF
--- a/pkgs/tools/networking/shapeshifter-dispatcher/default.nix
+++ b/pkgs/tools/networking/shapeshifter-dispatcher/default.nix
@@ -1,0 +1,34 @@
+{ lib, buildGoModule, fetchFromGitHub, fetchpatch, ... }:
+
+buildGoModule rec {
+  pname = "shapeshifter-dispatcher";
+  version = "3.0.1";
+
+  src = fetchFromGitHub {
+    owner = "OperatorFoundation";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-QhPlg0Jh1V9Zea5uo6lUqj/8yhNW/i9m4muaFKn8IZs=";
+  };
+
+  patches = [
+    # go.mod and go.sum files
+    (fetchpatch {
+      url =
+        "https://github.com/OperatorFoundation/shapeshifter-dispatcher/commit/b936dc8004db276a5b639bbe6377895284e8d8c9.patch";
+      sha256 = "sha256-4fJFdY4xYN1ZBOseDidOieGiOpFAabZRyM8icBpkITI=";
+    })
+  ];
+
+  vendorSha256 = "sha256-D1Og94NKf7PG+BJ3ieaZsKzEDo/i6Bx+FjNnAT47g+k=";
+
+  doCheck = false;
+
+  meta = with lib; {
+    description =
+      "The Shapeshifter project provides network protocol shapeshifting technology (also sometimes referred to as obfuscation).";
+    homepage = "https://github.com/OperatorFoundation/shapeshifter-dispatcher";
+    license = licenses.mit;
+    maintainers = with maintainers; [ kurnevsky ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10908,6 +10908,8 @@ with pkgs;
 
   shadowsocks-v2ray-plugin = callPackage ../tools/networking/shadowsocks-v2ray-plugin { };
 
+  shapeshifter-dispatcher = callPackage ../tools/networking/shapeshifter-dispatcher { };
+
   sharutils = callPackage ../tools/archivers/sharutils { };
 
   shelldap = callPackage ../tools/misc/shelldap { };


### PR DESCRIPTION
###### Description of changes

https://github.com/OperatorFoundation/shapeshifter-dispatcher

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
