### PR TITLE
solana-validator: rename pkgconfig to pkg-config

### DIFF
--- a/pkgs/applications/blockchains/solana-validator/default.nix
+++ b/pkgs/applications/blockchains/solana-validator/default.nix
@@ -13,7 +13,6 @@
 , protobuf
 , clang
 , llvm
-, pkgconfig
 , openssl
 , libclang
 , rustfmt
@@ -74,7 +73,7 @@ rustPlatform.buildRustPackage rec {
     "-isystem ${libclang.lib}/lib/clang/${lib.getVersion clang}/include";
   LLVM_CONFIG_PATH = "${llvm}/bin/llvm-config";
 
-  nativeBuildInputs = [ clang llvm pkgconfig protobuf rustfmt perl ];
+  nativeBuildInputs = [ clang llvm pkg-config protobuf rustfmt perl ];
   buildInputs =
     [ openssl zlib libclang hidapi ] ++ (lib.optionals stdenv.isLinux [ udev ]);
   strictDeps = true;


### PR DESCRIPTION
solana-validator: rename pkgconfig to pkg-config

* to fix treewide eval

Assigned to @happysalada because of #189872