### PR TITLE
juk: init at 22.08.1 DRAFT

### DIFF
--- a/pkgs/applications/audio/juk/default.nix
+++ b/pkgs/applications/audio/juk/default.nix
@@ -1,0 +1,72 @@
+/*
+
+nixpkgs $ nix-build . -A pkgs.juk
+
+FIXME playing music does not work
+  WARNING: bool Phonon::FactoryPrivate::createBackend() phonon backend plugin could not be loaded
+
+FIXME scrobbler config warning: kwallet is unavailable
+
+*/
+
+{ lib
+, mkDerivation
+, fetchFromGitLab
+, cmake
+, extra-cmake-modules
+, wrapQtAppsHook
+, kcoreaddons
+, kwidgetsaddons
+, kxmlgui
+, kconfig
+, kdoctools
+, ki18n
+, kiconthemes
+, kio
+, kwallet
+, phonon
+, taglib
+}:
+
+let
+
+in
+mkDerivation rec {
+  pname = "juk";
+  version = "22.08.1";
+
+  # https://invent.kde.org/multimedia/juk
+  src = fetchFromGitLab {
+    domain = "invent.kde.org";
+    owner = "multimedia";
+    repo = "juk";
+    rev = "v${version}";
+    sha256 = "sha256-a5ABeAB8bbbB8yTn85nPNZJ22BNfBjs6axHGnWvAk0Y=";
+  };
+
+  buildInputs = [
+    kcoreaddons
+    kiconthemes
+    kconfig
+    ki18n
+    kdoctools
+    kio
+    kxmlgui
+    kwallet # fix? kwallet is unavailable
+    kwidgetsaddons
+    phonon
+    taglib
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    wrapQtAppsHook
+  ];
+
+  meta = {
+    homepage = "https://apps.kde.org/juk/";
+    description = "audio player, tagger and music collection manager";
+    license = with lib.licenses; [ gpl2Only ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28911,6 +28911,8 @@ with pkgs;
 
   js8call = qt5.callPackage ../applications/radio/js8call { };
 
+  juk = libsForQt5.callPackage ../applications/audio/juk { };
+
   jwm = callPackage ../applications/window-managers/jwm { };
 
   jwm-settings-manager = callPackage ../applications/window-managers/jwm/jwm-settings-manager.nix { };


### PR DESCRIPTION
###### Description of changes

add package juk - audio player for KDE

part of #62168

for me, juk is too simple, and i prefer strawberry player

if someone needs juk, feel free to use my draft

todo: remove unneeded dependencies

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
