### PR TITLE
freedroidrpg: remove build-time flags embedding into binary

### DIFF
--- a/pkgs/games/freedroidrpg/default.nix
+++ b/pkgs/games/freedroidrpg/default.nix
@@ -18,6 +18,9 @@ in stdenv.mkDerivation {
       url = "https://gitlab.com/freedroid/freedroid-src/-/commit/e610d427374226b79da5258d979936459f30c761.patch";
       sha256 = "1s7sw4dkc7b6i72j6x47driq6v0k3wss48l9ivd4fw40n3iaxjb1";
     })
+
+    # Do not embed build flags in the binary to reduce closure size.
+    ./drop-build-deps.patch
   ];
 
   nativeBuildInputs = [ pkg-config gettext python3 ];

--- a/pkgs/games/freedroidrpg/drop-build-deps.patch
+++ b/pkgs/games/freedroidrpg/drop-build-deps.patch
@@ -1,0 +1,15 @@
+Do not embed paths to build-only depends (-I...SDL2-dev and friends)
+into savefile lua comments.
+--- a/src/savestruct_internal.c
++++ b/src/savestruct_internal.c
+@@ -486,8 +486,8 @@ void save_game_data(struct auto_string *strout)
+ 	autostr_append(strout,
+ 		"SAVEGAME: %s %s %s;sizeof(tux_t)=%d;sizeof(enemy)=%d;sizeof(bullet)=%d;MAXBULLETS=%d\n",
+ 		SAVEGAME_VERSION, SAVEGAME_REVISION, VERSION, (int)sizeof(tux_t), (int)sizeof(enemy), (int)sizeof(bullet), (int)MAXBULLETS);
+-	autostr_append(strout, "BUILD_CFLAGS: %s\n", BUILD_CFLAGS);
+-	autostr_append(strout, "BUILD_LDFLAGS: %s\n", BUILD_LDFLAGS);
++	autostr_append(strout, "BUILD_CFLAGS: %s\n", "<hidden>");
++	autostr_append(strout, "BUILD_LDFLAGS: %s\n", "<hidden>");
+ 	autostr_append(strout, "VERSION: %s\n", freedroid_version);
+ 	autostr_append(strout, "--]]\n");
+ 


### PR DESCRIPTION
Noticed extra -dev dependencies in the runtime closure.

Before the change:

    $ nix path-info -rsSh $(nix-build -A freedroidrpg) | nl | tail -n1 | unnix
    158  /<<NIX>>/freedroidrpg-0.16.1 228.2M  808.1M

After the change:

    $ nix path-info -rsSh $(nix-build -A freedroidrpg) | nl | tail -n1 | unnix
    141  /<<NIX>>/freedroidrpg-0.16.1 228.2M  450.7M

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
