### PR TITLE
yarr: init at 2.3

### DIFF
--- a/pkgs/applications/networking/feedreaders/yarr/default.nix
+++ b/pkgs/applications/networking/feedreaders/yarr/default.nix
@@ -1,0 +1,38 @@
+{ lib, buildGoModule, fetchFromGitHub, testers, yarr }:
+
+buildGoModule rec {
+  pname = "yarr";
+  version = "2.3";
+
+  src = fetchFromGitHub {
+    owner = "nkanaev";
+    repo = "yarr";
+    rev = "v${version}";
+    hash = "sha256-LW0crWdxS6zcY5rxR0F2FLDYy9Ph2ZKyB/5VFVss+tA=";
+  };
+
+  vendorHash = "sha256-yXnoibqa0+lHhX3I687thGgasaVeNiHpGFmtEnH7oWY=";
+
+  subPackages = [ "src" ];
+
+  ldflags = [ "-s" "-w" "-X main.Version=${version}" "-X main.GitHash=none" ];
+
+  tags = [ "sqlite_foreign_keys" "release" ];
+
+  postInstall = ''
+    mv $out/bin/{src,yarr}
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = yarr;
+    version = "v${version}";
+  };
+
+  meta = with lib; {
+    description = "Yet another rss reader";
+    homepage = "https://github.com/nkanaev/yarr";
+    changelog = "https://github.com/nkanaev/yarr/blob/v${version}/doc/changelog.txt";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sikmir ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12674,6 +12674,8 @@ with pkgs;
     mkYarnModules
     fixup_yarn_lock;
 
+  yarr = callPackage ../applications/networking/feedreaders/yarr { };
+
   yascreen = callPackage ../development/libraries/yascreen { };
 
   yasr = callPackage ../applications/audio/yasr { };


### PR DESCRIPTION
###### Description of changes

> **yarr** (yet another rss reader) is a web-based feed aggregator which can be used both as a desktop application and a personal self-hosted server.

Test instructions:
* Run `yarr -db local.db`
* Go to http://127.0.0.1:7070
* Add feed, e.g https://nixos.org/blog/
* Check result:
![scr](https://user-images.githubusercontent.com/688044/190850712-3a2e48a6-78b2-4912-ba4e-9e27dc461573.jpg)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
