### PR TITLE
tsduck: disable tests failing in sandbox

### DIFF
--- a/pkgs/tools/video/tsduck/default.nix
+++ b/pkgs/tools/video/tsduck/default.nix
@@ -49,6 +49,14 @@ stdenv.mkDerivation rec {
     sed -i"" \
       -e '/TSUNIT_TEST(testHomeDirectory);/ d' \
       src/utest/utestSysUtils.cpp
+
+    sed -i"" \
+      -e '/TSUNIT_TEST(testIPv4Address);/ d' \
+      -e '/TSUNIT_TEST(testIPv4AddressConstructors);/ d' \
+      -e '/TSUNIT_TEST(testIPv4SocketAddressConstructors);/ d' \
+      -e '/TSUNIT_TEST(testTCPSocket);/ d' \
+      -e '/TSUNIT_TEST(testUDPSocket);/ d' \
+      src/utest/utestNetworking.cpp
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Network tests succeed outside of sandbox, as they call 'localhost'. Disable to allow building in sandbox.

Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>
