### PR TITLE
mixRelease: refactor use rebar3WithPlugins

### DIFF
--- a/pkgs/development/beam-modules/mix-release.nix
+++ b/pkgs/development/beam-modules/mix-release.nix
@@ -1,10 +1,11 @@
-{ stdenv, lib, elixir, erlang, findutils, hex, rebar, rebar3, fetchMixDeps, makeWrapper, git, ripgrep }@inputs:
+{ stdenv, lib, elixir, erlang, findutils, hex, rebar, rebar3WithPlugins, fetchMixDeps, makeWrapper, git, ripgrep }@inputs:
 
 { pname
 , version
 , src
 , nativeBuildInputs ? [ ]
 , buildInputs ? [ ]
+, buildPlugins ? [ ]
 , meta ? { }
 , enableDebugInfo ? false
 , mixEnv ? "prod"
@@ -21,6 +22,9 @@
 , ...
 }@attrs:
 let
+  rebar3 = rebar3WithPlugins {
+    plugins = buildPlugins;
+  };
   # remove non standard attributes that cannot be coerced to strings
   overridable = builtins.removeAttrs attrs [ "compileFlags" "mixNixDeps" ];
 in


### PR DESCRIPTION
###### Description of changes
Use `rebar3WithPlugins` to support dependencies that require rebar3 plugins, like the port compiler (`pc`).
Adds `buildPlugins` argument with default value of empty list for backwards compatibility.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

This is a minimal derivation that represents my motivation for this change. Mix projects can depend on Rebar3 projects which may require plugins to build. Without this change, the following derivation fails because rebar3 tries to download pc from hex.pm, which is disallowed by the sandbox.

```nix
with pkgs;
let
  packages = beam.packagesWith beam.interpreters.erlang;
  src = ./.;

  pname =  "zeromqtest";
  version = "0.1.0";
  mixEnv = "prod";

  propagatedBuildInputs = [ libsodium ];
  buildPlugins = [ packages.pc ];
  hexDeps = import ./deps.nix {
    inherit lib;
    beamPackages = packages;
    overrides = (next: prev: {
      enacl = prev.enacl.override {
        beamDeps = [ packages.pc ];
        buildInputs = [ libsodium ];
        buildPlugins = [ packages.pc ];
      };
    });
  };

  mixNixDeps = hexDeps // rec {
    inherit (packages) pc;

    chumak = packages.buildRebar3 {
      name = "chumak";
      version = "1.3.0";

      src = builtins.fetchGit {
        url = "https://github.com/zeromq/chumak.git";
        ref = "master";
        rev = "f0de0b609c668370fe6b486d733a137ee53abe9f";
      };

      beamDeps = [ hexDeps.enacl packages.pc ];
      buildInputs = [ libsodium ];
      buildPlugins = [ packages.pc ];

      CHUMAK_CURVE_LIB = "enacl";
    };
  };

in packages.mixRelease {
  inherit src pname version buildPlugins propagatedBuildInputs mixEnv mixNixDeps;
  CHUMAK_CURVE_LIB = "enacl";
}
```
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
