### PR TITLE
cc-wrapper/setup-hook.sh: remove duplicate flags in NIX_CFLAGS_COMPILE

### DIFF
--- a/pkgs/build-support/cc-wrapper/setup-hook.sh
+++ b/pkgs/build-support/cc-wrapper/setup-hook.sh
@@ -69,10 +69,12 @@ ccWrapper_addCVars () {
     getHostRoleEnvHook
 
     if [ -d "$1/include" ]; then
+        (! echo "$NIX_CFLAGS_COMPILE" | grep -q -F "$1/include") &&
         export NIX_CFLAGS_COMPILE${role_post}+=" -isystem $1/include"
     fi
 
     if [ -d "$1/Library/Frameworks" ]; then
+        (! echo "$NIX_CFLAGS_COMPILE" | grep -q -F "$1/Library/Frameworks") &&
         export NIX_CFLAGS_COMPILE${role_post}+=" -iframework $1/Library/Frameworks"
     fi
 }


### PR DESCRIPTION
###### Description of changes

Currently, nix build environments have duplicate flags in `NIX_CFLAGS_COMPILE`. For example, consider the following `shell.nix`:
```
with (import <nixpkgs> {});

mkShell {
    buildInputs = [
      cmake
      gtest
    ];
}
```
which gives us
```
$ echo $NIX_CFLAGS_COMPILE
-frandom-seed=1cxirkw4xs 
-isystem /nix/store/qgifygqcicn2zr9fmaflzqc670d0b4ns-gtest-1.11.0-dev/include 
-isystem /nix/store/qgifygqcicn2zr9fmaflzqc670d0b4ns-gtest-1.11.0-dev/include
```
It is easy to remove this duplication by making `ccWrapper_addCVars` idempotent. After this change, we have
```
$ echo $NIX_CFLAGS_COMPILE
-frandom-seed=1cxirkw4xs 
-isystem /nix/store/qgifygqcicn2zr9fmaflzqc670d0b4ns-gtest-1.11.0-dev/include
```

This is mostly a cosmetic change, and will trigger a rebuild of the entire universe. I did so for the standard environment today and everything works fine. It has been bugging me since I started doing C++ dev on nix, especially for cmake projects with a lot of dependencies where I use `NIX_CFLAGS_COMPILE` to generate a `compile_commands.json` 

###### Things done

Make `ccWrapper_addCVars` idempotent.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
