### PR TITLE
fairfax-hd: init at unstable-2022-09-04

### DIFF
--- a/pkgs/data/fonts/fairfax-hd/default.nix
+++ b/pkgs/data/fonts/fairfax-hd/default.nix
@@ -1,0 +1,23 @@
+{ lib, fetchgit }:
+
+fetchgit {
+  name = "fairfax-hd-unstable-2022-09-04";
+  url = "https://github.com/kreativekorp/open-relay.git";
+  sparseCheckout = "FairfaxHD";
+  rev = "cbaca8d9d6d65bddbc05dd3e20b7063639f6664a";
+
+  postFetch = ''
+    mv $out/* .
+    mkdir -p $out/share/fonts/truetype
+    cp ./FairfaxHD/*.ttf $out/share/fonts/truetype
+  '';
+
+  hash = "sha256-JpmVFW2tGF34ZpvJlS1txVhuych+THKEsvl25l9k4CQ=";
+
+  meta = with lib; {
+    homepage = "https://www.kreativekorp.com/software/fonts/fairfaxhd/";
+    description = "Fairfax HD fonts";
+    license = licenses.ofl;
+    maintainers = with maintainers; [ anselmschueler ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25339,6 +25339,8 @@ with pkgs;
 
   f5_6 = callPackage ../data/fonts/f5_6 { };
 
+  fairfax-hd = callPackage ../data/fonts/fairfax-hd { };
+
   faba-icon-theme = callPackage ../data/icons/faba-icon-theme { };
 
   faba-mono-icons = callPackage ../data/icons/faba-mono-icons { };


### PR DESCRIPTION
###### Description of changes

Added the Fairfax HD fonts

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
