### PR TITLE
nixos/lemmy: settings.database.createLocally -> database.createLocally

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -486,6 +486,14 @@
       </listitem>
       <listitem>
         <para>
+          lemmy module option
+          <literal>services.lemmy.settings.database.createLocally</literal>
+          moved to
+          <literal>services.lemmy.database.createLocally</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           virtlyst package and <literal>services.virtlyst</literal>
           module removed, due to lack of maintainers.
         </para>

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -166,6 +166,9 @@ Available as [services.patroni](options.html#opt-services.patroni.enable).
 
 - dd-agent package removed along with the `services.dd-agent` module, due to the project being deprecated in favor of `datadog-agent`,  which is available via the `services.datadog-agent` module.
 
+- lemmy module option `services.lemmy.settings.database.createLocally`
+  moved to `services.lemmy.database.createLocally`.
+
 - virtlyst package and `services.virtlyst` module removed, due to lack of maintainers.
 
 - The `services.graphite.api` and `services.graphite.beacon` NixOS options, and

--- a/nixos/modules/services/web-apps/lemmy.nix
+++ b/nixos/modules/services/web-apps/lemmy.nix
@@ -28,6 +28,8 @@ in
 
     caddy.enable = mkEnableOption (lib.mdDoc "exposing lemmy with the caddy reverse proxy");
 
+    database.createLocally = mkEnableOption (lib.mdDoc "creation of database on the instance");
+
     settings = mkOption {
       default = { };
       description = lib.mdDoc "Lemmy configuration";
@@ -63,9 +65,6 @@ in
             description = lib.mdDoc "The difficultly of the captcha to solve.";
           };
         };
-
-        options.database.createLocally = mkEnableOption (lib.mdDoc "creation of database on the instance");
-
       };
     };
 
@@ -142,7 +141,7 @@ in
       };
 
       assertions = [{
-        assertion = cfg.settings.database.createLocally -> localPostgres;
+        assertion = cfg.database.createLocally -> localPostgres;
         message = "if you want to create the database locally, you need to use a local database";
       }];
 
@@ -163,9 +162,9 @@ in
 
         wantedBy = [ "multi-user.target" ];
 
-        after = [ "pict-rs.service" ] ++ lib.optionals cfg.settings.database.createLocally [ "lemmy-postgresql.service" ];
+        after = [ "pict-rs.service" ] ++ lib.optionals cfg.database.createLocally [ "lemmy-postgresql.service" ];
 
-        requires = lib.optionals cfg.settings.database.createLocally [ "lemmy-postgresql.service" ];
+        requires = lib.optionals cfg.database.createLocally [ "lemmy-postgresql.service" ];
 
         serviceConfig = {
           DynamicUser = true;
@@ -203,7 +202,7 @@ in
         };
       };
 
-      systemd.services.lemmy-postgresql = mkIf cfg.settings.database.createLocally {
+      systemd.services.lemmy-postgresql = mkIf cfg.database.createLocally {
         description = "Lemmy postgresql db";
         after = [ "postgresql.service" ];
         partOf = [ "lemmy.service" ];

--- a/nixos/tests/lemmy.nix
+++ b/nixos/tests/lemmy.nix
@@ -15,10 +15,10 @@ in
       services.lemmy = {
         enable = true;
         ui.port = uiPort;
+        database.createLocally = true;
         settings = {
           hostname = "http://${lemmyNodeName}";
           port = backendPort;
-          database.createLocally = true;
           # Without setup, the /feeds/* and /nodeinfo/* API endpoints won't return 200
           setup = {
             admin_username = "mightyiam";


### PR DESCRIPTION
###### Description of changes

The freeform option `services.lemmy.settings` generates a json configuration file for lemmy.
The option set for lemmy, includes a typical `database.createLocally`, which creates a database locally.
One would expect this option to be at the path `services.lemmy.database.createLocally` or similar.
However, it is currently at `services.lemmy.settings.database.createLocally`.
Its current path means that it ends up as part of the json configuration file that is passed into lemmy.
This was probably unintentional. Lemmy does not have such an option.

We noticed that `mkRenamedOptionModule` fails in this case. We figured it was because `services.lemmy.settings` is a freeform option module. We assume that `mkRemovedOptionModule` would fail as well.

Can we receive confirmation on these assumptions?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->