### PR TITLE
python310Packages.aioprocessing: 2.0.0 -> 2.0.1

### DIFF
--- a/pkgs/development/python-modules/aioprocessing/default.nix
+++ b/pkgs/development/python-modules/aioprocessing/default.nix
@@ -1,28 +1,37 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, flit-core
 , pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "aioprocessing";
-  version = "2.0.0";
+  version = "2.0.1";
+  format = "flit";
+
   disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "469dfb746e8c4e0c727ba135cfabf9e034c554f6a73c27f908bfe3625dd74b9e";
+    hash = "sha256-/gHHsaOMeBaGEdMEDnPZMDbDt8imSdY23J7Xo7ybG6I=";
   };
+
+  nativeBuildInputs = [
+    flit-core
+  ];
 
   # Tests aren't included in pypi package
   doCheck = false;
 
-  pythonImportsCheck = [ "aioprocessing" ];
+  pythonImportsCheck = [
+    "aioprocessing"
+  ];
 
-  meta = {
-    description = "A library that integrates the multiprocessing module with asyncio";
+  meta = with lib; {
+    description = "Library that integrates the multiprocessing module with asyncio";
     homepage = "https://github.com/dano/aioprocessing";
-    license = lib.licenses.bsd2;
-    maintainers = with lib.maintainers; [ uskudnik ];
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ uskudnik ];
   };
 }


### PR DESCRIPTION
###### Description of changes
https://github.com/dano/aioprocessing/releases/tag/v2.0.1
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
