### PR TITLE
adguardhome: 0.107.12 -> 0.107.13

### DIFF
--- a/pkgs/servers/adguardhome/bins.nix
+++ b/pkgs/servers/adguardhome/bins.nix
@@ -1,23 +1,23 @@
 { fetchurl, fetchzip }:
 {
 x86_64-darwin = fetchzip {
-  sha256 = "sha256-2QGXyXHU2p7DFKDWyau2+SCzaQnM+o0EbYqHFnErXX4=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.12/AdGuardHome_darwin_amd64.zip";
+  sha256 = "sha256-uJQPC1YNvkd9SD6OQCANbWXlA/ebfG1PjYnLdVCyjlo=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.13/AdGuardHome_darwin_amd64.zip";
 };
 aarch64-darwin = fetchzip {
-  sha256 = "sha256-16XJUh78B45d1uuLi1xcFeti6CvGUkXYUVe4pS/hhXs=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.12/AdGuardHome_darwin_arm64.zip";
+  sha256 = "sha256-oExdBohVLTw7w1nQbZZAHm10lpjBTOYJaLBsocWAhYI=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.13/AdGuardHome_darwin_arm64.zip";
 };
 i686-linux = fetchurl {
-  sha256 = "sha256-ML9WSJwQTC8F07MOTQBpZXH/tHSlbQEzAofGpjHZrLU=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.12/AdGuardHome_linux_386.tar.gz";
+  sha256 = "sha256-mjaz08pn/+LfSQQD53QdqudIceXiGv+gZsJFy4lphF8=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.13/AdGuardHome_linux_386.tar.gz";
 };
 x86_64-linux = fetchurl {
-  sha256 = "sha256-fGSBfQzlYQbsZExOqsxa2Zdb/gvo0c9O313ziSkvOjY=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.12/AdGuardHome_linux_amd64.tar.gz";
+  sha256 = "sha256-gAH5wE0rTaEhWxHdL41e2juNDaVJycREXNgc0VdjBlg=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.13/AdGuardHome_linux_amd64.tar.gz";
 };
 aarch64-linux = fetchurl {
-  sha256 = "sha256-WR8omfW5udMmXNKuUIfqdXvggumG4Pb1gESJV9YZ9rc=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.12/AdGuardHome_linux_arm64.tar.gz";
+  sha256 = "sha256-YHpvg8WkF9vlDtJUW6OfRzGJjamV0rzNJC4ALP7h+xQ=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.13/AdGuardHome_linux_arm64.tar.gz";
 };
 }

--- a/pkgs/servers/adguardhome/default.nix
+++ b/pkgs/servers/adguardhome/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/AdguardTeam/AdGuardHome";
     description = "Network-wide ads & trackers blocking DNS server";
     platforms = builtins.attrNames sources;
-    maintainers = with maintainers; [ numkem iagoq ];
+    maintainers = with maintainers; [ numkem iagoq rhoriguchi ];
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.gpl3Only;
   };

--- a/pkgs/servers/adguardhome/default.nix
+++ b/pkgs/servers/adguardhome/default.nix
@@ -7,7 +7,7 @@ in
 
 stdenv.mkDerivation rec {
   pname = "adguardhome";
-  version = "0.107.12";
+  version = "0.107.13";
   src = sources.${system} or (throw "Source for ${pname} is not available for ${system}");
 
   installPhase = ''


### PR DESCRIPTION
###### Things done

I've also added myself as a maintainer since I usually do the updates.

Please also take a look at #156547.

- [ ] Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

