### PR TITLE
python310Packages.angr: 9.2.18 -> 9.2.19

### DIFF
--- a/pkgs/development/python-modules/ailment/default.nix
+++ b/pkgs/development/python-modules/ailment/default.nix
@@ -7,7 +7,7 @@
 
 buildPythonPackage rec {
   pname = "ailment";
-  version = "9.2.18";
+  version = "9.2.19";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     owner = "angr";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-9l1TlJwwmc51z+Dwl8uDNlUSOhGaI1bIMoqokaT/IFE=";
+    hash = "sha256-nm8vumylqNefSN+RE/3nUB+fzwznnkefDlXeQGQdfEw=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/angr/default.nix
+++ b/pkgs/development/python-modules/angr/default.nix
@@ -46,7 +46,7 @@ in
 
 buildPythonPackage rec {
   pname = "angr";
-  version = "9.2.18";
+  version = "9.2.19";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -55,7 +55,7 @@ buildPythonPackage rec {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-wy+0VojvgRjIkiPxnJN+r3R4dkIqhHCP/jZqurf+1CY=";
+    hash = "sha256-3hgEWmP8uwSGE5gh5HAs7xMJnnzY1hlwE8UqW/dzk7c=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/archinfo/default.nix
+++ b/pkgs/development/python-modules/archinfo/default.nix
@@ -7,7 +7,7 @@
 
 buildPythonPackage rec {
   pname = "archinfo";
-  version = "9.2.18";
+  version = "9.2.19";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     owner = "angr";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-atLc02FoW2cmlvA/jzRsOeXEY9cyrSeLSl3+pO5nNKA=";
+    hash = "sha256-zfDOIkXwt393tu9QPXz/ADyIK3mJCQ6oSgKcaMipHLg=";
   };
 
   checkInputs = [

--- a/pkgs/development/python-modules/claripy/default.nix
+++ b/pkgs/development/python-modules/claripy/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "claripy";
-  version = "9.2.18";
+  version = "9.2.19";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "angr";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-LhLRuEHhNdr7WSnsbfv0ol+/MbEq+rAdw5UjxY/i9b8=";
+    hash = "sha256-amCt7ccAKXNicCHvhu0pLUKXPlkrD8UpLO94D78OGAk=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/cle/default.nix
+++ b/pkgs/development/python-modules/cle/default.nix
@@ -15,7 +15,7 @@
 
 let
   # The binaries are following the argr projects release cycle
-  version = "9.2.18";
+  version = "9.2.19";
 
   # Binary files from https://github.com/angr/binaries (only used for testing and only here)
   binaries = fetchFromGitHub {
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     owner = "angr";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-hg6G07rSPRFGBaJdJduDqb7BVGt/sZtCA4I0Hhl4wfw=";
+    hash = "sha256-uwCSgq7l5VByN1YPuqdnvj2ImV/rb8Xn7dz1p7EvrdQ=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pyvex/default.nix
+++ b/pkgs/development/python-modules/pyvex/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "pyvex";
-  version = "9.2.18";
+  version = "9.2.19";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-bwQveWnXsYmoJkyVZkzrXEbg2MdU6lj7Z56iu9t7XxE=";
+    hash = "sha256-f/Oc5IOVkOqCkpWnNclQ8eC4YZU9Iz/q4kfcTkP5x0o=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Description of changes
Update `angr` stack to 9.2.19
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
