### PR TITLE
cargo-ui: init at 0.3.2

### DIFF
--- a/pkgs/development/tools/rust/cargo-ui/default.nix
+++ b/pkgs/development/tools/rust/cargo-ui/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, rustPlatform
+, fetchCrate
+, cmake
+, pkg-config
+, makeWrapper
+, openssl
+, stdenv
+, fontconfig
+, libGL
+, libX11
+, libXcursor
+, libXi
+, libXrandr
+, libxcb
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-ui";
+  version = "0.3.2";
+
+  src = fetchCrate {
+    inherit pname version;
+    sha256 = "sha256-IL7BxiJg6eTuFM0pJ3qLxYCVofE/RjmgQjvOW96QF9A=";
+  };
+
+  cargoSha256 = "sha256-16mgp7GsjbizzCWN3MDpl6ps9CK1zdIpLiyNiKYjDI4=";
+
+  nativeBuildInputs = [ cmake pkg-config ] ++ lib.optionals stdenv.isLinux [
+    makeWrapper
+  ];
+
+  buildInputs = [ openssl ] ++ lib.optionals stdenv.isLinux [
+    fontconfig
+    libGL
+    libX11
+    libXcursor
+    libXi
+    libXrandr
+    libxcb
+  ];
+
+  postInstall = lib.optionalString stdenv.isLinux ''
+    wrapProgram $out/bin/cargo-ui \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libGL ]}
+  '';
+
+  meta = with lib; {
+    description = "A GUI for Cargo";
+    homepage = "https://github.com/slint-ui/cargo-ui";
+    changelog = "https://github.com/slint-ui/cargo-ui/blob/v${version}/CHANGELOG.md";
+    license = with licenses; [ mit asl20 gpl3Only ];
+    maintainers = with maintainers; [ figsoda ];
+    # figsoda: I can't figure how to make it build on darwin
+    broken = stdenv.isDarwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14691,6 +14691,10 @@ with pkgs;
   cargo-udeps = callPackage ../development/tools/rust/cargo-udeps {
     inherit (darwin.apple_sdk.frameworks) CoreServices Security SystemConfiguration;
   };
+  cargo-ui = callPackage ../development/tools/rust/cargo-ui {
+    inherit (xorg) libX11 libXcursor libXi libXrandr libxcb;
+    inherit (darwin.apple_sdk.frameworks);
+  };
 
   cargo-tauri = callPackage ../development/tools/rust/cargo-tauri { };
 


### PR DESCRIPTION
###### Description of changes

I can't figure out how to make it build on darwin, and it probably won't work on wayland as well in the current state
there is also an optional qt backend, but I am not very familiar with qt so I ignored it for now

https://github.com/slint-ui/cargo-ui

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
