### PR TITLE
tilemaker: fix build

### DIFF
--- a/pkgs/applications/misc/tilemaker/default.nix
+++ b/pkgs/applications/misc/tilemaker/default.nix
@@ -1,16 +1,24 @@
-{ lib, stdenv, fetchFromGitHub, buildPackages, cmake, installShellFiles
-, boost, lua, protobuf, rapidjson, shapelib, sqlite, zlib }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, buildPackages, cmake, installShellFiles
+, boost, lua, protobuf, rapidjson, shapelib, sqlite, zlib, testers }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tilemaker";
   version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "systemed";
-    repo = pname;
-    rev = "v${version}";
+    repo = "tilemaker";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-st6WDCk1RZ2lbfrudtcD+zenntyTMRHrIXw3nX5FHOU=";
   };
+
+  patches = [
+    # Fix build with Boost >= 1.79, remove on next upstream release
+    (fetchpatch {
+      url = "https://github.com/systemed/tilemaker/commit/252e7f2ad8938e38d51783d1596307dcd27ed269.patch";
+      hash = "sha256-YSkhmpzEYk/mxVPSDYdwZclooB3zKRjDPzqamv6Nvyc=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace src/tilemaker.cpp \
@@ -25,10 +33,17 @@ stdenv.mkDerivation rec {
   cmakeFlags = lib.optional (stdenv.hostPlatform != stdenv.buildPlatform)
     "-DPROTOBUF_PROTOC_EXECUTABLE=${buildPackages.protobuf}/bin/protoc";
 
+  NIX_CFLAGS_COMPILE = [ "-DTM_VERSION=${finalAttrs.version}" ];
+
   postInstall = ''
     installManPage ../docs/man/tilemaker.1
     install -Dm644 ../resources/* -t $out/share/tilemaker
   '';
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    command = "tilemaker --help";
+  };
 
   meta = with lib; {
     description = "Make OpenStreetMap vector tiles without the stack";
@@ -37,4 +52,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ sikmir ];
     platforms = platforms.unix;
   };
-}
+})


### PR DESCRIPTION
###### Description of changes
Fix build: https://hydra.nixos.org/build/190417934

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
