### PR TITLE
kluctl: init at 2.16.0

### DIFF
--- a/pkgs/applications/networking/cluster/kluctl/default.nix
+++ b/pkgs/applications/networking/cluster/kluctl/default.nix
@@ -1,0 +1,32 @@
+{ lib, stdenv, buildGoModule, fetchFromGitHub, testers, kluctl }:
+
+buildGoModule rec {
+  pname = "kluctl";
+  version = "2.16.0";
+
+  src = fetchFromGitHub {
+    owner = "kluctl";
+    repo = "kluctl";
+    rev = "v${version}";
+    hash = "sha256-NwjPClD3P9EP7gKPPgKXI3h+kLeGPd7Gf6gZXMCCLHk=";
+  };
+
+  vendorHash = "sha256-IC+sjctDqd0lQD5labl+UYWsRiptQKSjSHYf2SGkp14=";
+
+  ldflags = [ "-s" "-w" "-X main.version=v${version}" ];
+
+  # Depends on docker
+  doCheck = false;
+
+  passthru.tests.version = testers.testVersion {
+    package = kluctl;
+    version = "v${version}";
+  };
+
+  meta = with lib; {
+    description = "The missing glue to put together large Kubernetes deployments";
+    homepage = "https://kluctl.io/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ sikmir ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8273,6 +8273,8 @@ with pkgs;
     buildGoModule = buildGo117Module;
   };
 
+  kluctl = callPackage ../applications/networking/cluster/kluctl { };
+
   kibana7 = callPackage ../development/tools/misc/kibana/7.x.nix { };
   kibana = kibana7;
 


### PR DESCRIPTION
###### Description of changes
Resolves #187888

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
