### PR TITLE
python310Packages.pulumi-aws: mark as working on darwin and aarch64

### DIFF
--- a/pkgs/development/python-modules/pulumi-aws/default.nix
+++ b/pkgs/development/python-modules/pulumi-aws/default.nix
@@ -40,7 +40,6 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    broken = (stdenv.isLinux && stdenv.isAarch64) || stdenv.isDarwin;
     description = "Pulumi python amazon web services provider";
     homepage = "https://github.com/pulumi/pulumi-aws";
     license = licenses.asl20;


### PR DESCRIPTION
###### Description of changes

Marked as failing on specific archs for some reason, but actually the failure was: (https://hydra.nixos.org/log/jrabyrc0qifzc71hkiz4a9d2m0kn3s8a-python3.9-pulumi-aws-5.3.0.drv)
```
Requirement already satisfied: semver>=2.8.1 in /nix/store/80405vi4kb6847lmi8dpbpvxha44hqh1-python3.9-semver-2.13.0/lib/python3.9/site-packages (from pulumi-aws==0.0.0) (2.13.0)
Requirement already satisfied: parver>=0.2.1 in /nix/store/5935b9ypf09zdr9p7c4mafbxaq5j49ig-python3.9-parver-0.3.1/lib/python3.9/site-packages (from pulumi-aws==0.0.0) (0.3.1)
ERROR: Could not find a version that satisfies the requirement pulumi<4.0.0,>=3.0.0 (from pulumi-aws) (from versions: none)
ERROR: No matching distribution found for pulumi<4.0.0,>=3.0.0
```

Mark working everywhere again.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
