### PR TITLE
pantheon.elementary-music: backport a few changes

### DIFF
--- a/pkgs/desktops/pantheon/apps/elementary-music/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-music/default.nix
@@ -9,6 +9,8 @@
 , python3
 , vala
 , wrapGAppsHook4
+, elementary-gtk-theme
+, elementary-icon-theme
 , glib
 , granite7
 , gst_all_1
@@ -33,6 +35,24 @@ stdenv.mkDerivation rec {
       url = "https://github.com/elementary/music/commit/97a437edc7652e0b85b7d3c6fd87089c14ec02e2.patch";
       sha256 = "sha256-VmK5dKfSKWAIxfaKXsC8tjg6Pqq1XSGxJDQOZWJX92w=";
     })
+    # Skip invalid files instead of stopping playback
+    # https://github.com/elementary/music/pull/711
+    (fetchpatch {
+      url = "https://github.com/elementary/music/commit/88f332197d2131daeff3306ec2a484a28fa4db21.patch";
+      sha256 = "sha256-Zga0UmL1PAq4P58IjOuEiXGGn187a0/LHbXXze4sSpY=";
+    })
+    # Enable the NEXT button if repeat mode is set to ALL or ONE
+    # https://github.com/elementary/music/pull/712
+    (fetchpatch {
+      url = "https://github.com/elementary/music/commit/3249e3ca247dfd5ff6b14f4feeeeed63b435bcb8.patch";
+      sha256 = "sha256-nx/nlSSRxu4wy8QG5yYBi0BdRoUmnyry7mwzuk5NJxU=";
+    })
+    # Hard code GTK styles
+    # https://github.com/elementary/music/pull/723
+    (fetchpatch {
+      url = "https://github.com/elementary/music/commit/4e22268d38574e56eb3b42ae201c99cc98b510db.patch";
+      sha256 = "sha256-DZds7pg0vYL9vga+tP7KJHcjQTmdKHS+D+q/2aYfMmk=";
+    })
   ];
 
   nativeBuildInputs = [
@@ -45,6 +65,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
+    elementary-icon-theme
     glib
     granite7
     gtk4
@@ -59,6 +80,15 @@ stdenv.mkDerivation rec {
   postPatch = ''
     chmod +x meson/post_install.py
     patchShebangs meson/post_install.py
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      # The GTK theme is hardcoded.
+      --prefix XDG_DATA_DIRS : "${elementary-gtk-theme}/share"
+      # The icon theme is hardcoded.
+      --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS"
+    )
   '';
 
   passthru = {


### PR DESCRIPTION
###### Description of changes

void-linux is also backporting the theme hardcode fix (https://github.com/void-linux/void-packages/blob/master/srcpkgs/io.elementary.music/patches/hardcode-theme.patch), the app does not really look right on other themes.

No new Pantheon updates for a while.

This PR is for nixos-unstable only since elementary-music 7 is a major rewrite and not part of nixos-22.05

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
