### PR TITLE
ocamlPackages.mirage-unix: 4.0.1 → 5.0.1; mirage-crypto: 0.10.5 → 0.10.7

### DIFF
--- a/pkgs/development/ocaml-modules/mirage-crypto/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/default.nix
@@ -7,11 +7,11 @@ buildDunePackage rec {
   minimalOCamlVersion = "4.08";
 
   pname = "mirage-crypto";
-  version = "0.10.6";
+  version = "0.10.7";
 
   src = fetchurl {
     url = "https://github.com/mirage/mirage-crypto/releases/download/v${version}/mirage-crypto-${version}.tbz";
-    sha256 = "sha256-AdZHek7crQB7Vpg5VdMn8OYcPzZJSCLzdVAX0m6PlBA=";
+    sha256 = "sha256-PoGKdgwjXFtoTHtrQ7HN0qfdBOAQW2gNUk+DbrmIppw=";
   };
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/mirage-crypto/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/default.nix
@@ -1,23 +1,21 @@
-{ lib, fetchurl, buildDunePackage, ounit, cstruct, dune-configurator, eqaf, pkg-config
+{ lib, fetchurl, buildDunePackage, ounit2, cstruct, dune-configurator, eqaf, pkg-config
 , withFreestanding ? false
 , ocaml-freestanding
 }:
 
 buildDunePackage rec {
-  minimumOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.08";
 
   pname = "mirage-crypto";
-  version = "0.10.5";
+  version = "0.10.6";
 
   src = fetchurl {
-    url = "https://github.com/mirage/mirage-crypto/releases/download/v${version}/mirage-crypto-v${version}.tbz";
-    sha256 = "sha256-eeKMSRZrBiTzWLv80P5LeouPib24uTigk2HLtORKpJU=";
+    url = "https://github.com/mirage/mirage-crypto/releases/download/v${version}/mirage-crypto-${version}.tbz";
+    sha256 = "sha256-AdZHek7crQB7Vpg5VdMn8OYcPzZJSCLzdVAX0m6PlBA=";
   };
 
-  useDune2 = true;
-
   doCheck = true;
-  checkInputs = [ ounit ];
+  checkInputs = [ ounit2 ];
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ dune-configurator  ];

--- a/pkgs/development/ocaml-modules/mirage-crypto/ec.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/ec.nix
@@ -21,10 +21,8 @@ buildDunePackage rec {
   pname = "mirage-crypto-ec";
 
   inherit (mirage-crypto)
-    minimumOCamlVersion
     src
-    version
-    useDune2;
+    version;
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [

--- a/pkgs/development/ocaml-modules/mirage-crypto/pk.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/pk.nix
@@ -1,10 +1,10 @@
-{ buildDunePackage, ounit, randomconv, mirage-crypto, mirage-crypto-rng
+{ buildDunePackage, ounit2, randomconv, mirage-crypto, mirage-crypto-rng
 , cstruct, sexplib0, zarith, eqaf, gmp }:
 
 buildDunePackage rec {
   pname = "mirage-crypto-pk";
 
-  inherit (mirage-crypto) version src useDune2 minimumOCamlVersion;
+  inherit (mirage-crypto) version src;
 
   buildInputs = [ gmp ];
   propagatedBuildInputs = [ cstruct mirage-crypto mirage-crypto-rng
@@ -13,7 +13,7 @@ buildDunePackage rec {
   strictDeps = !doCheck;
 
   doCheck = true;
-  checkInputs = [ ounit randomconv ];
+  checkInputs = [ ounit2 randomconv ];
 
   meta = mirage-crypto.meta // {
     description = "Simple public-key cryptography for the modern age";

--- a/pkgs/development/ocaml-modules/mirage-crypto/rng-async.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/rng-async.nix
@@ -6,7 +6,7 @@
 buildDunePackage {
   pname = "mirage-crypto-rng-async";
 
-  inherit (mirage-crypto) useDune2 version minimumOCamlVersion src;
+  inherit (mirage-crypto) version src;
 
   buildInputs = [
     dune-configurator

--- a/pkgs/development/ocaml-modules/mirage-crypto/rng-mirage.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/rng-mirage.nix
@@ -6,7 +6,7 @@
 buildDunePackage rec {
   pname = "mirage-crypto-rng-mirage";
 
-  inherit (mirage-crypto-rng) version src useDune2 minimumOCamlVersion;
+  inherit (mirage-crypto-rng) version src;
 
   doCheck = true;
   checkInputs = [ mirage-unix mirage-clock-unix mirage-time-unix ];

--- a/pkgs/development/ocaml-modules/mirage-crypto/rng.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/rng.nix
@@ -1,13 +1,13 @@
-{ buildDunePackage, mirage-crypto, ounit, randomconv, dune-configurator
+{ buildDunePackage, mirage-crypto, ounit2, randomconv, dune-configurator
 , cstruct, duration, logs, mtime, ocaml_lwt }:
 
 buildDunePackage rec {
   pname = "mirage-crypto-rng";
 
-  inherit (mirage-crypto) version src useDune2 minimumOCamlVersion;
+  inherit (mirage-crypto) version src;
 
   doCheck = true;
-  checkInputs = [ ounit randomconv ];
+  checkInputs = [ ounit2 randomconv ];
 
   buildInputs = [ dune-configurator ];
   propagatedBuildInputs = [ cstruct mirage-crypto duration logs mtime ocaml_lwt ];

--- a/pkgs/development/ocaml-modules/mirage-unix/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-unix/default.nix
@@ -2,11 +2,11 @@
 
 buildDunePackage rec {
   pname = "mirage-unix";
-  version = "4.0.1";
+  version = "5.0.0";
 
   src = fetchurl {
-    url = "https://github.com/mirage/${pname}/releases/download/v${version}/${pname}-v${version}.tbz";
-    sha256 = "sha256-9ymVBb3dkhb+MN97/sXe/oQ36CVx0kruj3sd19LiFZ4=";
+    url = "https://github.com/mirage/${pname}/releases/download/v${version}/${pname}-${version}.tbz";
+    sha256 = "sha256-gQ16af73ebsg131d+DqUy7iKzdlWrxp2aczQJ4T8Hps=";
   };
 
   propagatedBuildInputs = [ lwt duration mirage-runtime io-page ];

--- a/pkgs/development/ocaml-modules/mirage-unix/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-unix/default.nix
@@ -1,15 +1,15 @@
-{ lib, buildDunePackage, fetchurl, lwt, duration, mirage-runtime, io-page }:
+{ lib, buildDunePackage, fetchurl, lwt, duration, mirage-runtime }:
 
 buildDunePackage rec {
   pname = "mirage-unix";
-  version = "5.0.0";
+  version = "5.0.1";
 
   src = fetchurl {
     url = "https://github.com/mirage/${pname}/releases/download/v${version}/${pname}-${version}.tbz";
-    sha256 = "sha256-gQ16af73ebsg131d+DqUy7iKzdlWrxp2aczQJ4T8Hps=";
+    sha256 = "sha256-U1oLznUDBcJLcVygfSiyl5qRLDM27cm/WrjT0vSGhPg=";
   };
 
-  propagatedBuildInputs = [ lwt duration mirage-runtime io-page ];
+  propagatedBuildInputs = [ lwt duration mirage-runtime ];
   doCheck = true;
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

Fixes & improvements:
https://github.com/mirage/mirage-unix/blob/v5.0.0/CHANGES.md#v500-2022-02-01
https://github.com/mirage/mirage-crypto/blob/v0.10.6/CHANGES.md#v0106-2022-03-29

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
