### PR TITLE
cataclysm-dda: fix build

### DIFF
--- a/pkgs/games/cataclysm-dda/stable.nix
+++ b/pkgs/games/cataclysm-dda/stable.nix
@@ -1,5 +1,13 @@
-{ lib, callPackage, CoreFoundation, fetchFromGitHub, pkgs, wrapCDDA, attachPkgs
-, tiles ? true, Cocoa
+{ lib
+, callPackage
+, CoreFoundation
+, fetchFromGitHub
+, fetchpatch
+, pkgs
+, wrapCDDA
+, attachPkgs
+, tiles ? true
+, Cocoa
 , debug ? false
 , useXdgDir ? false
 }:
@@ -22,6 +30,13 @@ let
     patches = [
       # Unconditionally look for translation files in $out/share/locale
       ./locale-path-stable.patch
+
+      # Fixes compiler errors when compiling against SDL2_ttf >= 1.20.0, https://github.com/CleverRaven/Cataclysm-DDA/pull/59083
+      # Remove with next version update.
+      (fetchpatch {
+        url = "https://github.com/CleverRaven/Cataclysm-DDA/commit/625fadf3d493c1712d9ade2b849ff6a79765c7a7.patch";
+        hash = "sha256-c0NXkd6jSGSruKrwuYUmLbgiL97YQDkUm313fnMJ7GA=";
+      })
     ];
 
     makeFlags = common.makeFlags ++ [
@@ -31,7 +46,7 @@ let
 
     meta = common.meta // {
       maintainers = with lib.maintainers;
-      common.meta.maintainers ++ [ skeidel ];
+        common.meta.maintainers ++ [ skeidel ];
     };
   });
 in


### PR DESCRIPTION
###### Description of changes

Currently [fails to build on master](https://hydra.nixos.org/build/190416782), because of an update of [SDL2_ttf](https://github.com/NixOS/nixpkgs/pull/187567). The patch this adds has already been [merged upstream](https://github.com/CleverRaven/Cataclysm-DDA/pull/59083).

Also ran nixpkgs-fmt to split up the parameters line.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
