### PR TITLE
[22.05] unbound: fix CVE-2022-3204

### DIFF
--- a/pkgs/tools/networking/unbound/CVE-2022-3204.patch
+++ b/pkgs/tools/networking/unbound/CVE-2022-3204.patch
@@ -1,0 +1,207 @@
+commit a32dc1b74b2132898bfb07425920a9d26e7496c9
+Author: W.C.A. Wijngaards <wouter@nlnetlabs.nl>
+Date:   Wed Sep 21 11:10:38 2022 +0200
+
+    - Patch for CVE-2022-3204 Non-Responsive Delegation Attack.
+    
+    (cherry picked from commit 137719522a8ea5b380fbb6206d2466f402f5b554)
+
+diff --git a/iterator/iter_delegpt.c b/iterator/iter_delegpt.c
+index bdac42b0..74050c23 100644
+--- a/iterator/iter_delegpt.c
++++ b/iterator/iter_delegpt.c
+@@ -77,6 +77,7 @@ struct delegpt* delegpt_copy(struct delegpt* dp, struct regional* region)
+ 	for(ns = dp->nslist; ns; ns = ns->next) {
+ 		if(!delegpt_add_ns(copy, region, ns->name, ns->lame))
+ 			return NULL;
++		copy->nslist->cache_lookup_count = ns->cache_lookup_count;
+ 		copy->nslist->resolved = ns->resolved;
+ 		copy->nslist->got4 = ns->got4;
+ 		copy->nslist->got6 = ns->got6;
+@@ -120,6 +121,7 @@ delegpt_add_ns(struct delegpt* dp, struct regional* region, uint8_t* name,
+ 	ns->namelen = len;
+ 	dp->nslist = ns;
+ 	ns->name = regional_alloc_init(region, name, ns->namelen);
++	ns->cache_lookup_count = 0;
+ 	ns->resolved = 0;
+ 	ns->got4 = 0;
+ 	ns->got6 = 0;
+@@ -598,6 +600,7 @@ int delegpt_add_ns_mlc(struct delegpt* dp, uint8_t* name, uint8_t lame)
+ 	}
+ 	ns->next = dp->nslist;
+ 	dp->nslist = ns;
++	ns->cache_lookup_count = 0;
+ 	ns->resolved = 0;
+ 	ns->got4 = 0;
+ 	ns->got6 = 0;
+diff --git a/iterator/iter_delegpt.h b/iterator/iter_delegpt.h
+index 9c8cfb28..bf15aa5d 100644
+--- a/iterator/iter_delegpt.h
++++ b/iterator/iter_delegpt.h
+@@ -101,6 +101,8 @@ struct delegpt_ns {
+ 	uint8_t* name;
+ 	/** length of name */
+ 	size_t namelen;
++	/** number of cache lookups for the name */
++	int cache_lookup_count;
+ 	/** 
+ 	 * If the name has been resolved. false if not queried for yet.
+ 	 * true if the A, AAAA queries have been generated.
+diff --git a/iterator/iter_utils.c b/iterator/iter_utils.c
+index 8480f41d..65af304c 100644
+--- a/iterator/iter_utils.c
++++ b/iterator/iter_utils.c
+@@ -1195,6 +1195,9 @@ int iter_lookup_parent_glue_from_cache(struct module_env* env,
+ 	struct delegpt_ns* ns;
+ 	size_t num = delegpt_count_targets(dp);
+ 	for(ns = dp->nslist; ns; ns = ns->next) {
++		if(ns->cache_lookup_count > ITERATOR_NAME_CACHELOOKUP_MAX_PSIDE)
++			continue;
++		ns->cache_lookup_count++;
+ 		/* get cached parentside A */
+ 		akey = rrset_cache_lookup(env->rrset_cache, ns->name,
+ 			ns->namelen, LDNS_RR_TYPE_A, qinfo->qclass,
+diff --git a/iterator/iter_utils.h b/iterator/iter_utils.h
+index 660d6dc1..75e08d77 100644
+--- a/iterator/iter_utils.h
++++ b/iterator/iter_utils.h
+@@ -62,6 +62,15 @@ struct ub_packed_rrset_key;
+ struct module_stack;
+ struct outside_network;
+ 
++/* max number of lookups in the cache for target nameserver names.
++ * This stops, for large delegations, N*N lookups in the cache. */
++#define ITERATOR_NAME_CACHELOOKUP_MAX	3
++/* max number of lookups in the cache for parentside glue for nameserver names
++ * This stops, for larger delegations, N*N lookups in the cache.
++ * It is a little larger than the nonpside max, so it allows a couple extra
++ * lookups of parent side glue. */
++#define ITERATOR_NAME_CACHELOOKUP_MAX_PSIDE	5
++
+ /**
+  * Process config options and set iterator module state.
+  * Sets default values if no config is found.
+diff --git a/iterator/iterator.c b/iterator/iterator.c
+index 7dc0e9c5..4bb28a5b 100644
+--- a/iterator/iterator.c
++++ b/iterator/iterator.c
+@@ -1206,6 +1206,15 @@ generate_dnskey_prefetch(struct module_qstate* qstate,
+ 		(qstate->query_flags&BIT_RD) && !(qstate->query_flags&BIT_CD)){
+ 		return;
+ 	}
++	/* we do not generate this prefetch when the query list is full,
++	 * the query is fetched, if needed, when the validator wants it.
++	 * At that time the validator waits for it, after spawning it.
++	 * This means there is one state that uses cpu and a socket, the
++	 * spawned while this one waits, and not several at the same time,
++	 * if we had created the lookup here. And this helps to keep
++	 * the total load down, but the query still succeeds to resolve. */
++	if(mesh_jostle_exceeded(qstate->env->mesh))
++		return;
+ 
+ 	/* if the DNSKEY is in the cache this lookup will stop quickly */
+ 	log_nametypeclass(VERB_ALGO, "schedule dnskey prefetch", 
+@@ -1923,6 +1932,14 @@ query_for_targets(struct module_qstate* qstate, struct iter_qstate* iq,
+ 				return 0;
+ 			}
+ 			query_count++;
++			/* If the mesh query list is full, exit the loop here.
++			 * This makes the routine spawn one query at a time,
++			 * and this means there is no query state load
++			 * increase, because the spawned state uses cpu and a
++			 * socket while this state waits for that spawned
++			 * state. Next time we can look up further targets */
++			if(mesh_jostle_exceeded(qstate->env->mesh))
++				break;
+ 		}
+ 		/* Send the A request. */
+ 		if(ie->supports_ipv4 && !ns->got4) {
+@@ -1935,6 +1952,9 @@ query_for_targets(struct module_qstate* qstate, struct iter_qstate* iq,
+ 				return 0;
+ 			}
+ 			query_count++;
++			/* If the mesh query list is full, exit the loop. */
++			if(mesh_jostle_exceeded(qstate->env->mesh))
++				break;
+ 		}
+ 
+ 		/* mark this target as in progress. */
+@@ -2093,6 +2113,15 @@ processLastResort(struct module_qstate* qstate, struct iter_qstate* iq,
+ 			}
+ 			ns->done_pside6 = 1;
+ 			query_count++;
++			if(mesh_jostle_exceeded(qstate->env->mesh)) {
++				/* Wait for the lookup; do not spawn multiple
++				 * lookups at a time. */
++				verbose(VERB_ALGO, "try parent-side glue lookup");
++				iq->num_target_queries += query_count;
++				target_count_increase(iq, query_count);
++				qstate->ext_state[id] = module_wait_subquery;
++				return 0;
++			}
+ 		}
+ 		if(ie->supports_ipv4 && !ns->done_pside4) {
+ 			/* Send the A request. */
+@@ -2461,7 +2490,12 @@ processQueryTargets(struct module_qstate* qstate, struct iter_qstate* iq,
+ 	if(iq->depth < ie->max_dependency_depth
+ 		&& iq->num_target_queries == 0
+ 		&& (!iq->target_count || iq->target_count[2]==0)
+-		&& iq->sent_count < TARGET_FETCH_STOP) {
++		&& iq->sent_count < TARGET_FETCH_STOP
++		/* if the mesh query list is full, then do not waste cpu
++		 * and sockets to fetch promiscuous targets. They can be
++		 * looked up when needed. */
++		&& !mesh_jostle_exceeded(qstate->env->mesh)
++		) {
+ 		tf_policy = ie->target_fetch_policy[iq->depth];
+ 	}
+ 
+diff --git a/services/cache/dns.c b/services/cache/dns.c
+index 99faaf67..96a33df7 100644
+--- a/services/cache/dns.c
++++ b/services/cache/dns.c
+@@ -404,6 +404,9 @@ cache_fill_missing(struct module_env* env, uint16_t qclass,
+ 	struct ub_packed_rrset_key* akey;
+ 	time_t now = *env->now;
+ 	for(ns = dp->nslist; ns; ns = ns->next) {
++		if(ns->cache_lookup_count > ITERATOR_NAME_CACHELOOKUP_MAX)
++			continue;
++		ns->cache_lookup_count++;
+ 		akey = rrset_cache_lookup(env->rrset_cache, ns->name, 
+ 			ns->namelen, LDNS_RR_TYPE_A, qclass, 0, now, 0);
+ 		if(akey) {
+diff --git a/services/mesh.c b/services/mesh.c
+index 544ca0aa..7a62d47d 100644
+--- a/services/mesh.c
++++ b/services/mesh.c
+@@ -2082,3 +2082,10 @@ mesh_serve_expired_callback(void* arg)
+ 		mesh_do_callback(mstate, LDNS_RCODE_NOERROR, msg->rep, c, &tv);
+ 	}
+ }
++
++int mesh_jostle_exceeded(struct mesh_area* mesh)
++{
++	if(mesh->all.count < mesh->max_reply_states)
++		return 0;
++	return 1;
++}
+diff --git a/services/mesh.h b/services/mesh.h
+index d0a4b5fb..2248178b 100644
+--- a/services/mesh.h
++++ b/services/mesh.h
+@@ -674,4 +674,15 @@ struct dns_msg*
+ mesh_serve_expired_lookup(struct module_qstate* qstate,
+ 	struct query_info* lookup_qinfo);
+ 
++/**
++ * See if the mesh has space for more queries. You can allocate queries
++ * anyway, but this checks for the allocated space.
++ * @param mesh: mesh area.
++ * @return true if the query list is full.
++ * 	It checks the number of all queries, not just number of reply states,
++ * 	that have a client address. So that spawned queries count too,
++ * 	that were created by the iterator, or other modules.
++ */
++int mesh_jostle_exceeded(struct mesh_area* mesh);
++
+ #endif /* SERVICES_MESH_H */

--- a/pkgs/tools/networking/unbound/default.nix
+++ b/pkgs/tools/networking/unbound/default.nix
@@ -116,6 +116,8 @@ stdenv.mkDerivation rec {
       hash = "sha256-tLHkQoAbtYqLr3ASYfYX6pGtjD2TWT4B5NUubT4EN90=";
       excludes = [ "doc/Changelog" ];
     })
+    # Fix CVE-2022-3204
+    ./CVE-2022-3204.patch
   ];
 
   postPatch = lib.optionalString withPythonModule ''


### PR DESCRIPTION
###### Description of changes

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).