### PR TITLE
xcaddy: init at 0.3.1

### DIFF
--- a/pkgs/servers/caddy/xcaddy/default.nix
+++ b/pkgs/servers/caddy/xcaddy/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "xcaddy";
+  version = "0.3.1";
+
+  subPackages = [ "cmd/xcaddy" ];
+
+  src = fetchFromGitHub {
+    owner = "caddyserver";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-oGTtS5UlEebIqv4SM4q0YclASJNu8DNOLrGLRRAtkd8=";
+  };
+
+  vendorHash = "sha256-RpbnoXyTrqGOI7DpgkO+J47P17T4QCVvM1CfS6kRO9Y=";
+
+  meta = with lib; {
+    homepage = "https://github.com/caddyserver/xcaddy";
+    description = "Build Caddy with plugins";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ tjni ];
+  };
+}

--- a/pkgs/servers/caddy/xcaddy/default.nix
+++ b/pkgs/servers/caddy/xcaddy/default.nix
@@ -13,6 +13,10 @@ buildGoModule rec {
     hash = "sha256-oGTtS5UlEebIqv4SM4q0YclASJNu8DNOLrGLRRAtkd8=";
   };
 
+  patches = [
+    ./use_tmpdir_on_darwin.diff
+  ];
+
   vendorHash = "sha256-RpbnoXyTrqGOI7DpgkO+J47P17T4QCVvM1CfS6kRO9Y=";
 
   meta = with lib; {

--- a/pkgs/servers/caddy/xcaddy/use_tmpdir_on_darwin.diff
+++ b/pkgs/servers/caddy/xcaddy/use_tmpdir_on_darwin.diff
@@ -1,0 +1,13 @@
+diff --git a/builder.go b/builder.go
+index ed6c5ef..36e8055 100644
+--- a/builder.go
++++ b/builder.go
+@@ -200,7 +200,7 @@ func NewReplace(old, new string) Replace {
+ // It is the caller's responsibility to remove the folder when finished.
+ func newTempFolder() (string, error) {
+ 	var parentDir string
+-	if runtime.GOOS == "darwin" {
++	if false && runtime.GOOS == "darwin" {
+ 		// After upgrading to macOS High Sierra, Caddy builds mysteriously
+ 		// started missing the embedded version information that -ldflags
+ 		// was supposed to produce. But it only happened on macOS after

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3221,6 +3221,8 @@ with pkgs;
 
   caddy = callPackage ../servers/caddy { };
 
+  xcaddy = callPackage ../servers/caddy/xcaddy { };
+
   traefik = callPackage ../servers/traefik { };
 
   traefik-certs-dumper = callPackage ../tools/misc/traefik-certs-dumper { };


### PR DESCRIPTION
A tool that can be used to build the Caddy webserver with plugins.

It functions as its own package manager and calls out to the network, so it can't build Caddy in nixpkgs, but it's useful for environments that:

1. Do not need sandboxed and reproducible builds.

2. Pin Caddy and plugin versions when using the tool and trust it to be a reproducible (fixed) derivation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
