### PR TITLE
tortoisehg: 6.1->6.2.2

### DIFF
--- a/pkgs/applications/version-management/tortoisehg/default.nix
+++ b/pkgs/applications/version-management/tortoisehg/default.nix
@@ -7,11 +7,11 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "tortoisehg";
-  version = "6.1";
+  version = "6.2.2";
 
   src = fetchurl {
     url = "https://www.mercurial-scm.org/release/tortoisehg/targz/tortoisehg-${version}.tar.gz";
-    sha256 = "sha256-UG13BlFY9DcsCPWaBiYa6r2oA3ieJtTYfXknDoKNkYI=";
+    sha256 = "sha256-Xbvg/FcuX/AL2reWsaM2oaFyLby3+HDCfYtRyswE7DA=";
   };
 
   # Extension point for when thg's mercurial is lagging behind mainline.
@@ -54,6 +54,6 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://tortoisehg.bitbucket.io/";
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ danbst ];
+    maintainers = with lib.maintainers; [ danbst gbtb ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Updated tortoisehg to 6.2.2, because 6.1 version is not fully compatible with mercurial 6.2.2 and it throws dialogs with errors in runtime :crying_cat_face: 
```
#!python
    ** Mercurial version (6.2.2).  TortoiseHg version (6.1)
    ** Command:
    ** CWD: *censored*
    ** Encoding: UTF-8
    ** Extensions loaded: tortoisehg.util.configitems
    ** Python version: 3.10.6 (main, Aug  1 2022, 20:38:21) [GCC 11.3.0]
    ** System: Linux nixos 5.19.8 #1-NixOS SMP PREEMPT_DYNAMIC Thu Sep 8 09:24:08 UTC 2022 x86_64
    ** Qt-5.15.5 PyQt-5.15.7 QScintilla-2.13.2
    Traceback (most recent call last):
      File "/nix/store/w8104s5ih3377pg29bwcmfkmdrf7flax-tortoisehg-6.1/lib/python3.10/site-packages/tortoisehg/hgqt/status.py", line 654, in onCurrentChange
        fd.load(changeselect)
      File "/nix/store/w8104s5ih3377pg29bwcmfkmdrf7flax-tortoisehg-6.1/lib/python3.10/site-packages/tortoisehg/hgqt/filedata.py", line 228, in load
        self._readStatus(ctx, ctx2, wfile, status, changeselect, force)
      File "/nix/store/w8104s5ih3377pg29bwcmfkmdrf7flax-tortoisehg-6.1/lib/python3.10/site-packages/tortoisehg/hgqt/filedata.py", line 388, in _readStatus
        fp = pycompat.bytesio()
    AttributeError: module 'mercurial.pycompat' has no attribute 'bytesio'
```

Also added myself as a maintainer, because, judging by the lack of bug reports, I'm the last person using thg on nixos-unstable :stuck_out_tongue: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
