### PR TITLE
linuxPackages.xpadneo: 0.9.4 -> 0.9.5

### DIFF
--- a/nixos/modules/hardware/xpadneo.nix
+++ b/nixos/modules/hardware/xpadneo.nix
@@ -16,7 +16,7 @@ in
       extraModprobeConfig =
         mkIf
           (config.hardware.bluetooth.enable &&
-           (lib.versionOlder config.boot.kernelPackages.kernel.version "5.12"))
+            (lib.versionOlder config.boot.kernelPackages.kernel.version "5.12"))
           "options bluetooth disable_ertm=1";
 
       extraModulePackages = with config.boot.kernelPackages; [ xpadneo ];

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -633,6 +633,7 @@ in {
   xfce = handleTest ./xfce.nix {};
   xmonad = handleTest ./xmonad.nix {};
   xmonad-xdg-autostart = handleTest ./xmonad-xdg-autostart.nix {};
+  xpadneo = handleTest ./xpadneo.nix {};
   xrdp = handleTest ./xrdp.nix {};
   xss-lock = handleTest ./xss-lock.nix {};
   xterm = handleTest ./xterm.nix {};

--- a/nixos/tests/xpadneo.nix
+++ b/nixos/tests/xpadneo.nix
@@ -1,0 +1,18 @@
+import ./make-test-python.nix ({ lib, pkgs, ... }: {
+  name = "xpadneo";
+  meta.maintainers = with lib.maintainers; [ kira-bruneau ];
+
+  nodes = {
+    machine = {
+      config.hardware.xpadneo.enable = true;
+    };
+  };
+
+  # This is just a sanity check to make sure the module was
+  # loaded. We'd have to find some way to mock an xbox controller if
+  # we wanted more in-depth testing.
+  testScript = ''
+    machine.start();
+    machine.succeed("modinfo hid_xpadneo | grep 'version:\s\+${pkgs.linuxPackages.xpadneo.version}'")
+  '';
+})

--- a/pkgs/os-specific/linux/xpadneo/default.nix
+++ b/pkgs/os-specific/linux/xpadneo/default.nix
@@ -1,14 +1,14 @@
 { lib, stdenv, fetchFromGitHub, kernel, bluez }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "xpadneo";
-  version = "0.9.4";
+  version = "0.9.5";
 
   src = fetchFromGitHub {
     owner = "atar-axis";
-    repo = pname;
-    rev = "refs/tags/v${version}";
-    sha256 = "sha256-4zd+x9uYl0lJgePM9LEgLYFqvcw6VPF/CbR1XiYSwGE=";
+    repo = "xpadneo";
+    rev = "refs/tags/v${finalAttrs.version}";
+    sha256 = "sha256-rT2Mq40fE055FemDG7PBjt+cxgIHJG9tTjtw2nW6B98=";
   };
 
   setSourceRoot = ''
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     "-C"
     "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "M=$(sourceRoot)"
-    "VERSION=${version}"
+    "VERSION=${finalAttrs.version}"
   ];
 
   buildFlags = [ "modules" ];
@@ -36,4 +36,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ kira-bruneau ];
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/os-specific/linux/xpadneo/default.nix
+++ b/pkgs/os-specific/linux/xpadneo/default.nix
@@ -1,4 +1,10 @@
-{ lib, stdenv, fetchFromGitHub, kernel, bluez }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, kernel
+, bluez
+, nixosTests
+}:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xpadneo";
@@ -28,6 +34,10 @@ stdenv.mkDerivation (finalAttrs: {
   buildFlags = [ "modules" ];
   installFlags = [ "INSTALL_MOD_PATH=${placeholder "out"}" ];
   installTargets = [ "modules_install" ];
+
+  passthru.tests = {
+    xpadneo = nixosTests.xpadneo;
+  };
 
   meta = with lib; {
     description = "Advanced Linux driver for Xbox One wireless controllers";


### PR DESCRIPTION
###### Description of changes

Update to the latest hotfix release: https://github.com/atar-axis/xpadneo/releases/tag/v0.9.5

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).