### PR TITLE
python310Packages.consul2: init at 0.1.5

### DIFF
--- a/pkgs/development/python-modules/consul2/default.nix
+++ b/pkgs/development/python-modules/consul2/default.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  requests,
+  six,
+}:
+
+buildPythonPackage rec {
+  pname = "python-consul2";
+  version = "0.1.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-KchZ3nPhfzarmb6DH9wdkk8W6HciMyd6KO+St7mZlc0=";
+  };
+
+  propagatedBuildInputs = [
+    six
+    requests
+  ];
+
+  # Some tests require Consul binaries.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Extended Python client for Consul";
+    homepage = "https://github.com/poppyred/python-consul2";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jakubgs ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2560,6 +2560,8 @@ self: super: with self; {
 
   consul = callPackage ../development/python-modules/consul { };
 
+  consul2 = callPackage ../development/python-modules/consul2 { };
+
   container-inspector = callPackage ../development/python-modules/container-inspector { };
 
   contexter = callPackage ../development/python-modules/contexter { };


### PR DESCRIPTION
###### Description of changes
An extended fork of `python-consul` library which supports additional features, for example querying services based on node metadata.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).