### PR TITLE
sublime4: pin to openssl_1_1

### DIFF
--- a/pkgs/applications/editors/sublime/4/common.nix
+++ b/pkgs/applications/editors/sublime/4/common.nix
@@ -2,7 +2,7 @@
 
 { fetchurl, stdenv, lib, xorg, glib, libglvnd, glibcLocales, gtk3, cairo, pango, makeWrapper, wrapGAppsHook
 , writeShellScript, common-updater-scripts, curl
-, openssl, bzip2, bash, unzip, zip
+, openssl_1_1, bzip2, bash, unzip, zip
 }:
 
 let
@@ -15,7 +15,7 @@ let
   versionUrl = "https://download.sublimetext.com/latest/${if dev then "dev" else "stable"}";
   versionFile = builtins.toString ./packages.nix;
 
-  libPath = lib.makeLibraryPath [ xorg.libX11 xorg.libXtst glib libglvnd openssl gtk3 cairo pango curl ];
+  libPath = lib.makeLibraryPath [ xorg.libX11 xorg.libXtst glib libglvnd openssl_1_1 gtk3 cairo pango curl ];
 in let
   binaryPackage = stdenv.mkDerivation rec {
     pname = "${pnameBase}-bin";
@@ -64,6 +64,9 @@ in let
 
     installPhase = ''
       runHook preInstall
+
+      # No need to patch these libraries, it works well with our own
+      rm libcrypto.so.1.1 libssl.so.1.1
 
       mkdir -p $out
       cp -r * $out/


### PR DESCRIPTION
###### Description of changes

It broke somewhere in the past week, I was traveling and received a week of updates so bisecting it would be hard, what I know from the broken state:

```console
╰─λ ./plugin_host-3.8
./plugin_host-3.8: error while loading shared libraries: libcrypto.so.1.1: cannot open shared object file: No such file or directory

╰─λ LD_PRELOAD=$PWD/libcrypto.so.1.1 ./plugin_host-3.8
./plugin_host-3.8: error while loading shared libraries: libssl.so.1.1: cannot open shared object file: No such file or directory

╰─λ ldd plugin_host-3.8 | grep crypto
  libcrypto.so.1.1 => not found

╰─λ LD_LIBRARY_PATH=$PWD ./plugin_host-3.8
./plugin_host-3.8: error while loading shared libraries: libz.so.1: cannot open shared object file: No such file or directory
```

Error from sublime's GUI:

![screenshot](https://user-images.githubusercontent.com/1368952/190499976-0025967d-9c0b-4db8-b64e-7090781425bc.png)

---

And it worked once I did:

```console
╰─λ LD_LIBRARY_PATH=/nix/store/a4g2mals99rhsq1q7rydszz5b5bhzbm3-openssl-1.1.1q/lib LD_PRELOAD=/nix/store/a4g2mals99rhsq1q7rydszz5b5bhzbm3-openssl-1.1.1q/lib/libcrypto.so.1.1 ./plugin_host-3.8
Unexpected number of arguments, expected 6
```

So I've hard-coded this version. And made sure to remove the libraries bundled with the package to skip patching and for us to easily notice when they change the version.

###### Things done

Built both `sublime4` and `sublime4-dev`, worked perfectly.

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
