### PR TITLE
haskell.packages.ghc942: make it work

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
@@ -2,10 +2,17 @@
 
 let
   inherit (pkgs) fetchpatch lib;
-  inherit (lib) throwIfNot versionOlder;
+  checkAgainAfter = pkg: ver: msg: act:
+    if builtins.compareVersions pkg.version ver <= 0 then act
+    else
+      builtins.throw "Check if '${msg}' was resolved in ${pkg.pname} ${pkg.version} and update or remove this";
 in
 
-self: super: {
+with haskellLib;
+self: super: let
+  doctest_0_20_broken = p: checkAgainAfter self.doctest "0.20.0" "doctest broken on 9.4" (dontCheck p);
+  jailbreakForCurrentVersion = p: v: checkAgainAfter p v "bad bounds" (doJailbreak p);
+in {
   llvmPackages = lib.dontRecurseIntoAttrs self.ghc.llvmPackages;
 
   # Disable GHC core libraries.
@@ -48,4 +55,173 @@ self: super: {
   # GHC only bundles the xhtml library if haddock is enabled, check if this is
   # still the case when updating: https://gitlab.haskell.org/ghc/ghc/-/blob/0198841877f6f04269d6050892b98b5c3807ce4c/ghc.mk#L463
   xhtml = if self.ghc.hasHaddock or true then null else self.xhtml_3000_2_2_1;
+
+  # Tests fail because of typechecking changes
+  conduit = dontCheck super.conduit;
+
+  # 0.30 introduced support for GHC 9.2.
+  cryptonite = doDistribute self.cryptonite_0_30;
+
+  # Too strict bound on base
+  # https://github.com/haskell/cabal/issues/8509
+  # Requested versions of Cabal, Cabal-syntax and process match GHC 9.4's for now
+  cabal-install = doJailbreak super.cabal-install;
+  cabal-install-solver = doJailbreak super.cabal-install-solver;
+
+  # Test failure due to new Cabal 3.8 version. Since the failure only pertains
+  # to a change in how Cabal internally represents some platforms and we depend
+  # on the type of representation anywhere, this failure is harmless. Can be
+  # removed after https://github.com/NixOS/cabal2nix/pull/571 is merged.
+  # TODO(@sternenseemann): merge and release a fixed version
+  distribution-nixpkgs = dontCheck super.distribution-nixpkgs;
+  cabal2nix = dontCheck super.cabal2nix;
+  cabal2nix-unstable = dontCheck super.cabal2nix-unstable;
+
+  # build fails on due to ghc api changes
+  # unfinished PR that doesn't yet compile:
+  # https://github.com/sol/doctest/pull/375
+  doctest = markBroken super.doctest_0_20_0;
+  # consequences of doctest breakage follow:
+  http-types = doctest_0_20_broken super.http-types;
+  iproute = doctest_0_20_broken super.iproute;
+  foldl = doctest_0_20_broken super.foldl;
+  prettyprinter-ansi-terminal = doctest_0_20_broken super.prettyprinter-ansi-terminal;
+  pretty-simple = doctest_0_20_broken super.pretty-simple;
+  http-date = doctest_0_20_broken super.http-date;
+  network-byte-order = doctest_0_20_broken super.network-byte-order;
+  co-log-core = doctest_0_20_broken (doJailbreak super.co-log-core);
+  xml-conduit = doctest_0_20_broken (dontCheck super.xml-conduit);
+  validation-selective = doctest_0_20_broken (dontCheck super.validation-selective);
+
+  double-conversion = markBroken super.double-conversion;
+  blaze-textual = checkAgainAfter super.double-conversion "2.0.4.1" "double-conversion fails to build; required for testsuite" (dontCheck super.blaze-textual);
+  ghc-source-gen = checkAgainAfter super.ghc-source-gen "0.4.3.0" "fails to build" (markBroken super.ghc-source-gen);
+
+  lucid = jailbreakForCurrentVersion super.lucid "2.11.1";
+  invariant = jailbreakForCurrentVersion super.invariant "0.5.6";
+  implicit-hie-cradle = jailbreakForCurrentVersion super.implicit-hie-cradle "0.5.0.0";
+
+  haskell-src-meta = doJailbreak super.haskell-src-meta;
+
+  # Tests fail in GHC 9.2
+  extra = dontCheck super.extra;
+
+  # Jailbreaks & Version Updates
+
+  aeson = self.aeson_2_1_1_0;
+  aeson-diff = doctest_0_20_broken (dontCheck super.aeson-diff);
+  lens-aeson = self.lens-aeson_1_2_2;
+
+  assoc = doJailbreak super.assoc;
+  async = doJailbreak super.async;
+  base64-bytestring = doJailbreak super.base64-bytestring;
+  base-compat = self.base-compat_0_12_2;
+  base-compat-batteries = self.base-compat-batteries_0_12_2;
+  binary-instances = doJailbreak super.binary-instances;
+  ChasingBottoms = doJailbreak super.ChasingBottoms;
+  constraints = doJailbreak super.constraints;
+  cpphs = overrideCabal (drv: { postPatch = "sed -i -e 's,time >=1.5 && <1.11,time >=1.5 \\&\\& <1.12,' cpphs.cabal";}) super.cpphs;
+  data-fix = doJailbreak super.data-fix;
+  dec = doJailbreak super.dec;
+  ed25519 = doJailbreak super.ed25519;
+  ghc-byteorder = doJailbreak super.ghc-byteorder;
+  ghc-lib = doDistribute self.ghc-lib_9_4_2_20220822;
+  ghc-lib-parser = doDistribute self.ghc-lib-parser_9_4_2_20220822;
+  ghc-lib-parser-ex = doDistribute self.ghc-lib-parser-ex_9_4_0_0;
+  hackage-security = doJailbreak super.hackage-security;
+  hashable = super.hashable_1_4_1_0;
+  hashable-time = doJailbreak super.hashable-time;
+  HTTP = overrideCabal (drv: { postPatch = "sed -i -e 's,! Socket,!Socket,' Network/TCP.hs"; }) (doJailbreak super.HTTP);
+  integer-logarithms = overrideCabal (drv: { postPatch = "sed -i -e 's, <1.1, <1.3,' integer-logarithms.cabal"; }) (doJailbreak super.integer-logarithms);
+  indexed-traversable = doJailbreak super.indexed-traversable;
+  indexed-traversable-instances = doJailbreak super.indexed-traversable-instances;
+  lifted-async = doJailbreak super.lifted-async;
+  lukko = doJailbreak super.lukko;
+  lzma-conduit = doJailbreak super.lzma-conduit;
+  parallel = doJailbreak super.parallel;
+  path = doJailbreak super.path;
+  polyparse = overrideCabal (drv: { postPatch = "sed -i -e 's, <0.11, <0.12,' polyparse.cabal"; }) (doJailbreak super.polyparse);
+  primitive = dontCheck (doJailbreak self.primitive_0_7_4_0);
+  regex-posix = doJailbreak super.regex-posix;
+  resolv = doJailbreak super.resolv;
+  singleton-bool = doJailbreak super.singleton-bool;
+
+  # 2022-09-02: Too strict bounds on lens
+  # https://github.com/GetShopTV/swagger2/pull/242
+  swagger2 = doctest_0_20_broken (dontCheck (doJailbreak super.swagger2));
+
+  base-orphans = dontCheck super.base-orphans;
+
+  # Note: Any compilation fixes need to be done on the versioned attributes,
+  # since those are used for the internal dependencies between the versioned
+  # hspec packages in configuration-common.nix.
+  hspec = self.hspec_2_10_6;
+  hspec-core = self.hspec-core_2_10_6;
+  hspec-meta = self.hspec-meta_2_10_5;
+  hspec-discover = self.hspec-discover_2_10_6;
+
+  # the dontHaddock is due to a GHC panic. might be this bug, not sure.
+  # https://gitlab.haskell.org/ghc/ghc/-/issues/21619
+  #
+  # We need >= 1.1.2 for ghc-9.4 support, but we don't have 1.1.x in
+  # hackage-packages.nix
+  hedgehog = doDistribute (dontHaddock super.hedgehog_1_2);
+  # does not work with hedgehog 1.2 yet:
+  # https://github.com/qfpl/tasty-hedgehog/pull/63
+  tasty-hedgehog = markBroken super.tasty-hedgehog;
+  # due to tasty-hedgehog
+  retry = checkAgainAfter super.tasty-hedgehog "1.3.0.0" "tasty-hedgehog broken" (dontCheck super.retry);
+
+  # https://github.com/dreixel/syb/issues/38
+  syb = dontCheck super.syb;
+
+  splitmix = doJailbreak super.splitmix;
+  th-desugar = self.th-desugar_1_14;
+  time-compat = doJailbreak super.time-compat;
+  tomland = doJailbreak super.tomland;
+  type-equality = doJailbreak super.type-equality;
+  unordered-containers = doJailbreak super.unordered-containers;
+  vector = dontCheck super.vector;
+  vector-binary-instances = doJailbreak super.vector-binary-instances;
+
+  # fixed in 1.16.x but it's not in hackage-packages yet.
+  rebase = jailbreakForCurrentVersion super.rebase "1.15.0.3";
+  rerebase = jailbreakForCurrentVersion super.rerebase "1.15.0.3";
+
+  hpack = overrideCabal (drv: {
+    # Cabal 3.6 seems to preserve comments when reading, which makes this test fail
+    # 2021-10-10: 9.2.1 is not yet supported (also no issue)
+    testFlags = [
+      "--skip=/Hpack/renderCabalFile/is inverse to readCabalFile/"
+    ] ++ drv.testFlags or [];
+  }) (doJailbreak super.hpack);
+
+  # lens >= 5.1 supports 9.2.1
+  lens = doDistribute self.lens_5_2;
+
+  # Apply patches from head.hackage.
+  language-haskell-extract = appendPatch (pkgs.fetchpatch {
+    url = "https://gitlab.haskell.org/ghc/head.hackage/-/raw/dfd024c9a336c752288ec35879017a43bd7e85a0/patches/language-haskell-extract-0.2.4.patch";
+    sha256 = "0w4y3v69nd3yafpml4gr23l94bdhbmx8xky48a59lckmz5x9fgxv";
+  }) (doJailbreak super.language-haskell-extract);
+
+  # Tests depend on `parseTime` which is no longer available
+  hourglass = dontCheck super.hourglass;
+
+  memory = super.memory_0_18_0;
+
+  # https://github.com/sjakobi/bsb-http-chunked/issues/38
+  bsb-http-chunked = dontCheck super.bsb-http-chunked;
+
+  # need bytestring >= 0.11 which is only bundled with GHC >= 9.2
+  regex-rure = doDistribute (markUnbroken super.regex-rure);
+  jacinda = doDistribute super.jacinda;
+  some = doJailbreak super.some;
+
+  # 1.3 introduced support for GHC 9.2.x, so when this assert fails, the jailbreak can be removed
+  hashtables = assert super.hashtables.version == "1.2.4.2"; doJailbreak super.hashtables;
+
+  # 2022-08-01: Tests are broken on ghc 9.2.4: https://github.com/wz1000/HieDb/issues/46
+  hiedb = dontCheck super.hiedb;
+
 }

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -53,6 +53,7 @@ let
     ghc8107
     ghc902
     ghc924
+    ghc942
   ];
 
   # packagePlatforms applied to `haskell.packages.*`
@@ -354,12 +355,26 @@ let
       # working as expected.
       cabal-install = released;
       Cabal_3_6_3_0 = released;
+      Cabal_3_8_1_0 = released;
       cabal2nix = released;
       cabal2nix-unstable = released;
       funcmp = released;
-      haskell-language-server = released;
+      haskell-language-server = [
+        compilerNames.ghc884
+        compilerNames.ghc8107
+        compilerNames.ghc902
+        compilerNames.ghc924
+        # https://github.com/haskell/haskell-language-server/issues/3190
+      ];
       hoogle = released;
-      hlint = released;
+      hlint = [
+        compilerNames.ghc884
+        compilerNames.ghc8107
+        compilerNames.ghc902
+        compilerNames.ghc924
+        # https://github.com/ndmitchell/hlint/issues/1413
+      ];
+      hpack = released;
       hsdns = released;
       jailbreak-cabal = released;
       language-nix = released;


### PR DESCRIPTION
###### Description of changes

Bring up ghc-9.4 enough that I can run `hpack` and the HLS dev shell, and HLS (with some limited overrides). It's still fairly thoroughly jacked. I copied the definitions from ghc-9.2 as a starting point then started fixing stuff.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
