### PR TITLE
ponyc: 0.50.0 -> 0.51.2

### DIFF
--- a/pkgs/development/compilers/ponyc/default.nix
+++ b/pkgs/development/compilers/ponyc/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation (rec {
   pname = "ponyc";
-  version = "0.50.0";
+  version = "0.51.2";
 
   src = fetchFromGitHub {
     owner = "ponylang";
     repo = pname;
     rev = version;
-    sha256 = "sha256-FnzlFTiJrqoUfnys+q9is6OH9yit5ExDiRszQ679QbY=";
+    sha256 = "sha256-hQvdVXNGEEbr4a0wjp/kEpdDsTXaRCpq+8jXUvTEZEI=";
 
     fetchSubmodules = true;
   };
@@ -17,8 +17,8 @@ stdenv.mkDerivation (rec {
   ponygbenchmark = fetchFromGitHub {
     owner = "google";
     repo = "benchmark";
-    rev = "v1.5.4";
-    sha256 = "1dbjdjzkpbsq3jl9ksyg8mw759vkac8qzq1557m73ldnavbhz48x";
+    rev = "v1.5.6";
+    sha256 = "sha256-DFm5cQh1b2BX6qCDaQZ1/XBNDeIYXKWbIETYu1EjDww=";
   };
 
   nativeBuildInputs = [ cmake makeWrapper which python3 ];
@@ -32,8 +32,8 @@ stdenv.mkDerivation (rec {
       googletest = fetchFromGitHub {
         owner = "google";
         repo = "googletest";
-        rev = "release-1.10.0";
-        sha256 = "1zbmab9295scgg4z2vclgfgjchfjailjnvzc6f5x9jvlsdi3dpwz";
+        rev = "release-1.11.0";
+        sha256 = "sha256-SjlJxushfry13RGA7BCjYC9oZqV4z6x8dOiHfl/wpF0=";
       };
     })
   ];
@@ -49,7 +49,6 @@ stdenv.mkDerivation (rec {
   postPatch = ''
     # Patching Vendor LLVM
     patchShebangs --host build/build_libs/gbenchmark-prefix/src/benchmark/tools/*.py
-    patch -d lib/llvm/src/ -p1 < lib/llvm/patches/2020-07-28-01-c-exports.diff
     substituteInPlace packages/process/_test.pony \
         --replace '"/bin/' '"${coreutils}/bin/' \
         --replace '=/bin' "${coreutils}/bin"

--- a/pkgs/development/compilers/ponyc/disable-tests.patch
+++ b/pkgs/development/compilers/ponyc/disable-tests.patch
@@ -1,8 +1,6 @@
-diff --git a/packages/net/_test.pony b/packages/net/_test.pony
-index 9044dfb1..f0ea10f7 100644
---- a/packages/net/_test.pony
-+++ b/packages/net/_test.pony
-@@ -26,11 +26,6 @@ actor \nodoc\ Main is TestList
+--- a/packages/net/_test.pony	2022-09-19 13:41:48.821294530 -0400
++++ b/packages/net/_test.pony	2022-09-19 13:42:25.760322375 -0400
+@@ -26,11 +26,6 @@
        test(_TestTCPThrottle)
      end
  

--- a/pkgs/development/compilers/ponyc/make-safe-for-sandbox.patch
+++ b/pkgs/development/compilers/ponyc/make-safe-for-sandbox.patch
@@ -1,8 +1,6 @@
-diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
-index dab2aaef..26b587b1 100644
---- a/lib/CMakeLists.txt
-+++ b/lib/CMakeLists.txt
-@@ -36,7 +36,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
+--- a/lib/CMakeLists.txt	2022-09-19 13:38:44.181162300 -0400
++++ b/lib/CMakeLists.txt	2022-09-19 13:41:11.564266900 -0400
+@@ -36,7 +36,7 @@
  endif()
  
  ExternalProject_Add(gbenchmark
@@ -11,7 +9,7 @@ index dab2aaef..26b587b1 100644
      CMAKE_ARGS -DCMAKE_BUILD_TYPE=${PONYC_LIBS_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DBENCHMARK_ENABLE_GTEST_TESTS=OFF -DCMAKE_CXX_FLAGS=${PONY_PIC_FLAG} --no-warn-unused-cli
  )
  
-@@ -46,7 +46,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
+@@ -46,7 +46,7 @@
  endif()
  
  ExternalProject_Add(googletest
@@ -20,13 +18,13 @@ index dab2aaef..26b587b1 100644
      CMAKE_ARGS -DCMAKE_BUILD_TYPE=${PONYC_LIBS_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DCMAKE_CXX_FLAGS=${PONY_PIC_FLAG} -Dgtest_force_shared_crt=ON --no-warn-unused-cli
  )
  
-@@ -59,82 +59,6 @@ install(TARGETS blake2
+@@ -59,82 +59,6 @@
      COMPONENT library
  )
  
 -find_package(Git)
 -
--set(LLVM_DESIRED_HASH "75e33f71c2dae584b13a7d1186ae0a038ba98838")
+-set(LLVM_DESIRED_HASH "1f9140064dfbfb0bbda8e51306ea51080b2f7aac")
 -set(PATCHES_DESIRED_HASH "a16f299fbfced16a2bbc628746db341f2a5af9ae8cc9c9ef4b1e9ca26de3c292")
 -
 -if(GIT_FOUND)


### PR DESCRIPTION
###### Description of Changes

* ponyc: 0.50.0 -> 0.51.2

Changelog: https://github.com/ponylang/ponyc/releases/tag/0.51.2

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
