### PR TITLE
SDL2_mixer: add "dev" output

### DIFF
--- a/pkgs/development/libraries/SDL2_mixer/default.nix
+++ b/pkgs/development/libraries/SDL2_mixer/default.nix
@@ -47,6 +47,8 @@ stdenv.mkDerivation rec {
     timidity
   ];
 
+  outputs = [ "out" "dev" ];
+
   # fix default path to timidity.cfg so MIDI files could be played
   postPatch = ''
     substituteInPlace timidity/options.h \

--- a/pkgs/games/eduke32/default.nix
+++ b/pkgs/games/eduke32/default.nix
@@ -58,7 +58,7 @@ in stdenv.mkDerivation rec {
     done
   '';
 
-  NIX_CFLAGS_COMPILE = "-I${SDL2.dev}/include/SDL2 -I${SDL2_mixer}/include/SDL2";
+  NIX_CFLAGS_COMPILE = "-I${lib.getDev SDL2}/include/SDL2 -I${lib.getDev SDL2_mixer}/include/SDL2";
 
   makeFlags = [
     "SDLCONFIG=${SDL2}/bin/sdl2-config"

--- a/pkgs/games/ivan/default.nix
+++ b/pkgs/games/ivan/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = ["-DCMAKE_CXX_FLAGS=-DWIZARD"];
 
   # Help CMake find SDL_mixer.h
-  NIX_CFLAGS_COMPILE = "-I${SDL2_mixer}/include/SDL2";
+  NIX_CFLAGS_COMPILE = "-I${lib.getDev SDL2_mixer}/include/SDL2";
 
   # Create "ivan.desktop" file
   ivanDesktop = makeDesktopItem {

--- a/pkgs/games/srb2/default.nix
+++ b/pkgs/games/srb2/default.nix
@@ -60,8 +60,8 @@ in stdenv.mkDerivation rec {
     "-DSRB2_ASSET_DIRECTORY=/build/source/assets"
     "-DGME_INCLUDE_DIR=${game-music-emu}/include"
     "-DOPENMPT_INCLUDE_DIR=${libopenmpt.dev}/include"
-    "-DSDL2_MIXER_INCLUDE_DIR=${SDL2_mixer}/include/SDL2"
-    "-DSDL2_INCLUDE_DIR=${SDL2.dev}/include/SDL2"
+    "-DSDL2_MIXER_INCLUDE_DIR=${lib.getDev SDL2_mixer}/include/SDL2"
+    "-DSDL2_INCLUDE_DIR=${lib.getDev SDL2}/include/SDL2"
   ];
 
   patches = [

--- a/pkgs/games/srb2kart/default.nix
+++ b/pkgs/games/srb2kart/default.nix
@@ -52,8 +52,8 @@ in stdenv.mkDerivation rec {
   cmakeFlags = [
     #"-DSRB2_ASSET_DIRECTORY=/build/source/assets"
     "-DGME_INCLUDE_DIR=${game-music-emu}/include"
-    "-DSDL2_MIXER_INCLUDE_DIR=${SDL2_mixer}/include/SDL2"
-    "-DSDL2_INCLUDE_DIR=${SDL2.dev}/include/SDL2"
+    "-DSDL2_MIXER_INCLUDE_DIR=${lib.getDev SDL2_mixer}/include/SDL2"
+    "-DSDL2_INCLUDE_DIR=${lib.getDev SDL2}/include/SDL2"
   ];
 
   patches = [


### PR DESCRIPTION
`SDL2_mixer` is a a popular game dependency. Split it's `dev` output to separate store path to reduce runtime closure size.

While at it amend a few games's include paths.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
