### PR TITLE
nextpnr: 0.3 -> 0.4; update trellis

### DIFF
--- a/pkgs/development/compilers/nextpnr/default.nix
+++ b/pkgs/development/compilers/nextpnr/default.nix
@@ -14,14 +14,14 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "nextpnr";
-  version = "0.3";
+  version = "0.4";
 
   srcs = [
     (fetchFromGitHub {
       owner = "YosysHQ";
       repo  = "nextpnr";
       rev   = "${pname}-${version}";
-      hash  = "sha256-q4h1TNAn66fJou8abNFowRbGXZTBfz5x+H5Q/psMvIw=";
+      hash  = "sha256-gnNUFSV+/SzCuP43KyUUgVNdAzjOM7lOLNJT72L8lTY=";
       name  = "nextpnr";
     })
     (fetchFromGitHub {

--- a/pkgs/development/embedded/fpga/trellis/default.nix
+++ b/pkgs/development/embedded/fpga/trellis/default.nix
@@ -1,30 +1,27 @@
 { lib, stdenv, fetchFromGitHub, python3, boost, cmake }:
 
 let
-  rev = "2f06397673bbca3da11928d538b8ab7d01c944c6";
+  rev = "488f4e71073062de314c55a037ede7cf03a3324c";
   # git describe --tags
-  realVersion = "1.0-534-g${builtins.substring 0 7 rev}";
+  realVersion = "1.2.1-14-g${builtins.substring 0 7 rev}";
 in stdenv.mkDerivation rec {
   pname = "trellis";
-  version = "2021-12-14";
+  version = "unstable-2022-09-14";
 
   srcs = [
     (fetchFromGitHub {
        owner  = "YosysHQ";
        repo   = "prjtrellis";
        inherit rev;
-       hash   = "sha256-m5CalAIbzY2bhOvpBbPBeLZeDp+itk1HlRsSmtiddaA=";
+       hash   = "sha256-Blbu+0rlM/3izbF0XCvkNpSAND0IclWEwK7anzyrpvw=";
        name   = "trellis";
      })
 
     (fetchFromGitHub {
       owner  = "YosysHQ";
       repo   = "prjtrellis-db";
-      # note: the upstream submodule points to revision 0ee729d20eaf,
-      # but that's just the tip of the branch that was merged into master.
-      # fdf4bf275a is the merge commit itself
-      rev    = "fdf4bf275a7402654bc643db537173e2fbc86103";
-      sha256 = "eDq2wU2pnfK9bOkEVZ07NQPv02Dc6iB+p5GTtVBiyQA=";
+      rev    = "35d900a94ff0db152679a67bf6e4fbf40ebc34aa";
+      hash   = "sha256-r6viR8y9ZjURGNbsa0/YY8lzy9kGzjuu408ntxwpqm0=";
       name   = "trellis-database";
     })
   ];


### PR DESCRIPTION
###### Description of changes
https://github.com/YosysHQ/nextpnr/releases/tag/nextpnr-0.4
Also update trellis, since the new version of nextpnr does not work with the old version of trellis.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).