### PR TITLE
svg2pdf: init at 0.4.0

### DIFF
--- a/pkgs/tools/graphics/svg2pdf/default.nix
+++ b/pkgs/tools/graphics/svg2pdf/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, stdenv
+, fetchCrate
+, rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "svg2pdf";
+  version = "0.4.0";
+  # This cargo package is usually a library, hence it does not track a
+  # Cargo.lock by default so we use fetchCrate
+  src = fetchCrate {
+    inherit version pname;
+    sha256 = "2Aw8VYFVw0rKeaDUTsYTHcHBDP1jLm4tVGfi6+RNK9E=";
+  };
+  cargoSha256 = "KADfBOnkY1T1xy4Oj7s85SXcDhjRhQQ2hWGWinMXux8=";
+  buildFeatures = [ "cli" ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Convert SVG files to PDFs";
+    homepage = "https://github.com/typst/svg2pdf";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15405,6 +15405,8 @@ with pkgs;
 
   svg2tikz = python27Packages.svg2tikz;
 
+  svg2pdf = callPackage ../tools/graphics/svg2pdf { };
+
   pew = callPackage ../development/tools/pew {};
 
   poetry = callPackage ../development/tools/poetry2nix/poetry2nix/pkgs/poetry {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
