### PR TITLE
julia_18: init at 1.8.1

### DIFF
--- a/pkgs/development/compilers/julia/1.8.nix
+++ b/pkgs/development/compilers/julia/1.8.nix
@@ -1,0 +1,153 @@
+{ lib
+, stdenv
+, fetchurl
+, which
+, python3
+, gfortran
+, gcc
+, cmake
+, perl
+, gnum4
+, libwhich
+, libxml2
+, libunwind
+, libgit2
+, curl
+, nghttp2
+, mbedtls
+, libssh2
+, gmp
+, mpfr
+, suitesparse
+, utf8proc
+, zlib
+, p7zip
+, ncurses
+, pcre2
+}:
+
+stdenv.mkDerivation rec {
+  pname = "julia";
+  version = "1.8.1";
+
+  src = fetchurl {
+    url = "https://github.com/JuliaLang/julia/releases/download/v${version}/julia-${version}-full.tar.gz";
+    sha256 = "sha256-MeRlX0s3fnPW9YPFOdAiHte0gKPqCRgz0ABTFhhcW2E=";
+  };
+
+  patches =
+    let
+      path = name: "https://raw.githubusercontent.com/archlinux/svntogit-community/6fd126d089d44fdc875c363488a7c7435a223cec/trunk/${name}";
+    in
+    [
+      (fetchurl {
+        url = path "julia-hardcoded-libs.patch";
+        sha256 = "sha256-kppSpVA7bRohd0wXDs4Jgct9ocHnpbeiiSz7ElFom1U=";
+      })
+      (fetchurl {
+        url = path "julia-libgit-1.4.patch";
+        sha256 = "sha256-rcVXYoGpAxwAbAl33n0/Rkwsi8ZJz8cnHQ5CalUx+1o=";
+      })
+      (fetchurl {
+        url = path "julia-libunwind-1.6.patch";
+        sha256 = "sha256-zqMh9+Fjgd15XuINe9Xtpk+bRTwB0T6WCWLrJyOQfiQ=";
+      })
+      ./patches/1.8/0001-skip-symlink-system-libraries.patch
+      ./patches/1.8/0002-skip-building-doc.patch
+      ./patches/1.8/0003-skip-failing-tests.patch
+      ./patches/1.8/0004-ignore-absolute-path-when-loading-library.patch
+    ];
+
+  nativeBuildInputs = [
+    which
+    python3
+    gfortran
+    cmake
+    perl
+    gnum4
+    libwhich
+  ];
+
+  buildInputs = [
+    libxml2
+    libunwind
+    libgit2
+    curl
+    nghttp2
+    mbedtls
+    libssh2
+    gmp
+    mpfr
+    utf8proc
+    zlib
+    p7zip
+    pcre2
+  ];
+
+  JULIA_RPATH = lib.makeLibraryPath (buildInputs ++ [ stdenv.cc.cc gfortran.cc ncurses ]);
+
+  dontUseCmakeConfigure = true;
+
+  postPatch = ''
+    patchShebangs .
+  '';
+
+  LDFLAGS = "-Wl,-rpath,${JULIA_RPATH}";
+
+  makeFlags = [
+    "prefix=$(out)"
+    "USE_BINARYBUILDER=0"
+    "USE_SYSTEM_CSL=1"
+    "USE_SYSTEM_LLVM=0" # a patched version is required
+    "USE_SYSTEM_LIBUNWIND=1"
+    "USE_SYSTEM_PCRE=1"
+    "USE_SYSTEM_LIBM=0"
+    "USE_SYSTEM_OPENLIBM=0"
+    "USE_SYSTEM_DSFMT=0" # not available in nixpkgs
+    "USE_SYSTEM_LIBBLASTRAMPOLINE=0" # not available in nixpkgs
+    "USE_SYSTEM_BLAS=0" # test failure
+    "USE_SYSTEM_LAPACK=0" # test failure
+    "USE_SYSTEM_GMP=1"
+    "USE_SYSTEM_MPFR=1"
+    "USE_SYSTEM_LIBSUITESPARSE=0" # test failure
+    "USE_SYSTEM_LIBUV=0" # a patched version is required
+    "USE_SYSTEM_UTF8PROC=1"
+    "USE_SYSTEM_MBEDTLS=1"
+    "USE_SYSTEM_LIBSSH2=1"
+    "USE_SYSTEM_NGHTTP2=1"
+    "USE_SYSTEM_CURL=1"
+    "USE_SYSTEM_LIBGIT2=1"
+    "USE_SYSTEM_PATCHELF=1"
+    "USE_SYSTEM_LIBWHICH=1"
+    "USE_SYSTEM_ZLIB=1"
+    "USE_SYSTEM_P7ZIP=1"
+
+    "PCRE_INCL_PATH=${pcre2.dev}/include/pcre2.h"
+  ];
+
+  doInstallCheck = true;
+  installCheckTarget = "testall";
+
+  preInstallCheck = ''
+    export HOME="$TMPDIR"
+    export JULIA_TEST_USE_MULTIPLE_WORKERS="true"
+  '';
+
+  dontStrip = true;
+
+  postFixup = ''
+    for file in $out/bin/julia $out/lib/libjulia.so $out/lib/julia/libjulia-internal.so $out/lib/julia/libjulia-codegen.so; do
+      patchelf --set-rpath "$out/lib:$out/lib/julia:${JULIA_RPATH}" $file
+    done
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "High-level performance-oriented dynamical language for technical computing";
+    homepage = "https://julialang.org/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ nickcao ];
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
+  };
+}

--- a/pkgs/development/compilers/julia/patches/1.8/0001-skip-symlink-system-libraries.patch
+++ b/pkgs/development/compilers/julia/patches/1.8/0001-skip-symlink-system-libraries.patch
@@ -1,0 +1,32 @@
+From f342b6bfab5eee9c7fea9ddc8804d9a5ff6953eb Mon Sep 17 00:00:00 2001
+From: Nick Cao <nickcao@nichi.co>
+Date: Tue, 20 Sep 2022 18:42:08 +0800
+Subject: [PATCH 1/4] skip symlink system libraries
+
+---
+ base/Makefile | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/base/Makefile b/base/Makefile
+index 23a9c40..12f92aa 100644
+--- a/base/Makefile
++++ b/base/Makefile
+@@ -181,7 +181,6 @@ $$(build_private_libdir)/$$(libname_$2):
+ 		fi; \
+ 	fi
+ ifneq ($$(USE_SYSTEM_$1),0)
+-SYMLINK_SYSTEM_LIBRARIES += symlink_$2
+ endif
+ endef
+ 
+@@ -265,7 +264,6 @@ $(build_private_libdir)/libLLVM.$(SHLIB_EXT):
+ 	ln -sf "$$REALPATH" "$@"
+ ifneq ($(USE_SYSTEM_LLVM),0)
+ ifneq ($(USE_LLVM_SHLIB),0)
+-SYMLINK_SYSTEM_LIBRARIES += symlink_libLLVM
+ endif
+ endif
+ 
+-- 
+2.37.2
+

--- a/pkgs/development/compilers/julia/patches/1.8/0002-skip-building-doc.patch
+++ b/pkgs/development/compilers/julia/patches/1.8/0002-skip-building-doc.patch
@@ -1,0 +1,25 @@
+From 6a7723be33261cdc302e0f7bdb37fb50d30cc5fc Mon Sep 17 00:00:00 2001
+From: Nick Cao <nickcao@nichi.co>
+Date: Tue, 20 Sep 2022 18:42:31 +0800
+Subject: [PATCH 2/4] skip building doc
+
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index d38311d..a775d36 100644
+--- a/Makefile
++++ b/Makefile
+@@ -227,7 +227,7 @@ define stringreplace
+ endef
+ 
+ 
+-install: $(build_depsbindir)/stringreplace $(BUILDROOT)/doc/_build/html/en/index.html
++install: $(build_depsbindir)/stringreplace
+ ifeq ($(BUNDLE_DEBUG_LIBS),1)
+ 	@$(MAKE) $(QUIET_MAKE) all
+ else
+-- 
+2.37.2
+

--- a/pkgs/development/compilers/julia/patches/1.8/0003-skip-failing-tests.patch
+++ b/pkgs/development/compilers/julia/patches/1.8/0003-skip-failing-tests.patch
@@ -1,0 +1,25 @@
+From a57c582eabc4703ed627b32f7f11893db9676fb6 Mon Sep 17 00:00:00 2001
+From: Nick Cao <nickcao@nichi.co>
+Date: Tue, 20 Sep 2022 18:42:59 +0800
+Subject: [PATCH 3/4] skip failing tests
+
+---
+ test/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test/Makefile b/test/Makefile
+index 24e137a..0e82acf 100644
+--- a/test/Makefile
++++ b/test/Makefile
+@@ -23,7 +23,7 @@ default:
+ 
+ $(TESTS):
+ 	@cd $(SRCDIR) && \
+-	$(call PRINT_JULIA, $(call spawn,$(JULIA_EXECUTABLE)) --check-bounds=yes --startup-file=no --depwarn=error ./runtests.jl $@)
++	$(call PRINT_JULIA, $(call spawn,$(JULIA_EXECUTABLE)) --check-bounds=yes --startup-file=no --depwarn=error ./runtests.jl --skip LibGit2_jll --skip MozillaCACerts_jll --skip NetworkOptions --skip nghttp2_jll $@)
+ 
+ $(addprefix revise-, $(TESTS)): revise-% :
+ 	@cd $(SRCDIR) && \
+-- 
+2.37.2
+

--- a/pkgs/development/compilers/julia/patches/1.8/0004-ignore-absolute-path-when-loading-library.patch
+++ b/pkgs/development/compilers/julia/patches/1.8/0004-ignore-absolute-path-when-loading-library.patch
@@ -1,0 +1,27 @@
+From a60100f06f48fbb4697aced65175bf3d41185e3e Mon Sep 17 00:00:00 2001
+From: Nick Cao <nickcao@nichi.co>
+Date: Tue, 20 Sep 2022 18:43:15 +0800
+Subject: [PATCH 4/4] ignore absolute path when loading library
+
+---
+ cli/loader_lib.c | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/cli/loader_lib.c b/cli/loader_lib.c
+index 0301b6e..5cbda61 100644
+--- a/cli/loader_lib.c
++++ b/cli/loader_lib.c
+@@ -50,9 +50,7 @@ static void * load_library(const char * rel_path, const char * src_dir, int err)
+ #endif
+ 
+     char path[2*JL_PATH_MAX + 1] = {0};
+-    strncat(path, src_dir, sizeof(path) - 1);
+-    strncat(path, PATHSEPSTRING, sizeof(path) - 1);
+-    strncat(path, rel_path, sizeof(path) - 1);
++    strncat(path, basename, sizeof(path) - 1);
+ 
+ #if defined(_OS_WINDOWS_)
+     wchar_t wpath[2*JL_PATH_MAX + 1] = {0};
+-- 
+2.37.2
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14192,6 +14192,8 @@ with pkgs;
   julia_16-bin = callPackage ../development/compilers/julia/1.6-bin.nix { };
   julia_18-bin = callPackage ../development/compilers/julia/1.8-bin.nix { };
 
+  julia_18 = callPackage ../development/compilers/julia/1.8.nix { };
+
   julia-lts-bin = julia_16-bin;
   julia-stable-bin = julia_18-bin;
   julia-bin = julia-stable-bin;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
