### PR TITLE
mynewt-newtmgr: init at 1.10.0

### DIFF
--- a/pkgs/tools/misc/mynewt-newtmgr/default.nix
+++ b/pkgs/tools/misc/mynewt-newtmgr/default.nix
@@ -2,6 +2,8 @@
 , buildGoModule
 , fetchFromGitHub
 , stdenv
+, testers
+, mynewt-newtmgr
 }:
 
 buildGoModule rec {
@@ -16,6 +18,11 @@ buildGoModule rec {
   };
 
   vendorSha256 = "sha256-+vOZoueoMqlGnopLKc6pCgTmcgI34pxaMNbr6Y+JCfQ=";
+
+  passthru.tests.version = testers.testVersion {
+    package = mynewt-newtmgr;
+    command = "newtmgr version";
+  };
 
   meta = with lib; {
     homepage = "https://mynewt.apache.org/";

--- a/pkgs/tools/misc/mynewt-newtmgr/default.nix
+++ b/pkgs/tools/misc/mynewt-newtmgr/default.nix
@@ -17,16 +17,15 @@ buildGoModule rec {
 
   vendorSha256 = "sha256-+vOZoueoMqlGnopLKc6pCgTmcgI34pxaMNbr6Y+JCfQ=";
 
-  doCheck = false;
-
   meta = with lib; {
     homepage = "https://mynewt.apache.org/";
     description = "Tool to communicate with devices running Mynewt OS";
     longDescription = ''
-    Newt Manager (newtmgr) is the application tool that enables a user to
-    communicate with and manage remote devices running the Mynewt OS
+      Newt Manager (newtmgr) is the application tool that enables a user to
+      communicate with and manage remote devices running the Mynewt OS
     '';
     license = licenses.asl20;
     maintainers = with maintainers; [ bezmuth ];
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/misc/mynewt-newtmgr/default.nix
+++ b/pkgs/tools/misc/mynewt-newtmgr/default.nix
@@ -28,11 +28,10 @@ buildGoModule rec {
     homepage = "https://mynewt.apache.org/";
     description = "Tool to communicate with devices running Mynewt OS";
     longDescription = ''
-      Newt Manager (newtmgr) is the application tool that enables a user to
-      communicate with and manage remote devices running the Mynewt OS
+      Newt Manager (newtmgr) an application that enables a user to communicate
+      with and manage remote devices running the Mynewt OS
     '';
     license = licenses.asl20;
     maintainers = with maintainers; [ bezmuth ];
-    platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/misc/mynewt-newtmgr/default.nix
+++ b/pkgs/tools/misc/mynewt-newtmgr/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, stdenv
+}:
+
+buildGoModule rec {
+  pname = "mynewt-newtmgr";
+  version = "1.10.0";
+
+  src = fetchFromGitHub {
+    owner = "apache";
+    repo = "mynewt-newtmgr";
+    rev = "mynewt_${builtins.replaceStrings ["."] ["_"] version}_tag";
+    sha256 = "sha256-fobaMkYLLK5qclogtClGdOjgTbmuse/72T3APNssYa4=";
+  };
+
+  vendorSha256 = "sha256-+vOZoueoMqlGnopLKc6pCgTmcgI34pxaMNbr6Y+JCfQ=";
+
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://mynewt.apache.org/";
+    description = "Tool to communicate with devices running Mynewt OS";
+    longDescription = ''
+    Newt Manager (newtmgr) is the application tool that enables a user to
+    communicate with and manage remote devices running the Mynewt OS
+    '';
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bezmuth ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/tools/misc/mynewt-newtmgr/default.nix
+++ b/pkgs/tools/misc/mynewt-newtmgr/default.nix
@@ -28,6 +28,5 @@ buildGoModule rec {
     '';
     license = licenses.asl20;
     maintainers = with maintainers; [ bezmuth ];
-    platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35837,6 +35837,8 @@ with pkgs;
 
   mynewt-newt = callPackage ../tools/package-management/mynewt-newt { };
 
+  mynewt-newtmgr = callPackage ../tools/misc/mynewt-newtmgr { };
+
   mysides = callPackage ../os-specific/darwin/mysides { };
 
   nar-serve = callPackage ../tools/nix/nar-serve { };


### PR DESCRIPTION
###### Description of changes
Add the mynewt-newtmgr package. [mynewt-newt ](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/tools/package-management/mynewt-newt/default.nix#) was already packaged, however it looks like this is a separate package for communication with devices running the Mynewt os

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
