### PR TITLE
dotnet-sdk_3: 3.1.422 -> 3.1.423

### DIFF
--- a/pkgs/development/compilers/dotnet/versions/3.1.nix
+++ b/pkgs/development/compilers/dotnet/versions/3.1.nix
@@ -4,134 +4,134 @@
 {
   aspnetcore_3_1 = buildAspNetCore {
     inherit icu;
-    version = "3.1.28";
+    version = "3.1.29";
     srcs = {
       x86_64-linux = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/effaa5bf-0fa7-4e5a-9ce8-9ac04ee86669/5afb2b1c2ad68550cec914d8fb303d20/aspnetcore-runtime-3.1.28-linux-x64.tar.gz";
-        sha512  = "fd66f9c0d0e9ed57abe5f81650c2ff49c694e05927e5280dbbdee1a9eb4299f0710bdc06ae0af0737c0a0584970b24d3eb952434b45ad8984fe3e37ca95cc1b1";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/d35c543b-44be-46ab-abf0-de8af9c5b3cb/4a17a6aaabe3f2f0e49de31f2f809713/aspnetcore-runtime-3.1.29-linux-x64.tar.gz";
+        sha512  = "991918a89c1372d8d1eef967777cc9dd55d0cef827d940f068e701ca877dd6e14045c3a309e6e9c4a7f843eef6d1b192b9ae1257141947f999f4e8dd6b0d43e3";
       };
       aarch64-linux = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/75b4f8b5-8aeb-4ba1-956d-bfc17ba5d6b3/bb3744801157ebc769808a92eabeee5c/aspnetcore-runtime-3.1.28-linux-arm64.tar.gz";
-        sha512  = "28371a6888d41e938f14cceb6c8a4471a1f0d7b585045e65b914f23ffb894f72a66a4a4cdaaf6d21dfd60063bb35d88c36fce8d4411a89c89b52023807639f82";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/35d465aa-769b-4b28-aded-0043dae97ef6/685bea2c3c4c7e0071e93c6263299fb3/aspnetcore-runtime-3.1.29-linux-arm64.tar.gz";
+        sha512  = "7cf6bccb85b39990d19ed5f42c8907e9fc615358330a060e9f93455c277143ec261f5255b6b05b081ade155f7965db5b092c956b0c77b2ebc9e2dae065f8e977";
       };
       x86_64-darwin = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/a9ad2468-f18b-4d35-9b9d-f2bccc681bdc/b3100ca07ee0e8dc4ef958921d4adbfa/aspnetcore-runtime-3.1.28-osx-x64.tar.gz";
-        sha512  = "965b23a32a9734c72515430e05d395db506a3a802997a6268ed42e24a700f06e5971cd38102f4ceb9c9d85d8515c1b0d11d4e5fbf8adc00c14060cb503a8faf1";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/09fc8ad1-3cbe-495c-b34e-0db458c81668/271a1c1b56be2c36057fabf005d15f4e/aspnetcore-runtime-3.1.29-osx-x64.tar.gz";
+        sha512  = "03978e8c131274d0bddb78ea6c4f590f015c0ce94527ff7b21cdcad4bd4a731dedb962cd773861f53b2e0178524f6fe5235f00f755b315ce4be47ae1573b382e";
       };
     };
   };
 
   runtime_3_1 = buildNetRuntime {
     inherit icu;
-    version = "3.1.28";
+    version = "3.1.29";
     srcs = {
       x86_64-linux = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/9a0b8ff8-d3da-4e77-9b5b-2fb3202afbbe/94dbcaacd4ebf59106a141c8e9e84167/dotnet-runtime-3.1.28-linux-x64.tar.gz";
-        sha512  = "b0760d463b8935a14bc247899b692038ded7d476a0cf2ed262eaac8ee6840350b29738cd1ab4961ba93b05f1802e7aba6e3c5e27e06ec9cb5e244149c52adea4";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/8a8cff44-0a23-413a-8643-2a0fa3b4da3c/c937fe6ed4d60efb1ef2929d983398cd/dotnet-runtime-3.1.29-linux-x64.tar.gz";
+        sha512  = "5c5ef6022abb5437e148c1cb22944eca7471a20a6a61300c6737c5f6e3ab0d95ba22d1ce55857e033c826a06359b601478228e3ef62cd321707911ad9d96bf67";
       };
       aarch64-linux = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/d71449b4-4504-410b-a805-48b3a6af5182/06abb8b35645e76dbe8cc4d17fdcbf89/dotnet-runtime-3.1.28-linux-arm64.tar.gz";
-        sha512  = "feb65d2926e21df802c600c8c8c060d15cf44458150b2be8a5d9dc42735cb89d1a5e990121f7ba5813d6f8acf88b6e6bae11d078156c84023e1337b917219b17";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/d859c2b0-4af9-441f-8c13-35e119224624/357a1322f8612211c336c63f25553f46/dotnet-runtime-3.1.29-linux-arm64.tar.gz";
+        sha512  = "aa3444a91d37a10e892338ff3df0e601cb47f469268f58acdece939e5455c774f7ee9d7600736f72195c312e03cd6ce3fa47b175bcfc62b9155d122f002d7e5d";
       };
       x86_64-darwin = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/ff22de78-4644-4395-a187-3910c27222d6/95c5a5334aa3c861238518a66696efa2/dotnet-runtime-3.1.28-osx-x64.tar.gz";
-        sha512  = "ad6ad23b08460eb09b5019760083906df96d064a5f0a34aa9b31b4e1eb4c8313ee59c1f3717056e3e9f4db8310329f9aed368bea6bba3c0a86c4a4ec7083bbb9";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/aaea7c1a-5c9d-44b3-8c9f-1968962010dc/0fc4b5693c319c46bf8911ec5c6e7a6a/dotnet-runtime-3.1.29-osx-x64.tar.gz";
+        sha512  = "c4e87afb80d6374a4ec66b1e043156b685b80778033565f55bff521cde82c6eb69f75d8edd54db65cb992cba2b24b0e0cb0f44b97a87d2baf4761eb7e966edb3";
       };
     };
   };
 
   sdk_3_1 = buildNetSdk {
     inherit icu;
-    version = "3.1.422";
+    version = "3.1.423";
     srcs = {
       x86_64-linux = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/4fd83694-c9ad-487f-bf26-ef80f3cbfd9e/6ca93b498019311e6f7732717c350811/dotnet-sdk-3.1.422-linux-x64.tar.gz";
-        sha512  = "690759982b12cce7a06ed22b9311ec3b375b8de8600bd647c0257c866d2f9c99d7c9add4a506f4c6c37ef01db85c0f7862d9ae3de0d11e9bec60958bd1b3b72c";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/e137cdac-0e15-46ec-bd60-14fe6ad50c41/30c102677cc4bd0f117cc026781ec5e8/dotnet-sdk-3.1.423-linux-x64.tar.gz";
+        sha512  = "bcb0efcc066a668eb390b57fd2c944abe73234fdbed57a4b1d21af5b880d102b765f2a790bb137d4b9f3d0d4e24fc53d39dc7666e665624c12e07d503c54ceae";
       };
       aarch64-linux = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/fdf76122-e9d5-4f66-b96f-4dd0c64e5bea/d756ca70357442de960db145f9b4234d/dotnet-sdk-3.1.422-linux-arm64.tar.gz";
-        sha512  = "3eb7e066568dfc0135f2b3229d0259db90e1920bb413f7e175c9583570146ad593b50ac39c77fb67dd3f460b4621137f277c3b66c44206767b1d28e27bf47deb";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/11abab07-d7a2-46b0-9ab5-19d5db67212f/783196073ecbd9fd64378fec412affbe/dotnet-sdk-3.1.423-linux-arm64.tar.gz";
+        sha512  = "ba4f82e939be43ed863f059f69cdfb80b6dfe7cf99638bd6e787b060c2c1c4934440b599c133f61e3a0995f73675ae5d927bb047597cdd6a15b9074891dfd62e";
       };
       x86_64-darwin = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/515fcb39-1e67-4cf5-908e-0e00f3cd76b2/6478e6b98726db240cb6b572f9eab97e/dotnet-sdk-3.1.422-osx-x64.tar.gz";
-        sha512  = "9f919e42a692e048405b52cce8938fd4c40e7dcdf9c6c29eaa41940af7846cd2a678b5c43222d1cb988236917e47d85f37212bfe0c2dc6973cd5a8f2799838ff";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/68bf0fe2-c2e9-4a57-b6fc-fcee862d6a92/6d13392c3596710426f91c6b46c6ff40/dotnet-sdk-3.1.423-osx-x64.tar.gz";
+        sha512  = "89c23bd2a4b9d10af443d609194db33de4a5b7ed5f1328b705a87d68bd4a413a7e2a3e18a8a047aa7ce757224f4e81f3582bc91c1f4ffe074847656f56b26098";
       };
     };
     packages = { fetchNuGet }: [
-      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-arm"; version = "3.1.28"; sha256 = "0ssf6qdsaihg86pb39162xi5sfnv6b2na85brk6h3gcw2ydqfgbc"; })
-      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-arm64"; version = "3.1.28"; sha256 = "0gri8zsq5qk5czfg2ik9fc0a3nscz2jn7g1knsp717qxix31ilaf"; })
-      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-musl-arm64"; version = "3.1.28"; sha256 = "0wp5nrb63k9p5850bfqjscf0hjyqi5dcw8vsymnfnjdd06zldp6j"; })
-      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-musl-x64"; version = "3.1.28"; sha256 = "16p8z8n47w7m89wy34wh7zyg8a21hbsv8vswrw3b6gh3r861jg24"; })
-      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-x64"; version = "3.1.28"; sha256 = "1cvgplsmg6d9bgxr7lnnnh7lhcmwhn3r08cnw4di9x92xaysgzwg"; })
-      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.osx-x64"; version = "3.1.28"; sha256 = "1zv3vjifjcd56q8xp47998d4016a8ma8x0a2pdlki2kghwjjpmcv"; })
-      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.win-arm"; version = "3.1.28"; sha256 = "0myfvrwn13z8l6j294jw9qrdzg4ld9dp683jdmy657q30vxqj9ci"; })
-      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.win-arm64"; version = "3.1.28"; sha256 = "1dhg0p820mg2v0gh9yd4snh062cbz0mg106idrii8mhkn09na698"; })
-      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.win-x64"; version = "3.1.28"; sha256 = "04ss3gd6frf7p9ipry427a0cw9jh4l1xapq3sc0p33hd9g3ggkp3"; })
-      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.win-x86"; version = "3.1.28"; sha256 = "07r9gd9gc4b0h7fdswk3c4bf617fkcy5jw9y2y8rm97c1gfxph3p"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-arm"; version = "3.1.28"; sha256 = "186i94wddk4j93pqmwzr6fdrf8vqhlipansjfpp530l8d3zba7zp"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-arm64"; version = "3.1.28"; sha256 = "0asdcnqf2vr9v159brdhg0wmfbvh8gl9n14ynv0h561dkdlps7fr"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-musl-arm64"; version = "3.1.28"; sha256 = "0y5m5azblkr2vi8qba83mnad7irmywn7i1b154yig9r09245plgp"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-musl-x64"; version = "3.1.28"; sha256 = "0bm99w4v4mw9nj400szvywripgv8vk96vyxmpr0vq96fpzkx66wr"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-x64"; version = "3.1.28"; sha256 = "09974p9xl37x3dgclpvv280kiclnlvlwg31id8bkrz7ir8iafwbx"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.osx-x64"; version = "3.1.28"; sha256 = "10rrf9gj81viisb31mc0nq90wr9fbnljzi0vn7bpylj68072sqi2"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.win-arm"; version = "3.1.28"; sha256 = "00wcigwd6pphmcb19pj6krj4p8ydzzclgvjxqj45fdj8ja94d0dq"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.win-arm64"; version = "3.1.28"; sha256 = "1rpj5mscc0b15dr6fphrb6lbkycd58d95n6r4vm40124c17nrp70"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.win-x64"; version = "3.1.28"; sha256 = "15fp5g6334ri43vk4cas50b1fg31y0l7inba1z7fwbcrlf7kj72k"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.win-x86"; version = "3.1.28"; sha256 = "1ac9538bx4l4skk295q6d3hm3yfrf3b57zavhlpy8wpclg97wqmc"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-arm"; version = "3.1.28"; sha256 = "0g2wdkm9dcs3d106r80q84i5plwhgnv34abpda8id993dprjpkg1"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-arm64"; version = "3.1.28"; sha256 = "175195fbgrzxs4zmgnx9xy3mlzdvbd8mrlya2is2s0pa0dz3aw61"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-musl-arm64"; version = "3.1.28"; sha256 = "03n58cibw0dk782yrxargnbcrhwv43pvyiic71hvf2kh6hi282gp"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-musl-x64"; version = "3.1.28"; sha256 = "1xs1x03xmmxpy686wydb2v9b3vwb57lhjdxm4spsh74n0iwgbznq"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-x64"; version = "3.1.28"; sha256 = "0pn000bgrb0lmqy34np3q974n3x4cv6rz1rc0w5n7kfnrlpwl15l"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.osx-x64"; version = "3.1.28"; sha256 = "0hgj4pib1ckl38hd197g9x22dvb2h0302zny6za6156sblizypr4"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.win-arm"; version = "3.1.28"; sha256 = "0irh5riigrpq0wfqsbphf3r1a4w29p547pnml8h5997mmch5ds13"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.win-arm64"; version = "3.1.28"; sha256 = "0fayr4rp3ykn0rp3jir81x9ilvg3hfj8s86raxv19k54x15grqw7"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.win-x64"; version = "3.1.28"; sha256 = "1j4hf84ycjhna8ng8hxl3bmwwbnzcfbsj751widwhlbnsy7vdiy4"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.win-x86"; version = "3.1.28"; sha256 = "0mb5kr8rqgh4m01n20xdw8ji87ixxan9qkbjjr7amiv38x1aimfa"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.DotNetAppHost"; version = "3.1.28"; sha256 = "16jm0pcjhmc83f5c5hk2n40xc73jg9358yw1mwm35jp5z15n9nah"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.DotNetHost"; version = "3.1.28"; sha256 = "184qcjc3h70q1w3mjjbmw7w7fq4j6daw5hk53zgbpicfd928i5fm"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.28"; sha256 = "1vx08xz65mapyjs6ixnn31c95i9b35h8fry4djdz167794zj2w0z"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.DotNetHostResolver"; version = "3.1.28"; sha256 = "18jnw2cp3vpm9zkfbjv51gpl5786hsf5fdm6y89c5m25pckilvgi"; })
-      (fetchNuGet { pname = "runtime.linux-arm64.Microsoft.NETCore.DotNetAppHost"; version = "3.1.28"; sha256 = "0k4qv1srcsyq9c0d0xik5bjrng6sxsl6c1n9f8q0vyar63d4dm6y"; })
-      (fetchNuGet { pname = "runtime.linux-arm64.Microsoft.NETCore.DotNetHost"; version = "3.1.28"; sha256 = "1knlnq8xn3z87h2pwp12rcfiwzv7rf9h9245dhsaq0kv0h2173w5"; })
-      (fetchNuGet { pname = "runtime.linux-arm64.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.28"; sha256 = "11m6hvf56iq7q736mx21yrk14qnbyz4ahm8517pz9amiilwnwdcg"; })
-      (fetchNuGet { pname = "runtime.linux-arm64.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.28"; sha256 = "1hp6cysrhm0fn18bmiicy0plvpcplrjbxn792ps6iipn82hfxlfa"; })
-      (fetchNuGet { pname = "runtime.linux-arm.Microsoft.NETCore.DotNetAppHost"; version = "3.1.28"; sha256 = "1b6rlnazbm9h3rwdz2qglqbn44qxbzny8x0cnj5aqa9wxg0ipkqw"; })
-      (fetchNuGet { pname = "runtime.linux-arm.Microsoft.NETCore.DotNetHost"; version = "3.1.28"; sha256 = "1klfr2a842xflc48mw2zds4cb8s95p1m2yb3w0h58rnpkry4r8cw"; })
-      (fetchNuGet { pname = "runtime.linux-arm.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.28"; sha256 = "01v74s41kyysy8v4q20zbl1ba9n6sc55mizybvgjl869h437bikf"; })
-      (fetchNuGet { pname = "runtime.linux-arm.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.28"; sha256 = "039an5v5yck70pl4y3h3nphf6jga6vl071iiakv5siccvkpg2zcr"; })
-      (fetchNuGet { pname = "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetAppHost"; version = "3.1.28"; sha256 = "03fmzxhhxdvs36zjp38h39g1x4zzabfhfac5k5a80m23kh8zk199"; })
-      (fetchNuGet { pname = "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHost"; version = "3.1.28"; sha256 = "0k7ngxhn39ybx3z64bds7kzwmnpyfzpyx6gyv8l0zw9gzaiakmzx"; })
-      (fetchNuGet { pname = "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.28"; sha256 = "0254fw61xcmvlah2c5fpl4ifslph9vqavba8b7i2b8hjj1ah569x"; })
-      (fetchNuGet { pname = "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.28"; sha256 = "0219z3dqiygl8j8q3khxdvkvpzb4lpk5r76an47lnxpqkw90ip4k"; })
-      (fetchNuGet { pname = "runtime.linux-musl-x64.Microsoft.NETCore.DotNetAppHost"; version = "3.1.28"; sha256 = "0ndcp8b1is2h9rjrkn9hs468n9z619qpbqcnj11algpj0gcs00qn"; })
-      (fetchNuGet { pname = "runtime.linux-musl-x64.Microsoft.NETCore.DotNetHost"; version = "3.1.28"; sha256 = "1fz9r6n018rzqarabfkqdbzm0d6nnprkx1cpyplxl6kmc60gp9f7"; })
-      (fetchNuGet { pname = "runtime.linux-musl-x64.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.28"; sha256 = "19lavwarm8svf725vilh1zzwlx27khy27n7nw9d1cvi40r3vpvfp"; })
-      (fetchNuGet { pname = "runtime.linux-musl-x64.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.28"; sha256 = "0b6wa3a479d4w1zxgk748q70nkcrzs3c2snlxhhciz4bv09mrbd3"; })
-      (fetchNuGet { pname = "runtime.linux-x64.Microsoft.NETCore.DotNetAppHost"; version = "3.1.28"; sha256 = "1pj7i6kdf8k31d9bczkggn6fdjrjigzsrvmh24zfz2n3q48g0grc"; })
-      (fetchNuGet { pname = "runtime.linux-x64.Microsoft.NETCore.DotNetHost"; version = "3.1.28"; sha256 = "0llnj78c9ds5y2cg2f1q1mz1kbmzm9vs35hq942d4lfv1hpxbd4n"; })
-      (fetchNuGet { pname = "runtime.linux-x64.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.28"; sha256 = "1nlxmpzb7qgznx0wmm6zci26y7wvkwndq34d4jm310g8qzrqkxn8"; })
-      (fetchNuGet { pname = "runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.28"; sha256 = "0lbsyn96a3nfy94x9n6k9aka5v7q34hbbjdjd0w0is7njrly1xg4"; })
-      (fetchNuGet { pname = "runtime.osx-x64.Microsoft.NETCore.DotNetAppHost"; version = "3.1.28"; sha256 = "0qyf2n35bn0wp4iy4f2whfm1syl44k42g3md2dbivppdc16qs828"; })
-      (fetchNuGet { pname = "runtime.osx-x64.Microsoft.NETCore.DotNetHost"; version = "3.1.28"; sha256 = "091iff9mpp837vakyy5h7mqh1m90gz9x76ch5n49znq7qf819jz4"; })
-      (fetchNuGet { pname = "runtime.osx-x64.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.28"; sha256 = "0byn4ng5cs54r1gz84wz9g914n0dby643fs4iyx14v5pg9ns7m7y"; })
-      (fetchNuGet { pname = "runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.28"; sha256 = "0jh7kmgxjf4xpsbxyf86yfq4ff0lxrhcykhc9mqizmgsp3kdzg36"; })
-      (fetchNuGet { pname = "runtime.win-arm64.Microsoft.NETCore.DotNetAppHost"; version = "3.1.28"; sha256 = "1x7xkjvx2j7khr6iafl1dvzsfqswr54y79lf17w8m196lbsvn13j"; })
-      (fetchNuGet { pname = "runtime.win-arm64.Microsoft.NETCore.DotNetHost"; version = "3.1.28"; sha256 = "18nqdrm8d2xdf7cq7hcbh5v2fa28kdyx682bb0wb4w06x4gziy55"; })
-      (fetchNuGet { pname = "runtime.win-arm64.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.28"; sha256 = "06gfp66ax9m2jhd07alcn0dp8hyxkyi934wy8asl64y1c08rhh09"; })
-      (fetchNuGet { pname = "runtime.win-arm64.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.28"; sha256 = "01q1vs13ifnbqywpmdli83w7bdhph88njz15dhmx7kxjadcicclc"; })
-      (fetchNuGet { pname = "runtime.win-arm.Microsoft.NETCore.DotNetAppHost"; version = "3.1.28"; sha256 = "1kd6np0i0wfz5kpq2528by8sxmp2q7fdsncks9s7sk9s2am6q6wr"; })
-      (fetchNuGet { pname = "runtime.win-arm.Microsoft.NETCore.DotNetHost"; version = "3.1.28"; sha256 = "1r9j70gykblfqd2cxnnhb0hpj0pidn9kk7c7v20bmnkv0vn8nb27"; })
-      (fetchNuGet { pname = "runtime.win-arm.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.28"; sha256 = "0aqinv4s9n61i66dd499x1adiw64a83iscddjaxml4qzyffp3v2g"; })
-      (fetchNuGet { pname = "runtime.win-arm.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.28"; sha256 = "13n0lshgwpwizz7zqm6cph621bk2ayhkkimfmp60wz0s9mhx78f3"; })
-      (fetchNuGet { pname = "runtime.win-x64.Microsoft.NETCore.DotNetAppHost"; version = "3.1.28"; sha256 = "0ky15gpji8hs8hnibk3ckcqk1fpk20kgsgkvczpvq88qd0nzlp1d"; })
-      (fetchNuGet { pname = "runtime.win-x64.Microsoft.NETCore.DotNetHost"; version = "3.1.28"; sha256 = "03n3ps5y45hgniirr9bb80cvrwsddb9ixj8xzlxzdg349j3cz5mw"; })
-      (fetchNuGet { pname = "runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.28"; sha256 = "0a91gv56gl6j97gn7p0ss0ivpnl7gxhb90sklgbvvwp3601gka6a"; })
-      (fetchNuGet { pname = "runtime.win-x64.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.28"; sha256 = "02i5cphwkqg5z5ariy2lrn8fbx15nbq3pzzw2ncja933zqg145zs"; })
-      (fetchNuGet { pname = "runtime.win-x86.Microsoft.NETCore.DotNetAppHost"; version = "3.1.28"; sha256 = "01xcvlrif0wqq02p1x74sqvm95b9aqm5ada1q2l2xr9yglrzh0lq"; })
-      (fetchNuGet { pname = "runtime.win-x86.Microsoft.NETCore.DotNetHost"; version = "3.1.28"; sha256 = "0j9b8xy9vq7vlgx4fbcrh1g2qypai2q5iar6fwsialrrgp3v599x"; })
-      (fetchNuGet { pname = "runtime.win-x86.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.28"; sha256 = "1pl66sqxiw103bknbwcazf82sr2q6x1fk21h0d5xl7cgpabx53gs"; })
-      (fetchNuGet { pname = "runtime.win-x86.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.28"; sha256 = "1jbg3gpmqrbnhy7rf7xjg84riyzfmlmzl8ixpy2ks59q0mm22vkw"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-arm"; version = "3.1.29"; sha256 = "044b2yaf9y3nczlibgrrb7sajhddrfy0vyz426r1zsrab0zwmaza"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-arm64"; version = "3.1.29"; sha256 = "0s3xfrvjh0wvkn82qsh2w9nnnmg444mfqb5x769zlwdaynbcilk9"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-musl-arm64"; version = "3.1.29"; sha256 = "13rjpmm4kzq4rvra5aa8bxsb4nxnlw1gfpldb542arab3pm8zlk7"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-musl-x64"; version = "3.1.29"; sha256 = "0gd7yq0d29rj4fs975lx60hsd2m3mxslz25hr0xy5snd8a87kjbl"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-x64"; version = "3.1.29"; sha256 = "1bc8cg76m1iazd6c125mdsm0vx3ln5v9wr61baixip6sda4g2llb"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.osx-x64"; version = "3.1.29"; sha256 = "19w3x6pz37bi894adl184pb1k0iz58kwkgr3awvxh4sc8r4xbw1y"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.win-arm"; version = "3.1.29"; sha256 = "1526b9smbv0n26bpsh7sl49wxd43g6pkasz387nkagh5xn4jfabl"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.win-arm64"; version = "3.1.29"; sha256 = "121x2vcn9ppyr12s2513ga4bchc2bw7y634fi3d1h2s6nkixcpyy"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.win-x64"; version = "3.1.29"; sha256 = "1583dcz8j8l853ba72x6h4ajw3b0zsyp63fg3b10wlb321d6wnf1"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.win-x86"; version = "3.1.29"; sha256 = "1xj92ra27k6yf8fmdb7bclr3nqmqwg42b94v5p410cwvss57c1pz"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-arm"; version = "3.1.29"; sha256 = "0kma4dqkpjvdld3q4vzd14kbb2jmqjy0aqqjw4p2f30ibv337jvn"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-arm64"; version = "3.1.29"; sha256 = "11ras34acbhi7rwcpn5j4lfkx50jvp2iz1mbm45aqzj6m2k27dxj"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-musl-arm64"; version = "3.1.29"; sha256 = "0r46zjrgg8zaskp83wp3q3k7sr1vvizc4xjvf6v34yhxi08aq43g"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-musl-x64"; version = "3.1.29"; sha256 = "12771skpb42mz9m932b2rhh51wc8jrbsmbjmjmdi0vl740dk07nq"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-x64"; version = "3.1.29"; sha256 = "04pjfa6blvyv4axvgbl3nlng92knc6a8i06xf23144m83crfkcm9"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.osx-x64"; version = "3.1.29"; sha256 = "0il74z0m7pk7w92jjavxlln6lfbkn5jpbwpynnrvbrzwjbqzpvdf"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.win-arm"; version = "3.1.29"; sha256 = "1i7wdxjpm5xczsh3jfqlv2ph98dzpa7nw95am5v1nxhddf1ry8pa"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.win-arm64"; version = "3.1.29"; sha256 = "10bqdwxmm7v73mwyzs5jgf9fahjdzzyxwyrqvbl7fjrm5c9f601a"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.win-x64"; version = "3.1.29"; sha256 = "0wz2w821hwii61vmxf5plfp188p42i4s4zhrqjjkxaz8bxqmp049"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.win-x86"; version = "3.1.29"; sha256 = "0yrqm145vkhpl4jprlzj6r9x0dd2kdlnqd4bmf1zr6lax4sxlakg"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-arm"; version = "3.1.29"; sha256 = "19qbbbib65bygqk80gkjsj416wjqi4mfjngginfsarq0shbl89ls"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-arm64"; version = "3.1.29"; sha256 = "04fvpjwldx0l9p3wb6r3lgha8bzv1vbgr0vhksdbwz49nnrx7bvb"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-musl-arm64"; version = "3.1.29"; sha256 = "0qx0lhd8kmxpsya942irsfknxk6l8wqfbgyb56gafg29j5w7fna1"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-musl-x64"; version = "3.1.29"; sha256 = "1scc0r3mrmd73lck285d6bg4arwf685q5z7pbawxdajrfk1xlqq9"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-x64"; version = "3.1.29"; sha256 = "1jn4fmjz3nb6y0cajrw93nr4qid3319yjpqsyfqrr6zas1gyk2v7"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.osx-x64"; version = "3.1.29"; sha256 = "02qgp4x0i5gzxqk1z9zwsd9pa94816yhvr70ig5y1faq343j1qcf"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.win-arm"; version = "3.1.29"; sha256 = "0za0ym9s7zjchfl561xp7jd1im1mpsvm2ibdhb6754v4qzr93vws"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.win-arm64"; version = "3.1.29"; sha256 = "1fhw97x4bbmpa1afzhmalnqi4fa1aw8qcqy4bnnwl18z00l269fw"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.win-x64"; version = "3.1.29"; sha256 = "0jgh3c3d29dqrjb9f41fxfawn5kd3bq1zcbvklpn1wiflqz9m7jg"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.win-x86"; version = "3.1.29"; sha256 = "19hprmp89jhf5q3yi2aryam6limmxppkqmr65w33gnzfx7iny3vz"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.DotNetAppHost"; version = "3.1.29"; sha256 = "1d3h117354dgp0j2395r9ic69dj5j1nfndxaly7vfn4ajl5g8jv3"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.DotNetHost"; version = "3.1.29"; sha256 = "0w1xirsyxr26jiadj6mdgxvhmn48nlpcg1pwv8ann1ln1kp8ascw"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.29"; sha256 = "032ahrcjb93hn6s4j16r1nanigmn8jfgjvqhmy2mgpmcxrkj4ikr"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.DotNetHostResolver"; version = "3.1.29"; sha256 = "0q2c7hkxrqkh1chwzp2ysq17z9npsflgq1nym66073rcvhhqxpgz"; })
+      (fetchNuGet { pname = "runtime.linux-arm64.Microsoft.NETCore.DotNetAppHost"; version = "3.1.29"; sha256 = "17lf1jl1d2i8w56i4gazglahv2wvijx0xxs81gxn9ipb76hgr0fb"; })
+      (fetchNuGet { pname = "runtime.linux-arm64.Microsoft.NETCore.DotNetHost"; version = "3.1.29"; sha256 = "0akljipsfv8vy0gwzj9kv6gi8iwfpiasx9zijp107iplmps3mpbr"; })
+      (fetchNuGet { pname = "runtime.linux-arm64.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.29"; sha256 = "0jgb0v2jl8bw75j84mj7ykxgw6dspz26jsg941wyirh5namdd7d7"; })
+      (fetchNuGet { pname = "runtime.linux-arm64.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.29"; sha256 = "1i8sjzbr93696gcx3a194zvqp9wadw9p7880la9s349xan30c37b"; })
+      (fetchNuGet { pname = "runtime.linux-arm.Microsoft.NETCore.DotNetAppHost"; version = "3.1.29"; sha256 = "1m1klh13bsvkgz145ibz07lzycqi0sxnl360d0l3wjs8qzfn09f6"; })
+      (fetchNuGet { pname = "runtime.linux-arm.Microsoft.NETCore.DotNetHost"; version = "3.1.29"; sha256 = "1qfrzw54gfq2583n4n992v828hzi11y30ylbwp9shb87jvqwcbcb"; })
+      (fetchNuGet { pname = "runtime.linux-arm.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.29"; sha256 = "0p5lq2hx315bc3dhh59liqzlx5gh4q9v862lc0d02yznxnfkmhfm"; })
+      (fetchNuGet { pname = "runtime.linux-arm.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.29"; sha256 = "1pviax5b66nw4420kz5cp2g2hxyjzfrk1bcgv3my28ravh0fyrjr"; })
+      (fetchNuGet { pname = "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetAppHost"; version = "3.1.29"; sha256 = "1p25ni981b0gwqfn67viyayfha47rpqr7m2l0vdbysq4b8nbc7dm"; })
+      (fetchNuGet { pname = "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHost"; version = "3.1.29"; sha256 = "0jsjmy07qmqp6fh7wnddz69q56c5kyx7vfpns5ba0k65ch1s3gn6"; })
+      (fetchNuGet { pname = "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.29"; sha256 = "0msdl6wf9v286pdski0hmszh6g73365k3fygyf7fb78qp262aj95"; })
+      (fetchNuGet { pname = "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.29"; sha256 = "07mgal05cqr05lwxrcdqjhnkmbf3hqjs7xx54pf55knxj3wwglhr"; })
+      (fetchNuGet { pname = "runtime.linux-musl-x64.Microsoft.NETCore.DotNetAppHost"; version = "3.1.29"; sha256 = "06rjafh7hx3pc0m4a24r1a8rapiz2d4ayvnvlw6dr01ajz8241q6"; })
+      (fetchNuGet { pname = "runtime.linux-musl-x64.Microsoft.NETCore.DotNetHost"; version = "3.1.29"; sha256 = "1j4mxr8xnm47bi81cszzd9kfhnggwdff865imib39h36m0sn5r5f"; })
+      (fetchNuGet { pname = "runtime.linux-musl-x64.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.29"; sha256 = "1c4m9qi1glarvbrsxrddjfbva1pk0k8blam9mpi6k0rkg8s3w187"; })
+      (fetchNuGet { pname = "runtime.linux-musl-x64.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.29"; sha256 = "1wnz47s15lhhxy49fraiyf70k3xqcad6bm6rq66n6kcy9b0miym4"; })
+      (fetchNuGet { pname = "runtime.linux-x64.Microsoft.NETCore.DotNetAppHost"; version = "3.1.29"; sha256 = "0vxpakngckjx3n7bq2ykjf0dfdjk79cpxj0mq7dgwvkvq350s96n"; })
+      (fetchNuGet { pname = "runtime.linux-x64.Microsoft.NETCore.DotNetHost"; version = "3.1.29"; sha256 = "0z1bn3afrp05rypq9wn74a5p7sn5l5pi2qhl9hfdf3ds01bsw20z"; })
+      (fetchNuGet { pname = "runtime.linux-x64.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.29"; sha256 = "0yl3wajrflysp7g0bhqig2a99pxghxmfzsys0s86pz01w2fnmp9b"; })
+      (fetchNuGet { pname = "runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.29"; sha256 = "198xck9pxx5yc9w6i6mi2wlbg67jchfl8v685s6sdvs0yjy8yyfd"; })
+      (fetchNuGet { pname = "runtime.osx-x64.Microsoft.NETCore.DotNetAppHost"; version = "3.1.29"; sha256 = "1fgl4z7ghrq7g35as2i8qpywq2g6nbh9fag9655np4973p68v4fv"; })
+      (fetchNuGet { pname = "runtime.osx-x64.Microsoft.NETCore.DotNetHost"; version = "3.1.29"; sha256 = "09w175d7zvfkp08c4sgpbsp1fccblrf480hfv2hcsaakz2g2zai9"; })
+      (fetchNuGet { pname = "runtime.osx-x64.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.29"; sha256 = "1phdxavas361204sm46la826392wxgyzx46viw7jbbnj6ywrkn6p"; })
+      (fetchNuGet { pname = "runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.29"; sha256 = "06xzc7w773dv73x2r1zx8sad7ryzjz4wwpmjx45z0a74vn6l00r7"; })
+      (fetchNuGet { pname = "runtime.win-arm64.Microsoft.NETCore.DotNetAppHost"; version = "3.1.29"; sha256 = "1imng24m75iaxf4hgjwq16m38lsadcsghwp85s983hr09w89z0sy"; })
+      (fetchNuGet { pname = "runtime.win-arm64.Microsoft.NETCore.DotNetHost"; version = "3.1.29"; sha256 = "1snjl0wkyzibm70k3diyz7sdqclgxj3py4xxkp66d64abqr0245s"; })
+      (fetchNuGet { pname = "runtime.win-arm64.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.29"; sha256 = "0g8w0m6ajym0hdbhf4gdjv6j863nsl6qbnh7avr6zx211f2jxln8"; })
+      (fetchNuGet { pname = "runtime.win-arm64.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.29"; sha256 = "0wr0myb0mkqihp8da5q6vg7nlaz1w0a2wdzhk66aqsfvg0qnj3xh"; })
+      (fetchNuGet { pname = "runtime.win-arm.Microsoft.NETCore.DotNetAppHost"; version = "3.1.29"; sha256 = "17n11bqlj0wpb1ixiag511m08ilhvhdmvlgb98rsbcms8jzynf62"; })
+      (fetchNuGet { pname = "runtime.win-arm.Microsoft.NETCore.DotNetHost"; version = "3.1.29"; sha256 = "089jd0l2j06fbh27qphhsf26lrxd614qg5ymn3y945qsvxf4662k"; })
+      (fetchNuGet { pname = "runtime.win-arm.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.29"; sha256 = "0zqmy7x1wr9shyzgq51l2a96v5kydap71lwcjbwgbc9vkxrpy0zx"; })
+      (fetchNuGet { pname = "runtime.win-arm.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.29"; sha256 = "1dnsgp2bkimp2pawfr79nrqixhyrl6bxshksgx4sgiw5ihh3i11j"; })
+      (fetchNuGet { pname = "runtime.win-x64.Microsoft.NETCore.DotNetAppHost"; version = "3.1.29"; sha256 = "1xjlxskm9i0f1chijbis883jrjfdlfhsy3blyjq1dg5wa3lyhb4s"; })
+      (fetchNuGet { pname = "runtime.win-x64.Microsoft.NETCore.DotNetHost"; version = "3.1.29"; sha256 = "0vrahr6gr043c6q7frrjllapifxc6zz55331g5xzsxdfygnk4mb3"; })
+      (fetchNuGet { pname = "runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.29"; sha256 = "0kzqygz1jbi7xk36bq76sy9yg4dbdnmcc42agx86igi8qlw0b1ar"; })
+      (fetchNuGet { pname = "runtime.win-x64.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.29"; sha256 = "1mzvnj1wqqv8gnmkq95yxhwqgkldfpr1a0xisp76if0235l14iq3"; })
+      (fetchNuGet { pname = "runtime.win-x86.Microsoft.NETCore.DotNetAppHost"; version = "3.1.29"; sha256 = "1zrmwm1shhvxn6c07f9mmjcxbgp18y9nshai8w02lwsw2lp7pan1"; })
+      (fetchNuGet { pname = "runtime.win-x86.Microsoft.NETCore.DotNetHost"; version = "3.1.29"; sha256 = "0ijn3n7b9h3a2hqxdfgndk8k7chzyb4gry2ymmvgfadhxy4b1vxz"; })
+      (fetchNuGet { pname = "runtime.win-x86.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.29"; sha256 = "0wlxy7pipblk6pyi8yxch181vvxxf1a203bk8rksgpikwswpci7s"; })
+      (fetchNuGet { pname = "runtime.win-x86.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.29"; sha256 = "11qnmn4cy54wgml04bb2xr3m9jmgss8v5c5215zmfzlsywr9gcfg"; })
     ];
   };
 }


### PR DESCRIPTION
###### Description of changes

See [release notes](https://github.com/dotnet/core/blob/main/release-notes/3.1/3.1.29/3.1.29.md)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
