### PR TITLE
Numary ledger

### DIFF
--- a/pkgs/tools/misc/numary/default.nix
+++ b/pkgs/tools/misc/numary/default.nix
@@ -1,4 +1,4 @@
-{ buildGoModule, fetchFromGitHub, lib, numary, testers }:
+{ buildGoModule, fetchFromGitHub, lib }:
 
 buildGoModule rec {
   pname = "numary";
@@ -8,17 +8,31 @@ buildGoModule rec {
     owner = "numary";
     repo = "ledger";
     rev = "v${version}";
-    hash = "sha256-fNV5a70Kno+6TozjcGRygxdJmrFepe+s8wIbbzO5q4k=";
+    hash = "sha256-wMfdCCycVXv6Lg1OVzyNXCDk39OdD9mZvbirPtRQols=";
+    # populate values that require us to use git. By doing this in postFetch we
+    # can delete .git afterwards and maintain better reproducibility of the src.
+    leaveDotGit = true;
+    postFetch = ''
+      date -u -d "@$(git -C $out log -1 --pretty=%ct)" "+%Y-%m-%d %H:%M UTC" > $out/DATE
+      git -C $out rev-parse HEAD > $out/COMMIT
+      rm -rf $out/.git
+    '';
   };
 
   vendorSha256 = "sha256-P4/wq2Sn6xEcIzYUFf6Vus1wrBBGKumTYFRoCEfkvrQ=";
 
-  passthru.tests.version = testers.testVersion {
-    package = numary;
-    command = "numary version";
-  };
+  ldflags = ["-X github.com/numary/ledger/cmd.Version=${version}"];
 
-  checkPhase = "";
+  # ldflags based on metadata from git and source
+  preBuild = ''
+    ldflags+=" -X github.com/numary/ledger/cmd.Commit=$(cat COMMIT)"
+    ldflags+=" -X 'github.com/numary/ledger/cmd.BuildDate=$(cat DATE)'"
+  '';
+
+  tags = ["json1" "netgo"];
+
+  # tests depend on docker runtime
+  doCheck = false;
 
   meta = with lib; {
     description = "A programmable financial ledger to build money-moving apps";

--- a/pkgs/tools/misc/numary/default.nix
+++ b/pkgs/tools/misc/numary/default.nix
@@ -21,6 +21,8 @@ buildGoModule rec {
 
   vendorSha256 = "sha256-P4/wq2Sn6xEcIzYUFf6Vus1wrBBGKumTYFRoCEfkvrQ=";
 
+  tags = ["json1" "netgo"];
+
   ldflags = ["-X github.com/numary/ledger/cmd.Version=${version}"];
 
   # ldflags based on metadata from git and source
@@ -29,7 +31,9 @@ buildGoModule rec {
     ldflags+=" -X 'github.com/numary/ledger/cmd.BuildDate=$(cat DATE)'"
   '';
 
-  tags = ["json1" "netgo"];
+  preInstall = ''
+    mv $GOPATH/bin/ledger $GOPATH/bin/numary
+  '';
 
   # tests depend on docker runtime
   doCheck = false;

--- a/pkgs/tools/misc/numary/default.nix
+++ b/pkgs/tools/misc/numary/default.nix
@@ -1,0 +1,28 @@
+{ buildGoModule, fetchFromGitHub, lib, numary, testers }:
+
+buildGoModule rec {
+  pname = "numary";
+  version = "1.7.4";
+
+  src = fetchFromGitHub {
+    owner = "numary";
+    repo = "ledger";
+    rev = "v${version}";
+    hash = "sha256-fNV5a70Kno+6TozjcGRygxdJmrFepe+s8wIbbzO5q4k=";
+  };
+
+  vendorSha256 = "sha256-P4/wq2Sn6xEcIzYUFf6Vus1wrBBGKumTYFRoCEfkvrQ=";
+
+  passthru.tests.version = testers.testVersion {
+    package = numary;
+    command = "numary version";
+  };
+
+  checkPhase = "";
+
+  meta = with lib; {
+    description = "A programmable financial ledger to build money-moving apps";
+    homepage = "https://www.formance.com/";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/tools/misc/numary/default.nix
+++ b/pkgs/tools/misc/numary/default.nix
@@ -8,12 +8,12 @@ buildGoModule rec {
     owner = "numary";
     repo = "ledger";
     rev = "v${version}";
-    hash = "sha256-wMfdCCycVXv6Lg1OVzyNXCDk39OdD9mZvbirPtRQols=";
+    hash = "sha256-ZHiWGKl63Tl0Es9W+ChY9dHsnke8NcoDIOzmlxbzHKI=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
     postFetch = ''
-      date -u -d "@$(git -C $out log -1 --pretty=%ct)" "+%Y-%m-%d %H:%M UTC" > $out/DATE
+      date -u -d "@$(git -C $out log -1 --pretty=%ct)" --iso-8601=seconds > $out/DATE
       git -C $out rev-parse HEAD > $out/COMMIT
       rm -rf $out/.git
     '';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -394,6 +394,8 @@ with pkgs;
 
   colorz = callPackage ../tools/misc/colorz { };
 
+  numary = callPackage ../tools/misc/numary { };
+
   colorpanes = callPackage ../tools/misc/colorpanes { };
 
   colorpicker = callPackage ../tools/misc/colorpicker { };


### PR DESCRIPTION
###### Description of changes

Numary (or Formance) ledger.
https://github.com/formancehq/ledger
A programmable financial ledger to build money-moving apps

###### Things I need help with

- [ ] It seems tests require a docker runtime. For now I've disable them with an empty `checkPhase`
- [x] The final binary ends up being called "ledger" because of how the go project is structured. How should I rename it? `postBuild` script?

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [X] arm64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
