### PR TITLE
probe-run: 0.3.3 -> 0.3.4

### DIFF
--- a/pkgs/development/tools/rust/probe-run/default.nix
+++ b/pkgs/development/tools/rust/probe-run/default.nix
@@ -3,21 +3,21 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "probe-run";
-  version = "0.3.3";
+  version = "0.3.4";
 
   src = fetchCrate {
     inherit pname version;
-    sha256 = "sha256-7o0aRiCxWoDoMysXIPyiBqH/8TtFo87im6Y0OFL0cTA=";
+    sha256 = "sha256-xVxigZET2/7xr+bb3r80F3y0yaNV1JeGeJ2EF0GWa1A=";
   };
 
-  cargoSha256 = "sha256-vREz3FTZXMrc18LXIycJXX6SgW6IKGIgL/+79dMfNjk=";
+  cargoSha256 = "sha256-MK3F3Kt80Xdbbm68Jv1uh78nAj1LzJ90H54NYdn+Oms=";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ libusb1 ]
     ++ lib.optionals stdenv.isDarwin [ libiconv AppKit IOKit ];
 
   meta = with lib; {
-    description = "Run embedded programs just like native ones.";
+    description = "Run embedded programs just like native ones";
     homepage = "https://github.com/knurling-rs/probe-run";
     changelog = "https://github.com/knurling-rs/probe-run/blob/v${version}/CHANGELOG.md";
     license = with licenses; [ asl20 /* or */ mit ];


### PR DESCRIPTION
###### Description of changes

this release bumped their dependency on probe-rs to one that has my fix for a typo in an error i see fairly often...

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
