### PR TITLE
lz4: fix static build

### DIFF
--- a/pkgs/tools/compression/lz4/default.nix
+++ b/pkgs/tools/compression/lz4/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, valgrind
+{ lib, stdenv, fetchFromGitHub, valgrind, fetchpatch
 , enableStatic ? stdenv.hostPlatform.isStatic
 , enableShared ? !stdenv.hostPlatform.isStatic
 }:
@@ -13,6 +13,14 @@ stdenv.mkDerivation rec {
     repo = pname;
     owner = pname;
   };
+
+  patches = [
+    (fetchpatch { # https://github.com/lz4/lz4/pull/1162
+      name = "build-shared-no.patch";
+      url = "https://github.com/lz4/lz4/commit/851ef4b23c7cbf4ceb2ba1099666a8b5ec4fa195.patch";
+      sha256 = "sha256-P+/uz3m7EAmHgXF/1Vncc0uKKxNVq6HNIsElx0rGxpw=";
+    })
+  ];
 
   # TODO(@Ericson2314): Separate binaries and libraries
   outputs = [ "bin" "out" "dev" ];


### PR DESCRIPTION
###### Description of changes

This patches lz4 with https://github.com/lz4/lz4/pull/1162, fixing the static build.

Before this, I see

```
$ nix build nixpkgs#pkgsStatic.lz4
error: builder for '/nix/store/4ssbvpxh8bp5gdk7517ip22myl6b39an-lz4-static-x86_64-unknown-linux-musl-1.9.4.drv' failed with exit code 2;
       last 10 log lines:
       > build flags: -j2 -l2 SHELL=/nix/store/p7bpdnxqd3i5hwm92mrscf7mvxk66404-bash-5.1-p16/bin/bash PREFIX=\$\(out\) INCLUDEDIR=\$\(dev\)/include BUILD_STATIC=yes BUILD_SHARED=no WINDRES:=x86_64-unknown-linux-musl-windres
       > make[1]: Entering directory '/build/source/lib'
       > compiling static library
       > compiling dynamic library 1.9.4
       > /nix/store/q8zpwwa77zaa5h0p15iiid26g5ak6s7l-x86_64-unknown-linux-musl-binutils-2.38/bin/x86_64-unknown-linux-musl-ld: /nix/store/ravnd17fg4maxzc5ns8vbijn7ah3p4b1-x86_64-unknown-linux-musl-stage-final-gcc-11.3.0/lib/gcc/x86_64-unknown-linux-musl/11.3.0/crtbeginT.o: relocation R_X86_64_32 against hidden symbol `__TMC_END__' can not be used when making a shared object
       > /nix/store/q8zpwwa77zaa5h0p15iiid26g5ak6s7l-x86_64-unknown-linux-musl-binutils-2.38/bin/x86_64-unknown-linux-musl-ld: failed to set dynamic section sizes: bad value
       > collect2: error: ld returned 1 exit status
       > make[1]: *** [Makefile:122: liblz4.so.1.9.4] Error 1
       > make[1]: Leaving directory '/build/source/lib'
       > make: *** [Makefile:57: lib-release] Error 2
```

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
