### PR TITLE
wolfssl: 5.4.0 -> 5.5.0

### DIFF
--- a/pkgs/development/libraries/wolfssl/default.nix
+++ b/pkgs/development/libraries/wolfssl/default.nix
@@ -7,19 +7,22 @@
 
 stdenv.mkDerivation rec {
   pname = "wolfssl";
-  version = "5.4.0";
+  version = "5.5.0";
 
   src = fetchFromGitHub {
     owner = "wolfSSL";
     repo = "wolfssl";
     rev = "v${version}-stable";
-    sha256 = "sha256-5a83Mi+S+mASdZ6O2+0I+qulsF6yNUe80a3qZvWmXHw=";
+    sha256 = "sha256-PqxwWPK5eBcS5d6e0CL4uZHybDye1K8pxniKU99YSAE=";
   };
 
   postPatch = ''
     patchShebangs ./scripts
     # ocsp tests require network access
     sed -i -e '/ocsp\.test/d' -e '/ocsp-stapling\.test/d' scripts/include.am
+    # ensure test detects musl-based systems too
+    substituteInPlace scripts/ocsp-stapling2.test \
+      --replace '"linux-gnu"' '"linux-"'
   '';
 
   # Almost same as Debian but for now using --enable-all --enable-reproducible-build instead of --enable-distro to ensure options.h gets installed


### PR DESCRIPTION
###### Description of changes

https://github.com/wolfSSL/wolfssl/releases/tag/v5.5.0-stable
Fixes CVE-2022-38152.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages marked as broken and skipped:</summary>
  <ul>
    <li>aqemu</li>
    <li>linuxKernel.packages.linux_testing_bcachefs.virtualbox</li>
  </ul>
</details>
<details>
  <summary>1 package failed to build:</summary>
  <ul>
    <li>ocamlPackages.ocaml-freestanding</li>
  </ul>
</details>
<details>
  <summary>54 packages built:</summary>
  <ul>
    <li>alpine-make-vm-image</li>
    <li>cloud-init</li>
    <li>cloud-utils</li>
    <li>colima</li>
    <li>cot (python310Packages.cot)</li>
    <li>diffoscope</li>
    <li>gnome.gnome-boxes</li>
    <li>libguestfs</li>
    <li>libguestfs-with-appliance</li>
    <li>lima</li>
    <li>linuxKernel.packages.linux_4_14.virtualbox</li>
    <li>linuxKernel.packages.linux_4_14_hardened.virtualbox</li>
    <li>linuxKernel.packages.linux_4_19.virtualbox</li>
    <li>linuxKernel.packages.linux_4_19_hardened.virtualbox</li>
    <li>linuxKernel.packages.linux_4_9.virtualbox</li>
    <li>linuxKernel.packages.linux_5_10.virtualbox</li>
    <li>linuxKernel.packages.linux_5_10_hardened.virtualbox</li>
    <li>linuxKernel.packages.linux_5_15.virtualbox</li>
    <li>linuxKernel.packages.linux_hardened.virtualbox (linuxKernel.packages.linux_5_15_hardened.virtualbox)</li>
    <li>linuxKernel.packages.linux_5_18.virtualbox</li>
    <li>linuxKernel.packages.linux_5_18_hardened.virtualbox</li>
    <li>linuxKernel.packages.linux_5_19.virtualbox</li>
    <li>linuxKernel.packages.linux_5_4.virtualbox</li>
    <li>linuxKernel.packages.linux_latest_libre.virtualbox</li>
    <li>linuxKernel.packages.linux_libre.virtualbox</li>
    <li>linuxKernel.packages.linux_lqx.virtualbox</li>
    <li>linuxKernel.packages.linux_xanmod.virtualbox</li>
    <li>linuxKernel.packages.linux_xanmod_latest.virtualbox</li>
    <li>linuxKernel.packages.linux_xanmod_tt.virtualbox</li>
    <li>linuxKernel.packages.linux_zen.virtualbox</li>
    <li>open-watcom-bin</li>
    <li>open-watcom-bin-unwrapped</li>
    <li>out-of-tree</li>
    <li>python310Packages.guestfs</li>
    <li>python39Packages.cot</li>
    <li>python39Packages.guestfs</li>
    <li>qemu</li>
    <li>qemu-utils</li>
    <li>qemu_full</li>
    <li>qemu_kvm</li>
    <li>qemu_test</li>
    <li>qtemu</li>
    <li>quickemu</li>
    <li>rpcs3</li>
    <li>simh</li>
    <li>solo5</li>
    <li>vagrant</li>
    <li>vde2</li>
    <li>virtualbox</li>
    <li>virtualboxHardened</li>
    <li>virtualboxHeadless</li>
    <li>virtualboxWithExtpack</li>
    <li>wolfssl</li>
    <li>zpool-auto-expand-partitions</li>
  </ul>
</details>

`ocamlPackages.ocaml-freestanding` appears to be already broken on `master`.