### PR TITLE
rizin: 0.4.0 -> 0.4.1

### DIFF
--- a/pkgs/development/libraries/capstone/default.nix
+++ b/pkgs/development/libraries/capstone/default.nix
@@ -1,4 +1,9 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, fixDarwinDylibNames
+}:
 
 stdenv.mkDerivation rec {
   pname = "capstone";
@@ -31,6 +36,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     pkg-config
+  ] ++ lib.optionals stdenv.isDarwin [
+    fixDarwinDylibNames
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/development/tools/analysis/rizin/default.nix
+++ b/pkgs/development/tools/analysis/rizin/default.nix
@@ -58,6 +58,9 @@ stdenv.mkDerivation rec {
       fi
     done
     export LIBRARY_PATH
+  '' + lib.optionalString stdenv.isDarwin ''
+    substituteInPlace binrz/rizin/macos_sign.sh \
+      --replace 'codesign' '# codesign'
   '';
 
   buildInputs = [
@@ -81,6 +84,6 @@ stdenv.mkDerivation rec {
     homepage = "https://rizin.re/";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ raskin makefu mic92 ];
-    platforms = with lib.platforms; linux;
+    platforms = with lib.platforms; unix;
   };
 }

--- a/pkgs/development/tools/analysis/rizin/default.nix
+++ b/pkgs/development/tools/analysis/rizin/default.nix
@@ -18,16 +18,15 @@
 , ninja
 , capstone
 , tree-sitter
-, python3
 }:
 
 stdenv.mkDerivation rec {
   pname = "rizin";
-  version = "0.4.0";
+  version = "0.4.1";
 
   src = fetchurl {
     url = "https://github.com/rizinorg/rizin/releases/download/v${version}/rizin-src-v${version}.tar.xz";
-    sha256 = "sha256-CeuoaE/oE89Cpxa1mobT1lr84BPX6LJ14UXoSdM2a1o=";
+    sha256 = "sha256-Zp2Va5l4IKNuQjzzXUgqqZhJJUuWWM72hERZkS39v7g=";
   };
 
   mesonFlags = [
@@ -41,7 +40,13 @@ stdenv.mkDerivation rec {
     "-Duse_sys_tree_sitter=enabled"
   ];
 
-  nativeBuildInputs = [ pkg-config meson ninja cmake (python3.withPackages (ps: [ ps.setuptools ])) ];
+  nativeBuildInputs = [
+    pkg-config
+    meson
+    meson.python3.pkgs.pyyaml
+    ninja
+    cmake
+  ];
 
   # meson's find_library seems to not use our compiler wrapper if static parameter
   # is either true/false... We work around by also providing LIBRARY_PATH

--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -103,6 +103,10 @@ python3.pkgs.buildPythonApplication rec {
     installShellCompletion --bash data/shell-completions/bash/meson
   '';
 
+  passthru = {
+    inherit python3;
+  };
+
   meta = with lib; {
     homepage = "https://mesonbuild.com";
     description = "An open source, fast and friendly build system made in Python";


### PR DESCRIPTION
###### Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2022-36039
https://nvd.nist.gov/vuln/detail/CVE-2022-36040
https://nvd.nist.gov/vuln/detail/CVE-2022-36041
https://nvd.nist.gov/vuln/detail/CVE-2022-36042
https://nvd.nist.gov/vuln/detail/CVE-2022-36043
https://nvd.nist.gov/vuln/detail/CVE-2022-36044

Bump needed new build-time dependency `pyyaml` for use with meson. Added `python3` passthru to meson so I could be sure I was getting `pyyaml` from the right python (cc @jtojnar @AndersonTorres). The previous `python3.withPackages` construct here seemed to be completely ignored by meson so I removed it. Slight surprised nobody in nixpkgs has come across the need to inject extra python dependencies into meson before. `meson.override { python3 = python3.withPackages ... }` also doesn't have the desired effect.

Enabled for darwin while I was at it.

Quite confident I can apply the patches to 22.05 so no auto-backport.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
