### PR TITLE
resholve: fix mangled pname/meta integrations

### DIFF
--- a/pkgs/development/misc/resholve/resholve-utils.nix
+++ b/pkgs/development/misc/resholve/resholve-utils.nix
@@ -167,7 +167,8 @@ rec {
       */
       unresholved = (stdenv.mkDerivation ((removeAttrs attrs [ "solutions" ])
         // {
-        inherit pname version src;
+        inherit version src;
+        pname = "${pname}-unresholved";
       }));
     in
     /*
@@ -178,8 +179,7 @@ rec {
     */
     lib.extendDerivation true passthru (stdenv.mkDerivation {
       src = unresholved;
-      version = unresholved.version;
-      pname = "resholved-${unresholved.pname}";
+      inherit version pname;
       buildInputs = [ resholve ];
 
       # retain a reference to the base
@@ -199,5 +199,8 @@ rec {
       # supports default python.logging levels
       # LOGLEVEL="INFO";
       preFixup = phraseSolutions solutions unresholved;
+
+      # don't break the metadata...
+      meta = unresholved.meta;
     });
 }


### PR DESCRIPTION
Two items in resholve's mkDerivation are causing trouble for some ecosystem tools:

1. I didn't pass through the original package's meta, which breaks the ability of at least nixos package search and r-ryantm to find the right source file (in the latter case breaking auto updates).

2. I was prepending "resholved-" to the pname, which at least nixos package search picks up as the package's name. Repology also tries to do this, but their current nix updater will prefer to get this data from the name. For now, this means changing to name will not stop repology from picking up the `resholved-<package>` names.
    
    Repology's code makes it clear that they *want* to use the pname/version, so I was inclined to settle with what I've got for now, but thiagokokada clarified that we aren't just waiting for nixpkgs fixes, but because Nix itself isn't exporting the pname/version in its JSON. See also:
    
    - https://github.com/repology/repology-updater/issues/854
    - https://github.com/repology/repology-updater/commit/9313110121df5
    
    For now, at least, I'll switch to appending "-unresholved" to the inner derivation's pname.

###### Description of changes

- Feed the meta attrset through.
- Prepend "resholved-" to `name` instead of `pname`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-darwin [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>12 packages built:</summary>
  <ul>
    <li>bash-preexec</li>
    <li>bashup-events32</li>
    <li>bashup-events44</li>
    <li>bats</li>
    <li>git-ftp</li>
    <li>ix</li>
    <li>mons</li>
    <li>msmtp</li>
    <li>packcc</li>
    <li>pdf2odt</li>
    <li>shunit2</li>
    <li>yadm</li>
  </ul>
</details>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
