### PR TITLE
[22.05] privacyidea: 3.7.2 -> 3.7.3

### DIFF
--- a/pkgs/applications/misc/privacyidea/default.nix
+++ b/pkgs/applications/misc/privacyidea/default.nix
@@ -35,19 +35,7 @@ let
         checkInputs = old.checkInputs ++ (with self; [
           requests
         ]);
-        disabledTests = old.disabledTests ++ [
-          # ResourceWarning: unclosed file
-          "test_basic"
-          "test_date_to_unix"
-          "test_easteregg"
-          "test_file_rfc2231_filename_continuations"
-          "test_find_terminator"
-          "test_save_to_pathlib_dst"
-        ];
-        disabledTestPaths = old.disabledTestPaths ++ [
-          # ResourceWarning: unclosed file
-          "tests/test_http.py"
-        ];
+        doCheck = false;
       });
       # Required by flask-1.1
       jinja2 = super.jinja2.overridePythonAttrs (old: rec {
@@ -77,18 +65,32 @@ let
       sqlsoup = super.sqlsoup.overrideAttrs ({ meta ? {}, ... }: {
         meta = meta // { broken = false; };
       });
+      click = super.click.overridePythonAttrs (old: rec {
+        version = "7.1.2";
+        src = old.src.override {
+          inherit version;
+          sha256 = "d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a";
+        };
+      });
+      # Now requires `lingua` as check input that requires a newer `click`,
+      # however `click-7` is needed by the older flask we need here. Since it's just
+      # for the test-suite apparently, let's skip it for now.
+      Mako = super.Mako.overridePythonAttrs (lib.const {
+        checkInputs = [];
+        doCheck = false;
+      });
     };
   };
 in
 python3'.pkgs.buildPythonPackage rec {
   pname = "privacyIDEA";
-  version = "3.7.2";
+  version = "3.7.3";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-bjMw69nKecv87nwsLfb4+h677WjZlkVcIpVe53AI9WU=";
+    sha256 = "sha256-odwYUGfgoRrGbLpOh8SuQzYby8Ya6hKSn0rdHp+RS/U=";
     fetchSubmodules = true;
   };
 
@@ -103,23 +105,29 @@ python3'.pkgs.buildPythonPackage rec {
   passthru.tests = { inherit (nixosTests) privacyidea; };
 
   checkInputs = with python3'.pkgs; [ openssl mock pytestCheckHook responses testfixtures ];
+  preCheck = "export HOME=$(mktemp -d)";
+  postCheck = "unset HOME";
   disabledTests = [
-    "AESHardwareSecurityModuleTestCase"
-    "test_01_cert_request"
+    # expects `/home/` to exist, fails with `FileNotFoundError: [Errno 2] No such file or directory: '/home/'`.
     "test_01_loading_scripts"
+
+    # Tries to connect to `fcm.googleapis.com`.
     "test_02_api_push_poll"
-    "test_02_cert_enrolled"
-    "test_02_enroll_rights"
-    "test_02_get_resolvers"
-    "test_02_success"
-    "test_03_get_identifiers"
-    "test_04_remote_user_auth"
+
+    # Timezone info not available in build sandbox
     "test_14_convert_timestamp_to_utc"
+
+    # Fails because of different logger configurations
+    "test_01_create_default_app"
+    "test_03_logging_config_file"
+    "test_04_logging_config_yaml"
+    "test_05_logging_config_broken_yaml"
   ];
 
   pythonImportsCheck = [ "privacyidea" ];
 
   postPatch = ''
+    patchShebangs tests/testdata/scripts
     substituteInPlace privacyidea/lib/resolvers/LDAPIdResolver.py --replace \
       "/etc/privacyidea/ldap-ca.crt" \
       "${cacert}/etc/ssl/certs/ca-bundle.crt"


### PR DESCRIPTION

###### Description of changes
Backport of #191748.

ChangeLog: https://github.com/privacyidea/privacyidea/blob/v3.7.3/Changelog Failing Hydra build: https://hydra.nixos.org/build/190981743

* Disable tests of `werkzeug` since a lot of it is now failing with `unclosed file handle` (partly just randomly) which is an indicator for a broken test-suite. Dependency updates that would help us to get rid of this hackery are apparently in progress upstream[1].

* Disable checkPhase for `Mako` since it now requires `lingua` as `checkInput`, but it'd require `click>8`, however we use v7 here for the older flask. To avoid even more dependency chaos, I decided to just turn off the tests here.

* Update disabled tests for `privacyidea` itself: a few tests are either removed or succeeding now (perhaps because we now set `$HOME` now for tests ;-) ). Documented on the remaining tests why they can't work in a `nix-build`.

[1] https://github.com/privacyidea/privacyidea/issues/2876

(cherry picked from commit f1fa5f1eb471a993e3b342fd95c92f3b38acb1b1)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
