### PR TITLE
protobuf3_21: 3.21.2 -> 21.5, update versioning scheme

### DIFF
--- a/pkgs/development/libraries/protobuf/21.nix
+++ b/pkgs/development/libraries/protobuf/21.nix
@@ -1,0 +1,6 @@
+{ callPackage, abseil-cpp, ... }:
+
+callPackage ./generic-v3-cmake.nix {
+  version = "21.12";
+  sha256 = "sha256-VZQEFHq17UsTH5CZZOcJBKiScGV2xPJ/e6gkkVliRCU=";
+}

--- a/pkgs/development/libraries/protobuf/3.21.nix
+++ b/pkgs/development/libraries/protobuf/3.21.nix
@@ -1,6 +1,0 @@
-{ callPackage, ... } @ args:
-
-callPackage ./generic-v3-cmake.nix ({
-  version = "3.21.12";
-  sha256 = "sha256-VZQEFHq17UsTH5CZZOcJBKiScGV2xPJ/e6gkkVliRCU=";
-} // args)

--- a/pkgs/development/libraries/protobuf/generic-v3-cmake.nix
+++ b/pkgs/development/libraries/protobuf/generic-v3-cmake.nix
@@ -46,7 +46,7 @@ let
         --replace 'tmpnam(b)' '"'$TMPDIR'/foo"'
     '';
 
-    patches = lib.optionals (lib.versionOlder version "3.22") [
+    patches = lib.optionals (lib.versionOlder version "22") [
       # fix protobuf-targets.cmake installation paths, and allow for CMAKE_INSTALL_LIBDIR to be absolute
       # https://github.com/protocolbuffers/protobuf/pull/10090
       (fetchpatch {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23080,7 +23080,10 @@ with pkgs;
 
   protobuf = protobuf3_21;
 
-  protobuf3_21 = callPackage ../development/libraries/protobuf/3.21.nix { };
+  # Versioning for protobuf changed scheme during 3.21.x releases
+  # See: https://developers.google.com/protocol-buffers/docs/news/2022-05-06
+  protobuf_21 = callPackage ../development/libraries/protobuf/21.nix { };
+  protobuf3_21 = protobuf_21;
   protobuf3_20 = callPackage ../development/libraries/protobuf/3.20.nix { };
   protobuf3_19 = callPackage ../development/libraries/protobuf/3.19.nix { };
   protobuf3_17 = callPackage ../development/libraries/protobuf/3.17.nix { };


### PR DESCRIPTION
###### Description of changes

Upstream dropped the previous "3" major version, to better help with handling changes to underlying ecosystems. https://developers.google.com/protocol-buffers/docs/news/2022-05-06

cc @infinisil if this is the correct way to do this version transition

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
