### PR TITLE
Libvirtd zfs storage

### DIFF
--- a/pkgs/development/libraries/libvirt/0002-substitute-zfs-and-zpool-commands.patch
+++ b/pkgs/development/libraries/libvirt/0002-substitute-zfs-and-zpool-commands.patch
@@ -1,0 +1,27 @@
+From dc5e3df2fd29a547ef0f9545e190a0ce3a73c95c Mon Sep 17 00:00:00 2001
+From: Tako Marks <me@github.tako.mx>
+Date: Tue, 6 Sep 2022 20:19:26 +0200
+Subject: [PATCH] substitute zfs and zpool commands
+
+---
+ src/storage/storage_backend_zfs.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/storage/storage_backend_zfs.c b/src/storage/storage_backend_zfs.c
+index 2a5d74357d..460b3025c4 100644
+--- a/src/storage/storage_backend_zfs.c
++++ b/src/storage/storage_backend_zfs.c
+@@ -33,8 +33,8 @@
+ 
+ VIR_LOG_INIT("storage.storage_backend_zfs");
+ 
+-#define ZFS "zfs"
+-#define ZPOOL "zpool"
++#define ZFS "@zfs@"
++#define ZPOOL "@zpool@"
+ 
+ /*
+  * Some common flags of zfs and zpool commands we use:
+-- 
+2.36.2
+

--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -33,6 +33,7 @@
 , readline
 , rpcsvc-proto
 , stdenv
+, substituteAll
 , xhtml1
 , yajl
 , writeScript
@@ -126,6 +127,11 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./0001-meson-patch-in-an-install-prefix-for-building-on-nix.patch
+    (substituteAll {
+      src = ./0002-substitute-zfs-and-zpool-commands.patch;
+      zfs = "${zfs}/bin/zfs";
+      zpool = "${zfs}/bin/zpool";
+    })
   ];
 
   # remove some broken tests


### PR DESCRIPTION
###### Description of changes
Patches `libvirtd` ZFS storage driver to use nix-store paths for `zfs` userspace tools that are necessary for operating the storage driver.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
