### PR TITLE
ocamlPackages.checkseum: 0.3.2 → 0.3.4

### DIFF
--- a/pkgs/development/ocaml-modules/checkseum/default.nix
+++ b/pkgs/development/ocaml-modules/checkseum/default.nix
@@ -1,27 +1,24 @@
 { lib, fetchurl, buildDunePackage, ocaml, dune-configurator, pkg-config
-, bigarray-compat, optint
+, optint
 , fmt, rresult, bos, fpath, astring, alcotest
 , withFreestanding ? false
 , ocaml-freestanding
 }:
 
 buildDunePackage rec {
-  version = "0.3.2";
+  version = "0.3.4";
   pname = "checkseum";
 
-  useDune2 = true;
-
-  minimumOCamlVersion = "4.07";
+  minimalOCamlVersion = "4.07";
 
   src = fetchurl {
-    url = "https://github.com/mirage/checkseum/releases/download/v${version}/checkseum-v${version}.tbz";
-    sha256 = "9cdd282ea1cfc424095d7284e39e4d0ad091de3c3f2580539d03f6966d45ccd5";
+    url = "https://github.com/mirage/checkseum/releases/download/v${version}/checkseum-${version}.tbz";
+    sha256 = "sha256-BL4BOwxXORrkOOba4QjRSetm8bF9JmlKHSFPq24+1zg=";
   };
 
   buildInputs = [ dune-configurator ];
   nativeBuildInputs = [ pkg-config ];
   propagatedBuildInputs = [
-    bigarray-compat
     optint
   ] ++ lib.optionals withFreestanding [
     ocaml-freestanding


### PR DESCRIPTION
###### Description of changes

https://github.com/mirage/checkseum/blob/v0.3.4/CHANGES.md#v034-2022-06-07-arles-france

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
