### PR TITLE
[gnome] gnome.mutter338: Fix build with separate sysprof

### DIFF
--- a/pkgs/desktops/gnome/core/mutter/3.38/default.nix
+++ b/pkgs/desktops/gnome/core/mutter/3.38/default.nix
@@ -1,4 +1,5 @@
 { fetchurl
+, fetchpatch
 , substituteAll
 , runCommand
 , lib
@@ -36,12 +37,12 @@
 , python3
 , wrapGAppsHook
 , sysprof
+, libsysprof-capture
 , desktop-file-utils
 , libcap_ng
 , egl-wayland
 , graphene
 , wayland-protocols
-, pantheon
 }:
 
 let self = stdenv.mkDerivation rec {
@@ -64,6 +65,20 @@ let self = stdenv.mkDerivation rec {
     # https://github.com/elementary/gala/issues/605
     # https://gitlab.gnome.org/GNOME/mutter/issues/536
     ./fix-glitches-in-gala.patch
+
+    # Stop using source_root()/build_root().
+    # https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/1957
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/mutter/-/commit/6288763671692edbc953a2b80225e9a7c7fc87e7.patch";
+      sha256 = "immnfZiY+Cgu7xTbo5y8xs0olTa6UGsKgDJ1Xhkhns0=";
+    })
+
+    # Fix build with separate sysprof.
+    # https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/2572
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/mutter/-/commit/285a5a4d54ca83b136b787ce5ebf1d774f9499d5.patch";
+      sha256 = "/npUE3idMSTVlFptsDpZmGWjZ/d2gqruVlJKq4eF4xU=";
+    })
 
     (substituteAll {
       src = ./fix-paths.patch;
@@ -122,7 +137,8 @@ let self = stdenv.mkDerivation rec {
     libXdamage
     pango
     pipewire
-    sysprof
+    sysprof # for D-Bus interfaces
+    libsysprof-capture
     xkeyboard_config
     xwayland
     wayland-protocols


### PR DESCRIPTION
###### Description of changes

```
ninja: error: '/nix/store/m5zqagkrl1m3mpms1nvl2p9z7ws566si-libsysprof-capture-3.46.0/share/dbus-1/interfaces/org.gnome.Sysprof3.Profiler.xml', needed by 'src/meta-dbus-sysprof3-profiler.h', missing and no known rule to make it
```

Use squash merge or rebase merge.

P.s. I was aware of the large number of broken Pantheon packages on the branch (https://github.com/NixOS/nixpkgs/projects/21#column-19099710).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
