### PR TITLE
minipro: 0.5 -> 0.6

### DIFF
--- a/pkgs/tools/misc/minipro/default.nix
+++ b/pkgs/tools/misc/minipro/default.nix
@@ -7,23 +7,25 @@
 
 stdenv.mkDerivation rec {
   pname = "minipro";
-  version = "0.5";
+  version = "0.6";
 
   src = fetchFromGitLab {
     owner = "DavidGriffith";
     repo = "minipro";
     rev = version;
-    sha256 = "sha256-Hyj2LyY7W8opjigH+QLHHbDyelC0LMgGgdN+u3nNoJc=";
+    sha256 = "sha256-6i4PYzSm6lcO/Nb6n3holrNe4TtAnG2o81ZIMAIGqOE=";
   };
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ libusb1 ];
   makeFlags = [
+    "VERSION=${version}"
     "PREFIX=$(out)"
     "UDEV_DIR=$(out)/lib/udev"
     "COMPLETIONS_DIR=$(out)/share/bash-completion/completions"
     "PKG_CONFIG=${pkg-config}/bin/${pkg-config.targetPrefix}pkg-config"
     "CC=${stdenv.cc.targetPrefix}cc"
+    "CFLAGS=-O2"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

Update version tagged upstream.
https://gitlab.com/DavidGriffith/minipro/-/tags/0.6

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
