### PR TITLE
keydb: init at 6.3.1

### DIFF
--- a/pkgs/servers/nosql/keydb/default.nix
+++ b/pkgs/servers/nosql/keydb/default.nix
@@ -1,0 +1,60 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, libuuid, curl
+, openssl
+, pkg-config
+, systemd
+}:
+
+stdenv.mkDerivation rec {
+  pname = "keydb";
+  version = "6.3.1";
+
+  src = fetchFromGitHub {
+    owner = "snapchat";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-00Dx6GRAXVpJUXhu4kjsVCEsoN615vhGvc7+gViERqI=";
+  };
+
+  postPatch = ''
+    substituteInPlace deps/lua/src/Makefile \
+      --replace "ar rcu" "${stdenv.cc.targetPrefix}ar rcu"
+    substituteInPlace src/Makefile \
+      --replace "as --64 -g" "${stdenv.cc.targetPrefix}as --64 -g"
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+  buildInputs = [
+    (curl.override { inherit openssl; })
+    libuuid
+    systemd
+    openssl
+  ];
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+    "USE_SYSTEMD=yes"
+    "BUILD_TLS=yes"
+    "AR=${stdenv.cc.targetPrefix}ar"
+    "RANLIB=${stdenv.cc.targetPrefix}ranlib"
+    "USEASM=${if stdenv.isx86_64 then "true" else "false"}"
+  ] ++ lib.optionals (!stdenv.isx86_64) [
+    "MALLOC=libc"
+  ];
+
+  enableParallelBuilding = true;
+
+  hardeningEnable = [ "pie" ];
+
+  meta = with lib; {
+    homepage = "https://keydb.dev";
+    description = "A Multithreaded Fork of Redis";
+    license = licenses.bsd3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ ajs124 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23672,6 +23672,10 @@ with pkgs;
 
   keycloak = callPackage ../servers/keycloak { };
 
+  keydb = callPackage ../servers/nosql/keydb {
+    openssl = openssl_1_1;
+  };
+
   knot-dns = callPackage ../servers/dns/knot-dns { };
   knot-resolver = callPackage ../servers/dns/knot-resolver {
     systemd = systemdMinimal; # in closure already anyway


### PR DESCRIPTION
###### Description of changes

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).