### PR TITLE
Revert "cglm: install correct include/lib dir in pkg-config"

### DIFF
--- a/pkgs/development/libraries/cglm/default.nix
+++ b/pkgs/development/libraries/cglm/default.nix
@@ -17,11 +17,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  cmakeFlags = [
-    "-DCMAKE_INSTALL_INCLUDEDIR=include"
-    "-DCMAKE_INSTALL_LIBDIR=lib"
-  ];
-
   meta = with lib; {
     homepage = "https://github.com/recp/cglm";
     description = "Highly Optimized Graphics Math (glm) for C";


### PR DESCRIPTION
Reverts NixOS/nixpkgs#190982

https://github.com/NixOS/nixpkgs/commit/3bf5a3cecfe22d1a26662edad3e235a7cb2550e2 is already on staging, so this fix will conflict with those changes. It's better to fix things on staging.

I'm currently looking into just fixing this upstream (in cglm).