### PR TITLE
Add readstat and pyreadstat

### DIFF
--- a/pkgs/applications/science/math/readstat/default.nix
+++ b/pkgs/applications/science/math/readstat/default.nix
@@ -1,0 +1,22 @@
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config }:
+
+stdenv.mkDerivation rec {
+  name = "readstat";
+  version = "1.1.8";
+
+  src = fetchFromGitHub {
+    owner = "WizardMac";
+    repo = "ReadStat";
+    rev = "v${version}";
+    sha256 = "1r04lq45h1yn34v1mgfiqjfzyaqv4axqlby0nkandamcsqyhc7y4";
+  };
+
+  nativeBuildInputs = [ pkg-config autoreconfHook ];
+
+  meta = {
+    homepage = "https://github.com/WizardMac/ReadStat";
+    description = "Command-line tool (+ C library) for converting SAS, Stata, and SPSS files";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ swflint ];
+  };
+}

--- a/pkgs/development/python-modules/pyreadstat/default.nix
+++ b/pkgs/development/python-modules/pyreadstat/default.nix
@@ -1,0 +1,34 @@
+{ lib, buildPythonPackage, fetchFromGitHub, cython, zlib, pandas, readstat }:
+
+buildPythonPackage rec {
+  pname = "pyreadstat";
+  version = "1.1.9";
+
+  src = fetchFromGitHub {
+    owner = "Roche";
+    repo = "pyreadstat";
+    rev = "v${version}";
+    sha256 = "16aa16ybh3ikmlxsg8zm19x9k6r4gpd0sxqagv318w76jjyw1nrs";
+  };
+
+  nativeBuildInputs = [
+    cython
+  ];
+
+  buildInputs = [
+    zlib
+  ];
+
+  propagatedBuildInputs = [
+    readstat
+    pandas
+  ];
+
+  meta = {
+    homepage = "https://github.com/Roche/pyreadstat";
+    description = "Python package to read SAS, SPSS and Stata files into pandas data frames using the readstat C library";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ swflint ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10510,6 +10510,8 @@ with pkgs;
 
   read-edid = callPackage ../os-specific/linux/read-edid { };
 
+  readstat = callPackage ../applications/science/math/readstat { };
+
   redir = callPackage ../tools/networking/redir { };
 
   redmine = callPackage ../applications/version-management/redmine { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9469,6 +9469,8 @@ in {
 
   readme_renderer = callPackage ../development/python-modules/readme_renderer { };
 
+  readstats = callPackage ../development/python-modules/pyreadstat { };
+
   readthedocs-sphinx-ext = callPackage ../development/python-modules/readthedocs-sphinx-ext { };
 
   rebulk = callPackage ../development/python-modules/rebulk { };


### PR DESCRIPTION
###### Description of changes

This adds the readstat and pyreadstat packages allowing users to read SAS, SPSS and Stata data files from within Python.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
