### PR TITLE
octavePackages.symbolic: unstable-2021-10-16 -> 3.0.1

### DIFF
--- a/pkgs/development/octave-modules/symbolic/default.nix
+++ b/pkgs/development/octave-modules/symbolic/default.nix
@@ -1,17 +1,18 @@
 { buildOctavePackage
 , lib
 , fetchFromGitHub
-# Octave's Python (Python 3)
+  # Octave's Python (Python 3)
 , python
 }:
 
 let
   pythonEnv = python.withPackages (ps: [
-      ps.sympy
-      ps.mpmath
-    ]);
+    ps.sympy
+    ps.mpmath
+  ]);
 
-in buildOctavePackage rec {
+in
+buildOctavePackage rec {
   pname = "symbolic";
   version = "unstable-2021-10-16";
 

--- a/pkgs/development/octave-modules/symbolic/default.nix
+++ b/pkgs/development/octave-modules/symbolic/default.nix
@@ -14,15 +14,13 @@ let
 in
 buildOctavePackage rec {
   pname = "symbolic";
-  version = "unstable-2021-10-16";
+  version = "3.0.1";
 
-  # https://github.com/cbm755/octsympy/issues/1023 has been resolved, however
-  # a new release has not been made
   src = fetchFromGitHub {
     owner = "cbm755";
     repo = "octsympy";
-    rev = "5b58530f4ada78c759829ae703a0e5d9832c32d4";
-    sha256 = "sha256-n6P1Swjl4RfgxfLY0ZuN3pcL8PcoknA6yxbnw96OZ2k=";
+    rev = "v${version}";
+    hash = "sha256-FJb5uazqEiyNI6TL9WVewMoQnC3CutcHENl+umNZeto=";
   };
 
   propagatedBuildInputs = [ pythonEnv ];


### PR DESCRIPTION
###### Description of changes
https://github.com/cbm755/octsympy/releases/tag/v3.0.1
Symbolic is currently broken, updating it makes it work.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
