### PR TITLE
paperless-ngx: 1.8.0 -> 1.9.1

### DIFF
--- a/pkgs/applications/office/paperless-ngx/default.nix
+++ b/pkgs/applications/office/paperless-ngx/default.nix
@@ -26,17 +26,12 @@ let
         src = fetchFromGitHub {
           owner = "paperless-ngx";
           repo = "django-q";
-          sha256 = "sha256-aoDuPig8Nf8fLzn7GjBn69aF2zH2l8gxascAu9lIG3U=";
-          rev = "71abc78fdaec029cf71e9849a3b0fa084a1678f7";
+          hash = "sha256-alu7tZwUn77xhUF9c/aGmwRwO//mR/FucXjvXUl/6ek=";
+          rev = "8b5289d8caf36f67fb99448e76ead20d5b498c1b";
         };
         # due to paperless-ngx modification of the pyproject.toml file
         # the patch is not needed any more
-        patches = [];
-      });
-
-      # django-extensions 3.1.5 is required, but its tests are incompatible with Django 4
-      django-extensions = super.django-extensions.overridePythonAttrs (_: {
-        doCheck = false;
+        patches = [ ];
       });
 
       aioredis = super.aioredis.overridePythonAttrs (oldAttrs: rec {
@@ -62,12 +57,12 @@ let
 in
 python.pkgs.pythonPackages.buildPythonApplication rec {
   pname = "paperless-ngx";
-  version = "1.8.0";
+  version = "1.9.1";
 
   # Fetch the release tarball instead of a git ref because it contains the prebuilt fontend
   src = fetchurl {
     url = "https://github.com/paperless-ngx/paperless-ngx/releases/download/v${version}/${pname}-v${version}.tar.xz";
-    hash = "sha256-BLfhh04RvBJFRQiPXkMl8XlWqZOWKmjjl+6lZ326stU=";
+    hash = "sha256-KWq3zUES8klXexNO9krlqZKZEajOhkTHF13t/3rxrPc=";
   };
 
   format = "other";
@@ -116,6 +111,7 @@ python.pkgs.pythonPackages.buildPythonApplication rec {
     inotifyrecursive
     joblib
     langdetect
+    pkgs.libmysqlclient
     lxml
     msgpack
     numpy

--- a/pkgs/applications/office/pdfmixtool/default.nix
+++ b/pkgs/applications/office/pdfmixtool/default.nix
@@ -1,23 +1,25 @@
 { lib
 , mkDerivation
 , fetchFromGitLab
+, fetchpatch
 , cmake
 , pkg-config
 , qtbase
 , qttools
 , qpdf
 , podofo
+, imagemagick
 }:
 
 mkDerivation rec {
   pname = "pdfmixtool";
-  version = "1.0.2";
+  version = "1.1";
 
   src = fetchFromGitLab {
     owner = "scarpetta";
     repo = pname;
     rev = "v${version}";
-    sha256 = "066ap1w05gj8n0kvilyhlr1fzwrmlczx3lax7mbw0rfid9qh3467";
+    hash = "sha256-S8hhWZ6nHyIWPwsfl+o9XnljLD3aE/vthCLuWEbm5nc=";
   };
 
   nativeBuildInputs = [
@@ -26,10 +28,20 @@ mkDerivation rec {
   ];
 
   buildInputs = [
+    imagemagick
     qtbase
     qttools
     qpdf
     podofo
+  ];
+
+  patches = [
+    # fix incompatibility with qpdf11
+    (fetchpatch {
+      url = "https://gitlab.com/scarpetta/pdfmixtool/-/commit/81f7e96f6e68dfeba3cd4e00d8553dfdd2d7f2fa.diff";
+      hash = "sha256-uBchYjUIqL7dJR7U/TSxhSGu1qY742cFUIv0XKU6L2g=";
+    })
+
   ];
 
   meta = with lib; {

--- a/pkgs/development/libraries/qpdf/default.nix
+++ b/pkgs/development/libraries/qpdf/default.nix
@@ -1,29 +1,28 @@
-{ lib, stdenv, fetchFromGitHub, libjpeg, zlib, perl }:
+{ lib, stdenv, fetchFromGitHub, libjpeg, zlib, cmake, perl }:
 
 stdenv.mkDerivation rec {
   pname = "qpdf";
-  version = "10.6.3";
+  version = "11.1.0";
 
   src = fetchFromGitHub {
     owner = "qpdf";
     repo = "qpdf";
-    rev = "release-qpdf-${version}";
-    hash = "sha256-SiZA8T7N1SWlbCFosSqFosLDV/3Q7+ywvgq1iB4umdg=";
+    rev = "v${version}";
+    hash = "sha256-T06BLtDZN6ulJ9Po3LN1RlI6q8ddAfo95RAhyfrn+qg=";
   };
 
-  nativeBuildInputs = [ perl ];
+  nativeBuildInputs = [ cmake perl ];
 
   buildInputs = [ zlib libjpeg ];
 
-  configureFlags = lib.optional (stdenv.hostPlatform != stdenv.buildPlatform)
-                     "--with-random=/dev/urandom";
-
-  preCheck = ''
+  preConfigure = ''
     patchShebangs qtest/bin/qtest-driver
+    patchShebangs run-qtest
+    # qtest needs to know where the source code is
+    substituteInPlace CMakeLists.txt --replace "run-qtest" "run-qtest --top $src --code $src --bin $out"
   '';
 
   doCheck = true;
-  enableParallelBuilding = true;
 
   meta = with lib; {
     homepage = "http://qpdf.sourceforge.net/";

--- a/pkgs/development/python-modules/pikepdf/default.nix
+++ b/pkgs/development/python-modules/pikepdf/default.nix
@@ -24,7 +24,7 @@
 
 buildPythonPackage rec {
   pname = "pikepdf";
-  version = "5.4.2";
+  version = "6.0.2";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     postFetch = ''
       rm "$out/.git_archival.txt"
     '';
-    hash = "sha256-b4QUn+wfkk6Yx74ViBg6yaE1+bXtxidoyXYgBaJ9iiM=";
+    hash = "sha256-rwMSmARUrScG2nmiYBSkcq0NuUMhn0pHOPvgdKZbH7w=";
   };
 
   patches = [
@@ -51,10 +51,8 @@ buildPythonPackage rec {
   ];
 
   postPatch = ''
-    sed -i 's|\S*/opt/homebrew.*|pass|' setup.py
-
     substituteInPlace setup.py \
-      --replace setuptools_scm_git_archive ""
+      --replace "shims_enabled = not cflags_defined" "shims_enabled = False"
   '';
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;

--- a/pkgs/development/python-modules/pikepdf/paths.patch
+++ b/pkgs/development/python-modules/pikepdf/paths.patch
@@ -12,33 +12,24 @@ index 2a170c6..5ee3ba1 100644
              check=True,
          )
 diff --git a/src/pikepdf/jbig2.py b/src/pikepdf/jbig2.py
-index be390a1..3818ec3 100644
+index 28c596b..aff3565 100644
 --- a/src/pikepdf/jbig2.py
 +++ b/src/pikepdf/jbig2.py
-@@ -31,7 +31,7 @@ def extract_jbig2(
+@@ -28,7 +28,7 @@ def _extract_jbig2_bytes(jbig2: bytes, jbig2_globals: bytes) -> bytes:
          output_path = Path(tmpdir) / "outfile"
- 
+
          args = [
 -            "jbig2dec",
 +            "@jbig2dec@",
              "--embedded",
              "--format",
              "png",
-@@ -64,7 +64,7 @@ def _extract_jbig2_bytes(jbig2: bytes, jbig2_globals: bytes) -> bytes:
-         output_path = Path(tmpdir) / "outfile"
- 
-         args = [
--            "jbig2dec",
-+            "@jbig2dec@",
-             "--embedded",
-             "--format",
-             "png",
-@@ -100,7 +100,7 @@ def extract_jbig2_bytes(
- 
- def _check_jbig2dec_available() -> None:  # pragma: no cover
-     try:
--        proc = run(['jbig2dec', '--version'], stdout=PIPE, check=True, encoding='ascii')
-+        proc = run(['@jbig2dec@', '--version'], stdout=PIPE, check=True, encoding='ascii')
-     except (CalledProcessError, FileNotFoundError) as e:
-         raise DependencyError("jbig2dec - not installed or not found") from e
-     else:
+@@ -88,7 +88,7 @@ class JBIG2Decoder(JBIG2DecoderInterface):
+     def _version(self) -> Version:
+         try:
+             proc = run(
+-                ['jbig2dec', '--version'], stdout=PIPE, check=True, encoding='ascii'
++                ['@jbig2dec@', '--version'], stdout=PIPE, check=True, encoding='ascii'
+             )
+         except (CalledProcessError, FileNotFoundError) as e:
+             raise DependencyError("jbig2dec - not installed or not found") from e


### PR DESCRIPTION
###### Description of changes

Update of paperless-ngx.

~~Due to the beta status currently a draft.~~

[Changelog](https://github.com/paperless-ngx/paperless-ngx/releases)

EDIT:

Now includes the following updates:

- qpdf: 10.6.3 -> 11.1.0 [Changelog](https://qpdf.readthedocs.io/en/stable/release-notes.html)
- python3Packages.pikepdf: 5.4.2 -> 6.0.2 [Changelog](https://pikepdf.readthedocs.io/en/latest/releasenotes/index.html)
- ~~pdfarranger: add support for newer pikepdf version~~
- pdfmixtool: 1.0.2 -> 1.1 add override to old qpdf version and track issue upstream

Both are major version updates. `qpdf` now builds with cmake and has some breaking changes in their API. `pikepdf` adapted to the changes in this newer version. 

The new version of `pikepdf` is necessary for the update in `paperless-ngx`  
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
