### PR TITLE
libexplain: init at 1.4

### DIFF
--- a/pkgs/development/tools/explain/default.nix
+++ b/pkgs/development/tools/explain/default.nix
@@ -1,0 +1,46 @@
+{ lib, stdenv, fetchurl, fetchpatch
+, libtool, bison, groff, ghostscript, gettext
+, acl, libcap, lsof }:
+stdenv.mkDerivation rec {
+  pname = "explain";
+  version = "1.4";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/libexplain/libexplain-${version}.tar.gz";
+    hash = "sha256-KIY7ZezMdJNOI3ysQTZMs8GALDbJ4jGO0EF0YP7oP4A=";
+  };
+
+  patches = let
+    debian-src = "https://sources.debian.org/data/main";
+    debian-ver = "${version}.D001-12";
+    debian-patch = fname: hash: fetchpatch {
+      name = fname;
+      url = "${debian-src}/libe/libexplain/${debian-ver}/debian/patches/${fname}";
+      hash = hash;
+    };
+  in [
+    (debian-patch "sanitize-bison.patch"
+      "sha256-gU6JG32j2yIOwehZTUSvIr4TSDdlg+p1U3bhfZHMEDY=")
+    (debian-patch "03_fsflags-4.5.patch"
+      "sha256-ML7Qvf85vEBp+iwm6PSosMAn/frYdEOSHRToEggmR8M=")
+    (debian-patch "linux5.11.patch"
+      "sha256-N7WwnTfwOxBfIiKntcFOqHTH9r2gd7NMEzic7szzR+Y=")
+    (debian-patch "termiox-no-more-exists-since-kernel-5.12.patch"
+      "sha256-cocgEYKoDMDnGk9VNQDtgoVxMGnnNpdae0hzgUlacOw=")
+    (debian-patch "gcc-10.patch"
+      "sha256-YNcYGyOOqPUuwpUpXGcR7zsWbepVg8SAqcVKlxENSQk=")
+  ];
+
+  nativeBuildInputs = [ libtool bison groff ghostscript gettext ];
+  buildInputs = [ acl libcap lsof ];
+
+  outputs = [ "bin" "dev" "out" "man" "doc" ];
+
+  meta = with lib; {
+    description = "Library and utility to explain system call errors";
+    homepage = "http://libexplain.sourceforge.net";
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ McSinyx ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16421,6 +16421,8 @@ with pkgs;
 
   eweb = callPackage ../development/tools/literate-programming/eweb { };
 
+  explain = callPackage ../development/tools/explain { };
+
   funnelweb = callPackage ../development/tools/literate-programming/funnelweb { };
 
   license_finder = callPackage ../development/tools/license_finder { };


### PR DESCRIPTION
###### Description of changes

The library is used by a program my lab is working on, but there's a CLI utility useful by itself.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).