### PR TITLE
freefilesync: init at 11.25

### DIFF
--- a/pkgs/applications/networking/freefilesync/default.nix
+++ b/pkgs/applications/networking/freefilesync/default.nix
@@ -1,0 +1,103 @@
+{ lib
+, gcc12Stdenv
+, fetchFromGitHub
+, fetchpatch
+, pkg-config
+, curl
+, glib
+, gtk3
+, libssh2
+, openssl
+, wxGTK32
+}:
+
+gcc12Stdenv.mkDerivation rec {
+  pname = "freefilesync";
+  version = "11.25";
+
+  src = fetchFromGitHub {
+    owner = "hkneptune";
+    repo = "FreeFileSync";
+    rev = "v${version}";
+    sha256 = "sha256-JV9qwBiF9kl+wc9+7lUufQVu6uiMQ6vojntxduNJ8MI=";
+  };
+
+  # Patches from ROSA Linux
+  patches = [
+    # Disable loading of the missing Animal.dat
+    (fetchpatch {
+      url = "https://abf.io/import/freefilesync/raw/rosa2021.1-11.25-1/ffs_devuan.patch";
+      sha256 = "sha256-o8T/tBinlhM1I82yXxm0ogZcZf+uri95vTJrca5mcqs=";
+      excludes = [ "FreeFileSync/Source/ffs_paths.cpp" ];
+      postFetch = ''
+        substituteInPlace $out --replace " for Rosa" ""
+      '';
+    })
+    # Fix build with GTK 3
+    (fetchpatch {
+      url = "https://abf.io/import/freefilesync/raw/rosa2021.1-11.25-1/ffs_devuan_gtk3.patch";
+      sha256 = "sha256-NXt/+BRTcMk8bnjR9Hipv1NzV9YqRJqy0e3RMInoWsA=";
+      postFetch = ''
+        substituteInPlace $out --replace "-isystem/usr/include/gtk-3.0" ""
+      '';
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace FreeFileSync/Source/ui/version_check.cpp \
+      --replace "openBrowserForDownload();" "openBrowserForDownload(parent);"
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    curl
+    glib
+    gtk3
+    libssh2
+    openssl
+    wxGTK32
+  ];
+
+  NIX_CFLAGS_COMPILE = [
+    # Undef g_object_ref on GLib 2.56+
+    "-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_54"
+    "-DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_54"
+    # Define libssh2 constants
+    "-DMAX_SFTP_READ_SIZE=30000"
+    "-DMAX_SFTP_OUTGOING_SIZE=30000"
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    chmod +w FreeFileSync/Build
+    cd FreeFileSync/Source
+    make -j$NIX_BUILD_CORES
+    cd RealTimeSync
+    make -j$NIX_BUILD_CORES
+    cd ../../..
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -R FreeFileSync/Build/* $out
+    mv $out/{Bin,bin}
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Open Source File Synchronization & Backup Software";
+    homepage = "https://freefilesync.org";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ wegank ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27859,6 +27859,8 @@ with pkgs;
 
   freebayes = callPackage ../applications/science/biology/freebayes { };
 
+  freefilesync = callPackage ../applications/networking/freefilesync { };
+
   freewheeling = callPackage ../applications/audio/freewheeling { };
 
   fritzing = libsForQt5.callPackage ../applications/science/electronics/fritzing { };


### PR DESCRIPTION
###### Description of changes

FreeFileSync is a folder comparison and synchronization software that creates and manages backup copies of all your important files.

The package targets:
- C++23 (requiring Linux + GCC 12)
- wxGTK 3.1.6+ (~we only have 3.1.5 in nixpkgs~ now using 3.2.1)

Maybe someone could backport it to C++17 or C++20, so that it can also be built on macOS + SDK 11.0?

Closes #191122.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
