### PR TITLE
fetchurl: display progress info via --trace-ascii

### DIFF
--- a/pkgs/build-support/fetchurl/builder.sh
+++ b/pkgs/build-support/fetchurl/builder.sh
@@ -4,6 +4,48 @@ source $mirrorsFile
 
 curlVersion=$(curl -V | head -1 | cut -d' ' -f2)
 
+atoi() {
+    printf '%d' "'$1"
+}
+
+# calculate a semi-unique activity ID from $out
+actionId=65536
+digit=0
+while read -n1 char; do
+    digit=$((digit + 1))
+    actionId=$((actionId + $(atoi "$char") * digit))
+done <<<"$out"
+
+traceFile="curl.trace"
+mkfifo "$traceFile"
+
+startActivity() {
+    # force-recreate the activity
+    echo '@nix { "action": "stop", "id": '$actionId' }' >&$NIX_LOG_FD
+    echo '@nix { "action": "start", "id": '$actionId', "type": 101, "level": 3, "text": "'$1'", "fields": [0,0,0,0] }' >&$NIX_LOG_FD
+}
+
+sendProgressToNix() {
+    echo '@nix { "action": "result", "type": 105, "id": '$actionId', "fields": [ '$1', '$2', 0, 0 ] }' >&$NIX_LOG_FD
+}
+
+# background job that parses the trace FIFO
+(
+    bytesExpected=0;
+    bytesRead=0;
+    tail -f $traceFile | while read line; do
+        if [[ "$line" = 0000:\ [Cc]ontent-[Ll]ength:* ]]; then
+            bytesExpected="${line#0000: [Cc]ontent-[Ll]ength: }"
+            sendProgressToNix "$bytesRead" "$bytesExpected"
+        elif [[ "$line" = \<=\ Recv\ data,* ]]; then
+            var1="${line#"<= Recv data, "}"
+            var2="${var1%\ bytes*}"
+            bytesRead=$((bytesRead + var2))
+            sendProgressToNix "$bytesRead" "$bytesExpected"
+        fi
+    done
+) &
+
 # Curl flags to handle redirects, not use EPSV, handle cookies for
 # servers to need them during redirects, and work on SSL without a
 # certificate (this isn't a security problem because we check the
@@ -15,6 +57,8 @@ curl=(
     --retry 3
     --disable-epsv
     --cookie-jar cookies
+    --no-progress-meter
+    --trace-ascii "$traceFile"
     --user-agent "curl/$curlVersion Nixpkgs/$nixpkgsVersion"
 )
 
@@ -37,6 +81,7 @@ tryDownload() {
     local url="$1"
     echo
     header "trying $url"
+    startActivity "downloading '$name' from '$url'"
     local curlexit=18;
 
     success=


### PR DESCRIPTION
###### Description of changes

!! This is a prototype, do NOT merge as-is !!

`pkgs.fetchurl` doesn't have a proper progress bar, there is no feedback on the download progress when downloading large files with it. This can even be a source of confusion, as Nix may appear to be "stuck" while curl silently downloads the file.

This PR contains a **very hacky** prototype implementation of a progress bar for fetchurl using the `@nix { }` JSON messaging protocol and curl's `--trace-ascii` option. Parsing the trace file is a very CPU-intensive process due to the amount of data being written to it by curl as well as the parser logic being implemented in pure bash.

I figured I'd open this PR to see if anyone else is interested in the idea. Maybe we can find a better solution than `--trace-ascii`, but I couldn't come up with anything short of patching curl.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


