### PR TITLE
sx-go: fix darwin build

### DIFF
--- a/pkgs/tools/security/sx-go/default.nix
+++ b/pkgs/tools/security/sx-go/default.nix
@@ -2,6 +2,7 @@
 , lib
 , buildGoModule
 , fetchFromGitHub
+, fetchpatch
 , libpcap
 }:
 
@@ -18,6 +19,16 @@ buildGoModule rec {
 
   vendorSha256 = "sha256-TWRMNt6x8zuvhP1nz4R6IVCX+9HityvVpzxRhDiMyO4=";
 
+  patches = [
+    # Fix darwin builds:
+    #   https://github.com/v-byte-cpu/sx/pull/120
+    (fetchpatch {
+      name = "non-linux-method-signature.patch";
+      url = "https://github.com/v-byte-cpu/sx/commit/56457bfaa49eb6fbb7a33d7092d9c636b9c85895.patch";
+      hash = "sha256-0lCu3tZ0fEiC7qWfk1APLVwwrK9eovbVa/yG7OuXEWQ=";
+    })
+  ];
+
   buildInputs = [
     libpcap
   ];
@@ -28,7 +39,6 @@ buildGoModule rec {
   '';
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
     description = "Command-line network scanner";
     homepage = "https://github.com/v-byte-cpu/sx";
     license = licenses.mit;

--- a/pkgs/tools/security/sx-go/default.nix
+++ b/pkgs/tools/security/sx-go/default.nix
@@ -20,8 +20,7 @@ buildGoModule rec {
   vendorSha256 = "sha256-TWRMNt6x8zuvhP1nz4R6IVCX+9HityvVpzxRhDiMyO4=";
 
   patches = [
-    # Fix darwin builds:
-    #   https://github.com/v-byte-cpu/sx/pull/120
+    # Fix darwin builds: https://github.com/v-byte-cpu/sx/pull/120
     (fetchpatch {
       name = "non-linux-method-signature.patch";
       url = "https://github.com/v-byte-cpu/sx/commit/56457bfaa49eb6fbb7a33d7092d9c636b9c85895.patch";


### PR DESCRIPTION
###### Description of changes

Backport a post-release patch. The project releases very unfrequently, so not waiting for them.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
