### PR TITLE
matrix-sdk-crypto-nodejs: init at 0.1.0-beta.2

### DIFF
--- a/pkgs/development/libraries/matrix-sdk-crypto-nodejs/default.nix
+++ b/pkgs/development/libraries/matrix-sdk-crypto-nodejs/default.nix
@@ -1,0 +1,65 @@
+{ lib, stdenv, fetchFromGitHub, rustPlatform, napi-rs-cli, nodejs, libiconv }:
+
+stdenv.mkDerivation rec {
+  pname = "matrix-sdk-crypto-nodejs";
+  version = "0.1.0-beta.2";
+
+  src = fetchFromGitHub {
+    owner = "matrix-org";
+    repo = "matrix-rust-sdk";
+    rev = "${pname}-v${version}";
+    hash = "sha256-E++0tm/2d8/3zAXwovJ71uF2sxDORWyJNnA3e1Q3NLA=";
+  };
+
+  patches = [
+    # This is needed because two versions of indexed_db_futures are present (which will fail to vendor, see https://github.com/rust-lang/cargo/issues/10310).
+    # (matrix-sdk-crypto-nodejs doesn't use this dependency, we only need to remove it to vendor the dependencies successfully.)
+    ./remove-duplicate-dependency.patch
+  ];
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src patches;
+    name = "${pname}-${version}";
+    hash = "sha256-G2Um7vHinOuOx9U2BH14LAx+s/0Sxtlc9Nz6nPJfmU8=";
+  };
+
+  postPatch = ''
+    cd bindings/${pname}
+  '';
+
+  nativeBuildInputs = [
+    rustPlatform.cargoSetupHook
+    rustPlatform.rust.cargo
+    rustPlatform.rust.rustc
+    napi-rs-cli
+    nodejs
+  ];
+
+  buildInputs = lib.optionals stdenv.isDarwin [ libiconv ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    npm run release-build --offline
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    local -r outPath="$out/lib/node_modules/@matrix-org/${pname}"
+    mkdir -p "$outPath"
+    cp package.json index.js index.d.ts matrix-sdk-crypto.*.node "$outPath"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A no-network-IO implementation of a state machine that handles E2EE for Matrix clients";
+    homepage = "https://github.com/matrix-org/matrix-rust-sdk/tree/${src.rev}/bindings/matrix-sdk-crypto-nodejs";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ winter ];
+    inherit (nodejs.meta) platforms;
+  };
+}

--- a/pkgs/development/libraries/matrix-sdk-crypto-nodejs/remove-duplicate-dependency.patch
+++ b/pkgs/development/libraries/matrix-sdk-crypto-nodejs/remove-duplicate-dependency.patch
@@ -1,0 +1,47 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 2ddfdd0..3fcca5f 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1985,20 +1985,6 @@ version = "0.3.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+ 
+-[[package]]
+-name = "indexed_db_futures"
+-version = "0.2.3"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d26ac735f676c52305becf53264b91cea9866a8de61ccbf464405b377b9cbca9"
+-dependencies = [
+- "cfg-if",
+- "js-sys",
+- "uuid 0.8.2",
+- "wasm-bindgen",
+- "wasm-bindgen-futures",
+- "web-sys",
+-]
+-
+ [[package]]
+ name = "indexed_db_futures"
+ version = "0.2.3"
+@@ -2558,8 +2544,7 @@ dependencies = [
+  "derive_builder",
+  "futures-util",
+  "getrandom 0.2.7",
+- "indexed_db_futures 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+- "indexed_db_futures 0.2.3 (git+https://github.com/Hywan/rust-indexed-db?branch=feat-factory-nodejs)",
++ "indexed_db_futures",
+  "js-sys",
+  "matrix-sdk-base",
+  "matrix-sdk-common",
+diff --git a/crates/matrix-sdk-indexeddb/Cargo.toml b/crates/matrix-sdk-indexeddb/Cargo.toml
+index 7f23dfc..c57e29a 100644
+--- a/crates/matrix-sdk-indexeddb/Cargo.toml
++++ b/crates/matrix-sdk-indexeddb/Cargo.toml
+@@ -30,7 +30,6 @@ js-sys = { version = "0.3.58" }
+ matrix-sdk-base = { version = "0.6.0", path = "../matrix-sdk-base", features = ["js"] }
+ matrix-sdk-crypto = { version = "0.6.0", path = "../matrix-sdk-crypto", features = ["js"], optional = true }
+ matrix-sdk-store-encryption = { version = "0.2.0", path = "../matrix-sdk-store-encryption" }
+-indexed_db_futures = "0.2.3"
+ indexed_db_futures_nodejs = { package = "indexed_db_futures", git = "https://github.com/Hywan/rust-indexed-db", branch = "feat-factory-nodejs", optional = true }
+ ruma = "0.7.0"
+ serde = "1.0.136"

--- a/pkgs/development/tools/napi-rs-cli/default.nix
+++ b/pkgs/development/tools/napi-rs-cli/default.nix
@@ -1,0 +1,33 @@
+{ lib, stdenv, fetchurl, makeWrapper, nodejs }:
+
+stdenv.mkDerivation rec {
+  pname = "napi-rs-cli";
+  version = "2.12.0";
+
+  src = fetchurl {
+    url = "https://registry.npmjs.org/@napi-rs/cli/-/cli-${version}.tgz";
+    hash = "sha256-TGhPPv73tb3tr1cY9mUuN4FaVql5tGh436uJeTkbnJs=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/bin" "$out/lib/napi-rs-cli"
+
+    cp scripts/index.js "$out/lib/napi-rs-cli"
+
+    makeWrapper ${nodejs}/bin/node "$out/bin/napi" --add-flags "$out/lib/napi-rs-cli/index.js"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "CLI tools for napi-rs";
+    homepage = "https://napi.rs";
+    license = licenses.mit;
+    maintainers = with maintainers; [ winter ];
+    inherit (nodejs.meta) platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9477,6 +9477,8 @@ with pkgs;
 
   pwsafe = callPackage ../applications/misc/pwsafe { };
 
+  napi-rs-cli = callPackage ../development/tools/napi-rs-cli { };
+
   neil = callPackage ../development/tools/neil { };
 
   niff = callPackage ../tools/package-management/niff { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8941,6 +8941,8 @@ with pkgs;
     sasl = gsasl;
   };
 
+  matrix-sdk-crypto-nodejs = callPackage ../development/libraries/matrix-sdk-crypto-nodejs { };
+
   email = callPackage ../tools/networking/email { };
 
   maim = callPackage ../tools/graphics/maim {};


### PR DESCRIPTION
###### Description of changes

This packages the [Node.js bindings](https://github.com/matrix-org/matrix-rust-sdk/tree/main/bindings/matrix-sdk-crypto-nodejs) for [matrix-sdk-crypto](https://github.com/matrix-org/matrix-rust-sdk/tree/main/crates/matrix-sdk-crypto), a no-network-IO implementation of a state machine that handles E2EE for Matrix clients.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
