### PR TITLE
wasilibc: unstable-2022-04-12 -> 16

### DIFF
--- a/pkgs/development/libraries/wasilibc/default.nix
+++ b/pkgs/development/libraries/wasilibc/default.nix
@@ -38,7 +38,10 @@ stdenv.mkDerivation {
       "SYSROOT_LIB:=$SYSROOT_LIB"
       "SYSROOT_INC:=$SYSROOT_INC"
       "SYSROOT_SHARE:=$SYSROOT_SHARE"
+      # https://bugzilla.mozilla.org/show_bug.cgi?id=1773200
+      "BULK_MEMORY_SOURCES:="
     )
+
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/wasilibc/default.nix
+++ b/pkgs/development/libraries/wasilibc/default.nix
@@ -1,4 +1,10 @@
-{ stdenv, buildPackages, fetchFromGitHub, lib }:
+{ stdenv
+, buildPackages
+, fetchFromGitHub
+, lib
+, firefox-unwrapped
+, firefox-esr-unwrapped
+}:
 
 let
   pname = "wasilibc";
@@ -43,6 +49,10 @@ stdenv.mkDerivation {
   preFixup = ''
     ln -s $share/share/undefined-symbols.txt $out/lib/wasi.imports
   '';
+
+  passthru.tests = {
+    inherit firefox-unwrapped firefox-esr-unwrapped;
+  };
 
   meta = with lib; {
     changelog = "https://github.com/WebAssembly/wasi-sdk/releases/tag/wasi-sdk-${version}";

--- a/pkgs/development/libraries/wasilibc/default.nix
+++ b/pkgs/development/libraries/wasilibc/default.nix
@@ -1,14 +1,17 @@
 { stdenv, buildPackages, fetchFromGitHub, lib }:
 
-stdenv.mkDerivation {
+let
   pname = "wasilibc";
-  version = "unstable-2022-04-12";
+  version = "16";
+in
+stdenv.mkDerivation {
+  inherit pname version;
 
   src = buildPackages.fetchFromGitHub {
     owner = "WebAssembly";
     repo = "wasi-libc";
-    rev = "a279514a6ef30cd8ee1469345b33172fcbc8d52d";
-    sha256 = "0a9ldas8p7jg7jlkhb9wdiw141z7vfz6p18mnmxnnnna7bp1y3fz";
+    rev = "refs/tags/wasi-sdk-${version}";
+    hash = "sha256-WnkAWA6F+Cl0ygcY5IteDA/HT1v2ykGWJnEm6Q5Q7Jc=";
     fetchSubmodules = true;
   };
 
@@ -42,6 +45,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with lib; {
+    changelog = "https://github.com/WebAssembly/wasi-sdk/releases/tag/wasi-sdk-${version}";
     description = "WASI libc implementation for WebAssembly";
     homepage = "https://wasi.dev";
     platforms = platforms.wasi;


### PR DESCRIPTION
###### Description of changes

- [x] build & test firefox

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
