### PR TITLE
electron_20: 20.1.0 -> 20.1.3

### DIFF
--- a/pkgs/development/tools/electron/default.nix
+++ b/pkgs/development/tools/electron/default.nix
@@ -132,12 +132,12 @@ rec {
     headers = "09dbx4qh0rgp5mdm6srz6fgx12zq6b9jqq1k6l3gzyvwigi3wny1";
   };
 
-  electron_20 = mkElectron "20.1.0" {
-    armv7l-linux = "3efbf6ca2e54f8292a521f368b710ae043a91ef1943a93b26a27860a494fbd49";
-    aarch64-linux = "b5ae63ee40b486058e234392e8ed959ca0b51de570cb6454cd787a41258385a9";
-    x86_64-linux = "46e334eeb03ad12b987b4d6d1ba176d4389fe54f6435e7dd3d7ebc840259847e";
-    x86_64-darwin = "5d790a90a6a156d846157e4ae210fd4c1013356a2849681b762e7dd8828bfedf";
-    aarch64-darwin = "551c7f9ecf3f9d40572b3971b02c30e492134ff9400d97d3055fa7d089eff3eb";
-    headers = "1m05pz5baypyphmxhnsbcxn9cn3s4ajjiwnk1iscjnm394y8vlhb";
+  electron_20 = mkElectron "20.1.3" {
+    armv7l-linux = "99710a57c55d95b540f4c3568da2a7caccb7f91da23b530c8c40db5ac861ab24";
+    aarch64-linux = "8f39562f20210d7cdedbb063683d632df442c8553f62104c7d676121f3d9a357";
+    x86_64-linux = "219fb6f01305669f78cf1881d257e3cc48e5563330338516f8b6592d85fdb4a3";
+    x86_64-darwin = "134714291dcbecbf10cbc27c490a6501e2810bd4147a74f3b2671503445f2ce8";
+    aarch64-darwin = "a09f83442f1e9f4b1edc07445a1dca73d9597529b23d62731eaa3fa0488f4ab0";
+    headers = "11cv0p52864k4knwlwakiq8v6rxdv3iz6kvwhn0w8mpap2h5pzii";
   };
 }


### PR DESCRIPTION
###### Description of changes
Update to 20.1.3.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
