### PR TITLE
nixos/emacs: Remove some confusing absolute paths from the documentation

### DIFF
--- a/nixos/modules/services/editors/emacs.xml
+++ b/nixos/modules/services/editors/emacs.xml
@@ -264,7 +264,9 @@ nix-env -f "<nixpkgs>" -qaP -A emacs.pkgs.orgPackages
 
    <para>
     If you are on NixOS, you can install this particular Emacs for all users by
-    adding it to the list of system packages (see
+    putting the <literal>emacs.nix</literal> file in
+    <literal>/etc/nixos</literal> and adding it to the list of system packages
+    (see
     <xref linkend="sec-declarative-package-mgmt" />). Simply modify your file
     <filename>configuration.nix</filename> to make it contain:
     <example xml:id="module-services-emacs-configuration-nix">
@@ -273,7 +275,7 @@ nix-env -f "<nixpkgs>" -qaP -A emacs.pkgs.orgPackages
 {
  environment.systemPackages = [
    # [...]
-   (import /path/to/emacs.nix { inherit pkgs; })
+   (import ./emacs.nix { inherit pkgs; })
   ];
 }
 ]]></programlisting>
@@ -292,7 +294,8 @@ https://nixos.org/nixpkgs/manual/#sec-modify-via-packageOverrides
 
    <para>
     If you are not on NixOS or want to install this particular Emacs only for
-    yourself, you can do so by adding it to your
+    yourself, you can do so by putting <literal>emacs.nix</literal> in
+    <literal>~/.config/nixpkgs</literal> and adding it to your
     <filename>~/.config/nixpkgs/config.nix</filename> (see
     <link xlink:href="https://nixos.org/nixpkgs/manual/#sec-modify-via-packageOverrides">Nixpkgs
     manual</link>):
@@ -301,7 +304,7 @@ https://nixos.org/nixpkgs/manual/#sec-modify-via-packageOverrides
 <programlisting><![CDATA[
 {
   packageOverrides = super: let self = super.pkgs; in {
-    myemacs = import /path/to/emacs.nix { pkgs = self; };
+    myemacs = import ./emacs.nix { pkgs = self; };
   };
 }
 ]]></programlisting>
@@ -376,7 +379,6 @@ in [...]
     daemon, add the following to your <filename>configuration.nix</filename>:
 <programlisting>
 <xref linkend="opt-services.emacs.enable"/> = true;
-<xref linkend="opt-services.emacs.package"/> = import /home/cassou/.emacs.d { pkgs = pkgs; };
 </programlisting>
    </para>
 


### PR DESCRIPTION
###### Description of changes

There were some absolute paths used in the manual. Apart from being a
bad practice, they are also confusing, especially the
`services.emacs.package` definition at "Running Emacs as a service"
section. Remove those confusing paths.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
