### PR TITLE
disable builds globally for manually downloaded packages

### DIFF
--- a/pkgs/applications/graphics/pixinsight/default.nix
+++ b/pkgs/applications/graphics/pixinsight/default.nix
@@ -128,7 +128,6 @@ stdenv.mkDerivation rec {
     license = licenses.unfree;
     platforms = [ "x86_64-linux" ];
     maintainers = [ maintainers.sheepforce ];
-    hydraPlatforms = [];
     mainProgram = "PixInsight";
   };
 }

--- a/pkgs/applications/video/obs-studio/plugins/obs-ndi.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-ndi.nix
@@ -40,6 +40,5 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     maintainers = with maintainers; [ jshcmpbll ];
     platforms = platforms.linux;
-    hydraPlatforms = ndi.meta.hydraPlatforms;
   };
 }

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -726,6 +726,7 @@ rec {
         _EOF_
         exit 1
       '';
+      meta.hydraPlatforms = [];
     };
 
 

--- a/pkgs/development/libraries/ndi/default.nix
+++ b/pkgs/development/libraries/ndi/default.nix
@@ -64,7 +64,6 @@ stdenv.mkDerivation rec {
     homepage = "https://ndi.tv/sdk/";
     description = "NDI Software Developer Kit";
     platforms = ["x86_64-linux"];
-    hydraPlatforms = [];
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
   };

--- a/pkgs/os-specific/linux/displaylink/default.nix
+++ b/pkgs/os-specific/linux/displaylink/default.nix
@@ -73,6 +73,5 @@ stdenv.mkDerivation rec {
     license = licenses.unfree;
     maintainers = with maintainers; [ abbradar peterhoeg eyjhb ];
     platforms = [ "x86_64-linux" "i686-linux" ];
-    hydraPlatforms = [];
   };
 }


### PR DESCRIPTION
[wip]

* disable builds globally for manually downloaded packages
  (that cannot be built at hydra/nixpkgs-review)
* revert individually disabled builds for manually downloaded packages
  - pixinsight
  - displaylink
  - ndi
  - obs-ndi

Goal is to avoid false positive failures on automated builds of unfree packages.

* Sample list of manually downloaded packages for testing this PR:
    - citrix-workspace
    - ib-tws
    - mathematica
    - wolfram-engine
    - javacard-devkit
    - oraclejdk
    - everspace
    - koboredux
    - sm64ex
    - snapdragon-profiler
    - sqldeveloper
    - worldofgoo

Pending:
* Investigating testing method used to validate this solution.