### PR TITLE
 qolibri: 2019-07-22 -> 2.1.4

### DIFF
--- a/pkgs/applications/misc/qolibri/default.nix
+++ b/pkgs/applications/misc/qolibri/default.nix
@@ -1,21 +1,25 @@
-{ mkDerivation, lib, fetchFromGitHub, pkg-config, cmake, libeb, lzo
-, qtbase, qtmultimedia, qttools, qtwebengine }:
+{ stdenv, lib, fetchFromGitHub, pkg-config, cmake, libeb, lzo
+, qtmultimedia, qttools, qtwebengine, wrapQtAppsHook }:
 
-mkDerivation {
+stdenv.mkDerivation rec {
   pname = "qolibri";
-  version = "2019-07-22";
+  version = "2.1.4";
 
   src = fetchFromGitHub {
     owner = "ludios";
     repo = "qolibri";
-    rev = "b58f9838d39300cba444eba725a369181c5d746b";
-    sha256 = "0kcc6dvbcmq9y7hk8mp23pydiaqz6f0clg64d1f2y04ppphmah42";
+    rev = version;
+    sha256 = "jyLF1MKDVH0Lt8lw+O93b+LQ4J+s42O3hebthJk83hg=";
   };
 
-  nativeBuildInputs = [ pkg-config cmake ];
+  nativeBuildInputs = [ pkg-config cmake qttools wrapQtAppsHook ];
   buildInputs = [
-    libeb lzo qtbase qtmultimedia qttools qtwebengine
+    libeb lzo qtmultimedia qtwebengine
   ];
+
+  postInstall = ''
+    install -D $src/qolibri.desktop -t $out/share/applications
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/ludios/qolibri";


### PR DESCRIPTION
###### Description of changes
* https://github.com/ludios/qolibri/releases/tag/2.1.4
* Install the desktop file in the source folder
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
