### PR TITLE
dotnet-sdk: 6.0.400 -> 6.0.401

### DIFF
--- a/pkgs/development/compilers/dotnet/versions/6.0.nix
+++ b/pkgs/development/compilers/dotnet/versions/6.0.nix
@@ -4,163 +4,171 @@
 {
   aspnetcore_6_0 = buildAspNetCore {
     inherit icu;
-    version = "6.0.8";
+    version = "6.0.9";
     srcs = {
       x86_64-linux = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/5cc06c3a-4d8a-4fb2-8f7a-ecd23cd8c4e0/dd386c0e3a41ea54f459907c834acedf/aspnetcore-runtime-6.0.8-linux-x64.tar.gz";
-        sha512  = "b74676ca0d2f47a95533739fd36977bb1552890a81820ee51b29b3d6514398f0952362417bbb31fad4bdf031803cb3e8d2aaf065dfb154a78a1b471a536d4abd";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/1a2bca2e-f525-4ecf-9c46-06889b4ce3a4/1a7ad60df284ca6b00ca5d31cc1b1c7c/aspnetcore-runtime-6.0.9-linux-x64.tar.gz";
+        sha512  = "e808036155bc324335c309aaf948b2be1940a62eaf0135752989644698653c8f3a5ce310c3ee6742e3af73dbe175c6e529298eedf6eeb31cc38bfeab628f6d7b";
       };
       aarch64-linux = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/83695c9b-c954-459e-b9bf-2f1ac269e34e/1316ff4a6fe4c6916e7ecb3623d67cee/aspnetcore-runtime-6.0.8-linux-arm64.tar.gz";
-        sha512  = "07babe85c8872ca303a17268b0d23c382a9ac49f8b923c45c496db039f6c01094303cd18cd31f964ba7369bb993c896eeadbb7e458a77d5b86992222b91db52c";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/bff2e771-8180-47eb-b12a-757a67001e21/63a7f79af649efe65c20f2ca56834048/aspnetcore-runtime-6.0.9-linux-arm64.tar.gz";
+        sha512  = "ed3315276f918f52188430b0d84d843e938c770e0be06afaec6de0b398a1268bae0195c71a29971923b5b7331b6bb64a623a27f48e21a4c8538fde2a543b2dd2";
       };
       x86_64-darwin = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/0601cae2-aa41-4318-a996-36633cd641f3/ffc290161ae37b28894ff7465dd50c17/aspnetcore-runtime-6.0.8-osx-x64.tar.gz";
-        sha512  = "73d3569c13965de927e9d1eb02ce7d31b44643335a351ddc6392be1a693837263287d9bc5e82a89f2456b7a9cf1bd6c217d9f98cf9fa8da1b6c820e9ddf43933";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/5d9f409c-0fd2-477f-8a80-44eb18f9ccdb/3dc6bc3edf033ab3d84b36889f1253cf/aspnetcore-runtime-6.0.9-osx-x64.tar.gz";
+        sha512  = "d67dd72cfd0fb9d96077bc6c3518fabbde107d97b4645c13dc82ec99abdfb4030e10638e4fb0c52aa5246d90628348fd877625469f14fb45e4467934229749d7";
       };
       aarch64-darwin = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/7859a31f-74c9-4756-a9ab-f040550666ac/3c4ad4317e732436f8c092eb9cdb4168/aspnetcore-runtime-6.0.8-osx-arm64.tar.gz";
-        sha512  = "a6cabc3b4c7350deb141e122c194c7eefaf99127cee726ee227e4218add7155b8decdb2a5cd217f757410e267f2370a78806c22a0294098f245105cea925a7b2";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/e13f930a-a71a-4cea-8f3a-2280505fa0aa/cdd56e3fbfadbed989b2acbf7d3aae3f/aspnetcore-runtime-6.0.9-osx-arm64.tar.gz";
+        sha512  = "d47e828c160b7e162f26d0074a47a1646863fc63fde393758d020546d03843e3f98adb92e3c0041a9088ad31043314317a2e8be616f8079d8c98754f94eb55cc";
       };
     };
   };
 
   runtime_6_0 = buildNetRuntime {
     inherit icu;
-    version = "6.0.8";
+    version = "6.0.9";
     srcs = {
       x86_64-linux = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/5596ef6f-a174-4fba-aef1-99173e3f3c67/77edd755d605688885ca7114bc4f9ae9/dotnet-runtime-6.0.8-linux-x64.tar.gz";
-        sha512  = "c776813bf87c25766b31a3a514d124d0526086ceea514a10f104d70ba435c91a6bd3c8bf10c6662b4df2b13ffcdf385518f3418e51d05cccec6a2cf2c26099de";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/05f1a3dd-75f2-49f4-a976-25ce08f77cbb/b6e8e327a84b91513c2744bfccf90140/dotnet-runtime-6.0.9-linux-x64.tar.gz";
+        sha512  = "a6df2cfef73047247bd36f51eaf696f616c6aa9b428e42f219bf91dcf05c03dff817a8ec826740002c8aa83df2fce8a7ace562ad2e2956789542f0b8ab8b1173";
       };
       aarch64-linux = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/866ce4df-8aaa-417d-ad81-26131a2b8734/7ba8391188bc194156ee7d82f494ee00/dotnet-runtime-6.0.8-linux-arm64.tar.gz";
-        sha512  = "7cd60eda5219a6b882e53e85e2b6543dedc91605503ce8085f447835382fd1b6abd7c8810e0fd865ecaa33167cedf2a33884dd4eb2bdd2857fe69d509cd62a9c";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/2dc40bad-57b6-42ae-b9dd-bd457af4e73e/b95f86d6f9cf49e156227bad231d4aa0/dotnet-runtime-6.0.9-linux-arm64.tar.gz";
+        sha512  = "a4ce5ec71c60690e577e96a2cd821c05d5f05b7c1754fb753353db77e938349a53d4cc55596f7384813bc44f74eac8f991a1c00cbee60483f552663cf4d8ac31";
       };
       x86_64-darwin = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/1c11dcab-2b1b-4f89-88a8-32665c56a131/c1654a9f3d01805033b7fd8d505050e8/dotnet-runtime-6.0.8-osx-x64.tar.gz";
-        sha512  = "8100003430b073e9f1f16910eef8af5a5ea806754a1818971ba15f4ba44e12455330334bd1488088880f7ed3ff67c2a4c4a3d8037f4202c95e6bc029806c8b15";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/cd4ba3ed-7f37-46d5-ab1c-dc479a08333d/f27d3ab52b0830861bed594be6da86a8/dotnet-runtime-6.0.9-osx-x64.tar.gz";
+        sha512  = "b52542c1850c14b409c0938a31188821b428199a7f3f55779f4986867a78eedfe06478f8ea79e8b20d078fcfd9201dc10d4a73146ef8fd56753f0cd23c5328ac";
       };
       aarch64-darwin = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/0b8a7b71-8f77-439b-a4d8-b4fd863466d3/7a852ca4536bdef2e63d9f5e98731777/dotnet-runtime-6.0.8-osx-arm64.tar.gz";
-        sha512  = "99264f4e34e2b6e1a82f3716cce5753967f3386348593e7f51085d96dbec4acf1400a451e9320afbfb45a9b777df1f8bbed8e78d7c4810336f3d226bdfd4343f";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/c7c51353-ded6-4846-87ac-d840b1ac2f9f/88641f913c8e886b4e38fc5b0c547ed4/dotnet-runtime-6.0.9-osx-arm64.tar.gz";
+        sha512  = "07dfd194fdc67bd096db0edc691fc2a2d0e41d8a3023582ef1ff7348eb0fca3a58d97b79c454e5c67339f6d9c9b0f3b997d68f6ec7bd0e8c86d584da6d94cd8c";
       };
     };
   };
 
   sdk_6_0 = buildNetSdk {
     inherit icu;
-    version = "6.0.400";
+    version = "6.0.401";
     srcs = {
       x86_64-linux = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/cd0d0a4d-2a6a-4d0d-b42e-dfd3b880e222/008a93f83aba6d1acf75ded3d2cfba24/dotnet-sdk-6.0.400-linux-x64.tar.gz";
-        sha512  = "8decbba0a6b09501daede52cbb5a9ae9e5f31ade201918c03efcd1b4cc345ec934f88321704ec3beb1f90f2204934be7259c76f66d9204cbdd15933582602763";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/8159607a-e686-4ead-ac99-b4c97290a5fd/ec6070b1b2cc0651ebe57cf1bd411315/dotnet-sdk-6.0.401-linux-x64.tar.gz";
+        sha512  = "6fce5f29e6cfc80da1df86d2de3a637108023397d275e0dcfa0b79ef36eb85c2c3433db467aa5d8fda7e32bc21205a126636b53d56c4eb4c547d9d3b2370cb31";
       };
       aarch64-linux = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/901f7928-5479-4d32-a9e5-ba66162ca0e4/d00b935ec4dc79a27f5bde00712ed3d7/dotnet-sdk-6.0.400-linux-arm64.tar.gz";
-        sha512  = "a21010f9e0e091bf0a4df9dfc4ec9893c056c2b07b10be093ea392a4fa5c8a38bad9535f66e570b45dc25165b685199fb729434b845bcfb35f8b79cceb22c632";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/a567a07f-af9d-451a-834c-a746ac299e6b/1d9d74b54cf580f93cad71a6bf7b32be/dotnet-sdk-6.0.401-linux-arm64.tar.gz";
+        sha512  = "8c05f9e02e0a48fcc3e4534fa7225fe5b974c07f1a4788c46207e18e94031194e1c881e40452ee6c432764e92331c50ae47305d4aec5afa363fab3a8a6727cdf";
       };
       x86_64-darwin = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/f52fb2f4-a0a3-4094-9f75-add72fcbc21e/d46eda7abf39baf278c0b0b040c7b81d/dotnet-sdk-6.0.400-osx-x64.tar.gz";
-        sha512  = "35b80347e31baefdbd42e7434ffa0df1069367a4f8deec8b4051a44658b3ed531832f0e92357887a2f5a27c6433304537c846cdd4793aac874bace82a899053e";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/e79e447d-20fd-4ed9-992d-39165aaf964a/1f101c161bc4a931e16c697e3934e413/dotnet-sdk-6.0.401-osx-x64.tar.gz";
+        sha512  = "6cc47bd279ba3d5e2df9f41b14b25662c8a3d61d5dee0fe021ad54a8709aa8a34430deb644c3525d66124a6a1bdf6a273008ea5fcbddccee238f4c470bac3e05";
       };
       aarch64-darwin = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/0e45597f-a72d-42fa-95c5-85a811a7a8b6/1d77d2eeb8c08815edd1a6e9e9dfda4a/dotnet-sdk-6.0.400-osx-arm64.tar.gz";
-        sha512  = "c3b016bc558f42fba29a8aebcc04be7b3aa3b0290755b6ee2fea1f48f921da78b86cb31913c4b7e32c0421b45a617b551ba593f98f349fae43ea1faa38348412";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/dfeaba35-b5b0-4299-b4fa-56735e3f224e/80cc6c2404d0319fb3eab5d0f407b169/dotnet-sdk-6.0.401-osx-arm64.tar.gz";
+        sha512  = "0e1974a99863afe0b2c03fe52874ad388c3e019e34c7e0a1dc29955dfa9783a946082270fbd767272817509b30d1928d0c9f12cda43777292587693e0b0fc604";
       };
     };
     packages = { fetchNuGet }: [
-      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Ref"; version = "6.0.8"; sha256 = "1sxl6nsv8magamqbykdr6jnd9q6r1afavc7pzm2jmcqyxv121hv3"; })
-      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-arm"; version = "6.0.8"; sha256 = "1qksplqav4nrjbib6hrbdqg8rd8lxr63ljq57p4h7lbgw0wpxa5c"; })
-      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-arm64"; version = "6.0.8"; sha256 = "049s2617s3aqcqxbvb0idrmjw6vnwjjfnqrn7s6hi2w4w5f4z10x"; })
-      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-musl-arm"; version = "6.0.8"; sha256 = "0pphpvag4i0zq7c51r72b9zjlj726wv2hn1vxd1mdsj85f2q77zz"; })
-      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-musl-arm64"; version = "6.0.8"; sha256 = "00hhv36d8wjdhnz10jjdv3nikpd4x0sj6v2jfi5p3firl64p5wf2"; })
-      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-musl-x64"; version = "6.0.8"; sha256 = "1lcvphg7s6iwh3dkl9c2c0h5mx9gsp0aic7v2xaqgaq3sz0jalnk"; })
-      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-x64"; version = "6.0.8"; sha256 = "1lmcy66m1yrm0ii1agydn8zmvydjf2sdvng5x07vda574shrr39h"; })
-      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.osx-arm64"; version = "6.0.8"; sha256 = "14q6sjbcs1xvd1lz670bnq4pgi1cgayih2bpsjbv33z6w1wshay5"; })
-      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.osx-x64"; version = "6.0.8"; sha256 = "14968kh3c0028nyyxivx01wj1k6a6mk2wm4fk0sbh6p2g7wpaqdp"; })
-      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.win-arm"; version = "6.0.8"; sha256 = "1dmajf3hqs5njm6yd6g9vy72sndf93g4p6ghsjkxizgz46z3qsxh"; })
-      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.win-arm64"; version = "6.0.8"; sha256 = "1cyczl8a4b3plb7f1w0jp06v65yd1fk7mcx2y1jr8qpcmxrad3gl"; })
-      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.win-x64"; version = "6.0.8"; sha256 = "1qcg7awjd9xf6bvn5wsbd8kiy3vf6iag8q2myzzzy5jj4azbl2wd"; })
-      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.win-x86"; version = "6.0.8"; sha256 = "1dm953nh7d1k9cpclxxf3831rlx739skrxxw1whqnczffd8rjfmd"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Composite"; version = "6.0.8"; sha256 = "1g21mp68ljpvv6g4xgzihpfn96szchpny1h0g9g71bwbgp93aad8"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-arm"; version = "6.0.8"; sha256 = "0gp93f4ch0h95wl30xbz60xn7i752hvjkiivn3q7wnkary2g8mpr"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-arm64"; version = "6.0.8"; sha256 = "1bdfpxs31x0a6cbb911vl3ncy26gsffgba3v598k6ki4662xlawv"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-musl-arm"; version = "6.0.8"; sha256 = "0w5pxahcgxr4826hv6b72aq60gpbbrj6va2hvj4gzi917dkqdb94"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-musl-arm64"; version = "6.0.8"; sha256 = "03x0zz9ig1m78gmf2r8wny1y1ripyzsdxak6cqha1zl8gbf0bcck"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-musl-x64"; version = "6.0.8"; sha256 = "167kc0766ppkfrv66b0xg844cm7vj7q6p3bm695j8m0gakz71kx3"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-x64"; version = "6.0.8"; sha256 = "0a0zrk6lcmbjyl0wkal9p0xw3n5qzvbc72by492vi3cwl8j6qv6d"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.osx-arm64"; version = "6.0.8"; sha256 = "04l1smar1hrg0r5pzqa5580aw17jx4cbk7i2mrgj7yy2m86m3d4s"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.osx-x64"; version = "6.0.8"; sha256 = "0j1qdixwxj2bwgcfxf6fbs2krw6gcm7s9mcx41z9l9q4lq9qh1gc"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.win-arm"; version = "6.0.8"; sha256 = "17ji5vjqw59dkrjqfrdbmwf318x9f61ch855l6z3099g84bp9nqk"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.win-arm64"; version = "6.0.8"; sha256 = "0c9pxqsi99m91c25n7j2pq9gmyl88k9bf4a5bisqv7v5w7mi2h9x"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.win-x64"; version = "6.0.8"; sha256 = "1k8jh8s2rqyp7rr2vdwqfj35zkr77vnba4jnmgx5ank87z24vmhd"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.win-x86"; version = "6.0.8"; sha256 = "1z5ja82jxmlndivxrm4abapg41zkgs5bjc7ks2azzn8znghksvya"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Ref"; version = "6.0.8"; sha256 = "1654jcqp80i3gkasf9axnfrjnk8iaxkhgfkbrgv5fi5vz0lbgi2h"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-arm"; version = "6.0.8"; sha256 = "0999pi4dyr4l7grrw47xip8prqsc3inpz9gkxjd34dzi7wcpfy47"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-arm64"; version = "6.0.8"; sha256 = "040c6505idayhym3j90ixw85h4l6m23nlwp5g9zf4p9dl2mfgicv"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-musl-arm"; version = "6.0.8"; sha256 = "0qd9pz33wibc3db2sn452wd5vipzq6kf7gclc6lfzz4cavlzqxc4"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-musl-arm64"; version = "6.0.8"; sha256 = "0qzkybsfx4pps97kzyy8325brljdi4h9vqapcgyfb2rmkvvfqsby"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-musl-x64"; version = "6.0.8"; sha256 = "0fxp7zz6pjxhmasy7xza9gi83zag81b2gpp08cam69kjn1razlq1"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-x64"; version = "6.0.8"; sha256 = "01fci2411qhi6gxp0jddmy4pb248n08ng8wxap37ysh5zc1qmjcm"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.osx-arm64"; version = "6.0.8"; sha256 = "06ahjlsr43vx3dnw28fpkk2vmagrrn1m8jds8pdgj44jpn57lc8r"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.osx-x64"; version = "6.0.8"; sha256 = "0bz6qja5lbi1a7iqkbin4p97dinn9iykw0x0nmmjs4ihx33ic1jr"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.win-arm"; version = "6.0.8"; sha256 = "080jaw5y9zwfsj3b0ziw3s75whankyn99q5sjhq7pmpi6763xw48"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.win-arm64"; version = "6.0.8"; sha256 = "0wmb4jx6l9dg17ng5cf4k3s54s08lf220gzphdgrcl0w1jihg7n5"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.win-x64"; version = "6.0.8"; sha256 = "067blnpwccsfp201803yrb4j4gp9vzkppgc4h7s13dxjz78cf7ss"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.win-x86"; version = "6.0.8"; sha256 = "1ws1sbsly7n7p6p5k057m063vk5by88fxfkkqw5i61vh6iwkcbnd"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.DotNetAppHost"; version = "6.0.8"; sha256 = "04dknyln95q0qx0h374d3xxs5rwh4sm0j489p370bkv0czl0ha4b"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.DotNetHost"; version = "6.0.8"; sha256 = "1rav7v08nc01b443cy58gk32n6d30zkjx99m8hpsz17vcxw8jiqq"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.DotNetHostPolicy"; version = "6.0.8"; sha256 = "1g03lm7ckqa67m9l701lmw6pwxym8l390zlf8km02gfq0x1g2fyj"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.DotNetHostResolver"; version = "6.0.8"; sha256 = "1wb9db76nnm9sr2kj8q53j8wamybkrk7x6gwqw17xk6cxq2fgxq4"; })
-      (fetchNuGet { pname = "runtime.linux-arm64.Microsoft.NETCore.DotNetAppHost"; version = "6.0.8"; sha256 = "02l7ahcrhq8lnxnf323d6qk3saha73d2sbmgjmp1rcy5q2mqly05"; })
-      (fetchNuGet { pname = "runtime.linux-arm64.Microsoft.NETCore.DotNetHost"; version = "6.0.8"; sha256 = "0cinkimphbrpjmz38acrmjqr9md4vi7ad7r757gm363z0hal2783"; })
-      (fetchNuGet { pname = "runtime.linux-arm64.Microsoft.NETCore.DotNetHostPolicy"; version = "6.0.8"; sha256 = "1dr2a2bgia8i5pwk8b8z3jwlbkshh9pb8hhzbkhjmc56sx49h0lx"; })
-      (fetchNuGet { pname = "runtime.linux-arm64.Microsoft.NETCore.DotNetHostResolver"; version = "6.0.8"; sha256 = "1kj8a9l65slgb3r45b8x5qnhcs80bx8437cfisyfbhjkw17i5cgg"; })
-      (fetchNuGet { pname = "runtime.linux-arm.Microsoft.NETCore.DotNetAppHost"; version = "6.0.8"; sha256 = "1v06qri2f6h2ndbaydgsnpas6nfhvi58yx68v3w4gdbdablnycvb"; })
-      (fetchNuGet { pname = "runtime.linux-arm.Microsoft.NETCore.DotNetHost"; version = "6.0.8"; sha256 = "0vskm16p0aj7jlwsp5mfbilszwvfaglp6p69196v7kdqmskwxw8c"; })
-      (fetchNuGet { pname = "runtime.linux-arm.Microsoft.NETCore.DotNetHostPolicy"; version = "6.0.8"; sha256 = "1j1j81az67rwdnqfapjnvxx35fjr1n035pwb2nlg6kz2r2mfw4ph"; })
-      (fetchNuGet { pname = "runtime.linux-arm.Microsoft.NETCore.DotNetHostResolver"; version = "6.0.8"; sha256 = "0sfqc7v6zi3ma446jgrd4bjfjl0d48wpyb40wc1frcsvms9zskwr"; })
-      (fetchNuGet { pname = "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetAppHost"; version = "6.0.8"; sha256 = "0sp90fz8qyz7gn2fmgavsq909dpk44ymq3cs1mxdwfp3v9dssmyh"; })
-      (fetchNuGet { pname = "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHost"; version = "6.0.8"; sha256 = "08k90llf2p1bg62w1mk7vv5lk8s4ymfq5j6hdl1al5an4gl7niif"; })
-      (fetchNuGet { pname = "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHostPolicy"; version = "6.0.8"; sha256 = "1akvfw5p9s7w9jr09s20ph4x82kfbabsbd5dafpvakd4zw7cawfx"; })
-      (fetchNuGet { pname = "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHostResolver"; version = "6.0.8"; sha256 = "0r4fbkjqy1g9cmaa55rpbsphslcmlpzmag5w47kmq4hxz0ll68d2"; })
-      (fetchNuGet { pname = "runtime.linux-musl-arm.Microsoft.NETCore.DotNetAppHost"; version = "6.0.8"; sha256 = "015dadmlghkbvxz7d7m3fanrq2lqls094immxdv0laxl3smkg7pw"; })
-      (fetchNuGet { pname = "runtime.linux-musl-arm.Microsoft.NETCore.DotNetHost"; version = "6.0.8"; sha256 = "0gnnpxv0pnbrsx4zf28agwrgra7y3zm0z4lsr09i0wvrz97n65p7"; })
-      (fetchNuGet { pname = "runtime.linux-musl-arm.Microsoft.NETCore.DotNetHostPolicy"; version = "6.0.8"; sha256 = "136kjcl98n019764sy3pck9v4pmrz6q68qi8a2cdqm6hw7canc05"; })
-      (fetchNuGet { pname = "runtime.linux-musl-arm.Microsoft.NETCore.DotNetHostResolver"; version = "6.0.8"; sha256 = "0ibrah9jzcs7i27z9alllg1d46dx0px0m3mgvnsg34zhbpqfbilp"; })
-      (fetchNuGet { pname = "runtime.linux-musl-x64.Microsoft.NETCore.DotNetAppHost"; version = "6.0.8"; sha256 = "0i4vmdgrvnr9fkmk2h88h1x37m4g4ksz7c24l585q6sg0343p0hp"; })
-      (fetchNuGet { pname = "runtime.linux-musl-x64.Microsoft.NETCore.DotNetHost"; version = "6.0.8"; sha256 = "0rpb7py9j40jqhi9ndfpvspdkrbl4vwqq8r6hva7kfjva61x9ky2"; })
-      (fetchNuGet { pname = "runtime.linux-musl-x64.Microsoft.NETCore.DotNetHostPolicy"; version = "6.0.8"; sha256 = "06jf5qv6ldsapbjd8g01pwm0yw20w7slpi9yrgxr8q2y0f9fqnhy"; })
-      (fetchNuGet { pname = "runtime.linux-musl-x64.Microsoft.NETCore.DotNetHostResolver"; version = "6.0.8"; sha256 = "1mj8gzvnk5f16vchwc94bp6726m6n8j6bi9d3rzbly8k63xdnnv3"; })
-      (fetchNuGet { pname = "runtime.linux-x64.Microsoft.NETCore.DotNetAppHost"; version = "6.0.8"; sha256 = "05491m5xzd6sbbpad6v7z1apkf00ip13sl23d9r2g5hv22i61qr9"; })
-      (fetchNuGet { pname = "runtime.linux-x64.Microsoft.NETCore.DotNetHost"; version = "6.0.8"; sha256 = "1wsafi273xsh9q9cbfq123p33k2kgvrqz7hvkj4hlshl0dzlky7z"; })
-      (fetchNuGet { pname = "runtime.linux-x64.Microsoft.NETCore.DotNetHostPolicy"; version = "6.0.8"; sha256 = "1661dn6v40g8yzwxdfskv0llvwf422zs5b5ndrhbs15cihh10axw"; })
-      (fetchNuGet { pname = "runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver"; version = "6.0.8"; sha256 = "17dicgyc24x4krjy37j36cln0770cl52ihyyrg40n8l1b6q3hcdx"; })
-      (fetchNuGet { pname = "runtime.osx-arm64.Microsoft.NETCore.DotNetAppHost"; version = "6.0.8"; sha256 = "0pjhfxkzbgf0zxibrwrkzjhqz163qhczc476pzvd5fy9cxcdnkl5"; })
-      (fetchNuGet { pname = "runtime.osx-arm64.Microsoft.NETCore.DotNetHost"; version = "6.0.8"; sha256 = "145zkswksir8q0n83jw1kv2xsg5x4sf6w80hyynfjmpfhv7klmcw"; })
-      (fetchNuGet { pname = "runtime.osx-arm64.Microsoft.NETCore.DotNetHostPolicy"; version = "6.0.8"; sha256 = "1r473bl4g9xgn69q9jp1mfxrvllsg7a2z4lan7nv58anwsz1bfyl"; })
-      (fetchNuGet { pname = "runtime.osx-arm64.Microsoft.NETCore.DotNetHostResolver"; version = "6.0.8"; sha256 = "1kcx09jsklbnjl6mhdarg0c2j84553q6zj9bs73n70idczzn6iyp"; })
-      (fetchNuGet { pname = "runtime.osx-x64.Microsoft.NETCore.DotNetAppHost"; version = "6.0.8"; sha256 = "1g7vb2dba007aqw51k1ab962d63xh549zd3j9jsrnrmwpbk7yp58"; })
-      (fetchNuGet { pname = "runtime.osx-x64.Microsoft.NETCore.DotNetHost"; version = "6.0.8"; sha256 = "0p2rv3n9pkv27q20jmps4xl29dmraqc1wgcyw78wm5pgz1717wr4"; })
-      (fetchNuGet { pname = "runtime.osx-x64.Microsoft.NETCore.DotNetHostPolicy"; version = "6.0.8"; sha256 = "0153c9n7zx4cpxwa71yddgjpy021c98r7h2w6mxg4fqnb8hrk23b"; })
-      (fetchNuGet { pname = "runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver"; version = "6.0.8"; sha256 = "199qscm2is4xrbhnvyjp0lb4wwgw71c436vfxn7g6qmq7c4y1cyz"; })
-      (fetchNuGet { pname = "runtime.win-arm64.Microsoft.NETCore.DotNetAppHost"; version = "6.0.8"; sha256 = "1h5ndqz2djp21d3qj2rqcf41z7y6njb5gjflvhzgjgpqb2xmsqaz"; })
-      (fetchNuGet { pname = "runtime.win-arm64.Microsoft.NETCore.DotNetHost"; version = "6.0.8"; sha256 = "0d10q75a645gdfk2krcwyhj3ncivmgbdkr1j7p7varl38ml1631i"; })
-      (fetchNuGet { pname = "runtime.win-arm64.Microsoft.NETCore.DotNetHostPolicy"; version = "6.0.8"; sha256 = "1lb78gjg28r3s0wwjsz3hvannlhqafc5jf8aqlyfk6w92c7p9y3z"; })
-      (fetchNuGet { pname = "runtime.win-arm64.Microsoft.NETCore.DotNetHostResolver"; version = "6.0.8"; sha256 = "05nay2zf8fp2y2ki232pkgwb29119fkhhg3z5dgbqn44dpsk7x1h"; })
-      (fetchNuGet { pname = "runtime.win-arm.Microsoft.NETCore.DotNetAppHost"; version = "6.0.8"; sha256 = "14yn29p83il7jympnnl34srqcygvlzn797702vg1qfdjs18iy6j9"; })
-      (fetchNuGet { pname = "runtime.win-arm.Microsoft.NETCore.DotNetHost"; version = "6.0.8"; sha256 = "1d8z4yk06qcqzfhs1424bwvvpy07m4dafilgxl3qlnynfb2i4jzi"; })
-      (fetchNuGet { pname = "runtime.win-arm.Microsoft.NETCore.DotNetHostPolicy"; version = "6.0.8"; sha256 = "1np746181wn7mzf424qg4j68bs7nwr2iylq18hi1jcl2ysrdcfn3"; })
-      (fetchNuGet { pname = "runtime.win-arm.Microsoft.NETCore.DotNetHostResolver"; version = "6.0.8"; sha256 = "1b4qb36sgqbp5mpfni3iz2qs2kvvj341xn6w2rncvjajvgl73mpx"; })
-      (fetchNuGet { pname = "runtime.win-x64.Microsoft.NETCore.DotNetAppHost"; version = "6.0.8"; sha256 = "19ha49v8wfn48v011jhrg9mlpalmb254rvkv409s4zj089612nfc"; })
-      (fetchNuGet { pname = "runtime.win-x64.Microsoft.NETCore.DotNetHost"; version = "6.0.8"; sha256 = "1g6raxhpx7vlwl68xcw4r0xjra95zcbwifnj95w21wzv0nndna91"; })
-      (fetchNuGet { pname = "runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy"; version = "6.0.8"; sha256 = "1imhc4a3yb9q0cslp0mnsvrvjm152kmj8iiw58c9j8g8sypxcw5g"; })
-      (fetchNuGet { pname = "runtime.win-x64.Microsoft.NETCore.DotNetHostResolver"; version = "6.0.8"; sha256 = "1ynn1apan8czndb4n8pdvday2jw6jc19zx8nsla8rv6m7q3vc23r"; })
-      (fetchNuGet { pname = "runtime.win-x86.Microsoft.NETCore.DotNetAppHost"; version = "6.0.8"; sha256 = "03xkg1yg2h4k2y774vc438ahs0mlrbgh0w7nxyzn15pvlp95yyc6"; })
-      (fetchNuGet { pname = "runtime.win-x86.Microsoft.NETCore.DotNetHost"; version = "6.0.8"; sha256 = "0dgcnlsmjhqz8m2y8lpyd0s626pj48whb8fzsxv51l125acinsn7"; })
-      (fetchNuGet { pname = "runtime.win-x86.Microsoft.NETCore.DotNetHostPolicy"; version = "6.0.8"; sha256 = "05xisaphkmpfx2w1irb7vhc0f2rfycxkicbyjhgmpqq9cbdxg09l"; })
-      (fetchNuGet { pname = "runtime.win-x86.Microsoft.NETCore.DotNetHostResolver"; version = "6.0.8"; sha256 = "1p5h36si87c461k854ky7hn5h5354mh9cprlkf6k814bhi4hjx7y"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-arm"; version = "6.0.9"; sha256 = "1grw9xypa4wlpqdjbgn73j4vlsz1xsrzil0pzb86r4902pcvvf37"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-arm64"; version = "6.0.9"; sha256 = "0xjhg58dzsqajl5y24rb4kwq87l6qplnffvr34bi2w94kw0s5kjc"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-musl-arm64"; version = "6.0.9"; sha256 = "1ycidvr1h7k3i1fijw8nfsvhrj3vqggyz82jykllmxwligx5fpm5"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-musl-x64"; version = "6.0.9"; sha256 = "1imicpzyyr1dhiqqnx6klkqmi1jr56lfiqgjzwjbv49d1jjx1m1j"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-x64"; version = "6.0.9"; sha256 = "1a2fw406dmffdl75046qc7z3rj76jbc74xgml7gis109i1s693pq"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.osx-x64"; version = "6.0.9"; sha256 = "10dmgv1rd4rac58xvhggkv2icq78ci0c8jfmnri3z32p14brlqwd"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.win-arm"; version = "6.0.9"; sha256 = "1z268bp615g4k9bq7hscq418i9k8f126lf8w60yq88rh0phslvyk"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.win-arm64"; version = "6.0.9"; sha256 = "0j2wxpvdgvipzy2qbpil8rbxszbp8wwgr28n3gn2r23gnsbkqpwq"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.win-x64"; version = "6.0.9"; sha256 = "0w3mrb1c21w0ri2pi9pxrpazxm94pbh6glfknjbc45awalqc94xq"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.win-x86"; version = "6.0.9"; sha256 = "1ws4x3l82m3kdrmaj67g6s9cc6p03rkg0pfaj11k4vmin5xbn9c4"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Ref"; version = "6.0.9"; sha256 = "16zdir94cacz2qrndspkyvwq7gp0cp20wdixkazfzxk8h5fhgbzw"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-musl-arm"; version = "6.0.9"; sha256 = "12flsql4wzgq1pp6w2xdc0ar493s9znzx17fvk9kz9kpbiwfivlh"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.osx-arm64"; version = "6.0.9"; sha256 = "0zhsvrydnhzxjmc2jjm95lzx93w8x4hh2wckcr8rpmvrlpr6gs9y"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-arm"; version = "6.0.9"; sha256 = "1lq8gdmkl1a68fr7ra74q4rlcc28fs0krsymhpiki5vch0jphjlw"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-arm64"; version = "6.0.9"; sha256 = "145viis984mdg29wdm21r13kd9dhiapjfxvm2wlvfdn617aymrkk"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-musl-arm64"; version = "6.0.9"; sha256 = "0ncw5kilaq3gl9smd4jy32z63kqaqagmxiii0hyp3ai3cg6zpwj3"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-musl-x64"; version = "6.0.9"; sha256 = "1rxi40ikai558dgy8n9izgkl4xbvqgyyh4pf0865a5qg1hhbis4w"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-x64"; version = "6.0.9"; sha256 = "07mkd56q2285izciy5dcc4y38dpl16xmpsz7401lg7drkwwkxxn9"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.osx-x64"; version = "6.0.9"; sha256 = "11nxvyf51c78hhjrjd9zmjb70nrp4iqg6gm2p30gsviii91y3gry"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.win-arm"; version = "6.0.9"; sha256 = "1l51bnw559mas6rza92wfdwksr59y105rpkjlhq2q2ymf3klys8z"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.win-arm64"; version = "6.0.9"; sha256 = "1iqs93klibsy08zw147zflajizkih1p748q3c37y9gp8glwqxcd5"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.win-x64"; version = "6.0.9"; sha256 = "18cmj54f39albhmkpisrwvzdjv5hxc6bc8fjfcs4hh79clxhb6pk"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.win-x86"; version = "6.0.9"; sha256 = "11zsyjn5smg797alfzzk0ilw5b8jiffsy9f734djpkpkykh4dvgy"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-arm"; version = "6.0.9"; sha256 = "0rn22v2hxr7a1rzbrwml9wbjh2s3356lm28ks4aqah9iaj607q27"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-arm64"; version = "6.0.9"; sha256 = "0jq73m9gzph7a91xgs9h683n2y552d1shhhr4h1ihiwm2nnwdkqm"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-musl-arm64"; version = "6.0.9"; sha256 = "13kk1k1011bi2fmzfrg4vhv480kbl7yc9zdk09d7660xxqavxgyc"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-musl-x64"; version = "6.0.9"; sha256 = "1wrgdv2av0v4wpxw2fv8ryfaha8yg3yaf5zynz67pbb5r3yimkmd"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-x64"; version = "6.0.9"; sha256 = "0bzfymrni9vibimpi85pggz3d0k625dl35sigjmn0lgpn2w53f01"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.osx-x64"; version = "6.0.9"; sha256 = "0ggh4iargpjsgjjcisi4bgfqlv9h3gkwff14cfw34lnficqykm8p"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.win-arm"; version = "6.0.9"; sha256 = "089bpm0yh0n59a4fn6abbwc4c6imgr9msrscbjaqas8v5amisg6y"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.win-arm64"; version = "6.0.9"; sha256 = "0hmb4ysplch0lms8s2v2hs9lh3gk3pidvpv0h2qxbbfq2qwhjz7r"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.win-x64"; version = "6.0.9"; sha256 = "0yka0ymd36qksgrl94m300yiy803daf4vr1lns06ybr39dlgwvan"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.win-x86"; version = "6.0.9"; sha256 = "15kw84wvy0g6q16293yj4blr0i1yvj1w7rgq9fqxgfmjgakrqg0z"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.DotNetAppHost"; version = "6.0.9"; sha256 = "1gfl347dxcfc0y4a5a171cn040pb6llvg9vxpgab4l33asgph5gb"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.DotNetHost"; version = "6.0.9"; sha256 = "0qf05pl6b5xgcwk42cph9baxqmfim6kzxxck4imh645js0bhkl6r"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.DotNetHostPolicy"; version = "6.0.9"; sha256 = "0a6c83s7lr7vrw170cigxw83ffxjsnzgxc652ig73pbi0y4p7d9g"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.DotNetHostResolver"; version = "6.0.9"; sha256 = "0mhbsh4p118nwja0v5di1la7h49hjws6nnvjd799cp65ybqap986"; })
+      (fetchNuGet { pname = "runtime.linux-arm64.Microsoft.NETCore.DotNetAppHost"; version = "6.0.9"; sha256 = "1ncc1x9paky7380z4djzx8i881ks56izkfb10pzigb2azm87knhs"; })
+      (fetchNuGet { pname = "runtime.linux-arm64.Microsoft.NETCore.DotNetHost"; version = "6.0.9"; sha256 = "1ywscs59f0qvmy9w5ls1dkqzk5lg0a5p0nvhlzkxc4zmwr65vq5n"; })
+      (fetchNuGet { pname = "runtime.linux-arm64.Microsoft.NETCore.DotNetHostPolicy"; version = "6.0.9"; sha256 = "0qj4ns9f8yf5wk4h0n6dnz3banix1jhgn3bd57x62cghfpwr7jn9"; })
+      (fetchNuGet { pname = "runtime.linux-arm64.Microsoft.NETCore.DotNetHostResolver"; version = "6.0.9"; sha256 = "1g7mvb5js3kdcmylnn22z9vcvwndzrqps23klnz7cjs207pldhw6"; })
+      (fetchNuGet { pname = "runtime.linux-arm.Microsoft.NETCore.DotNetAppHost"; version = "6.0.9"; sha256 = "172pxzsxr0x4nvyslm4gh6ar4mhy85fd9bmwqqja9k395rc9vh48"; })
+      (fetchNuGet { pname = "runtime.linux-arm.Microsoft.NETCore.DotNetHost"; version = "6.0.9"; sha256 = "1zwlc5y7zis93jzyixpgnhx1cjxi76mawxvcwcf215shrq80i5r8"; })
+      (fetchNuGet { pname = "runtime.linux-arm.Microsoft.NETCore.DotNetHostPolicy"; version = "6.0.9"; sha256 = "04hxa7924vaabqiw2imwn4d4jbxxyg950wpss420g6jxshv19zcy"; })
+      (fetchNuGet { pname = "runtime.linux-arm.Microsoft.NETCore.DotNetHostResolver"; version = "6.0.9"; sha256 = "0srwj2xgxi0w8hfgpfbqjrsm79kghb9x6fkkfwqjxsa7v95jh4bc"; })
+      (fetchNuGet { pname = "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetAppHost"; version = "6.0.9"; sha256 = "0b45wvpidp5zcchn5qspdqc9b60ivj67ic2a210px8vf57973a3b"; })
+      (fetchNuGet { pname = "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHost"; version = "6.0.9"; sha256 = "0jhflmmih4dhazyd7dqqiy207i3d153080hdy5bqqs21zl5ipc5v"; })
+      (fetchNuGet { pname = "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHostPolicy"; version = "6.0.9"; sha256 = "04dpv282hibxlq23g75sji7f9k4w4z64azl8j399ny4l409vw339"; })
+      (fetchNuGet { pname = "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHostResolver"; version = "6.0.9"; sha256 = "11b4p88jbx5amzb3y04yziq3wmrm9kqzhwmrhlsw0n8aa0fwc633"; })
+      (fetchNuGet { pname = "runtime.linux-musl-x64.Microsoft.NETCore.DotNetAppHost"; version = "6.0.9"; sha256 = "1cxrww0m61l883jmrjx5f6kgmk75p0jf4dwv8jkb5jnpq5lncjwk"; })
+      (fetchNuGet { pname = "runtime.linux-musl-x64.Microsoft.NETCore.DotNetHost"; version = "6.0.9"; sha256 = "03wgcvxyrm6hk5z8m87m1n0idgsyv54lsgbk8iz4qiww89r8xq61"; })
+      (fetchNuGet { pname = "runtime.linux-musl-x64.Microsoft.NETCore.DotNetHostPolicy"; version = "6.0.9"; sha256 = "1b4b3751jjh87g62w6fkrpfk3h92wh6927lwi0k2yxgdsbvadabv"; })
+      (fetchNuGet { pname = "runtime.linux-musl-x64.Microsoft.NETCore.DotNetHostResolver"; version = "6.0.9"; sha256 = "1vk22ff2jhaf3di1p2pkz0il1knl3hpfyhqw10b9mpxg3pk4ap3p"; })
+      (fetchNuGet { pname = "runtime.linux-x64.Microsoft.NETCore.DotNetAppHost"; version = "6.0.9"; sha256 = "09q38lwkx53fdl09ariv1d14md4brib9f0azah0bqhldkrjk92kv"; })
+      (fetchNuGet { pname = "runtime.linux-x64.Microsoft.NETCore.DotNetHost"; version = "6.0.9"; sha256 = "1mxi37xq6ghafg174x527xsv8l6r9cvrpskkf9h9lhk4lr9y2z67"; })
+      (fetchNuGet { pname = "runtime.linux-x64.Microsoft.NETCore.DotNetHostPolicy"; version = "6.0.9"; sha256 = "0cyddk0ylsa48xwjhi5cy498ys9y92r8kad1x7kqb0qkrzkjpzvv"; })
+      (fetchNuGet { pname = "runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver"; version = "6.0.9"; sha256 = "1jvilnvibx13hnkygfgkgkn3r1n549f67qzyg6z6ycd3cp8l915q"; })
+      (fetchNuGet { pname = "runtime.osx-x64.Microsoft.NETCore.DotNetAppHost"; version = "6.0.9"; sha256 = "1cb29wz495fwrbm7kwg8h4cmblsaqjff4f7kzmhw6qin56bvcw6r"; })
+      (fetchNuGet { pname = "runtime.osx-x64.Microsoft.NETCore.DotNetHost"; version = "6.0.9"; sha256 = "1q8fnyl6yzgjb1pmilgj0hnwkg482py7avpsfc7fsvygpk8izipz"; })
+      (fetchNuGet { pname = "runtime.osx-x64.Microsoft.NETCore.DotNetHostPolicy"; version = "6.0.9"; sha256 = "04az20nar6n43vrg131ppwnwzgij8781lb9wb113af5q323j94xk"; })
+      (fetchNuGet { pname = "runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver"; version = "6.0.9"; sha256 = "1h5hk3mfz730960hj86v6f1sqwb1kg2pfnp14l42cfdhjjs20zlv"; })
+      (fetchNuGet { pname = "runtime.win-arm64.Microsoft.NETCore.DotNetAppHost"; version = "6.0.9"; sha256 = "14xm25ynrjymrp2xmmblv523zsgggn35qzl88qcs4gbvp2j25hn8"; })
+      (fetchNuGet { pname = "runtime.win-arm64.Microsoft.NETCore.DotNetHost"; version = "6.0.9"; sha256 = "1kz2shcfhhy9aswzja1hk4lyrvicfppzkz4ggbn32vsbxlfaxyzx"; })
+      (fetchNuGet { pname = "runtime.win-arm64.Microsoft.NETCore.DotNetHostPolicy"; version = "6.0.9"; sha256 = "1a6k4gww8752pll4jz0wing1sqsplp9w0jxl5s5mfwj3p0laywly"; })
+      (fetchNuGet { pname = "runtime.win-arm64.Microsoft.NETCore.DotNetHostResolver"; version = "6.0.9"; sha256 = "0kkbb6dxwgjnaazvhs81qbp6g0bc6w11mmrbx7cz65ps1hks1gl9"; })
+      (fetchNuGet { pname = "runtime.win-arm.Microsoft.NETCore.DotNetAppHost"; version = "6.0.9"; sha256 = "1kzvyncbqdn9vn6lbvqzw1i3fzzdbj5xp5yzasdf843qi60vzv37"; })
+      (fetchNuGet { pname = "runtime.win-arm.Microsoft.NETCore.DotNetHost"; version = "6.0.9"; sha256 = "12dxp96s115xrhh18q7bf5r2rk1d485dqcbiwfhqi9xcbs11hlqg"; })
+      (fetchNuGet { pname = "runtime.win-arm.Microsoft.NETCore.DotNetHostPolicy"; version = "6.0.9"; sha256 = "1b6hzkn9pflbdr2lzrmdqpw93g23817ga5g4zbjdz05rd2ar2j95"; })
+      (fetchNuGet { pname = "runtime.win-arm.Microsoft.NETCore.DotNetHostResolver"; version = "6.0.9"; sha256 = "06va78yd32rhrylmy7hfkf6a92zaj9vkn3kmqzzzzisjzzrwws2d"; })
+      (fetchNuGet { pname = "runtime.win-x64.Microsoft.NETCore.DotNetAppHost"; version = "6.0.9"; sha256 = "0k7kyqdm2mlb2w7q5fpzj3sc20dqc1yc3bdzgx0qy5sfp3n2qdkq"; })
+      (fetchNuGet { pname = "runtime.win-x64.Microsoft.NETCore.DotNetHost"; version = "6.0.9"; sha256 = "1dcc9kf1abkdcq7n09s1vjyl39kbnpi8cqgmnhkhzlzh3l3xgvaa"; })
+      (fetchNuGet { pname = "runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy"; version = "6.0.9"; sha256 = "15zlpkf4ms616whp251q387fwabfmbvcxkhnx8m1jvfjc40smm0k"; })
+      (fetchNuGet { pname = "runtime.win-x64.Microsoft.NETCore.DotNetHostResolver"; version = "6.0.9"; sha256 = "1i2fzw6d8kpn8jrl0zmz0l6sxyaahs15f97xymkhv9xfj7w87ipr"; })
+      (fetchNuGet { pname = "runtime.win-x86.Microsoft.NETCore.DotNetAppHost"; version = "6.0.9"; sha256 = "0dyrizlh0vyvjjrjzn7p4wqzsr7360ppizifjl4y3fjxsixc7r76"; })
+      (fetchNuGet { pname = "runtime.win-x86.Microsoft.NETCore.DotNetHost"; version = "6.0.9"; sha256 = "1jsn0nadpnnlhn7y3s8zrkkm6fl1fsl4xxcf157m483qlswmlf9j"; })
+      (fetchNuGet { pname = "runtime.win-x86.Microsoft.NETCore.DotNetHostPolicy"; version = "6.0.9"; sha256 = "114a4y1xn6n0qwn9ssz510yq634liw5nkzyg8qqwka3d61g9vxap"; })
+      (fetchNuGet { pname = "runtime.win-x86.Microsoft.NETCore.DotNetHostResolver"; version = "6.0.9"; sha256 = "0qvhh2qzj0676vcbls6pmx0yydlm2fyb4pr1393siag7rn59ivhr"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Composite"; version = "6.0.9"; sha256 = "1wll6y5jg3f24pf6zs2aygmnz2lc71436svfqn6kxrfk6v3c32zq"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-musl-arm"; version = "6.0.9"; sha256 = "1kxql8yzi47prsl0ymjgyplfkxdfv1a048wghi7mc94zzjapz67w"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.osx-arm64"; version = "6.0.9"; sha256 = "1mf7xgjqn2d4pcvdy6g1igihygfjlplmfr2c88y8vq75l42bj641"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-musl-arm"; version = "6.0.9"; sha256 = "0djmb6i7jn9qgc9cv52c3jvkzqhm7688xcj9wb19594dcrdmrq9y"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.osx-arm64"; version = "6.0.9"; sha256 = "1ia7g6rx6jka54c0b5bvy45yr0nfs0cd64vwq1hkd5fq4wq0pmsc"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Ref"; version = "6.0.9"; sha256 = "0mrpvpvyxvkbk3q2ngs5ls3j4nq0pr2zhd0vls9bcv2sysby8yw0"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.Mono.linux-arm"; version = "6.0.9"; sha256 = "0p8a9001f9bv85k4fm76skc1zam4k1damxk8k8cyrg11m3p1m4zp"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.Mono.linux-arm64"; version = "6.0.9"; sha256 = "04fndyh42irxgxk99y6bvay415ikb63xr0hqjsg1l2ympzv0n19f"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.Mono.linux-musl-x64"; version = "6.0.9"; sha256 = "1d7alkqfbh58jdj1m9r99ppf5bm8br40a8xqd6p64mj88iwmz2i5"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.Mono.linux-x64"; version = "6.0.9"; sha256 = "0bqr8sgd7d1lwyyyclrpyi4p0d5nm7jk4hkapna142mxl1gckc8r"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.Mono.osx-arm64"; version = "6.0.9"; sha256 = "0cp47v4xjyjfwmm2r6spgiys60qsjkah9pf4ynl02jhyfncv4rdp"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.Mono.osx-x64"; version = "6.0.9"; sha256 = "06xi0hknlpwbxkdr8rj3paw5gigyp16m8r4w9ghwgdzigszwfcb2"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.Mono.win-x64"; version = "6.0.9"; sha256 = "1sp1zwld1kdcaax177laqfdgc8yma54w1k84xnjxrb8w2qkyw1wr"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.Mono.win-x86"; version = "6.0.9"; sha256 = "1didb5656m40g0h42ldw4qzwzvnfxsgyp90qlm8z2f4xjr2z2vvk"; })
+      (fetchNuGet { pname = "runtime.linux-musl-arm.Microsoft.NETCore.DotNetAppHost"; version = "6.0.9"; sha256 = "1lk2afw5x6dyfj88jk5a7iwnf5p1g2zs1xp9vbgqqcfw64lxw04s"; })
+      (fetchNuGet { pname = "runtime.linux-musl-arm.Microsoft.NETCore.DotNetHost"; version = "6.0.9"; sha256 = "0n87srqrh1xrlj9xz1q7fb6l1yzvcbajy5p6906iasvshyrj90aq"; })
+      (fetchNuGet { pname = "runtime.linux-musl-arm.Microsoft.NETCore.DotNetHostPolicy"; version = "6.0.9"; sha256 = "1jksa2j7v33lj0rdpcrmj4ibjafs7qm60knfxxa7xsp4zvqyhwx0"; })
+      (fetchNuGet { pname = "runtime.linux-musl-arm.Microsoft.NETCore.DotNetHostResolver"; version = "6.0.9"; sha256 = "0qdrx14chj6yx78cn2zxxfp9qs90alqb718z4y9ca1ix49wld8kh"; })
+      (fetchNuGet { pname = "runtime.osx-arm64.Microsoft.NETCore.DotNetAppHost"; version = "6.0.9"; sha256 = "0afrgd5l531jlgf3s93cqxphiirnifiw6rlqp3zaz3ijxwlikzkz"; })
+      (fetchNuGet { pname = "runtime.osx-arm64.Microsoft.NETCore.DotNetHost"; version = "6.0.9"; sha256 = "1gb4cr6f8ridwg8krh6fd6lygl7d3kcv5a3jda47ppvwi1kc6i4m"; })
+      (fetchNuGet { pname = "runtime.osx-arm64.Microsoft.NETCore.DotNetHostPolicy"; version = "6.0.9"; sha256 = "1yqmq0raafi7i8s8v3mjwdl45gxfs3gb6dm2cb4n19w2jihrn7nl"; })
+      (fetchNuGet { pname = "runtime.osx-arm64.Microsoft.NETCore.DotNetHostResolver"; version = "6.0.9"; sha256 = "09pr6llr1zy9l74lhrla7aa1mxw444qn817kxkwrfqdj0nq0aqx3"; })
     ];
   };
 }


### PR DESCRIPTION
###### Description of changes

See [release notes](https://github.com/dotnet/core/blob/main/release-notes/6.0/6.0.9/6.0.9.md)

Also, in this PR I added an `updateScript` to `dotnet-sdk`, which should (coupled with the previous change to exclude package-specific lockfiles, which avoids having to regenerate all lockfiles) allow all dotnet versions to be updated automatically.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
