### PR TITLE
xfce.xfce4-windowck-plugin: 0.4.10 -> 0.5.0

### DIFF
--- a/pkgs/desktops/xfce/panel-plugins/xfce4-windowck-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-windowck-plugin/default.nix
@@ -1,49 +1,37 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, intltool, python3, imagemagick, libwnck, libxfce4ui, xfce4-panel, xfconf, xfce4-dev-tools, xfce, gitUpdater }:
+{ lib
+, mkXfceDerivation
+, imagemagick
+, libwnck
+, libxfce4ui
+, python3
+, xfce4-panel
+, xfconf
+}:
 
-stdenv.mkDerivation rec {
-  pname  = "xfce4-windowck-plugin";
-  version = "0.4.10";
-
-  src = fetchFromGitHub {
-    owner = "invidian";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-luCQzqWX3Jl2MlBa3vi1q7z1XOhpFxE8PUxscoIyBlA=";
-  };
-
-  nativeBuildInputs = [
-    pkg-config
-    intltool
-  ];
+mkXfceDerivation {
+  category = "panel-plugins";
+  pname = "xfce4-windowck-plugin";
+  version = "0.5.0";
+  rev-prefix = "v";
+  odd-unstable = false;
+  sha256 = "sha256-MhNSgI74VLdoS5yL6nfRrVrPvv7+0P5meO4zQheYFzo=";
 
   buildInputs = [
-    python3
     imagemagick
     libwnck
     libxfce4ui
+    python3
     xfce4-panel
     xfconf
-    xfce4-dev-tools
   ];
 
-  preConfigure = ''
-    ./autogen.sh
-    patchShebangs .
+  postPatch = ''
+    patchShebangs themes/windowck{,-dark}/{xfwm4,unity}/generator.py
   '';
 
-  enableParallelBuilding = true;
-
-  passthru.updateScript = gitUpdater {
-    inherit pname version;
-    attrPath = "xfce.${pname}";
-    rev-prefix = "v";
-  };
-
   meta = with lib; {
-    homepage = "https://goodies.xfce.org/projects/panel-plugins/xfce4-windowck-plugin";
-    description = "Xfce plugins which allows to put the maximized window title and buttons on the panel";
-    license = licenses.gpl2Plus;
-    platforms = platforms.unix;
+    description = "Xfce panel plugin for displaying window title and buttons";
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ ] ++ teams.xfce.members;
   };
 }


### PR DESCRIPTION

###### Description of changes

- Update to version [0.5.0](https://gitlab.xfce.org/panel-plugins/xfce4-windowck-plugin/-/blob/master/NEWS)
- Use mkXfceDerivation


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
