### PR TITLE
rare: 1.8.9 -> 1.9.2

### DIFF
--- a/pkgs/games/rare/default.nix
+++ b/pkgs/games/rare/default.nix
@@ -1,16 +1,15 @@
 { lib, fetchFromGitHub, buildPythonApplication, qt5
-, psutil, pypresence, pyqt5, python, qtawesome, requests }:
+, legendary-gl, pypresence, pyqt5, python, qtawesome, requests, typing-extensions }:
 
 buildPythonApplication rec {
   pname = "rare";
-  version = "1.8.9";
+  version = "1.9.2";
 
   src = fetchFromGitHub {
     owner = "Dummerle";
     repo = "Rare";
     rev = version;
-    sha256 = "sha256-2l8Id+bA5Ugb8+3ioiZ78dUtDusU8cvZEAMhmYBcJFc=";
-    fetchSubmodules = true;
+    sha256 = "sha256-mL23tq5Fvd/kXAr7PZ+le5lRXwV3rKG/s8GuXE+S11M=";
   };
 
   nativeBuildInputs = [
@@ -18,19 +17,17 @@ buildPythonApplication rec {
   ];
 
   propagatedBuildInputs = [
-    psutil
+    legendary-gl
     pypresence
     pyqt5
     qtawesome
     requests
+    typing-extensions
   ];
 
-  dontWrapQtApps = true;
+  patches = [ ./fix-instance.patch ];
 
-  preBuild = ''
-    # Solves "PermissionError: [Errno 13] Permission denied: '/homeless-shelter'"
-    export HOME=$(mktemp -d)
-  '';
+  dontWrapQtApps = true;
 
   postInstall = ''
     install -Dm644 misc/rare.desktop -t $out/share/applications/

--- a/pkgs/games/rare/fix-instance.patch
+++ b/pkgs/games/rare/fix-instance.patch
@@ -1,0 +1,10 @@
+diff --git a/rare/utils/misc.py b/rare/utils/misc.py
+index 4492074..5352dac 100644
+--- a/rare/utils/misc.py
++++ b/rare/utils/misc.py
+@@ -190,6 +190,7 @@ def get_rare_executable() -> List[str]:
+         executable = [sys.executable]
+ 
+     executable[0] = os.path.abspath(executable[0])
++    executable.pop(0)
+     return executable

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33861,7 +33861,7 @@ with pkgs;
 
   leela-zero = libsForQt5.callPackage ../games/leela-zero { };
 
-  legendary-gl = python38Packages.callPackage ../games/legendary-gl { };
+  legendary-gl = python3Packages.callPackage ../games/legendary-gl { };
 
   left4gore-bin = callPackage ../games/left4gore { };
 


### PR DESCRIPTION
###### Description of changes
https://github.com/Dummerle/Rare/releases/tag/1.9.0
Unfortunately, games do not launch in the current state (unless you launch them via CLI).
I suspect that the reason why is this change:

> Run Games in a second rare process to keep them running, if rare closes

And I guess that [this line](https://github.com/Dummerle/Rare/blob/main/rare/components/tabs/games/game_utils.py#L60) and #150841 the cause of the problem.
I'm not sure how to continue from here, so I'm waiting for your input.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
