### PR TITLE
ImageMagick: Enable Pango when enabling librsvg

### DIFF
--- a/pkgs/applications/graphics/ImageMagick/default.nix
+++ b/pkgs/applications/graphics/ImageMagick/default.nix
@@ -18,7 +18,7 @@
 , libpngSupport ? true, libpng
 , liblqr1Support ? true, liblqr1
 , librawSupport ? true, libraw
-, librsvgSupport ? !stdenv.hostPlatform.isMinGW, librsvg
+, librsvgSupport ? !stdenv.hostPlatform.isMinGW, librsvg, pango
 , libtiffSupport ? true, libtiff
 , libxml2Support ? true, libxml2
 , openjpegSupport ? !stdenv.hostPlatform.isMinGW, openjpeg
@@ -64,6 +64,7 @@ stdenv.mkDerivation rec {
     "--with-frozenpaths"
     (lib.withFeatureAs (arch != null) "gcc-arch" arch)
     (lib.withFeature librsvgSupport "rsvg")
+    (lib.withFeature librsvgSupport "pango")
     (lib.withFeature liblqr1Support "lqr")
     (lib.withFeature libjxlSupport "jxl")
     (lib.withFeatureAs ghostscriptSupport "gs-font-dir" "${ghostscript}/share/ghostscript/fonts")
@@ -88,7 +89,10 @@ stdenv.mkDerivation rec {
     ++ lib.optional djvulibreSupport djvulibre
     ++ lib.optional libjxlSupport libjxl
     ++ lib.optional openexrSupport openexr
-    ++ lib.optional librsvgSupport librsvg
+    ++ lib.optionals librsvgSupport [
+      librsvg
+      pango
+    ]
     ++ lib.optional openjpegSupport openjpeg
     ++ lib.optionals stdenv.isDarwin [
       ApplicationServices


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Added `pango` to rundeps (Pango would be part of IM's closure anyway as it's required by librsvg) and passed `--with-pango`. This enables the niche [rich text markup](https://imagemagick.org/Usage/text/#pango_markup) feature.

~~I went to check if ImageMagick was working with this changeset, and it seemed to be, apart from the Pango integration :(
It prints~~
```
Fontconfig error: Cannot load default config file: No such file: (null)
Fontconfig error: No writable cache directories
Fontconfig error: No writable cache directories
Fontconfig error: No writable cache directories
Fontconfig error: No writable cache directories
```
~~though that may be because I'm on non-NixOS and don't have a Nix fontconfig installed. (Comparing this against the baseline of running the same `magick` invocation with IM installed from the Arch repos, which I got working earlier.) I've marked this PR as a draft until that's been debugged.~~ see below
edit: I've done the same as https://github.com/NixOS/nixpkgs/commit/f9943cd28a2520831f27aceadec598ef04b8019c / https://github.com/NixOS/nixpkgs/pull/172097/commits/8bb5266e2ad109a1f1087b0a45fc10ce36ed8ddd but it hasn't fixed the errors.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
