### PR TITLE
issue template: fill 'about' field

### DIFF
--- a/.github/ISSUE_TEMPLATE/missing_documentation.md
+++ b/.github/ISSUE_TEMPLATE/missing_documentation.md
@@ -1,6 +1,6 @@
 ---
 name: Missing or incorrect documentation
-about:
+about: Help us improve the Nixpkgs and NixOS reference manuals
 title: ''
 labels: '9.needs: documentation'
 assignees: ''


### PR DESCRIPTION
according to [GitHub documentation] some fields are required.
`about` is not listed, but it probably is required.

[GitHub documentation]: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms