### PR TITLE
nixos/neovim: fix remote plugin manifest generation

### DIFF
--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -100,7 +100,7 @@ let
         if ! $out/bin/nvim-wrapper \
           -u ${writeText "manifest.vim" manifestRc} \
           -i NONE -n \
-          -E -V1rplugins.log -s \
+          -V1rplugins.log \
           +UpdateRemotePlugins +quit! > outfile 2>&1; then
           cat outfile
           echo -e "\nGenerating rplugin.vim failed!"


### PR DESCRIPTION
###### Description of changes

Stops using ex mode when running neovim for remote plugin manifest generation, since that leads to errors in more recent neovim versions with various plugins.

Relevant discussion in and fix for #189804 



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

Fix personally tested for `vim-polyglot` and with 
<details>
<summary>currently used in my configuration</summary>

- nvim-lspconfig
- vim-automkdir
- vim-vsnip
- vim-vsnip-integ
- nvim-cmp
- cmp-nvim-lsp
- cmp-buffer
- cmp-path
- cmp-calc
- cmp-spell
- cmp-emoji
- cmp-treesitter
- cmp-latex-symbols
- cmp-omni
- cmp-vsnip
- vim-grammarous
- vim-matchup
- NeoSolarized
- nerdtree
- nerdtree-git-plugin
- vim-commentary
- camelcasemotion
- vim-closetag
- vim-polyglot
- vim-surround
- vim-indent-guides
- gruvbox
- vim-repeat
- vim-airline
- rainbow
- vim-devicons
- nvim-web-devicons
- vim-shellcheck
- editorconfig-vim
- plantuml-syntax
- nvim-treesitter
- vim-gnupg
- base16-vim
- base16-vim-airline-themes
- vim-ledger
- plenary-nvim 
- telescope-nvim
- telescope-fzf-native-nvim
- gitsigns-nvim
- neorg
- trouble-nvim
- friendly-snippets


</details>

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
