### PR TITLE
peertube: fix with openssl 3

### DIFF
--- a/pkgs/servers/peertube/0001-Add-compat-with-openssl-3.patch
+++ b/pkgs/servers/peertube/0001-Add-compat-with-openssl-3.patch
@@ -1,0 +1,254 @@
+From 13d3234e4e265b11f62176da4c71a56377e39208 Mon Sep 17 00:00:00 2001
+From: Chocobozzz <me@florianbigard.com>
+Date: Tue, 12 Jul 2022 10:54:21 +0200
+Subject: [PATCH] Add compat with openssl 3
+
+---
+ package.json                                  |  4 +-
+ server/helpers/core-utils.ts                  | 56 +++++++++++++++++--
+ .../custom-validators/activitypub/actor.ts    |  4 +-
+ server/helpers/peertube-crypto.ts             |  9 +--
+ .../migrations/0605-actor-missing-keys.ts     |  7 +--
+ yarn.lock                                     | 25 ++-------
+ 6 files changed, 63 insertions(+), 42 deletions(-)
+
+diff --git a/package.json b/package.json
+index 2e7530e4d..67df7d22e 100644
+--- a/package.json
++++ b/package.json
+@@ -85,7 +85,7 @@
+     "@aws-sdk/node-http-handler": "^3.82.0",
+     "@babel/parser": "7.17.8",
+     "@peertube/feed": "^5.0.1",
+-    "@peertube/http-signature": "^1.6.0",
++    "@peertube/http-signature": "^1.7.0",
+     "@uploadx/core": "^5.1.2",
+     "async": "^3.0.1",
+     "async-lru": "^1.1.1",
+@@ -135,7 +135,6 @@
+     "oauth2-server": "3.1.1",
+     "parse-torrent": "^9.1.0",
+     "password-generator": "^2.0.2",
+-    "pem": "^1.12.3",
+     "pg": "^8.2.1",
+     "prompt": "^1.0.0",
+     "proxy-addr": "^2.0.7",
+@@ -189,7 +188,6 @@
+     "@types/node": "^14.14.31",
+     "@types/nodemailer": "^6.2.0",
+     "@types/oauth2-server": "^3.0.8",
+-    "@types/pem": "^1.9.3",
+     "@types/request": "^2.0.3",
+     "@types/supertest": "^2.0.3",
+     "@types/validator": "^13.0.0",
+diff --git a/server/helpers/core-utils.ts b/server/helpers/core-utils.ts
+index 0ec45eb2e..49e1e0fc6 100644
+--- a/server/helpers/core-utils.ts
++++ b/server/helpers/core-utils.ts
+@@ -6,9 +6,8 @@
+ */
+ 
+ import { exec, ExecOptions } from 'child_process'
+-import { randomBytes } from 'crypto'
++import { ED25519KeyPairOptions, generateKeyPair, randomBytes, RSAKeyPairOptions } from 'crypto'
+ import { truncate } from 'lodash'
+-import { createPrivateKey as createPrivateKey_1, getPublicKey as getPublicKey_1 } from 'pem'
+ import { pipeline } from 'stream'
+ import { URL } from 'url'
+ import { promisify } from 'util'
+@@ -217,6 +216,51 @@ function toEven (num: number) {
+ 
+ // ---------------------------------------------------------------------------
+ 
++function generateRSAKeyPairPromise (size: number) {
++  return new Promise<{ publicKey: string, privateKey: string }>((res, rej) => {
++    const options: RSAKeyPairOptions<'pem', 'pem'> = {
++      modulusLength: size,
++      publicKeyEncoding: {
++        type: 'spki',
++        format: 'pem'
++      },
++      privateKeyEncoding: {
++        type: 'pkcs1',
++        format: 'pem'
++      }
++    }
++
++    generateKeyPair('rsa', options, (err, publicKey, privateKey) => {
++      if (err) return rej(err)
++
++      return res({ publicKey, privateKey })
++    })
++  })
++}
++
++function generateED25519KeyPairPromise () {
++  return new Promise<{ publicKey: string, privateKey: string }>((res, rej) => {
++    const options: ED25519KeyPairOptions<'pem', 'pem'> = {
++      publicKeyEncoding: {
++        type: 'spki',
++        format: 'pem'
++      },
++      privateKeyEncoding: {
++        type: 'pkcs8',
++        format: 'pem'
++      }
++    }
++
++    generateKeyPair('ed25519', options, (err, publicKey, privateKey) => {
++      if (err) return rej(err)
++
++      return res({ publicKey, privateKey })
++    })
++  })
++}
++
++// ---------------------------------------------------------------------------
++
+ function promisify0<A> (func: (cb: (err: any, result: A) => void) => void): () => Promise<A> {
+   return function promisified (): Promise<A> {
+     return new Promise<A>((resolve: (arg: A) => void, reject: (err: any) => void) => {
+@@ -243,8 +287,6 @@ function promisify2<T, U, A> (func: (arg1: T, arg2: U, cb: (err: any, result: A)
+ }
+ 
+ const randomBytesPromise = promisify1<number, Buffer>(randomBytes)
+-const createPrivateKey = promisify1<number, { key: string }>(createPrivateKey_1)
+-const getPublicKey = promisify1<string, { publicKey: string }>(getPublicKey_1)
+ const execPromise2 = promisify2<string, any, string>(exec)
+ const execPromise = promisify1<string, string>(exec)
+ const pipelinePromise = promisify(pipeline)
+@@ -272,8 +314,10 @@ export {
+   promisify2,
+ 
+   randomBytesPromise,
+-  createPrivateKey,
+-  getPublicKey,
++
++  generateRSAKeyPairPromise,
++  generateED25519KeyPairPromise,
++
+   execPromise2,
+   execPromise,
+   pipelinePromise,
+diff --git a/server/helpers/custom-validators/activitypub/actor.ts b/server/helpers/custom-validators/activitypub/actor.ts
+index a4b152722..f43c35b23 100644
+--- a/server/helpers/custom-validators/activitypub/actor.ts
++++ b/server/helpers/custom-validators/activitypub/actor.ts
+@@ -41,9 +41,9 @@ function isActorPreferredUsernameValid (preferredUsername: string) {
+ function isActorPrivateKeyValid (privateKey: string) {
+   return exists(privateKey) &&
+     typeof privateKey === 'string' &&
+-    privateKey.startsWith('-----BEGIN RSA PRIVATE KEY-----') &&
++    (privateKey.startsWith('-----BEGIN RSA PRIVATE KEY-----') || privateKey.startsWith('-----BEGIN PRIVATE KEY-----')) &&
+     // Sometimes there is a \n at the end, so just assert the string contains the end mark
+-    privateKey.includes('-----END RSA PRIVATE KEY-----') &&
++    (privateKey.includes('-----END RSA PRIVATE KEY-----') || privateKey.includes('-----END PRIVATE KEY-----')) &&
+     validator.isLength(privateKey, CONSTRAINTS_FIELDS.ACTORS.PRIVATE_KEY)
+ }
+ 
+diff --git a/server/helpers/peertube-crypto.ts b/server/helpers/peertube-crypto.ts
+index 1a7ee24a7..1d9cab2ce 100644
+--- a/server/helpers/peertube-crypto.ts
++++ b/server/helpers/peertube-crypto.ts
+@@ -5,7 +5,7 @@ import { cloneDeep } from 'lodash'
+ import { sha256 } from '@shared/extra-utils'
+ import { BCRYPT_SALT_SIZE, HTTP_SIGNATURE, PRIVATE_RSA_KEY_SIZE } from '../initializers/constants'
+ import { MActor } from '../types/models'
+-import { createPrivateKey, getPublicKey, promisify1, promisify2 } from './core-utils'
++import { generateRSAKeyPairPromise, promisify1, promisify2 } from './core-utils'
+ import { jsonld } from './custom-jsonld-signature'
+ import { logger } from './logger'
+ 
+@@ -15,13 +15,10 @@ const bcryptHashPromise = promisify2<any, string | number, string>(hash)
+ 
+ const httpSignature = require('@peertube/http-signature')
+ 
+-async function createPrivateAndPublicKeys () {
++function createPrivateAndPublicKeys () {
+   logger.info('Generating a RSA key...')
+ 
+-  const { key } = await createPrivateKey(PRIVATE_RSA_KEY_SIZE)
+-  const { publicKey } = await getPublicKey(key)
+-
+-  return { privateKey: key, publicKey }
++  return generateRSAKeyPairPromise(PRIVATE_RSA_KEY_SIZE)
+ }
+ 
+ // User password checks
+diff --git a/server/initializers/migrations/0605-actor-missing-keys.ts b/server/initializers/migrations/0605-actor-missing-keys.ts
+index 72d9b359d..aa89a500c 100644
+--- a/server/initializers/migrations/0605-actor-missing-keys.ts
++++ b/server/initializers/migrations/0605-actor-missing-keys.ts
+@@ -1,5 +1,5 @@
+ import * as Sequelize from 'sequelize'
+-import { createPrivateKey, getPublicKey } from '../../helpers/core-utils'
++import { generateRSAKeyPairPromise } from '../../helpers/core-utils'
+ import { PRIVATE_RSA_KEY_SIZE } from '../constants'
+ 
+ async function up (utils: {
+@@ -15,10 +15,9 @@ async function up (utils: {
+     const actors = await utils.sequelize.query<any>(query, options)
+ 
+     for (const actor of actors) {
+-      const { key } = await createPrivateKey(PRIVATE_RSA_KEY_SIZE)
+-      const { publicKey } = await getPublicKey(key)
++      const { privateKey, publicKey } = await generateRSAKeyPairPromise(PRIVATE_RSA_KEY_SIZE)
+ 
+-      const queryUpdate = `UPDATE "actor" SET "publicKey" = '${publicKey}', "privateKey" = '${key}' WHERE id = ${actor.id}`
++      const queryUpdate = `UPDATE "actor" SET "publicKey" = '${publicKey}', "privateKey" = '${privateKey}' WHERE id = ${actor.id}`
+       await utils.sequelize.query(queryUpdate)
+     }
+   }
+diff --git a/yarn.lock b/yarn.lock
+index 9f0654709..9bd2e9bb4 100644
+--- a/yarn.lock
++++ b/yarn.lock
+@@ -1601,10 +1601,10 @@
+   dependencies:
+     xml-js "^1.6.11"
+ 
+-"@peertube/http-signature@^1.6.0":
+-  version "1.6.0"
+-  resolved "https://registry.yarnpkg.com/@peertube/http-signature/-/http-signature-1.6.0.tgz#22bef028384e6437e8dbd94052ba7b8bd7f7f1ae"
+-  integrity sha512-Bx780c7FPYtkV4LgCoaJcXYcKQqaMef2iQR2V2r5klkYkIQWFxbTOpyhKxvVXYIBIFpj5Cb8DGVDAmhkm7aavg==
++"@peertube/http-signature@^1.7.0":
++  version "1.7.0"
++  resolved "https://registry.yarnpkg.com/@peertube/http-signature/-/http-signature-1.7.0.tgz#12a84f3fc62e786aa3a2eb09426417bad65736dc"
++  integrity sha512-aGQIwo6/sWtyyqhVK4e1MtxYz4N1X8CNt6SOtCc+Wnczs5S5ONaLHDDR8LYaGn0MgOwvGgXyuZ5sJIfd7iyoUw==
+   dependencies:
+     assert-plus "^1.0.0"
+     jsprim "^1.2.2"
+@@ -2006,13 +2006,6 @@
+     "@types/node" "*"
+     "@types/parse-torrent-file" "*"
+ 
+-"@types/pem@^1.9.3":
+-  version "1.9.6"
+-  resolved "https://registry.yarnpkg.com/@types/pem/-/pem-1.9.6.tgz#c3686832e935947fdd9d848dec3b8fe830068de7"
+-  integrity sha512-IC67SxacM9fxEi/w7hf98dTun83OwUMeLMo1NS2gE0wdM9MHeg73iH/Pp9nB02OUCQ7Zb2UuKE/IpFCmQw9jxw==
+-  dependencies:
+-    "@types/node" "*"
+-
+ "@types/qs@*":
+   version "6.9.7"
+   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
+@@ -6973,16 +6966,6 @@ peek-stream@^1.1.1:
+     duplexify "^3.5.0"
+     through2 "^2.0.3"
+ 
+-pem@^1.12.3:
+-  version "1.14.6"
+-  resolved "https://registry.yarnpkg.com/pem/-/pem-1.14.6.tgz#89babca3a73466fb844df70666dbf1b25eb0dc56"
+-  integrity sha512-I5GKUer2PPv5qzUfxaZ6IGRkhp+357Kyv2t1JJg9vP8hGGI13qU34N2QupmggbpIZGPuudH0jn8KU5hjFpPk3g==
+-  dependencies:
+-    es6-promisify "^6.0.0"
+-    md5 "^2.2.1"
+-    os-tmpdir "^1.0.1"
+-    which "^2.0.2"
+-
+ pg-connection-string@^2.5.0:
+   version "2.5.0"
+   resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.5.0.tgz#538cadd0f7e603fc09a12590f3b8a452c2c0cf34"
+-- 
+2.36.2
+

--- a/pkgs/servers/peertube/default.nix
+++ b/pkgs/servers/peertube/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, callPackage, fetchurl, fetchFromGitHub, buildGoModule, fetchYarnDeps, nixosTests
+{ lib, stdenv, applyPatches, fetchurl, fetchFromGitHub, fetchYarnDeps, nixosTests
 , fixup_yarn_lock, jq, nodejs, yarn
 }:
 let
@@ -8,16 +8,23 @@ let
 
   version = "4.2.2";
 
-  source = fetchFromGitHub {
-    owner = "Chocobozzz";
-    repo = "PeerTube";
-    rev = "v${version}";
-    sha256 = "sha256-q6wSk5AO91Z6dw5MgpO7QTAlA8Q5Xx1CboBr7SElVUA=";
+  source = applyPatches {
+    src = fetchFromGitHub {
+      owner = "Chocobozzz";
+      repo = "PeerTube";
+      rev = "v${version}";
+      sha256 = "sha256-q6wSk5AO91Z6dw5MgpO7QTAlA8Q5Xx1CboBr7SElVUA=";
+    };
+
+    patches = [
+      # https://github.com/Chocobozzz/PeerTube/commit/5d7cb63ede7c4bba93954c0586f589ad9748d5ea
+      ./0001-Add-compat-with-openssl-3.patch
+    ];
   };
 
   yarnOfflineCacheServer = fetchYarnDeps {
     yarnLock = "${source}/yarn.lock";
-    sha256 = "sha256-MMsxh20jcbW4YYsJyoupKbT9+Xa1BWZAmYHoj2/t+LM=";
+    sha256 = "sha256-sJ7UCsjb2qZOYa/PVqqBV0eOopDyVLyM8DVsBUBM/lQ=";
   };
 
   yarnOfflineCacheTools = fetchYarnDeps {
@@ -46,6 +53,7 @@ in stdenv.mkDerivation rec {
   buildPhase = ''
     # Build node modules
     export HOME=$PWD
+    export NODE_OPTIONS=--openssl-legacy-provider # required for webpack compatibility with OpenSSL 3 (https://github.com/webpack/webpack/issues/14532)
     fixup_yarn_lock ~/yarn.lock
     fixup_yarn_lock ~/server/tools/yarn.lock
     fixup_yarn_lock ~/client/yarn.lock


### PR DESCRIPTION
###### Description of changes

This fixes peertube to work with openssl 3. Two things were changed to achieve this:

Webpack needs to be run with `NODE_OPTIONS=--openssl-legacy-provider` as described in https://github.com/webpack/webpack/issues/14532. This is the case even though PeerTube already uses a recent webpack version (updating it also did not make it work without the workaround).

An [upstream patch](https://github.com/Chocobozzz/PeerTube/commit/5d7cb63ede7c4bba93954c0586f589ad9748d5ea) is applied to the source. Because it did not apply to the tagged version, I had to rebase it and include the file. Also, the yarn lockfile had to be included because fetchYarnDeps doesn’t use the patched file from the main derivation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

I did not test this on an actual deployment, only with the NixOS system test.

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
