### PR TITLE
i-dot-ming: 7.01 -> 8.00

### DIFF
--- a/pkgs/data/fonts/i-dot-ming/default.nix
+++ b/pkgs/data/fonts/i-dot-ming/default.nix
@@ -1,16 +1,38 @@
-{ lib, fetchzip }:
+{ lib, fetchurl, writeScript }:
 
 let
-  version = "7.01";
+  version = "8.00";
 in
-fetchzip {
+fetchurl {
   name = "i.ming-${version}";
   url = "https://raw.githubusercontent.com/ichitenfont/I.Ming/${version}/${version}/I.Ming-${version}.ttf";
-  sha256 = "1b2dj7spkznpkad8a0blqigj9f6ism057r0wn9wdqg5g88yp32vd";
+  hash = "sha256-JGu9H0+IdJL6QQtLwvqlFLEaJdq1JVRiqLm5zptwjyE=";
 
+  recursiveHash = true;
+  downloadToTemp = true;
   postFetch = ''
     install -DT -m444 $downloadedFile $out/share/fonts/truetype/I.Ming/I.Ming.ttf
   '';
+
+  passthru = {
+    updateScript = writeScript "updater" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p curl gnused
+      set -e
+      version=$(curl -i -s https://github.com/ichitenfont/I.Ming/releases/latest | sed -n -E 's|^location.*releases/tag/([0-9.]+).*$|\1|p')
+      if [[ $version != ${version} ]]; then
+        tmp=$(mktemp -d)
+        curl -Lo $tmp/I.Ming.ttf https://raw.githubusercontent.com/ichitenfont/I.Ming/$version/$version/I.Ming-$version.ttf
+        install -DT -m444 $tmp/I.Ming.ttf $tmp/share/fonts/truetype/I.Ming/I.Ming.ttf
+        rm $tmp/I.Ming.ttf
+        hash=$(nix hash path --type sha256 --base32 --sri $tmp)
+        sed -i -E \
+          -e "s/version = \"[0-9.]+\"/version = \"$version\"/" \
+          -e "s|hash = \".*\"|hash = \"$hash\"|" \
+          pkgs/data/fonts/i-dot-ming/default.nix
+      fi
+    '';
+  };
 
   meta = with lib; {
     description = "An open source Pan-CJK serif typeface";


### PR DESCRIPTION
###### Description of changes
Also add updateScript.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
