### PR TITLE
sm64ex-coop: 0.pre+date=2022-05-14 -> 0.pre+date=2022-08-05, cleanup

### DIFF
--- a/pkgs/games/sm64ex/coop.nix
+++ b/pkgs/games/sm64ex/coop.nix
@@ -1,0 +1,41 @@
+{ callPackage
+, fetchFromGitHub
+, autoPatchelfHook
+, zlib
+, stdenvNoCC
+}:
+
+callPackage ./generic.nix {
+  pname = "sm64ex-coop";
+  version = "0.pre+date=2022-08-05";
+
+  src = fetchFromGitHub {
+    owner = "djoslin0";
+    repo = "sm64ex-coop";
+    rev = "68634493de4cdd9db263e0f4f0b9b6772a60d30a";
+    sha256 = "sha256-3Ve93WGyBd8SAA0TBrpIrhj+ernjn1q7qXSi9mp36cQ=";
+  };
+
+  extraNativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  extraBuildInputs = [
+    zlib
+  ];
+
+  postInstall =
+    let
+      sharedLib = stdenvNoCC.hostPlatform.extensions.sharedLibrary;
+    in
+    ''
+      mkdir -p $out/lib
+      cp $src/lib/bass/libbass{,_fx}${sharedLib} $out/lib
+      cp $src/lib/discordsdk/libdiscord_game_sdk${sharedLib} $out/lib
+    '';
+
+  extraMeta = {
+    homepage = "https://github.com/djoslin0/sm64ex-coop";
+    description = "Super Mario 64 online co-op mod, forked from sm64ex";
+  };
+}

--- a/pkgs/games/sm64ex/default.nix
+++ b/pkgs/games/sm64ex/default.nix
@@ -1,55 +1,9 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, callPackage
-, autoPatchelfHook
+{ callPackage
 , branch
 }:
 
 {
-  sm64ex = callPackage ./generic.nix {
-    pname = "sm64ex";
-    version = "0.pre+date=2021-11-30";
+  sm64ex = callPackage ./sm64ex.nix { };
 
-    src = fetchFromGitHub {
-      owner = "sm64pc";
-      repo = "sm64ex";
-      rev = "db9a6345baa5acb41f9d77c480510442cab26025";
-      sha256 = "sha256-q7JWDvNeNrDpcKVtIGqB1k7I0FveYwrfqu7ZZK7T8F8=";
-    };
-
-    extraMeta = {
-      homepage = "https://github.com/sm64pc/sm64ex";
-      description = "Super Mario 64 port based off of decompilation";
-    };
-  };
-
-  sm64ex-coop = callPackage ./generic.nix {
-    pname = "sm64ex-coop";
-    version = "0.pre+date=2022-05-14";
-
-    src = fetchFromGitHub {
-      owner = "djoslin0";
-      repo = "sm64ex-coop";
-      rev = "8200b175607fe2939f067d496627c202a15fe24c";
-      sha256 = "sha256-c1ZmMBtvYYcaJ/WxkZBVvNGVCeSXfm8NKe/BiAIJtks=";
-    };
-
-    extraNativeBuildInputs = [
-      autoPatchelfHook
-    ];
-
-    postInstall = let
-      sharedLib = stdenv.hostPlatform.extensions.sharedLibrary;
-    in ''
-      mkdir -p $out/lib
-      cp $src/lib/bass/libbass{,_fx}${sharedLib} $out/lib
-      cp $src/lib/discordsdk/libdiscord_game_sdk${sharedLib} $out/lib
-    '';
-
-    extraMeta = {
-      homepage = "https://github.com/djoslin0/sm64ex-coop";
-      description = "Super Mario 64 online co-op mod, forked from sm64ex";
-    };
-  };
+  sm64ex-coop = callPackage ./coop.nix { };
 }.${branch}

--- a/pkgs/games/sm64ex/generic.nix
+++ b/pkgs/games/sm64ex/generic.nix
@@ -2,7 +2,8 @@
 , version
 , src
 , extraNativeBuildInputs ? [ ]
-, extraMeta ? {}
+, extraBuildInputs ? [ ]
+, extraMeta ? { }
 , compileFlags ? [ ]
 , postInstall ? ""
 , region ? "us"
@@ -44,7 +45,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     audiofile
     SDL2
-  ];
+  ] ++ extraBuildInputs;
 
   enableParallelBuilding = true;
 

--- a/pkgs/games/sm64ex/sm64ex.nix
+++ b/pkgs/games/sm64ex/sm64ex.nix
@@ -1,0 +1,21 @@
+{ callPackage
+, fetchFromGitHub
+}:
+
+callPackage ./generic.nix {
+  pname = "sm64ex";
+  version = "0.pre+date=2021-11-30";
+
+  src = fetchFromGitHub {
+    owner = "sm64pc";
+    repo = "sm64ex";
+    rev = "db9a6345baa5acb41f9d77c480510442cab26025";
+    sha256 = "sha256-q7JWDvNeNrDpcKVtIGqB1k7I0FveYwrfqu7ZZK7T8F8=";
+  };
+
+  extraMeta = {
+    homepage = "https://github.com/sm64pc/sm64ex";
+    description = "Super Mario 64 port based off of decompilation";
+  };
+}
+


### PR DESCRIPTION
###### Description of changes
This splits the two derivations into their own files to reduce clutter, and updates `sm64ex-coop` to its latest version.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and “core” functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
