### PR TITLE
directoryListingUpdater: init; enlightenment.enlightenment: add update script

### DIFF
--- a/pkgs/common-updater/directory-listing-updater.nix
+++ b/pkgs/common-updater/directory-listing-updater.nix
@@ -1,0 +1,19 @@
+{ lib
+, genericUpdater
+, common-updater-scripts
+}:
+
+{ pname ? null
+, version ? null
+, attrPath ? null
+, ignoredVersions ? ""
+, rev-prefix ? ""
+, odd-unstable ? false
+, patchlevel-unstable ? false
+, url ? null
+}:
+
+genericUpdater {
+  inherit pname version attrPath ignoredVersions rev-prefix odd-unstable patchlevel-unstable;
+  versionLister = "${common-updater-scripts}/bin/list-directory-versions ${lib.optionalString (url != null) "--url=${lib.escapeShellArg url}"}";
+}

--- a/pkgs/common-updater/generic-updater.nix
+++ b/pkgs/common-updater/generic-updater.nix
@@ -62,7 +62,7 @@ let
       return 1
     }
 
-    tags=$($version_lister --pname=$pname --attr-path=$attr_path --file="${fileForGitCommands}") || exit 1
+    tags=$(sh -c "$version_lister --pname=$pname --attr-path=$attr_path --file=\"${fileForGitCommands}\"") || exit 1
 
     # print available tags
     for tag in $tags; do

--- a/pkgs/common-updater/http-two-levels-updater.nix
+++ b/pkgs/common-updater/http-two-levels-updater.nix
@@ -15,5 +15,5 @@
 
 genericUpdater {
   inherit pname version attrPath ignoredVersions rev-prefix odd-unstable patchlevel-unstable;
-  versionLister = "${common-updater-scripts}/bin/list-archive-two-levels-versions ${lib.optionalString (url != null) "--url=${url}"}";
+  versionLister = "${common-updater-scripts}/bin/list-archive-two-levels-versions ${lib.optionalString (url != null) "--url=${lib.escapeShellArg url}"}";
 }

--- a/pkgs/common-updater/scripts/list-archive-two-levels-versions
+++ b/pkgs/common-updater/scripts/list-archive-two-levels-versions
@@ -4,7 +4,7 @@
 
 pname=""  # package name
 attr_path=""  # package attribute path
-url=""  # directory list url
+url=""  # directory listing url
 file=""  # file for writing debugging information
 
 while (( $# > 0 )); do
@@ -31,7 +31,7 @@ while (( $# > 0 )); do
 done
 
 if [[ -z "$pname" ]]; then
-    pname="$UPDATE_NIX_NAME"
+    pname="$UPDATE_NIX_PNAME"
 fi
 
 if [[ -z "$attr_path" ]]; then

--- a/pkgs/common-updater/scripts/list-directory-versions
+++ b/pkgs/common-updater/scripts/list-directory-versions
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+
+import argparse
+import requests
+import os
+import subprocess
+import json
+import re
+from bs4 import BeautifulSoup
+
+parser = argparse.ArgumentParser(
+    description="Get all available versions listed for a package in a site."
+)
+
+parser.add_argument(
+    "--pname",
+    default=os.environ.get("UPDATE_NIX_PNAME"),
+    required="UPDATE_NIX_PNAME" not in os.environ,
+    help="name of the package",
+)
+parser.add_argument(
+    "--attr-path",
+    default=os.environ.get("UPDATE_NIX_ATTR_PATH"),
+    help="attribute path of the package",
+)
+parser.add_argument("--url", help="url of the page that lists the package versions")
+parser.add_argument("--file", help="file name for writing debugging information")
+
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+
+    pname = args.pname
+
+    attr_path = args.attr_path or pname
+
+    url = args.url or json.loads(
+        subprocess.check_output(
+            [
+                "nix-instantiate",
+                "--json",
+                "--eval",
+                "-E",
+                f"with import ./. {{}}; dirOf (lib.head {attr_path}.src.urls)",
+            ],
+            text=True,
+        )
+    )
+
+    # print a debugging message
+    if args.file:
+        with open(args.file, "a") as f:
+            f.write(f"# Listing versions for {pname} from {url}\n")
+
+    page = requests.get(url)
+    soup = BeautifulSoup(page.content, "html.parser")
+    links = soup.find_all("a")
+    for link in links:
+        link_url = link.get("href", None)
+        if link_url is not None:
+            match = re.fullmatch(
+                rf"{args.pname}-([\d.]+?(-[\d\w.-]+?)?)(\.tar)?(\.[^.]*)", link_url
+            )
+            if match:
+                print(match.group(1))

--- a/pkgs/common-updater/scripts/list-git-tags
+++ b/pkgs/common-updater/scripts/list-git-tags
@@ -31,7 +31,7 @@ while (( $# > 0 )); do
 done
 
 if [[ -z "$pname" ]]; then
-    pname="$UPDATE_NIX_NAME"
+    pname="$UPDATE_NIX_PNAME"
 fi
 
 if [[ -z "$attr_path" ]]; then

--- a/pkgs/desktops/enlightenment/enlightenment/default.nix
+++ b/pkgs/desktops/enlightenment/enlightenment/default.nix
@@ -14,10 +14,10 @@
 , pam
 , xkeyboard_config
 , udisks2
-
 , waylandSupport ? false, wayland-protocols, xwayland
 , bluetoothSupport ? true, bluez5
 , pulseSupport ? !stdenv.isDarwin, libpulseaudio
+, directoryListingUpdater
 }:
 
 stdenv.mkDerivation rec {
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   version = "0.25.4";
 
   src = fetchurl {
-    url = "http://download.enlightenment.org/rel/apps/${pname}/${pname}-${version}.tar.xz";
+    url = "https://download.enlightenment.org/rel/apps/${pname}/${pname}-${version}.tar.xz";
     sha256 = "sha256-VttdIGuCG5qIMdJucT5BCscLIlWm9D/N98Ae794jt6I=";
   };
 
@@ -70,6 +70,8 @@ stdenv.mkDerivation rec {
   ] ++ lib.optional waylandSupport "-Dwl=true";
 
   passthru.providedSessions = [ "enlightenment" ];
+
+  passthru.updateScript = directoryListingUpdater { };
 
   meta = with lib; {
     description = "The Compositing Window Manager and Desktop Shell";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -126,6 +126,8 @@ with pkgs;
 
   _experimental-update-script-combinators = callPackage ../common-updater/combinators.nix { };
 
+  directoryListingUpdater = callPackage ../common-updater/directory-listing-updater.nix { };
+
   gitUpdater = callPackage ../common-updater/git-updater.nix { };
 
   httpTwoLevelsUpdater = callPackage ../common-updater/http-two-levels-updater.nix { };


### PR DESCRIPTION
###### Description of changes

- `directoryListingUpdater`: init
  Update a package looking for available versions in a html page

- `gitUpdater` and `httpTwoLevelsUpdater`: fix variable default value

- `enlightenment.enlightenment`: add update script

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
