### PR TITLE
v2ray: 4.45.0 -> 5.1.0

### DIFF
--- a/nixos/modules/services/networking/v2ray.nix
+++ b/nixos/modules/services/networking/v2ray.nix
@@ -71,7 +71,7 @@ with lib;
         name = "v2ray.json";
         text = builtins.toJSON cfg.config;
         checkPhase = ''
-          ${cfg.package}/bin/v2ray -test -config $out
+          ${cfg.package}/bin/v2ray test -c $out
         '';
       };
 
@@ -88,7 +88,7 @@ with lib;
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
-        ExecStart = "${cfg.package}/bin/v2ray -config ${configFile}";
+        ExecStart = "${cfg.package}/bin/v2ray run -c ${configFile}";
       };
     };
   };

--- a/pkgs/tools/networking/v2ray/core.nix
+++ b/pkgs/tools/networking/v2ray/core.nix
@@ -1,0 +1,28 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "v2ray-core";
+  version = "5.1.0";
+
+  src = fetchFromGitHub {
+    owner = "v2fly";
+    repo = "v2ray-core";
+    rev = "v${version}";
+    sha256 = "1w5mp6qi5i59w8ipg7nm6rivdbk8630fhgllkpiadsjdlb4nvc7k";
+  };
+
+  vendorSha256 = "1xl3wg7m7rpydi5j9cpwyha7h761nv3za6jcgnwhgazk0h1c5q26";
+
+  subPackages = [ "main" ];
+
+  postInstall = ''
+    mv $out/bin/{main,v2ray}
+  '';
+
+  meta = {
+    homepage = "https://www.v2fly.org/en_US/";
+    description = "A platform for building proxies to bypass network restrictions";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ servalcatty nickcao ];
+  };
+}

--- a/pkgs/tools/networking/v2ray/default.nix
+++ b/pkgs/tools/networking/v2ray/default.nix
@@ -1,69 +1,31 @@
-{ lib, fetchFromGitHub, fetchurl, symlinkJoin, buildGoModule, runCommand, makeWrapper, nixosTests
-, v2ray-geoip, v2ray-domain-list-community, assets ? [ v2ray-geoip v2ray-domain-list-community ]
+{ lib
+, callPackage
+, symlinkJoin
+, runCommand
+, makeWrapper
+, nixosTests
+, v2ray-geoip
+, v2ray-domain-list-community
+, assets ? [ v2ray-geoip v2ray-domain-list-community ]
 }:
 
 let
-  version = "4.45.0";
-
-  src = fetchFromGitHub {
-    owner = "v2fly";
-    repo = "v2ray-core";
-    rev = "v${version}";
-    sha256 = "sha256-vVCWCppGeAc7dwY0fX+G0CU3Vy6OBPpDBUOBK3ykg60=";
-  };
-
-  vendorSha256 = "sha256-TbWMbIT578I8xbNsKgBeSP4MewuEKpfh62ZbJIeHgDs=";
-
-  assetsDrv = symlinkJoin {
+  core = callPackage ./core.nix { };
+  asset = symlinkJoin {
     name = "v2ray-assets";
     paths = assets;
   };
-
-  core = buildGoModule rec {
-    pname = "v2ray-core";
-    inherit version src;
-
-    inherit vendorSha256;
-
-    doCheck = false;
-
-    buildPhase = ''
-      buildFlagsArray=(-v -p $NIX_BUILD_CORES -ldflags="-s -w")
-      runHook preBuild
-      go build "''${buildFlagsArray[@]}" -o v2ray ./main
-      go build "''${buildFlagsArray[@]}" -o v2ctl -tags confonly ./infra/control/main
-      runHook postBuild
-    '';
-
-    installPhase = ''
-      install -Dm755 v2ray v2ctl -t $out/bin
-    '';
-
-    meta = {
-      homepage = "https://www.v2fly.org/en_US/";
-      description = "A platform for building proxies to bypass network restrictions";
-      license = with lib.licenses; [ mit ];
-      maintainers = with lib.maintainers; [ servalcatty ];
-    };
-  };
-
-in runCommand "v2ray-${version}" {
-  inherit src version;
-  inherit (core) meta;
-
+in
+runCommand "v2ray-${core.version}"
+{
+  inherit (core) src version meta;
   nativeBuildInputs = [ makeWrapper ];
-
   passthru = {
     inherit core;
     updateScript = ./update.sh;
-    tests = {
-      simple-vmess-proxy-test = nixosTests.v2ray;
-    };
+    tests.simple = nixosTests.v2ray;
   };
-
 } ''
-  for file in ${core}/bin/*; do
-    makeWrapper "$file" "$out/bin/$(basename "$file")" \
-      --set-default V2RAY_LOCATION_ASSET ${assetsDrv}/share/v2ray
-  done
+  makeWrapper "${core}/bin/v2ray" "$out/bin/v2ray" \
+    --suffix XDG_DATA_DIRS ${asset}/share
 ''

--- a/pkgs/tools/networking/v2ray/update.sh
+++ b/pkgs/tools/networking/v2ray/update.sh
@@ -3,8 +3,7 @@
 set -eo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-version_nix=./default.nix
-deps_nix=./deps.nix
+version_nix=./core.nix
 nixpkgs=../../../..
 
 old_core_rev=$(sed -En 's/.*\bversion = "(.*?)".*/\1/p' "$version_nix")


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
