### PR TITLE
python310Packages.stanza: add missing input

### DIFF
--- a/pkgs/development/python-modules/stanza/default.nix
+++ b/pkgs/development/python-modules/stanza/default.nix
@@ -1,28 +1,30 @@
 { lib
 , buildPythonPackage
-, fetchFromGitHub
-, pythonOlder
 , emoji
+, fetchFromGitHub
 , numpy
 , protobuf
+, pythonOlder
 , requests
 , six
 , torch
 , tqdm
+, transformers
 }:
 
 buildPythonPackage rec {
   pname = "stanza";
   version = "1.4.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "stanfordnlp";
     repo = pname;
     rev = "refs/tags/v${version}";
-    sha256 = "sha256-EAES3UpJqE7wmvCPycFhwI1lMrReN+L6W8CEDwdHTlA=";
+    hash = "sha256-EAES3UpJqE7wmvCPycFhwI1lMrReN+L6W8CEDwdHTlA=";
   };
-
-  disabled = pythonOlder "3.6";
 
   propagatedBuildInputs = [
     emoji
@@ -32,13 +34,15 @@ buildPythonPackage rec {
     six
     torch
     tqdm
+    transformers
   ];
 
-  # disabled, because the tests try to connect to the internet which
-  # is forbidden in the sandbox
+  # Tests require network access
   doCheck = false;
 
-  pythonImportsCheck = [ "stanza" ];
+  pythonImportsCheck = [
+    "stanza"
+  ];
 
   meta = with lib; {
     description = "Official Stanford NLP Python Library for Many Human Languages";


### PR DESCRIPTION
###### Description of changes
Add `transformers`
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
