### PR TITLE
stratis-cli: add checks to itself and various dependencies

### DIFF
--- a/pkgs/development/python-modules/dbus-python-client-gen/default.nix
+++ b/pkgs/development/python-modules/dbus-python-client-gen/default.nix
@@ -21,9 +21,12 @@ buildPythonPackage rec {
     into-dbus-python
     dbus-python
   ];
+
   checkInputs = [
     pytestCheckHook
   ];
+
+  pythonImportsCheck = [ "dbus_python_client_gen" ];
 
   meta = with lib; {
     description = "A Python library for generating dbus-python client code";

--- a/pkgs/development/python-modules/dbus-signature-pyparsing/default.nix
+++ b/pkgs/development/python-modules/dbus-signature-pyparsing/default.nix
@@ -25,6 +25,8 @@ buildPythonPackage rec {
     hs-dbus-signature
   ];
 
+  pythonImportsCheck = [ "dbus_signature_pyparsing" ];
+
   meta = with lib; {
     description = "A Parser for a D-Bus Signature";
     homepage = "https://github.com/stratis-storage/dbus-signature-pyparsing";

--- a/pkgs/development/python-modules/hs-dbus-signature/default.nix
+++ b/pkgs/development/python-modules/hs-dbus-signature/default.nix
@@ -19,6 +19,8 @@ buildPythonPackage rec {
     hypothesis
   ];
 
+  pythonImportsCheck = [ "hs_dbus_signature" ];
+
   meta = with lib; {
     description = "A Hypothesis Strategy for Generating Arbitrary DBus Signatures";
     homepage = "https://github.com/stratis-storage/hs-dbus-signature";

--- a/pkgs/development/python-modules/into-dbus-python/default.nix
+++ b/pkgs/development/python-modules/into-dbus-python/default.nix
@@ -23,11 +23,14 @@ buildPythonPackage rec {
     dbus-signature-pyparsing
     dbus-python
   ];
+
   checkInputs = [
     pytestCheckHook
     hypothesis
     hs-dbus-signature
   ];
+
+  pythonImportsCheck = [ "into_dbus_python" ];
 
   meta = with lib; {
     description = "A transformer to dbus-python types";

--- a/pkgs/tools/filesystems/stratis-cli/default.nix
+++ b/pkgs/tools/filesystems/stratis-cli/default.nix
@@ -25,6 +25,18 @@ python3Packages.buildPythonApplication rec {
     packaging
   ];
 
+  checkInputs = with python3Packages; [
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # tests below require dbus daemon
+    "tests/whitebox/integration"
+    "tests/whitebox/monkey_patching"
+  ];
+
+  pythonImportsCheck = [ "stratis_cli" ];
+
   passthru.tests = nixosTests.stratis;
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes
Addresses https://github.com/NixOS/nixpkgs/pull/186940#pullrequestreview-1110738598
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
