### PR TITLE
cglm: install correct include/lib dir in pkg-config

### DIFF
--- a/pkgs/development/libraries/cglm/default.nix
+++ b/pkgs/development/libraries/cglm/default.nix
@@ -17,6 +17,11 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+  ];
+
   meta = with lib; {
     homepage = "https://github.com/recp/cglm";
     description = "Highly Optimized Graphics Math (glm) for C";


### PR DESCRIPTION
###### Description of changes

Currently the cglm package has the following pkgconfig:

```
$ nix build nixpkgs#cglm && cat result/lib/pkgconfig/cglm.pc
prefix=/nix/store/3b25lbw0vnglfar91mich3mliqchxmiy-cglm-0.8.5
exec_prefix=/nix/store/3b25lbw0vnglfar91mich3mliqchxmiy-cglm-0.8.5
libdir=${prefix}//nix/store/3b25lbw0vnglfar91mich3mliqchxmiy-cglm-0.8.5/lib
includedir=${prefix}//nix/store/3b25lbw0vnglfar91mich3mliqchxmiy-cglm-0.8.5/include

Name: cglm
Description: OpenGL Mathematics (glm) for C
URL: https://github.com/recp/cglm
Version: 0.8.5
Cflags: -I${includedir}
Libs: -L${libdir} -lcglm 
```

The includedir and libdir resolve into `/nix/store/3b25lbw0vnglfar91mich3mliqchxmiy-cglm-0.8.5//nix/store/3b25lbw0vnglfar91mich3mliqchxmiy-cglm-0.8.5/{include,lib}`. This is incorrect.

I attempted to fix this by setting `CMAKE_INSTALL_INCLUDEDIR` and `CMAKE_INSTALL_LIBDIR`.

After the change it results in correct pkgconfig:

```
$ nix build .#cglm && cat result/lib/pkgconfig/cglm.pc
prefix=/nix/store/g29bhhjrnb2mwm6l4n38f1k8aspcsr47-cglm-0.8.5
exec_prefix=/nix/store/g29bhhjrnb2mwm6l4n38f1k8aspcsr47-cglm-0.8.5
libdir=${prefix}/lib
includedir=${prefix}/include

Name: cglm
Description: OpenGL Mathematics (glm) for C
URL: https://github.com/recp/cglm
Version: 0.8.5
Cflags: -I${includedir}
Libs: -L${libdir} -lcglm 

```

The only package that depends on cglm seems to be `taisei`. I was able to successfully build taisei with these changes.

The reason to do this change is to be able to build `wxrc`, which currently fails.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
