### PR TITLE
ocamlPackages.happy-eyeballs-{mirage,lwt}: init at 0.1.3

### DIFF
--- a/pkgs/development/ocaml-modules/happy-eyeballs/lwt.nix
+++ b/pkgs/development/ocaml-modules/happy-eyeballs/lwt.nix
@@ -1,0 +1,26 @@
+{ buildDunePackage
+, happy-eyeballs
+, cmdliner
+, dns-client
+, logs
+, lwt
+}:
+
+buildDunePackage {
+  pname = "happy-eyeballs-lwt";
+  inherit (happy-eyeballs) src version;
+
+  buildInputs = [ cmdliner ];
+
+  propagatedBuildInputs = [
+    dns-client
+    happy-eyeballs
+    logs
+    lwt
+  ];
+
+  meta = happy-eyeballs.meta // {
+    description = "Connecting to a remote host via IP version 4 or 6 using Lwt_unix";
+  };
+
+}

--- a/pkgs/development/ocaml-modules/happy-eyeballs/mirage.nix
+++ b/pkgs/development/ocaml-modules/happy-eyeballs/mirage.nix
@@ -1,0 +1,25 @@
+{ buildDunePackage
+, happy-eyeballs
+, dns-client
+, logs
+, lwt
+, tcpip
+}:
+
+buildDunePackage {
+  pname = "happy-eyeballs-mirage";
+  inherit (happy-eyeballs) src version;
+
+  propagatedBuildInputs = [
+    dns-client
+    happy-eyeballs
+    logs
+    lwt
+    tcpip
+  ];
+
+  meta = happy-eyeballs.meta // {
+    description = "Connecting to a remote host via IP version 4 or 6 using Mirage";
+  };
+
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -517,6 +517,8 @@ let
 
     happy-eyeballs = callPackage ../development/ocaml-modules/happy-eyeballs { };
 
+    happy-eyeballs-lwt = callPackage ../development/ocaml-modules/happy-eyeballs/lwt.nix { };
+
     happy-eyeballs-mirage = callPackage ../development/ocaml-modules/happy-eyeballs/mirage.nix { };
 
     hashcons = callPackage ../development/ocaml-modules/hashcons { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -517,6 +517,8 @@ let
 
     happy-eyeballs = callPackage ../development/ocaml-modules/happy-eyeballs { };
 
+    happy-eyeballs-mirage = callPackage ../development/ocaml-modules/happy-eyeballs/mirage.nix { };
+
     hashcons = callPackage ../development/ocaml-modules/hashcons { };
 
     herelib = callPackage ../development/ocaml-modules/herelib { };


### PR DESCRIPTION
###### Description of changes

Dependencies of OCaml `git` libraries.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
