### PR TITLE
vapoursynth-editor: R19-mod-4 -> 19-mod-5.4

### DIFF
--- a/pkgs/development/libraries/vapoursynth/editor.nix
+++ b/pkgs/development/libraries/vapoursynth/editor.nix
@@ -1,18 +1,19 @@
 { lib, mkDerivation, fetchFromGitHub, makeWrapper, runCommand
 , python3, vapoursynth
 , qmake, qtbase, qtwebsockets
+, testers, vapoursynth-editor
 }:
 
 let
   unwrapped = mkDerivation rec {
     pname = "vapoursynth-editor";
-    version = "R19-mod-4";
+    version = "19-mod-5.4";
 
     src = fetchFromGitHub {
       owner = "YomikoR";
       repo = pname;
-      rev = lib.toLower version;
-      sha256 = "sha256-+/9j9DJDGXbuTvE8ZXIu6wjcof39SyatS36Q6y9hLPg=";
+      rev = "r${version}";
+      sha256 = "sha256-rDMdr/dhcKpz2v5VUj6k1FXc51BgRZc398cQQ3GcXZM=";
     };
 
     nativeBuildInputs = [ qmake ];
@@ -31,7 +32,13 @@ let
       done
     '';
 
-    passthru = { inherit withPlugins; };
+    passthru = {
+      inherit withPlugins;
+      tests.version = testers.testVersion {
+        package = vapoursynth-editor;
+        version = "R${version}";
+      };
+    };
 
     meta = with lib; {
       description = "Cross-platform editor for VapourSynth scripts";
@@ -39,6 +46,7 @@ let
       license = licenses.mit;
       maintainers = with maintainers; [ tadeokondrak ];
       platforms = platforms.all;
+      mainProgram = "vsedit";
     };
   };
 


### PR DESCRIPTION
###### Description of changes

Also changes version format, adds version test and mainProgram.

Uses version format that is discussed in https://github.com/NixOS/rfcs/pull/107. Some packages already use it. This should fix the issue that Nix does not show the version correctly.

![Screenshot from 2022-09-15 05-25-45](https://user-images.githubusercontent.com/91113/190311380-1176c9df-1c4a-40d4-ab31-afc6e63ddd1a.png)

I don't know what this program is supposed to do, so please test carefully! The GUI does start.

What needs to be ckecked:

- [ ] Is the commit message correct with the different version formats?
- [ ] I can't run the test. What's wrong?

```
[davidak@gaming:~/code/nixpkgs]$ nix build .#vapoursynth-editor.tests.version --no-link --print-build-logs
error: flake 'git+file:///home/davidak/code/nixpkgs' does not provide attribute 'packages.x86_64-linux.vapoursynth-editor.tests.version', 'legacyPackages.x86_64-linux.vapoursynth-editor.tests.version' or 'vapoursynth-editor.tests.version'
```

- [ ] The mainProgram does not work for nix run. What's wrong?

```
[davidak@gaming:~/code/nixpkgs]$ nix run .#vapoursynth-editor -- --version
error: unable to execute '/nix/store/8sa86nrkyi01s516j0ng43wxwx6zs06k-vapoursynth-editor-19-mod-5.4-with-plugins/bin/vapoursynth-editor': No such file or directory
```

cc maintainer @tadeokondrak

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
