### PR TITLE
resholve: use originalSrc for nixpkgs-update bot

### DIFF
--- a/pkgs/development/misc/resholve/resholve-utils.nix
+++ b/pkgs/development/misc/resholve/resholve-utils.nix
@@ -185,6 +185,8 @@ rec {
       # retain a reference to the base
       passthru = unresholved.passthru // {
         unresholved = unresholved;
+        # fallback attr for update bot to query our src
+        originalSrc = unresholved.src;
       };
 
       # do these imply that we should use NoCC or something?


### PR DESCRIPTION
###### Description of changes

Effort to fix automatic nixpkgs-update updates for resholved packages in 9f6310d (#191003) did help the bot get further along, but it still failed to find the source outputHash (because the outer derivation's source is the inner derivation; the bot is looking for outer.src.outputHash but before this commit it is at outer.src.src.outputHash). ([log](https://r.ryantm.com/log/bats/2022-09-15.log))

Change abuses passthru to set the outer src to `inner.src` in a way that (IIUC) will not affect the build, but will affect ~queries like nixpkgs-update is using (e.g. `nix eval -f . --raw pkgs.bats.src.drvAttrs.outputHash`)

I'm not at all certain this will satisfy nixpkgs-update; treat me with some skepticism :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

This one's a bit weird, so I've confirmed that:
- nixpkgs-review reports `No diff detected, stopping review...`
- I can `nix-build` both `bats` and `bats.tests` (bats is built with resholve)
- The nixpkgs-update `nix eval` command I'm trying to fix appears to work:

    ```console
    $ nix eval -f . --raw pkgs.bats.src.drvAttrs.outputHash
    sha256-joNne/dDVCNtzdTQ64rK8GimT+DOWUa7f410hml2s8Q=
    ```