### PR TITLE
plasma-mobile: Add QtFeedback

### DIFF
--- a/pkgs/desktops/plasma-5/plasma-mobile/default.nix
+++ b/pkgs/desktops/plasma-5/plasma-mobile/default.nix
@@ -8,7 +8,7 @@
   kdeclarative, kdelibs4support, kpeople, kconfig, krunner, kinit, kwayland, kwin,
   plasma-framework, telepathy, libphonenumber, protobuf, libqofono, modemmanager-qt,
   networkmanager-qt, plasma-workspace,
-  maliit-framework, maliit-keyboard,
+  maliit-framework, maliit-keyboard, qtfeedback,
 
   qtwayland, qttools
 }:
@@ -23,7 +23,7 @@ mkDerivation {
     appstream libdbusmenu pam wayland
     kdeclarative kdelibs4support kpeople kconfig krunner kinit kwayland kwin
     plasma-framework telepathy libphonenumber protobuf libqofono modemmanager-qt
-    networkmanager-qt maliit-framework maliit-keyboard plasma-workspace
+    networkmanager-qt maliit-framework maliit-keyboard plasma-workspace qtfeedback
   ];
 
   postPatch = ''


### PR DESCRIPTION

###### Description of changes

This fixes an issue where *on devices*, Plasma Mobile would show error messages instead of the expected applets (taskbar, desktop, etc).

###### Things done

What was tested

 - QEMU UEFI VM, still works as expected
 - `google-blueline` (Pixel 3), no works

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
