### PR TITLE
1password-gui: fix crash opening file selector

### DIFF
--- a/pkgs/applications/misc/1password-gui/beta.nix
+++ b/pkgs/applications/misc/1password-gui/beta.nix
@@ -2,6 +2,7 @@
 , stdenv
 , fetchurl
 , makeWrapper
+, wrapGAppsHook
 , alsa-lib
 , at-spi2-atk
 , at-spi2-core
@@ -58,11 +59,13 @@ in stdenv.mkDerivation rec {
         sha256 = "0vqrcwn5y350g91w3kh8n43gw21kck1cwim92dw9i0xxxch91hrg";
       };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper wrapGAppsHook ];
+  buildInputs = [ glib ];
 
   dontConfigure = true;
   dontBuild = true;
   dontPatchELF = true;
+  dontWrapGApps = true;
 
   installPhase =
     let rpath = lib.makeLibraryPath [
@@ -123,16 +126,20 @@ in stdenv.mkDerivation rec {
         patchelf --set-rpath ${rpath}:$out/share/1password $file
       done
 
-      # Electron is trying to open udev via dlopen()
-      # and for some reason that doesn't seem to be impacted from the rpath.
-      # Adding udev to LD_LIBRARY_PATH fixes that.
-      # Make xdg-open overrideable at runtime.
-      makeWrapper $out/share/1password/1password $out/bin/1password \
-        --suffix PATH : ${lib.makeBinPath [ xdg-utils ]} \
-        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ udev ]}
-
       runHook postInstall
     '';
+
+  preFixup = ''
+    # Electron is trying to open udev via dlopen()
+    # and for some reason that doesn't seem to be impacted from the rpath.
+    # Adding udev to LD_LIBRARY_PATH fixes that.
+    # Make xdg-open overrideable at runtime.
+    makeWrapper $out/share/1password/1password $out/bin/1password \
+      ''${gappsWrapperArgs[@]} \
+      --suffix PATH : ${lib.makeBinPath [ xdg-utils ]} \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ udev ]}
+  '';
+
 
   meta = with lib; {
     description = "Multi-platform password manager";

--- a/pkgs/applications/misc/1password-gui/default.nix
+++ b/pkgs/applications/misc/1password-gui/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , fetchurl
 , makeWrapper
+, wrapGAppsHook
 , alsa-lib
 , at-spi2-atk
 , at-spi2-core
@@ -58,11 +59,13 @@ in stdenv.mkDerivation rec {
         sha256 = "1rcvxxcz2q7kgf6qbcjnjhysnx9z81hvl0jfv0nkp0p1w8bf1h66";
       };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper wrapGAppsHook ];
+  buildInputs = [ glib ];
 
   dontConfigure = true;
   dontBuild = true;
   dontPatchELF = true;
+  dontWrapGApps = true;
 
   installPhase =
     let rpath = lib.makeLibraryPath [
@@ -123,16 +126,19 @@ in stdenv.mkDerivation rec {
         patchelf --set-rpath ${rpath}:$out/share/1password $file
       done
 
-      # Electron is trying to open udev via dlopen()
-      # and for some reason that doesn't seem to be impacted from the rpath.
-      # Adding udev to LD_LIBRARY_PATH fixes that.
-      # Make xdg-open overrideable at runtime.
-      makeWrapper $out/share/1password/1password $out/bin/1password \
-        --suffix PATH : ${lib.makeBinPath [ xdg-utils ]} \
-        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ udev ]}
-
       runHook postInstall
     '';
+
+  preFixup = ''
+    # Electron is trying to open udev via dlopen()
+    # and for some reason that doesn't seem to be impacted from the rpath.
+    # Adding udev to LD_LIBRARY_PATH fixes that.
+    # Make xdg-open overrideable at runtime.
+    makeWrapper $out/share/1password/1password $out/bin/1password \
+      ''${gappsWrapperArgs[@]} \
+      --suffix PATH : ${lib.makeBinPath [ xdg-utils ]} \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ udev ]}
+  '';
 
   meta = with lib; {
     description = "Multi-platform password manager";


### PR DESCRIPTION
###### Description of changes

Fixes #189429

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).