### PR TITLE
mypy: add `setuptools` to runtime dependencies

### DIFF
--- a/pkgs/development/python-modules/pip/default.nix
+++ b/pkgs/development/python-modules/pip/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , bootstrapped-pip
 , fetchFromGitHub
+, setuptools
 , mock
 , scripttest
 , virtualenv
@@ -26,6 +27,11 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [ bootstrapped-pip ];
+  propagatedBuildInputs = [
+    # vendored pep517 uses it to parse wheels:
+    #   https://github.com/NixOS/nixpkgs/pull/185815#issuecomment-1247660712
+    setuptools
+  ];
 
   # pip detects that we already have bootstrapped_pip "installed", so we need
   # to force it a little.


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/185815 exposed missing `setuptools` test dependency in `staging`:
https://github.com/NixOS/nixpkgs/pull/185815#issuecomment-1247660712

    $ nix build --no-link -f. -L mypy
    ...
    python3.10-mypy>   File "/nix/store/xbxx4rybspani1wxp7aph1925z2f8prp-python3.10-pip-22.1.2/lib/python3.10/site-packages/pip/_vendor/pep517/wrappers.py", line 332, in _call_hook
    python3.10-mypy>     raise BackendUnavailable(data.get('traceback', ''))
    python3.10-mypy> pip._vendor.pep517.wrappers.BackendUnavailable: Traceback (most recent call last):
    python3.10-mypy>   File "/nix/store/xbxx4rybspani1wxp7aph1925z2f8prp-python3.10-pip-22.1.2/lib/python3.10/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 89, in _build_backend
    python3.10-mypy>     obj = import_module(mod_path)
    ...
    python3.10-mypy> ModuleNotFoundError: No module named 'setuptools'

The change adds a runtime depend to `setuptools` for `pip`.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
