### PR TITLE
xed: 12.0.1 -> 2022.08.11

### DIFF
--- a/pkgs/development/libraries/xed/default.nix
+++ b/pkgs/development/libraries/xed/default.nix
@@ -4,25 +4,25 @@ let
   # mbuild is a custom build system used only to build xed
   mbuild = python3Packages.buildPythonPackage rec {
     pname = "mbuild";
-    version = "0.2496-dev";
+    version = "2022.07.28";
 
     src = fetchFromGitHub {
       owner = "intelxed";
       repo = "mbuild";
-      rev = "3e8eb33aada4153c21c4261b35e5f51f6e2019e8";
-      sha256 = "0yamgzkzw4v6x1a857psw9f7i62ydgd0zaqrf33dbdg8hfd2mq3q";
+      rev = "v${version}";
+      sha256 = "sha256-eOAqmoPotdXGcBmrD9prXph4XOL6noJU6GYT/ud/VXk=";
     };
   };
 
 in stdenv.mkDerivation rec {
   pname = "xed";
-  version = "12.0.1";
+  version = "2022.08.11";
 
   src = fetchFromGitHub {
     owner = "intelxed";
     repo = "xed";
-    rev = version;
-    sha256 = "07zfff8zf29c2n0wal87hiqfq3cwcjn80zz78mz0nyjfj09nd39f";
+    rev = "v${version}";
+    sha256 = "sha256-Iil+dfjuWYPbzmSjgwKTKScSE/IsWuHEKQ5HsBJDqWM=";
   };
 
   nativeBuildInputs = [ mbuild ];


### PR DESCRIPTION
###### Description of changes
https://github.com/intelxed/xed/tags
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
