### PR TITLE
python3Packages.dirsearch: init at 0.4.3

### DIFF
--- a/pkgs/development/python-modules/dirsearch/default.nix
+++ b/pkgs/development/python-modules/dirsearch/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, buildPythonPackage
+, python
+, fetchFromGitHub
+, pysocks
+, jinja2
+, certifi
+, urllib3
+, cryptography
+, defusedxml
+, pyopenssl
+, chardet
+, charset-normalizer
+, requests
+, requests_ntlm
+, colorama
+, beautifulsoup4
+, pyparsing
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "dirsearch";
+  version = "0.4.3";
+
+  src = fetchFromGitHub {
+    owner = "maurosoria";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    sha256 = "sha256-eXB103qUB3m7V/9hlq2xv3Y3bIz89/pGJsbPZQ+AZXs=";
+  };
+
+  doCheck = false; # disabled because of TypeError: DynamicContentParser.__init__() missing 4 required positional arguments: 'requester', 'path', 'firstPage', and 'secondPage', also appears to require network connection
+
+  buildInputs = [ python ];
+
+  propagatedBuildInputs = [ pysocks jinja2 certifi urllib3 cryptography defusedxml pyopenssl chardet charset-normalizer requests requests_ntlm colorama beautifulsoup4 pyparsing setuptools ];
+
+  pythonImportsCheck = [
+    "socks" "jinja2" "certifi" "urllib3" "cryptography" "cffi" "defusedxml" "markupsafe"
+    "OpenSSL" "idna" "chardet" "charset_normalizer" "requests" "requests_ntlm" "colorama" "ntlm_auth" "pyparsing" "bs4" "setuptools"
+  ];
+
+  # installPhase was overridden because of the "[....]/nix-support/setup-hook: line 13: pushd: dist: No such file or directory" error
+  installPhase = ''
+    ${python.pythonForBuild.interpreter} -m pip install --no-build-isolation --no-index --prefix=$out  --ignore-installed --no-dependencies --no-cache .
+  '';
+
+  meta = with lib; {
+    description = "An advanced command-line tool designed to brute force directories and files in webservers, AKA web path scanner.";
+    homepage = "https://github.com/maurosoria/dirsearch";
+    changelog = "https://github.com/maurosoria/dirsearch/releases/tag/${version}";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2436,6 +2436,8 @@ in {
 
   directv = callPackage ../development/python-modules/directv { };
 
+  dirsearch = callPackage ../development/python-modules/dirsearch { };
+
   dirty-equals = callPackage ../development/python-modules/dirty-equals { };
 
   discid = callPackage ../development/python-modules/discid { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add a new package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
