### PR TITLE
wrapFish: Add `localConfig` and `shellAliases` parameters.

### DIFF
--- a/pkgs/shells/fish/wrapper.nix
+++ b/pkgs/shells/fish/wrapper.nix
@@ -1,25 +1,47 @@
-{ lib, writeShellScriptBin, fish }:
+{ lib, writeShellScriptBin, fish, writeTextFile }:
 
-with lib;
-
-makeOverridable ({
+lib.makeOverridable ({
   completionDirs ? [],
   functionDirs ? [],
   confDirs ? [],
-  pluginPkgs ? []
+  pluginPkgs ? [],
+  localConfig ? "",
+  shellAliases ? {}
 }:
 
 let
+  aliasesStr = builtins.concatStringsSep "\n"
+      (lib.mapAttrsToList (k: v: "alias ${k} ${lib.escapeShellArg v}") shellAliases);
+
+  shellAliasesFishConfig = writeTextFile {
+    name = "wrapfish.aliases.fish";
+    destination = "/share/fish/vendor_conf.d/aliases.fish";
+    text = ''
+      status --is-interactive; and begin
+        # Aliases
+        ${aliasesStr}
+      end
+    '';
+  };
+
+  localFishConfig = writeTextFile {
+    name = "wrapfish.local.fish";
+    destination = "/share/fish/vendor_conf.d/config.local.fish";
+    text = localConfig;
+  };
+
   vendorDir = kind: plugin: "${plugin}/share/fish/vendor_${kind}.d";
   complPath = completionDirs ++ map (vendorDir "completions") pluginPkgs;
   funcPath = functionDirs ++ map (vendorDir "functions") pluginPkgs;
-  confPath = confDirs ++ map (vendorDir "conf") pluginPkgs;
+  confPath = confDirs
+    ++ (map (vendorDir "conf") pluginPkgs)
+    ++ (map (vendorDir "conf") [ localFishConfig shellAliasesFishConfig ]);
 
 in writeShellScriptBin "fish" ''
   ${fish}/bin/fish --init-command "
-    set --prepend fish_complete_path ${escapeShellArgs complPath}
-    set --prepend fish_function_path ${escapeShellArgs funcPath}
-    set --local fish_conf_source_path ${escapeShellArgs confPath}
+    set --prepend fish_complete_path ${lib.escapeShellArgs complPath}
+    set --prepend fish_function_path ${lib.escapeShellArgs funcPath}
+    set --local fish_conf_source_path ${lib.escapeShellArgs confPath}
     for c in \$fish_conf_source_path/*; source \$c; end
   " "$@"
 '')


### PR DESCRIPTION
Hi nixers,

This PR add 2 new parameters to the `wrapFish` wrapper derivation: `localConfig` and `shellAliases`.

* `localConfig`: (text) To load a custom fish config.
* `shellAliases`: (set) To load custom shell aliases.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
