### PR TITLE
nodePackages.next: init

### DIFF
--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -220,6 +220,7 @@
 , "multi-file-swagger"
 , "musescore-downloader"
 , "near-cli"
+, "next"
 , "neovim"
 , "nijs"
 , "node-gyp"


### PR DESCRIPTION
###### Description of changes

Adds the `next` binary as `nodePackages.next`. Note this was already existing as part of `nodePackages.vercel`, it just wasn't exposed.

The tool is used in documentation here: https://nextjs.org/docs/deployment#nextjs-build-api

Demo of use:

```
~/git/scratch 
❯ nix shell ../nixos/nixpkgs#yarn ../nixos/nixpkgs#nodejs ../nixos/nixpkgs#nodePackages.next

~/git/scratch 
❯ yarn create next-app
yarn create v1.22.19
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...

success Installed "create-next-app@12.3.0" with binaries:
      - create-next-app
✔ What is your project named? … my-app
Creating a new Next.js app in /home/ana/git/scratch/my-app.

Using yarn.
#... A bunch of yarn output

~/git/scratch took 8s 
❯ cd my-app/

my-app on  main via  v18.9.0 
❯ yarn run build
yarn run v1.22.19
$ next build
Attention: Next.js now collects completely anonymous telemetry regarding usage.
This information is used to shape Next.js' roadmap and prioritize features.
You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
https://nextjs.org/telemetry

info  - Linting and checking validity of types  
info  - Creating an optimized production build  
info  - Compiled successfully
info  - Collecting page data  
info  - Generating static pages (3/3)
info  - Finalizing page optimization  

Route (pages)                              Size     First Load JS
┌ ○ /                                      5.35 kB        83.4 kB
├   └ css/ae0e3e027412e072.css             707 B
├   /_app                                  0 B              78 kB
├ ○ /404                                   182 B          78.2 kB
└ λ /api/hello                             0 B              78 kB
+ First Load JS shared by all              78.3 kB
  ├ chunks/framework-09a2284fdc01dc36.js   45.5 kB
  ├ chunks/main-017a64f48d901a37.js        31.2 kB
  ├ chunks/pages/_app-620102ba3a9296b8.js  497 B
  ├ chunks/webpack-cc9c69bc14c8e1bc.js     750 B
  └ css/ab44ce7add5c3d11.css               247 B

λ  (Server)  server-side renders at runtime (uses getInitialProps or getServerSideProps)
○  (Static)  automatically rendered as static HTML (uses no initial props)

Done in 7.05s.
```

This was done by following the instructions laid out in https://github.com/NixOS/nixpkgs/blob/1158501e7c7cba26d922723cf9f70099995eb755/doc/languages-frameworks/javascript.section.md?plain=1#L108-L141 .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
