### PR TITLE
skip builds on manual download for several packages

### DIFF
--- a/pkgs/applications/misc/kdbplus/default.nix
+++ b/pkgs/applications/misc/kdbplus/default.nix
@@ -72,5 +72,6 @@ stdenv.mkDerivation rec {
     license     = lib.licenses.unfree;
     platforms   = [ "i686-linux" ];
     maintainers = [ lib.maintainers.thoughtpolice ];
+    hydraPlatforms = [];
   };
 }

--- a/pkgs/applications/networking/cisco-packet-tracer/7.nix
+++ b/pkgs/applications/networking/cisco-packet-tracer/7.nix
@@ -87,5 +87,6 @@ in stdenv.mkDerivation {
     license = licenses.unfree;
     maintainers = with maintainers; [ lucasew ];
     platforms = [ "x86_64-linux" ];
+    hydraPlatforms = [];
   };
 }

--- a/pkgs/applications/networking/cisco-packet-tracer/8.nix
+++ b/pkgs/applications/networking/cisco-packet-tracer/8.nix
@@ -130,5 +130,6 @@ stdenv.mkDerivation {
     license = licenses.unfree;
     maintainers = with maintainers; [ lucasew ];
     platforms = [ "x86_64-linux" ];
+    hydraPlatforms = [];
   };
 }

--- a/pkgs/applications/networking/remote/citrix-workspace/generic.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/generic.nix
@@ -210,5 +210,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     maintainers = with maintainers; [ pmenke michaeladler ];
     inherit homepage;
+    hydraPlatforms = [];
   };
 }

--- a/pkgs/applications/office/ib/tws/default.nix
+++ b/pkgs/applications/office/ib/tws/default.nix
@@ -93,5 +93,6 @@ stdenv.mkDerivation rec {
     license = licenses.unfree;
     maintainers = [ ];
     platforms = platforms.linux;
+    hydraPlatforms = [];
   };
 }

--- a/pkgs/applications/science/math/mathematica/default.nix
+++ b/pkgs/applications/science/math/mathematica/default.nix
@@ -50,5 +50,6 @@ callPackage real-drv {
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     maintainers = with maintainers; [ herberteuler ];
     platforms = [ "x86_64-linux" ];
+    hydraPlatforms = [];
   };
 }

--- a/pkgs/applications/science/math/wolfram-engine/default.nix
+++ b/pkgs/applications/science/math/wolfram-engine/default.nix
@@ -144,5 +144,6 @@ stdenv.mkDerivation rec {
     license = licenses.unfree;
     maintainers = with maintainers; [ fbeffa ];
     platforms = [ "x86_64-linux" ];
+    hydraPlatforms = [];
   };
 }

--- a/pkgs/development/compilers/javacard-devkit/default.nix
+++ b/pkgs/development/compilers/javacard-devkit/default.nix
@@ -66,5 +66,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.unfree;
     maintainers = [ lib.maintainers.ekleog ];
     platforms = [ "i686-linux" "x86_64-linux" ];
+    hydraPlatforms = [];
   };
 }

--- a/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
@@ -185,6 +185,7 @@ let result = stdenv.mkDerivation rec {
     license = licenses.unfree;
     platforms = [ "i686-linux" "x86_64-linux" "armv7l-linux" "aarch64-linux" ]; # some inherit jre.meta.platforms
     mainProgram = "java";
+    hydraPlatforms = [];
   };
 
 }; in result

--- a/pkgs/development/embedded/fpga/lattice-diamond/default.nix
+++ b/pkgs/development/embedded/fpga/lattice-diamond/default.nix
@@ -113,5 +113,6 @@ stdenv.mkDerivation {
     license = lib.licenses.unfree;
     maintainers = with lib.maintainers; [ q3k ];
     platforms = [ "x86_64-linux" ];
+    hydraPlatforms = [];
   };
 }

--- a/pkgs/development/libraries/science/math/tensorrt/generic.nix
+++ b/pkgs/development/libraries/science/math/tensorrt/generic.nix
@@ -86,5 +86,6 @@ stdenv.mkDerivation rec {
     license = licenses.unfree;
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ aidalgol ];
+    hydraPlatforms = [];
   };
 }

--- a/pkgs/development/libraries/wtk/default.nix
+++ b/pkgs/development/libraries/wtk/default.nix
@@ -23,5 +23,6 @@ stdenv.mkDerivation rec {
     description = "Sun Java Wireless Toolkit 2.5.2_01 for CLDC";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
+    hydraPlatforms = [];
   };
 }

--- a/pkgs/development/tools/analysis/cov-build/default.nix
+++ b/pkgs/development/tools/analysis/cov-build/default.nix
@@ -44,5 +44,6 @@ stdenv.mkDerivation rec {
     license     = lib.licenses.unfreeRedistributable;
     platforms   = lib.platforms.linux;
     maintainers = [ lib.maintainers.thoughtpolice ];
+    hydraPlatforms = [];
   };
 }

--- a/pkgs/development/tools/database/sqldeveloper/default.nix
+++ b/pkgs/development/tools/database/sqldeveloper/default.nix
@@ -80,5 +80,6 @@ in
     license = licenses.unfree;
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ ardumont ];
+    hydraPlatforms = [];
   };
 }

--- a/pkgs/development/tools/iaca/2.1.nix
+++ b/pkgs/development/tools/iaca/2.1.nix
@@ -31,5 +31,6 @@ stdenv.mkDerivation rec {
     license = licenses.unfree;
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ kazcw ];
+    hydraPlatforms = [];
   };
 }

--- a/pkgs/development/tools/iaca/3.0.nix
+++ b/pkgs/development/tools/iaca/3.0.nix
@@ -22,5 +22,6 @@ stdenv.mkDerivation rec {
     license = licenses.unfree;
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ kazcw ];
+    hydraPlatforms = [];
   };
 }

--- a/pkgs/games/everspace/default.nix
+++ b/pkgs/games/everspace/default.nix
@@ -114,5 +114,6 @@ stdenv.mkDerivation rec {
     license = licenses.unfree;
     maintainers = with maintainers; [ jtrees ];
     platforms = [ "x86_64-linux" ];
+    hydraPlatforms = [];
   };
 }

--- a/pkgs/games/koboredux/default.nix
+++ b/pkgs/games/koboredux/default.nix
@@ -82,6 +82,7 @@ stdenv.mkDerivation rec {
     license = with licenses; if useProprietaryAssets then unfree else gpl2;
     platforms = platforms.all;
     maintainers = with maintainers; [ fgaz ];
+    hydraPlatforms = [];
   };
 }
 

--- a/pkgs/games/planetaryannihilation/default.nix
+++ b/pkgs/games/planetaryannihilation/default.nix
@@ -38,5 +38,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.unfree;
     platforms = platforms.linux;
     maintainers = [ maintainers.domenkozar ];
+    hydraPlatforms = [];
   };
 }

--- a/pkgs/games/sm64ex/generic.nix
+++ b/pkgs/games/sm64ex/generic.nix
@@ -79,5 +79,6 @@ stdenv.mkDerivation rec {
     license = licenses.unfree;
     maintainers = with maintainers; [ ivar ];
     platforms = platforms.unix;
+    hydraPlatforms = [];
   } // extraMeta;
 }

--- a/pkgs/games/ue4/default.nix
+++ b/pkgs/games/ue4/default.nix
@@ -77,6 +77,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.unfree;
     platforms = lib.platforms.linux;
     maintainers = [ ];
+    hydraPlatforms = [];
     # See issue https://github.com/NixOS/nixpkgs/issues/17162
     broken = true;
   };

--- a/pkgs/games/vessel/default.nix
+++ b/pkgs/games/vessel/default.nix
@@ -79,6 +79,7 @@ stdenv.mkDerivation rec {
     homepage = "http://www.strangeloopgames.com";
     license = licenses.unfree;
     maintainers = with maintainers; [ jcumming ];
+    hydraPlatforms = [];
   };
 
 }

--- a/pkgs/games/worldofgoo/default.nix
+++ b/pkgs/games/worldofgoo/default.nix
@@ -71,5 +71,6 @@ stdenv.mkDerivation rec {
     license = licenses.unfree;
     platforms = [ "i686-linux" "x86_64-linux" ];
     maintainers = with maintainers; [ jcumming maxeaubrey ];
+    hydraPlatforms = [];
   };
 }

--- a/pkgs/os-specific/linux/kinect-audio-setup/default.nix
+++ b/pkgs/os-specific/linux/kinect-audio-setup/default.nix
@@ -87,5 +87,6 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ berbiche ];
     platforms = platforms.linux;
     license = licenses.unfree;
+    hydraPlatforms = [];
   };
 }

--- a/pkgs/tools/graphics/snapdragon-profiler/default.nix
+++ b/pkgs/tools/graphics/snapdragon-profiler/default.nix
@@ -85,5 +85,6 @@ stdenv.mkDerivation rec {
     license = licenses.unfree;
     maintainers = [ maintainers.ivar ];
     platforms = [ "x86_64-linux" ];
+    hydraPlatforms = [];
   };
 }


### PR DESCRIPTION
Goal is to avoid this (for all versions of every package on list):
  ![image](https://user-images.githubusercontent.com/5861043/191822960-3754f3ba-a860-412b-9379-8c1c08485f15.png)

Notice how many of these packages are listed in large builds: 
* https://github.com/NixOS/nixpkgs/pull/192233#issuecomment-1255694474

---

Pending:
* **Confirm setting hydraPlatforms to `[]` has intended effect in nixpkgs-review results.**
  * Some conflicting listings of packages that have hydraPlatforms set has been [observed](https://github.com/NixOS/nixpkgs/pull/192233#issuecomment-1255694474) in nixpkgs-review results. Such as: `obs-ndi`, `pixinsight`
      * Is setting hydraPlatforms a faulty solution to trying to hide manual builds from results?
        * @Mic92 Thoughts?
          * https://github.com/Mic92/nixpkgs-review/issues/63

superherointj:
> I seek advice on how to solve requireFile noise issue in nixpkgs-review results.
> I naively thought that by setting meta.hydraPlatforms to [] for each package would solve issue, but I'm uncertain of that behavior. (if you could confirm that would be nice.)

Mic92:
> That's a tricky one
> Because it's not the derivation itself that fails but any dependency to that.
> I think what could work is to mark requireFile by something as broken
> So that eval would fail of this.
> I think ofborg could even do this so it does not even show up in the eval cache

---

Skip builds (at hydra/nixpkgs-review) on manual download for:

* cisco-packet-tracer
* citrix-workspace
* cov-build
* everspace
* fpga/lattice-diamond
* iaca
* ib-tws
* javacard-devkit
* kdbplus
* kinect-audio-setup
* koboredux
* mathematica
* oraclejdk
* planetaryannihilation
* sm64ex
* snapdragon-profiler
* sqldeveloper
* tensorrt
* ue4
* vessel
* wolfram-engine
* worldofgoo
* wtk

Pending:
* airwave requires `vstsdk368_08_11_2017_build_121.zip`
* ib-controller

Notes:

* Would be great if we could automatically skip builds at hydra/nixpkgs-review when requireFile is used.
  * But I don't have a solution for that. Maybe @Mic92 ?

* In case the effectiveness of setting `hydraPlatforms = [];` is confirmed:
  * Ideally the procedure of adding hydraPlatforms when `requireFile` is used should be documented.
    * But this PR is just disabling hydra builds for a list of packages.

* Related:
  * https://github.com/Mic92/nixpkgs-review/issues/138
  * https://github.com/Mic92/nixpkgs-review/issues/63