### PR TITLE
[22.05] rizin: add patches for multiple CVEs

### DIFF
--- a/pkgs/development/tools/analysis/rizin/default.nix
+++ b/pkgs/development/tools/analysis/rizin/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchurl
+, fetchpatch
 , pkg-config
 , libusb-compat-0_1
 , readline
@@ -29,6 +30,39 @@ stdenv.mkDerivation rec {
     url = "https://github.com/rizinorg/rizin/releases/download/v${version}/rizin-src-v${version}.tar.xz";
     sha256 = "sha256-7qSbOWOHwJ0ZcFqrAqYXzbFWgvymfxAf8rJ+75SnEOk=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2022-36039.patch";
+      url = "https://github.com/rizinorg/rizin/commit/52361f4f55107968820b1f3561c2ea7c451aed9d.patch";
+      sha256 = "sha256-rox4vKfRcS3YKPP55VxmEiZ8KezLV53SK1QHE4Bc8g0=";
+    })
+    (fetchpatch {
+      name = "CVE-2022-36040.patch";
+      url = "https://github.com/rizinorg/rizin/commit/bfb5f751e6fc720b61829aab84eb3749cd8f696a.patch";
+      sha256 = "sha256-xzMTSsHumN8FaIsWmBBIayCafvQXUJ0jPVQvOCodyRE=";
+    })
+    (fetchpatch {
+      name = "CVE-2022-36041.patch";
+      url = "https://github.com/rizinorg/rizin/commit/eeaf7c6a6fc64516fee82a4f0b8fbc1141e03d50.patch";
+      sha256 = "sha256-MA2XmOuK91w1U6eWiHx8qhYB+13zdohMe8YmkdXN27g=";
+    })
+    (fetchpatch {
+      name = "CVE-2022-36043.patch";
+      url = "https://github.com/rizinorg/rizin/commit/9819f69ecfa02d5f0c3886df46c85df09a51db80.patch";
+      sha256 = "sha256-u3CU5amtd5DRK7sg8Thp7wdg5SrcCFisdxRYFLdb7Zw=";
+    })
+    (fetchpatch {
+      name = "CVE-2022-36044.part-1.patch";
+      url = "https://github.com/rizinorg/rizin/commit/0f8e58bce910d7bcf4474f25277295c397e2fa7b.patch";
+      sha256 = "sha256-o11UwH34Ew6EnksY5YLoFcZDeW8iYkznLpUW92tcX40=";
+    })
+    (fetchpatch {
+      name = "CVE-2022-36044.part-2.patch";
+      url = "https://github.com/rizinorg/rizin/commit/b9443604d5555cd02b1ca43c6fc0ec4896a73982.patch";
+      sha256 = "sha256-mkPEmw6oGv1Tuo1mXT44gEuDHQ59anQuYzFkm7z/o7w=";
+    })
+  ];
 
   mesonFlags = [
     "-Duse_sys_capstone=enabled"


### PR DESCRIPTION
###### Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2022-36039
https://nvd.nist.gov/vuln/detail/CVE-2022-36040
https://nvd.nist.gov/vuln/detail/CVE-2022-36041
https://nvd.nist.gov/vuln/detail/CVE-2022-36043
https://nvd.nist.gov/vuln/detail/CVE-2022-36044

https://nvd.nist.gov/vuln/detail/CVE-2022-36042 doesn't appear to affect 0.3.4: looks like it's a bug in the "dyld4 Atlas-style Shared Library Caches" support added in https://github.com/rizinorg/rizin/commit/c19eaa88431505f267093aca7feead37ce804d49.

Addressed in unstable through bump in  #191582

Personally tested this fixes the issues for which PoCs were published.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
