### PR TITLE
lttng-ust: reduce runtime closure size

### DIFF
--- a/pkgs/development/tools/misc/lttng-ust/generic.nix
+++ b/pkgs/development/tools/misc/lttng-ust/generic.nix
@@ -22,12 +22,16 @@ stdenv.mkDerivation rec {
     inherit sha256;
   };
 
+  outputs = [ "bin" "out" "dev" "devdoc" ];
+
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ numactl python3 ];
 
   preConfigure = ''
     patchShebangs .
   '';
+
+  configureFlags = [ "--disable-examples" ];
 
   propagatedBuildInputs = [ liburcu ];
 


### PR DESCRIPTION
###### Description of changes

lttng-ust contains a [python script](https://github.com/lttng/lttng-ust/blob/master/tools/lttng-gen-tp) in its build output. It is a code generator that is only used at development time, so move it to a seperate output. Because of this script, currently every reverse dependency of lttng-ust has python3 in its closure.

New file structure:
<details>
<pre>result
├── lib
│   ├── liblttng-ust-common.la
│   ├── liblttng-ust-common.so -> liblttng-ust-common.so.1.0.0
│   ├── liblttng-ust-common.so.1 -> liblttng-ust-common.so.1.0.0
│   ├── liblttng-ust-common.so.1.0.0
│   ├── liblttng-ust-ctl.la
│   ├── liblttng-ust-ctl.so -> liblttng-ust-ctl.so.5.0.0
│   ├── liblttng-ust-ctl.so.5 -> liblttng-ust-ctl.so.5.0.0
│   ├── liblttng-ust-ctl.so.5.0.0
│   ├── liblttng-ust-cyg-profile-fast.la
│   ├── liblttng-ust-cyg-profile-fast.so -> liblttng-ust-cyg-profile-fast.so.1.0.0
│   ├── liblttng-ust-cyg-profile-fast.so.1 -> liblttng-ust-cyg-profile-fast.so.1.0.0
│   ├── liblttng-ust-cyg-profile-fast.so.1.0.0
│   ├── liblttng-ust-cyg-profile.la
│   ├── liblttng-ust-cyg-profile.so -> liblttng-ust-cyg-profile.so.1.0.0
│   ├── liblttng-ust-cyg-profile.so.1 -> liblttng-ust-cyg-profile.so.1.0.0
│   ├── liblttng-ust-cyg-profile.so.1.0.0
│   ├── liblttng-ust-dl.la
│   ├── liblttng-ust-dl.so -> liblttng-ust-dl.so.1.0.0
│   ├── liblttng-ust-dl.so.1 -> liblttng-ust-dl.so.1.0.0
│   ├── liblttng-ust-dl.so.1.0.0
│   ├── liblttng-ust-fd.la
│   ├── liblttng-ust-fd.so -> liblttng-ust-fd.so.1.0.0
│   ├── liblttng-ust-fd.so.1 -> liblttng-ust-fd.so.1.0.0
│   ├── liblttng-ust-fd.so.1.0.0
│   ├── liblttng-ust-fork.la
│   ├── liblttng-ust-fork.so -> liblttng-ust-fork.so.1.0.0
│   ├── liblttng-ust-fork.so.1 -> liblttng-ust-fork.so.1.0.0
│   ├── liblttng-ust-fork.so.1.0.0
│   ├── liblttng-ust.la
│   ├── liblttng-ust-libc-wrapper.la
│   ├── liblttng-ust-libc-wrapper.so -> liblttng-ust-libc-wrapper.so.1.0.0
│   ├── liblttng-ust-libc-wrapper.so.1 -> liblttng-ust-libc-wrapper.so.1.0.0
│   ├── liblttng-ust-libc-wrapper.so.1.0.0
│   ├── liblttng-ust-pthread-wrapper.la
│   ├── liblttng-ust-pthread-wrapper.so -> liblttng-ust-pthread-wrapper.so.1.0.0
│   ├── liblttng-ust-pthread-wrapper.so.1 -> liblttng-ust-pthread-wrapper.so.1.0.0
│   ├── liblttng-ust-pthread-wrapper.so.1.0.0
│   ├── liblttng-ust.so -> liblttng-ust.so.1.0.0
│   ├── liblttng-ust.so.1 -> liblttng-ust.so.1.0.0
│   ├── liblttng-ust.so.1.0.0
│   ├── liblttng-ust-tracepoint.la
│   ├── liblttng-ust-tracepoint.so -> liblttng-ust-tracepoint.so.1.0.0
│   ├── liblttng-ust-tracepoint.so.1 -> liblttng-ust-tracepoint.so.1.0.0
│   └── liblttng-ust-tracepoint.so.1.0.0
└── share
    └── doc
        └── lttng-ust
            ├── ChangeLog
            ├── java-agent.txt
            ├── LICENSE
            └── README.md
result-bin
├── bin
│   └── lttng-gen-tp
└── share
    └── man
        └── man1
            └── lttng-gen-tp.1.gz
result-dev
├── include
│   └── lttng
│       ├── tp
│       │   ├── lttng-ust-tracef.h
│       │   └── lttng-ust-tracelog.h
│       ├── tracef.h
│       ├── tracelog.h
│       ├── tracepoint-event.h
│       ├── tracepoint.h
│       ├── tracepoint-rcu.h
│       ├── tracepoint-types.h
│       ├── urcu
│       │   ├── pointer.h
│       │   ├── static
│       │   │   ├── pointer.h
│       │   │   └── urcu-ust.h
│       │   └── urcu-ust.h
│       ├── ust-abi.h
│       ├── ust-api-compat.h
│       ├── ust-arch.h
│       ├── ust-cancelstate.h
│       ├── ust-clock.h
│       ├── ust-common.h
│       ├── ust-compiler.h
│       ├── ust-config.h
│       ├── ust-ctl.h
│       ├── ust-endian.h
│       ├── ust-error.h
│       ├── ust-events.h
│       ├── ust-fork.h
│       ├── ust-getcpu.h
│       ├── ust-libc-wrapper.h
│       ├── ust-ringbuffer-context.h
│       ├── ust-sigbus.h
│       ├── ust-thread.h
│       ├── ust-tracepoint-event.h
│       ├── ust-tracepoint-event-nowrite.h
│       ├── ust-tracepoint-event-reset.h
│       ├── ust-tracepoint-event-write.h
│       ├── ust-tracer.h
│       ├── ust-utils.h
│       └── ust-version.h
├── lib
│   └── pkgconfig
│       ├── lttng-ust-ctl.pc
│       └── lttng-ust.pc
└── nix-support
    └── propagated-build-inputs
result-devdoc
└── share
    └── man
        └── man3
            ├── do_tracepoint.3.gz
            ├── lttng-ust.3.gz
            ├── lttng-ust-cyg-profile.3.gz
            ├── lttng-ust-dl.3.gz
            ├── lttng_ust_do_tracepoint.3.gz
            ├── lttng_ust_tracef.3.gz
            ├── lttng_ust_tracelog.3.gz
            ├── lttng_ust_tracepoint.3.gz
            ├── lttng_ust_tracepoint_enabled.3.gz
            ├── lttng_ust_vtracef.3.gz
            ├── lttng_ust_vtracelog.3.gz
            ├── tracef.3.gz
            ├── tracelog.3.gz
            ├── tracepoint.3.gz
            └── tracepoint_enabled.3.gz

3 directories, 15 files</pre>
</details>

nixpkgs-review of a very small subset of reverse dependencies:
Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>5 packages built:</summary>
  <ul>
    <li>dotnetCorePackages.aspnetcore_6_0</li>
    <li>libcamera</li>
    <li>lttng-ust</li>
    <li>lttng-ust_2_12</li>
    <li>qt6.qtbase</li>
  </ul>
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
