### PR TITLE
kodiPlugins.visualization-waveform: init at 19.0.2

### DIFF
--- a/pkgs/applications/video/kodi/addons/visualization-waveform/default.nix
+++ b/pkgs/applications/video/kodi/addons/visualization-waveform/default.nix
@@ -1,0 +1,25 @@
+{ lib, rel, buildKodiBinaryAddon, fetchFromGitHub, pkg-config, glm, libGL }:
+
+buildKodiBinaryAddon rec {
+  pname = "visualization-waveform";
+  namespace = "visualization.waveform";
+  version = "19.0.2";
+
+  src = fetchFromGitHub {
+    owner = "xbmc";
+    repo = namespace;
+    rev = "${version}-${rel}";
+    hash = "sha256-IQLW4CDNtt/ptE679hnoXbharq61Ru9S2m7QbJLtNSI=";
+  };
+
+  extraBuildInputs = [ pkg-config libGL ];
+
+  propagatedBuildInputs = [ glm ];
+  meta = with lib; {
+    homepage = "https://github.com/xbmc/visualization.waveform";
+    description = "Waveform visualization for kodi";
+    platforms = platforms.all;
+    license = licenses.gpl2Only;
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -100,6 +100,8 @@ let self = rec {
 
   vfs-libarchive = callPackage ../applications/video/kodi/addons/vfs-libarchive { };
 
+  visualization-waveform = callPackage ../applications/video/kodi/addons/visualization-waveform { };
+
   youtube = callPackage ../applications/video/kodi/addons/youtube { };
 
   # addon packages (dependencies)


### PR DESCRIPTION
###### Description of changes

I notices `kodi` didn't have any visualizations. After digging a bit, I found out they are referenced in the [binary-addons-repo](https://github.com/xbmc/repo-binary-addons). Just to get the hang of it, I packaged [visualization.waveform](https://github.com/xbmc/visualization.waveform) and made sure it works.

For testing purposes, it can be build with `nix-build -A kodiPlugins.visualization-waveform .` and activated within kodi with `pkgs.kodi.withPackages (p: with p; [ visualization-waveform])`

@NixOS/kodi shall I leave you as maintainers, or shall I add myself?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
