### PR TITLE
skyspell: init at unstable-20220506

### DIFF
--- a/pkgs/tools/text/skyspell/default.nix
+++ b/pkgs/tools/text/skyspell/default.nix
@@ -1,0 +1,43 @@
+{
+  fetchgit,
+  lib,
+  rustPlatform,
+  hunspellDicts,
+  hunspellWithDicts,
+  enchant2,
+  pkg-config,
+  sqlite,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "skyspell";
+  version = "unstable-20220506";
+
+  src = fetchgit {
+    url = "https://git.sr.ht/~dmerej/skyspell";
+    rev = "dc2a58e30963a2922555e42231266b00020dfb8f";
+    sha256 = "sha256-3dHSZ/qCmm1qflYP/XBex9TftMZgUwaqHLjEMzS2j0w=";
+  };
+
+  cargoSha256 = "sha256-ofjqlENfZTspUjxbJx3PuhRxIVrZe397z+EKV6xDr/A=";
+  doCheck = false;
+
+  nativeBuildInputs = [
+    pkg-config
+    (hunspellWithDicts [hunspellDicts.en-us])
+  ];
+  buildInputs = [
+    (hunspellWithDicts [hunspellDicts.en-us])
+    enchant2
+    sqlite
+  ];
+  checkInputs = [
+    (hunspellWithDicts [hunspellDicts.en-us])
+  ];
+
+  meta = with lib; {
+    description = "Fast and handy spell checker for the command line";
+    homepage = "https://git.sr.ht/~dmerej/skyspell";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [mmlb];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1357,6 +1357,8 @@ with pkgs;
 
   sgrep = callPackage ../tools/text/sgrep { };
 
+  skyspell = callPackage ../tools/text/skyspell { };
+
   smbscan = callPackage ../tools/security/smbscan { };
 
   spectre-cli = callPackage ../tools/security/spectre-cli { };


### PR DESCRIPTION
###### Description of changes

Adds the skyspell enchant based spell checker.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
