### PR TITLE
vdrPlugins.markad: 2.0.4 -> 3.0.25

### DIFF
--- a/pkgs/applications/video/vdr/plugins.nix
+++ b/pkgs/applications/video/vdr/plugins.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, fetchgit, vdr, fetchFromGitHub
-, graphicsmagick, libav, pcre, xorgserver, ffmpeg
+, graphicsmagick, pcre, xorgserver, ffmpeg
 , libiconv, boost, libgcrypt, perl, util-linux, groff, libva, xorg, ncurses
 , callPackage
 }: let
@@ -53,16 +53,16 @@ in {
 
   markad = stdenv.mkDerivation rec {
     pname = "vdr-markad";
-    version = "2.0.4";
+    version = "3.0.25";
 
     src = fetchFromGitHub {
       repo = "vdr-plugin-markad";
-      owner = "jbrundiers";
-      sha256 = "sha256-Y4KsEtUq+KoUooXiw9O9RokBxNwWBkiGB31GncmHkYM=";
-      rev = "288e3dae93421b0176f4f62b68ea4b39d98e8793";
+      owner = "kfb77";
+      sha256 = "sha256-m7cUAxwXj62spelHYH6uTIoViSavSR0d4psr7+KLJg8=";
+      rev = "v${version}";
     };
 
-    buildInputs = [ vdr libav ];
+    buildInputs = [ vdr ffmpeg ];
 
     postPatch = ''
       substituteInPlace command/Makefile --replace '/usr' ""
@@ -78,6 +78,8 @@ in {
     buildFlags = [
       "DESTDIR=$(out)"
       "LIBDIR=/lib/vdr"
+      "BINDIR=/bin"
+      "MANDIR=/share/man"
       "APIVERSION=${vdr.version}"
       "VDRDIR=${vdr.dev}/include/vdr"
       "LOCDIR=/share/locale"
@@ -86,7 +88,7 @@ in {
     installFlags = buildFlags;
 
     meta = with lib; {
-      homepage = "https://github.com/jbrundiers/vdr-plugin-markad";
+      homepage = "https://github.com/kfb77/vdr-plugin-markad";
       description = "MarkAd marks advertisements in VDR recordings.";
       maintainers = [ maintainers.ck3d ];
       license = licenses.gpl2;


### PR DESCRIPTION
###### Description of changes

Update vdr plugin markad which allows to replace insecure libav by ffmpeg.
I run this code on my system since one week without issues.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
