### PR TITLE
wlhax: init at unstable-2022-04-17

### DIFF
--- a/pkgs/development/tools/wlhax/default.nix
+++ b/pkgs/development/tools/wlhax/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildGoModule
+, fetchFromSourcehut
+}:
+
+buildGoModule rec {
+  pname = "wlhax";
+  version = "unstable-2022-04-17";
+
+  src = fetchFromSourcehut {
+    owner = "~kennylevinsen";
+    repo = "wlhax";
+    rev = "a8e83a4dc1c0c4ebf7bd2f3103abae2d148941f9";
+    sha256 = "sha256-1sCS4HKmegiwjdCF+vYH/yyBFpxblZeld6aQxflCm8Q=";
+  };
+
+  vendorSha256 = "sha256-1zAKVg+l1frdE+PYgc0sjjQ+v/OJa9b7leikPwbDl3o=";
+
+  meta = with lib; {
+    description = "Wayland proxy that monitors and displays various application state, such as the current surface tree, in a nice little TUI.";
+    homepage = "https://git.sr.ht/~kennylevinsen/wlhax";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ emantor ];
+    mainProgram = "wl_hax";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3441,6 +3441,8 @@ with pkgs;
 
   wl-mirror = callPackage ../tools/wayland/wl-mirror { };
 
+  wlhax = callPackage ../development/tools/wlhax { };
+
   wlogout = callPackage ../tools/wayland/wlogout { };
 
   wlopm = callPackage ../tools/wayland/wlopm { };


### PR DESCRIPTION
Add wlhax, a terminal based wayland proxy which exposes the wayland interface messages.

###### Description of changes

Add wlhax for wayland debugging.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
