### PR TITLE
cf-terraforming: init at 0.8.5

### DIFF
--- a/pkgs/tools/misc/cf-terraforming/default.nix
+++ b/pkgs/tools/misc/cf-terraforming/default.nix
@@ -1,0 +1,32 @@
+{ buildGoModule, fetchFromGitHub, lib, cf-terraforming, testers }:
+
+buildGoModule rec {
+  pname = "cf-terraforming";
+  version = "0.8.5";
+
+  src = fetchFromGitHub {
+    owner = "cloudflare";
+    repo = "cf-terraforming";
+    rev = "v${version}";
+    sha256 = "1h0apmcddz1c32rlnjs81fjwpxpkz9n2zalwmk05frrgd8zdbixs";
+  };
+
+  vendorSha256 = "sha256-a/gUxW4/Kv1BuhXpwibb6u7gO8lBo250ark1kwMLToo=";
+  ldflags = [ "-X github.com/cloudflare/cf-terraforming/internal/app/cf-terraforming/cmd.versionString=${version}" ];
+
+  # The test suite insists on downloading a binary release of Terraform from
+  # Hashicorp at runtime, which isn't going to work in a nix build
+  doCheck = false;
+
+  passthru.tests = testers.testVersion {
+    package = cf-terraforming;
+    command = "cf-terraforming version";
+  };
+
+  meta = with lib; {
+    description = "A command line utility to facilitate terraforming your existing Cloudflare resources";
+    homepage = "https://github.com/cloudflare/cf-terraforming/";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ benley ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3287,6 +3287,8 @@ with pkgs;
     openssl = openssl_1_1;
   };
 
+  cf-terraforming = callPackage ../tools/misc/cf-terraforming { };
+
   charliecloud = callPackage ../applications/virtualization/charliecloud { };
 
   chelf = callPackage ../tools/misc/chelf { };


### PR DESCRIPTION
###### Description of changes

new package: cf-terraforming (https://github.com/cloudflare/cf-terraforming/)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

