### PR TITLE
logseq: add darwin platform

### DIFF
--- a/pkgs/applications/misc/logseq/default.nix
+++ b/pkgs/applications/misc/logseq/default.nix
@@ -15,6 +15,7 @@ let
     license = licenses.agpl3Plus;
     maintainers = with maintainers; [ weihua ];
     platforms = [ "x86_64-linux" "x86_64-darwin" ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
   };
 
   src =

--- a/pkgs/applications/misc/logseq/default.nix
+++ b/pkgs/applications/misc/logseq/default.nix
@@ -1,59 +1,85 @@
-{ lib, stdenv, fetchurl, appimageTools, makeWrapper, electron, git }:
+{ lib, stdenv, fetchurl, appimageTools, makeWrapper, autoPatchelfHook, electron
+, git, curl, expat, gcc, openssl, undmg, zlib }:
+let
+  inherit (stdenv.hostPlatform) system;
 
-stdenv.mkDerivation rec {
+  throwSystem = throw "Unsupported system: ${system}";
+
   pname = "logseq";
   version = "0.8.5";
 
-  src = fetchurl {
-    url = "https://github.com/logseq/logseq/releases/download/${version}/logseq-linux-x64-${version}.AppImage";
-    sha256 = "sha256-1nvkjucMRAwpqg2LI+1UrICMLzSd6t0yGnYdCUNQslU=";
-    name = "${pname}-${version}.AppImage";
-  };
-
-  appimageContents = appimageTools.extract {
-    inherit pname src version;
-  };
-
-  dontUnpack = true;
-  dontConfigure = true;
-  dontBuild = true;
-
-  nativeBuildInputs = [ makeWrapper ];
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/bin $out/share/${pname} $out/share/applications
-    cp -a ${appimageContents}/{locales,resources} $out/share/${pname}
-    cp -a ${appimageContents}/Logseq.desktop $out/share/applications/${pname}.desktop
-
-    # remove the `git` in `dugite` because we want the `git` in `nixpkgs`
-    chmod +w -R $out/share/${pname}/resources/app/node_modules/dugite/git
-    chmod +w $out/share/${pname}/resources/app/node_modules/dugite
-    rm -rf $out/share/${pname}/resources/app/node_modules/dugite/git
-    chmod -w $out/share/${pname}/resources/app/node_modules/dugite
-
-    substituteInPlace $out/share/applications/${pname}.desktop \
-      --replace Exec=Logseq Exec=${pname} \
-      --replace Icon=Logseq Icon=$out/share/${pname}/resources/app/icons/logseq.png
-
-    runHook postInstall
-  '';
-
-  postFixup = ''
-    # set the env "LOCAL_GIT_DIRECTORY" for dugite so that we can use the git in nixpkgs
-    makeWrapper ${electron}/bin/electron $out/bin/${pname} \
-      --set "LOCAL_GIT_DIRECTORY" ${git} \
-      --add-flags $out/share/${pname}/resources/app
-  '';
-
-  passthru.updateScript = ./update.sh;
-
   meta = with lib; {
-    description = "A local-first, non-linear, outliner notebook for organizing and sharing your personal knowledge base";
+    description =
+      "A local-first, non-linear, outliner notebook for organizing and sharing your personal knowledge base";
     homepage = "https://github.com/logseq/logseq";
     license = licenses.agpl3Plus;
     maintainers = with maintainers; [ weihua ];
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
   };
-}
+
+  src =
+    let base = "https://github.com/logseq/logseq/releases/download/${version}";
+    in {
+      x86_64-linux = fetchurl {
+        url = "${base}/logseq-linux-x64-${version}.AppImage";
+        sha256 = "sha256-1nvkjucMRAwpqg2LI+1UrICMLzSd6t0yGnYdCUNQslU=";
+      };
+      x86_64-darwin = fetchurl {
+        url = "${base}/logseq-darwin-x64-${version}.dmg";
+        sha256 = "sha256-YV4aQj1lU5EsOxumf4hU3euZkM/U4PzlC4A2X92qbnU=";
+      };
+    }.${system} or throwSystem;
+
+  darwin = stdenv.mkDerivation {
+    inherit pname version src meta;
+
+    passthru.updateScript = ./update.sh;
+
+    nativeBuildInputs = [ undmg ];
+
+    sourceRoot = "Logseq.app";
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/Applications/Logseq.app
+      cp -R . $out/Applications/Logseq.app
+      runHook postInstall
+    '';
+  };
+
+  linux = stdenv.mkDerivation rec {
+    inherit pname version src meta;
+
+    appimageContents = appimageTools.extract {
+      name = "${pname}-${version}";
+      inherit src;
+    };
+
+    dontUnpack = true;
+    dontConfigure = true;
+    dontBuild = true;
+
+    nativeBuildInputs = [ makeWrapper autoPatchelfHook ];
+    buildInputs = [ stdenv.cc.cc curl expat openssl zlib ];
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/bin $out/share/${pname} $out/share/applications
+      cp -a ${appimageContents}/{locales,resources} $out/share/${pname}
+      cp -a ${appimageContents}/Logseq.desktop $out/share/applications/${pname}.desktop
+      substituteInPlace $out/share/applications/${pname}.desktop \
+        --replace Exec=Logseq Exec=${pname} \
+        --replace Icon=Logseq Icon=$out/share/${pname}/resources/app/icons/logseq.png
+      runHook postInstall
+    '';
+
+    postFixup = ''
+      makeWrapper ${electron}/bin/electron $out/bin/${pname} \
+        --prefix PATH : ${lib.makeBinPath [ git ]} \
+        --add-flags $out/share/${pname}/resources/app
+    '';
+
+    passthru.updateScript = ./update.sh;
+
+  };
+in if stdenv.isDarwin then darwin else linux


### PR DESCRIPTION
###### Description of changes
Add darwin platform for logseq
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
