### PR TITLE
pkgsStatic.glib: fix build

### DIFF
--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -96,6 +96,8 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://gitlab.gnome.org/qyliss/glib/-/commit/339a06d66685107280ca6bdca5da5d96b8222fb5.patch";
       sha256 = "sha256-/NdFkuiJvyass3jTDEJPeciA2Lwe53IUd3kAnKAvTaw=";
     })
+    # https://gitlab.gnome.org/GNOME/glib/-/merge_requests/2867
+    ./tests-skip-shared-libs-if-default_library-static.patch
 
     ./skip-timer-test.patch
   ];

--- a/pkgs/development/libraries/glib/tests-skip-shared-libs-if-default_library-static.patch
+++ b/pkgs/development/libraries/glib/tests-skip-shared-libs-if-default_library-static.patch
@@ -1,0 +1,141 @@
+From b804e4b82cd8e85631112d935543c62ef56783e5 Mon Sep 17 00:00:00 2001
+From: Alyssa Ross <hi@alyssa.is>
+Date: Tue, 23 Aug 2022 13:13:44 +0000
+Subject: [PATCH] tests: skip shared libs if default_library=static
+
+Otherwise, the build will fail when the toolchain is static-only, even
+with -Ddefault_library=static.  I talked to a Meson developer in their
+IRC channel, who told me that the correct fix was to ensure that
+shared_library is only used if default_library != static.
+
+Part-of: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/2867
+[Backported to 2.72.3]
+---
+ gio/tests/meson.build  | 43 +++++++++++++++++++++++-------------------
+ glib/tests/meson.build |  2 +-
+ tests/meson.build      | 30 +++++++++++++++--------------
+ 3 files changed, 41 insertions(+), 34 deletions(-)
+
+diff --git a/gio/tests/meson.build b/gio/tests/meson.build
+index 3ed23a5f2..7b1aba80d 100644
+--- a/gio/tests/meson.build
++++ b/gio/tests/meson.build
+@@ -203,7 +203,7 @@ if host_machine.system() != 'windows'
+   }
+ 
+   # LD_PRELOAD modules don't work so well with AddressSanitizer
+-  if have_rtld_next and get_option('b_sanitize') == 'none'
++  if have_rtld_next and get_option('default_library') != 'static' and get_option('b_sanitize') == 'none'
+     gio_tests += {
+       'gsocketclient-slow' : {
+         'depends' : [
+@@ -607,24 +607,26 @@ if not meson.is_cross_build() or meson.has_exe_wrapper()
+ 
+   compiler_type = '--compiler=@0@'.format(cc.get_id())
+ 
+-  plugin_resources_c = custom_target('plugin-resources.c',
+-    input : 'test4.gresource.xml',
+-    output : 'plugin-resources.c',
+-    command : [glib_compile_resources,
+-               compiler_type,
+-               '--target=@OUTPUT@',
+-               '--sourcedir=' + meson.current_source_dir(),
+-               '--internal',
+-               '--generate-source',
+-               '--c-name', '_g_plugin',
+-               '@INPUT@'])
++  if get_option('default_library') != 'static'
++    plugin_resources_c = custom_target('plugin-resources.c',
++      input : 'test4.gresource.xml',
++      output : 'plugin-resources.c',
++      command : [glib_compile_resources,
++                 compiler_type,
++                 '--target=@OUTPUT@',
++                 '--sourcedir=' + meson.current_source_dir(),
++                 '--internal',
++                 '--generate-source',
++                 '--c-name', '_g_plugin',
++                 '@INPUT@'])
+ 
+-  shared_module('resourceplugin', 'resourceplugin.c', plugin_resources_c,
+-    link_args : export_dynamic_ldflags,
+-    dependencies : common_gio_tests_deps,
+-    install_dir : installed_tests_execdir,
+-    install : installed_tests_enabled
+-  )
++    shared_module('resourceplugin', 'resourceplugin.c', plugin_resources_c,
++      link_args : export_dynamic_ldflags,
++      dependencies : common_gio_tests_deps,
++      install_dir : installed_tests_execdir,
++      install : installed_tests_enabled
++    )
++  endif
+ 
+   # referenced by test2.gresource.xml
+   big_test_resource = custom_target(
+@@ -917,4 +919,7 @@ if installed_tests_enabled
+ endif
+ 
+ subdir('services')
+-subdir('modules')
++
++if get_option('default_library') != 'static'
++  subdir('modules')
++endif
+diff --git a/glib/tests/meson.build b/glib/tests/meson.build
+index 301158e0f..6203ff45e 100644
+--- a/glib/tests/meson.build
++++ b/glib/tests/meson.build
+@@ -172,7 +172,7 @@ else
+     'include' : {},
+     'unix' : {},
+   }
+-  if have_rtld_next
++  if have_rtld_next and get_option('default_library') != 'static'
+     glib_tests += {
+       'gutils-user-database' : {
+         'depends' : [
+diff --git a/tests/meson.build b/tests/meson.build
+index c95fa1d00..25144c941 100644
+--- a/tests/meson.build
++++ b/tests/meson.build
+@@ -72,20 +72,22 @@ if ['darwin', 'ios'].contains(host_machine.system())
+   module_suffix = 'so'
+ endif
+ 
+-foreach module : ['moduletestplugin_a', 'moduletestplugin_b']
+-  shared_module(module + '_plugin', 'lib@0@.c'.format(module),
+-    dependencies : [libglib_dep, libgmodule_dep],
+-    install_dir : installed_tests_execdir,
+-    install : installed_tests_enabled,
+-    name_suffix : module_suffix
+-  )
+-  shared_library(module + '_library', 'lib@0@.c'.format(module),
+-    dependencies : [libglib_dep, libgmodule_dep],
+-    install_dir : installed_tests_execdir,
+-    install : installed_tests_enabled,
+-    name_suffix : module_suffix
+-  )
+-endforeach
++if get_option('default_library') != 'static'
++  foreach module : ['moduletestplugin_a', 'moduletestplugin_b']
++    shared_module(module + '_plugin', 'lib@0@.c'.format(module),
++      dependencies : [libglib_dep, libgmodule_dep],
++      install_dir : installed_tests_execdir,
++      install : installed_tests_enabled,
++      name_suffix : module_suffix
++    )
++    shared_library(module + '_library', 'lib@0@.c'.format(module),
++      dependencies : [libglib_dep, libgmodule_dep],
++      install_dir : installed_tests_execdir,
++      install : installed_tests_enabled,
++      name_suffix : module_suffix
++    )
++  endforeach
++endif
+ 
+ common_c_args = test_cargs + ['-DGLIB_DISABLE_DEPRECATION_WARNINGS']
+ common_deps = [libm, thread_dep, libglib_dep]
+-- 
+2.37.1
+


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Since #183507, glib's tests are built (but not run by default) in pkgsStatic.  This broke the build because some of the tests required shared libraries. This patch (which is awaiting review upstream) disables building those libraries and any tests that depend on them in a static-only build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
