### PR TITLE
python3Packages.psutil: fix on darwin

### DIFF
--- a/pkgs/development/python-modules/psutil/default.nix
+++ b/pkgs/development/python-modules/psutil/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, buildPythonPackage, fetchPypi, isPy27, python
-, IOKit
+, CoreFoundation, IOKit
 , pytestCheckHook
 , mock
 , unittest2
@@ -41,7 +41,10 @@ buildPythonPackage rec {
     "cpu_freq"
   ];
 
-  buildInputs = lib.optionals stdenv.isDarwin [ IOKit ];
+  buildInputs =
+    # workaround for https://github.com/NixOS/nixpkgs/issues/146760
+    lib.optionals (stdenv.isDarwin && stdenv.isx86_64) [ CoreFoundation ] ++
+    lib.optionals stdenv.isDarwin [ IOKit ];
 
   pythonImportsCheck = [ "psutil" ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7260,7 +7260,7 @@ in {
   psd-tools = callPackage ../development/python-modules/psd-tools { };
 
   psutil = callPackage ../development/python-modules/psutil {
-    inherit (pkgs.darwin.apple_sdk.frameworks) IOKit;
+    inherit (pkgs.darwin.apple_sdk.frameworks) CoreFoundation IOKit;
   };
 
   psutil-home-assistant = callPackage ../development/python-modules/psutil-home-assistant { };


### PR DESCRIPTION
###### Description of changes

Closes: #146760

```
Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   CoreFoundation                	0x00000001095273b6 CFNumberGetValue + 54
1   _psutil_osx.cpython-310-darwin.so	0x000000010b94e8bf psutil_disk_io_counters + 607
2   libpython3.10.dylib           	0x00000001097dfc22 cfunction_call + 130
3   libpython3.10.dylib           	0x0000000109798aac _PyObject_Call + 140
4   libpython3.10.dylib           	0x0000000109886f55 _PyEval_EvalFrameDefault + 28837
5   libpython3.10.dylib           	0x000000010987fd81 _PyEval_Vector + 145
6   libpython3.10.dylib           	0x0000000109889bfc call_function + 428
```


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
