### PR TITLE
catppuccin-cursors: init at unstable-2022-08-23

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10386,6 +10386,15 @@
       fingerprint = "B00F E582 FD3F 0732 EA48  3937 F558 14E4 D687 4375";
     }];
   };
+  PlayerNameHere = {
+    name = "Dixon Sean Low Yan Feng";
+    email = "dixonseanlow@protonmail.com";
+    github = "PlayerNameHere";
+    githubId = 56017218;
+    keys = [{
+      fingerprint = "E6F4 BFB4 8DE3 893F 68FC  A15F FF5F 4B30 A41B BAC8";
+    }];
+  };
   plchldr = {
     email = "mail@oddco.de";
     github = "plchldr";

--- a/pkgs/data/icons/catppuccin-cursors/default.nix
+++ b/pkgs/data/icons/catppuccin-cursors/default.nix
@@ -1,0 +1,81 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, inkscape
+, xcursorgen
+, makeFontsConf
+}:
+
+let
+  dimensions = {
+    palette = [ "Frappe" "Latte" "Macchiato" "Mocha" ];
+    color = [ "Blue" "Dark" "Flamingo" "Green" "Lavender" "Light" "Maroon" "Mauve" "Peach" "Pink" "Red" "Rosewater" "Sapphire" "Sky" "Teal" "Yellow" ];
+  };
+  product = lib.attrsets.cartesianProductOfSets dimensions;
+  variantName = { palette, color }: (lib.strings.toLower palette) + color;
+  variants = map variantName product;
+in
+stdenvNoCC.mkDerivation {
+  pname = "catppuccin-cursors";
+  version = "unstable-2022-08-23";
+
+  src = fetchFromGitHub {
+    owner = "catppuccin";
+    repo = "cursors";
+    rev = "3d3023606939471c45cff7b643bffc5d5d4ff29c";
+    sha256 = "1z9cjxxsj3vrmhsw1k05b31zmncz1ksaswc4r1k3vd2mmpigq1nk";
+  };
+
+  outputs = variants ++ [ "out" ]; # dummy "out" output to prevent breakage
+
+  outputsToInstall = [];
+
+  nativeBuildInputs = [
+    inkscape
+    xcursorgen
+  ];
+
+  postPatch = ''
+    patchShebangs ./build.sh
+  '';
+
+  # Make fontconfig stop warning about being unable to load config
+  FONTCONFIG_FILE = makeFontsConf { fontDirectories = [ ]; };
+
+  # Make inkscape stop warning about being unable to create profile directory
+  preBuild = ''
+    export HOME="$NIX_BUILD_ROOT"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    for output in $outputs; do
+      if [ "$output" != "out" ]; then
+        local outputDir="''${!output}"
+        local iconsDir="$outputDir"/share/icons
+
+        mkdir -p "$iconsDir"
+
+        # Convert to kebab case with the first letter of each word capitalized
+        local variant=$(sed 's/\([A-Z]\)/-\1/g' <<< "$output")
+        local variant=''${variant^}
+
+        cp -r dist/Catppuccin-"$variant"-Cursors "$iconsDir"
+      fi
+    done
+
+    # Needed to prevent breakage
+    mkdir -p "$out"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Catppuccin cursor theme based on Volantes";
+    homepage = "https://github.com/catppuccin/cursors";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ PlayerNameHere ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25096,6 +25096,8 @@ with pkgs;
 
   cascadia-code = callPackage ../data/fonts/cascadia-code { };
 
+  catppuccin-cursors = callPackage ../data/icons/catppuccin-cursors { };
+
   ccsymbols = callPackage ../data/fonts/ccsymbols { };
 
   charis-sil = callPackage ../data/fonts/charis-sil { };


### PR DESCRIPTION
###### Description of changes
Catppuccin cursor theme based on Volantes.
[Homepage](https://github.com/catppuccin/cursors)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
