### PR TITLE
lief: 0.12.1 -> 0.12.2

### DIFF
--- a/pkgs/development/libraries/lief/default.nix
+++ b/pkgs/development/libraries/lief/default.nix
@@ -10,14 +10,18 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "lief";
-  version = "0.12.1";
+  version = "0.12.2";
 
   src = fetchFromGitHub {
     owner = "lief-project";
     repo = "LIEF";
     rev = version;
-    sha256 = "sha256-IQqPwTNFHLOr8iwg8IhXpuiyg2rIdFuVDzwT39eA6/c=";
+    sha256 = "sha256-/ndScq6qfQt68bWtRs/RTQjLykbjnTu1K56Rlc35WjI=";
   };
+
+  patches = [
+    ./setup-py-complete-copy2-transition.patch
+  ];
 
   outputs = [ "out" "py" ];
 

--- a/pkgs/development/libraries/lief/default.nix
+++ b/pkgs/development/libraries/lief/default.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
     description = "Library to Instrument Executable Formats";
     homepage = "https://lief.quarkslab.com/";
     license = [ licenses.asl20 ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = [ maintainers.lassulus ];
   };
 }

--- a/pkgs/development/libraries/lief/setup-py-complete-copy2-transition.patch
+++ b/pkgs/development/libraries/lief/setup-py-complete-copy2-transition.patch
@@ -1,0 +1,18 @@
+See https://github.com/lief-project/LIEF/issues/770#issuecomment-1250394972
+
+diff --git a/setup.py b/setup.py
+index 7af3e203..d276cc23 100644
+--- a/setup.py
++++ b/setup.py
+@@ -346,9 +346,8 @@ class BuildLibrary(build_ext):
+             sdk_path = str(sdk_path.pop())
+             sdk_output = str(pathlib.Path(CURRENT_DIR) / "build")
+ 
+-            copy_file(
+-                sdk_path, sdk_output, verbose=self.verbose,
+-                dry_run=self.dry_run)
++            if not self.dry_run:
++                copy2(sdk_path, sdk_output)
+ 
+ def get_platform():
+     out = get_platform_backup()


### PR DESCRIPTION
###### Description of changes
https://nvd.nist.gov/vuln/detail/CVE-2022-38497
https://nvd.nist.gov/vuln/detail/CVE-2022-38496
https://nvd.nist.gov/vuln/detail/CVE-2022-38495
https://nvd.nist.gov/vuln/detail/CVE-2022-38307
https://nvd.nist.gov/vuln/detail/CVE-2022-38306

Enabled on darwin while I was at it as it WFM.

For stable we can cherry-pick this along with the earlier 0.12.1 bump, both are quite minor releases.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
