### PR TITLE
aacgain: 1.9.0 -> 2.0.0 | dgilman fork

### DIFF
--- a/pkgs/applications/audio/aacgain/default.nix
+++ b/pkgs/applications/audio/aacgain/default.nix
@@ -1,56 +1,33 @@
-{ lib, stdenv, fetchFromGitLab, fetchpatch }:
+{ lib, pkgs, stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
   pname = "aacgain";
-  version = "1.9.0";
+  version = "2.0.0";
 
-  src = fetchFromGitLab {
-    owner = "mulx";
+  src = fetchFromGitHub {
+    owner = "dgilman";
     repo = "aacgain";
-    rev = "7c29dccd878ade1301710959aeebe87a8f0828f5";
-    sha256 = "07hl432vsscqg01b6wr99qmsj4gbx0i02x4k565432y6zpfmaxm0";
+    rev = "9f9ae95a20197d1072994dbd89672bba2904bdb5";
+    sha256 = "sha256-WqL9rKY4lQD7wQSZizoM3sHNzLIG0E9xZtjw8y7fgmE=";
+    fetchSubmodules = true;
   };
 
-  hardeningDisable = [ "format" ];
-
-  # -Wnarrowing is enabled by default in recent GCC versions,
-  # causing compilation to fail.
-  NIX_CFLAGS_COMPILE = "-Wno-narrowing";
-
-  postPatch = ''
-    (
-      cd mp4v2
-      patch -p0 < ${fetchpatch {
-        name = "fix_missing_ptr_deref.patch";
-        url = "https://aur.archlinux.org/cgit/aur.git/plain/fix_missing_ptr_deref.patch?h=aacgain-cvs&id=e1a19c920f57063e64bab75cb0d8624731f6e3d7";
-        sha256 = "1cq7r005nvmwdjb25z80grcam7jv6k57jnl2bh349mg3ajmslbq9";
-      }}
-    )
-  '';
+  buildInputs = [
+    pkgs.cmake pkgs.autoconf pkgs.automake pkgs.libtool
+  ];
 
   configurePhase = ''
     runHook preConfigure
-    cd mp4v2
-    ./configure
 
-    cd ../faad2
-    ./configure
+    mkdir build
+    cmake -H. -Bbuild
 
-    cd ..
-    ./configure
     runHook postConfigure
   '';
 
   buildPhase = ''
     runHook preBuild
-    cd mp4v2
-    make libmp4v2.la
-
-    cd ../faad2
-    make LDFLAGS=-static
-
-    cd ..
-    make
+    cd build; make
     runHook postBuild
   '';
 
@@ -60,9 +37,9 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "ReplayGain for AAC files";
-    homepage = "https://aacgain.altosdesign.com";
+    homepage = "https://github.com/dgilman/aacgain";
     license = licenses.gpl2;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = [ maintainers.robbinch ];
   };
 }


### PR DESCRIPTION
###### Description of changes

This PR updates `aacgain` to version `2.0.0`. It's currently pointing to what seems [like a dead fork](https://gitlab.com/mulx/aacgain). With this PR, it now uses [a more recent fork](https://github.com/dgilman/aacgain).

With this PR, it now builds on mac successfully.

Co-authored with @klautcomputing - Second attempt on https://github.com/NixOS/nixpkgs/pull/191114 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

<details>
  <summary>`nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`</summary>


```
❯ nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"
these 3 paths will be fetched (0.10 MiB download, 0.47 MiB unpacked):
  /nix/store/51zlypw5hnf1b9lg56vlgfwla5zq1s9w-bash-interactive-5.1-p16-dev
  /nix/store/asfbajai0kzdw2vd88fyv14f7yal1h9f-nixpkgs-review-2.6.4
  /nix/store/viwmk7z6fxrd1xc09dximdk3w37kx1qn-stdenv-linux
copying path '/nix/store/asfbajai0kzdw2vd88fyv14f7yal1h9f-nixpkgs-review-2.6.4' from 'https://cache.nixos.org'...
copying path '/nix/store/51zlypw5hnf1b9lg56vlgfwla5zq1s9w-bash-interactive-5.1-p16-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/viwmk7z6fxrd1xc09dximdk3w37kx1qn-stdenv-linux' from 'https://cache.nixos.org'...
$ git -c fetch.prune=false fetch --no-tags --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
From https://github.com/NixOS/nixpkgs
   74f38e6684c..3ff5deafc47  master     -> refs/nixpkgs-review/0
$ git worktree add /home/jojo/.cache/nixpkgs-review/rev-b573215001b5709530c7198ce09040490fcbced1/nixpkgs 3ff5deafc470403d5cb7ec8edbc7b21b719d2894
Preparing worktree (detached HEAD 3ff5deafc47)
Updating files: 100% (31832/31832), done.
HEAD is now at 3ff5deafc47 Merge pull request #190924 from linj-fork/pr/bump-emacs-28.2
$ nix-env --option system x86_64-linux -f /home/jojo/.cache/nixpkgs-review/rev-b573215001b5709530c7198ce09040490fcbced1/nixpkgs -qaP --xml --out-path --show-trace
$ git merge --no-commit --no-ff b573215001b5709530c7198ce09040490fcbced1
Automatic merge went well; stopped before committing as requested
$ nix-env --option system x86_64-linux -f /home/jojo/.cache/nixpkgs-review/rev-b573215001b5709530c7198ce09040490fcbced1/nixpkgs -qaP --xml --out-path --show-trace --meta
7 packages updated:
aacgain (1.9.0 → 2.0.0) beets beets-unstable soundkonverter soundkonverter soundkonverter soundkonverter

$ nix --experimental-features nix-command build --no-link --keep-going --option build-use-sandbox relaxed -f /home/jojo/.cache/nixpkgs-review/rev-b573215001b5709530c7198ce09040490fcbced1/build.nix
error: builder for '/nix/store/r2xwsj6986ivpphhfl29a60hmvlrfp31-review-shell.drv' failed with exit code 1;
       last 3 log lines:
       > Error: detected mismatched Qt dependencies:
       >     /nix/store/gkxdmfacg7rvfibx4vzpyiqy4sbx852b-qtbase-5.15.5-dev
       >     /nix/store/hxwyg9v3xhxr8xvrgmd7na58xsh3q5ix-qtbase-5.15.5-dev
       For full logs, run 'nix log /nix/store/r2xwsj6986ivpphhfl29a60hmvlrfp31-review-shell.drv'.
2 packages marked as broken and skipped:
libsForQt512.soundkonverter libsForQt514.soundkonverter

5 packages built:
aacgain beets beets-unstable libsForQt5.soundkonverter libsForQt5_openssl_1_1.soundkonverter

$ nix-shell /home/jojo/.cache/nixpkgs-review/rev-b573215001b5709530c7198ce09040490fcbced1/shell.nix
these 4 paths will be fetched (0.55 MiB download, 2.67 MiB unpacked):
  /nix/store/5dlhkb2as8j03pp2f16blzh0yzh8lcmc-bash-interactive-5.1-p16-doc
  /nix/store/jjglfgj6jwb8chrjyxgiingjq35vfmk9-bash-interactive-5.1-p16-man
  /nix/store/kpvlvj6abv0lfk2pxi54nyw24pr8bji2-bash-interactive-5.1-p16-dev
  /nix/store/sjz7k58ab24vw97jib214cy0q02gc19r-bash-interactive-5.1-p16-info
copying path '/nix/store/jjglfgj6jwb8chrjyxgiingjq35vfmk9-bash-interactive-5.1-p16-man' from 'https://cache.nixos.org'...
copying path '/nix/store/sjz7k58ab24vw97jib214cy0q02gc19r-bash-interactive-5.1-p16-info' from 'https://cache.nixos.org'...
copying path '/nix/store/5dlhkb2as8j03pp2f16blzh0yzh8lcmc-bash-interactive-5.1-p16-doc' from 'https://cache.nixos.org'...
copying path '/nix/store/kpvlvj6abv0lfk2pxi54nyw24pr8bji2-bash-interactive-5.1-p16-dev' from 'https://cache.nixos.org'...
Error: detected mismatched Qt dependencies:
    /nix/store/gkxdmfacg7rvfibx4vzpyiqy4sbx852b-qtbase-5.15.5-dev
    /nix/store/hxwyg9v3xhxr8xvrgmd7na58xsh3q5ix-qtbase-5.15.5-dev
$ git worktree prune
```
  

</details>

```
❯ nix-build -A aacgain -K
/nix/store/m5s215mjp1cpkaw1wb9nddxr790bg4nw-aacgain-2.0.0
❯ ./result/bin/aacgain
aacgain version 2.0.0, derived from mp3gain version 1.5.2
copyright(c) 2001-2009 by Glen Sawyer
AAC support copyright(c) 2004-2009 David Lasker, Altos Design, Inc.
uses mpglib, which can be found at http://www.mpg123.de
AAC support uses faad2 (http://www.audiocoding.com), and
mpeg4ip's mp4v2 (http://www.mpeg4ip.net)
Usage: ./result/bin/aacgain [options] <infile> [<infile 2> ...]
  --use -? or -h for a full list of options
```

cc @robbinch 