### PR TITLE
unpaper: 6.1 -> 7.0.0

### DIFF
--- a/pkgs/applications/graphics/gscan2pdf/default.nix
+++ b/pkgs/applications/graphics/gscan2pdf/default.nix
@@ -10,12 +10,16 @@ with lib;
 
 perlPackages.buildPerlPackage rec {
   pname = "gscan2pdf";
-  version = "2.12.6";
+  version = "2.12.8";
 
   src = fetchurl {
     url = "mirror://sourceforge/gscan2pdf/gscan2pdf-${version}.tar.xz";
-    sha256 = "sha256-9ntpUEM3buT3EhneXz9G8bibvzOnEK6Xt0jJcTvLKT0=";
+    hash = "sha256-dmN2fMBDZqgvdHQryQgjmBHeH/h2dihRH8LkflFYzTk=";
   };
+
+  patches = [
+    ./ffmpeg5-compat.patch
+  ];
 
   nativeBuildInputs = [ wrapGAppsHook ];
 

--- a/pkgs/applications/graphics/gscan2pdf/ffmpeg5-compat.patch
+++ b/pkgs/applications/graphics/gscan2pdf/ffmpeg5-compat.patch
@@ -1,0 +1,15 @@
+--- a/t/351_unpaper.t
++++ b/t/351_unpaper.t
+@@ -88,8 +88,10 @@
+ 
+                         # if we use unlike, we no longer
+                         # know how many tests there will be
+-                        if ( $msg !~
+-/(deprecated|Encoder did not produce proper pts, making some up)/
++                        if ( $msg !~ /( deprecated |
++                            \Qdoes not contain an image sequence pattern\E |
++                            \QEncoder did not produce proper pts, making some up\E |
++                            \Quse the -update option\E )/x
+                           )
+                         {
+                             fail 'no warnings';

--- a/pkgs/tools/graphics/unpaper/default.nix
+++ b/pkgs/tools/graphics/unpaper/default.nix
@@ -1,16 +1,52 @@
-{ lib, stdenv, fetchurl, buildPackages, pkg-config, ffmpeg_4 }:
+{ lib
+, stdenv
+, fetchurl
+
+# build
+, meson
+, ninja
+, pkg-config
+
+# docs
+, sphinx
+
+# runtime
+, buildPackages
+, ffmpeg_5
+
+# tests
+, nixosTests
+}:
 
 stdenv.mkDerivation rec {
   pname = "unpaper";
-  version = "6.1";
+  version = "7.0.0";
 
   src = fetchurl {
     url = "https://www.flameeyes.eu/files/${pname}-${version}.tar.xz";
-    sha256 = "0c5rbkxbmy9k8vxjh4cv0bgnqd3wqc99yzw215vkyjslvbsq8z13";
+    hash = "sha256-JXX7vybCJxnRy4grWWAsmQDH90cRisEwiD9jQZvkaoA=";
   };
 
-  nativeBuildInputs = [ pkg-config buildPackages.libxslt.bin ];
-  buildInputs = [ ffmpeg_4 ];
+  outputs = [
+    "out"
+    "man"
+  ];
+
+  nativeBuildInputs = [
+    buildPackages.libxslt.bin
+    meson
+    ninja
+    pkg-config
+    sphinx
+  ];
+
+  buildInputs = [
+    ffmpeg_5
+  ];
+
+  passthru.tests = {
+    inherit (nixosTests) paperless;
+  };
 
   meta = with lib; {
     homepage = "https://www.flameeyes.eu/projects/unpaper";


### PR DESCRIPTION
Migrates the build to meson and ninja and adds support for ffmpeg 5.

The package now creates a man page that we divert into a dedicated man output.

Adds the paperless test into passthru.tests for good measure.

###### Description of changes

Moved out of #192249 because this changes breaks gscan2pdf and it makes the other pr less controversial.


https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1020458


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
