### PR TITLE
gst_all_1: fix build with X11, Wayland or GL disabled

### DIFF
--- a/pkgs/development/libraries/gstreamer/base/default.nix
+++ b/pkgs/development/libraries/gstreamer/base/default.nix
@@ -148,6 +148,7 @@ stdenv.mkDerivation rec {
     # vs what was built) and to make them easier to search for.
     glEnabled = enableGl;
     waylandEnabled = enableWayland;
+    x11Enabled = enableX11;
   };
 
   meta = with lib; {

--- a/pkgs/development/libraries/gstreamer/base/default.nix
+++ b/pkgs/development/libraries/gstreamer/base/default.nix
@@ -22,6 +22,7 @@
 , enableX11 ? stdenv.isLinux
 , libXv
 , libXext
+, xorg
 , enableWayland ? stdenv.isLinux
 , wayland
 , wayland-protocols
@@ -78,7 +79,6 @@ stdenv.mkDerivation rec {
     libpng
     libjpeg
     tremor
-    libGL
     pango
   ] ++ lib.optionals (!stdenv.isDarwin) [
     libvisual
@@ -97,6 +97,10 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [
     gstreamer
+  ] ++ lib.optionals (enableX11 && enableGl) [
+    xorg.libxcb
+  ] ++ lib.optionals enableGl [
+    libGL
   ];
 
   mesonFlags = [

--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -101,6 +101,7 @@ stdenv.mkDerivation rec {
     libXext
     libXfixes
     ncurses
+    xorg.libX11
     xorg.libXfixes
     xorg.libXdamage
     wavpack

--- a/pkgs/development/libraries/gstreamer/vaapi/default.nix
+++ b/pkgs/development/libraries/gstreamer/vaapi/default.nix
@@ -7,11 +7,10 @@
 , bzip2
 , libva
 , wayland
+, wayland-protocols
 , libdrm
 , udev
 , xorg
-, libGLU
-, libGL
 , gstreamer
 , gst-plugins-bad
 , nasm
@@ -49,26 +48,25 @@ stdenv.mkDerivation rec {
     gst-plugins-base
     gst-plugins-bad
     libva
-    wayland
     libdrm
     udev
-    xorg.libX11
-    xorg.libXext
-    xorg.libXv
-    xorg.libXrandr
-    xorg.libSM
-    xorg.libICE
-    libGL
-    libGLU
     nasm
     libvpx
     python3
+  ] ++ lib.optionals gst-plugins-base.glEnabled [
+    xorg.libX11 # required by EGL even with X11 support disabled
+  ] ++ lib.optionals gst-plugins-base.waylandEnabled [
+    wayland
+    wayland-protocols
+  ] ++ lib.optionals gst-plugins-base.x11Enabled [
+    xorg.libXrandr
   ];
 
   mesonFlags = [
     "-Dexamples=disabled" # requires many dependencies and probably not useful for our users
     "-Ddoc=disabled" # `hotdoc` not packaged in nixpkgs as of writing
-  ];
+  ]
+  ++ lib.optional (!gst-plugins-base.x11Enabled) "-Dwith_x11=no";
 
   postPatch = ''
     patchShebangs \


### PR DESCRIPTION
###### Description of changes

Fix the implementation of the `enableWayland`, `enableX11` and `enableGl` options.

With this PR, all of `gst_all_1` (except for `gstreamermm`, which is broken for unrelated reasons) can be built with all valid combinations of these options (the only invalid one is GL enabled without X11 or Wayland).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
