### PR TITLE
bpftools: decouple version from linux_latest

### DIFF
--- a/pkgs/os-specific/linux/bpftools/default.nix
+++ b/pkgs/os-specific/linux/bpftools/default.nix
@@ -8,11 +8,11 @@
 
 stdenv.mkDerivation rec {
   pname = "bpftools";
-  version = "5.19.9";
+  version = "5.19.8";
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${version}.tar.xz";
-    sha256 = "0dvzjbyknzlx4ndz77fsm6v28fj2chxbq1z85fbc3bckcscbbm8a";
+    sha256 = "1kl7fifsa6vsm34xg3kd2svhx18n771hfj67nhwnlalmb9whhqv1";
   };
 
   nativeBuildInputs = [ python3 bison flex ];

--- a/pkgs/os-specific/linux/bpftools/default.nix
+++ b/pkgs/os-specific/linux/bpftools/default.nix
@@ -1,14 +1,19 @@
-{ lib, stdenv
+{ lib, stdenv, fetchurl
 , libopcodes, libopcodes_2_38
 , libbfd, libbfd_2_38
 , elfutils, readline
-, linuxPackages_latest, zlib
+, zlib
 , python3, bison, flex
 }:
 
 stdenv.mkDerivation rec {
   pname = "bpftools";
-  inherit (linuxPackages_latest.kernel) version src;
+  version = "5.19.9";
+
+  src = fetchurl {
+    url = "mirror://kernel/linux/kernel/v5.x/linux-${version}.tar.xz";
+    sha256 = "0dvzjbyknzlx4ndz77fsm6v28fj2chxbq1z85fbc3bckcscbbm8a";
+  };
 
   nativeBuildInputs = [ python3 bison flex ];
   buildInputs = (if (lib.versionAtLeast version "5.20")


### PR DESCRIPTION
Usual checklist doesn't apply, as binary-wise we're returning everything to the hashes from yesterday.


<!--
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
