### PR TITLE
nixos/oauth2_proxy_nginx: re-do virtualHosts option

### DIFF
--- a/nixos/modules/services/security/oauth2_proxy_nginx.nix
+++ b/nixos/modules/services/security/oauth2_proxy_nginx.nix
@@ -4,6 +4,11 @@ let
   cfg = config.services.oauth2_proxy.nginx;
 in
 {
+  imports = [
+    (mkRemovedOptionModule [ "services" "oauth2_proxy" "nginx" "virtualHosts" ]
+      "This option has been removed in favor of 'services.oauth2_proxy.nginx.virtualHostLocations' which allows setting the proxy protection at a per-location level.")
+  ];
+
   options.services.oauth2_proxy.nginx = {
     proxy = mkOption {
       type = types.str;
@@ -13,54 +18,66 @@ in
         The address of the reverse proxy endpoint for oauth2_proxy
       '';
     };
-    virtualHosts = mkOption {
-      type = types.listOf types.str;
-      default = [];
-      description = lib.mdDoc ''
-        A list of nginx virtual hosts to put behind the oauth2 proxy
+    virtualHostLocations = mkOption {
+      type = types.attrsOf (types.listOf types.str);
+      example = literalExpression ''
+        {
+          "example.com" = [ "/" "/assets/" ];
+        };
       '';
+      default = { };
+      description = lib.mdDoc "List of locations per virtual host to put behind the oauth2_proxy";
     };
   };
-  config.services.oauth2_proxy = mkIf (cfg.virtualHosts != [] && (hasPrefix "127.0.0.1:" cfg.proxy)) {
-    enable = true;
-  };
-  config.services.nginx = mkIf config.services.oauth2_proxy.enable (mkMerge
-  ((optional (cfg.virtualHosts != []) {
-    recommendedProxySettings = true; # needed because duplicate headers
-  }) ++ (map (vhost: {
-    virtualHosts.${vhost} = {
-      locations."/oauth2/" = {
-        proxyPass = cfg.proxy;
-        extraConfig = ''
-          proxy_set_header X-Scheme                $scheme;
-          proxy_set_header X-Auth-Request-Redirect $scheme://$host$request_uri;
-        '';
-      };
-      locations."/oauth2/auth" = {
-        proxyPass = cfg.proxy;
-        extraConfig = ''
-          proxy_set_header X-Scheme         $scheme;
-          # nginx auth_request includes headers but not body
-          proxy_set_header Content-Length   "";
-          proxy_pass_request_body           off;
-        '';
-      };
-      locations."/".extraConfig = ''
-        auth_request /oauth2/auth;
-        error_page 401 = /oauth2/sign_in;
+  config = {
+    assertions = [{
+      assertion = !lib.any (loc: lib.elem loc (flatten (lib.attrValues cfg.virtualHostLocations))) [ "/oauth2/" "/oauth2/auth" ];
+      message = "services.oauth2_proxy.nginx.virtualHostLocations: The OAuth2 specific locations cannot be protected.";
+    }];
 
-        # pass information via X-User and X-Email headers to backend,
-        # requires running with --set-xauthrequest flag
-        auth_request_set $user   $upstream_http_x_auth_request_user;
-        auth_request_set $email  $upstream_http_x_auth_request_email;
-        proxy_set_header X-User  $user;
-        proxy_set_header X-Email $email;
+    services.nginx = mkIf (cfg.virtualHostLocations != { }) {
+      recommendedProxySettings = true; # needed because duplicate headers
+      virtualHosts = lib.mapAttrs
+        (vhost: locations: mkMerge [
+          {
+            locations."/oauth2/" = {
+              proxyPass = cfg.proxy;
+              extraConfig = ''
+                proxy_set_header X-Scheme                $scheme;
+                proxy_set_header X-Auth-Request-Redirect $scheme://$host$request_uri;
+              '';
+            };
+            locations."/oauth2/auth" = {
+              proxyPass = cfg.proxy;
+              extraConfig = ''
+                proxy_set_header X-Scheme         $scheme;
+                # nginx auth_request includes headers but not body
+                proxy_set_header Content-Length   "";
+                proxy_pass_request_body           off;
+              '';
+            };
+          }
+          {
+            locations = genAttrs locations (_: {
+              extraConfig = ''
+                auth_request /oauth2/auth;
+                error_page 401 = /oauth2/sign_in;
 
-        # if you enabled --cookie-refresh, this is needed for it to work with auth_request
-        auth_request_set $auth_cookie $upstream_http_set_cookie;
-        add_header Set-Cookie $auth_cookie;
-      '';
+                # pass information via X-User and X-Email headers to backend,
+                # requires running with --set-xauthrequest flag
+                auth_request_set $user   $upstream_http_x_auth_request_user;
+                auth_request_set $email  $upstream_http_x_auth_request_email;
+                proxy_set_header X-User  $user;
+                proxy_set_header X-Email $email;
 
+                # if you enabled --cookie-refresh, this is needed for it to work with auth_request
+                auth_request_set $auth_cookie $upstream_http_set_cookie;
+                add_header Set-Cookie $auth_cookie;
+              '';
+            });
+          }
+        ])
+        cfg.virtualHostLocations;
     };
-  }) cfg.virtualHosts)));
+  };
 }


### PR DESCRIPTION
###### Description of changes

It is now possible to list all the webroot (per vhost) locations you want to be protected behind the OAuth2 proxy.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
