### PR TITLE
swaynotificationcenter: 0.6.3 -> 0.7.1

### DIFF
--- a/pkgs/applications/misc/swaynotificationcenter/default.nix
+++ b/pkgs/applications/misc/swaynotificationcenter/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: rec {
     owner = "ErikReider";
     repo = "SwayNotificationCenter";
     rev = "v${version}";
-    hash = "sha256-/rLzdli+/YTfk+jQ+RhHUEzeORVnJU4KHDlOG3QCPr0=";
+    hash = "sha256-s4yacSK5ajuq+BeGcPX+/o9wuDOcTOdZu4p8nPS8wk4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/swaynotificationcenter/default.nix
+++ b/pkgs/applications/misc/swaynotificationcenter/default.nix
@@ -18,6 +18,7 @@
 , meson
 , ninja
 , pkg-config
+, python3
 , scdoc
 , vala
 , xvfb-run
@@ -25,13 +26,13 @@
 
 stdenv.mkDerivation (finalAttrs: rec {
   pname = "SwayNotificationCenter";
-  version = "0.6.3";
+  version = "0.7.1";
 
   src = fetchFromGitHub {
     owner = "ErikReider";
     repo = "SwayNotificationCenter";
     rev = "v${version}";
-    hash = "sha256-79Kda2Mi2r38f0J12bRm9wbHiZCy9+ojPDxwlFG8EYw=";
+    hash = "sha256-/rLzdli+/YTfk+jQ+RhHUEzeORVnJU4KHDlOG3QCPr0=";
   };
 
   nativeBuildInputs = [
@@ -43,6 +44,7 @@ stdenv.mkDerivation (finalAttrs: rec {
     meson
     ninja
     pkg-config
+    python3
     scdoc
     vala
     wrapGAppsHook
@@ -61,15 +63,9 @@ stdenv.mkDerivation (finalAttrs: rec {
     # systemd # ends with broken permission
   ];
 
-  # Fix-Me: Broken in 0.6.3, but fixed on master. Enable on next release. Requires python3 in nativeBuildInputs.
-  # postPatch = ''
-  #   chmod +x build-aux/meson/postinstall.py
-  #   patchShebangs build-aux/meson/postinstall.py
-  # '';
-
-  # Remove past 0.6.3
-  postInstall = ''
-    glib-compile-schemas "$out"/share/glib-2.0/schemas
+  postPatch = ''
+    chmod +x build-aux/meson/postinstall.py
+    patchShebangs build-aux/meson/postinstall.py
   '';
 
   passthru.tests.version = testers.testVersion {


### PR DESCRIPTION
###### Description of changes

- Bump version;
- Remove 0.6.3-specific hack;

###### Things done

~I'll remove from draft after testing.~ Tested both daemon and client.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
