### PR TITLE
pkgsMusl.libtasn1: fix build

### DIFF
--- a/pkgs/development/libraries/libtasn1/default.nix
+++ b/pkgs/development/libraries/libtasn1/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, perl, texinfo }:
+{ lib, stdenv, fetchurl, fetchpatch, perl, texinfo }:
 
 stdenv.mkDerivation rec {
   pname = "libtasn1";
@@ -8,6 +8,14 @@ stdenv.mkDerivation rec {
     url = "mirror://gnu/libtasn1/libtasn1-${version}.tar.gz";
     sha256 = "sha256-FhPwrBz0hNbsDOO4wG1WJjzHJC8cI7MNgtI940WmP3o=";
   };
+
+  # Patch borrowed from alpine to work around a specific test failure with musl libc
+  # Upstream is patching this test in their own CI because that CI is using alpine and thus musl
+  # https://github.com/gnutls/libtasn1/commit/06e7433c4e587e2ba6df521264138585a63d07c7#diff-037ea159eb0a7cb0ac23b851e66bee30fb838ee8d0d99fa331a1ba65283d37f7R293
+  patches = lib.optional stdenv.hostPlatform.isMusl (fetchpatch {
+    url = "https://git.alpinelinux.org/aports/plain/main/libtasn1/failed-test.patch?id=aaed9995acc1511d54d5d93e1ea3776caf4aa488";
+    sha256 = "sha256-GTfwqEelEsGtLEcBwGRfBZZz1vKXRfWXtMx/409YqX8=";
+  });
 
   outputs = [ "out" "dev" "devdoc" ];
   outputBin = "dev";


### PR DESCRIPTION
Patch borrowed from alpine to work around a specific test failure with musl libc Upstream is patching this test in their own CI because that CI is using alpine and thus musl https://github.com/gnutls/libtasn1/commit/06e7433c4e587e2ba6df521264138585a63d07c7#diff-037ea159eb0a7cb0ac23b851e66bee30fb838ee8d0d99fa331a1ba65283d37f7R293

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
