### PR TITLE
dbmonster: init at unstable-2022-09-17

### DIFF
--- a/pkgs/tools/security/dbmonster/default.nix
+++ b/pkgs/tools/security/dbmonster/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, aircrack-ng
+, fetchFromGitHub
+, iproute2
+, networkmanager
+, python3
+, tshark
+, wirelesstools
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "dbmonster";
+  version = "unstable-2022-09-17";
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "90N45-d3v";
+    repo = "dBmonster";
+    rev = "4c79549079782a2991309120a55c8158701a9b70";
+    hash = "sha256-9RP3LmZF7P2c0+Jt/kMSVPb4cBtyH6P3FZ5UrQpBP0I=";
+  };
+
+  propagatedBuildInputs = [
+    aircrack-ng
+    iproute2
+    networkmanager
+    tshark
+    wirelesstools
+  ] ++ (with python3.pkgs; [
+    matplotlib
+  ]);
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -vD dBmonster.py $out/bin/$pname.py
+
+    makeWrapper ${python3.interpreter} $out/bin/$pname \
+      --set PYTHONPATH "$PYTHONPATH:$out/bin/$pname" \
+      --add-flags "-O $out/bin/$pname.py"
+
+    runHook postInstall
+  '';
+
+  # Only script available
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Tool to track WiFi devices by signal strength";
+    homepage = "https://github.com/90N45-d3v/dBmonster";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13313,6 +13313,8 @@ with pkgs;
 
   dbmate = callPackage ../development/tools/database/dbmate { };
 
+  dbmonster = callPackage ../tools/security/dbmonster { };
+
   devpi-client = python3Packages.callPackage ../development/tools/devpi-client {};
 
   devpi-server = callPackage ../development/tools/devpi-server {};


### PR DESCRIPTION
###### Description of changes
Tool to track WiFi devices by signal strength

https://github.com/90N45-d3v/dBmonster

Related to https://github.com/NixOS/nixpkgs/issues/81418
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
