### PR TITLE
gnome-info-collect: init at 0.1-7

### DIFF
--- a/pkgs/desktops/gnome/misc/gnome-info-collect/default.nix
+++ b/pkgs/desktops/gnome/misc/gnome-info-collect/default.nix
@@ -1,0 +1,61 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, python3
+, meson
+, ninja
+, accountsservice
+, gnome
+, gnome-online-accounts
+, malcontent
+, gobject-introspection
+, wrapGAppsNoGuiHook
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "gnome-info-collect";
+  version = "1.0-7";
+
+  format = "other";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "vstanek";
+    repo = "gnome-info-collect";
+    rev = "v${version}";
+    sha256 = "sha256-9C1pVCOaGLz0xEd2eKuOQRu49GOLD7LnDYvgxpCgtF4=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    gobject-introspection
+    wrapGAppsNoGuiHook
+  ];
+
+  buildInputs = [
+    accountsservice
+    gnome.gnome-remote-desktop
+    gnome.gnome-settings-daemon
+    gnome.gnome-shell
+    gnome.mutter
+    gnome-online-accounts
+    malcontent
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    pygobject3
+    requests
+  ];
+
+  meta = with lib; {
+    homepage = "https://gitlab.gnome.org/vstanek/gnome-info-collect";
+    description = "Simple utility to collect system information for improving GNOME";
+    maintainers = teams.gnome.members;
+    license = with licenses; [
+      lgpl21Only # Cambalache
+      gpl2Only # tools
+    ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7001,6 +7001,8 @@ with pkgs;
 
   gnome-frog = callPackage ../applications/misc/gnome-frog { };
 
+  gnome-info-collect = callPackage ../desktops/gnome/misc/gnome-info-collect { };
+
   gnome-keysign = callPackage ../tools/security/gnome-keysign { };
 
   gnome-secrets = callPackage ../applications/misc/gnome-secrets { };


### PR DESCRIPTION
###### Description of changes

Oops, forgot to push this, last day to submit a report: https://blogs.gnome.org/aday/2022/09/15/gnome-info-collect-closing-soon/

You can run the following command to generate a report (you will be asked to confirm before sending any data):

```
nix-shell -I nixpkgs=https://github.com/jtojnar/nixpkgs/archive/refs/heads/g-i-c.tar.gz -p gnome-info-collect --run gnome-info-collect
```

https://blogs.gnome.org/aday/2022/08/25/help-improve-gnome/

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
