### PR TITLE
input-remapper: 1.4.2 -> 1.5.0

### DIFF
--- a/pkgs/tools/inputmethods/input-remapper/default.nix
+++ b/pkgs/tools/inputmethods/input-remapper/default.nix
@@ -29,28 +29,20 @@
   # failures when building. Override this to true to run tests anyway
   # See upstream issue: https://github.com/sezanzeb/input-remapper/issues/306
 , withDoCheck ? false
-  # Version and rev and hash are package arguments to allow overriding
-  # while ensuring the values in prePatch and src match
-  # https://discourse.nixos.org/t/avoid-rec-expresions-in-nixpkgs/8293/7
-  # The names are prefixed with input_remapper to avoid potential
-  # collisions with package names
-, input_remapper_version ? "1.5.0"
-, input_remapper_src_rev ? "e31a1b2bc5d23fe13130afcc242063196335399f"
-, input_remapper_src_hash ? "sha256-KPQLgXSonuOgphagYN2JN+CMIpmjTIPUTCqOPDk0UYU="
 }:
 
 let
   maybeXmodmap = lib.optional withXmodmap xmodmap;
 in
-buildPythonApplication {
+(buildPythonApplication {
   pname = "input-remapper";
-  version = input_remapper_version;
+  version = "1.5.0";
 
   src = fetchFromGitHub {
-    rev = input_remapper_src_rev;
+    rev = "e31a1b2bc5d23fe13130afcc242063196335399f";
     owner = "sezanzeb";
     repo = "input-remapper";
-    hash = input_remapper_src_hash;
+    hash = "sha256-KPQLgXSonuOgphagYN2JN+CMIpmjTIPUTCqOPDk0UYU=";
   };
 
   # Fixes error
@@ -58,17 +50,14 @@ buildPythonApplication {
   # at startup, see https://github.com/NixOS/nixpkgs/issues/56943
   strictDeps = false;
 
-  prePatch = ''
-    # set revision for --version output
-    echo "COMMIT_HASH = '${input_remapper_src_rev}'" > inputremapper/commit_hash.py
-
+  postPatch = ''
     # fix FHS paths
     substituteInPlace inputremapper/configs/data.py \
       --replace "/usr/share/input-remapper"  "$out/usr/share/input-remapper"
-  '' + (lib.optionalString (withDebugLogLevel) ''
+  '' + lib.optionalString withDebugLogLevel ''
     # if debugging
     substituteInPlace inputremapper/logger.py --replace "logger.setLevel(logging.INFO)"  "logger.setLevel(logging.DEBUG)"
-  '');
+  '';
 
   doCheck = withDoCheck;
   checkInputs = [
@@ -161,4 +150,14 @@ buildPythonApplication {
     maintainers = with maintainers; [ LunNova ];
     mainProgram = "input-remapper-gtk";
   };
-}
+}).overrideAttrs (final: prev: {
+  # Set in an override as buildPythonApplication doesn't yet support
+  # the `final:` arg yet from #119942 'overlay style overridable recursive attributes'
+  # this ensures the rev matches the input src's rev after overriding
+  # See https://discourse.nixos.org/t/avoid-rec-expresions-in-nixpkgs/8293/7 for more
+  # discussion
+  postPatch = prev.postPatch or "" + ''
+    # set revision for --version output
+    echo "COMMIT_HASH = '${final.src.rev}'" > inputremapper/commit_hash.py
+  '';
+})

--- a/pkgs/tools/inputmethods/input-remapper/default.nix
+++ b/pkgs/tools/inputmethods/input-remapper/default.nix
@@ -34,9 +34,9 @@
   # https://discourse.nixos.org/t/avoid-rec-expresions-in-nixpkgs/8293/7
   # The names are prefixed with input_remapper to avoid potential
   # collisions with package names
-, input_remapper_version ? "1.4.2"
-, input_remapper_src_rev ? "af20f87a1298153e765b840a2164ba63b9ef937a"
-, input_remapper_src_hash ? "sha256-eG4Fx1z74Bq1HrfmzOuULQLziGdWnHLax8y2dymjWsI="
+, input_remapper_version ? "1.5.0"
+, input_remapper_src_rev ? "e31a1b2bc5d23fe13130afcc242063196335399f"
+, input_remapper_src_hash ? "sha256-KPQLgXSonuOgphagYN2JN+CMIpmjTIPUTCqOPDk0UYU="
 }:
 
 let


### PR DESCRIPTION
###### Description of changes

Minor version bump.

See https://github.com/sezanzeb/input-remapper/releases/tag/1.5.0 for changes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
