### PR TITLE
cc-wrapper: Allow to (un)define _FORTIFY_SOURCE to make ASan works.

### DIFF
--- a/pkgs/build-support/cc-wrapper/add-hardening.sh
+++ b/pkgs/build-support/cc-wrapper/add-hardening.sh
@@ -38,7 +38,9 @@ for flag in "${!hardeningEnableMap[@]}"; do
   case $flag in
     fortify)
       if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling fortify >&2; fi
-      hardeningCFlags+=('-O2' '-D_FORTIFY_SOURCE=2')
+      if [ "${dontFortify}" -eq 0 ]; then
+        hardeningCFlags+=('-O2' '-D_FORTIFY_SOURCE=2')
+      fi
       ;;
     stackprotector)
       if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling stackprotector >&2; fi

--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -29,6 +29,9 @@ cc1=0
 cxxInclude=1
 cxxLibrary=1
 cInclude=1
+# ASan need to disable _FORTIFY_SOURCE to works
+# https://github.com/google/sanitizers/issues/247
+dontFortify=0
 
 expandResponseParams "$@"
 linkType=$(checkLinkType "${params[@]}")
@@ -46,6 +49,7 @@ while (( "$n" < "$nParams" )); do
         -nostdinc) cInclude=0 cxxInclude=0 ;;
         -nostdinc++) cxxInclude=0 ;;
         -nostdlib) cxxLibrary=0 ;;
+        *_FORTIFY_SOURCE*) dontFortify=1 ;;
         -x)
             case "$p2" in
                 *-header) dontLink=1 ;;


### PR DESCRIPTION
###### Description of changes

ASan doesn't works with _FORTIFY_SOURCE defined we get:
```
In file included from <built-in>:372:
<command line>:1:9: error: '_FORTIFY_SOURCE' macro redefined [-Werror,-Wmacro-redefined]
#define _FORTIFY_SOURCE 2
        ^
<built-in>:359:9: note: previous definition is here
#define _FORTIFY_SOURCE 0
        ^
1 error generated.
make: *** [Makefile:128: build/DEV/convert_name.o] Error 1
```

One way to disable is using `hardeningDisable = [ "fortify" ]` but this has the bad effect to disable also for production even if the build system support two modes.

The -O2 seems unrelated to fortify ? Does it enable more check because the compiler propagate more informations ?

if _FORTIFY_SOURCE is on command line then the devs know which value it need to have so don't define it.

Questions:
- Should I also intercept `-fsanitize=*address*` to define dontFortify ?
- Should I unset _FORTIFY_SOURCE automatically when as a usage is detected ?

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin (I duplicated wrapCCWith and changed call in the compiler version I used to test it. Thus I didn't rebuild full dependencies.)
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
