### PR TITLE
spatialite_gui: init at 2.1.0-beta1

### DIFF
--- a/pkgs/applications/gis/spatialite-gui/default.nix
+++ b/pkgs/applications/gis/spatialite-gui/default.nix
@@ -1,0 +1,77 @@
+{ lib
+, stdenv
+, fetchurl
+, pkg-config
+, desktopToDarwinBundle
+, curl
+, freexl
+, geos
+, librasterlite2
+, librttopo
+, libspatialite
+, libwebp
+, libxlsxwriter
+, libxml2
+, lz4
+, minizip
+, openjpeg
+, postgresql
+, proj
+, sqlite
+, virtualpg
+, wxGTK
+, wxmac
+, zstd
+, Carbon
+, Cocoa
+, IOKit
+}:
+
+stdenv.mkDerivation rec {
+  pname = "spatialite-gui";
+  version = "2.1.0-beta1";
+
+  src = fetchurl {
+    url = "https://www.gaia-gis.it/gaia-sins/spatialite-gui-sources/spatialite_gui-${version}.tar.gz";
+    hash = "sha256-ukjZbfGM68P/I/aXlyB64VgszmL0WWtpuuMAyjwj2zM=";
+  };
+
+  nativeBuildInputs = [ pkg-config ]
+    ++ lib.optional stdenv.isDarwin desktopToDarwinBundle;
+
+  buildInputs = [
+    curl
+    freexl
+    geos
+    librasterlite2
+    librttopo
+    libspatialite
+    libwebp
+    libxlsxwriter
+    libxml2
+    lz4
+    minizip
+    openjpeg
+    postgresql
+    proj
+    sqlite
+    virtualpg
+    zstd
+  ] ++ lib.optional stdenv.isLinux wxGTK
+    ++ lib.optionals stdenv.isDarwin [ Carbon Cocoa IOKit wxmac ];
+
+  enableParallelBuilding = true;
+
+  postFixup = lib.optionalString stdenv.isDarwin ''
+    rm -fr $out/share
+  '';
+
+  meta = with lib; {
+    description = "Graphical user interface for SpatiaLite";
+    homepage = "https://www.gaia-gis.it/fossil/spatialite_gui";
+    license = licenses.gpl3Plus;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ sikmir ];
+    mainProgram = "spatialite_gui";
+  };
+}

--- a/pkgs/development/libraries/librasterlite2/default.nix
+++ b/pkgs/development/libraries/librasterlite2/default.nix
@@ -1,0 +1,90 @@
+{ lib
+, stdenv
+, fetchurl
+, pkg-config
+, validatePkgConfig
+, cairo
+, curl
+, fontconfig
+, freetype
+, freexl
+, geos
+, giflib
+, libgeotiff
+, libjpeg
+, libpng
+, librttopo
+, libspatialite
+, libtiff
+, libwebp
+, libxml2
+, lz4
+, minizip
+, openjpeg
+, pixman
+, proj
+, sqlite
+, zstd
+, ApplicationServices
+}:
+
+stdenv.mkDerivation rec {
+  pname = "librasterlite2";
+  version = "1.1.0-beta1";
+
+  src = fetchurl {
+    url = "https://www.gaia-gis.it/gaia-sins/librasterlite2-sources/librasterlite2-${version}.tar.gz";
+    hash = "sha256-9yhM38B600OjFOSHjfAwCHSwFF2dMxsGOwlrSC5+RPQ=";
+  };
+
+  # Fix error: unknown type name 'time_t'
+  postPatch = ''
+    sed -i '49i #include <time.h>' headers/rasterlite2_private.h
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+    validatePkgConfig
+    geos # for geos-config
+  ];
+
+  buildInputs = [
+    cairo
+    curl
+    fontconfig
+    freetype
+    freexl
+    giflib
+    geos
+    libgeotiff
+    libjpeg
+    libpng
+    librttopo
+    libspatialite
+    libtiff
+    libwebp
+    libxml2
+    lz4
+    minizip
+    openjpeg
+    pixman
+    proj
+    sqlite
+    zstd
+  ] ++ lib.optional stdenv.isDarwin ApplicationServices;
+
+  enableParallelBuilding = true;
+
+  # Failed tests:
+  # - check_sql_stmt
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Advanced library supporting raster handling methods";
+    homepage = "https://www.gaia-gis.it/fossil/librasterlite2";
+    # They allow any of these
+    license = with licenses; [ gpl2Plus lgpl21Plus mpl11 ];
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ sikmir ];
+  };
+}

--- a/pkgs/development/libraries/virtualpg/default.nix
+++ b/pkgs/development/libraries/virtualpg/default.nix
@@ -1,0 +1,26 @@
+{ lib, stdenv, fetchurl, validatePkgConfig, postgresql, sqlite }:
+
+stdenv.mkDerivation rec {
+  pname = "virtualpg";
+  version = "2.0.1";
+
+  src = fetchurl {
+    url = "https://www.gaia-gis.it/gaia-sins/virtualpg-${version}.tar.gz";
+    hash = "sha256-virr64yf8nQ4IIX1HUIugjhYvKT2vC+pCYFkZMah4Is=";
+  };
+
+  nativeBuildInputs = [
+    validatePkgConfig
+    postgresql  # for pg_config
+  ];
+
+  buildInputs = [ postgresql sqlite ];
+
+  meta = with lib; {
+    description = "Loadable dynamic extension to both SQLite and SpatiaLite";
+    homepage = "https://www.gaia-gis.it/fossil/virtualpg";
+    license = with licenses; [ mpl11 gpl2Plus lgpl21Plus ];
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ sikmir ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22179,6 +22179,8 @@ with pkgs;
 
   vlock = callPackage ../misc/screensavers/vlock { };
 
+  virtualpg = callPackage ../development/libraries/virtualpg { };
+
   vmime = callPackage ../development/libraries/vmime { };
 
   vrb = callPackage ../development/libraries/vrb { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26478,6 +26478,11 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Cocoa;
   };
 
+  spatialite_gui = callPackage ../applications/gis/spatialite-gui {
+    inherit (darwin.apple_sdk.frameworks) Carbon Cocoa IOKit;
+    wxGTK = wxGTK30-gtk3;
+  };
+
   spatialite_tools = callPackage ../applications/gis/spatialite-tools { };
 
   udig = callPackage ../applications/gis/udig { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24621,6 +24621,10 @@ with pkgs;
     python = python3;
   };
 
+  librasterlite2 = callPackage ../development/libraries/librasterlite2 {
+    inherit (darwin.apple_sdk.frameworks) ApplicationServices;
+  };
+
   libraw = callPackage ../development/libraries/libraw { };
   libraw_unstable = callPackage ../development/libraries/libraw/unstable.nix { };
 


### PR DESCRIPTION
###### Description of changes
[spatialite-gui](https://www.gaia-gis.it/fossil/spatialite_gui) is an open source Graphical User Interface (GUI) tool supporting SpatiaLite.

 [![Packaging status](https://repology.org/badge/tiny-repos/spatialite-gui.svg)](https://repology.org/project/spatialite-gui/versions)

Dependencies (new packages):
* [virtualpg](https://www.gaia-gis.it/fossil/virtualpg) [![Packaging status](https://repology.org/badge/tiny-repos/virtualpg.svg)](https://repology.org/project/virtualpg/versions)
* [librasterlite2](https://www.gaia-gis.it/fossil/librasterlite2) [![Packaging status](https://repology.org/badge/tiny-repos/librasterlite2.svg)](https://repology.org/project/librasterlite2/versions)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
