### PR TITLE
python3Packages.elastic-transport: init at 8.4.0; python3Packages.elasticsearch: 7.16.3 -> 8.4.2

### DIFF
--- a/pkgs/development/python-modules/elastic-transport/default.nix
+++ b/pkgs/development/python-modules/elastic-transport/default.nix
@@ -1,0 +1,93 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+
+# docs
+, furo
+, sphinx-autodoc-typehints
+, sphinxHook
+
+# propagates
+, certifi
+, urllib3
+
+# tests
+, aiohttp
+, mock
+, pytest-asyncio
+, pytest-httpserver
+, pytest-mock
+, requests
+, pytestCheckHook
+, trustme
+}:
+
+buildPythonPackage rec {
+  pname = "elastic-transport";
+  version = "8.4.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "elastic";
+    repo = "elastic-transport-python";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-rZdl2gjY5Yg2Ls777tj12pPATMn//xVvEM4wkrZ3qUY=";
+  };
+
+  postPatch = ''
+    sed -i '/addopts/d' setup.cfg
+  '';
+
+  outputs = [
+    "out"
+    "doc"
+  ];
+
+  nativeBuildInputs = [
+    furo
+    sphinx-autodoc-typehints
+    sphinxHook
+  ];
+
+  sphinxRoot = "docs/sphinx";
+
+  propgatedBuildInputs = [
+    certifi
+    urllib3
+  ];
+
+  checkInputs = [
+    aiohttp
+    mock
+    pytest-asyncio
+    pytest-httpserver
+    pytest-mock
+    pytestCheckHook
+    requests
+    trustme
+  ];
+
+  disabledTests = [
+    # network access
+    "test_unsupported_tls_versions"
+    "test_supported_tls_versions"
+    "test_assert_fingerprint_in_cert_chain"
+    "test_assert_fingerprint_in_cert_chain_failure"
+    "test_ssl_assert_fingerprint"
+    "test_head"
+    "test_custom_user_agent"
+    "test_custom_headers"
+    "test_default_headers"
+  ];
+
+  meta = with lib; {
+    changelog = "https://github.com/elastic/elastic-transport-python/releases/tag/v${version}";
+    description = "Transport classes and utilities shared among Python Elastic client libraries";
+    homepage = "https://github.com/elastic/elastic-transport-python";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/development/python-modules/elasticsearch/default.nix
+++ b/pkgs/development/python-modules/elasticsearch/default.nix
@@ -1,29 +1,78 @@
-{ buildPythonPackage
-, fetchPypi
-, urllib3, requests
-, nosexcover, mock
-, lib
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+
+# docs
+, sphinx-rtd-theme
+, sphinxHook
+
+# propagates
+, elastic-transport
+
+# extras
+, aiohttp
+, requests
+
+# tests
+, numpy
+, pandas
+, pytest-asyncio
+, pytestCheckHook
+, python-dateutil
+, pyyaml
 }:
 
 buildPythonPackage (rec {
   pname = "elasticsearch";
-  version = "7.16.3";
+  version = "8.4.2";
+  format = "setuptools";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "8adf8bc351ed55df7296be1009d38a1c999c0abc7d8700fa88533f1ad6087c5e";
+  src = fetchFromGitHub {
+    owner = "elastic";
+    repo = "elasticsearch-py";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-OjgfqEcKQH8ESvkcr2Ue2Q7KW2ykfrZccxm8kxzOClU=";
   };
 
-  # Check is disabled because running them destroy the content of the local cluster!
-  # https://github.com/elasticsearch/elasticsearch-py/tree/master/test_elasticsearch
-  doCheck = false;
-  propagatedBuildInputs = [ urllib3 requests ];
-  buildInputs = [ nosexcover mock ];
+  postPatch = ''
+    sed -i '/addopts/d' setup.cfg
+  '';
+
+  outputs = [
+    "out"
+    "doc"
+  ];
+
+  nativeBuildInputs = [
+    sphinx-rtd-theme
+    sphinxHook
+  ];
+
+  sphinxRoot = "docs/sphinx";
+
+  propagatedBuildInputs = [
+    elastic-transport
+  ];
+
+  passthru.optional-dependencies = {
+    async = [ aiohttp ];
+    requests = [ requests ];
+  };
+
+  checkInputs = [
+    numpy
+    pandas
+    pytest-asyncio
+    pytestCheckHook
+    python-dateutil
+    pyyaml
+  ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
 
   meta = with lib; {
+    changelog = "https://github.com/elastic/elasticsearch-py/releases/tag/v${version}";
     description = "Official low-level client for Elasticsearch";
     homepage = "https://github.com/elasticsearch/elasticsearch-py";
     license = licenses.asl20;
-    maintainers = with maintainers; [ desiderius ];
+    maintainers = with maintainers; [ ];
   };
 })

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2914,6 +2914,8 @@ in {
 
   elastic-apm = callPackage ../development/python-modules/elastic-apm { };
 
+  elastic-transport = callPackage ../development/python-modules/elastic-transport { };
+
   elasticsearch = callPackage ../development/python-modules/elasticsearch { };
 
   elasticsearch-dsl = callPackage ../development/python-modules/elasticsearch-dsl { };


### PR DESCRIPTION
###### Description of changes

Updating this package after #192268 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
