### PR TITLE
surrealdb: init at 1.0.0-beta.7

### DIFF
--- a/pkgs/servers/nosql/surrealdb/default.nix
+++ b/pkgs/servers/nosql/surrealdb/default.nix
@@ -1,0 +1,39 @@
+{ lib, stdenv, rustPlatform, fetchFromGitHub, pkg-config, openssl, llvmPackages
+, testers, surrealdb
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "surrealdb";
+  version = "1.0.0-beta.7";
+
+  src = fetchFromGitHub {
+    owner = "surrealdb";
+    repo = "surrealdb";
+    rev = "v${version}";
+    hash = "sha256-Zl2ONMmVN+gXnsvTUPH37TIBquu3F1kUsATGHszNO/s=";
+  };
+
+  cargoHash = "sha256-VQlW78NNpJqKOCpOXBmNf37heftWXCIzMpYw+yQdGv4=";
+
+  LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+
+  nativeBuildInputs = [
+    pkg-config
+    llvmPackages.clang # needed for librocksdb-sys
+  ];
+
+  buildInputs = [ openssl ];
+
+  passthru.tests.version = testers.testVersion {
+    package = surrealdb;
+    command = "surreal version";
+  };
+
+  meta = with lib; {
+    description = "A scalable, distributed, collaborative, document-graph database, for the realtime web";
+    homepage = "https://surrealdb.com/";
+    mainProgram = "surreal";
+    license = licenses.bsl11;
+    maintainers = with maintainers; [ sikmir ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23711,6 +23711,8 @@ with pkgs;
     libtool = darwin.cctools;
   };
 
+  surrealdb = callPackage ../servers/nosql/surrealdb { };
+
   # Fails to compile with boost <= 1.72
   rippled = callPackage ../servers/rippled {
     boost = boost172;


### PR DESCRIPTION
###### Description of changes
Resolves #187973
cc @Anderssorby

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
