### PR TITLE
neovimUtils: put optional plugins in incorrect folder

### DIFF
--- a/pkgs/applications/editors/neovim/tests/default.nix
+++ b/pkgs/applications/editors/neovim/tests/default.nix
@@ -7,7 +7,7 @@
 , pkgs
 }:
 let
-  inherit (vimUtils) buildVimPluginFrom2Nix;
+  inherit (vimUtils) buildVimPluginFrom2Nix packDir;
   inherit (neovimUtils) makeNeovimConfig;
 
   packages.myVimPackage.start = with vimPlugins; [ vim-nix ];
@@ -229,11 +229,11 @@ rec {
     extraName = "-with-opt-plug";
     configure.packages.plugins = with pkgs.vimPlugins; {
       opt = [
-        (base16-vim.overrideAttrs(old: { pname = old.pname + "-unique-for-tests-please-dont-use"; }))
+        (base16-vim.overrideAttrs(old: { pname = old.pname + "-unique-for-tests-please-dont-use-opt"; }))
       ];
     };
     configure.customRC = ''
-      packadd base16-vim
+      packadd base16-vim-unique-for-tests-please-dont-use-opt
       color base16-tomorrow-night
       set background=dark
     '';

--- a/pkgs/applications/editors/neovim/tests/default.nix
+++ b/pkgs/applications/editors/neovim/tests/default.nix
@@ -11,6 +11,7 @@ let
   inherit (neovimUtils) makeNeovimConfig;
 
   packages.myVimPackage.start = with vimPlugins; [ vim-nix ];
+  packages.myVimPackage.opt = with vimPlugins; [ vim-fugitive ];
 
   plugins = with vimPlugins; [
     {
@@ -221,5 +222,25 @@ rec {
   nvim_with_lua_packages = runTest nvimWithLuaPackages ''
     export HOME=$TMPDIR
     ${nvimWithLuaPackages}/bin/nvim -i NONE --noplugin -es
+  '';
+
+  # nixpkgs should install optional packages in the opt folder
+  nvim_with_opt_plug = neovim.override {
+    extraName = "-with-opt-plug";
+    configure.packages.plugins = with pkgs.vimPlugins; {
+      opt = [
+        (base16-vim.overrideAttrs(old: { pname = old.pname + "-unique-for-tests-please-dont-use"; }))
+      ];
+    };
+    configure.customRC = ''
+      packadd base16-vim
+      color base16-tomorrow-night
+      set background=dark
+    '';
+  };
+
+  run_nvim_with_opt_plug = runTest nvim_with_opt_plug ''
+    export HOME=$TMPDIR
+    ${nvim_with_opt_plug}/bin/nvim -i NONE -c 'color base16-tomorrow-night'  +quit! -e
   '';
 })

--- a/pkgs/applications/editors/neovim/tests/default.nix
+++ b/pkgs/applications/editors/neovim/tests/default.nix
@@ -7,11 +7,10 @@
 , pkgs
 }:
 let
-  inherit (vimUtils) buildVimPluginFrom2Nix packDir;
+  inherit (vimUtils) buildVimPluginFrom2Nix;
   inherit (neovimUtils) makeNeovimConfig;
 
   packages.myVimPackage.start = with vimPlugins; [ vim-nix ];
-  packages.myVimPackage.opt = with vimPlugins; [ vim-fugitive ];
 
   plugins = with vimPlugins; [
     {
@@ -235,7 +234,6 @@ rec {
     configure.customRC = ''
       packadd base16-vim-unique-for-tests-please-dont-use-opt
       color base16-tomorrow-night
-      set background=dark
     '';
   };
 

--- a/pkgs/applications/editors/neovim/tests/default.nix
+++ b/pkgs/applications/editors/neovim/tests/default.nix
@@ -227,7 +227,7 @@ rec {
   nvim_with_opt_plugin = neovim.override {
     extraName = "-with-opt-plugin";
     configure.packages.plugins = with pkgs.vimPlugins; {
-      start = [
+      opt = [
         (dashboard-nvim.overrideAttrs(old: { pname = old.pname + "-unique-for-tests-please-dont-use-opt"; }))
       ];
     };

--- a/pkgs/applications/editors/neovim/tests/default.nix
+++ b/pkgs/applications/editors/neovim/tests/default.nix
@@ -228,17 +228,21 @@ rec {
     extraName = "-with-opt-plug";
     configure.packages.plugins = with pkgs.vimPlugins; {
       opt = [
-        (base16-vim.overrideAttrs(old: { pname = old.pname + "-unique-for-tests-please-dont-use-opt"; }))
+        (dashboard-nvim.overrideAttrs(old: { pname = old.pname + "-unique-for-tests-please-dont-use-opt"; }))
       ];
     };
     configure.customRC = ''
-      packadd base16-vim-unique-for-tests-please-dont-use-opt
-      color base16-tomorrow-night
+      try
+        Dashboard
+      catch /^Vim\%((\a\+)\)\=:E492/
+        echo "Dashboard not found"
+      endtry
+      packadd dashboard-nvim-unique-for-tests-please-dont-use-opt
     '';
   };
 
   run_nvim_with_opt_plug = runTest nvim_with_opt_plug ''
     export HOME=$TMPDIR
-    ${nvim_with_opt_plug}/bin/nvim -i NONE -c 'color base16-tomorrow-night'  +quit! -e
+    ${nvim_with_opt_plug}/bin/nvim -i NONE -c 'Dashboard'  +quit! -e
   '';
 })

--- a/pkgs/applications/editors/neovim/tests/default.nix
+++ b/pkgs/applications/editors/neovim/tests/default.nix
@@ -226,7 +226,7 @@ rec {
   # nixpkgs should install optional packages in the opt folder
   nvim_with_opt_plugin = neovim.override {
     extraName = "-with-opt-plugin";
-    configure.packages.plugins = with pkgs.vimPlugins; {
+    configure.packages.opt-plugins = with pkgs.vimPlugins; {
       opt = [
         (dashboard-nvim.overrideAttrs(old: { pname = old.pname + "-unique-for-tests-please-dont-use-opt"; }))
       ];

--- a/pkgs/applications/editors/neovim/utils.nix
+++ b/pkgs/applications/editors/neovim/utils.nix
@@ -170,8 +170,8 @@ let
           throw "The neovim legacy wrapper doesn't support configure.plug anymore, please setup your plugins via 'configure.packages' instead"
         else
           lib.flatten (lib.mapAttrsToList genPlugin (configure.packages or {}));
-      genPlugin = packageName: {start ? [], opt?[]}:
-        start ++ (map (p: { plugin = p; optional = true; }) opt);
+      genPlugin = packageName: {start ? [], opt ? []}:
+        (map (p: { plugin = p; optional = false; }) start) ++ (map (p: { plugin = p; optional = true; }) opt);
 
       res = makeNeovimConfig {
         inherit withPython3;

--- a/pkgs/applications/editors/neovim/utils.nix
+++ b/pkgs/applications/editors/neovim/utils.nix
@@ -171,7 +171,7 @@ let
         else
           lib.flatten (lib.mapAttrsToList genPlugin (configure.packages or {}));
       genPlugin = packageName: {start ? [], opt?[]}:
-        start ++ opt;
+        start ++ (map (p: { plugin = p; optional = true; }) opt);
 
       res = makeNeovimConfig {
         inherit withPython3;

--- a/pkgs/applications/editors/neovim/utils.nix
+++ b/pkgs/applications/editors/neovim/utils.nix
@@ -171,7 +171,7 @@ let
         else
           lib.flatten (lib.mapAttrsToList genPlugin (configure.packages or {}));
       genPlugin = packageName: {start ? [], opt ? []}:
-        (map (p: { plugin = p; optional = false; }) start) ++ (map (p: { plugin = p; optional = true; }) opt);
+        start ++ (map (p: { plugin = p; optional = true; }) opt);
 
       res = makeNeovimConfig {
         inherit withPython3;

--- a/pkgs/applications/editors/vim/plugins/vim-utils.nix
+++ b/pkgs/applications/editors/vim/plugins/vim-utils.nix
@@ -421,7 +421,7 @@ rec {
 
   # figures out which python dependencies etc. is needed for one vim package
   requiredPluginsForPackage = { start ? [], opt ? []}:
-    start ++ opt;
+    (map (p: { plugin = p; optional = false; }) start) ++ (map (p: { plugin = p; optional = true; }) opt);
 
   toVimPlugin = drv:
     drv.overrideAttrs(oldAttrs: {

--- a/pkgs/applications/editors/vim/plugins/vim-utils.nix
+++ b/pkgs/applications/editors/vim/plugins/vim-utils.nix
@@ -421,7 +421,7 @@ rec {
 
   # figures out which python dependencies etc. is needed for one vim package
   requiredPluginsForPackage = { start ? [], opt ? []}:
-    (map (p: { plugin = p; optional = false; }) start) ++ (map (p: { plugin = p; optional = true; }) opt);
+    start ++ opt;
 
   toVimPlugin = drv:
     drv.overrideAttrs(oldAttrs: {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Neovim used to put plugins marked as `opt` into the `start` folder. This hopefully fixes that. This is my first PR, so I'm not sure exactly how to do things, but hopefully this helps.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
