### PR TITLE
haskell-language-server: 1.7.0.0 -> 1.8.0.0

### DIFF
--- a/maintainers/scripts/haskell/update-stackage.sh
+++ b/maintainers/scripts/haskell/update-stackage.sh
@@ -58,7 +58,14 @@ sed -r \
     -e '/ jailbreak-cabal /d' \
     -e '/ language-nix /d' \
     -e '/ cabal-install /d' \
+    -e '/ lsp /d' \
+    -e '/ lsp-types /d' \
+    -e '/ lsp-test /d' \
+    -e '/ hie-bios /d' \
     < "${tmpfile_new}" >> $stackage_config
+# Explanations:
+# cabal2nix, distribution-nixpkgs, jailbreak-cabal, language-nix: These are our packages and we know what we are doing.
+# lsp, lsp-types, lsp-test, hie-bios: These are tightly coupled to hls which is not in stackage. They have no rdeps in stackage.
 
 if [[ "${1:-}" == "--do-commit" ]]; then
 git add $stackage_config

--- a/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
@@ -96,30 +96,19 @@ self: super: {
       executableHaskellDepends = drv.executableToolDepends or [] ++ [ self.repline ];
     }) super.hnix);
 
+  haskell-language-server = addBuildDepend self.hls-brittany-plugin (super.haskell-language-server.overrideScope (lself: lsuper: {
+    Cabal = lself.Cabal_3_6_3_0;
+    aeson = lself.aeson_1_5_6_0;
+    lsp-types = doJailbreak lsuper.lsp-types; # Checks require aeson >= 2.0
+  }));
+
+  hls-brittany-plugin = super.hls-brittany-plugin.overrideScope (lself: lsuper: {
+    brittany = doJailbreak lself.brittany_0_13_1_2;
+    aeson = lself.aeson_1_5_6_0;
+    lsp-types = doJailbreak lsuper.lsp-types; # Checks require aeson >= 2.0
+  });
+
   mime-string = disableOptimization super.mime-string;
-
-  # Older compilers need the latest ghc-lib to build this package.
-  # Fix build with ghc-lib >= 9.0 and ghc <= 8.10.7
-  # https://github.com/haskell/haskell-language-server/issues/2728
-  hls-hlint-plugin = addBuildDepend self.ghc-lib (appendPatch (pkgs.fetchpatch {
-    name = "hls-hlint-plugin-workaround.patch";
-    url = "https://github.com/haskell/haskell-language-server/pull/2854.patch";
-    hash = "sha256-bLGu0OQtXsmMF3rZM+R6k7bsZm4Vgf2r0ert5Wunong=";
-    stripLen = 2;
-    includes = ["src/Ide/Plugin/Hlint.hs"];
-  }) super.hls-hlint-plugin);
-
-  haskell-language-server = appendConfigureFlags [
-      "-f-stylishhaskell"
-      "-f-brittany"
-    ]
-  super.haskell-language-server;
-
-  # has a restrictive lower bound on Cabal
-  fourmolu = doJailbreak super.fourmolu;
-
-  # ormolu 0.3 requires Cabal == 3.4
-  ormolu = super.ormolu_0_2_0_0;
 
   # weeder 2.3.0 no longer supports GHC 8.10
   weeder = doDistribute (doJailbreak self.weeder_2_2_0);

--- a/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
@@ -141,20 +141,23 @@ self: super: {
 
   mime-string = disableOptimization super.mime-string;
 
-  # Older compilers need the latest ghc-lib to build this package.
-  hls-hlint-plugin = addBuildDepend self.ghc-lib (overrideCabal (drv: {
-      # Workaround for https://github.com/haskell/haskell-language-server/issues/2728
-      postPatch = ''
-        sed -i 's/(GHC.RealSrcSpan x,/(GHC.RealSrcSpan x Nothing,/' src/Ide/Plugin/Hlint.hs
-      '';
-    })
-     super.hls-hlint-plugin);
+  haskell-language-server = addBuildDepend self.hls-brittany-plugin (super.haskell-language-server.overrideScope (lself: lsuper: {
+    ghc-lib-parser = lself.ghc-lib-parser_8_10_7_20220219;
+    ghc-lib-parser-ex = addBuildDepend lself.ghc-lib-parser lself.ghc-lib-parser-ex_8_10_0_24;
+    # Pick old ormolu and fourmolu because ghc-lib-parser is not compatible
+    ormolu = doJailbreak lself.ormolu_0_1_4_1;
+    fourmolu = doJailbreak lself.fourmolu_0_3_0_0;
+    hlint = lself.hlint_3_2_8;
+    aeson = lself.aeson_1_5_6_0;
+    stylish-haskell = lself.stylish-haskell_0_13_0_0;
+    lsp-types = doJailbreak lsuper.lsp-types;
+  }));
 
-  haskell-language-server = appendConfigureFlags [
-      "-f-stylishhaskell"
-      "-f-brittany"
-    ]
-  super.haskell-language-server;
+  hls-brittany-plugin = super.hls-brittany-plugin.overrideScope (lself: lsuper: {
+    brittany = doJailbreak lself.brittany_0_13_1_2;
+    aeson = lself.aeson_1_5_6_0;
+    lsp-types = doJailbreak lsuper.lsp-types;
+  });
 
   # has a restrictive lower bound on Cabal
   fourmolu = doJailbreak super.fourmolu;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
@@ -99,6 +99,12 @@ self: super: {
     sha256 = "0rgzrq0513nlc1vw7nw4km4bcwn4ivxcgi33jly4a7n3c1r32v1f";
   }) (doJailbreak super.language-haskell-extract);
 
+  haskell-language-server = super.haskell-language-server.overrideScope (lself: lsuper: {
+    # Needed for modern ormolu and fourmolu.
+    # Apply this here and not in common, because other ghc versions offer different Cabal versions.
+    Cabal = lself.Cabal_3_6_3_0;
+  });
+
   # The test suite depends on ChasingBottoms, which is broken with ghc-9.0.x.
   unordered-containers = dontCheck super.unordered-containers;
 

--- a/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
@@ -190,8 +190,13 @@ self: super: {
     revision = null;
   } super.memory);
 
-  # Use hlint from git for GHC 9.2.1 support
-  hlint = self.hlint_3_4_1;
+  # For -fghc-lib see cabal.project in haskell-language-server.
+  stylish-haskell = enableCabalFlag "ghc-lib" super.stylish-haskell;
+
+  # For "ghc-lib" flag see https://github.com/haskell/haskell-language-server/issues/3185#issuecomment-1250264515
+  hlint = enableCabalFlag "ghc-lib" (super.hlint_3_4_1.override {
+    ghc-lib-parser-ex = self.ghc-lib-parser-ex_9_2_0_4;
+  });
 
   # https://github.com/sjakobi/bsb-http-chunked/issues/38
   bsb-http-chunked = dontCheck super.bsb-http-chunked;
@@ -201,13 +206,8 @@ self: super: {
   jacinda = doDistribute super.jacinda;
   some = doJailbreak super.some;
 
-  # 2022-06-05: this is not the latest version of fourmolu because
-  # hls-fourmolu-plugin 1.0.3.0 doesn‘t support a newer one.
-  fourmolu = super.fourmolu_0_6_0_0;
-  # hls-fourmolu-plugin in this version has a to strict upper bound of fourmolu <= 0.5.0.0
-  hls-fourmolu-plugin = assert super.hls-fourmolu-plugin.version == "1.0.3.0"; doJailbreak super.hls-fourmolu-plugin;
+  fourmolu = super.fourmolu_0_8_2_0;
 
-  hls-ormolu-plugin = assert super.hls-ormolu-plugin.version == "1.0.2.1"; doJailbreak super.hls-ormolu-plugin;
   implicit-hie-cradle = doJailbreak super.implicit-hie-cradle;
   # 1.3 introduced support for GHC 9.2.x, so when this assert fails, the jailbreak can be removed
   hashtables = assert super.hashtables.version == "1.2.4.2"; doJailbreak super.hashtables;
@@ -215,20 +215,15 @@ self: super: {
   # 2022-08-01: Tests are broken on ghc 9.2.4: https://github.com/wz1000/HieDb/issues/46
   hiedb = doJailbreak (dontCheck super.hiedb);
 
+  apply-refact = doDistribute super.apply-refact_0_10_0_0;
+
   # 2022-02-05: The following plugins don‘t work yet on ghc9.2.
   # Compare: https://haskell-language-server.readthedocs.io/en/latest/supported-versions.html
-  haskell-language-server = overrideCabal (old: {libraryHaskellDepends = builtins.filter (x: x != super.hls-tactics-plugin) old.libraryHaskellDepends;})
-    (appendConfigureFlags [
-    "-f-haddockComments"
-    "-f-retrie"
-    "-f-splice"
-    "-f-tactics"
-  ] (super.haskell-language-server.override {
+  haskell-language-server = super.haskell-language-server.override {
     hls-haddock-comments-plugin = null;
-    hls-hlint-plugin = null;
-    hls-retrie-plugin = null;
     hls-splice-plugin = null;
-  }));
+    hls-tactics-plugin = null;
+  };
 
   # https://github.com/fpco/inline-c/pull/131
   inline-c-cpp =

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -113,7 +113,6 @@ extra-packages:
   - dhall == 1.29.0                     # required for ats-pkg
   - dhall == 1.38.1                     # required for spago
   - doctest == 0.18.*                   # 2021-11-19: closest to stackage version for GHC 9.*
-  - fourmolu == 0.6.0.0                 # 2022-06-05: Last fourmolu version compatible with hls 1.7/ hls-fourmolu-plugin 1.0.3.0
   - ghc-api-compat == 8.10.7            # 2022-02-17: preserve for GHC 8.10.7
   - ghc-api-compat == 8.6               # 2021-09-07: preserve for GHC 8.8.4
   - ghc-lib == 8.10.7.*                 # 2022-02-17: preserve for GHC 8.10.7
@@ -121,7 +120,7 @@ extra-packages:
   - ghc-lib-parser == 8.10.7.*          # 2022-02-17: preserve for GHC 8.10.7
   - ghc-lib-parser == 9.2.*             # 2022-02-17: preserve for GHC 9.2
   - ghc-lib-parser-ex == 8.10.*         # 2022-02-17: preserve for GHC 8.10.7
-  - ghc-lib-parser-ex == 9.2.*           # 2022-07-13: preserve for GHC 9.2
+  - ghc-lib-parser-ex == 9.2.*          # 2022-07-13: preserve for GHC 9.2
   - ghc-lib-parser-ex >= 9.2.0.3 && < 9.2.1 # 2022-07-13: needed by hlint 3.4.1
   - haddock == 2.23.*                   # required on GHC < 8.10.x
   - haddock-api == 2.23.*               # required on GHC < 8.10.x
@@ -153,6 +152,13 @@ extra-packages:
   - basement < 0.0.15                   # 2022-08-30: last version to support GHC < 8.10
   - foundation < 0.0.29                 # 2022-08-30: last version to support GHC < 8.10
   - cabal-install-parsers < 0.5         # 2022-08-31: required by haskell-ci 0.14.3
+  - lsp == 1.4.0.0                      # 2022-09-18: need for dhall-lsp-server 1.1.2
+  - lsp-types == 1.4.0.1                # 2022-09-18: need for dhall-lsp-server 1.1.2
+  - stylish-haskell == 0.13.0.0         # 2022-09-19: needed for hls on ghc 8.8
+  - brittany == 0.13.1.2                # 2022-09-20: needed for hls on ghc 8.8
+  - fourmolu == 0.3.0.0                 # 2022-09-21: needed for hls on ghc 8.8
+  - ormolu == 0.1.4.1                   # 2022-09-21: needed for hls on ghc 8.8
+  - hlint == 3.2.8                      # 2022-09-21: needed for hls on ghc 8.8
 
 package-maintainers:
   abbradar:

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/stackage.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/stackage.yaml
@@ -1048,7 +1048,6 @@ default-package-overrides:
   - hgeometry-combinatorial ==0.14
   - hid ==0.2.2
   - hidapi ==0.1.8
-  - hie-bios ==0.9.1
   - hi-file-parser ==0.1.3.0
   - higher-leveldb ==0.6.0.0
   - highlighting-kate ==0.6.4
@@ -1455,9 +1454,6 @@ default-package-overrides:
   - lpeg ==1.0.3
   - lrucache ==1.2.0.1
   - lrucaching ==0.3.3
-  - lsp ==1.4.0.0
-  - lsp-test ==0.14.0.2
-  - lsp-types ==1.4.0.1
   - lua ==2.1.0
   - lua-arbitrary ==1.0.1
   - lucid ==2.11.1

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -498,6 +498,14 @@ self: super: builtins.intersectAttrs super {
     librarySystemDepends = drv.librarySystemDepends or [] ++ [ pkgs.cyrus_sasl.dev ];
   }) super.LDAP);
 
+  # Not running the "example" test because it requires a binary from lsps test
+  # suite which is not part of the output of lsp.
+  lsp-test = overrideCabal (old: { testTarget = "tests func-test"; }) super.lsp-test;
+
+  # the test suite attempts to run the binaries built in this package
+  # through $PATH but they aren't in $PATH
+  dhall-lsp-server = dontCheck super.dhall-lsp-server;
+
   # Expects z3 to be on path so we replace it with a hard
   #
   # The tests expect additional solvers on the path, replace the
@@ -935,11 +943,11 @@ self: super: builtins.intersectAttrs super {
   }) super.procex;
 
   # Test suite wants to run main executable
-  fourmolu_0_7_0_1 = overrideCabal (drv: {
+  fourmolu_0_8_2_0 = overrideCabal (drv: {
     preCheck = drv.preCheck or "" + ''
       export PATH="$PWD/dist/build/fourmolu:$PATH"
     '';
-  }) super.fourmolu_0_7_0_1;
+  }) super.fourmolu_0_8_2_0;
 
   # Apply a patch which hardcodes the store path of graphviz instead of using
   # whatever graphviz is in PATH.
@@ -1053,9 +1061,13 @@ self: super: builtins.intersectAttrs super {
     hls-fourmolu-plugin
     hls-module-name-plugin
     hls-pragmas-plugin
-    hls-splice-plugin;
+    hls-splice-plugin
+    hls-refactor-plugin
+    hls-code-range-plugin
+    hls-explicit-fixity-plugin;
   # Tests have file permissions expections that don‘t work with the nix store.
   hls-stylish-haskell-plugin = dontCheck super.hls-stylish-haskell-plugin;
+  hls-gadt-plugin = dontCheck super.hls-gadt-plugin;
 
   # Flaky tests
   hls-hlint-plugin = dontCheck super.hls-hlint-plugin;


### PR DESCRIPTION
###### Description of changes

This updates the package set to build haskell-language-server 1.8 successfully
on ghc 8.8, 8.10, 9.0 and 9.2.

The following design decisions have been made:
* All plugins listed as available under https://haskell-language-server.readthedocs.io/en/latest/supported-versions.html are working, with the following exception: 
* stan and brittany only could work on 8.8 and 8.10, both packages have multiple build failures with insufficient version bounds. stan is effectively unmaintained, so I decided to not invest more time to get them working.
* It is very hard to find a consistent version of ghc-lib-parser and similar packages which works for all plugins on all versions so I decided to allow inconsistent dependency versions. Because of the architecture of hls plugins and the fact that this causes no compile errors, I believe this is a safe change.
* lsp and similar packages are tracked on stackage without any rdeps in stackage, but are in truth tightly coupled to hls development and are mainly used by hls. I decided to exclude those packages from our stackage pins.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
