### PR TITLE
flac: 1.3.4 -> 1.4.0

### DIFF
--- a/pkgs/applications/audio/flac/default.nix
+++ b/pkgs/applications/audio/flac/default.nix
@@ -2,11 +2,12 @@
 
 stdenv.mkDerivation rec {
   pname = "flac";
-  version = "1.3.4";
+  version = "1.4.0";
 
   src = fetchurl {
     url = "http://downloads.xiph.org/releases/flac/${pname}-${version}.tar.xz";
-    sha256 = "0dz7am8kbc97a6afml1h4yp085274prg8j7csryds8m3fmz61w4g";
+    # Official checksum is published at https://github.com/xiph/flac/releases/tag/1.4.0.
+    sha256 = "af41c0733c93c237c3e52f64dd87e3b0d9af38259f1c7d11e8cbf583c48c2506";
   };
 
   buildInputs = [ libogg ];
@@ -20,5 +21,6 @@ stdenv.mkDerivation rec {
     description = "Library and tools for encoding and decoding the FLAC lossless audio file format";
     platforms = platforms.all;
     license = licenses.bsd3;
+    maintainers = with maintainers; [ ruuda ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Upstream tag/release notes: https://github.com/xiph/flac/releases/tag/1.4.0

Note, [there will be a 1.4.1 soon](https://lists.xiph.org/pipermail/flac-dev/2022-September/006571.html), if this causes a lot of rebuilds, it may be better to wait for 1.4.1 before merging.

Also adopt the package as a maintainer, since it did not have any yet. I am subscribed to the flac-dev mailing list and I maintain an alternative flac decoder so I keep an eye out on developments upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
