### PR TITLE
fetchzip: don't error out if the directory inside the archive starts with a "."

### DIFF
--- a/pkgs/build-support/fetchzip/default.nix
+++ b/pkgs/build-support/fetchzip/default.nix
@@ -52,12 +52,12 @@ in {
       chmod -R +w "$unpackDir"
     ''
     + (if stripRoot then ''
-      if [ $(ls "$unpackDir" | wc -l) != 1 ]; then
+      if [ $(ls -A "$unpackDir" | wc -l) != 1 ]; then
         echo "error: zip file must contain a single file or directory."
         echo "hint: Pass stripRoot=false; to fetchzip to assume flat list of files."
         exit 1
       fi
-      fn=$(cd "$unpackDir" && echo *)
+      fn=$(cd "$unpackDir" && ls -A)
       if [ -f "$unpackDir/$fn" ]; then
         mkdir $out
       fi

--- a/pkgs/build-support/fetchzip/tests.nix
+++ b/pkgs/build-support/fetchzip/tests.nix
@@ -1,4 +1,4 @@
-{ testers, fetchzip, ... }:
+{ testers, fetchzip, runCommand, ... }:
 
 let
   url = "https://gist.github.com/glandium/01d54cefdb70561b5f6675e08f2990f2/archive/2f430f0c136a69b0886281d0c76708997d8878af.zip";
@@ -12,6 +12,14 @@ in
   postFetch = testers.invalidateFetcherByDrvHash fetchzip {
     inherit url;
     sha256 = "sha256-7sAOzKa+9vYx5XyndHxeY2ffWAjOsgCkXC9anK6cuV0=";
-    postFetch = ''touch $out/filee'';
+    postFetch = "touch $out/filee";
+  };
+
+  hiddenDir = testers.invalidateFetcherByDrvHash fetchzip {
+    url = "file://${runCommand "hiddendir.tar" {} ''
+      mkdir .foo
+      tar -cf $out .foo
+    ''}";
+    sha256 = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
   };
 }


### PR DESCRIPTION
###### Description of changes

Include hidden directories/files for the count of directories/files.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).