### PR TITLE
agi: 3.2.0-dev-20220831 -> 3.0.1, switch to stable release

### DIFF
--- a/pkgs/tools/graphics/agi/default.nix
+++ b/pkgs/tools/graphics/agi/default.nix
@@ -1,5 +1,5 @@
 { lib
-, stdenv
+, stdenvNoCC
 , fetchzip
 , autoPatchelfHook
 , makeWrapper
@@ -9,63 +9,69 @@
 , gobject-introspection
 , gdk-pixbuf
 , jre
-, androidenv
+, android-tools
 }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "agi";
-  version = "3.2.0-dev-20220831";
+  version = "3.0.1";
 
   src = fetchzip {
-    url = "https://github.com/google/agi-dev-releases/releases/download/v${version}/agi-${version}-linux.zip";
-    sha256 = "sha256-pAPYIhNqr7TpVDnHhRVGkd6HCqu945OCXa5dpGi2UhU=";
+    url = "https://github.com/google/agi/releases/download/v${version}/agi-${version}-linux.zip";
+    sha256 = "sha256-793lOJL1/wqETkWfiksnLY3Lmxx500fw4PIzT9ZQqQs=";
   };
 
   nativeBuildInputs = [
-    autoPatchelfHook
-    makeWrapper
     wrapGAppsHook
     gdk-pixbuf
     gobject-introspection
+    autoPatchelfHook
     copyDesktopItems
-  ];
-
-  buildInputs = [
-    stdenv.cc.cc.lib
+    makeWrapper
   ];
 
   installPhase = ''
     runHook preInstall
-    mkdir -p $out/{bin,lib}
+
+    mkdir -p $out/bin
     cp ./{agi,gapis,gapir,gapit,device-info} $out/bin
-    cp lib/gapic.jar $out/lib
-    wrapProgram $out/bin/agi \
-      --add-flags "--vm ${jre}/bin/java" \
-      --add-flags "--jar $out/lib/gapic.jar" \
-      --add-flags "--adb ${androidenv.androidPkgs_9_0.platform-tools}/bin/adb"
+    cp -r lib $out
+
     for i in 16 32 48 64 96 128 256 512 1024; do
-      install -D ${src}/icon.png $out/share/icons/hicolor/''${i}x$i/apps/agi.png
+      install -D ${src}/icon.png $out/share/icons/hicolor/$ix$i/apps/agi.png
     done
+
     runHook postInstall
   '';
 
-  desktopItems = [(makeDesktopItem {
+  dontWrapGApps = true;
+
+  preFixup = ''
+    wrapProgram $out/bin/agi \
+      --add-flags "--vm ${jre}/bin/java" \
+      --add-flags "--adb ${android-tools}/bin/adb" \
+      --add-flags "--jar $out/lib/gapic.jar" \
+      "''${gappsWrapperArgs[@]-}"
+  '';
+
+  desktopItems = lib.toList (makeDesktopItem {
     name = "agi";
     desktopName = "Android GPU Inspector";
     exec = "agi";
     icon = "agi";
     categories = [ "Development" "Debugger" "Graphics" "3DGraphics" ];
-  })];
+  });
 
   meta = with lib; {
-    homepage = "https://github.com/google/agi/";
     description = "Android GPU Inspector";
+    homepage = "https://gpuinspector.dev";
+    changelog = "https://github.com/google/agi/releases/tag/v${version}";
+    platforms = [ "x86_64-linux" ];
+    license = licenses.asl20;
+    maintainers = [ maintainers.ivar ];
     sourceProvenance = with sourceTypes; [
       binaryBytecode
       binaryNativeCode
     ];
-    license = licenses.asl20;
-    platforms = [ "x86_64-linux" ];
-    maintainers = [ maintainers.ivar ];
   };
 }


### PR DESCRIPTION
###### Description of changes
This switches agi to the latest stable release instead of the development one. It also cleans up the derivation in a few ways:

* Do not depend on `androidenv` anymore for `adb`, instead `android-tools` is used which should be a lot more minimal.
* Use `wrapGAppsHook` correctly, and avoid double wrapping because of it.
* Install all files from the `lib` directory, which contains some shared objects useful for vulkan support.
* Switch to `stdenvNoCC` as `libstdc++.so.6` is automatically picked up by `autoPatchelfHook` now.
* Set `meta.changelog`.

See [the changelog](https://github.com/google/agi/releases/tag/v3.0.1) for more information.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and “core” functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
