### PR TITLE
 semgrep: 0.108.0 -> 0.112.1 

### DIFF
--- a/pkgs/tools/security/semgrep/common.nix
+++ b/pkgs/tools/security/semgrep/common.nix
@@ -1,13 +1,13 @@
 { lib, fetchFromGitHub, fetchzip, stdenv }:
 
 rec {
-  version = "0.108.0";
+  version = "0.112.1";
 
   src = fetchFromGitHub {
     owner = "returntocorp";
     repo = "semgrep";
     rev = "v${version}";
-    sha256 = "sha256-Vdrv7lVPsBsxkwwfviD5zRAdsD02RfWmM+IlaThduQs=";
+    sha256 = "sha256-SZtxZz4x6YUKw1uO5HQTU4lRY989SoCNsPQphJr+L0Y=";
   };
 
   # submodule dependencies
@@ -17,25 +17,25 @@ rec {
   langsSrc = fetchFromGitHub {
     owner = "returntocorp";
     repo = "semgrep-langs";
-    rev = "98e4aacb0d58539b50a642a28d916a5d749e2a42";
-    sha256 = "sha256-7w+8vLmzqBjbeV+a4Br7kLQ2bJv3aZJw8cB0R9d/D+E=";
+    rev = "91e288062eb794e8a5e6967d1009624237793491";
+    sha256 = "sha256-z2t2bTRyj5zu9h/GBg2YeRFimpJsd3dA7dK8VBaKzHo=";
   };
 
   interfacesSrc = fetchFromGitHub {
     owner = "returntocorp";
     repo = "semgrep-interfaces";
-    rev = "bad298d06a5dc50e69b6818ba73f0cc9b9a17b58";
-    sha256 = "sha256-AgNSvjVsP4b4zwkmq6BoNcOX3xdCSnQmXK+fVSkDXxQ=";
+    rev = "7bc457a32e088ef21adf1529fa0ddeea634b9131";
+    sha256 = "sha256-xN8Qm1/YLa49k9fZKDoPPmHASI2ipI3mkKlwEK2ajO4=";
   };
 
   # fetch pre-built semgrep-core since the ocaml build is complex and relies on
   # the opam package manager at some point
   coreRelease = if stdenv.isDarwin then fetchzip {
       url = "https://github.com/returntocorp/semgrep/releases/download/v${version}/semgrep-v${version}-osx.zip";
-      sha256 = "sha256-f3ah4yGvtUL3Ievz+3hhh5Am1YMplRxsRQzdRAoF9uU=";
+      sha256 = "sha256-JiOH39vMDL6r9WKuPO0CDkRwGZtzl/GIFoSegVddFpw=";
   } else fetchzip {
       url = "https://github.com/returntocorp/semgrep/releases/download/v${version}/semgrep-v${version}-ubuntu-16.04.tgz";
-      sha256 = "sha256-qie9svlzRoAsI33W+Sxh4YTVk1iPV0NVXfzfKlEUul4=";
+      sha256 = "sha256-V6r+VQrgz8uVSbRa2AmW4lnLxovk63FL7LqVKD46RBw=";
   };
 
   meta = with lib; {

--- a/pkgs/tools/security/semgrep/default.nix
+++ b/pkgs/tools/security/semgrep/default.nix
@@ -22,6 +22,7 @@ buildPythonApplication rec {
 
   nativeBuildInputs = [ pythonRelaxDepsHook ];
   pythonRelaxDeps = [
+    "attrs"
     "boltons"
     "jsonschema"
     "typing-extensions"

--- a/pkgs/tools/security/semgrep/default.nix
+++ b/pkgs/tools/security/semgrep/default.nix
@@ -4,6 +4,7 @@
 , semgrep-core
 , buildPythonApplication
 , pythonPackages
+, pythonRelaxDepsHook
 
 , pytestCheckHook
 , git
@@ -19,12 +20,14 @@ buildPythonApplication rec {
 
   SEMGREP_CORE_BIN = "${semgrep-core}/bin/semgrep-core";
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "typing-extensions~=4.2" "typing-extensions" \
-      --replace "jsonschema~=3.2" "jsonschema" \
-      --replace "boltons~=21.0" "boltons"
+  nativeBuildInputs = [ pythonRelaxDepsHook ];
+  pythonRelaxDeps = [
+    "boltons"
+    "jsonschema"
+    "typing-extensions"
+  ];
 
+  postPatch = ''
     # remove git submodule placeholders
     rm -r ./src/semgrep/{lang,semgrep_interfaces}
     # link submodule dependencies


### PR DESCRIPTION
###### Description of changes

Relaxes the `attrs` version specification in setup.py which gets semgrep building again and thus fixes #188310.

Updates to latest release.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).