### PR TITLE
dockerTools: add missing mkdir to caCertificates derivation

### DIFF
--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -424,5 +424,12 @@ import ./make-test-python.nix ({ pkgs, ... }: {
         docker.succeed("docker run --rm etc | grep localhost")
         docker.succeed("docker image rm etc:latest")
 
+    with subtest("image-with-certs"):
+        docker.succeed("<${examples.image-with-certs} docker load")
+        docker.succeed("docker run --rm image-with-certs:latest test -r /etc/ssl/certs/ca-bundle.crt")
+        docker.succeed("docker run --rm image-with-certs:latest test -r /etc/ssl/certs/ca-certificates.crt")
+        docker.succeed("docker run --rm image-with-certs:latest test -r /etc/pki/tls/certs/ca-bundle.crt")
+        docker.succeed("docker image rm image-with-certs:latest")
+
   '';
 })

--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -794,6 +794,7 @@ rec {
 
   # This provides the ca bundle in common locations
   caCertificates = runCommand "ca-certificates" { } ''
+    mkdir -p $out/etc/ssl/certs $out/etc/pki/tls/certs
     # Old NixOS compatibility.
     ln -s ${cacert}/etc/ssl/certs/ca-bundle.crt $out/etc/ssl/certs/ca-bundle.crt
     # NixOS canonical location + Debian/Ubuntu/Arch/Gentoo compatibility.

--- a/pkgs/build-support/docker/examples.nix
+++ b/pkgs/build-support/docker/examples.nix
@@ -701,19 +701,18 @@ rec {
 
   # ensure that caCertificates builds
   image-with-certs = buildImage {
-    name = "curl";
+    name = "image-with-certs";
     tag = "latest";
 
     copyToRoot = pkgs.buildEnv {
       name = "image-with-certs-root";
       paths = [
-        pkgs.curl
+        pkgs.coreutils
         pkgs.dockerTools.caCertificates
       ];
     };
 
     config = {
-      Entrypoint = [ "/bin/curl" ];
     };
   };
 }

--- a/pkgs/build-support/docker/examples.nix
+++ b/pkgs/build-support/docker/examples.nix
@@ -698,4 +698,22 @@ rec {
     tag = "latest";
     contents = [ pkgs.bashInteractive ./test-dummy ];
   };
+
+  # ensure that caCertificates builds
+  image-with-certs = buildImage {
+    name = "curl";
+    tag = "latest";
+
+    copyToRoot = pkgs.buildEnv {
+      name = "image-with-certs-root";
+      paths = [
+        pkgs.curl
+        pkgs.dockerTools.caCertificates
+      ];
+    };
+
+    config = {
+      Entrypoint = [ "/bin/curl" ];
+    };
+  };
 }


### PR DESCRIPTION
###### Description of changes

The `dockerTools.caCertificates` derivation introduced in #170906 currently fails with:

```plain
building '/nix/store/02barkhxh9aqb5sq5s1wf2zym3xaz4bc-ca-certificates.drv'...
ln: failed to create symbolic link '/nix/store/k54bmwg44cc0fn8l90id7l3rj79zmsix-ca-certificates/etc/ssl/certs/ca-bundle.crt': No such file or directory
```

This change introduces a `mkdir -p` call to create the missing directories. It's unclear to me why Hydra is not testing this derivation: any hints as to how to improve testing would be appreciated and avoid future issues with this derivation.

FYI @roberth and @Sohalt

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).