### PR TITLE
gvisor: 20220905.0 -> 20220919.0

### DIFF
--- a/pkgs/applications/virtualization/gvisor/default.nix
+++ b/pkgs/applications/virtualization/gvisor/default.nix
@@ -9,18 +9,24 @@
 
 buildGoModule rec {
   pname = "gvisor";
-  version = "20220905.0";
+  version = "20220919.0";
+
+  # gvisor provides a synthetic go branch (https://github.com/google/gvisor/tree/go)
+  # that can be used to build gvisor without bazel.
+  # For updates, you should stick to the commits labeled "Merge release-** (automated)"
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "gvisor";
-    rev = "442a3cd44a0858ac2a8e773b6fbba67cf3bd3767";
-    sha256 = "sha256-LKY7AKAHX29eGuXRrkCVCFl/bdHAVOC0QNZfzlpXqwc=";
+    rev = "4e7fd140e8d0056f8f031950fcace8ff4d48a526";
+    sha256 = "sha256-II0lnthabkyCgPum7EBdyOYwB0rWjA2Jd9DVGLJQy6Q=";
   };
 
-  vendorSha256 = "sha256-Fn8A8iwTv0lNI9ZBJkq3SlRelnAGIQY0GInTxaCzSAU=";
+  vendorSha256 = "sha256-iGLWxx/Kn1QaJTNOZcc+mwoF3ecEDOkaqmA0DH4pdgU=";
 
   nativeBuildInputs = [ makeWrapper ];
+
+  CGO_ENABLED = 0;
 
   ldflags = [ "-s" "-w" ];
 


### PR DESCRIPTION
###### Description of changes

gvisor: 20220905.0 -> 20220919.0

Upstream some overrides I had locally, the package did build and had some very basic functionality but did not actually work.  Upstream recommends CGO_ENABLED=0.

Additionally close out https://github.com/NixOS/nixpkgs/pull/189698/files#r964640334

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
