### PR TITLE
tncattach: init at 0.1.9

### DIFF
--- a/pkgs/applications/radio/tncattach/default.nix
+++ b/pkgs/applications/radio/tncattach/default.nix
@@ -1,0 +1,32 @@
+{ lib, stdenv, fetchFromGitHub, installShellFiles }:
+
+stdenv.mkDerivation rec {
+  pname = "tncattach";
+  version = "0.1.9";
+
+  src = fetchFromGitHub {
+    owner = "markqvist";
+    repo = "tncattach";
+    rev = version;
+    sha256 = "0n7ad4gqvpgabw2i67s51lfz386wmv0cvnhxq9ygxpsqmx9aynxk";
+  };
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  makeFlags = [ "compiler=$(CC)" ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 tncattach -t $out/bin
+    installManPage tncattach.8
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Attach KISS TNC devices as network interfaces";
+    homepage = "https://github.com/markqvist/tncattach";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sarcasticadmin ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11665,6 +11665,8 @@ with pkgs;
 
   tmsu = callPackage ../tools/filesystems/tmsu { };
 
+  tncattach = callPackage ../applications/radio/tncattach { };
+
   toilet = callPackage ../tools/misc/toilet { };
 
   tokei = callPackage ../development/tools/misc/tokei {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Originally leveraged in an overlay: https://github.com/sarcasticadmin/ham-overlay/tree/master/pkgs/tncattach

I have been using this to provide TCP/IP over packet for my amateur radio equipment. CC @pkharvey 

```
$ ./result/bin/tncattach --help
Usage: tncattach [OPTION...] port baudrate

Attach TNC devices as system network interfaces

  -m, --mtu=MTU              Specify interface MTU
  -e, --ethernet             Create a full ethernet device
  -i, --ipv4=IP_ADDRESS      Configure an IPv4 address on interface
  -n, --noipv6               Filter IPv6 traffic from reaching TNC
      --noup                 Only create interface, don't bring it up
  -T, --kisstcp              Use KISS over TCP instead of serial port
  -H, --tcphost=TCP_HOST     Host to connect to when using KISS over TCP
  -P, --tcpport=TCP_PORT     TCP port when using KISS over TCP
  -t, --interval=SECONDS     Maximum interval between station identifications
  -s, --id=CALLSIGN          Station identification data
  -d, --daemon               Run tncattach as a daemon
  -v, --verbose              Enable verbose output
  -?, --help                 Give this help list
      --usage                Give a short usage message
  -V, --version              Print program version

Mandatory or optional arguments to long options are also mandatory or optional
for any corresponding short options.

To attach the TNC connected to /dev/ttyUSB0 as an ethernet device with an MTU
of 512 bytes and assign an IPv4 address, while filtering IPv6 traffic, use:

	tncattach /dev/ttyUSB0 115200 -m 512 -e --noipv6 --ipv4 10.0.0.1/24

Station identification can be performed automatically to comply with Part 97
rules. See the README for a complete description. Use the --id and --interval
options, which should commonly be set to your callsign, and 600 seconds.

Report bugs to <mark@unsigned.io>.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
