### PR TITLE
ocamlPackages.piaf: disable (failing) tests

### DIFF
--- a/pkgs/development/ocaml-modules/lwt_ssl/default.nix
+++ b/pkgs/development/ocaml-modules/lwt_ssl/default.nix
@@ -4,9 +4,6 @@ buildDunePackage rec {
   pname = "lwt_ssl";
   version = "1.1.3";
 
-  minimumOCamlVersion = "4.02";
-  useDune2 = true;
-
   src = fetchFromGitHub {
     owner = "aantron";
     repo = "lwt_ssl";

--- a/pkgs/development/ocaml-modules/piaf/default.nix
+++ b/pkgs/development/ocaml-modules/piaf/default.nix
@@ -8,7 +8,6 @@
 , lwt_ssl
 , magic-mime
 , mrmime
-, openssl
 , pecu
 , psq
 , ssl
@@ -28,8 +27,6 @@ buildDunePackage rec {
     substituteInPlace ./vendor/dune --replace "mrmime.prettym" "prettym"
   '';
 
-  useDune2 = true;
-
   propagatedBuildInputs = [
     logs
     magic-mime
@@ -43,7 +40,8 @@ buildDunePackage rec {
     alcotest-lwt
     dune-site
   ];
-  doCheck = true;
+  # Check fails with OpenSSL 3
+  doCheck = false;
 
   meta = {
     description = "An HTTP library with HTTP/2 support written entirely in OCaml";


### PR DESCRIPTION
###### Description of changes

Tests for the OCaml `piaf` library are broken (not compatible with the recent update of OpenSSL): the simplest workaround is to simply disable them waiting for a new release (of `piaf`).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
