### PR TITLE
mariadb: patch releases

### DIFF
--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -267,7 +267,7 @@ in {
   };
   mariadb_109 = mariadbPackage {
     # Supported until 2023-08(?)
-    version = "10.9.2";
-    hash = "sha256-X0X/deBDlmVVqV+9uPCS5gzipsR7pZ0UTbRuE46SL0g=";
+    version = "10.9.3";
+    hash = "sha256-mh4imXL8zMgnDmM/aNP7gk2hUdz09T2h342UesqHa+4=";
   };
 }

--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -262,8 +262,8 @@ in {
   };
   mariadb_108 = mariadbPackage {
     # Supported until 2023-05
-    version = "10.8.4";
-    hash = "sha256-ZexgyjZYjs0RzYw/wM414dYDAp4SN4z4i6qGX9CJEWY=";
+    version = "10.8.5";
+    hash = "sha256-z37TjDYTTNgYP93WTLPlD1ROgmS6dCAlXbEpcJfgjos=";
   };
   mariadb_109 = mariadbPackage {
     # Supported until 2023-08(?)

--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -46,7 +46,7 @@ commonOptions = packageSettings: rec { # attributes common to both builds
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ CoreServices cctools perl libedit ]
     ++ lib.optional (!stdenv.hostPlatform.isDarwin) [ jemalloc ]
     ++ (if (lib.versionOlder version "10.5") then [ pcre ] else [ pcre2 ])
-    ++ (if (lib.versionOlder version "10.8")
+    ++ (if (lib.versionOlder version "10.6")
       then [ openssl_1_1 (curl.override { openssl = openssl_1_1; }) ]
       else [ openssl curl ]);
 

--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -257,8 +257,8 @@ in {
   };
   mariadb_107 = mariadbPackage {
     # Supported until 2023-02. TODO: remove ahead of 22.11 release.
-    version = "10.7.5";
-    hash = "sha256-f/OkzNoe7S8aZBO4DE7WjMqRFzD1Aaaf1/STo0oJVLo=";
+    version = "10.7.6";
+    hash = "sha256-erX7pDmQV33BdPG5a9NAszN8G9Rv48NmIgsJ0siNLqA=";
   };
   mariadb_108 = mariadbPackage {
     # Supported until 2023-05

--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -252,8 +252,8 @@ in {
   };
   mariadb_106 = mariadbPackage {
     # Supported until 2026-07
-    version = "10.6.9";
-    hash = "sha256-N5Wfi1+8ZNlOGA3NiuW9+v1AYgOgf0j3vs1rinYzdEw=";
+    version = "10.6.10";
+    hash = "sha256-atn6hvDIXI7q+tJkNUnV/13ShyAClk51R1LekYY6o7c=";
   };
   mariadb_107 = mariadbPackage {
     # Supported until 2023-02. TODO: remove ahead of 22.11 release.


### PR DESCRIPTION
###### Description of changes
See commits for release notes

Automatic backport will most likely fail, because of 109 and the openssl 3 change.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).