### PR TITLE
pytestCheckHook: disable resource and deprecation warnings by default

### DIFF
--- a/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
@@ -33,6 +33,8 @@ function pytestCheckPhase() {
 
     # Compose arguments
     args=" -m pytest"
+    args+=" -W ignore::DeprecationWarning"
+    args+=" -W ignore::ResourceWarning"
     if [ -n "$disabledTests" ]; then
         disabledTestsString=$(_pytestComputeDisabledTestsString "${disabledTests[@]}")
       args+=" -k \""$disabledTestsString"\""

--- a/pkgs/development/python-modules/acoustics/default.nix
+++ b/pkgs/development/python-modules/acoustics/default.nix
@@ -39,10 +39,6 @@ buildPythonPackage rec {
     echo "backend: ps" > $HOME/.matplotlib/matplotlibrc
   '';
 
-  pytestFlagsArray = [
-    "-Wignore::DeprecationWarning"
-  ];
-
   disabledTestPaths = [
     # All tests fail with TypeError
     "tests/test_aio.py"

--- a/pkgs/development/python-modules/aiohttp-jinja2/default.nix
+++ b/pkgs/development/python-modules/aiohttp-jinja2/default.nix
@@ -35,11 +35,6 @@ buildPythonPackage rec {
       --replace " --cov=aiohttp_jinja2 --cov-report xml --cov-report html --cov-report term" ""
   '';
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
-  ];
-
   pythonImportsCheck = [
     "aiohttp_jinja2"
   ];

--- a/pkgs/development/python-modules/aiohttp-remotes/default.nix
+++ b/pkgs/development/python-modules/aiohttp-remotes/default.nix
@@ -42,8 +42,6 @@ buildPythonPackage rec {
   ];
 
   pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
     "--asyncio-mode=auto"
   ];
 

--- a/pkgs/development/python-modules/build/default.nix
+++ b/pkgs/development/python-modules/build/default.nix
@@ -51,11 +51,6 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
-  ];
-
   disabledTests = [
     # Tests often fail with StopIteration
     "test_isolat"

--- a/pkgs/development/python-modules/certbot/default.nix
+++ b/pkgs/development/python-modules/certbot/default.nix
@@ -47,9 +47,6 @@ buildPythonPackage rec {
 
   pytestFlagsArray = [
     "-o cache_dir=$(mktemp -d)"
-    # See https://github.com/certbot/certbot/issues/8746
-    "-W ignore::ResourceWarning"
-    "-W ignore::DeprecationWarning"
   ];
 
   doCheck = true;

--- a/pkgs/development/python-modules/cherrypy/default.nix
+++ b/pkgs/development/python-modules/cherrypy/default.nix
@@ -64,11 +64,6 @@ buildPythonPackage rec {
     requests-toolbelt
   ];
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
-  ];
-
   disabledTests = [
     # Keyboard interrupt ends test suite run
     "KeyboardInterrupt"

--- a/pkgs/development/python-modules/fastapi/default.nix
+++ b/pkgs/development/python-modules/fastapi/default.nix
@@ -55,12 +55,6 @@ buildPythonPackage rec {
     trio
   ] ++ passlib.optional-dependencies.bcrypt;
 
-  pytestFlagsArray = [
-    # ignoring deprecation warnings to avoid test failure from
-    # tests/test_tutorial/test_testing/test_tutorial001.py
-    "-W ignore::DeprecationWarning"
-  ];
-
   disabledTestPaths = [
     # Disabled tests require orjson which requires rust nightly
     "tests/test_default_response_class.py"

--- a/pkgs/development/python-modules/flax/default.nix
+++ b/pkgs/development/python-modules/flax/default.nix
@@ -60,7 +60,6 @@ buildPythonPackage rec {
 
   pytestFlagsArray = [
     "-W ignore::FutureWarning"
-    "-W ignore::DeprecationWarning"
   ];
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/globus-sdk/default.nix
+++ b/pkgs/development/python-modules/globus-sdk/default.nix
@@ -46,11 +46,6 @@ buildPythonPackage rec {
     --replace "pyjwt[crypto]>=2.0.0,<3.0.0" "pyjwt[crypto]>=2.0.0,<3.0.0"
   '';
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
-  ];
-
   pythonImportsCheck = [
     "globus_sdk"
   ];

--- a/pkgs/development/python-modules/httpx/default.nix
+++ b/pkgs/development/python-modules/httpx/default.nix
@@ -84,11 +84,6 @@ buildPythonPackage rec {
     export PYTHONPATH=$out/${python.sitePackages}:$PYTHONPATH
   '';
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
-  ];
-
   disabledTests = [
     # httpcore.ConnectError: [Errno 101] Network is unreachable
     "test_connect_timeout"

--- a/pkgs/development/python-modules/jax/default.nix
+++ b/pkgs/development/python-modules/jax/default.nix
@@ -62,7 +62,6 @@ buildPythonPackage rec {
   # anyhow.
   pytestFlagsArray = [
     "--numprocesses=4"
-    "-W ignore::DeprecationWarning"
     "tests/"
   ];
 

--- a/pkgs/development/python-modules/jupyterlab_server/default.nix
+++ b/pkgs/development/python-modules/jupyterlab_server/default.nix
@@ -56,12 +56,6 @@ buildPythonPackage rec {
     export HOME=$(mktemp -d)
   '';
 
-  pytestFlagsArray = [
-    # DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12.
-    # Use setuptools or check PEP 632 for potential alternatives.
-    "-W ignore::DeprecationWarning"
-  ];
-
   __darwinAllowLocalNetworking = true;
 
   meta = with lib; {

--- a/pkgs/development/python-modules/marshmallow-dataclass/default.nix
+++ b/pkgs/development/python-modules/marshmallow-dataclass/default.nix
@@ -35,12 +35,6 @@ buildPythonPackage rec {
     typeguard
   ];
 
-  pytestFlagsArray = [
-    # DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12.
-    "-W"
-    "ignore::DeprecationWarning"
-  ];
-
   disabledTests = lib.optionals (pythonAtLeast "3.10") [
     # TypeError: UserId is not a dataclass and cannot be turned into one.
     "test_newtype"

--- a/pkgs/development/python-modules/nbconvert/default.nix
+++ b/pkgs/development/python-modules/nbconvert/default.nix
@@ -72,11 +72,6 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [
-    # DeprecationWarning: Support for bleach <5 will be removed in a future version of nbconvert
-    "-W ignore::DeprecationWarning"
-  ];
-
   disabledTests = [
     # Attempts network access (Failed to establish a new connection: [Errno -3] Temporary failure in name resolution)
     "test_export"

--- a/pkgs/development/python-modules/pelican/default.nix
+++ b/pkgs/development/python-modules/pelican/default.nix
@@ -80,11 +80,6 @@ buildPythonPackage rec {
       --replace "'git'" "'${git}/bin/git'"
   '';
 
-  pytestFlagsArray = [
-    # DeprecationWarning: 'jinja2.Markup' is deprecated and...
-    "-W ignore::DeprecationWarning"
-  ];
-
   disabledTests = [
     # AssertionError
     "test_basic_generation_works"

--- a/pkgs/development/python-modules/pims/default.nix
+++ b/pkgs/development/python-modules/pims/default.nix
@@ -38,11 +38,6 @@ buildPythonPackage rec {
     "pims"
   ];
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
-  ];
-
   disabledTests = [
     # NotImplementedError: Do not know how to deal with infinite readers
     "TestVideo_ImageIO"

--- a/pkgs/development/python-modules/rtoml/default.nix
+++ b/pkgs/development/python-modules/rtoml/default.nix
@@ -50,11 +50,6 @@ buildPythonPackage rec {
     cd tests
   '';
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
-  ];
-
   meta = with lib; {
     description = "Rust based TOML library for Python";
     homepage = "https://github.com/samuelcolvin/rtoml";

--- a/pkgs/development/python-modules/sunpy/default.nix
+++ b/pkgs/development/python-modules/sunpy/default.nix
@@ -144,11 +144,6 @@ buildPythonPackage rec {
     "sunpy/io/setup_package.py"
   ];
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
-  ];
-
   # Wants a configuration file
   # pythonImportsCheck = [
   #   "sunpy"

--- a/pkgs/development/python-modules/trio-asyncio/default.nix
+++ b/pkgs/development/python-modules/trio-asyncio/default.nix
@@ -38,12 +38,6 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [
-    # https://github.com/python-trio/trio-asyncio/issues/112
-    "-W"
-    "ignore::DeprecationWarning"
-  ];
-
   disabledTestPaths = [
     "tests/python" # tries to import internal API test.test_asyncio
   ];

--- a/pkgs/development/python-modules/trio/default.nix
+++ b/pkgs/development/python-modules/trio/default.nix
@@ -63,10 +63,6 @@ buildPythonPackage rec {
     "fallback_when_no_hook_claims_it"
   ];
 
-  pytestFlagsArray = [
-    "-W" "ignore::DeprecationWarning"
-  ];
-
   meta = {
     description = "An async/await-native I/O library for humans and snake people";
     homepage = "https://github.com/python-trio/trio";

--- a/pkgs/development/python-modules/wheel-inspect/default.nix
+++ b/pkgs/development/python-modules/wheel-inspect/default.nix
@@ -51,11 +51,6 @@ buildPythonPackage rec {
     "wheel_inspect"
   ];
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
-  ];
-
   meta = with lib; {
     description = "Extract information from wheels";
     homepage = "https://github.com/jwodder/wheel-inspect";

--- a/pkgs/tools/security/maigret/default.nix
+++ b/pkgs/tools/security/maigret/default.nix
@@ -69,11 +69,6 @@ python3.pkgs.buildPythonApplication rec {
       --replace "future-annotations" ""
   '';
 
-  pytestFlagsArray = [
-    # DeprecationWarning: There is no current event loop
-    "-W ignore::DeprecationWarning"
-  ];
-
   disabledTests = [
     # Tests require network access
     "test_extract_ids_from_page"


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
