### PR TITLE
git: include info documentation in doc output

### DIFF
--- a/pkgs/applications/emulators/ppsspp/default.nix
+++ b/pkgs/applications/emulators/ppsspp/default.nix
@@ -38,14 +38,14 @@ in
       + lib.optionalString enableQt "-qt"
       + lib.optionalString (!enableQt) "-sdl"
       + lib.optionalString forceWayland "-wayland";
-    version = "1.13.1";
+    version = "1.13.2";
 
     src = fetchFromGitHub {
       owner = "hrydgard";
       repo = "ppsspp";
       rev = "v${finalAttrs.version}";
       fetchSubmodules = true;
-      sha256 = "sha256-WsFy2aSOmkII2Lte5et4W6qj0AXUKWWkYe88T0OQP08=";
+      sha256 = "sha256-Ubbl2KCZ4QlWDtTxl4my0nKNGY25DOkD/iEurzVx4gU=";
     };
 
     postPatch = ''

--- a/pkgs/applications/emulators/wineasio/default.nix
+++ b/pkgs/applications/emulators/wineasio/default.nix
@@ -1,0 +1,53 @@
+{ multiStdenv
+, lib
+, fetchFromGitHub
+, libjack2
+, pkg-config
+, wineWowPackages
+, pkgsi686Linux
+}:
+
+multiStdenv.mkDerivation rec {
+  pname = "wineasio";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-HEnJj9yfXe+NQuPATMpPvseFs+3TkiMLd1L+fIfQd+o=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ pkg-config wineWowPackages.stable ];
+
+  buildInputs = [ pkgsi686Linux.libjack2 libjack2 ];
+
+  dontConfigure = true;
+
+  makeFlags = [ "PREFIX=${wineWowPackages.stable}" ];
+
+  buildPhase = ''
+    runHook preBuild
+    make "''${makeFlags[@]}" 32
+    make "''${makeFlags[@]}" 64
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -D build32/wineasio.dll $out/lib/wine/i386-windows/wineasio.dll
+    install -D build32/wineasio.dll.so $out/lib/wine/i386-unix/wineasio.dll.so
+    install -D build64/wineasio.dll $out/lib/wine/x86_64-windows/wineasio.dll
+    install -D build64/wineasio.dll.so $out/lib/wine/x86_64-unix/wineasio.dll.so
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/wineasio/wineasio";
+    description = "ASIO to JACK driver for WINE";
+    license = with licenses; [ gpl2 lgpl21 ];
+    maintainers = with maintainers; [ lovesegfault ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -144,6 +144,7 @@ stdenv.mkDerivation (finalAttrs: {
   #          We need many of these files during the installCheckPhase.
 
   installFlags = [ "NO_INSTALL_HARDLINKS=1" ];
+  outputInfo = "doc";
 
   preInstall = (lib.optionalString osxkeychainSupport ''
     mkdir -p $out/bin
@@ -252,8 +253,9 @@ stdenv.mkDerivation (finalAttrs: {
       '')
 
    + lib.optionalString withManual ''# Install man pages
-       make -j $NIX_BUILD_CORES -l $NIX_BUILD_CORES PERL_PATH="${buildPackages.perl}/bin/perl" cmd-list.made install install-html \
-         -C Documentation ''
+       make -j $NIX_BUILD_CORES -l $NIX_BUILD_CORES infodir=$doc/share/info PERL_PATH="${buildPackages.perl}/bin/perl" cmd-list.made install install-html install-info \
+         -C Documentation
+       ''
 
    + (if guiSupport then ''
        # Wrap Tcl/Tk programs

--- a/pkgs/applications/version-management/git-and-tools/git/docbook2texi.patch
+++ b/pkgs/applications/version-management/git-and-tools/git/docbook2texi.patch
@@ -1,6 +1,4 @@
-This patch does two things: (1) use the right name for `docbook2texi',
-and (2) make sure `gitman.info' isn't produced since it's broken (duplicate
-node names).
+This patch uses the right name for `docbook2texi'.
 
 diff --git a/Documentation/Makefile b/Documentation/Makefile
 index 26a2342bea..ceccd67ebb 100644
@@ -15,24 +13,3 @@ index 26a2342bea..ceccd67ebb 100644
  DBLATEX = dblatex
  ASCIIDOC_DBLATEX_DIR = /etc/asciidoc/dblatex
  DBLATEX_COMMON = -p $(ASCIIDOC_DBLATEX_DIR)/asciidoc-dblatex.xsl -s $(ASCIIDOC_DBLATEX_DIR)/asciidoc-dblatex.sty
-@@ -250,7 +250,7 @@ man1: $(DOC_MAN1)
- man5: $(DOC_MAN5)
- man7: $(DOC_MAN7)
- 
--info: git.info gitman.info
-+info: git.info
- 
- pdf: user-manual.pdf
- 
-@@ -266,10 +266,9 @@ install-man: man
- 
- install-info: info
- 	$(INSTALL) -d -m 755 $(DESTDIR)$(infodir)
--	$(INSTALL) -m 644 git.info gitman.info $(DESTDIR)$(infodir)
-+	$(INSTALL) -m 644 git.info $(DESTDIR)$(infodir)
- 	if test -r $(DESTDIR)$(infodir)/dir; then \
- 	  $(INSTALL_INFO) --info-dir=$(DESTDIR)$(infodir) git.info ;\
--	  $(INSTALL_INFO) --info-dir=$(DESTDIR)$(infodir) gitman.info ;\
- 	else \
- 	  echo "No directory found in $(DESTDIR)$(infodir)" >&2 ; \
- 	fi

--- a/pkgs/servers/klipper/default.nix
+++ b/pkgs/servers/klipper/default.nix
@@ -6,13 +6,13 @@
 }:
 stdenv.mkDerivation rec {
   pname = "klipper";
-  version = "unstable-2022-06-18";
+  version = "unstable-2022-09-11";
 
   src = fetchFromGitHub {
     owner = "KevinOConnor";
     repo = "klipper";
-    rev = "d3c4ba4839dd7a4339ae024752e6c6424884c185";
-    sha256 = "sha256-2Fq56JIk5qcKpWffz1k/EJ+xYAnUpuxvCryq88l//8E=";
+    rev = "ee5bdbadd1d00cf161e0b2cdfbcf5c622abc8326";
+    sha256 = "sha256-nVnJQEi6xNMNpC5byG1ce3M5hpJOd53g1ugjHXKY2zI=";
   };
 
   sourceRoot = "source/klippy";

--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -46,11 +46,11 @@ with lib;
 
 stdenv.mkDerivation rec {
   pname = "samba";
-  version = "4.15.5";
+  version = "4.15.9";
 
   src = fetchurl {
     url = "mirror://samba/pub/samba/stable/${pname}-${version}.tar.gz";
-    sha256 = "sha256-aRFeM4MZN7pRUb4CR5QxR3Za7OZYunQ/RHQWcq1o0X8=";
+    sha256 = "sha256-loKixxwv8lOqJ8uwEmDqyJf/YlzznbIO4yBz5Thv4hk=";
   };
 
   outputs = [ "out" "dev" "man" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36513,6 +36513,8 @@ with pkgs;
     wineRelease = "wayland";
   });
 
+  wineasio = callPackage ../applications/emulators/wineasio { };
+
   wishbone-tool = callPackage ../development/tools/misc/wishbone-tool { };
 
   with-shell = callPackage ../applications/misc/with-shell { };


### PR DESCRIPTION
###### Description of changes

Including gitman.info, which is not broken (anymore?) and is useful.

Motivated by Magit:
https://magit.vc/manual/magit/How-to-install-the-gitman-info-manual_003f.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
