### PR TITLE
cargo: add patches for CVE-2022-36113 and CVE-2022-36114

### DIFF
--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, pkgsHostHost
-, file, curl, pkg-config, python3, openssl, cmake, zlib
+, fetchpatch, file, curl, pkg-config, python3, openssl, cmake, zlib
 , installShellFiles, makeWrapper, cacert, rustPlatform, rustc
 , CoreFoundation, Security
 }:
@@ -7,6 +7,19 @@
 rustPlatform.buildRustPackage {
   pname = "cargo";
   inherit (rustc) version src;
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2022-36113.patch";
+      url = "https://raw.githubusercontent.com/rust-lang/wg-security-response/4bbe734e6404ece6f4e85027564f8995d4ab70e0/patches/CVE-2022-36113/0001-CVE-2022-36113-avoid-unpacking-.cargo-ok-from-the-cr.patch";
+      hash = "sha256-ioPwKnzVbvycxZ8kysqZ7D3MH8A3lXpPdYJNbl14u5w=";
+    })
+    (fetchpatch {
+      name = "CVE-2022-36114.patch";
+      url = "https://raw.githubusercontent.com/rust-lang/wg-security-response/4bbe734e6404ece6f4e85027564f8995d4ab70e0/patches/CVE-2022-36114/0001-CVE-2022-36114-limit-the-maximum-unpacked-size-of-a-.patch";
+      hash = "sha256-T85mBRC2guhBiytsYOUpSX9IMUgMymFcGyQurK+Q9Jg=";
+    })
+  ];
 
   # the rust source tarball already has all the dependencies vendored, no need to fetch them again
   cargoVendorDir = "vendor";


### PR DESCRIPTION
###### Description of changes

[Security advisory](https://blog.rust-lang.org/2022/09/14/cargo-cves.html)

> These issues have been assigned CVE-2022-36113 and CVE-2022-36114. The severity of these vulnerabilities is "low" for users of alternate registries. Users relying on crates.io are not affected.

> Since these vulnerabilities are just a more limited way to accomplish what a malicious build scripts or procedural macros can do, we decided not to publish Rust point releases backporting the security fix. Patch files for Rust 1.63.0 are available [in the wg-security-response repository](https://github.com/rust-lang/wg-security-response/tree/master/patches) for people building their own toolchains.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
