### PR TITLE
cargo-watch, stdenv: resolve aarch64-darwin objc redefinition errors

### DIFF
--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -122,6 +122,31 @@ fi
 
 if [[ "$isCxx" = 1 ]]; then
     if [[ "$cxxInclude" = 1 ]]; then
+        #
+        # The motivation for this comment is to explain the reason for appending
+        # the C++ stdlib to NIX_CFLAGS_COMPILE, which I initially thought should
+        # change and later realized it shouldn't in:
+        #
+        #   https://github.com/NixOS/nixpkgs/pull/185569#issuecomment-1234959249
+        #
+        # NIX_CFLAGS_COMPILE contains dependencies added using "-isystem", and
+        # NIX_CXXSTDLIB_COMPILE adds the C++ stdlib using "-isystem". Appending
+        # NIX_CXXSTDLIB_COMPILE to NIX_CLAGS_COMPILE emulates this part of the
+        # include lookup order from GCC/Clang:
+        #
+        # > 4. Directories specified with -isystem options are scanned in
+        # >    left-to-right order.
+        # > 5. Standard system directories are scanned.
+        # > 6. Directories specified with -idirafter options are scanned
+        # >    in left-to-right order.
+        #
+        # NIX_CXX_STDLIB_COMPILE acts as the "standard system directories" that
+        # are otherwise missing from CC in nixpkgs, so should be added last.
+        #
+        # This means that the C standard library should never be present inside
+        # NIX_CFLAGS_COMPILE, because it MUST come after the C++ stdlib. It is
+        # added automatically by cc-wrapper later using "-idirafter".
+        #
         NIX_CFLAGS_COMPILE_@suffixSalt@+=" $NIX_CXXSTDLIB_COMPILE_@suffixSalt@"
     fi
     if [[ "$cxxLibrary" = 1 ]]; then

--- a/pkgs/os-specific/darwin/apple-sdk-11.0/apple_sdk.nix
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/apple_sdk.nix
@@ -168,7 +168,7 @@ in rec {
   bareFrameworks = (
     lib.mapAttrs framework (import ./frameworks.nix {
       inherit frameworks libs;
-      inherit (pkgs.darwin.apple_sdk_11_0) libnetwork Libsystem;
+      inherit (pkgs.darwin.apple_sdk_11_0) libnetwork;
       libobjc = pkgs.darwin.apple_sdk_11_0.objc4;
     })
   ) // (

--- a/pkgs/os-specific/darwin/apple-sdk-11.0/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/default.nix
@@ -50,7 +50,9 @@ let
     libcharset = callPackage ./libcharset.nix {};
     libunwind = callPackage ./libunwind.nix {};
     libnetwork = callPackage ./libnetwork.nix {};
-    objc4 = callPackage ./libobjc.nix {};
+    # Avoid introducing a new objc4 if stdenv already has one, to prevent
+    # conflicting LLVM modules.
+    objc4 = if stdenv ? objc4 then stdenv.objc4 else callPackage ./libobjc.nix {};
 
     # questionable aliases
     configd = pkgs.darwin.apple_sdk.frameworks.SystemConfiguration;

--- a/pkgs/os-specific/darwin/apple-sdk-11.0/frameworks.nix
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/frameworks.nix
@@ -89,9 +89,7 @@
   IOBluetooth                      = { inherit CoreBluetooth IOKit; };
   IOBluetoothUI                    = { inherit IOBluetooth; };
   IOKit                            = {};
-  # `IOSurface` should depend on `Libsystem` (in place of `xpc`) but this currently causes build
-  # issues due to incompatibility issues between `Libsystem` and `libcxx`.
-  IOSurface                        = { inherit IOKit xpc; };
+  IOSurface                        = { inherit IOKit; };
   IOUSBHost                        = {};
   IdentityLookup                   = {};
   ImageCaptureCore                 = {};

--- a/pkgs/os-specific/darwin/apple-sdk-11.0/frameworks.nix
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/frameworks.nix
@@ -1,4 +1,4 @@
-{ frameworks, libs, libobjc, Libsystem, libnetwork }: with frameworks; with libs;
+{ frameworks, libs, libobjc, libnetwork }: with frameworks; with libs;
 {
   AGL                              = { inherit Carbon OpenGL; };
   AVFoundation                     = { inherit ApplicationServices AVFCapture AVFCore CoreGraphics simd UniformTypeIdentifiers; };

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -698,6 +698,11 @@ rec {
         libc = pkgs.darwin.Libsystem;
         shellPackage = pkgs.bash;
         inherit bootstrapTools;
+      } // lib.optionalAttrs useAppleSDKLibs {
+        # This objc4 will be propagated to all builds using the final stdenv,
+        # and we shouldn't mix different builds, because they would be
+        # conflicting LLVM modules. Export it here so we can grab it later.
+        inherit (pkgs.darwin) objc4;
       };
 
       allowedRequisites = (with pkgs; [


### PR DESCRIPTION
###### Description of changes

Resolve compilation failures related to redefining symbols on aarch64-darwin that have broken builds of `cargo-watch`, `starship`, and others.

This includes a revised version of https://github.com/NixOS/nixpkgs/pull/161561 which no longer breaks `xcbuild` and will resolve #163052.

As a whole, these two commits are extracted from a part of the excellent work done in #189977 and resolves #189687 (at least, the errors that result from it) and #146349.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
