### PR TITLE
ocamlPackages.paf: 0.0.8 → 0.1.0; hpack, h2: 0.8.0 → 0.9.0

### DIFF
--- a/pkgs/development/ocaml-modules/h2/default.nix
+++ b/pkgs/development/ocaml-modules/h2/default.nix
@@ -28,10 +28,9 @@ buildDunePackage rec {
   inherit (hpack)
     version
     src
-    useDune2
     ;
 
-  minimumOCamlVersion = "4.06";
+  minimalOCamlVersion = "4.06";
 
   propagatedBuildInputs = [
     angstrom
@@ -42,7 +41,7 @@ buildDunePackage rec {
     httpaf
   ];
 
-  # Tests fail with 4.06
+  # Tests fail with ≤ 4.07
   doCheck = lib.versionAtLeast ocaml.version "4.08";
   preCheck = ''
     ln -s "${http2-frame-test-case}" lib_test/http2-frame-test-case

--- a/pkgs/development/ocaml-modules/hpack/default.nix
+++ b/pkgs/development/ocaml-modules/hpack/default.nix
@@ -7,15 +7,14 @@
 
 buildDunePackage rec {
   pname = "hpack";
-  version = "0.8.0";
+  version = "0.9.0";
 
   src = fetchurl {
     url = "https://github.com/anmonteiro/ocaml-h2/releases/download/${version}/h2-${version}.tbz";
-    sha256 = "0qcn3yvyz0h419fjg9nb20csfmwmh3ihz0zb0jfzdycf5w4mlry6";
+    sha256 = "sha256-7gjRhJs2mufQbImAXiKFT9mZ1kHGSHHwjCVZM5f0C14=";
   };
 
-  useDune2 = true;
-  minimumOCamlVersion = "4.04";
+  minimalOCamlVersion = "4.04";
 
   propagatedBuildInputs = [
     angstrom

--- a/pkgs/development/ocaml-modules/paf/cohttp.nix
+++ b/pkgs/development/ocaml-modules/paf/cohttp.nix
@@ -22,8 +22,6 @@ buildDunePackage {
   inherit (paf)
     version
     src
-    useDune2
-    minimumOCamlVersion
   ;
 
   propagatedBuildInputs = [
@@ -34,7 +32,7 @@ buildDunePackage {
     ipaddr
   ];
 
-  doCheck = false;  # tests fail
+  doCheck = true;
   checkInputs = [
     alcotest-lwt
     fmt

--- a/pkgs/development/ocaml-modules/paf/default.nix
+++ b/pkgs/development/ocaml-modules/paf/default.nix
@@ -25,15 +25,14 @@
 
 buildDunePackage rec {
   pname = "paf";
-  version = "0.0.8";
+  version = "0.1.0";
 
   src = fetchurl {
     url = "https://github.com/dinosaure/paf-le-chien/releases/download/${version}/paf-${version}.tbz";
-    sha256 = "CyIIV11G7oUPPHuhov52LP4Ih4pY6bcUApD23/9q39k=";
+    sha256 = "sha256-JIJjECEbajauowbXot19vtiDhTpGAQiSCBY0AHZOyZM=";
   };
 
-  useDune2 = true;
-  minimumOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.08";
 
   propagatedBuildInputs = [
     mirage-stack
@@ -49,7 +48,7 @@ buildDunePackage rec {
     tcpip
   ];
 
-  doCheck = false;
+  doCheck = true;
   checkInputs = [
     lwt
     logs

--- a/pkgs/development/ocaml-modules/paf/le.nix
+++ b/pkgs/development/ocaml-modules/paf/le.nix
@@ -17,8 +17,6 @@ buildDunePackage {
   inherit (paf)
     version
     src
-    useDune2
-    minimumOCamlVersion
   ;
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Description of changes

https://github.com/dinosaure/paf-le-chien/blob/0.1.0/CHANGES.md#010-2022-08-28-paris---france
https://github.com/anmonteiro/ocaml-h2/blob/0.9.0/CHANGES.md#090-2022-08-14

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
