### PR TITLE
buildRustPackage: dont rely on NIX_BUILD_TOP in cargoSetupPostPatchHook

### DIFF
--- a/pkgs/applications/blockchains/zcash/default.nix
+++ b/pkgs/applications/blockchains/zcash/default.nix
@@ -40,7 +40,7 @@ rustPlatform.buildRustPackage.override { inherit stdenv; } rec {
   postPatch = ''
     # Have to do this here instead of in preConfigure because
     # cargoDepsCopy gets unset after postPatch.
-    configureFlagsArray+=("RUST_VENDORED_SOURCES=$NIX_BUILD_TOP/$cargoDepsCopy")
+    configureFlagsArray+=("RUST_VENDORED_SOURCES=$cargoDepsCopy")
   '';
 
   CXXFLAGS = [

--- a/pkgs/build-support/rust/hooks/cargo-setup-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-setup-hook.sh
@@ -7,23 +7,23 @@ cargoSetupPostUnpackHook() {
     # this for us automatically.
     if [ -z $cargoVendorDir ]; then
         unpackFile "$cargoDeps"
-        export cargoDepsCopy=$(stripHash $cargoDeps)
+        export cargoDepsCopy="$(realpath "$(stripHash $cargoDeps)")"
     else
-      cargoDepsCopy="$sourceRoot/${cargoRoot:+$cargoRoot/}${cargoVendorDir}"
+        cargoDepsCopy="$(realpath "$(pwd)/$sourceRoot/${cargoRoot:+$cargoRoot/}${cargoVendorDir}")"
     fi
 
     if [ ! -d .cargo ]; then
         mkdir .cargo
     fi
 
-    config="$(pwd)/$cargoDepsCopy/.cargo/config";
+    config="$cargoDepsCopy/.cargo/config";
     if [[ ! -e $config ]]; then
       config=@defaultConfig@
     fi;
 
     tmp_config=$(mktemp)
     substitute $config $tmp_config \
-      --subst-var-by vendor "$(pwd)/$cargoDepsCopy"
+      --subst-var-by vendor "$cargoDepsCopy"
     cat ${tmp_config} >> .cargo/config
 
     cat >> .cargo/config <<'EOF'
@@ -39,8 +39,8 @@ EOF
 cargoSetupPostPatchHook() {
     echo "Executing cargoSetupPostPatchHook"
 
-    cargoDepsLockfile="$NIX_BUILD_TOP/$cargoDepsCopy/Cargo.lock"
-    srcLockfile="$NIX_BUILD_TOP/$sourceRoot/${cargoRoot:+$cargoRoot/}/Cargo.lock"
+    cargoDepsLockfile="$cargoDepsCopy/Cargo.lock"
+    srcLockfile="$(pwd)/${cargoRoot:+$cargoRoot/}Cargo.lock"
 
     echo "Validating consistency between $srcLockfile and $cargoDepsLockfile"
     if ! @diff@ $srcLockfile $cargoDepsLockfile; then

--- a/pkgs/tools/misc/popsicle/default.nix
+++ b/pkgs/tools/misc/popsicle/default.nix
@@ -49,7 +49,7 @@ rustPlatform.buildRustPackage.override { stdenv = stdenv; } rec {
   postPatch = ''
     # Have to do this here instead of in preConfigure because
     # cargoDepsCopy gets unset after postPatch.
-    configureFlagsArray+=("RUST_VENDORED_SOURCES=$NIX_BUILD_TOP/$cargoDepsCopy")
+    configureFlagsArray+=("RUST_VENDORED_SOURCES=$cargoDepsCopy")
   '';
 
   makeFlags = [


### PR DESCRIPTION
###### Description of changes

This PR fixes `buildRustPackage` breaking either in an `nix-shell` environment or when `keepBuildTree` was used. This problem occured because of a dependency on `NIX_BUILD_TOP` (which is not very reliable, see https://github.com/NixOS/nixpkgs/issues/189691), which messed up paths to the cargo lockfiles. See the commit description for more information.

Note that this will currently break two packages, which for some reason depend on `cargoDepsCopy` even though its unset later in the hook. The fix is very simple for both of them (`$NIX_BUILD_TOP/$cargoDepsCopy` -> `$cargoDepsCopy`), but im not sure if its preferable to do that in another PR. Figured I'd ask for some feedback.

I've tested compiling a few programs with this, both in the sandbox and in a `nix-shell`, with `keepBuildTree` both used and unused.

Fixes: #138554



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
