### PR TITLE
python3Packages.reportlab: Ignore special casing for m1 macs

### DIFF
--- a/pkgs/development/python-modules/reportlab/darwin-m1-compat.patch
+++ b/pkgs/development/python-modules/reportlab/darwin-m1-compat.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index 7625074..b3aa2fc 100644
+--- a/setup.py
++++ b/setup.py
+@@ -249,7 +249,7 @@ class inc_lib_dirs:
+             aDir(L, os.path.join("/usr/lib", "python%s" % sys.version[:3], "config"))
+         elif platform == "darwin":
+             machine = sysconfig_platform.split('-')[-1]
+-            if machine=='arm64' or os.environ.get('ARCHFLAGS','')=='-arch arm64':
++            if False and machine=='arm64' or os.environ.get('ARCHFLAGS','')=='-arch arm64':
+                 #print('!!!!! detected darwin arm64 build')
+                 #probably an M1
+                 target = pjoin(

--- a/pkgs/development/python-modules/reportlab/default.nix
+++ b/pkgs/development/python-modules/reportlab/default.nix
@@ -19,6 +19,10 @@ in buildPythonPackage rec {
     sha256 = "sha256-BPxEIPBUiBXQYj4DHIah9/PzAD5pnZr3FIdC4tcrAko=";
   };
 
+  patches = [
+    ./darwin-m1-compat.patch
+  ];
+
   checkInputs = [ glibcLocales ];
 
   buildInputs = [ ft pillow ];


### PR DESCRIPTION
Some special casing for darwin seems to cause issues.

Closes #191460

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
