### PR TITLE
plantuml-c4: init at unstable-2022-08-21

### DIFF
--- a/pkgs/tools/misc/plantuml/plantuml-c4.nix
+++ b/pkgs/tools/misc/plantuml/plantuml-c4.nix
@@ -16,12 +16,17 @@ let
     sha256 = "sha256-vk4YWdGb47OsI9mApGTQ7OfELRZdBouzKfUZq3kchcM=";
   };
 
+  sprites = fetchzip {
+    url = "https://github.com/tupadr3/plantuml-icon-font-sprites/archive/fa3f885dbd45c9cd0cdf6c0e5e4fb51ec8b76582.zip";
+    sha256 = "sha256-lt9+NNMIaZSkKNsGyHoqXUCTlKmZFGfNYYGjer6X0Xc=";
+  };
+
   # In order to pre-fix the plantuml.jar parameter with the argument
   # -Dplantuml.include.path=..., we post-fix the java command using a wrapper.
   # This way the plantuml derivation can remain unchanged.
   plantumlWithExtraPath =
     let
-      plantumlIncludePath = lib.concatStringsSep ":" [ c4-lib ];
+      plantumlIncludePath = lib.concatStringsSep ":" [ c4-lib sprites ];
       includeFlag = "-Dplantuml.include.path=${lib.escapeShellArg plantumlIncludePath}";
       postFixedJre =
         runCommand "jre-postfixed" { nativeBuildInputs = [ makeWrapper ]; } ''
@@ -53,10 +58,13 @@ stdenv.mkDerivation rec {
     runCommand "c4-plantuml-sample.png" { nativeBuildInputs = [ plantuml-c4 ]; } ''
       sed 's/https:.*\///' "${c4-lib}/samples/C4_Context Diagram Sample - enterprise.puml" > sample.puml
       plantuml sample.puml -o $out
+
+      sed 's/!include ..\//!include /' ${sprites}/examples/complex-example.puml > sprites.puml
+      plantuml sprites.puml -o $out
     '';
 
   meta = with lib; {
-    description = "PlantUML bundled with C4-Plantuml library";
+    description = "PlantUML bundled with C4-Plantuml and plantuml sprites library";
     homepage = "https://github.com/plantuml-stdlib/C4-PlantUML";
     license = licenses.mit;
     maintainers = with maintainers; [ tfc ];

--- a/pkgs/tools/misc/plantuml/plantuml-c4.nix
+++ b/pkgs/tools/misc/plantuml/plantuml-c4.nix
@@ -1,0 +1,65 @@
+{ lib, stdenv, makeWrapper, fetchzip, runCommand, plantuml, plantuml-c4, jre }:
+
+# The C4-PlantUML docs say that it suffices to run plantuml with the
+# -DRELATIVE_INCLUDE="..." arg to make plantuml find the C4 templates
+# when included like "!include C4_Container.puml".
+# Unfortunately, this is not sufficient in practise, when the path is not ".".
+# What helps is setting -Dplantuml.include.path="..." *before* the jar
+# parameter.
+# The -DRELATIVE_INCLUDE param then *still* needs to be set (*after* the jar
+# argument), because the C4 template vars check for existence of this variable
+# and if it is not set, reference paths in the internet.
+
+let
+  c4-lib = fetchzip {
+    url = "https://github.com/plantuml-stdlib/C4-PlantUML/archive/88a3f99150c6ff7953c4a99b184d03412ffdedb1.zip";
+    sha256 = "sha256-vk4YWdGb47OsI9mApGTQ7OfELRZdBouzKfUZq3kchcM=";
+  };
+
+  # In order to pre-fix the plantuml.jar parameter with the argument
+  # -Dplantuml.include.path=..., we post-fix the java command using a wrapper.
+  # This way the plantuml derivation can remain unchanged.
+  plantumlWithExtraPath =
+    let
+      plantumlIncludePath = lib.concatStringsSep ":" [ c4-lib ];
+      includeFlag = "-Dplantuml.include.path=${lib.escapeShellArg plantumlIncludePath}";
+      postFixedJre =
+        runCommand "jre-postfixed" { nativeBuildInputs = [ makeWrapper ]; } ''
+          mkdir -p $out/bin
+
+          makeWrapper ${jre}/bin/java $out/bin/java \
+            --add-flags ${lib.escapeShellArg includeFlag}
+        '';
+    in
+    plantuml.override { jre = postFixedJre; };
+in
+
+stdenv.mkDerivation rec {
+  pname = "plantuml-c4";
+  version = "unstable-2022-08-21";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildCommand = ''
+    mkdir -p $out/bin
+
+    makeWrapper ${plantumlWithExtraPath}/bin/plantuml $out/bin/plantuml \
+      --add-flags "-DRELATIVE_INCLUDE=\"${c4-lib}\""
+
+    $out/bin/plantuml -help
+  '';
+
+  passthru.tests.example-c4-diagram =
+    runCommand "c4-plantuml-sample.png" { nativeBuildInputs = [ plantuml-c4 ]; } ''
+      sed 's/https:.*\///' "${c4-lib}/samples/C4_Context Diagram Sample - enterprise.puml" > sample.puml
+      plantuml sample.puml -o $out
+    '';
+
+  meta = with lib; {
+    description = "PlantUML bundled with C4-Plantuml library";
+    homepage = "https://github.com/plantuml-stdlib/C4-PlantUML";
+    license = licenses.mit;
+    maintainers = with maintainers; [ tfc ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10074,6 +10074,8 @@ with pkgs;
 
   plantuml = callPackage ../tools/misc/plantuml { };
 
+  plantuml-c4 = callPackage ../tools/misc/plantuml/plantuml-c4.nix { };
+
   plantuml-server = callPackage ../tools/misc/plantuml-server { };
 
   plan9port = callPackage ../tools/system/plan9port {


### PR DESCRIPTION
###### Description of changes

There is a nice inofficial plantuml library for generating C4 software architecture diagrams.
This PR creates a new package `plantuml-c4` that bundles `plantuml` with this library. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
