### PR TITLE
pythonPackages.unittestCheckHook: align to docs, support dynamic flags in `preCheck` script

### DIFF
--- a/pkgs/applications/misc/haxor-news/default.nix
+++ b/pkgs/applications/misc/haxor-news/default.nix
@@ -54,7 +54,7 @@ buildPythonApplication rec {
 
   checkInputs = [ unittestCheckHook mock ];
 
-  unittestFlagsArray = [ "-s" "tests" "-v" ];
+  unittestFlags = [ "-s" "tests" "-v" ];
 
   meta = with lib; {
     homepage = "https://github.com/donnemartin/haxor-news";

--- a/pkgs/development/interpreters/python/hooks/unittest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/unittest-check-hook.sh
@@ -5,7 +5,13 @@ unittestCheckPhase() {
     echo "Executing unittestCheckPhase"
     runHook preCheck
 
-    eval "@pythonCheckInterpreter@ -m unittest discover $unittestFlagsArray"
+    # Old bash empty array hack
+    # shellcheck disable=SC2086
+    local flagsArray=(
+        ${unittestFlags:-} "${unittestFlagsArray[@]}"
+    )
+    echoCmd 'unittest check flags' "${flagsArray[@]}"
+    @pythonCheckInterpreter@ -m unittest discover "${flagsArray[@]}"
 
     runHook postCheck
     echo "Finished executing unittestCheckPhase"

--- a/pkgs/development/python-modules/arxiv2bib/default.nix
+++ b/pkgs/development/python-modules/arxiv2bib/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   };
 
   checkInputs = [ unittestCheckHook mock ];
-  unittestFlagsArray = [ "-s" "tests" ];
+  unittestFlags = [ "-s" "tests" ];
 
   meta = with lib; {
     description = "Get a BibTeX entry from an arXiv id number, using the arxiv.org API";

--- a/pkgs/development/python-modules/backports_tempfile/default.nix
+++ b/pkgs/development/python-modules/backports_tempfile/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   checkInputs = [ unittestCheckHook ];
 
-  unittestFlagsArray = [ "-s" "tests" ];
+  unittestFlags = [ "-s" "tests" ];
 
   meta = {
     description = "Backport of new features in Python's tempfile module";

--- a/pkgs/development/python-modules/backports_weakref/default.nix
+++ b/pkgs/development/python-modules/backports_weakref/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   checkInputs = [ unittestCheckHook ];
 
-  unittestFlagsArray = [ "tests" ];
+  unittestFlags = [ "tests" ];
 
   meta = with lib; {
     description = "Backports of new features in Python’s weakref module";

--- a/pkgs/development/python-modules/bitstring/default.nix
+++ b/pkgs/development/python-modules/bitstring/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   checkInputs = [ unittestCheckHook ];
 
-  unittestFlagsArray = [ "-s" "test" ];
+  unittestFlags = [ "-s" "test" ];
 
   pythonImportsCheck = [ "bitstring" ];
 

--- a/pkgs/development/python-modules/cvxopt/default.nix
+++ b/pkgs/development/python-modules/cvxopt/default.nix
@@ -53,7 +53,7 @@ buildPythonPackage rec {
 
   checkInputs = [ unittestCheckHook ];
 
-  unittestFlagsArray = [ "-s" "tests" ];
+  unittestFlags = [ "-s" "tests" ];
 
   meta = with lib; {
     homepage = "http://cvxopt.org/";

--- a/pkgs/development/python-modules/fido2/default.nix
+++ b/pkgs/development/python-modules/fido2/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   checkInputs = [ unittestCheckHook mock pyfakefs ];
 
-  unittestFlagsArray = [ "-v" ];
+  unittestFlags = [ "-v" ];
 
   pythonImportsCheck = [ "fido2" ];
 

--- a/pkgs/development/python-modules/flask-babel/default.nix
+++ b/pkgs/development/python-modules/flask-babel/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     speaklater
   ];
 
-  unittestFlagsArray = [ "-s" "tests" ];
+  unittestFlags = [ "-s" "tests" ];
 
   meta = with lib; {
     description = "Adds i18n/l10n support to Flask applications";

--- a/pkgs/development/python-modules/greenlet/default.nix
+++ b/pkgs/development/python-modules/greenlet/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   checkInputs = [ unittestCheckHook ];
 
-  unittestFlagsArray = [ "-v" "greenlet.tests" ];
+  unittestFlags = [ "-v" "greenlet.tests" ];
 
   meta = with lib; {
     homepage = "https://github.com/python-greenlet/greenlet";

--- a/pkgs/development/python-modules/isodate/default.nix
+++ b/pkgs/development/python-modules/isodate/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   checkInputs = [ unittestCheckHook ];
 
-  unittestFlagsArray = [ "-s" "src/isodate/tests" ];
+  unittestFlags = [ "-s" "src/isodate/tests" ];
 
   meta = with lib; {
     description = "ISO 8601 date/time parser";

--- a/pkgs/development/python-modules/jxmlease/default.nix
+++ b/pkgs/development/python-modules/jxmlease/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   checkInputs = [ unittestCheckHook ];
 
-  unittestFlagsArray = [ "-v" ];
+  unittestFlags = [ "-v" ];
 
   meta = with lib; {
     description = "Converts between XML and intelligent Python data structures";

--- a/pkgs/development/python-modules/mat2/default.nix
+++ b/pkgs/development/python-modules/mat2/default.nix
@@ -95,7 +95,7 @@ buildPythonPackage rec {
 
   checkInputs = [ unittestCheckHook ];
 
-  unittestFlagsArray = [ "-v" ];
+  unittestFlags = [ "-v" ];
 
   meta = with lib; {
     description = "A handy tool to trash your metadata";

--- a/pkgs/development/python-modules/mkdocs/default.nix
+++ b/pkgs/development/python-modules/mkdocs/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
     mock
   ];
 
-  unittestFlagsArray = [ "-v" "-p" "'*tests.py'" "mkdocs" ];
+  unittestFlags = [ "-v" "-p" "'*tests.py'" "mkdocs" ];
 
   pythonImportsCheck = [ "mkdocs" ];
 

--- a/pkgs/development/python-modules/pycparser/default.nix
+++ b/pkgs/development/python-modules/pycparser/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
 
   checkInputs = [ unittestCheckHook ];
 
-  unittestFlagsArray = [ "-s" "tests" ];
+  unittestFlags = [ "-s" "tests" ];
 
   meta = with lib; {
     description = "C parser in Python";

--- a/pkgs/development/python-modules/pysensors/default.nix
+++ b/pkgs/development/python-modules/pysensors/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage {
 
   checkInputs = [ unittestCheckHook ];
 
-  unittestFlagsArray = [ "-s" "tests" ];
+  unittestFlags = [ "-s" "tests" ];
 
   meta = with lib; {
     maintainers = with maintainers; [ guibou ];

--- a/pkgs/development/python-modules/pyserial/default.nix
+++ b/pkgs/development/python-modules/pyserial/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   checkInputs = [ unittestCheckHook ];
 
-  unittestFlagsArray = [ "-s" "test" ];
+  unittestFlags = [ "-s" "test" ];
 
   pythonImportsCheck = [
     "serial"

--- a/pkgs/development/python-modules/pytz/default.nix
+++ b/pkgs/development/python-modules/pytz/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
 
   checkInputs = [ unittestCheckHook ];
 
-  unittestFlagsArray = [ "-s" "pytz/tests" ];
+  unittestFlags = [ "-s" "pytz/tests" ];
 
   pythonImportsCheck = [ "pytz" ];
 

--- a/pkgs/development/python-modules/readlike/default.nix
+++ b/pkgs/development/python-modules/readlike/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   checkInputs = [ unittestCheckHook ];
 
-  unittestFlagsArray = [ "-s" "tests" ];
+  unittestFlags = [ "-s" "tests" ];
 
   meta = with lib; {
     description = "GNU Readline-like line editing module";

--- a/pkgs/development/python-modules/sphinx-testing/default.nix
+++ b/pkgs/development/python-modules/sphinx-testing/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   checkInputs = [ unittestCheckHook mock ];
   propagatedBuildInputs = [ sphinx six ];
 
-  unittestFlagsArray = [ "-s" "tests" ];
+  unittestFlags = [ "-s" "tests" ];
 
   # Test failures https://github.com/sphinx-doc/sphinx-testing/issues/5
   doCheck = false;

--- a/pkgs/development/python-modules/sphinxcontrib-blockdiag/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-blockdiag/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   checkInputs = [ unittestCheckHook ];
 
-  unittestFlagsArray = [ "-s" "tests" ];
+  unittestFlags = [ "-s" "tests" ];
 
   meta = with lib; {
     description = "Sphinx blockdiag extension";

--- a/pkgs/development/python-modules/tornado/4.nix
+++ b/pkgs/development/python-modules/tornado/4.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   # We specify the name of the test files to prevent
   # https://github.com/NixOS/nixpkgs/issues/14634
-  unittestFlagsArray = [ "*_test.py" ];
+  unittestFlags = [ "*_test.py" ];
 
   __darwinAllowLocalNetworking = true;
 

--- a/pkgs/development/python-modules/tornado/5.nix
+++ b/pkgs/development/python-modules/tornado/5.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   # We specify the name of the test files to prevent
   # https://github.com/NixOS/nixpkgs/issues/14634
-  unittestFlagsArray = [ "*_test.py" ];
+  unittestFlags = [ "*_test.py" ];
 
   __darwinAllowLocalNetworking = true;
 

--- a/pkgs/development/python-modules/trytond/default.nix
+++ b/pkgs/development/python-modules/trytond/default.nix
@@ -67,7 +67,7 @@ buildPythonPackage rec {
     export DB_NAME=":memory:";
   '';
 
-  unittestFlagsArray = [ "-s" "trytond.tests" ];
+  unittestFlags = [ "-s" "trytond.tests" ];
 
   meta = with lib; {
     description = "The server of the Tryton application platform";

--- a/pkgs/development/python-modules/unidiff/default.nix
+++ b/pkgs/development/python-modules/unidiff/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
 
   checkInputs = [ unittestCheckHook ];
 
-  unittestFlagsArray = [ "-s" "tests" ];
+  unittestFlags = [ "-s" "tests" ];
 
   pythonImportsCheck = [ "unidiff" ];
 

--- a/pkgs/development/python-modules/untangle/default.nix
+++ b/pkgs/development/python-modules/untangle/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   checkInputs = [ unittestCheckHook ];
 
-  unittestFlagsArray = [ "-s" "tests" ];
+  unittestFlags = [ "-s" "tests" ];
 
   meta = with lib; {
     description = "Convert XML documents into Python objects";

--- a/pkgs/development/python-modules/vapoursynth/default.nix
+++ b/pkgs/development/python-modules/vapoursynth/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage {
     unittestCheckHook
   ];
 
-  unittestFlagsArray = [ "-s" "$src/test" "-p" "'*test.py'" ];
+  unittestFlags = [ "-s" "$src/test" "-p" "'*test.py'" ];
 
   passthru = {
     withPlugins = plugins:

--- a/pkgs/development/python-modules/webcolors/default.nix
+++ b/pkgs/development/python-modules/webcolors/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   checkInputs = [ unittestCheckHook ];
 
-  unittestFlagsArray = [ "-s" "tests" ];
+  unittestFlags = [ "-s" "tests" ];
 
   pythonImportsCheck = [
     "webcolors"

--- a/pkgs/development/python-modules/zake/default.nix
+++ b/pkgs/development/python-modules/zake/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
       --replace "test_child_watch_no_create" "_test_child_watch_no_create"
   '';
 
-  unittestFlagsArray = [ "zake/tests" ];
+  unittestFlags = [ "zake/tests" ];
 
   meta = with lib; {
     homepage = "https://github.com/yahoo/Zake";

--- a/pkgs/development/python-modules/zope_copy/default.nix
+++ b/pkgs/development/python-modules/zope_copy/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   doCheck = !isPy27; # namespace conflicts
   checkInputs = [ unittestCheckHook zope_location zope_schema ];
 
-  unittestFlagsArray = [ "-s" "src/zope/copy" ];
+  unittestFlags = [ "-s" "src/zope/copy" ];
 
   meta = {
     maintainers = with lib.maintainers; [ domenkozar ];

--- a/pkgs/development/python2-modules/typing/default.nix
+++ b/pkgs/development/python2-modules/typing/default.nix
@@ -22,7 +22,7 @@ in buildPythonPackage rec {
 
   checkInputs = [ unittestCheckHook ];
 
-  unittestFlagsArray = [ "-s" testDir ];
+  unittestFlags = [ "-s" testDir ];
 
   meta = with lib; {
     description = "Backport of typing module to Python versions older than 3.5";


### PR DESCRIPTION
###### Description of changes

In the docs, the flags for the `unittestCheckHook` are described as [belonging in `unittestFlags`](https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/python.section.md#using-unittestcheckhook-using-unittestcheckhook), but it seems that the hook script was expecting them to be set as `unittestFlagsArray`. In stdenv at least it seems that the `*Array` variants are used for dynamically configuring the flags in a `pre*` script, e.g. `preCheck = "unittestFlagsArray+=(--foo)"`, so this PR aligns the script behavior to the docs/stdenv instead of just updating the docs to match the current implementation.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
