### PR TITLE
python310Packages.ormar: 0.11.2 -> 0.11.3

### DIFF
--- a/pkgs/development/python-modules/ormar/default.nix
+++ b/pkgs/development/python-modules/ormar/default.nix
@@ -24,7 +24,7 @@
 
 buildPythonPackage rec {
   pname = "ormar";
-  version = "0.11.2";
+  version = "0.11.3";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -33,7 +33,7 @@ buildPythonPackage rec {
     owner = "collerek";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-L0Tc/MmXDeNbUaHgWaxaY8lu+wUhq1ereqpya150SBg=";
+    hash = "sha256-4tGwhgHLZmvsbaDjmmQ3tXBwUBIxb5EpQrT8VIu/XwY=";
   };
 
   nativeBuildInputs = [
@@ -70,13 +70,51 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace 'SQLAlchemy = ">=1.3.18,<1.4.39"' 'SQLAlchemy = ">=1.3.18"' \
-      --replace 'databases = ">=0.3.2,!=0.5.0,!=0.5.1,!=0.5.2,!=0.5.3,<0.6.1"' 'databases = ">=0.5.5"'
+      --replace 'SQLAlchemy = ">=1.3.18,<1.4.42"' 'SQLAlchemy = ">=1.3.18"' \
+      --replace 'databases = ">=0.3.2,!=0.5.0,!=0.5.1,!=0.5.2,!=0.5.3,<0.6.2"' 'databases = ">=0.5.5"'
   '';
 
   disabledTests = [
     # TypeError: Object of type bytes is not JSON serializable
     "test_bulk_operations_with_json"
+    # Tests require a database
+    "test_model_multiple_instances_of_same_table_in_schema"
+    "test_load_all_multiple_instances_of_same_table_in_schema"
+    "test_filter_groups_with_instances_of_same_table_in_schema"
+    "test_model_multiple_instances_of_same_table_in_schema"
+    "test_right_tables_join"
+    "test_multiple_reverse_related_objects"
+    "test_related_with_defaults"
+    "test_model_creation"
+    "test_default_orders_is_applied_on_related_two_fields"
+    "test_default_orders_is_applied_from_relation"
+    "test_sum_method"
+    "test_count_method "
+    "test_queryset_methods"
+    "test_queryset_update"
+    "test_selecting_subset"
+    "test_selecting_subset_of_through_model"
+    "test_simple_queryset_values"
+    "test_queryset_values_nested_relation"
+    "test_queryset_simple_values_list"
+    "test_queryset_nested_relation_values_list"
+    "test_queryset_nested_relation_subset_of_fields_values_list"
+    "test_m2m_values"
+    "test_nested_m2m"
+    "test_nested_flatten_and_exception"
+    "test_queryset_values_multiple_select_related"
+    "test_querysetproxy_values"
+    "test_querysetproxy_values_list"
+    "test_reverse_many_to_many_cascade"
+    "test_not_saved_raises_error"
+    "test_not_existing_raises_error"
+    "test_assigning_related_objects"
+    "test_quering_of_the_m2m_models"
+    "test_removal_of_the_relations"
+    "test_selecting_related"
+    "test_adding_unsaved_related"
+    "test_removing_unsaved_related"
+    "test_quering_of_related_model_works_but_no_result"
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
###### Description of changes
https://github.com/collerek/ormar/releases/tag/0.11.3
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
