### PR TITLE
openai-whisper: init at unstable-2022-09-21

### DIFF
--- a/pkgs/development/python-modules/openai-whisper/default.nix
+++ b/pkgs/development/python-modules/openai-whisper/default.nix
@@ -1,0 +1,64 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+
+# propagates
+, numpy
+, torch
+, tqdm
+, more-itertools
+, transformers
+, ffmpeg-python
+
+# tests
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "whisper";
+  version = "unstable-2022-09-23";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "openai";
+    repo = pname;
+    rev = "8cf36f3508c9acd341a45eb2364239a3d81458b9";
+    hash = "sha256-2RH8eM/SezqFJltelv5AjQEGpqXm980u57vrlkTEUvQ=";
+  };
+
+  postPatch = ''
+    # Rely on the ffmpeg path already patched into the ffmpeg-python library
+    substituteInPlace whisper/audio.py \
+      --replace 'run(cmd="ffmpeg",' 'run('
+  '';
+
+  propagatedBuildInputs = [
+    numpy
+    torch
+    tqdm
+    more-itertools
+    transformers
+    ffmpeg-python
+  ];
+
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # requires network access to download models
+    "test_transcribe"
+  ];
+
+  meta = with lib; {
+    description = "General-purpose speech recognition model";
+    homepage = "https://github.com/openai/whisper";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hexa ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16986,6 +16986,8 @@ with pkgs;
 
   openai = with python3Packages; toPythonApplication openai;
 
+  openai-whisper = with python3.pkgs; toPythonApplication openai-whisper;
+
   opengrok = callPackage ../development/tools/misc/opengrok { };
 
   openocd = callPackage ../development/embedded/openocd { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6378,6 +6378,8 @@ in {
 
   open-meteo = callPackage ../development/python-modules/open-meteo { };
 
+  openai-whisper = callPackage ../development/python-modules/openai-whisper { };
+
   openant = callPackage ../development/python-modules/openant { };
 
   openapi-schema-validator = callPackage ../development/python-modules/openapi-schema-validator { };


### PR DESCRIPTION
###### Description of changes

New-fangled speech recognition model. Naming collision with the biology tool whisper. I'm not yet sure whether I want to maintain this. Up until now it is just a code dump.

Fixes #192386 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
