### PR TITLE
cool-retro-term 1.1.1 -> 1.2.0

### DIFF
--- a/pkgs/applications/terminal-emulators/cool-retro-term/default.nix
+++ b/pkgs/applications/terminal-emulators/cool-retro-term/default.nix
@@ -1,22 +1,26 @@
 { lib, stdenv, fetchFromGitHub, mkDerivation, qtbase, qtquick1, qmltermwidget
-, qtquickcontrols, qtgraphicaleffects, qmake, nixosTests }:
+, qtquickcontrols, qtquickcontrols2, qtgraphicaleffects, qmake, nixosTests }:
 
 mkDerivation rec {
-  version = "1.1.1";
   pname = "cool-retro-term";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "Swordfish90";
     repo = "cool-retro-term";
     rev = version;
-    sha256 = "0mird4k88ml6y61hky2jynrjmnxl849fvhsr5jfdlnv0i7r5vwi5";
+    sha256 = "PewHLVmo+RTBHIQ/y2FBkgXsIvujYd7u56JdFC10B4c=";
   };
 
-  patchPhase = ''
-    sed -i -e '/qmltermwidget/d' cool-retro-term.pro
-  '';
+  patches = [ ./use-system-qmltermwidget.patch ];
 
-  buildInputs = [ qtbase qtquick1 qmltermwidget qtquickcontrols qtgraphicaleffects ];
+  buildInputs = [
+    qtbase
+    qtquick1
+    qmltermwidget
+    qtquickcontrols2
+    qtgraphicaleffects
+  ] ++ lib.optional stdenv.isDarwin qtquickcontrols;
   nativeBuildInputs = [ qmake ];
 
   installFlags = [ "INSTALL_ROOT=$(out)" ];

--- a/pkgs/applications/terminal-emulators/cool-retro-term/use-system-qmltermwidget.patch
+++ b/pkgs/applications/terminal-emulators/cool-retro-term/use-system-qmltermwidget.patch
@@ -1,0 +1,12 @@
+diff --git a/cool-retro-term.pro b/cool-retro-term.pro
+index 851f0b4..b24c473 100644
+--- a/cool-retro-term.pro
++++ b/cool-retro-term.pro
+@@ -2,7 +2,6 @@ TEMPLATE = subdirs
+ 
+ CONFIG += ordered
+ 
+-SUBDIRS += qmltermwidget
+ SUBDIRS += app
+ 
+ desktop.files += cool-retro-term.desktop

--- a/pkgs/development/libraries/qmltermwidget/default.nix
+++ b/pkgs/development/libraries/qmltermwidget/default.nix
@@ -1,27 +1,19 @@
-{ lib, stdenv, fetchFromGitHub, qtbase, qtquick1, qmake, qtmultimedia, utmp, fetchpatch }:
+{ lib, stdenv, fetchFromGitHub, qtbase, qtquick1, qmake, qtmultimedia, utmp }:
 
 stdenv.mkDerivation {
-  version = "2018-11-24";
   pname = "qmltermwidget-unstable";
+  version = "unstable-2022-09-16";
 
   src = fetchFromGitHub {
     repo = "qmltermwidget";
     owner = "Swordfish90";
-    rev = "48274c75660e28d44af7c195e79accdf1bd44963";
-    sha256 = "028nb1xp84jmakif5mmzx52q3rsjwckw27jdpahyaqw7j7i5znq6";
+    rev = "63228027e1f97c24abb907550b22ee91836929c5";
+    sha256 = "aVaiRpkYvuyomdkQYAgjIfi6a3wG2a6hNH1CfkA2WKQ=";
   };
 
   buildInputs = [ qtbase qtquick1 qtmultimedia ]
                 ++ lib.optional stdenv.isDarwin utmp;
   nativeBuildInputs = [ qmake ];
-
-  patches = [
-    (fetchpatch {
-      name = "fix-missing-includes.patch";
-      url = "https://github.com/Swordfish90/qmltermwidget/pull/27/commits/485f8d6d841b607ba49e55a791f7f587e4e193bc.diff";
-      sha256 = "186s8pv3642vr4lxsds919h0y2vrkl61r7wqq9mc4a5zk5vprinj";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace qmltermwidget.pro \


### PR DESCRIPTION
###### Description of changes

First-time PR; reviewed the contribution notes on GitHub and the manual carefully but still might have missed something.

Update `cool-retro-term` from `1.1.1` to `1.2.0` primarily for the reason that `Ctrl-Space`/`^@` was not working in `1.1.1` and was fixed in the new version.  It was also necessary to update `qmltermwidget` to fix the `cool-retro-term` build.

[Release notes for `cool-retro-term`](https://github.com/Swordfish90/cool-retro-term/releases/tag/1.2.0).  `Swordfish90/qmltermwidget` does not have any release notes (just a commit is referenced in the git submodule), but the upstream `lxqt/qmltermwidget` has [release notes](https://github.com/lxqt/qtermwidget/releases) (`0.9.0` to the most recent are relevant to this update).

Testing
- `nix-build ../nixpkgs/ -A cool-retro-term.passthru.tests.test`
- Ran the newly compiled binary briefly without issue

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
