### PR TITLE
kpmcore: patch trustedprefixes

### DIFF
--- a/pkgs/development/libraries/kpmcore/default.nix
+++ b/pkgs/development/libraries/kpmcore/default.nix
@@ -13,6 +13,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-Ws20hKX2iDdke5yBBKXukVUD4OnLf1OmwlhW+jUXL24=";
   };
 
+  patches = [
+    ./nixostrustedprefix.patch
+  ];
+
   nativeBuildInputs = [ extra-cmake-modules ];
 
   buildInputs = [
@@ -29,6 +33,8 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     substituteInPlace src/util/CMakeLists.txt \
       --replace \$\{POLKITQT-1_POLICY_FILES_INSTALL_DIR\} $out/share/polkit-1/actions
+    substituteInPlace src/backend/corebackend.cpp \
+      --replace /usr/share/polkit-1/actions/org.kde.kpmcore.externalcommand.policy $out/share/polkit-1/actions/org.kde.kpmcore.externalcommand.policy
   '';
 
   meta = with lib; {

--- a/pkgs/development/libraries/kpmcore/nixostrustedprefix.patch
+++ b/pkgs/development/libraries/kpmcore/nixostrustedprefix.patch
@@ -1,0 +1,13 @@
+diff --git a/src/util/externalcommandhelper.cpp b/src/util/externalcommandhelper.cpp
+index a879c8d..3d7863b 100644
+--- a/src/util/externalcommandhelper.cpp
++++ b/src/util/externalcommandhelper.cpp
+@@ -387,7 +387,7 @@ QVariantMap ExternalCommandHelper::RunCommand(const QString& command, const QStr
+     if (dirname == QStringLiteral("bin") || dirname == QStringLiteral("sbin")) {
+         prefix.cdUp();
+     }
+-    if (trustedPrefixes.find(prefix.path()) == trustedPrefixes.end()) { // TODO: C++20: replace with contains
++    if (!prefix.path().startsWith(QStringLiteral("/nix/store")) && !prefix.path().startsWith(QStringLiteral("/run/current-system/sw"))) { // TODO: C++20: replace with contains
+         qInfo() << prefix.path() << "prefix is not one of the trusted command prefixes";
+         reply[QStringLiteral("success")] = false;
+         return reply;


### PR DESCRIPTION
###### Description of changes

Adds a patch to kpmcore to fix execution on Nix/NixOS.
Ever since the following commit, kpmcore checks where executions are being called from, and blacklists anything not in `/{bin,sbin}` or `/usr/{bin,sbin}`.
https://invent.kde.org/system/kpmcore/-/commit/6b260fa84e75944fd15c3fff1a77723086af2038

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

Patch the trusted prefix method to check for `/nix/store` or `/run/current-system/sw` instead.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
