### PR TITLE
factorio: 1.1.65 -> 1.1.69

### DIFF
--- a/pkgs/games/factorio/versions.json
+++ b/pkgs/games/factorio/versions.json
@@ -2,56 +2,56 @@
   "x86_64-linux": {
     "alpha": {
       "experimental": {
-        "name": "factorio_alpha_x64-1.1.65.tar.xz",
+        "name": "factorio_alpha_x64-1.1.69.tar.xz",
         "needsAuth": true,
-        "sha256": "0rzifli06s3k3gyzxpzzisxkvnvcidw4njkibrld2n5pwhjg8qbb",
+        "sha256": "0ckvcwnwv1hh946qavfgaywhspd3cyasf8v7w0qmbx359dsv6yb9",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.65/alpha/linux64",
-        "version": "1.1.65"
+        "url": "https://factorio.com/get-download/1.1.69/alpha/linux64",
+        "version": "1.1.69"
       },
       "stable": {
-        "name": "factorio_alpha_x64-1.1.61.tar.xz",
+        "name": "factorio_alpha_x64-1.1.69.tar.xz",
         "needsAuth": true,
-        "sha256": "1rgb3i6l9v5vv3qw0ngfxryamql2fhhqymv4dr86rxjy863rpx65",
+        "sha256": "0ckvcwnwv1hh946qavfgaywhspd3cyasf8v7w0qmbx359dsv6yb9",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.61/alpha/linux64",
-        "version": "1.1.61"
+        "url": "https://factorio.com/get-download/1.1.69/alpha/linux64",
+        "version": "1.1.69"
       }
     },
     "demo": {
       "experimental": {
-        "name": "factorio_demo_x64-1.1.60.tar.xz",
+        "name": "factorio_demo_x64-1.1.69.tar.xz",
         "needsAuth": false,
-        "sha256": "1sckcc8dndml2ahka96qlhyjqinbgzh2sns2qfphsph9x26q1vxn",
+        "sha256": "08nakf6f31dra3rzv2l57pnww04i4ppil6c3vvvhjcv8j35b5k29",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.60/demo/linux64",
-        "version": "1.1.60"
+        "url": "https://factorio.com/get-download/1.1.69/demo/linux64",
+        "version": "1.1.69"
       },
       "stable": {
-        "name": "factorio_demo_x64-1.1.59.tar.xz",
+        "name": "factorio_demo_x64-1.1.69.tar.xz",
         "needsAuth": false,
-        "sha256": "1nddk8184kgq4ni0y9j2l8sa3szvcbsq9l90b35l9jb6sqflgki0",
+        "sha256": "08nakf6f31dra3rzv2l57pnww04i4ppil6c3vvvhjcv8j35b5k29",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.59/demo/linux64",
-        "version": "1.1.59"
+        "url": "https://factorio.com/get-download/1.1.69/demo/linux64",
+        "version": "1.1.69"
       }
     },
     "headless": {
       "experimental": {
-        "name": "factorio_headless_x64-1.1.65.tar.xz",
+        "name": "factorio_headless_x64-1.1.69.tar.xz",
         "needsAuth": false,
-        "sha256": "1h5ziip9jbqr03ci2fvf3zqwmy0l7m25br3rm5xv0af9wig9wvh1",
+        "sha256": "1rgspyynz8b8s1kwh67dwnn2mc53jrmmhy7bp7qi0vgbwpb5vhw3",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.65/headless/linux64",
-        "version": "1.1.65"
+        "url": "https://factorio.com/get-download/1.1.69/headless/linux64",
+        "version": "1.1.69"
       },
       "stable": {
-        "name": "factorio_headless_x64-1.1.61.tar.xz",
+        "name": "factorio_headless_x64-1.1.69.tar.xz",
         "needsAuth": false,
-        "sha256": "0ndnc0f22bqjg1v6ah7i4nzghvk7cn73sgm22lf715di6f6srr38",
+        "sha256": "1rgspyynz8b8s1kwh67dwnn2mc53jrmmhy7bp7qi0vgbwpb5vhw3",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.61/headless/linux64",
-        "version": "1.1.61"
+        "url": "https://factorio.com/get-download/1.1.69/headless/linux64",
+        "version": "1.1.69"
       }
     }
   }


### PR DESCRIPTION
###### Description of changes
Update factorio to 1.1.69
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
