### PR TITLE
optifinePackages: update versions, refactor version generation

### DIFF
--- a/pkgs/tools/games/minecraft/optifine/default.nix
+++ b/pkgs/tools/games/minecraft/optifine/default.nix
@@ -1,67 +1,17 @@
 { recurseIntoAttrs
 , callPackage
+, lib
 }:
 
-recurseIntoAttrs rec {
-  optifine-latest = optifine_1_18_1;
+# All versions are taken from `version.json` created by `update.py`, and realised with `generic.nix`.
+# The `update.py` is a web scraper script that writes the latest versions into `version.json`.
 
-  optifine_1_18_1 = callPackage ./generic.nix {
-    version = "1.18.1_HD_U_H4";
-    sha256 = "sha256-MlFoVpshotzegpmYdvaeydivdSAqcCFpHyq+3k2B3Ow=";
-  };
+# The `versions.json` can be automatically updated and committed with a commit summary.
+# To do so, change directory to nixpkgs root, and do:
+# $ nix-shell ./maintainers/scripts/update.nix --argstr package optifinePackages.optifine-latest --argstr commit true
 
-  optifine_1_17_1 = callPackage ./generic.nix {
-    version = "1.17.1_HD_U_H1";
-    sha256 = "sha256-HHt747bIHYY/WNAx19mNgvnLrLCqaKIqwXmmB7A895M=";
-  };
-
-  optifine_1_16_5 = callPackage ./generic.nix {
-    version = "1.16.5_HD_U_G8";
-    sha256 = "sha256-PHa8kO1EvOVnzufCDrLENhkm8jqG5TZ9WW9uYk0LSU8=";
-  };
-
-  optifine_1_15_2 = callPackage ./generic.nix {
-    version = "1.16.5_HD_U_G8";
-    sha256 = "sha256-PHa8kO1EvOVnzufCDrLENhkm8jqG5TZ9WW9uYk0LSU8=";
-  };
-
-  optifine_1_14_4 = callPackage ./generic.nix {
-    version = "1.14.4_HD_U_G5";
-    sha256 = "sha256-I+65vQO6yG4AQ0ZLAfX73ImsFKAQkTyrIOnQHldTibs=";
-  };
-
-  optifine_1_13_2 = callPackage ./generic.nix {
-    version = "1.13.2_HD_U_G5";
-    sha256 = "sha256-sjUQot8fPdbZTiLqt+exbF5T8kI5bLQevu7atW9Xu3E=";
-  };
-
-  optifine_1_12_2 = callPackage ./generic.nix {
-    version = "1.12.2_HD_U_G5";
-    sha256 = "sha256-OwAGeXdx/rl/LQ0pCK58mnjO+y5zCvHC6F0IqDm6Jx4=";
-  };
-
-  optifine_1_11_2 = callPackage ./generic.nix {
-    version = "1.11.2_HD_U_G5";
-    sha256 = "sha256-1sLUBtM5e5LDTUFCRZf9UeH6WOA8zY6TAmB9PCS5iv4=";
-  };
-
-  optifine_1_10 = callPackage ./generic.nix {
-    version = "1.10_HD_U_I5";
-    sha256 = "sha256-oKOsaNFnOKfhWLDDYG/0Z4h/ZCDtyJWS9LXPaKAApc0=";
-  };
-
-  optifine_1_9_4 = callPackage ./generic.nix {
-    version = "1.9.4_HD_U_I5";
-    sha256 = "sha256-t+OxIf0Tl/NZxUTl+LGnWRUhEwZ+vxiZfhclxEAf6yI=";
-  };
-
-  optifine_1_8_9 = callPackage ./generic.nix {
-    version = "1.8.9_HD_U_M5";
-    sha256 = "sha256-Jzl2CnD8pq5cfcgXvMYoPxj1Xjj6I3eNp/OHprckssQ=";
-  };
-
-  optifine_1_7_10 = callPackage ./generic.nix {
-    version = "1.7.10_HD_U_E7";
-    sha256 = "sha256-i82dg94AGgWR9JgQXzafBwxH0skZJ3TVpbafZG5E+rQ=";
-  };
-}
+recurseIntoAttrs (
+  lib.mapAttrs
+    (name: value: callPackage ./generic.nix value)
+    (lib.importJSON ./versions.json)
+)

--- a/pkgs/tools/games/minecraft/optifine/generic.nix
+++ b/pkgs/tools/games/minecraft/optifine/generic.nix
@@ -22,6 +22,11 @@ runCommand "optifine-${mcVersion}" {
 
   nativeBuildInputs = [ jre makeWrapper ];
 
+  passthru.updateScript = {
+    command = [ ./update.py ];
+    supportedFeatures = [ "commit" ];
+  };
+
   meta = with lib; {
     homepage = "https://optifine.net/";
     description = "A Minecraft ${mcVersion} optimization mod";

--- a/pkgs/tools/games/minecraft/optifine/update.py
+++ b/pkgs/tools/games/minecraft/optifine/update.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I nixpkgs=./. -i python3 -p python3.pkgs.requests python3.pkgs.lxml nix
+
+from lxml import html
+import json
+import os.path
+import re
+import requests
+import subprocess
+
+def nix_prefetch_sha256(name):
+    return subprocess.run(['nix-prefetch-url', '--type', 'sha256', 'https://optifine.net/download?f=' + name], capture_output=True, text=True).stdout.strip()
+
+# fetch download page
+sess = requests.session()
+page = sess.get('https://optifine.net/downloads')
+tree = html.fromstring(page.content)
+
+# parse and extract main jar file names
+href = tree.xpath('//tr[@class="downloadLine downloadLineMain"]/td[@class="colMirror"]/a/@href')
+expr = re.compile('(OptiFine_)([0-9.]*)(.*)\.jar')
+result = [ expr.search(x) for x in href ]
+
+# format name, version and hash for each file
+catalogue = {}
+for i, r in enumerate(result):
+    index = r.group(1).lower() + r.group(2).replace('.', '_')
+    version = r.group(2) + r.group(3)
+    catalogue[index] = {
+        "version": version,
+        "sha256": nix_prefetch_sha256(r.group(0))
+    }
+
+# latest version should be the first entry
+if len(catalogue) > 0:
+    catalogue['optifine-latest'] = list(catalogue.values())[0]
+
+# read previous versions
+d = os.path.dirname(os.path.abspath(__file__))
+with open(os.path.join(d, 'versions.json'), 'r') as f:
+    prev = json.load(f)
+
+# `maintainers/scripts/update.py` will extract stdout to write commit message
+# embed the commit message in json and print it
+changes = [ { 'commitMessage': 'optifinePackages: update versions\n\n' } ]
+
+# build a longest common subsequence, natural sorted by keys
+for key, value in sorted({**prev, **catalogue}.items(), key=lambda item: [int(s) if s.isdigit() else s for s in re.split(r'(\d+)', item[0])]):
+    if key not in prev:
+        changes[0]['commitMessage'] += 'optifinePackages.{}: init at {}\n'.format(key, value['version'])
+    elif value['version'] != prev[key]['version']:
+        changes[0]['commitMessage'] += 'optifinePackages.{}: {} -> {}\n'.format(key, prev[key]['version'], value['version'])
+
+# print the changes in stdout
+print(json.dumps(changes))
+
+# write catalogue to file
+with open(os.path.join(d, 'versions.json'), 'w') as f:
+    json.dump(catalogue, f, indent=4)
+    f.write('\n')

--- a/pkgs/tools/games/minecraft/optifine/versions.json
+++ b/pkgs/tools/games/minecraft/optifine/versions.json
@@ -1,0 +1,142 @@
+{
+    "optifine_1_19_2": {
+        "version": "1.19.2_HD_U_H9",
+        "sha256": "1xyg98i7zar5x3xbgpn2nm48mc3r9q6yqisxnqk3g254ghjcy4xx"
+    },
+    "optifine_1_19_1": {
+        "version": "1.19.1_HD_U_H9",
+        "sha256": "1p5a3i383ca2l3snsm36dyngfz9a1f9xffaxk439149h0i2d0nlj"
+    },
+    "optifine_1_19": {
+        "version": "1.19_HD_U_H9",
+        "sha256": "19zjvwg0sr6279plj5qxj7hdlw9w8q3qd78dg6911m356z6g87ah"
+    },
+    "optifine_1_18_2": {
+        "version": "1.18.2_HD_U_H7",
+        "sha256": "169ajvw3zrb0xrz2h1z3x6vdr4122s8m3rxb461s8y2fk6i4y9kr"
+    },
+    "optifine_1_18_1": {
+        "version": "1.18.1_HD_U_H6",
+        "sha256": "0nh8ls306rs1qcbyibb6idapws4z5cyaqrgh9ipvm1vcwvxxj9ys"
+    },
+    "optifine_1_18": {
+        "version": "1.18_HD_U_H3",
+        "sha256": "11zqiwmqj4ja6l87acwzs7cnabsgn2x36510hap8gj139l3vbrvb"
+    },
+    "optifine_1_17_1": {
+        "version": "1.17.1_HD_U_H1",
+        "sha256": "14zp7jq0g9krq4ma4s5an2ncpyc2ipcxfcfhb0zqc7f8nvipnyqw"
+    },
+    "optifine_1_16_5": {
+        "version": "1.16.5_HD_U_G8",
+        "sha256": "0ks91d6n4vkgb5ykdrc67br2c69nqjr0xhp7rrkybg24xn8bqxiw"
+    },
+    "optifine_1_16_4": {
+        "version": "1.16.4_HD_U_G7",
+        "sha256": "063zdfmhzq5jgfdy27c8b0008sribl8rbvfxa7nkk86qwpvz6v8h"
+    },
+    "optifine_1_16_3": {
+        "version": "1.16.3_HD_U_G5",
+        "sha256": "0pipr77jrva5wrllil40myansyrxxvcckxlvf4k2vhqf2g1mfigl"
+    },
+    "optifine_1_16_2": {
+        "version": "1.16.2_HD_U_G5",
+        "sha256": "1iav08qqk7wb43ars9nilbgm4ybdi02pd0ahb0xy7clkxvlnjcx2"
+    },
+    "optifine_1_16_1": {
+        "version": "1.16.1_HD_U_G2",
+        "sha256": "1gwbxv3dx82lxkbp9gaf1nqczkcxdzlfsspxlrv6gcn7w8vvwf5v"
+    },
+    "optifine_1_15_2": {
+        "version": "1.15.2_HD_U_G6",
+        "sha256": "10qz6y3h80s56wsk3f5wwg52d0d7mkklhhhvgp6y84zlzq6xdbq4"
+    },
+    "optifine_1_14_4": {
+        "version": "1.14.4_HD_U_G5",
+        "sha256": "1fw9adbixl7942mkr48hl0aar2fwzgsh2js68c06xj5s0fyvkvi3"
+    },
+    "optifine_1_14_3": {
+        "version": "1.14.3_HD_U_F2",
+        "sha256": "00wys29pmgfsc4j2jy2mpfl493vy52jdxprxl92hcg2xz77ipqjh"
+    },
+    "optifine_1_14_2": {
+        "version": "1.14.2_HD_U_F1",
+        "sha256": "0645d38z8llnnv546zfkflqp441kxvf8vd0l3zjsls81w3bpc6n8"
+    },
+    "optifine_1_13_2": {
+        "version": "1.13.2_HD_U_G5",
+        "sha256": "0wdvaxpvbnpfpqgb8v1r8br56pkcn7kvgsi29vcxcg8zvyi10ddj"
+    },
+    "optifine_1_13_1": {
+        "version": "1.13.1_HD_U_E4",
+        "sha256": "0r5x703pgwi8vakii0nhlij7j24zkq1xvyscqd8lv6w3yq7xd5b3"
+    },
+    "optifine_1_13": {
+        "version": "1.13_HD_U_E4",
+        "sha256": "0x8ynnm9dglzrajb3ffmvmwkx6ipzs306qadwhcp0ah148wiz1l3"
+    },
+    "optifine_1_12_2": {
+        "version": "1.12.2_HD_U_G5",
+        "sha256": "07i7p8wsh22xx31g22kk5vxwwy4sgjp0ha8d5mzvkzkifxwhc01v"
+    },
+    "optifine_1_12_1": {
+        "version": "1.12.1_HD_U_G5",
+        "sha256": "1jn02mknpf622q6i942v63x3kzs9q7n394x188nfh508rn9fpipn"
+    },
+    "optifine_1_12": {
+        "version": "1.12_HD_U_G5",
+        "sha256": "1slbz0ss670gwlzv4dw362cc5wlpxjv81004n04vcsip8l491pdb"
+    },
+    "optifine_1_11_2": {
+        "version": "1.11.2_HD_U_G5",
+        "sha256": "1zlap4j3qzb00a9qxk9ww1cgmqaiznblahj19p1r4yrrsc3d9hnn"
+    },
+    "optifine_1_11": {
+        "version": "1.11_HD_U_G5",
+        "sha256": "1azgnsqbl71087i83dn6wyb7qdz2wa42f04cabnlhmdcmdd4kcsj"
+    },
+    "optifine_1_10_2": {
+        "version": "1.10.2_HD_U_I5",
+        "sha256": "0m05xqcmh8kaqvlb57yz0mslf22wr89wamlf1q1cma4fn385i57f"
+    },
+    "optifine_1_10": {
+        "version": "1.10_HD_U_I5",
+        "sha256": "1kd502h6ikxmyj99bj7d41j7z237yipn1hxhb3hsff37s5lar8x0"
+    },
+    "optifine_1_9_4": {
+        "version": "1.9.4_HD_U_I5",
+        "sha256": "08pb3x0c898pgsciigvy0q9j25arlyqzira4qmcz75qkzlhv3qxp"
+    },
+    "optifine_1_9_2": {
+        "version": "1.9.2_HD_U_E3",
+        "sha256": "1bgyxhs554wswavidsnmm6mahngndd5bc98jma6wgi7g5qrngcrp"
+    },
+    "optifine_1_9_0": {
+        "version": "1.9.0_HD_U_I5",
+        "sha256": "1nyiv91hm9765244xa6mh9cf62l329ppm8rdib35lb3ghgasid9n"
+    },
+    "optifine_1_8_9": {
+        "version": "1.8.9_HD_U_M5",
+        "sha256": "1i5j4jvsd1zkly6pf8zs71gga61z533bq5y8gmfax9pwf057cf97"
+    },
+    "optifine_1_8_8": {
+        "version": "1.8.8_HD_U_I7",
+        "sha256": "0x4aambs2kww9lanm4kp2jw4h3cwk25fa6xwsm9r7a1jv42jlyay"
+    },
+    "optifine_1_8_0": {
+        "version": "1.8.0_HD_U_I7",
+        "sha256": "1ig013l61f7yj061ncnvmjsp9j2nd8fy8j03f8ry045d0s7idnfk"
+    },
+    "optifine_1_7_10": {
+        "version": "1.7.10_HD_U_E7",
+        "sha256": "1d7s8ip697xnlpap89qrr794f307kwv5y44qyj8ha6h0vs1rvkcb"
+    },
+    "optifine_1_7_2": {
+        "version": "1.7.2_HD_U_F7",
+        "sha256": "18lzyh639mi7r2hzwnmxv0a6v1ay7dk9bzasvwff82dxq0y9zi7m"
+    },
+    "optifine-latest": {
+        "version": "1.19.2_HD_U_H9",
+        "sha256": "1xyg98i7zar5x3xbgpn2nm48mc3r9q6yqisxnqk3g254ghjcy4xx"
+    }
+}


### PR DESCRIPTION
From https://github.com/NixOS/nixpkgs/pull/179372.

A python script is created to automatically look up the available mainstream optifine versions (the ones highlighted in blue on the [optifine download page](https://optifine.net/downloads)), then write the appropriate metadata into `versions.json` for `default.nix` to pick up from.

Since the implementation is acceptable, I decided to not change much besides updating the `versions.json`. But if that's not enough then I will try to cook up something else instead.

This should have been completed a month ago, but turns out university is a heavier burden than what I have prepared for.
cc @IvarWithoutBones :DD

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
