### PR TITLE
nixos/paperless: add required syscall

### DIFF
--- a/nixos/modules/services/misc/paperless.nix
+++ b/nixos/modules/services/misc/paperless.nix
@@ -80,7 +80,7 @@ let
     RestrictSUIDSGID = true;
     SupplementaryGroups = optional enableRedis redisServer.user;
     SystemCallArchitectures = "native";
-    SystemCallFilter = [ "@system-service" "~@privileged @resources @setuid @keyring" ];
+    SystemCallFilter = [ "@system-service" "~@privileged @setuid @keyring" ];
     # Does not work well with the temporary root
     #UMask = "0066";
   };


### PR DESCRIPTION
#### Copy of commit msg
`unpaper` requires syscall 238 (`set_mempolicy`).
Add this by un-blocking the systemd syscall filter set `@resources` which is safe in the context of paperless.

#### Things done
- [x] `nixosTests.paperless` succeeds on `x86_64-linux`