### PR TITLE
unigine-valley,unigine-tropics,unigine-sanctuary: fix source url and hash

### DIFF
--- a/pkgs/applications/graphics/unigine-sanctuary/default.nix
+++ b/pkgs/applications/graphics/unigine-sanctuary/default.nix
@@ -20,8 +20,8 @@ stdenv.mkDerivation rec{
   version = "2.3";
 
   src = fetchurl {
-    url = "https://m12-assets.unigine.com/d/Unigine_Sanctuary-${version}.run";
-    sha256 = "1m9r79q33hx213zg3c2kknnc7hi8jp2h88s9qynny4k4rg8vpa18";
+    url = "https://assets.unigine.com/d/Unigine_Sanctuary-${version}.run";
+    sha256 = "sha256-KKi70ctkEm+tx0kjBMWVKMLDrJ1TsPH+CKLDMXA6OdU=";
   };
 
   libPath = lib.makeLibraryPath [
@@ -94,5 +94,6 @@ stdenv.mkDerivation rec{
     license = lib.licenses.unfree;
     maintainers = [ lib.maintainers.BarinovMaxim ];
     platforms = [ "x86_64-linux" "i686-linux" ];
+    mainProgram = "Sanctuary";
   };
 }

--- a/pkgs/applications/graphics/unigine-tropics/default.nix
+++ b/pkgs/applications/graphics/unigine-tropics/default.nix
@@ -22,8 +22,8 @@ stdenv.mkDerivation {
   inherit version;
 
   src = fetchurl {
-    url = "http://m12-assets.unigine.com/d/Unigine_Tropics-${version}.run";
-    sha256 = "0icasdp46fjnic7gk83pknjx0gpap9j202dm0llcfg5zin5kbq7x";
+    url = "https://assets.unigine.com/d/Unigine_Tropics-${version}.run";
+    sha256 = "sha256-/eA1i42/PMcoBbUJIGS66j7QpZ13oPkOi1Y6Q27TikU=";
   };
 
   libPath = lib.makeLibraryPath [
@@ -92,5 +92,6 @@ stdenv.mkDerivation {
     license = lib.licenses.unfree;
     maintainers = [ lib.maintainers.BarinovMaxim ];
     platforms = [ "x86_64-linux" "i686-linux" ];
+    mainProgram = "Tropics";
   };
 }

--- a/pkgs/applications/graphics/unigine-valley/default.nix
+++ b/pkgs/applications/graphics/unigine-valley/default.nix
@@ -38,8 +38,8 @@ stdenv.mkDerivation rec {
   inherit version;
 
   src = fetchurl {
-    url = "https://m11-assets.unigine.com/d/Unigine_Valley-${version}.run";
-    sha256 = "5f0c8bd2431118551182babbf5f1c20fb14e7a40789697240dcaf546443660f4";
+    url = "https://assets.unigine.com/d/Unigine_Valley-${version}.run";
+    sha256 = "sha256-XwyL0kMRGFURgrq79fHCD7FOekB4lpckDcr1RkQ2YPQ=";
   };
 
   sourceRoot = "Unigine_Valley-${version}";
@@ -132,6 +132,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.unfree; # see also: $out/$instPath/documentation/License.pdf
     maintainers = [ lib.maintainers.kierdavis ];
     platforms = [ "x86_64-linux" "i686-linux" ];
+    mainProgram = "valley";
   };
 }
 


### PR DESCRIPTION
unigine-valley,unigine-tropics,unigine-sanctuary
* Fix source url/hash
* Added mainProgram

Currently:
* unigine-sanctuary fails to download at master
* unigine-tropics fails to download at master
* unigine-valley would eventually fail too (fixing in advance)