### PR TITLE
python3Packages.tesserocr: enable tests, cleanup

### DIFF
--- a/pkgs/development/python-modules/tesserocr/default.nix
+++ b/pkgs/development/python-modules/tesserocr/default.nix
@@ -1,14 +1,18 @@
-{
-  buildPythonPackage,
-  fetchPypi,
-  lib,
-  # build dependencies
-  cython,
-  leptonica,
-  pkg-config,
-  tesseract,
-  # extra python packages
-  pillow
+{ buildPythonPackage
+, fetchPypi
+, lib
+
+# build dependencies
+, cython
+, leptonica
+, pkg-config
+, tesseract
+
+# propagates
+, pillow
+
+# tests
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -20,11 +24,30 @@ buildPythonPackage rec {
     sha256 = "1bmj76gi8401lcqdaaznfmz9yf11myy1bzivqwwq08z3dwzxswck";
   };
 
-  nativeBuildInputs = [ cython pkg-config ];
-  buildInputs = [ leptonica tesseract ];
-  propagatedBuildInputs = [ pillow ];
+  nativeBuildInputs = [
+    cython
+    pkg-config
+  ];
+
+  buildInputs = [
+    leptonica
+    tesseract
+  ];
+
+  propagatedBuildInputs = [
+    pillow
+  ];
+
+  pythonImportsCheck = [
+    "tesserocr"
+  ];
+
+  checkInputs = [
+    unittestCheckHook
+  ];
 
   meta = with lib; {
+    changelog = "https://github.com/sirfz/tesserocr/releases/tag/v${version}";
     description = "A simple, Pillow-friendly, wrapper around the tesseract-ocr API for Optical Character Recognition (OCR)";
     homepage = "https://github.com/sirfz/tesserocr";
     license = licenses.mit;


### PR DESCRIPTION
Some improvements to the package that I did in error, because I mixed two packages up. :muscle: 

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
