### PR TITLE
steghide: init at 0.5.1

### DIFF
--- a/pkgs/tools/graphics/steghide/buildsystem.patch
+++ b/pkgs/tools/graphics/steghide/buildsystem.patch
@@ -1,0 +1,10 @@
+diff -urN steghide-0.5.1/src/Makefile.am steghide-0.5.1-new/src/Makefile.am
+--- steghide-0.5.1/src/Makefile.am	2003-09-28 09:33:21.000000000 -0700
++++ steghide-0.5.1-new/src/Makefile.am	2003-10-30 21:05:40.000000000 -0800
+@@ -33,5 +33,5 @@
+ WavPCMSampleValue.cc error.cc main.cc msg.cc SMDConstructionHeuristic.cc
+ LIBS = @LIBINTL@ @LIBS@
+ localedir = $(datadir)/locale
+-LIBTOOL = $(SHELL) libtool
++LIBTOOL = /usr/bin/libtool
+ MAINTAINERCLEANFILES = Makefile.in

--- a/pkgs/tools/graphics/steghide/default.nix
+++ b/pkgs/tools/graphics/steghide/default.nix
@@ -1,0 +1,34 @@
+{ fetchurl
+, lib
+, stdenv
+, gettext
+, libmhash
+, libjpeg
+, libmcrypt
+, zlib
+, libtool
+}:
+
+stdenv.mkDerivation rec {
+  pname = "steghide";
+  version = "0.5.1";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "78069b7cfe9d1f5348ae43f918f06f91d783c2b3ff25af021e6a312cf541b47b";
+  };
+
+  patches = [ ./buildsystem.patch ./gcc-4.2.patch ./steghide-climits.patch ./steghide-gcc6.patch ];
+
+  nativeBuildInputs = [ gettext libmhash libjpeg libmcrypt zlib libtool ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with lib; {
+    homepage = "http://steghide.sourceforge.net/";
+    description = "Embeds a message in a file by replacing some of the least significant bits";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ k3a ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/tools/graphics/steghide/gcc-4.2.patch
+++ b/pkgs/tools/graphics/steghide/gcc-4.2.patch
@@ -1,0 +1,75 @@
+diff -Naur steghide-0.5.1.orig/src/AuData.h steghide-0.5.1.new/src/AuData.h
+--- steghide-0.5.1.orig/src/AuData.h	2003-09-28 11:30:29.000000000 -0400
++++ steghide-0.5.1.new/src/AuData.h	2007-06-28 17:22:44.000000000 -0400
+@@ -26,22 +26,30 @@
+ 
+ // AuMuLawAudioData
+ typedef AudioDataImpl<AuMuLaw,BYTE> AuMuLawAudioData ;
++template<>
+ inline BYTE AuMuLawAudioData::readValue (BinaryIO* io) const { return (io->read8()) ; }
++template<>
+ inline void AuMuLawAudioData::writeValue (BinaryIO* io, BYTE v) const { io->write8(v) ; }
+ 
+ // AuPCM8AudioData
+ typedef AudioDataImpl<AuPCM8,SBYTE> AuPCM8AudioData ;
++template<>
+ inline SBYTE AuPCM8AudioData::readValue (BinaryIO* io) const { return ((SBYTE) io->read8()) ; }
++template<>
+ inline void AuPCM8AudioData::writeValue (BinaryIO* io, SBYTE v) const { io->write8((BYTE) v) ; }
+ 
+ // AuPCM16AudioData
+ typedef AudioDataImpl<AuPCM16,SWORD16> AuPCM16AudioData ;
++template<>
+ inline SWORD16 AuPCM16AudioData::readValue (BinaryIO* io) const { return ((SWORD16) io->read16_be()) ; }
++template<>
+ inline void AuPCM16AudioData::writeValue (BinaryIO* io, SWORD16 v) const { io->write16_be((UWORD16) v) ; }
+ 
+ // AuPCM32AudioData
+ typedef AudioDataImpl<AuPCM32,SWORD32> AuPCM32AudioData ;
++template<>
+ inline SWORD32 AuPCM32AudioData::readValue (BinaryIO* io) const { return ((SWORD32) io->read32_be()) ; }
++template<>
+ inline void AuPCM32AudioData::writeValue (BinaryIO* io, SWORD32 v) const { io->write32_be((UWORD32) v) ; }
+ 
+ #endif // ndef SH_AUDATA_H
+diff -Naur steghide-0.5.1.orig/src/AuSampleValues.cc steghide-0.5.1.new/src/AuSampleValues.cc
+--- steghide-0.5.1.orig/src/AuSampleValues.cc	2003-09-28 11:30:30.000000000 -0400
++++ steghide-0.5.1.new/src/AuSampleValues.cc	2007-06-28 17:23:52.000000000 -0400
+@@ -21,17 +21,25 @@
+ #include "AuSampleValues.h"
+ 
+ // AuMuLawSampleValue
++template<>
+ const BYTE AuMuLawSampleValue::MinValue = 0 ;
++template<>
+ const BYTE AuMuLawSampleValue::MaxValue = BYTE_MAX ;
+ 
+ // AuPCM8SampleValue
++template<>
+ const SBYTE AuPCM8SampleValue::MinValue = SBYTE_MIN ;
++template<>
+ const SBYTE AuPCM8SampleValue::MaxValue = SBYTE_MAX ;
+ 
+ // AuPCM16SampleValue
++template<>
+ const SWORD16 AuPCM16SampleValue::MinValue = SWORD16_MIN ;
++template<>
+ const SWORD16 AuPCM16SampleValue::MaxValue = SWORD16_MAX ;
+ 
+ // AuPCM32SampleValue
++template<>
+ const SWORD32 AuPCM32SampleValue::MinValue = SWORD32_MIN ;
++template<>
+ const SWORD32 AuPCM32SampleValue::MaxValue = SWORD32_MAX ;
+diff -Naur steghide-0.5.1.orig/src/MHashPP.cc steghide-0.5.1.new/src/MHashPP.cc
+--- steghide-0.5.1.orig/src/MHashPP.cc	2003-10-05 06:17:50.000000000 -0400
++++ steghide-0.5.1.new/src/MHashPP.cc	2007-06-28 17:22:44.000000000 -0400
+@@ -120,7 +120,7 @@
+ 
+ std::string MHashPP::getAlgorithmName (hashid id)
+ {
+-	char *name = mhash_get_hash_name (id) ;
++	char *name = (char *) mhash_get_hash_name (id) ;
+ 	std::string retval ;
+ 	if (name == NULL) {
+ 		retval = std::string ("<algorithm not found>") ;

--- a/pkgs/tools/graphics/steghide/result
+++ b/pkgs/tools/graphics/steghide/result
@@ -1,0 +1,1 @@
+/nix/store/4jccll8a44cmhmmswzjwjv0fdkhqfycz-steghide-0.5.1

--- a/pkgs/tools/graphics/steghide/steghide-climits.patch
+++ b/pkgs/tools/graphics/steghide/steghide-climits.patch
@@ -1,0 +1,11 @@
+diff -ruN steghide-0.5.1.orig/src/Graph.cc steghide-0.5.1/src/Graph.cc
+--- steghide-0.5.1.orig/src/Graph.cc	2003-10-11 23:54:26.000000000 +0200
++++ steghide-0.5.1/src/Graph.cc	2008-12-14 14:23:27.000000000 +0100
+@@ -22,6 +22,7 @@
+ #include <list>
+ #include <map>
+ #include <vector>
++#include <climits>
+ 
+ #include "BitString.h"
+ #include "CvrStgFile.h"

--- a/pkgs/tools/graphics/steghide/steghide-gcc6.patch
+++ b/pkgs/tools/graphics/steghide/steghide-gcc6.patch
@@ -1,0 +1,22 @@
+--- steghide-0.5.1/src/Arguments.h.orig	2018-06-09 11:04:48.795952519 +0000
++++ steghide-0.5.1/src/Arguments.h	2018-06-09 11:00:57.239290249 +0000
+@@ -100,7 +100,7 @@
+ 	static const VERBOSITY	Default_Verbosity = NORMAL ;
+ 	static const unsigned long	Default_Radius = 0 ; // there is no default radius for all file formats
+ 	static const unsigned int	Max_Algorithm = 3 ;
+-	static const float		Default_Goal = 100.0 ;
++	static constexpr float		Default_Goal = 100.0 ;
+ 	static const DEBUGCOMMAND	Default_DebugCommand = NONE ;
+ 	static const bool		Default_Check = false ;
+ 	static const unsigned int	Default_DebugLevel = 0 ;
+--- steghide-0.5.1/src/ProgressOutput.h.orig	2018-06-09 11:01:44.662622682 +0000
++++ steghide-0.5.1/src/ProgressOutput.h	2018-06-09 11:01:57.755955767 +0000
+@@ -64,7 +64,7 @@
+ 	 **/
+ 	void done (float rate, float avgweight = NoAvgWeight) const ;
+ 
+-	static const float NoAvgWeight = -1.0 ;
++	static constexpr float NoAvgWeight = -1.0 ;
+ 
+ 	protected:
+ 	std::string vcompose (const char *msgfmt, va_list ap) const ;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1244,6 +1244,8 @@ with pkgs;
 
   spectre-cli = callPackage ../tools/security/spectre-cli { };
 
+  steghide = callPackage ../tools/graphics/steghide { };
+
   sx-go = callPackage ../tools/security/sx-go { };
 
   systeroid = callPackage ../tools/system/systeroid { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
