### PR TITLE
rustscan: 2.0.1 -> 2.1.0, add figsoda as a maintainer

### DIFF
--- a/pkgs/tools/security/rustscan/default.nix
+++ b/pkgs/tools/security/rustscan/default.nix
@@ -1,38 +1,36 @@
-{ lib, stdenv, fetchFromGitHub, rustPlatform, nmap, Security }:
+{ lib, rustPlatform, fetchCrate, nmap, stdenv, Security, perl, python3 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "rustscan";
-  version = "2.0.1";
+  version = "2.1.0";
 
-  src = fetchFromGitHub {
-    owner = "RustScan";
-    repo = pname;
-    rev = version;
-    sha256 = "0fdbsz1v7bb5dm3zqjs1qf73lb1m4qzkqyb3h3hbyrp9vklgxsgw";
+  src = fetchCrate {
+    inherit pname version;
+    sha256 = "sha256-f9QFsVGGKoWqZGIg8Z8FgZGcUo5M8MFNUavK69SgHkg=";
   };
 
-  cargoSha256 = "0658jbx59qrsgpfczzlfrbp2qm7kh0c5561bsxzmgiri7fcz9w0n";
+  cargoSha256 = "sha256-ZoDE7SJ6snWTFvYXHZdVCC6UCug2wGghH93FfDTDsv0=";
 
   postPatch = ''
-    substituteInPlace src/main.rs \
-      --replace 'Command::new("nmap")' 'Command::new("${nmap}/bin/nmap")'
+    substituteInPlace src/scripts/mod.rs \
+      --replace 'call_format = "nmap' 'call_format = "${nmap}/bin/nmap'
+    patchShebangs fixtures/.rustscan_scripts/*
   '';
 
   buildInputs = lib.optional stdenv.isDarwin Security;
 
+  checkInputs = [ perl python3 ];
+
+  # these tests require network access
   checkFlags = [
-    "--skip=infer_ulimit_lowering_no_panic"
-    "--skip=google_dns_runs"
     "--skip=parse_correct_host_addresses"
     "--skip=parse_hosts_file_and_incorrect_hosts"
-    "--skip=run_perl_script"
-    "--skip=run_python_script"
   ];
 
   meta = with lib; {
     description = "Faster Nmap Scanning with Rust";
     homepage = "https://github.com/RustScan/RustScan";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ figsoda ];
   };
 }


### PR DESCRIPTION
###### Description of changes

switched to `fetchCrate` because `Cargo.lock` is outdated in the github repository

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
