### PR TITLE
firefox{,-bin}-unwrapped: 105.0 -> 105.0.1; also firefox-{beta,devedition}-bin-unwrapped updates

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
@@ -1,985 +1,985 @@
 {
-  version = "105.0b9";
+  version = "106.0b2";
   sources = [
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/ach/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/ach/firefox-106.0b2.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "79770ceaeba02d97cb15d371df933bbf4945d8c41f13b4fa9d9b4f71cc342a98";
+      sha256 = "e6751881f8fb534d18de09f0dd9fd55f32e15d8cb9f71bdd46477967fcc07676";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/af/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/af/firefox-106.0b2.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "64828c77cdc223eb2da7257f9b606bedf542295ad1c0d3eda6b689cfb93d7726";
+      sha256 = "463d7b34617a2e0b52c26287ce45e359023ebb7c0ba232cf88e6ff8ecca56702";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/an/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/an/firefox-106.0b2.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "ff9ffea76d0d00fe13cc98550611075cb191c8bec8859c06ab289dba60af0a08";
+      sha256 = "e5cf072404e62873d1210fd5794e2f0415196a7761327812f540962579e8030f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/ar/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/ar/firefox-106.0b2.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "87483cf7a378d9921398e45f1b47e0f700786232de95575da2ae2b7b514d7489";
+      sha256 = "bb4c6ee1cf3beeead17a02e1449ee698f4e88bdc07016abe0338a9491dc13c3d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/ast/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/ast/firefox-106.0b2.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "f401f8e17804b705fdb24e046d746fec1e6686c2dae3dabd65ad5d4550753a63";
+      sha256 = "cb22952c1f11d918beb6e454ff8254a5a751cf8732649102d4d66ab209e12f9e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/az/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/az/firefox-106.0b2.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "fd869f8fb79ae4b4ef896c04c12ea811c7801354b0726d6d9bdc2c0651058ef8";
+      sha256 = "5515d457b294c6007af3c3756e0fe5557850e297fb5b203cd7955d073b2e879a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/be/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/be/firefox-106.0b2.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "46c1dc6f236a6b093c5700fbb16c2928fd1b9076809dada1646f633722d5accb";
+      sha256 = "dd85a5c0dc4bf029f73e16cfd34a18ef3a32f02d240958875c4dbb926f4d96bb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/bg/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/bg/firefox-106.0b2.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "b4bebc53162139f6c3c6705d6f67d180cb5325d4295e0258730b8da2dd4312d6";
+      sha256 = "b6c97985d0809d885c9d27a02ef6bb221820547fd5482c65052db9a43d2bdbe3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/bn/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/bn/firefox-106.0b2.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "ecb0aded7ad67330abbc7d82ae1fcfea9f2dd2b36464423223838e8ab5274108";
+      sha256 = "0bede38ac8a350d78b79e92ad6eb5dd6fd8ac7ba66700eab3af5fabc8fd3d2a0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/br/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/br/firefox-106.0b2.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "8be66ca9b85502156cf99ffb05106ac8af68dadae342e03414548a3b3a6f1410";
+      sha256 = "86e0082310d924cb6e18022ae834845ee30ec27b3f2e1eef6622f387c4791bf9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/bs/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/bs/firefox-106.0b2.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "3c96e1ac621374fbc36cf8a62ad75b705cfb7a98d3e5f477ad8d2f65886139a5";
+      sha256 = "c4ec174eb04b3dc336cd6d242d102330435d1bc346ccc96979bf943266d9c7ea";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/ca-valencia/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/ca-valencia/firefox-106.0b2.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "b7a7aa8b0c6eb8356b8d43a5442a2230d573ddf43def3e6199b4c5b30f1d7d1c";
+      sha256 = "d3c174eeba1669137a9b03835d47a574a345d6c2cc1b798da7303cbdc21ab160";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/ca/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/ca/firefox-106.0b2.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "2499dcf4f9c0f430b9aeb53d395c0958a70cb1c80550bf9770d3020d6212b661";
+      sha256 = "82b75c880883c8f4d11b3aa2025b9d5c984ac26564c44341831f212a3fd4c11e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/cak/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/cak/firefox-106.0b2.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "0a3e7a8163b7738ff36e5a66e607234d251d693f56ad1b018891b0fad0b213cc";
+      sha256 = "5f9aa0adc8e0e9e52aed15de2d1b2e6c0bedfbf768978237dd7ae1593c8fe00b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/cs/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/cs/firefox-106.0b2.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "8c7e43f8d6e5cad2454b07008db7437959219c0e0b09797d7d99509c0dca7b83";
+      sha256 = "2d3236d64606abe39927419e9c1161d2fc8fe02665ec0c11447aa5983e1be271";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/cy/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/cy/firefox-106.0b2.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "3072f2cb496dc65c09d2b38fe99622dedf28cdac6140e93128f4bfdb8efd2a60";
+      sha256 = "fb06a45f366ac0aca6cc8c5fd58b6f0d7ac4c5a816bed61616d2aac1e1323dba";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/da/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/da/firefox-106.0b2.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "3bf824ae1891e81ee1354f04b27166c232967451fa09278b7cbc32ba188f06ca";
+      sha256 = "bcbdd457d0f90cee062b65628fde19db4b435ba55e431b345d050a20030dd354";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/de/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/de/firefox-106.0b2.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "60bc38dcb4a09819fd707ff97f99472bcf81d5210cc015ba90f68535fbc137fc";
+      sha256 = "3acb7217b01918c766a9e752acb30b5750d74dba6ae693807aca1ed14c989b6e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/dsb/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/dsb/firefox-106.0b2.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "4ae1090c039da3dbf719b60656979a711c5d51aa6f379c1675f8dca9aeacd832";
+      sha256 = "2c818572f2da44e386618b60bb579b3cbbf905003e47d7eb01e1393ff03ea8ae";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/el/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/el/firefox-106.0b2.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "bfb169c8f9be4f5d0d0426e1cb5da5ded616d8e1bdd5a6aac1901e278f4aec53";
+      sha256 = "63c1ac349505f483729440ded96ef0f43344aecbc5fa9c06fb39ae52c83dad40";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/en-CA/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/en-CA/firefox-106.0b2.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "8387de677806f4eb444c6844d0cb0050f2fb6f15378743e07766559f1afacb66";
+      sha256 = "498be02d1f09481846f853b8b6d1503b050b4906b3431bafbadf0483c6bd5113";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/en-GB/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/en-GB/firefox-106.0b2.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "cd17534df2e3442f441b94cf32a3de523b4fb5626faeee6483d58d0070f8e47b";
+      sha256 = "81da585d3248e1942a557ec2d04666cd08807ba193a2ff51b9055559d93e4aba";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/en-US/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/en-US/firefox-106.0b2.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "5f63efc11ae3c61c894aa320215a74a9430456b556a2d35f2b60ed19dd5dff75";
+      sha256 = "85998b089622f49e368997e89efcabf1dd6aeec9798ba0f1e915c308e8ad8e3c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/eo/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/eo/firefox-106.0b2.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "2e6d0c6a3f697a7b1d805328240f734a02547066fc62ecc176ad9300707ecae8";
+      sha256 = "3a0f7aeb89bbf4debb458ddb71a37e6a03453024b52b6403216cb4fa79f8468f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/es-AR/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/es-AR/firefox-106.0b2.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "260c91053bb7f993578717595bb7dc177d8217c382dabb080b1d663ee823e960";
+      sha256 = "67beca85c2464b16b7327e8fca1e9c7c52f3c75b3c605f003a58f99a91678bea";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/es-CL/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/es-CL/firefox-106.0b2.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "b23ddce54271e9967db533d3e93bf818b8a11aec52d99ceefca82c5c1409f9ca";
+      sha256 = "99094943294c3319ebb9d10d6fa871e50ef698233311c2b8335aeea6c2b385c3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/es-ES/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/es-ES/firefox-106.0b2.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "a8bde5586eb5b350214089a41edaba0f35b8fb4674746c07d57c6fba9689cfa2";
+      sha256 = "420245f8768ad9e64a78e84bb45b23a5ba1a871251e07b7c7be3f148b5d6b4c8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/es-MX/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/es-MX/firefox-106.0b2.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "c83aee7dfe43ae5f8372e66d4c3da71d70368f46ad1bd67fe10fc9bb21c38590";
+      sha256 = "5cfafb07c49e083bfbc4da5b434f0c7805bf7074254e80711210c6cd9b61ca04";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/et/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/et/firefox-106.0b2.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "7b79c467c2621cc66be63e73cab0c7844bfc1ac9344dfff366df4ab2487aaffa";
+      sha256 = "2a1a72d813db92d3de81e3aa58eb4d71dda654440385e6f20419815d6425c86e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/eu/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/eu/firefox-106.0b2.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "e8c70159786931e9bd371ae53f1090e662c8e0d97aff6fa62034504192a01534";
+      sha256 = "7a35ba12ec46b3b61cb90e5620723a1ee1f4b7b56a0df89d4703ab6f6c28847a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/fa/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/fa/firefox-106.0b2.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "7d0e7236140259df054f95eff774035b2c3338beb6f9e7ee71d340d87286dde7";
+      sha256 = "31b0990299c6fd7a9cc6306f12da4c505c3d9d7bf8966277675862f55a2c50c5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/ff/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/ff/firefox-106.0b2.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "fb8562d09c6fc893a1454cbed985f31281c02f090f8d2f0aed8849b4a0d03585";
+      sha256 = "1f1c1b5901ae7c795265c96c5b4ffc9286676fc3a3ecab696f479dad19d7f875";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/fi/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/fi/firefox-106.0b2.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "77bd828db9878f9335b7afbee104a2605a327a1b6d18e7d8d61ccc9efc62073f";
+      sha256 = "180f5cd0c88f7892105457214c336a3c72233421283afe96fb8e4973d763a17a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/fr/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/fr/firefox-106.0b2.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "7e883f450156e71c2f8a783a1fa7ceb265667e093416fc9162e695051935332e";
+      sha256 = "dabda291439d159ad2a4e12f232a870718ab3cd53d2681dada9008754426c54d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/fy-NL/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/fy-NL/firefox-106.0b2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "368f139d4e0021f85a897d81046d0283e0f2be89def31b1670e12b7bb8876d4d";
+      sha256 = "04b5c8d853012648b3efffc298f92339249815dbc65b73c3fb09d9d2e9c47bde";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/ga-IE/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/ga-IE/firefox-106.0b2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "3be7ceac760ed77b082365109de6d0aa517c8d7960364ee7065ee182ace85e91";
+      sha256 = "ae258d5583de27162a935ff6758636e1836855ce3d3620969d27efb7d3df7ad1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/gd/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/gd/firefox-106.0b2.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "d2826639d43e2529d65b9c64dea8915c1847728df21710057a4a2df8a6a41ce2";
+      sha256 = "85f470b3312463bd5307219b2e214aa6a093b9768ddc4a0021cc18e05e334c8c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/gl/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/gl/firefox-106.0b2.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "f193b93c97f58bab188750106e1b7a0f9e876f33efc704cae6b103278a3bb02b";
+      sha256 = "de6a5a0d44d56d614dc8d212641d2251e3d724b1ae647bbcad045108af4d351e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/gn/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/gn/firefox-106.0b2.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "399a34c200c1b844ca9782d52faf2cacb9efd88c2b2483b83cb00cf91406eb46";
+      sha256 = "e78a1d0e38e446bc8d56df1ca85faf115019b79375edce0df35a8ea377b1d859";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/gu-IN/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/gu-IN/firefox-106.0b2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "32d03f86d869b46af12acf6ceb95931d4529f59aa30c02e0f5fbca8fd836a58c";
+      sha256 = "eb2ec25451a1a22297f36febf39d72f5ecfefc435d5bc70a02dc5b7cafbd5b17";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/he/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/he/firefox-106.0b2.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "b2ad2bb06de8a931be129545693d4ea2144561ec5addae76a2f87fc1008dbae6";
+      sha256 = "e7e1bdb24eb2f9d49320127724174886d998707e90d5e8fd567b5d0b52d02560";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/hi-IN/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/hi-IN/firefox-106.0b2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "651e91851ff12b1f654e0bc2a7c338c6b1cb52aac53da34739dec9c1848f259c";
+      sha256 = "64424ae77bdbcce8780206ad233f3ccdf6f8549b52ca38c59c7468b5e602df17";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/hr/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/hr/firefox-106.0b2.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "47d7ae728acca6dbee5f23a7761770c4597c9108a7d2b3267e05199d6e39a098";
+      sha256 = "c4c10d18c0096663a350d991f92918645498df12de7a7d31abff97ee8d975fdd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/hsb/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/hsb/firefox-106.0b2.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "f603ce1b6dbe9d924485d4dfdc500aacc0a4da60950fe9025644eaaaa893eac3";
+      sha256 = "675c259d2ae57c90bfa668ac3aca78355cd7ffb3d2bc62da5818f3a915516b25";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/hu/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/hu/firefox-106.0b2.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "f4abb340d830f4071256d633a2afc67e99dd2e3d33cace206efb2bff62713cd0";
+      sha256 = "56001af5b995cdcd1dc966974b7e376d78d38e072d6ba6dff765329c5453600c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/hy-AM/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/hy-AM/firefox-106.0b2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "5c6b2d3620dfe0b64696fc30e54994eaed8c8d063203bbc0b5a25f646266d403";
+      sha256 = "498493344a251b3500cc4fe0445225983863e73443fc8b7814edfbb28eb41680";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/ia/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/ia/firefox-106.0b2.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "cb61082fc67b5c0cf96e887ab74c16896c889f44ef9b0a9fe184f8de8a9f69c6";
+      sha256 = "d109b630122685f23fe0fa3a24b25f6d52c59dcd4c75db2ab923310e5205cba3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/id/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/id/firefox-106.0b2.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "6d6de61f61e2d9263fda9dc6123b9c1aa8ddcbf87c1b8cb6244e245f20a485d4";
+      sha256 = "2fb18d144a4a95da5f7869698f5bfef5d07e672de63f25821c8405fbee96f846";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/is/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/is/firefox-106.0b2.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "f63230b3358e0dcacba6bca7509467316ffb94e6dc59b90e82b362fea6eb7c9f";
+      sha256 = "009930a81dd9eb1bcd1d312d68448f5d9298c6b09b131f08eaf1787163f3b8dd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/it/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/it/firefox-106.0b2.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "4709c194e40a0cb5be0d0f5459aecb718d5d7f652656bdbcaf1082ad2ffd0403";
+      sha256 = "c489f676ae785f57e8e45fe92fa01f0b88c4055ab68292003dcef77baee61cd3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/ja/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/ja/firefox-106.0b2.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "8a4fdaa21fbef73014d5c538065dc3b563515de76f5fac6275fde3869ec50f77";
+      sha256 = "00db1825231bc9c7932a47cd8bc3e81f6f6850c7a7bab9ec669f7f5273287247";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/ka/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/ka/firefox-106.0b2.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "21daca829963e747d3b08c04acbfb5f7f74a64d840b664e8ce75e4c8fe97545c";
+      sha256 = "af93272aa01a2022278f0337e8de8242f8859f8c77162faf0fea0667fbb3d456";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/kab/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/kab/firefox-106.0b2.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "70c2ba0023f7671826087e70235bcc206c01d466990c85a73e8d69713d840a8c";
+      sha256 = "46d629c375aa63e6c0130a430ab50ff207a07616e5f0279df94b1831d00d9114";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/kk/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/kk/firefox-106.0b2.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "fdbc98622abee3c484972ddbc2f91942e5d16d03d71ca8dd3810b498c93fd4b1";
+      sha256 = "9418c2bd1cfa97e219cc014e72d1cd9d5110757764079005413682eb8abe4282";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/km/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/km/firefox-106.0b2.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "24f870e4b441c216b453b858718698229cb97952953e123e187a3c39d15eb4cb";
+      sha256 = "cab6d10e4d1da7a775d836ea10141dae60a96e29bd1bc9a0d38a5ad9e4c5c74c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/kn/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/kn/firefox-106.0b2.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "fb995447906f84a230cde2a1eb2204058ae2cdfc88bb0bf621b0c6a9db8038e5";
+      sha256 = "4f0b233fc03cce40f45a009d0e5e118a17007ff56fd5da10b2db294b448d5529";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/ko/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/ko/firefox-106.0b2.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "58d82905acca3ea509229c71e22ed3621d31809cb0ba967471176ef2b08afece";
+      sha256 = "d2a1f756c3fa443d6ed5e948f4f631be2030795321df86984a068473bbf23827";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/lij/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/lij/firefox-106.0b2.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "c7d50bfcb6fecd13cc660dc4783e97d0ebaa4e0ef605ba11dc2390e2fd46dc96";
+      sha256 = "487bd1a6a09fc174e697a67eb7e1aa7bf9edb8ec27b63dfa48c67d1f5aaad621";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/lt/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/lt/firefox-106.0b2.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "42bac4f21713dd140ef0db688cd09d5af3d997e281dc398a61090a44e2d3622c";
+      sha256 = "ce7f3100392d9dd01aeffd2ba1e6b25b249a656c83b851d796ade188aadb6302";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/lv/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/lv/firefox-106.0b2.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "3e3128eea7f9945499ebc4aabdc48d7e980dd1efd2ee89bb8c333db5e1cb6c09";
+      sha256 = "a16d8b8efe7668948fa3f46615ea55e1bf8c82880f2f0661bbcfba5ed2990da2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/mk/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/mk/firefox-106.0b2.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "6f0c048caf2c176394df914717c71da441f516651d3b329aa385b75f2c3170b1";
+      sha256 = "5b075f3bb969b10bcb3c136bf1603a784111a4356f87388246f7b0cd6eb9d252";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/mr/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/mr/firefox-106.0b2.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "d9f72b91ba4da93cf060b9a1d2ff8ea2baed332dec3b5d9a5f45fb24c8739230";
+      sha256 = "078ee1ba9ba8be52f274c02effb02c2490a6d32fb50d2541b039abc06e2b90db";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/ms/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/ms/firefox-106.0b2.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "4dd0089509cd93ddfb0196161ed5ec029d53c5d46eb1ecb6cf3eda6917f6b7a9";
+      sha256 = "e54c4853da55476fcd6eaf9977da9902bbb18ed0e0dbd70936e9864b7ef79491";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/my/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/my/firefox-106.0b2.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "35bc81b184b274abe59e382f0315b77cd5331d4ec17f52a5254ec05b399be3fb";
+      sha256 = "0417b62343abca9861ab3981020e2d0ea5ff9341d56f25c2fad73942d0c147ea";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/nb-NO/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/nb-NO/firefox-106.0b2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "b74206fc6ec161e617bf070614bca733f6670171cf178b054885a4b71ca1a8d3";
+      sha256 = "7ec9fe2fd3d7c2e49ce34fbe2819cb4750c996751d7ac16749113dd5b5424c2e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/ne-NP/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/ne-NP/firefox-106.0b2.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "54ddfde0dee5d1341fb3502186bac336643f7e0d333f6c69da8a5c27384d6d3e";
+      sha256 = "c885bb1c16b8433f880158bf4f4d7ffe741092eb247774e2ed810cb8fbde69cb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/nl/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/nl/firefox-106.0b2.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "d376c29d72c9915ec03fe133ab82fe348099490940e9eca9b9521371f3553101";
+      sha256 = "1b05e07285727953050683b63557fe7a9f075a63f89d5b1bf179ebb5e326ecdb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/nn-NO/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/nn-NO/firefox-106.0b2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "80ee20201c974e9ba7e6082106ad43aaab60c440ff1b923c0da7583368a15283";
+      sha256 = "1c250d10d471b5a5ae3d73cb4e98eb478f137cc4bfad9f3d96dfbabfbb84a103";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/oc/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/oc/firefox-106.0b2.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "77a02c90fee1de7102d53d93eef80ec9bb3070b64bb8e6d8cee67fd2f453315c";
+      sha256 = "334b1e46ba5d3bf9aa426a245fc6aaa3bffce4f343342d2cecab3d0488c273af";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/pa-IN/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/pa-IN/firefox-106.0b2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "9e68752b0fd0731e6079e715947a9fec1502f3640cfe49be1acdde6b8ab0f599";
+      sha256 = "274c24477fd0d026a53b3adb8002761f0082198431dc87a768baef966ed0c331";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/pl/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/pl/firefox-106.0b2.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "2d823ad10a5ff9c127337e5b3961af408ca5773662e4dff0eeb44bd2b828f597";
+      sha256 = "ed2da752ff24653bb9caa035b87d7cfa02c857e9c438184792df532acb5c1a68";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/pt-BR/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/pt-BR/firefox-106.0b2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "be777e0758ab5117bfdb837f5ed0c8502a95877899b2e2d79f9d2616be2916bd";
+      sha256 = "7365ce27389fbb08229bebc6d2a318f35bb77ce99c5bce91f2f97e0095ca6114";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/pt-PT/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/pt-PT/firefox-106.0b2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "227280a96a21bf3dd728cf10a61311c7902d6cbf3185bc6018d0d21cae702f37";
+      sha256 = "a571ae959cf5770d29a8aaab7b30bebba3b9730cd80b9ce24ad54d446e8fbacb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/rm/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/rm/firefox-106.0b2.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "08a572c80a824e18e3669afdfcfb64798968b24569b29120c3d9ade287c63523";
+      sha256 = "3483abadecb9f6c1bbf81e76062781f9c1fabf9443129b4031bd9d082c672df5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/ro/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/ro/firefox-106.0b2.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "d419868e403ae4f14469b35c9a4e13367faf166e9b0a3b2da81d02b3e2caf51f";
+      sha256 = "8a6ad1467525d547d49ee4014177a1ea5049fe620d131f0cdd88b942a05e1af0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/ru/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/ru/firefox-106.0b2.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "66cae70d4ba24d6880bf8cf57e44dbcc137a14050be31dbb795904a67c873756";
+      sha256 = "8f828371905074a6b368e8bd5c205c76f68f04f1066dd2209c1a20cd8e17b041";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/sco/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/sco/firefox-106.0b2.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "aeffd2f9b7a617895bbdbcef183fbda82e46daca27c6b5c15e95eb843bc0a167";
+      sha256 = "0ceb75ee2199bbf1962d325178bc645ea1eaae6ee0ec55b6cca7581375a53a49";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/si/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/si/firefox-106.0b2.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "bbf22a219e215869952680fff013399a301df7dac443addbe179da8ab1e07d6f";
+      sha256 = "83968683080ea32f07d3012b77443e283c56d788e6bcded937677137753dfdfd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/sk/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/sk/firefox-106.0b2.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "38b86a085825a0a666214564e18c12367103a4a9ecb26870aa461a842a6d934c";
+      sha256 = "a2751ba104dcd89989b73741bf01f1cab0f982041098b638f6a70727575d9740";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/sl/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/sl/firefox-106.0b2.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "599febd947ed08480a6d98641de388c78ee6b977e6fae542d6b626af8a5441da";
+      sha256 = "ee19028e9cb895b102010a378bdb5555a21a1c3aa67da3294553b944f91f25bd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/son/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/son/firefox-106.0b2.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "1c6e35175e482dbccc657aeb0d643fc9940f99ea6f7aa0103cea54f53f24d1ed";
+      sha256 = "ff7fed4d807b59c094608ff5170b22a7ff5a2dc4b93a92aa087f6adc1cca5eb5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/sq/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/sq/firefox-106.0b2.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "749b935221ab4f8e9f4cd646c2580eafbb57c20614698f24f334e47b7594df12";
+      sha256 = "31b89117424cc3c2605e5e355e8d3e547d0766e76df3799d0e4bc76560872fbc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/sr/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/sr/firefox-106.0b2.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "532e3b636ceaab8a3a956771d89304120164bc3a83e7c97af1104221f3f01151";
+      sha256 = "9a8bda003e65f65a220ebc59c0425ef44083fd9f59695143cdb80cfd885f1900";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/sv-SE/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/sv-SE/firefox-106.0b2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "0cacde7645bdfd4b439ecf151ffa6add2f4ad2e15f1cf032739b8d84551a1ee8";
+      sha256 = "8553f61232ddfd378c25a0a2e665b04f367c110bc026c87e3817e439c731b9cd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/szl/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/szl/firefox-106.0b2.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "f1902e223b4e53cfff7487d30b48a57e9bff156b5dae4f2eefb4bd5c0c4e9a7c";
+      sha256 = "9f86028a1100dc9f8d9b6d73a52570a23a157d8262b34e2fcc28dc8075111f61";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/ta/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/ta/firefox-106.0b2.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "45f17b3cd8fe452508c467735a65085b0a88da33db16bf2dc8531035f1e43ee0";
+      sha256 = "2d9b301d79fbe2ff56c6cc17b1b853e1bbbc21a5bf485cbb79bbda92e004573c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/te/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/te/firefox-106.0b2.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "04741abd4ff358cc679c13fcff0191d96481055380ac11747fcd852627fc4202";
+      sha256 = "d7d7d45312412935c3e592cbe9c9d8607bccc79e7f490a255186dc6265ba1147";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/th/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/th/firefox-106.0b2.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "77ef4bdf663f7e43db9be37a9564fbe531d84af0863583570906f5ae92cbfdf5";
+      sha256 = "9096da808a030d9d773436122b19c7b71d0430798e5924451177764af390411c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/tl/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/tl/firefox-106.0b2.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "5c5a2736cf16605befb73eb8942ea6bc486f1907010d099525801271bc6920dc";
+      sha256 = "422cc7c2766c8d2d04efb82f09ca2b5831059f828da319a0170f0fedbc38139a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/tr/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/tr/firefox-106.0b2.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "cc4a279b031b655c17e40a2b78bfb686d2e693927fe8bbe8f72f55a901c3a0e3";
+      sha256 = "c74e4802023171757feed0fbc74769bd5958be4364ffdec07bb8c6767c9f62ee";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/trs/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/trs/firefox-106.0b2.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "b118fc8f5ee0a83aae00bda27d21fb07f102deb35cd9d0cd0f5e9eca9095dcb0";
+      sha256 = "e9b21a565119cd614f7278beb9261861820e667dfc959da4a8eb13ae8dffc8ac";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/uk/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/uk/firefox-106.0b2.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "2f2efbe9d588f3a0004ba71a9a9b15f909624cc26aede7e4036f30aeeade6d6f";
+      sha256 = "98bcc4ed75e80f6794797c2188f1f928141e113e7d1b626f0077b07dc7fee947";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/ur/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/ur/firefox-106.0b2.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "350dc300a083a5a0a5fa7c6ba013065f6eba8855eaf5ecbb2058f99952520eda";
+      sha256 = "020c05973ac8c9a17fd4b28e3110a0e5c699804076d03a9b090b8d627ad9763d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/uz/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/uz/firefox-106.0b2.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "09165c6ceeab7b12d798be02256576a387b5e344274fdb560823936935f99158";
+      sha256 = "5f628b775040d8269994f12aaf5aa765a02cfac4909904eb7a96e2602ec906a7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/vi/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/vi/firefox-106.0b2.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "5ca9ba7498a73bcc9bcb57302ed3275f58fc00d0d7e0dffbdc008ea257649f08";
+      sha256 = "7c56cd3a54cd5873fc1b733d8b54fe9ca3d37ddcfe5e1d72b82a1c143968414a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/xh/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/xh/firefox-106.0b2.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "618f73a822864fe233c73a955eade48d60e383e8b37b228d77afba037953c3d9";
+      sha256 = "e69e22be3ccd30af08f491c4a418e6b4026f5edba6593a24c5a89d54e50de64c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/zh-CN/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/zh-CN/firefox-106.0b2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "a890055f137223b517aa36f27486a34cfe0525120e8df63c07dd0ac17b3045e4";
+      sha256 = "95eb6af88e82e85d48c67ba01ddb20a549067fab9e0c8f47e73cb52364046333";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-x86_64/zh-TW/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-x86_64/zh-TW/firefox-106.0b2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "fe72854b473bf718def041994891a8dd0eea7f8b66752efde8c48c7d62d21d95";
+      sha256 = "cac628ef12712d520c286c80e5301f147b2cf7c7ee16b06a5b45b1764a549562";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/ach/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/ach/firefox-106.0b2.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "2c5355185433c9f5b220ec907e016ee2a4761beddaa4830f50fa92cb0d5c5e39";
+      sha256 = "295dd9c5efa3df52ced97b86bd2e15426cb41187b5bbd0618c8e7a0553da33ad";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/af/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/af/firefox-106.0b2.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "ddec0b2f6f77728d0bc99bc83b90ab62683be5d997edae6704a4c1d0f87ccc35";
+      sha256 = "2e9fbfe43cdcf589a4c6fceb1517880815d10ffd66881f671f2c3ddbcf70fddd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/an/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/an/firefox-106.0b2.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "f3641af3c977927a6d8b97e4bccc1b30c57742f2244b28b488cb3ec164e2a2e5";
+      sha256 = "335776b1c71bce7bdabf59cdeceebb66919c9c346dccefacda375253441e0c4c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/ar/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/ar/firefox-106.0b2.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "904c808576b8e72307a9f18e314c9e23f7fae6767a9c6bd338a2b33e6a8791bf";
+      sha256 = "298ae97cf5dd506976db6f365b05a5873b29d96c245cfc2f25b23c488e6750d0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/ast/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/ast/firefox-106.0b2.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "110243e1bfffb1cce24add92b91ac05ef7f05d1933da5ef6201e40a8621db4ad";
+      sha256 = "c8039427e0f718c49f2d590723e20a2f3c00b87be8e074c15fea7e423f07828e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/az/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/az/firefox-106.0b2.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "e31177931cba5d852be4b45405e82dc78ad8deb50cd6df54f570f8ad87b13f0a";
+      sha256 = "652743a11f257946c1a87d495bd5aaee7afecc98231c2036467e4e99130c4d90";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/be/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/be/firefox-106.0b2.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "ac14108e9aefa5b66ecdb0f76840604cc8328d6548be4d57ae756c4ff57f55b9";
+      sha256 = "41bfcee9f441e7266b0625802d23bfda1efea3ab9dacebc121907b935c4d0980";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/bg/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/bg/firefox-106.0b2.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "35136e3c2f110f91ac783cca0a31f15428a09c05da23367550932bbb6ddebb6f";
+      sha256 = "913704db38595232bf866a2244767e4706896dde24f4e75b37aaefd0299ef3ed";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/bn/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/bn/firefox-106.0b2.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "8253fd176f97443fb9af7bf3125163fc1673335fa51dd1da48e481b42e349dde";
+      sha256 = "b360612a0407788b2e23dc6d414ee035c7b65568473decd2c78900c0eef23434";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/br/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/br/firefox-106.0b2.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "2c81f29fdedd5567431771cfb30cf2284966ebbb73009d2513fc892d00205ddb";
+      sha256 = "6bbdb07e87f03ac8773643ecad878efb9efc8d63ec0b1c40fd11497a7f264da3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/bs/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/bs/firefox-106.0b2.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "9e519ebe10a6cc1d63ad40247e5b938fe99d32cb82efad0a8e1b79ae98019ce3";
+      sha256 = "026da184f2d628c1b976e149563054a3b771d96ba82641d404ddb487e0c85bd2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/ca-valencia/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/ca-valencia/firefox-106.0b2.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "0992baee440f77f6972a55a3aa4ff1657caed77613481e11d6b2d70142d0bda7";
+      sha256 = "854598a2bdb530bfba01c99f56365a98256a3a6d6e0914606d5ad0780bc8050e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/ca/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/ca/firefox-106.0b2.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "54a752d34aa9b8f3b524b87468106ad447d30cba8fca3c04eb7b0dc3209ed8f2";
+      sha256 = "e513ca8e32c6d6a42fe56c6799abc782131a631bc90f3ab76b2ee65e156ecd08";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/cak/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/cak/firefox-106.0b2.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "3dc9bb67ca3c77ed2fc3af17c4b905aa49c573e93ecf25da2a037a5c2c3291e5";
+      sha256 = "95dce437a4336dd1fcc3ac0e15f9bed69a1299f428bdc69ddd02a27e2ac549ae";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/cs/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/cs/firefox-106.0b2.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "a531591021d974ddc8d407f99dd642bb1aa4413864edf5ee791aedf1c29a98ad";
+      sha256 = "3635dd84f75611f20a25ea886732deaed8cd9606bc43adfb62eeda4d35a314f5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/cy/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/cy/firefox-106.0b2.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "d12c598c695f6a26de0491a05cf0be710ca65038efe0f5d7256d5e5c7b8ae636";
+      sha256 = "9c174820de1d198db96ae7edd350fb2760a02f03a05eecbb0d6fec5561373ef9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/da/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/da/firefox-106.0b2.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "b5eb8724b33ab141f60eea9d58ab1c8a4df1c9d0d533352722958effa931f3e0";
+      sha256 = "0a90d3a6297a80b2d878a9d776e1624a7994b89f16e4c69a1cc160aff8c5dcb4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/de/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/de/firefox-106.0b2.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "f87fae783c52009c3fe110e908ddf2deb44a4132cdb0f92c5882156fadb73202";
+      sha256 = "df9c422c172a92d57ca4ab90ff1d671bade4fa93d3eaecb928f480748c9c696f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/dsb/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/dsb/firefox-106.0b2.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "73fd3057f6c4a7de0c9015c50c99db3d99849d8057279ce3a832e4c1164ef176";
+      sha256 = "f90b19cb6fbefef64d516cac18600f8a05a59294414e95b25444139a5a786c98";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/el/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/el/firefox-106.0b2.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "0072e858a0dbd54f34dda266e0d7311cd1f4b6d54e7880b6569923c6a50b7c41";
+      sha256 = "2a329860dd3b8a683314eee2687f62f07294dce14629ebd56e6d520608fe5dd6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/en-CA/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/en-CA/firefox-106.0b2.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "2279f3cbc3ced337c0778a667bb5e2d4aab38dfe23ba2ebedf1dff42388bc803";
+      sha256 = "5c6ab9f7b826a6bf012a83549a0a8585115dd6ecd6c35d46bc065eb71b884e1b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/en-GB/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/en-GB/firefox-106.0b2.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "0e29daa605fe409cd0f809b5fae6dc2f8ab9e4e8f87759b47b4ea5879b7ab705";
+      sha256 = "5ab6a568210a3d849a08bbe002064e9ac9bbc7139c9673d5e23c2f1c8a7f4c88";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/en-US/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/en-US/firefox-106.0b2.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "6468cb28940d9bc8b774f320beb1091d61cb34f90db0ff793a0af5053fa9a353";
+      sha256 = "c8337352f183277941fb5b1540782c31d939a6b9c4841497b8972ea99601ab16";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/eo/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/eo/firefox-106.0b2.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "4b161af2ddd91937c1c26a6f69b46fbb2fc053153e5e19071b06f077c6ae201f";
+      sha256 = "1d7c118fcb6a296a1bdf242a0129b3aea5767f4a3192913901549f7876eb583c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/es-AR/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/es-AR/firefox-106.0b2.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "ab2e74390eab2defdc8ba2a091ff3ae5a256e3f2980a412c046f5871ac0e6cb7";
+      sha256 = "670da9ccac00211b48f81fcd25afcf29111a24021b104416a09b7fb642cee399";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/es-CL/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/es-CL/firefox-106.0b2.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "35393f50a0c50201923a27634e6f3322eb91f8769de60d1c527900ca6dcb4d7a";
+      sha256 = "60a1599975635e5c1e29a3eda2686729c5896746880962c1942f469072dcbff5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/es-ES/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/es-ES/firefox-106.0b2.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "4dd68e48fd997f48f39f8a15063445931c79b64a6a8c4bbc456928b6a8649f28";
+      sha256 = "a3c6fd7bcafaf932dc2faf90d7b19b1875ce8f31c97746e11eb4b96d2845bc16";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/es-MX/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/es-MX/firefox-106.0b2.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "e5b576b50c606b33e6876d4c49f33d3d73a8907bb148c2ba183ca50ec9191707";
+      sha256 = "35c204b4898cf1f8fd24d529c02586fbd537c036a9e8b401539cbb69f6d087a9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/et/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/et/firefox-106.0b2.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "a9dc091e93d5ab4e35ff210c537c04c8b327092b469657db6566f82d09e606b2";
+      sha256 = "f40572bf2844deef7b7124bdb41ae4899a5ccef14b5c3c25d3f4217ecde4f150";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/eu/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/eu/firefox-106.0b2.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "c86ca29ee06f3627e0a17df7eb51ac260ecb455c8820000d4102cd627c5b2b03";
+      sha256 = "466338aca1d1a26233576f3097a0cba9e55eeac85f203cf1fcc7d31801329ddc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/fa/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/fa/firefox-106.0b2.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "c22d8e376dba57992540e578d77b674001fac7348e1d4715074b79e72e0b1aeb";
+      sha256 = "fea5474085b86c4b6a9bdf2a033e9a92b444128c11145e8c8ef61f6c2f261d43";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/ff/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/ff/firefox-106.0b2.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "719b6e69f024390bca5ec48a3c3295d7011a48f68de7853fbf8ae08a20e8c8a6";
+      sha256 = "652a2d28ebd0ac203561df3dcba4719f4c54ddf4ea15709fd409820e2792f88f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/fi/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/fi/firefox-106.0b2.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "5f562052bbba14d080301378a41a6de2e1363b52e5ee0e416dc73eb9cdc05e8d";
+      sha256 = "737dea199be03930495ae10bf4bd4293932214b2dca898702f0844d7a5f93eb3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/fr/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/fr/firefox-106.0b2.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "484820b310ef3aa98229497a442220f465ee72e344fa34bab5d2ac2b51e1fd1c";
+      sha256 = "c4aff6c895e1ebe1946ef6aa39f094e6f2d54d6a57a633afd857b55b89bc8110";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/fy-NL/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/fy-NL/firefox-106.0b2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "d317cf868516e2144de1a1eea57fd5fd40785af8c1e8b7c856f0cd031a617b22";
+      sha256 = "5ddf5fcb1545da814b6eeba7c8c323e10853ec0827c8ebb26dca131bb9729764";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/ga-IE/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/ga-IE/firefox-106.0b2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "9a649cc40c714aabaab7ce5133f325e45bed00152c9630438ec730ac5e22426a";
+      sha256 = "3601f6128d2bd5a41b8471d7651b630b5b0c1fe3c5a840f60f12c97782c509a2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/gd/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/gd/firefox-106.0b2.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "6ed25d372c686084071a3ccca77b4b14be29493679fc7840adebec828147e15c";
+      sha256 = "a11e9ccdbb26435b945cc874f221ab09f84e4936c65feaca0f959faa87263d5d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/gl/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/gl/firefox-106.0b2.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "2fe922fa9505996710463b881f619e01828ca75d1ccf78ed7061551c7f713fb9";
+      sha256 = "994e6ba6fdc1c082a8c8b6f7ffb606b5526ac20a4c9519b1b931ef5da302af8a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/gn/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/gn/firefox-106.0b2.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "e81023c1edf4796d4fed407a19ab58e9145a29132293424b23ac6c2e079414b2";
+      sha256 = "cb05a76e0355584ab9b0d9e6600a8d024487dcbe042b59feba5f6167e31d9f10";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/gu-IN/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/gu-IN/firefox-106.0b2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "4f66a3423624d385b5e81132e94c93ce1f8b622c9e034fbb52a4be4fb4d195a9";
+      sha256 = "42328bd90dd4d6b4296c3d7da279fae510b417cadda5071e1aa83de07f338a38";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/he/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/he/firefox-106.0b2.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "1a493aa87247855e50ee275fa02c81c7075487c7624a7d4ad07d02901138c408";
+      sha256 = "87f000aed76c83dfd63141147eaa2ce1fbd3ae987db46fae79855fcf73ceb5a8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/hi-IN/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/hi-IN/firefox-106.0b2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "4dad7c8ebaf3680005251da3e55025974fae4953f4438e13ce06dacf51820c62";
+      sha256 = "5c514f8f1d68261248ff165922b921d600fac18a7cd5ffc839deb80cba866cc9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/hr/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/hr/firefox-106.0b2.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "fdc7f06b3ff74bbfd124a9d38574bea48de9b390e23252d6100fbef953f274db";
+      sha256 = "46b3f1564b9a47de6889e3c58d2534af6375a020137d87e73d75862645cf3999";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/hsb/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/hsb/firefox-106.0b2.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "fcbe0795420501016855ae1ff4e44237c9fdcaccdb6811279ecf32edc3f2d0c6";
+      sha256 = "33762373fae6257dcf7169e027b9395aff46090d89c44ab07911fc6726185028";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/hu/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/hu/firefox-106.0b2.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "75d5c3cda24d13a99742f72969416fd064c2e4f45f3f9610fdb7c1de50c1b44f";
+      sha256 = "fae3af6c9bed6f681a7c78b55914676bc973995506771a1659465111e9ddf0bc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/hy-AM/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/hy-AM/firefox-106.0b2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "5ea4726ea262e5ebed05d384b0b80f3456a03fdd102c6adad00df3c67422bc42";
+      sha256 = "d9b90f45eb40b871d4a76c88fa7eff65bbcf3d58066d682d5f134333f547b80e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/ia/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/ia/firefox-106.0b2.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "a901fe6722da3db6b9808d3b6070aa61bc2cf803dec9878ef6106e860a3e58ab";
+      sha256 = "fd057fd32607b8ffe97a9a8cfeb2b261e610be148de4766cd00d661b14e11b5a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/id/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/id/firefox-106.0b2.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "d338c3fcaac4fec8664ac11a685ada42b75f8302b500398a67853d9fc5d1b1b7";
+      sha256 = "26bf3b04a237af06dbd47e2c571439ff4da3533508b3076513e0bf5557c572e3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/is/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/is/firefox-106.0b2.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "920be60dd3c6788d963acc11caaab1248906f64772879fcbf034da6f8a1c1431";
+      sha256 = "dd5632f03f091a0bf1bc107e7cf2500a5c96403ba25f6014863fdadf450af0d1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/it/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/it/firefox-106.0b2.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "6cd036b350e78a749d4edb01a7d57cbbda0f0cdd69a1b4abe773f7f345e4f1f2";
+      sha256 = "c74689aedd59aac1ff4a1c105f39be9687fb1497c18e68ed564649b58da3b5b4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/ja/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/ja/firefox-106.0b2.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "86cd8e1f2981f4f712ef25434908c76f212811d273fcc1f912603354b297b321";
+      sha256 = "fc98606fd7d37e9da7ba39e212847f1e6d1d978a6ce4f513be07e90caa54cb29";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/ka/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/ka/firefox-106.0b2.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "25afc48601b448f9347c78790c8670bbaba0c92e2e9c4b1a5ce0aa9385d65c1f";
+      sha256 = "b1831934053ad54ff57d62bb6317872990ca55c1efa24e8708a8bc1af82016fd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/kab/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/kab/firefox-106.0b2.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "274e7ecd83be64e7ec85f0f5d121919fb07d41f10cc7fd2c2bb8fc16f96731fe";
+      sha256 = "fb8a29a02276fab0651c205989bbfd915bdad026287812582b21b847b626f484";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/kk/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/kk/firefox-106.0b2.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "93a27f2288176085deba86e14fecc9ec395b1cbb6d6173b945931903aee8baf3";
+      sha256 = "c6a658c5fe7e4d697abab4499c8bda3bf9b73d3304d1a40880362e9f303e0502";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/km/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/km/firefox-106.0b2.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "32aade41b03d442ea2922e2f36117dfcd9485be8348f7822d514d0084444bbbf";
+      sha256 = "795fac450f4d08e0c1587c0cb544c9bf9cc5a6c60222096f222d9666d41d607d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/kn/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/kn/firefox-106.0b2.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "eaffe915385d03471763c4aceb23a312b3b29fba46502ac35b4e3d690d450e07";
+      sha256 = "7c54b7d7db3fb7b9a9272658304ef31715e26f40959be34786fc7612c8d256f8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/ko/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/ko/firefox-106.0b2.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "822256dcd7f10abea1075f85b1200caad002d572746b10bb4e29428954852077";
+      sha256 = "aa0f69ea0f9cef98ad1ed2f22d1a2819daf7de745e46abb7238db19b14bf2343";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/lij/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/lij/firefox-106.0b2.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "3ff0e125d02faf490ba24486b3b05386da06458b70a98b7617ce014a7e6672da";
+      sha256 = "6c4da6f2f31dcd823ad8eed7d9d891b551e055970785017187ad98216b21cb29";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/lt/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/lt/firefox-106.0b2.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "3fc55ef46e89aa617203d220bccca425676d64a794273daa1ba0cf377c156427";
+      sha256 = "3a74f4249338afa0a3b9c223d474511b8d9268bddfcce6edfdefeef0bc691bb5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/lv/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/lv/firefox-106.0b2.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "40e91426d6b6a069308d836221b7542cf99e39a5656d7c81664063f676834700";
+      sha256 = "5b166b795698be544aa3cced7d33980036cbf81c8fa658ea36256eb6ec8d28a2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/mk/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/mk/firefox-106.0b2.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "c0a2ba1e86ebf6b4d4e4b0f03c2692e79b8bdee8d3fe14ce4f53f6ad81171e58";
+      sha256 = "02839eeb8d191898a489f3db51615687299736a675702674fa03357d50f46ee6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/mr/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/mr/firefox-106.0b2.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "0d5c641dbc37a6bb621a2bfb930c9c38218f482a6c4cfe95c0afbf5761ea9309";
+      sha256 = "af2dc5ee9d664006f5e92f9aa562f29cbdb110896245bc7ae20c6ac59fee2958";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/ms/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/ms/firefox-106.0b2.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "e7c7850d7121a5e4595f3f941a81fb15cfb40027c6792f4a279f9dfd8fa4fa06";
+      sha256 = "b4be7647594003fb2ac6d7af237670665a46901b135505a98357f1cc62df7913";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/my/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/my/firefox-106.0b2.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "ca33e2bfaf86d7bcb31452f8c96a0a58ee0fc02cde779de173b109f172837e4c";
+      sha256 = "e9902720b9ee28f14217dd9aa63e4f84c4ccc44c1025812b43b9418fdc990d4a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/nb-NO/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/nb-NO/firefox-106.0b2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "2ba4bcc31c776d11587d8ff1ece9361af00a2f202fb4a3ce7923c5b7651bd752";
+      sha256 = "b565b49e98ffaa1899b149a4105f7be5a76351ae505e2937eca57f4d4f6d7bd8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/ne-NP/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/ne-NP/firefox-106.0b2.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "1b1bffd0562975f19ac6b2700621423fd8825910d6d9f97471a01c1a92b587db";
+      sha256 = "b656aefab0531ed66ba87ffdfa806c32b69a8c965082e12cfaeeece1becc8d1b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/nl/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/nl/firefox-106.0b2.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "130ff17cc9efc21b1705270cdb0850f2ed05568ddd84e5ac4b60ffc741d78edd";
+      sha256 = "3ac4f38b8db18138d7901a9a93e725fc81992b2d541b3e3b50a3091ed3d3c032";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/nn-NO/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/nn-NO/firefox-106.0b2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "a028ac3d577c071e0ee8abbae51bf9476729f46eb99b65dae1a6e8ec026d6dbf";
+      sha256 = "10e82c0e50a47750f94f16de95295a16fa05eb03f2f1e8cfe1794cccfbfddc98";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/oc/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/oc/firefox-106.0b2.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "640fc1b632861a411fa86aec78a4a8ddfb3c1f5659789b66be4a680b11d0372b";
+      sha256 = "93c5ac9dae4a50e58522a366371b21b3654fac915ee9dbf03518a9a0d1e83334";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/pa-IN/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/pa-IN/firefox-106.0b2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "325caef6d5de3e4d9de88812bcaa75b913c857f0fccda16920429ce3174c6b29";
+      sha256 = "2340656b67eec0ed06e04a60834137dacada2b7ddc917bd4477a90cde4723308";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/pl/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/pl/firefox-106.0b2.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "17214cacb9b02e07064388fb73f46802c21c6686656a6982356e1d9056c21967";
+      sha256 = "38aa00113260e1e8ae19062792f7519977a1cb53b73e993e28806d5e34f1e9e2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/pt-BR/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/pt-BR/firefox-106.0b2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "b1e5ec447e383645ac796fa120c66ddedb8c81053db95ba3c7bec52ce4fa9f93";
+      sha256 = "d3984fa1c630115c42740a47111bb94d968dc13ddb57ae9b1d325158c80d0bb6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/pt-PT/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/pt-PT/firefox-106.0b2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "5cbdb249fe7ca280d89cfeca9cd15bd3806b74ab782ec9e3ef89315e64098c81";
+      sha256 = "0f248ce02403b6716ec05bf0f606bf0ad6032fe990033d56cc0a4b862a497780";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/rm/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/rm/firefox-106.0b2.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "e1e8f6e01b3373502244db65351950baf460573f453aedc9292c9a28ae4ccf5b";
+      sha256 = "6e7cf5d3cb1ff5f0b353d01ebd3f18ef02d671165fbda1b9f3fc32212c2f70b2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/ro/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/ro/firefox-106.0b2.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "a2caaed2fe2b02b75f75d8824a0e7ab094c745136c6fc1413cefd31812495ec3";
+      sha256 = "c30ee37a10741a5f8f4c16c897b6493cbe0343cdef4c25582a6133004b88c609";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/ru/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/ru/firefox-106.0b2.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "a215f91d472cd9ff56d672e63c1232fb8bfe054cb02d991644f1926c07ecb993";
+      sha256 = "1ded58968c63efe9714c68095ac9a17a0d61f0a3e8101c2896b32cc8872b92cc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/sco/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/sco/firefox-106.0b2.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "cb2c861d0d98be8c5028747c62db2a404c3c2f0d6eeaed417809d3eb2278d245";
+      sha256 = "3c7ac1f51a2c6908a0c09818a873447f4394ee9f2ae039980768ebeff1a0228a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/si/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/si/firefox-106.0b2.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "e86fa7036a64ec0bbf564e04feb4bd333d0d77d6a592a83f37d85b9460e9dc8f";
+      sha256 = "ab1c3bd46b8d5c4dc7c6babbeca042b4a89110cde972cc2686e47fc07d229756";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/sk/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/sk/firefox-106.0b2.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "070ec7dda8a0d45ef7a1dfdca30ce33d25f8e80abbfb37d42ccc65f41795f329";
+      sha256 = "3613b1bdcfe91475b13c6998396c467cbb67c2988bcb0b7b4997d126ce75017d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/sl/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/sl/firefox-106.0b2.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "ce7b92a0f30139dc6790849a5a22348013e45d7c622a3f04784575a9d64574f4";
+      sha256 = "ed4b14ee52edc2e71791da7cb35c4996ffb965d12b28a5f9048fa44bfa041274";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/son/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/son/firefox-106.0b2.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "9488a008a014ed5f28723d45216244ca082c56084c607c77e11a64d274cde4e4";
+      sha256 = "d6d26895d32a6d88cf5acc81777f8cc94134fd4c9ab3c7e189d17ec781a8f637";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/sq/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/sq/firefox-106.0b2.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "f319400e6df0e4d6ac4702ab9bc0a7fc525ae4eab68a99dd58c0242c6da8ac09";
+      sha256 = "ba07bd3fdf199b58ebc02866c6a58a2b15e64917ac7ad6bb48ae82990b8c20b1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/sr/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/sr/firefox-106.0b2.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "6bad31fd676c7dfa10fb39717e9f56242bdedc72e79540a632cb0df3504efe65";
+      sha256 = "da94b246aca6573d91170d4b4e5ee0a4d12f3b722d712fe17226601a2e1315fc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/sv-SE/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/sv-SE/firefox-106.0b2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "d6920092fcf49412d2dc178c2cc484bef5cc6e11190bccc54a84aee3d9bbf342";
+      sha256 = "185499fb8cd52014c4f6b43e4a1dd49c34d5b18c8b9f6903b3c5dbfe5399c243";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/szl/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/szl/firefox-106.0b2.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "7e0a1ce4e278811d2790df93ab73ce3a02e19cd1e5b33ba90579cf293bf8a790";
+      sha256 = "1de424833ad58e22f13821f41e1777f6de69431df372cdb3b06431154ae45c51";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/ta/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/ta/firefox-106.0b2.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "4cc6ee0ffb3c47acd8e58be027331726d0d82c1b42cd619d34d2913f4574e428";
+      sha256 = "3c1885c017574b1677993e2aca6bb52e88994ed07926bf28beb9574209db332f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/te/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/te/firefox-106.0b2.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "83d5ca04abc678e8eb043d07c97f8d02b89d707dae634c96f741b7a0ac7cbedb";
+      sha256 = "a22b4e0aab2dcbfbb9c82e502c83130cc4c3f4a3ac9ebdb7731babc030a1cf10";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/th/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/th/firefox-106.0b2.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "843b6c1a5c58dc904dae493c8f8bfd39ff0250e574ecf839eb19bf747f5dbe12";
+      sha256 = "fa71a2d7c216f7fe3dab88c0b6e8639b764aca2014f2537fb7bb34ceccf04efe";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/tl/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/tl/firefox-106.0b2.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "526b596a1c51f6d0014c94ebab0b24a4231ca917a8e77012a423e70e6bd4f6c4";
+      sha256 = "0a36f5a458632ab519c96e59d17d107b36a486b3b419b4787232bbbe5ecf7a06";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/tr/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/tr/firefox-106.0b2.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "d8e70b493a2602108dbff36076462ccd1f1ee8c9f497d8ae684ed3f5f8e097df";
+      sha256 = "54d33cac6a27434186936249f191d7fdc969e22f0b6475d01bffec1eefa85cda";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/trs/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/trs/firefox-106.0b2.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "b7252ccdaeaec5e1436097824813feb02c57843e2c9265f430cbac589fe28ee2";
+      sha256 = "a93d669a4555d80abaeb4b33f753137fce6bf9dacdb9c3b4e914ebc0772d502f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/uk/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/uk/firefox-106.0b2.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "b898c523c032bf6a14a84f2c5ce21704f11161b04ea4e45dc258e09e1b775265";
+      sha256 = "14f2cd11d20643314c227c7f9120f0c63d3380ed0f24899a53e325dd277eeb42";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/ur/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/ur/firefox-106.0b2.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "e7f9b3178f29895eb2afc4a40632f09c7f0fdfd71edb5e4ae9f3892e900a9f2b";
+      sha256 = "cd51d89baab5a9ab0f1dfa6aee9c9b1934c2eb6e97af8335c4355c39249a8efd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/uz/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/uz/firefox-106.0b2.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "ff4fb6ccc88f14a91ea862813cd51971eb1c65c567728d8936fbc17675dcdd38";
+      sha256 = "ec767ef6dfd78da2e7cf0020548d9aaaec751193255e4f1403b67ebd93a58903";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/vi/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/vi/firefox-106.0b2.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "9426039edd4597fb1c19a8717085eaed373d4c151beb8b84cb15bf5dac571e04";
+      sha256 = "151de0cb6ebd96d944bbef8b914c6d42e0748f984b3137a26188c9a8843d1de4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/xh/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/xh/firefox-106.0b2.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "9599991073c8c3367e2a6e94a0bd7a194275c2dd76bbc5517e2531496b528313";
+      sha256 = "bbf4bd493deaddf71459991b3151feb363beec2e48b436a89fb3725fe4514544";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/zh-CN/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/zh-CN/firefox-106.0b2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "943ffc4c11b9ec256709b305aa06515f0c5980582ca917f839f3e2f02af37abc";
+      sha256 = "d09cf68190dbc2c84acf9a34be01f0aceb56347d50e536c15bf95b95ffd4648d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0b9/linux-i686/zh-TW/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0b2/linux-i686/zh-TW/firefox-106.0b2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "e18784a328b94455107df70ee1dddf34e3c6e2edee49facd90aef78eb7878d3f";
+      sha256 = "ab75d10b30d310df232d6f4ffbf9af9baea1766c674c0b506f15459bf7244dee";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
@@ -1,985 +1,985 @@
 {
-  version = "105.0b9";
+  version = "106.0b3";
   sources = [
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/ach/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/ach/firefox-106.0b3.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "8020f4d9d6c5b3052835e47ccdd739bfbbf27db14a3d771b1bbc8a0292ec0159";
+      sha256 = "e463e54551231c570f8802074587f839b9e78d37ab93bdcd15458be917f1f2a8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/af/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/af/firefox-106.0b3.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "6cdd01fba7c40976cdea9405616f68d05f58cc282dcd43901e685788e15d990a";
+      sha256 = "e6250b78de9aa47f883eaee3e08d28647a4b0fc95e38b2fc1ffbf711fec6d0f9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/an/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/an/firefox-106.0b3.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "c265d73be5aad088a516215409e482e9ffd32b27de04f3d74d70d6c37301df8d";
+      sha256 = "b070074594aa0f710bd4dc2df3d3874d347ef59ba49465c1c3690743f11b9405";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/ar/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/ar/firefox-106.0b3.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "9b694e424a714054f93dea9984fe54d2948f74b64b5e6d03c0b3ffea75d9a8bd";
+      sha256 = "bf4b816e7e5646bfda6df9754c932e3c8fdd7d5aeebbe2c6d1b0257e60c37d1b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/ast/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/ast/firefox-106.0b3.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "e10247626a71b067b61549d477b82519a5b0ad6a0748a6c32820a493c4a418f9";
+      sha256 = "226fcbb78bdf928f7876a342c5a9aee70e61427f1002f92d451af1d364366720";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/az/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/az/firefox-106.0b3.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "fad9c7fe6a2df16b2fcbc4704403d1fab7c127f91f774d4ad03509fef54774ab";
+      sha256 = "4cf75b84255ef1a6b307534ac97d98c39fb902eaa4858e062bd5d43e4f8b1001";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/be/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/be/firefox-106.0b3.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "7f7fca5e0c7697cc3bb93316f1cc4c962e245451680566e02f4079dfd8cd44f0";
+      sha256 = "2234e46ace57d3c9f6a0553f67f9f650464a08955b35ad77a2f501d8b2c878cb";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/bg/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/bg/firefox-106.0b3.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "9f5c95591bfc2e0c68002f30a3aa5252bfe57b5c1419798e8960aeeb80b62558";
+      sha256 = "c644f63cbf8c4aa01a0c98634903a152c1856d3323b981a47722ce876eb7cd73";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/bn/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/bn/firefox-106.0b3.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "48d4d2d5889abe7e6ddf5d0eb1cd373e9bcada6ea75dd5bd11d9a3caf31911e1";
+      sha256 = "866fb6fad4c5ebb939c68d8867656f543028cc43da02a5ec7def22245667d4c4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/br/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/br/firefox-106.0b3.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "86d285e71fd154924e5cb7b9772bc4c1c8f8b49418951b45e58f4a3412e4f57c";
+      sha256 = "1b42d36234d85e5f57c9a7de0dca3f4087723b68a162c201535ae7b4301d53c1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/bs/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/bs/firefox-106.0b3.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "776d97cca84697da8043d1c565814d50f9399460a1409c3ee1d1d93c87f12b5b";
+      sha256 = "ca38d54268d4907984350fd3935004d07ffcbbfb4f2bd4a530ec80bc6047008b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/ca-valencia/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/ca-valencia/firefox-106.0b3.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "c1feb9ed9ce33c21e411f6eaf32150e0690aa2ed2d73ad66c9d59a8ea0fc52f7";
+      sha256 = "8949880d826cdb165bc4f48bdbf1a1bd0ee08fe4635893eac7a3fdaf011d1149";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/ca/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/ca/firefox-106.0b3.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "a1d0ec5a1d1303945d78f2308eb5216d7eaeee9f07a32600d42a88ee2a3fa822";
+      sha256 = "d324234eacaca5c7da76b9d8a2915358b6735ad0e347216108e5016fe3e14532";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/cak/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/cak/firefox-106.0b3.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "faad994362555029fd57f10fc4493652881c595e22c876c5827bb9ac51c21bf0";
+      sha256 = "d97bd0cf79c64b50853681031bdc7ffaf1490e2770ee44f81ad7364c0157255e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/cs/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/cs/firefox-106.0b3.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "2ef5dcc31f4e19f17a74389f92ab52689394a0b1522093ef1ec0a0fd6736dfea";
+      sha256 = "ba8b38a28bea4b64aade6627a4ffe5220e0ec873a47d877a5c3952f1441e838e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/cy/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/cy/firefox-106.0b3.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "9fc5f9671c817cfd24cb63510509f819eb873a80c72e41b4d18031d749eea888";
+      sha256 = "8754ed3f6e5f24d5c4c036d8e27ee6e37c3fef48822958962bbce53bc90cdbe9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/da/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/da/firefox-106.0b3.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "41a82e42e5333f8d97f67d5b42dfb3f27675bd921cc93a874c028c22409a7eca";
+      sha256 = "757c77227c97804878b010b07f7d499cf6fffe20a2df3ee088be2d77ee5b90d9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/de/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/de/firefox-106.0b3.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "f8e57272a828d0cc9896200877f141d0c3ef2c7061ac39d43005f0d344382ebd";
+      sha256 = "e59b6300bf60a297a475603769001e8cf64354e1e74b9b79cfe135a73092bd21";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/dsb/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/dsb/firefox-106.0b3.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "892cbf1aeaaef5747207311647227e491bd418052ce6a441b138c93d76ae7798";
+      sha256 = "5897ee5f2dfbd970bfa6304dcd9e9003d6d85f4d0d9180abd37f98eaa88241ae";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/el/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/el/firefox-106.0b3.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "eabb4f00fd215059ed74e0c9bace0d35124910f43f83cf17f91706c2a1df93ae";
+      sha256 = "0ff0f28da627a48f951103dacee2fcda5a9fc7f4e2945f3e8aa8cd277a9b1e6b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/en-CA/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/en-CA/firefox-106.0b3.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "891b4e1b91b8afa550c36ae0ae49672176ae55d58a4bc6ff9057d8e6233bff8e";
+      sha256 = "425d0f1e253a722968d430bbd4a4d3f916abbcae6d99e4d720c4884f06c64fd0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/en-GB/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/en-GB/firefox-106.0b3.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "cba93155a82cb31edc9f22c7988d94e79e016fbea81ba3566e28571c7eef5a6b";
+      sha256 = "048b1ab1e46ef3d1574c88e72208e0179922f40069ae6de62a3d0a3034d4d1e6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/en-US/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/en-US/firefox-106.0b3.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "6643432a47864c77445f8648b28e2ca3092ceefac83af72884983bedea6e9c01";
+      sha256 = "cb7c9a4ed20e37971c79dcf673516e74ce9c2496fc59e779350f3adc818fafbd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/eo/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/eo/firefox-106.0b3.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "88c8a38b67d41822dca35aef42ee1360f96a3e3bcce762a5fd8cc7e9e0197e20";
+      sha256 = "1a25f81ecb0824134ba50251940e79047c8dd33d194cfd62cc7e8e8b67a60c9d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/es-AR/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/es-AR/firefox-106.0b3.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "80fae5da5823f20bdb4401e1913b0ff4a972de3248ea471a0da6e071681103da";
+      sha256 = "412ec2928d5917335ad72d995af09bfb11683f0747705cc138e0b295cf58fb53";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/es-CL/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/es-CL/firefox-106.0b3.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "144859955e1dbcc2b5821f614bbc8d362cc163bd5828e420c8f1fdfe04681400";
+      sha256 = "12c37dfa3c8b88f8cf3726719979a9440350a3b5cedf705b71a1d632c647f268";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/es-ES/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/es-ES/firefox-106.0b3.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "f66cf4134e5ed89f2fb2d545bb460079109cf585311b4d2d7db425078c130193";
+      sha256 = "cfe71a36b2aeb75d4331a59be5094ecb2f5292e7a173ed1cb73f3e9232896a4e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/es-MX/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/es-MX/firefox-106.0b3.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "ba7217257eb41fe74f5c1c8f7ad2d2a29b51e21a1503b33e37a20dfe6f8abfa7";
+      sha256 = "1f3051983e0cbce87afd3fc8e6716b973038234fbe4ff52309abffe922194e2d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/et/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/et/firefox-106.0b3.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "883a0f722d5079bbd0e7e61870a9487f895027b8b73d12567ed8af709b7179eb";
+      sha256 = "2c0a0dce5c2294f01b878387d0b1b0a3eea5e6a9396dc221bab8c971c9df6efc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/eu/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/eu/firefox-106.0b3.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "3e2e49bd977e3d17d0ba4ec6d99b216246e10d105f402441a50f4502d4788ed7";
+      sha256 = "bb635909dc108ea6b75605443f5b37b8a1706c747d91b59e62ecebf2f01ab407";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/fa/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/fa/firefox-106.0b3.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "b0249e65d168d842115d2dcbf5adeaa6f2f30375c6fd88c45f63fa2ef928cc52";
+      sha256 = "00b43871bb77b7ce866520a04b90ad6b829c7b377d46c97c25eb5f0821904c0b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/ff/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/ff/firefox-106.0b3.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "63f0b0e36059b3a633f48c3e17549d5a766878e597719500087eec0ce475b3dd";
+      sha256 = "ad04c8296c6ca99ee5c2b698b2ffe2b19c50bc4cffe672839b68e1af68d11537";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/fi/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/fi/firefox-106.0b3.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "d3cc4af7b34cb0c4323f3377907c9e61a45d413a06c2d902dfc860f7d54e6632";
+      sha256 = "441c3c48274d123d0006e6dfd59c71ebd5cb718d2e8501beb6fcdf8c9ec276c9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/fr/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/fr/firefox-106.0b3.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "31b22f94e9ae69f653eff9dd97bde7b3430a6f590005164a212713a003687cfc";
+      sha256 = "b7a4ea4df1917b9c65c98370d65559b1330751382f512049df4f7633c802c6d0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/fy-NL/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/fy-NL/firefox-106.0b3.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "9e1337bd9c457c2001db18136c9fe361594f990064d9e3a8e0cbdf173cfb3dfc";
+      sha256 = "838b635c5456c7565fdf744742b2b70fe47a3c2316656c606067961a6bd4d2c4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/ga-IE/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/ga-IE/firefox-106.0b3.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "913a3f838a80155a1bb6a147c3f787a8d86c90f300350658dc11866d77c97dbb";
+      sha256 = "13551a85014408a835c933015368d090cd55e35a4b774fc4359f62f48365ac78";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/gd/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/gd/firefox-106.0b3.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "ae54f0fbc0a0255b54c37c30bee8e0d384427e0a9b753358149640212891ee13";
+      sha256 = "85ab7babb0373cc054dfe043c2b23696b85c9f211a4650bd4772ab7b7ed92cf6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/gl/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/gl/firefox-106.0b3.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "ba95438b7d2f019a80bea37ac3e39e0261c8ede8e8935b28ec6bca7f599c454d";
+      sha256 = "e67a442433ea996d7a7d48aef1db16cbaf1f5a4fa9a2e239f6dcc2c34a1711e1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/gn/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/gn/firefox-106.0b3.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "a70710575dbee102e9edb06530c1c5473b0b9f39a8a8f796564ce65019e6269c";
+      sha256 = "9120bd521e4fdf4c34e5dbd5879a2a50da8172e1fb18f81d2e66738457185eca";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/gu-IN/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/gu-IN/firefox-106.0b3.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "3283dad0045e859414638d004af1e61a1e3c6830570d0e123d4ffdde47f068b3";
+      sha256 = "13e8f1da90102734e44ebc4240eb5b6f0110125f831ac569d42aec8018e12cde";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/he/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/he/firefox-106.0b3.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "4ca1aa762b2a80a5771d73b474254e147cbf0d2ab60df6037423f7e6e65cbc6c";
+      sha256 = "843dc3d7262c777b68641b1bd03cd3d57cfa1330c5b651f3946bdb2f7f8286a5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/hi-IN/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/hi-IN/firefox-106.0b3.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "98b6276510ff641092b507230a3d9555d6c7cee8c8ef1c70f229c8080a8575e6";
+      sha256 = "5de727ee6658965ffa9d37a6c09234d68c86dee36616428faeeb11003c196226";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/hr/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/hr/firefox-106.0b3.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "44adf2d8985e8b089fe11e69f70fa0b3697100e96fd140c9545baa5115ba6af0";
+      sha256 = "f025459ab2321de8c772b9620237f6b83a5544852feb76a0fae09535a7f7c248";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/hsb/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/hsb/firefox-106.0b3.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "20d44c489de6dcca94f0f0bc6e8f3d3c788c285d02ba39fec06dbbbc01b37928";
+      sha256 = "95a9001379ec8394c36fddd65f7b078bc93ed1c2c1e3529948e53703e52f89e7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/hu/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/hu/firefox-106.0b3.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "20a4842c9545ab67b2394bd583e5ef753cfbf56c95efb37049beaca9a12d4943";
+      sha256 = "9fcc29f54e8268fc1fc5304f616db55083c54ce89879e25be9c6b9b98150b393";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/hy-AM/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/hy-AM/firefox-106.0b3.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "961c54dbcca02d4142cdff48f3d577803468d597223679d4d656fa998a2e1b4d";
+      sha256 = "c4e289635f3581738a2dccc5d322998be772020f0800b7d515370b6d77b6c787";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/ia/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/ia/firefox-106.0b3.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "11fbac1e4b34beb6972793d792eaef9fee02598ede1f45b18aca6c2938c1f246";
+      sha256 = "97af51d19a39e36d1d67bb1d08b9cdc24377e8241ce802db8470e2dab371cb12";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/id/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/id/firefox-106.0b3.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "d43810fad162db466900f9e1ef78c571ca2dae3a96cadea15fc53aa8c2950c91";
+      sha256 = "36ca009d15df7467ba2081920eabfc9682b546c99bb5abf0fa07002e1230f1a9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/is/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/is/firefox-106.0b3.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "af22e21039d056409aa375ee5baee45d1f5a71da81418c4a462264612bb481a0";
+      sha256 = "df803624034cd56fc86cc22a55dc19df9a72eb1a189ee2d9879856addc6f2ee4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/it/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/it/firefox-106.0b3.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "f4def4ff1ced33b748a8114733ab484a0a53893184ea49c67c5a1b423bbd9e03";
+      sha256 = "008d658dc952c178f03a2fe4b8962f116e6c0164e2007acc8fe3a86df3ea7dae";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/ja/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/ja/firefox-106.0b3.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "c60a5e0eee07b83c7f6aaaeb7780637af63679deaade5fc28a87f567f89fff59";
+      sha256 = "65ef07119b4768b283d7dc9ac061058d5b472801d0c3e1018e4232f40981b048";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/ka/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/ka/firefox-106.0b3.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "f2ded37f9187ed8723215f7f71d500063ff7494f26ddc38b79004cf90a9019ac";
+      sha256 = "d6e95006003e050e07c287c7d424a302fd3ed44b1298d1af2c81d0e4656aa695";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/kab/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/kab/firefox-106.0b3.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "3065ae4fbb834c4de88c077ccf3a9aa0d229506715fd447c639411a841a18673";
+      sha256 = "ec9f8e30b2e121c92e807084c40fd06a46ee2c41a2383a01790e9267ff411b8e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/kk/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/kk/firefox-106.0b3.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "d929fcab7b833374ff1f4c38572cd3f8bb1564c683bfb3e4dce8e3bb0a97a637";
+      sha256 = "c55ebd781149563efe1deae01fd7daa1cf8dc5430b6ee841ed292bb0ec4237bf";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/km/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/km/firefox-106.0b3.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "aa62d5aee571b28792b8e13fbe6dff386446215a8acb0699c91158aa6815f74d";
+      sha256 = "75b4cb380fed3afcc347da6e807183c7191636f620f564ca0321274e4826d094";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/kn/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/kn/firefox-106.0b3.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "b86cdafccab0de5742ae6dbf783690fd68419f289f462ec527141b96700e341d";
+      sha256 = "4936f48719163564daa9c33765a8169fd49eddf198049f3fc95506e8bdae3740";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/ko/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/ko/firefox-106.0b3.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "2538d91d8b834718faf7e06daade9f31e1c7b1c1f74ea0cc5a9c97af3ba25dbb";
+      sha256 = "e98fc3de5a60763886313ddda8b2e70f4cb95b3b04709ee275a67a4900389bab";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/lij/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/lij/firefox-106.0b3.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "b4494f7de1e58150f9a8f3d50b642e2fcff73ee8b9b83d51e6f71d0f7ffc8b33";
+      sha256 = "98efda385c1b0b866ab24103eb2c319e339acd84a0e3de04b4316d6f6d1f3c59";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/lt/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/lt/firefox-106.0b3.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "88210cc2a14a1051b96a1f5b10ad4d9034eca12033cdb703da964ad5aed4f94b";
+      sha256 = "6b982365360b2d3e5abee7a830e9bb92c958c689bfea6bc2202a36555fb33dba";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/lv/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/lv/firefox-106.0b3.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "c74a0fffbb560f1350df6b539df93f93d2d1ceeddb64882b5e0c13633ffe1f92";
+      sha256 = "81447de12dfab7247b371f2eae6fbc9757c5040e37f668ddba6a4ff81c7be185";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/mk/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/mk/firefox-106.0b3.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "b0b4f95afd3d5eaf2bd40fc4ef439e1b012037c97b23ce65c5849bd72a69472c";
+      sha256 = "0ff1d70e486d6d2bc60f28115382beb94d4808f52c93fa44b1d61212daa75977";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/mr/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/mr/firefox-106.0b3.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "af5969821dc72f988502315f52cdf9a74914115d2c229c78b8dfe8a6babc3cba";
+      sha256 = "3caf31fcacf0bdd36bc755c0a223b27c62c658934acc069a1eb1d2e6a1c3119e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/ms/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/ms/firefox-106.0b3.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "28c04610ad0889d2d34fa2e10024d7ec83ebe444977f55f9439e632e6bd31706";
+      sha256 = "5de5bd3be15f48eda0f38e048fcbd3ca1ea2eb0600e159fe014248646a8c1696";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/my/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/my/firefox-106.0b3.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "0b9c5f32a212050f94bba7cded521f53097ea335895c1efef7151d70c6134b83";
+      sha256 = "627519b4d177234500a1b4a219f0804b1e58eb6dfcbc00effe319da4d8ca1912";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/nb-NO/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/nb-NO/firefox-106.0b3.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "f5d1fdb733624eedf6fb52cc3f18a1155c8e39758ca0ace03b0e9dae43019f2b";
+      sha256 = "5f4656e62e417570623f9fe0ce2f85c615dd1ac5381258443262a2127c8ec862";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/ne-NP/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/ne-NP/firefox-106.0b3.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "1f883699bd09d948612c07f08bded186a3b820636bc35c828c7ca9a8493e6df9";
+      sha256 = "5615f7e1cc247eace8bf1427a74a429860f3d3607b3bdd56ae96519b6a1e701b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/nl/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/nl/firefox-106.0b3.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "3483bb5596da364ca5a7fa496cdf4716dd1364a5fb8e42d2a75e3e4afa3aae60";
+      sha256 = "84431b965068964c5cdfb4c0dcdb0bb2f4001bfc29d5e573611f380da9f9595c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/nn-NO/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/nn-NO/firefox-106.0b3.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "6fdde89c3fc90339d8876cfe8534b89324137e0eeb0f15264e8a84d54b52a59d";
+      sha256 = "9cdcfd00bc619217403a9dcbbab63c28bfca479590e7157e2e377a71b7c0d366";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/oc/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/oc/firefox-106.0b3.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "dded656e83d50a47afa10fc342da7035d425ef3889494720dacb47fc237fdb48";
+      sha256 = "690f945f9f719cbd9f8252b4dd855c658248365a686d537c4170b0ce4acc8952";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/pa-IN/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/pa-IN/firefox-106.0b3.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "2b05b061d6ea887f63c1ef2d8b19554fe94c2a319cc2221d6c99c221a6108bd5";
+      sha256 = "4860ba23550f4255949e6985c2f20b6cd22a3656e09476f703ed94b5651ba8c5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/pl/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/pl/firefox-106.0b3.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "0ca3de0e41efd736475cee393c954d0d8703f7d298fc5991e2db51883ab7ca37";
+      sha256 = "f7354aa68375c07ff0c3e73a20b9b0181a686f071ea768ed7d5ba8b0ee36757c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/pt-BR/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/pt-BR/firefox-106.0b3.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "c04bfd72fadd3b9bf4b3a067145a286914693f25959d4f4f561afb1fca217f99";
+      sha256 = "48ea57e2f823c20ea1d17b6431e38e29c1d34de911cae4ba29123451704f4f30";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/pt-PT/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/pt-PT/firefox-106.0b3.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "49d56768aa5958340f8e257dec70fd491d56a544b9bc96b5161ad2d891afd387";
+      sha256 = "5b731fdb0bde6e97deaa850dcc864db9d2aa9a30dd28c33bdaff6c8ecad7e1c6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/rm/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/rm/firefox-106.0b3.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "3609868864a146fd4778bde63e4a3bfec3d1ee23e144170c94eb2a015c87391c";
+      sha256 = "aa85d8dece1c19ff2dcbb2ef242caae55b1588502fb482aa08130fe4d4843345";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/ro/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/ro/firefox-106.0b3.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "924bb2dc01902860808b54c68498b3d99fa1cb5e1c493c336b4613feebe448f5";
+      sha256 = "99eedcc8c1e0c77d745cbce5e41ab888508e2fcdd03f5f89b8b4386bda9ea7ec";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/ru/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/ru/firefox-106.0b3.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "b47cd3c37c0b213c8649a4daa4b519daa3584a2684a05742ba62b8ffd8a58b12";
+      sha256 = "e9cedcdc53e6ec019d0bee22be26538b4d3044d2739fdc368cf7a2a193821411";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/sco/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/sco/firefox-106.0b3.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "f2ae256a94388c24e39d4cc9fc29a74e9232b070f5d446446c52db7cf6a067c8";
+      sha256 = "c78525232a51437bc00fb0c022dd63e118ffa553ce917ba04725564b017c9d9a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/si/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/si/firefox-106.0b3.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "100f001ee0815a0eea54883441ff8f596e4ed0d2e8eadb4ebb54cf443b6b4f22";
+      sha256 = "1505ae3d5c83c6e0b9d9a2c352b22ff04aa8f68ca3bd829dff0a90500a1712c0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/sk/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/sk/firefox-106.0b3.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "ca345f4d57611dab1b671e05783049f11e759123503a395da9b52de883902ddb";
+      sha256 = "e09264ecf4c1f5b21af4edf247dd0a6d44f988489e5f6a4ad213200e5be8d017";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/sl/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/sl/firefox-106.0b3.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "c6825d5da5ff7db6e276201bc5f895d4cd89efdb7ac19f2b904b62f932083e80";
+      sha256 = "72659a864885d6a1a79f17e24e648979c408da501b533867c5ee14a290d830f8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/son/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/son/firefox-106.0b3.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "c8416e68678ff8479f1aa693de9b26805dedec37f541eea28c434788be2036c1";
+      sha256 = "9cd9d33ee567a50d5d24e94d3b7d9e70d27c5af5b3ce8b7ae222d45232087af1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/sq/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/sq/firefox-106.0b3.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "d6dbccbebe1309fc892cb0ba67c5a0261a91cd8f90084ab40461a36b899be017";
+      sha256 = "3a891a39e774379cacd8d15d7f19b8ea99cae087958bb398f95a02709aa24963";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/sr/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/sr/firefox-106.0b3.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "678aa8a40ac51886f06fc7ccc834af6637143a21d2bda8f100384df10a518e40";
+      sha256 = "f38e8aff090e6340eec9f0979ea00acd897253118fa7c136b7bbed00c548286f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/sv-SE/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/sv-SE/firefox-106.0b3.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "a48c48dd3ea6df061ba67941466e33972f12e6a7b1c274f0e50f5d336c1fcd44";
+      sha256 = "d2e3f28504317fe099d3e01b3e032e543714a0370225fece5652bae3df26fe33";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/szl/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/szl/firefox-106.0b3.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "f6571462487527f10be6f131981fca90270e48c3883b0b7415244495903b5114";
+      sha256 = "2082bc6c435caf0389b518faa97b0fafba1ec114e1e6566ebe19d95a79bdd1ce";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/ta/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/ta/firefox-106.0b3.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "6a3b6df39db96ab9dcd5c94322570e426a1fb94db8023edabcf045d63a7bb25d";
+      sha256 = "c773019739f8488d12f180c0c2e13bd2c9386edd534e7a3499af6e4dd362b83e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/te/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/te/firefox-106.0b3.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "921ce974f2e883529430de161857ed55452858dbaffdc251c107d29b93883820";
+      sha256 = "c8274b14b8664e7f3048f27c2e13004f6f97e827cdeac51db469972ef0ee7746";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/th/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/th/firefox-106.0b3.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "4848b32981b51bfc6c00ddbe5cb0a877d2d7f5fb037cfaaf8ace44fb5b4759c2";
+      sha256 = "c7e4e02c9856852118ff380264725ad99b842a0a351750f74ddf3c065b19bddc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/tl/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/tl/firefox-106.0b3.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "090d3b6e8cb63a6f1920de59cb5a6a4e5fe44ff00ca871952a37800bfbe774a4";
+      sha256 = "b6c4df24a3706773f88c9c5bbdc9905d02622b11fff206557da9a138cbf1a9ee";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/tr/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/tr/firefox-106.0b3.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "158eac8adcfbc7379ac2a10320347f3933f8b259b7ec65053d78c3339cd3c2aa";
+      sha256 = "647f3eaa4cff80f9b47b382770126f8f40b387749bff7cb904cfc3ef5fd72fd7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/trs/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/trs/firefox-106.0b3.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "ce3ecb1e84c3dac41db95055fee99e8a3b246eba4e14e93f40e778b54b81be6a";
+      sha256 = "5831ef9c011215a7aef2be56c91d8ca2d8cc3c85f14b630586cd8382b6a92a5c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/uk/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/uk/firefox-106.0b3.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "29c06e826e4047689e509e8c114d353ae5d7e24679bb99309397ba59e1a96d8f";
+      sha256 = "66f4172235aef99ef3b804556350be22ab72c227c01d5a11ac05b57b363dd90e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/ur/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/ur/firefox-106.0b3.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "1de2eb1fba3f3b988c348e2f1b0a71f1f879c02d53154fd7c05ce05c4d898776";
+      sha256 = "b429c9ac394479d9ce48a769b92b812f0df2c9c4d32de80e9fbb8785c0965868";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/uz/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/uz/firefox-106.0b3.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "d62efd4451a2f68eab196a5b420b48dd0a04b83b95f9847ab9af3ca01086336a";
+      sha256 = "70314ebe800531973d3069c84c9f72efbef7f81393458088d49b26fefcbbbe23";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/vi/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/vi/firefox-106.0b3.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "1ae78c21a4ea20d5a748a8543bbbdc47a0f7e331337dc7b723f6384b4c7d5f8d";
+      sha256 = "7915dbe530cdf16b6a52e88b8f2b4d516af7ca05a8bf5587d1db026c4c04455b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/xh/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/xh/firefox-106.0b3.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "fb55c502b18873399d4204b8a08594dee9c2b8c254fb05428ec78841e6640708";
+      sha256 = "56f14020c3b106e0526ce8b8f98ae987e399ba84bdef6d4d23bc31a80496bd49";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/zh-CN/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/zh-CN/firefox-106.0b3.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "95059e4f6d8e6e919caa2ca4e0b9fe22de476ac7ae09042dab892ad2622e5f28";
+      sha256 = "cd4e3e7089298a352d969f91c3d1fa48243f9509fbdf898dfd1d11c35b7f5832";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-x86_64/zh-TW/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-x86_64/zh-TW/firefox-106.0b3.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "a457b8eb240a87e5ddb1de01dca15b67069146487d3f2486158cc9a607b06993";
+      sha256 = "b2b997a416f19200b8bf0f59b4beb3da1ecefaca6298438bf8adafea8e41304c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/ach/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/ach/firefox-106.0b3.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "077f539335d08473cdf09087ac0be3fb6d28fedfd05f80f0bb8343073b2f98a2";
+      sha256 = "c4965abd58e242e7e1c3b25b9c453a27d3fe05c2adfd21d809b34843d83ff269";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/af/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/af/firefox-106.0b3.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "b475413ef512a4f87b59a97eeeaf85eee1d0081fc766d968eda2d9d39f2d9075";
+      sha256 = "cc031b4906ab8075375c614fb7e38ca356f2a6483e2d7a9a882d0652c4d5b112";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/an/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/an/firefox-106.0b3.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "cdced2ab00ebc4e83fb3401338fedb69488b0f532baf64af08b37e85a96cdfdc";
+      sha256 = "56b94ad1e3559f3a9d1775c82e4fac47256708ca8fb1dc3f3a242cf858b07adb";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/ar/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/ar/firefox-106.0b3.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "d19069b61d91c148c4ee024081602e6ab488a46de03881064f6feb7e79e34c91";
+      sha256 = "bd53ffe4c0f767a3a5a127a8b0587e6803541fe6e01c310aa65cab679725c37b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/ast/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/ast/firefox-106.0b3.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "dbcd4dc09b97ff5d7d31acc92873cebb3d3d8e6244a1a4844bc77ee8d51cb233";
+      sha256 = "935e8d259fca0b9e553c3a202e5f60a5de44df2f5dd1c3ea1dbe87224bc5458f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/az/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/az/firefox-106.0b3.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "0d15881ed71fb93823455f8183059967f74a0a29fd2de8b881a4d97877d20a06";
+      sha256 = "9449ee0390d974a65d2788cd0c1b4396042cdc15d90fa8d14fc87ef9f655209a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/be/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/be/firefox-106.0b3.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "b7adc44f4211f9f7b49f3c8499e3bc9a23717eafd7ab3b1d8d43beccf00d0b3f";
+      sha256 = "d779494f18291d301b77cc9a6701783df608fb2db297e6ac5e7e337d0516aa60";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/bg/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/bg/firefox-106.0b3.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "8d343f5fa6cbe7c7981a6382afc465f3ef11e1f7d9897d2cb854d943c9e341e0";
+      sha256 = "6e9b7b62bd0ea19b0dd791ced2e2e87b94b69beae8036ee41c55b3759425a04c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/bn/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/bn/firefox-106.0b3.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "68b81e5551fa0d6895b8a51c3bbb77a3c0ad218e5b0017190492610fdeef0f15";
+      sha256 = "adcda71b13ff0d134b0593bddc28bde54d8e7605cc16f18f25a5032ccf428cc6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/br/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/br/firefox-106.0b3.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "90920303c8c5ca76653a6fc7c6a84aa225b462f4855cd4092326b198e770b7ac";
+      sha256 = "ddb971e459d11408ad5bb9ddad8f259aad1d92c8e1db8ae02edf01df3a4b9bcc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/bs/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/bs/firefox-106.0b3.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "c5747cac58fad675afc2b5b162466091437c969f82ce4f52b7db78e835310ec3";
+      sha256 = "2f5d7ef7ffd089739cf0fc7278e2beb9935d4bb34d6937dc4eca3e03574c4e2e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/ca-valencia/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/ca-valencia/firefox-106.0b3.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "2777de62d320f0c5979e76efcd2b725d39f1f6c4b2f4844198610c635d92f6c4";
+      sha256 = "0580369df466b60adb69fb96e302845ddcdb1ee67ed12c9e53d77fafd2af6465";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/ca/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/ca/firefox-106.0b3.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "cd0202599bbd99279b4e5908357f3afc2790d8ab820d3edfe66f67fcc5319034";
+      sha256 = "c7dc2deab96b41f9d57e0fd7dbeffa6f83e3da89a46d3980e1ef27ecd6b5a6d7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/cak/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/cak/firefox-106.0b3.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "ce85166af8e377bb1e1e3f47290e76f03ede0439fcbc5c1c3f2c56ed2e159268";
+      sha256 = "5b18a494a603af3c8ee5c8e1f664eff5b9cada61c2f5e1cb1bd19789bf977279";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/cs/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/cs/firefox-106.0b3.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "df60c8950e42f85bfe0e0e2d3f44f16a27bf6620e6db87e6064c32b3f3612157";
+      sha256 = "2d9b7a1f812f50796c91d5edb2ede07892762baf74612cc524053aeebf8c1585";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/cy/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/cy/firefox-106.0b3.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "91ee79502bc40a621babbbcd8e391d3ba2435c16c6f5892257343fcbeab94e67";
+      sha256 = "ed41d01289e4e37baa3ec01b68ef546b66cd598ebc956a8ff9747621ab4d76e8";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/da/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/da/firefox-106.0b3.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "a06628c8527c3c016c1482c703a489e40efa5365f6abce317b87c1e8cb2969f3";
+      sha256 = "f9ce4962286f55b4e5294d633fc0c068ea51fe79070d100d5054a876ecfff8c1";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/de/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/de/firefox-106.0b3.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "7398689b2c80284b209a5ff3ef2883a7b404affa30853df04eae8ea02ae4b6fc";
+      sha256 = "548d7100c555cad4d505c193a89c27dcc6cfa472c7b7d8d405e0b3a74d52b451";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/dsb/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/dsb/firefox-106.0b3.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "0d77345729eab32e8a9b7760e3049d294e40f550b5fa6a113659b8e9d9984994";
+      sha256 = "6660d5d6822475698b1fbd023fb42c2b86bef6730c1fcda251bb3efce3ae1b5a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/el/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/el/firefox-106.0b3.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "ad33aa612923a25cdc1a33b4fc02b9463b721c68aa5645a227872c3bfdaa2af2";
+      sha256 = "e79f02f8490141005bd0bc1dd7d939ce6c5e56ff67e81d92c29f608f791f80ca";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/en-CA/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/en-CA/firefox-106.0b3.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "0645424a50d40b2704c919c33c0ebbbedc69b94f2aa6383bf8ddb8228fffc606";
+      sha256 = "4307601552854c8126649de164c5bfba72c941caedc136a7e45d49840582c175";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/en-GB/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/en-GB/firefox-106.0b3.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "fdcfa1be0a73bb51277b0d4fafcf0bac2b86a2ec7376462fe6204f601ace2c2d";
+      sha256 = "02f9423909a3729bcd00db0633a05997144105b653afe6306e17763e77c9e059";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/en-US/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/en-US/firefox-106.0b3.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "aefcb690a14c83fd280be3cc7450812cc8f0c443a8a0d0e9b3eaa2228a836327";
+      sha256 = "bb78b73082455e30e232f2529b04e365bb0df47f09ff51c0dd713e102a3c794b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/eo/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/eo/firefox-106.0b3.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "f7fae825f565fe70858ad9a9eb735133abf9cc9b352ad04ef8ae116c2d3a615e";
+      sha256 = "2d4e42af295194bd3949b19a28a57823d7d4c4041fb7eb74d7e7da3fc34f967e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/es-AR/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/es-AR/firefox-106.0b3.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "99c2c2d151999628b095d36badb6f05b293bc5f92244ffbd393769e6cbb9d51d";
+      sha256 = "57a889570350a417ca021fd531c9830b7bec051c62435c69465b0ae9570cba3f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/es-CL/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/es-CL/firefox-106.0b3.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "92f0b699e3f967e2e185d36dd68ee24fb56671db3ee646da99ccf86e789f63fc";
+      sha256 = "946305a809c447e467f1e44dc90a440459da25e8ac8bd8b76acff2016d5c0fce";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/es-ES/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/es-ES/firefox-106.0b3.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "3bfdd754036b68c8d36ed7c4f5b1cec9979884b809bfa237cc7b31fe272db62d";
+      sha256 = "840491012154c99b0edfec794f644b780a2dfd46befa1d26a2ff51ca2eb7b7e6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/es-MX/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/es-MX/firefox-106.0b3.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "121031b3e733b98e73f935e9a046f1addae7557906b6f7f235c6412be87ecd02";
+      sha256 = "225380aa890e1a02b2ecd2038984b0d2229aa6ccbe29c13b8967c7d3590b57dc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/et/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/et/firefox-106.0b3.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "10ade3ab5d155a283021c16e616c562e49b4c0b8c68be38e2a4a96b19655913d";
+      sha256 = "66671cc626f96120ede75b60eb5295ecf21f5061639465153db4d559954558e0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/eu/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/eu/firefox-106.0b3.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "a822481a3a1907f5c1a7b238b65ad8b64466fb058c8562396fb1d7d93d9752c5";
+      sha256 = "5254cbdc906d7c4957f6f22ffa67fdcf2ebeef0f5672c725c96deb8d8a03c395";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/fa/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/fa/firefox-106.0b3.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "a2014b52559d5544939c96f7e8101e650b915d68d99adeaaba7fcac3c7dd2c41";
+      sha256 = "4e4a2b33c5df2cf4451388ac849bd35de4c2e12c350b49327a3a56af94a6f423";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/ff/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/ff/firefox-106.0b3.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "b7effc3a0453783d8e6f8b03c378d40a678608a056671d79a2d8edcd8040d904";
+      sha256 = "b0ac40065c62c104e462c44fccb1e6b5a282a472f7756b08cbec9621ad94dbba";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/fi/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/fi/firefox-106.0b3.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "32516b04d66d173c15ba5406775df99f063faf5561e678936ab00d66c97995b3";
+      sha256 = "7b1864cac0b3f8081dc0015af2a0081b8620e0629ac51c93d7983afabbde0fa3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/fr/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/fr/firefox-106.0b3.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "db9aa0b522c86136e0e470e91c4dec26726bfa2e3c89297a69e913295559cfe0";
+      sha256 = "7b25652dc72f7a8314727fbe67fde7404ef777c780ef4c5b73636ef745cf818e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/fy-NL/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/fy-NL/firefox-106.0b3.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "b5dc0b045b015692d8f58f44d19993801b73ce769d852ee4fcc50a15912c95c0";
+      sha256 = "1925ad2f86ebf8c7fa469f4ecd7ce05cf13ac42700fc1c98dd2f9b80e43c2fe0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/ga-IE/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/ga-IE/firefox-106.0b3.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "18a1d3075a4276c1fefc0363f983f1009cb1a13ac466c90adfcf3407dcc5a809";
+      sha256 = "487e474e6d3ddb9e7aade1c354a27ca65d9a18e1a211baf692c0cc3a7d53cbba";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/gd/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/gd/firefox-106.0b3.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "b3c3c29b4d27cfaecbdbbedec4f7535db7a16c20d7fb02bcab56102ce4cecba5";
+      sha256 = "26a1b16d7fd974f238c623ce6dc92dedd6a8838221d5640a25876a1ef3da2667";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/gl/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/gl/firefox-106.0b3.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "25c17bc45ff4d30b81144fd216238a81a22efab4616b805c7912f72a3471af7b";
+      sha256 = "b6518aa4dc6afa8630d63a5eff5781ee8498db7c05c240b0f72d421fa381bd84";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/gn/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/gn/firefox-106.0b3.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "80f270b6bd7fba7c1591b83855715e7218978f1059ed63c76042429540b5e96b";
+      sha256 = "966104a41fee3b0bfb0ea666d137482be4490263058d98ea313f371ae001f4bf";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/gu-IN/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/gu-IN/firefox-106.0b3.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "20db10717bf46223c6da7febd93ad0eec0cfe4f0bab3141509fe3a35d3b85ce5";
+      sha256 = "c234c07f88c5f9651b06bdde55cf3cc224f1b01baf76dfdb3aa837530999a2ca";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/he/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/he/firefox-106.0b3.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "523708bd975ea3d3a3f84230e725f85b1a5dfc4efc0af29f5857052a0cb0c692";
+      sha256 = "e2af05cd377ef9e495797d537b482076c559ad6ce525e3a51e053443c09d1be4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/hi-IN/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/hi-IN/firefox-106.0b3.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "163baa66e71dd58f321eabb53e04ad0841a9bde958974d0c10c68df93e85b2af";
+      sha256 = "d64bc4a1af080f1f87a634de315785744347145aafb8bdfece9a6fd63bfb59e3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/hr/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/hr/firefox-106.0b3.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "52faed68c572de7d17068398df7ae3781a3e1fa01cb43b4feefa583d962ede3e";
+      sha256 = "615a5635f3c82b4d2ca53bb701f842e15687da6c4e24b05cd9122250eebdca84";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/hsb/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/hsb/firefox-106.0b3.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "9785eaefbc0f25cff559c99f387169a1ca45398436f67d8c4d7e10e1b6db9d1b";
+      sha256 = "857b062c18a42c2d67aaa3eec035927709545a2dfa87e8fda3f892cb4a016675";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/hu/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/hu/firefox-106.0b3.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "5be0655faac91e6b891cf8cc38e798c6ce182dc591a8f0fa9263a37bc482fc3c";
+      sha256 = "ce683bed79893a6225e9ed53e7f8b7645c30908da29185996e7d73564b30db71";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/hy-AM/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/hy-AM/firefox-106.0b3.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "58151ed4a63d10a527945a7851f0dd5d341f1cb615e7fd2611cba6d949261bce";
+      sha256 = "84cbe39875c176a71ba1555ef07494127691fbab75b1acca2df5f1f3d52d40a7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/ia/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/ia/firefox-106.0b3.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "3419edb87595c744b8890f0f458ebe7dd881b2a3545c1fa6ef4716f20e6ddaad";
+      sha256 = "f615177f141ac347113b1b255152793308477e8ba54b71635a2becff9297cb11";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/id/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/id/firefox-106.0b3.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "95735d6865e13f1e868e9fa582dd86bda1715be06a80534a72cb6d255728f78a";
+      sha256 = "c06e3b974cca5e68d856991a3a9d47dcee848b1be8b3177d004e458f887e564b";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/is/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/is/firefox-106.0b3.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "942bb818eb8922d9f86eda1f1347699437b161e63ab2ca54d43971701581c1fb";
+      sha256 = "7544bb02271f0ff91d963e3abf63e0e736fe68e14b6f7c8b1a945f641048715c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/it/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/it/firefox-106.0b3.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "7a30e107554b6d4d5438d21d3df7e53327a8fa0f001399c89ccc534f686959ff";
+      sha256 = "2bebb76660a12ed410b327aa957761f66bad14c9095a89045d5a94f6a2186612";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/ja/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/ja/firefox-106.0b3.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "bfdf4acf3c3606b61a6f02d286400ffd56ce672e2f5a6aad9212d5fcd2742fa5";
+      sha256 = "b0dc503133ec86e0055d82372c2160e948a2891c321835d20be3443ada07e376";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/ka/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/ka/firefox-106.0b3.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "bd37a60fa36a0687ca1a97d431382ecb10aee1100e7a589e418884d1ed4cd5a8";
+      sha256 = "74c85b6bd4e74005271031f973b8562d277d69bde9ff4aed72fa563ddb94cb42";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/kab/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/kab/firefox-106.0b3.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "ac6df8191c7376fd03cc96209665cce4862086b249a824a39e10f34668121480";
+      sha256 = "c9caffd3e795275c8e77d6689693a85ce0d77901674db71836c708b07c8fec63";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/kk/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/kk/firefox-106.0b3.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "a84d03efe81e44275f91a20c0bc369dee296deac1bb7a6173657d56a4b71a460";
+      sha256 = "c9b368d8f860f3be20bb1309c4d03ea931382d7be6d83113a71332037dea9830";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/km/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/km/firefox-106.0b3.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "d84c74e09bcb6d9dff3ae550d0dc09172d4318dfe88e466d1f80f53f020b91e7";
+      sha256 = "e5252605b9cdeef02fe235fa5f8b4bf8d0550cd3c47951d5d23b0ad3a8e7c8c5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/kn/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/kn/firefox-106.0b3.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "c4ec29e2057c0cfac9154b40bc918f49c77025f202ec5cde9943dae36dc100b1";
+      sha256 = "b2f36f393ed2260da707531c63b41c7aa7bd4510a5691adf7b4a9a6120eee8f5";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/ko/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/ko/firefox-106.0b3.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "ee54595d77e5d7a036ea6d768917c82e1b72d5fcfc51aa250b9ceee705a196a3";
+      sha256 = "bfb098b40b321a090987886df22faf3d0b678193e3060d4d27db209e19df04a3";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/lij/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/lij/firefox-106.0b3.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "79181c3212f137b020a662b36c161f926e3c41f025497257ad0477cf22eb9872";
+      sha256 = "484cfcc3ff03acd2ddd1f990a29b6028a1eae08eb0cde9841357f12c125c1bbc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/lt/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/lt/firefox-106.0b3.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "00e7057b34c272396d3b3f1cd72213acd460c798ab9ac17bb035ceb6cf2f5afb";
+      sha256 = "0f467a329fa018a97758774a95d6065e0f1510a1518b36a75a7089485c71a3cc";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/lv/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/lv/firefox-106.0b3.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "35b759cc6cf1ca411e3be03eaa189c1e4f37bb766e91563b8f87c8eb5c7abdcd";
+      sha256 = "094dd348d617ede6a6291a333eb65c1eaefce44a5a6c7ae1f354ac51a5c02ddf";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/mk/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/mk/firefox-106.0b3.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "178c7452297fa99eb7f487250444c711849f7baf8973221ccc9255a1ee9d6402";
+      sha256 = "7fa9a0b0b4fb91eab676d687cfd8147df376096c0f5126e67f974f18b3702225";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/mr/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/mr/firefox-106.0b3.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "67f3e0eb39497e4ab1e05f2a64c27701730e49ccf9376f0e20915126457797cc";
+      sha256 = "0d8515e46b4fd3f321cc59926d3d9acfb7f45c1ddae4b81214f481284951a3ec";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/ms/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/ms/firefox-106.0b3.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "851f4455e3e3d2588fbf2170df9dd740b4f18540b0a6ca18ae219d6f1b912a5a";
+      sha256 = "537506a6ab68357d82f79754a31c8bf2fce84860ebf6c562680fed03273b7b9e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/my/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/my/firefox-106.0b3.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "a93ac7cdde56c1a75a80dea32846591ce0f80d409ef5d2794b6fb6cdad0d6255";
+      sha256 = "0756c5eab91e3ad8cf22b22bc69820eda18e077f43e383df921002877dc0072d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/nb-NO/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/nb-NO/firefox-106.0b3.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "27e2f6d7051d77e4f4cdde55e4b77c5b6b14aaea43a88e20026884e75febe3de";
+      sha256 = "be7186bcd63476ad19aaad3c9d909297dc8abcef44ff603b2092446a2f2e5c2e";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/ne-NP/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/ne-NP/firefox-106.0b3.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "856f82d7a84a7dd4c50cb2b239210fe1fa06a2bd2509640305b4528f27d318c3";
+      sha256 = "eb5f1361dd7f10005ed23538e76e16f6e704a295dd41a286881436194a70ca62";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/nl/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/nl/firefox-106.0b3.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "004cb6370433a1c146d90ed2b4f5fc685a53585bac520f60473c145a6c7c014e";
+      sha256 = "8c50cd3037fc2afad2937c25c3a0c7e5832c703fdc878a3c35aaa0f59583da9d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/nn-NO/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/nn-NO/firefox-106.0b3.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "5a898859bb5c3c2630213883c818a9078a30e843d79ac0005984df8e406068cd";
+      sha256 = "7b9b33c98b4ac09416c80e423bdb2ca5b0fc5de976663add470fc07ba65fdb5a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/oc/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/oc/firefox-106.0b3.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "d5f9e2894aaa00dfeb0b87031fbb366d790a652ef1d89ef3bf0e450abb77a42d";
+      sha256 = "80f45ca3656399ab0c7aed3203ae3d726df381ea539833ff68048453f3783e8d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/pa-IN/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/pa-IN/firefox-106.0b3.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "575d5c415aa9750f2bff121a39595e1a10164d098597c3a4d87d2fc7f26e855f";
+      sha256 = "a14fa2be62c8616095846ef60791ad314660696356fc36a5819b36c8d098703f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/pl/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/pl/firefox-106.0b3.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "4df2c428595923a73cc540e1e5bada6e785f7cf0a511c88f165e4ae60325df78";
+      sha256 = "da43bda18dd53db74a8f21f63508318062c152dbd2033b075b0bec8aefd0d3a9";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/pt-BR/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/pt-BR/firefox-106.0b3.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "76d3cfcbba8bb94f1ae8a9e7632032d313d2f9c766310fa528128347c597fb57";
+      sha256 = "eff28a0773543d664b5dc106aca6fa22d6455f49c8c73617085dfe003a240497";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/pt-PT/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/pt-PT/firefox-106.0b3.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "b0575a86bb28ad8a8d313167aaa199caf95f0a74cd9424adc64096fe8dba3d38";
+      sha256 = "17c77a2cec7b281d8389d30c0b1f2584b921ef04f71a96ab772930633d4e8b91";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/rm/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/rm/firefox-106.0b3.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "bf5e9b966bc54be129ffc7f5c8155eda28aa4b89726ae62255b2981d281eafe9";
+      sha256 = "6ccb9d232408657c6d9a0fa1e2f0d08ccb2340cc22a17317ef33f092621a41ac";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/ro/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/ro/firefox-106.0b3.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "604a23fdc0699918dd013851a588e90801d1c7a3fcb94f5983dee5fdd3851201";
+      sha256 = "147aca32e5b58e12221706b079688f357d7cf678407a43cfc4fe1d28d8c39b71";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/ru/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/ru/firefox-106.0b3.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "3794ddca37f69efbd26c808f28b558a44f5def86bfbc0c5023ee58409b08a07b";
+      sha256 = "c5c25d8139651e68a6ed05a19f22a98bb488c5ec1326fa85f76cedd04d1dcbfd";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/sco/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/sco/firefox-106.0b3.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "814ed63cfaa58b186472704bb69d5561f5d75a9a83b854672b7808c7e15e3dd3";
+      sha256 = "1767490ca56ef443c6142c69af4543b55a7374a3fa95baaf50eb94e68cc20055";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/si/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/si/firefox-106.0b3.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "58c552417b36a5769680c8ea31c0525855c16eb7789c8318066526a6297ef207";
+      sha256 = "b9f580a402d39a2d3639b6c87606cc0d5b32a7807762350defa96a51c4486ecb";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/sk/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/sk/firefox-106.0b3.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "21cd5e16eb498ed6bdea3cd41adf1ed3155f87ea9c33bd2e3cec31c53c67d494";
+      sha256 = "20e5dffb28a5dc6c615032e4635178db8c0991ef8482417c8892565017821055";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/sl/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/sl/firefox-106.0b3.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "6cb2d2644c374f61afe790768b03693f4d041644a7368150a991cd0fb2ab52ab";
+      sha256 = "5ae21eeda64041965ba7084f148e96fd7ce36734b7cf7d616db38943c2bcfc1f";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/son/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/son/firefox-106.0b3.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "f54b3097d68d4639d4648ae5e10908d65fb5273f06c5a29302fc41a82fede683";
+      sha256 = "9ced1c97546f868f6081e8735b33a44112fb72f58c02609eaafb54dd9d204a97";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/sq/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/sq/firefox-106.0b3.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "94c7b240be6fc90629675956c555fb8f830a8f21b4797bf560b5803baa023500";
+      sha256 = "581ea6d1c066b50fa1087662c6f264acb096733036d44f22af5a99fedbc8fa90";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/sr/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/sr/firefox-106.0b3.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "0d53baf330168accb3baf8213ce658fccd123449be2122c29babfaf0d68a520c";
+      sha256 = "7d5206bca5d699513d85d778e157bc5e4b662cb8d9023891b181ae2dcd99cead";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/sv-SE/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/sv-SE/firefox-106.0b3.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "965b92624b9a60f1aeec899c2558243bd5cef73a21941b285cff653472707996";
+      sha256 = "bc07818899a4d33d029008f3265a566494fe096d69a95d166bd66cae5fa5348d";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/szl/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/szl/firefox-106.0b3.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "ac5ca00d0644bd545b28cc4b0b3ec94481ef3ae1c894dc107b579b3e6df20139";
+      sha256 = "a005bc787bab1ebb3bc7a5b310e5ac36b8db709cf0a6483c5b94cd44afe8f3d0";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/ta/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/ta/firefox-106.0b3.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "d62359bdcf776f6b589c30021dedc16a304652c8656814ef6e03bbe1093a34ea";
+      sha256 = "0c6de995767d5b01b2120d9876546c459b5b1c6da0851c65bef9859c0014e1ff";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/te/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/te/firefox-106.0b3.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "1ff6dc680ff913a454f1a4530a070a28bed872f254090ffed30fc633da7c0428";
+      sha256 = "4a3ee2a19127edddd98014f4125e2df415a1ad82b9171d01b113faafb5280fef";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/th/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/th/firefox-106.0b3.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "73978861cd35ff8348cfbfb194df588dacb4e4bc4c90710a22eab1f534d5de7e";
+      sha256 = "f96eec3a103e71ebb2aaf5c7dfa455f8a66826d5a293cb2ec38cba5e69ca1512";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/tl/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/tl/firefox-106.0b3.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "b5fa8cd13d050ae8b834e45144033afb26967399986814411081c6fec47e1c34";
+      sha256 = "f96ca052c4ea09c441e878fbd9ae2ade397139762ec14832333b1e9d274d3374";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/tr/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/tr/firefox-106.0b3.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "f502a2dd9338020178cd7e6d88a51df5486cc4fa760b612ea01d6d9750ce4a8f";
+      sha256 = "5f8f867cea2a7e3eaf732ce397f44a511c7198f3040c1c81745a4155933bc9a7";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/trs/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/trs/firefox-106.0b3.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "baa2ac9fa3f4d41b31e82d66f1ff5d651170d77b99b05bf475a5c297a89570ba";
+      sha256 = "8929d42419651e535ebd047b6c78760c91bf5df124114cf69f59836ebf5362d6";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/uk/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/uk/firefox-106.0b3.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "d2ecdabafacd4abad6809457e76975637717e6a832cd0c9bb2b871e9ed5712af";
+      sha256 = "bab026f462d0aafec3d1a23a325c11eac694c39bc217d640b1745e41de1ca53a";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/ur/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/ur/firefox-106.0b3.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "c50bc8f450767960fc444deaccf0cfc63bd34b7c3d532be605e9a82e7eb05e32";
+      sha256 = "d728db2ed8466a4b0966584f71c3e5b96d4f572dd6790a89b3e9607dc62bf501";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/uz/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/uz/firefox-106.0b3.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "bbb6e86693afdd573aac40d2b0664b8e2699567aeeee32c71aca05c90fd0aa67";
+      sha256 = "33fcb54dca835032bfc2ccafe606a2115a92519eca262ca8474aa07401818744";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/vi/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/vi/firefox-106.0b3.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "c69e88577023555cddf20c62df9c9836452c5ddd930ea9fed00b629e3be85263";
+      sha256 = "b245b05777431d7676b7f1e146632b726940ae443179bdead42c7f56ec9d6239";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/xh/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/xh/firefox-106.0b3.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "7f2ecbcb64141eafc7f1d8cc62c93387b8cf4fd19a83d77c207dde63c51b8757";
+      sha256 = "0b186036c34fc05e517052ec8a17e0db3bd5855fd4b9668b2bab7ca74bdf911c";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/zh-CN/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/zh-CN/firefox-106.0b3.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "b864b41d58db6d57c36cf8e57b283a33e91cb398a771591cdab729001c82257d";
+      sha256 = "8b42db49e369c79450858de54e22e27f9c701fd264c8e4b3b14112111ead3ab4";
     }
-    { url = "https://archive.mozilla.org/pub/devedition/releases/105.0b9/linux-i686/zh-TW/firefox-105.0b9.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/devedition/releases/106.0b3/linux-i686/zh-TW/firefox-106.0b3.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "342aaca830e468d1373668895e15f31721b740a147e924e7eb5b1f401fffc4a9";
+      sha256 = "f6e30d56a071009498822f31923325585abf347f75298317766c2bdcddee8c4f";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,985 +1,985 @@
 {
-  version = "105.0";
+  version = "105.0.1";
   sources = [
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/ach/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/ach/firefox-105.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "1a292c13229b7451c4148f909935c06ac6d7c4e544a845b0f44e0eb43743f512";
+      sha256 = "2a292e4d140ea74bf51fb150fcf07c053d3b670780bbf865597a90195e41c88d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/af/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/af/firefox-105.0.1.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "00378925e52096dc7e454db44b94fa8e5312b812027885a5e1a5cb0a2b8dc8ca";
+      sha256 = "001f428c1923dfdebf73bfcbe7e56b6387c98f2c7b55f2c068c314bb3d0e394c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/an/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/an/firefox-105.0.1.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "f1d1f8848e979865e633351d55bbd67ef6ad6a294426829b01d986e9b010d049";
+      sha256 = "515c8ff97fff98703c1b7a225411ed8cfe256c2b389ce9777a52a711ada7d8de";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/ar/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/ar/firefox-105.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "f92bcd6547128c5292cf78bed33222a96f04fc7d74715ed611d2f2450be6c3a8";
+      sha256 = "e1c07b1be533debf394c3d5120cc54a1403963dbae6044004db41ea00795f238";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/ast/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/ast/firefox-105.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "41bd4cc67ca2a40d295479ae9d6938175ff7d2987afaafd822105b61f4368ce3";
+      sha256 = "b3c36cb5c6d9365dd9b070ece37896cd83405dfd7d5bd34c4438e50454e1fc14";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/az/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/az/firefox-105.0.1.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "b9a91104a75e3d881a0194c7155046e9c6c89b51b4df58bf74fe12a34de98d92";
+      sha256 = "456b1e3609e8e4629b64795870c20fd231bdb53223b24046a19649e367f37ecc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/be/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/be/firefox-105.0.1.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "088d4f2e052d9167a0e8eac39de5958d13fb77731946d21aaa91ba6715d5f8fc";
+      sha256 = "75d5ac806ff70fce1671636794c9bc0451eb33fc7109a9e195cef8246d80919e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/bg/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/bg/firefox-105.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "e2d41150df32428899e4076ee06f2fd4311945c077507503d78f2522da2322aa";
+      sha256 = "436126b9edf631eea6e68b7068cc752a3e3e6d86e77722cb74fcb1c3dbef7bd5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/bn/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/bn/firefox-105.0.1.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "b1883a5fc51b0a718bf7ae10996ebfa14ce5f015a6d036e5d103b265e751a945";
+      sha256 = "2f08c7ac904ea50df7cff5645ff4bc56e470b6a7215affeeee1497e63edaad06";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/br/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/br/firefox-105.0.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "20844c95fb0151babfda31807c37a8799c7df858e8e6a62a758d1fca36e98f78";
+      sha256 = "aa77c3646cb0753d80bb52f3fd1e71a2d1e13b004d3924481dc175c453154269";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/bs/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/bs/firefox-105.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "96c8df2c1b9253a865199174ba9d97e1298af51fc8105728ad17e4ea91caecf4";
+      sha256 = "ae2cf70e774eddb67c6c311f3d325b921b7db74a0f8b06146ef2431cf79df804";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/ca-valencia/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/ca-valencia/firefox-105.0.1.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "2bda535430ed14e6e2e63655c1c1306e172673bf52de65f21e850978140d667c";
+      sha256 = "b85b6d597939f559270fda3993298db51717c2b86ce9ab8d50fe777b1101bc1e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/ca/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/ca/firefox-105.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "c0d174f3436b4a0dd1aab701fd1121aa702dfcd0f588ea966e37a0389bca2e71";
+      sha256 = "01764fb52c22caf81291e25efa606e28796fc3c9489fc95d9312bfb60a6590e7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/cak/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/cak/firefox-105.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "d74a1176d6ed324798742f967c807b94b54c3a3f43fe20b175ab2cc6ba260401";
+      sha256 = "56b87331ad9c5aefd3890fa760a64397d878b93b48bed93a5d743f72273df943";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/cs/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/cs/firefox-105.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "80ee86b86d90db7243e39f40f32a0cc78daccc54647cbad37aa01913a21ca09f";
+      sha256 = "f4ab7f935c4d13510c82d0c05627f1173f2e6f0c314b5e4eb27210982d837238";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/cy/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/cy/firefox-105.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "200484dbcc4bf3bf1690c7d573b88b6b915784941ce00bf3e3a9a9c2f5889cf6";
+      sha256 = "0d77c652ce5deef61ae2ad0bc78de9a5fd1578d4e6c7cd0152fb7d80df125ea8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/da/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/da/firefox-105.0.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "001a37c29430cea9adc81f17e6f2aeae561cc4da84d112cbab56a07ceeb83940";
+      sha256 = "e0ed75c3d18380782d229940be3686599a29368a3525d28d5390cc8a4d76322d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/de/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/de/firefox-105.0.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "732cc0f264038acbd33e060e88cf0fe2ffbfda75b50cfdaa9a73e49e827bf1b3";
+      sha256 = "ffb8157e40d92992e6119094ceeb30621b111804956dfd0bcb09c75949fd5b7c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/dsb/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/dsb/firefox-105.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "edf1e13ab617b9d8ee8522125197ec07e0b8b3f594dab4b4885fbddc700c5a77";
+      sha256 = "32ef53801f3e3cebb410956d13c8280e5ee4ac90f5eefbb367a667a578f5c558";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/el/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/el/firefox-105.0.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "acb45ad22ac1cebfc8a69290a965c4885fe7c5fb3d1bd59f103fb9c5d4ab1405";
+      sha256 = "ece05bdbaf75cde0d42d528f5445ee8d36ad312df58d2aee6f35d70f635ca977";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/en-CA/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/en-CA/firefox-105.0.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "7e7c21020c50de04645bc48dd64b033e1493533e458b7f82e39a46b311e12715";
+      sha256 = "258eea4191b27d4d677769b0e9d24befc8bb186ab820265e6a89706469d4fdc5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/en-GB/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/en-GB/firefox-105.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "c6a35861212c90d7a8bc63f024c19a6529a7d84dad39f1bc6bd764c704bef799";
+      sha256 = "72323eeef336612e706e200b0e4bff9e7dd6041a5f968810e274b697469cccf6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/en-US/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/en-US/firefox-105.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "50d57e7439e8edaaa274dc180a06c9c88b725026baaf2f5654e459c8d6411961";
+      sha256 = "99d277ca46e0f6f79a8b7f7b77d05a0f4d2aa63b6c582ff6f248984d87fb2c4b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/eo/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/eo/firefox-105.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "fb0dad5b579fd25ccae8be9e6e7711fc2bd21183eb4e9db287fce0332c09f6ac";
+      sha256 = "9c0fcbc3febed025550d4f1739a13a5765c09c3d79be15b2f58d935a09a14f78";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/es-AR/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/es-AR/firefox-105.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "047f03d455d4e29e01945d4628f6a028dca7fc471f67b61b037e0bab553ea7d9";
+      sha256 = "3cb6116afdeeb4a39e5d40ca31fcd2123266956000ddfcb5886c2a31c2596a8c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/es-CL/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/es-CL/firefox-105.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "702aa0d91bb6ed52f1312e16224c3dc889377c3a53e918547a59a2b20f3d1d7c";
+      sha256 = "2dee3c9d15841b7fdeb446b06de5638d0938f47374b91aa76da3f0c6ead516d3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/es-ES/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/es-ES/firefox-105.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "b918bf014e400c6566062d76adf78a29ce878c060c2af335d67a2c393da2b023";
+      sha256 = "0bec68bf87c51280895aad0f524780e62acbdd9227227634aff8431802f2536a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/es-MX/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/es-MX/firefox-105.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "2baa4c0111e55bbd3b0427e4d9b3bd45137f46210372a064c1e6e63fd24aaca3";
+      sha256 = "dbbd6228aa426432bfd8772c3ef3ac54fd1f9c548d8b0472033f56b3f94864f3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/et/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/et/firefox-105.0.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "2f6ab458dd99d4cb7ea588da9ae8e4c0cfa3a0e313cd4ab742488b732834ed8b";
+      sha256 = "bf88a2d9bd8e1650342a06807c261c4d46d7f58380151bb4beb17416315dc7a0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/eu/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/eu/firefox-105.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "4441f02b9cf1262422cd8fdd7e757ac0b313a3759375ac561ca7be100e2e0bf8";
+      sha256 = "9635765d8b7ea51881a012298882e7f644ffcbe6b0d6b227db15cda6d568b92f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/fa/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/fa/firefox-105.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "d268d5f57843b8c63fdb4ac4c563e4352634ad0226ba72c25f0ab799a976fd75";
+      sha256 = "d97dd45457d806e5d9adcfb05ec5000469ccdc7d97fcb866f7d27bd693000985";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/ff/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/ff/firefox-105.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "3b3c3d30f54e338bbf2145316746a252e1c01048e2e93ff79952748be2d91fe0";
+      sha256 = "d812c9d77ed85b6876ac13f9930799b90b74dfd8d1a7c48593aece3529913243";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/fi/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/fi/firefox-105.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "74e873db63f7077c9b3787de73b8cd6ed65a0828ae96e273f8a73fab5979410e";
+      sha256 = "e6a50f893698ebb52406d837fe8de3aea1588477c65af7b5580c04d69d1cd5ac";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/fr/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/fr/firefox-105.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "95e30f350723ee4beefeab95a7475f2b65821b7349ad04c9c674f7e0b21dccc1";
+      sha256 = "4567e8b6092b6a027ba50249244ac3b3c2ff5d3d2b00e9abeb0836cfbce2bd6e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/fy-NL/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/fy-NL/firefox-105.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "ab62a3c819e05cade2613a38a7852e6d45569fed2b6d3538d1efe39c1bb709b7";
+      sha256 = "375ddfcb709e820a568f3a3aa5dfe62b6699636506aea3045ba0f499d8163937";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/ga-IE/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/ga-IE/firefox-105.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "c29d32e1a1edd44a6fedfb6bfca84819f73380ac2162bca054c335f85f3e8456";
+      sha256 = "0fc745fdaad6978e093b7b736b9676dc830c6e60a924e2a095278b6a14f76ae9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/gd/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/gd/firefox-105.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "fd90b4cf6a3d788bd92e5f2a923dea008383d0206dafa34cd6da9e2d36ca783e";
+      sha256 = "9a8aad8ca0baf54ef2eb0c77175c394c6f4aa676c51781fb78c6e5b00e407758";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/gl/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/gl/firefox-105.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "fcc5cdd6dbdb1b09a066f02c399423e46b9edc7ada6d1b57d4bada8b8c51e279";
+      sha256 = "8979485ed7c0a1bfa950749aa3d291bc25c7f5aaac6563996a5b991e05989cd1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/gn/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/gn/firefox-105.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "3c98df7fbcc0aadd0f5c034fb33350417cd01e701d73b11b4c8fedc08ef7b29c";
+      sha256 = "1dce9550f3d2942a8688fc9263ffad3abbbd11545d9c29255924fe88e1cbf020";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/gu-IN/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/gu-IN/firefox-105.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "df5813062506de9dd1372d4b9f9f7fc0cf5bb2ada7c3d5a4edaaba4eef446231";
+      sha256 = "3429fe9b7be0daf7ae039e00b7d16ca16b2dcdd77434575091c2deaa33dabbff";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/he/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/he/firefox-105.0.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "b7f21ff10b77d952a1429912f92471cd64e9a336ce182e04c37ec613e5694eaa";
+      sha256 = "c5b93b8b0aa69ef0a9c29dbc81bcc532652d08a2891874c12d7048a475240b2f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/hi-IN/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/hi-IN/firefox-105.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "63f7c05c0e850ec78ad0314dd1e771b25fff9503c9647b1d23889bb578d32e47";
+      sha256 = "54d3ac7e94abab83b03b88de143523e56a6e0c85314c61b3c821b8145e49593d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/hr/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/hr/firefox-105.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "f62266b8bae9ab840f826be6122391b48eb1dee8272007544e6a614986a84049";
+      sha256 = "1bb9a4b332aa13786fa21dd23ba51b5faa69669fc41ba996b84979ec1d0cd638";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/hsb/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/hsb/firefox-105.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "5ec0a74fc56802c1a59930d7e96da8b8bf4f364ee4efda58be205847b6f4767b";
+      sha256 = "d3edfbf7b52beee12fe098e20d4a76dc092f1bdb5717779f19a3ed58ace4c6ee";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/hu/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/hu/firefox-105.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "12f88fc857922e8f577703aa9ec5bab2442cfac411562ca2ca9a402a0f9ba2ca";
+      sha256 = "47823efccb14195f7deafbe49021d2e9224852f5d87771ce680e05ed33927209";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/hy-AM/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/hy-AM/firefox-105.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "8987f60b7ab54a045ba3b7fa87a2b2cf462584fa193384860fb9fd245e37cc07";
+      sha256 = "130856c658b356bfa8de750fd4e36f940a3367e4db368acdab0e071954abb1d5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/ia/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/ia/firefox-105.0.1.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "1d13bc5613e508c72d66c2ae0e44cb6ea5b73bc094589cce8695f9d0ee548eea";
+      sha256 = "f6f99a21f73c43049f0935eda76b866e47b6d6e1ab0cb82464550ce13b06f4fc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/id/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/id/firefox-105.0.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "64a5a51340fdf7978c1a2a6be36bd39949a65949821817dc2022437b0dbca5bb";
+      sha256 = "11155d40d29b241e4d10d3d71d11a81353498f40a33d2ec3e8a16ecba1ebb9b0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/is/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/is/firefox-105.0.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "eebcc9a6d514a7a378781325e52f0b16a002dc70510e1685771212a5ea7a6525";
+      sha256 = "ef750f5c5fcca99fddfc6a28c5531211873770efdff403b0c4f6ba4ea6492375";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/it/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/it/firefox-105.0.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "542e04dcb045f0b9cb14e355bb65004715edd54fb99d412953b5656377860453";
+      sha256 = "f77fabfe81caf68142429d8840f9c3a0c3532e7bc02d4425e3394801840ce607";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/ja/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/ja/firefox-105.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "70e1f464e5561e9808676197b56ae59905296b10fa16a427f3f6132f3f7011c6";
+      sha256 = "618404d115720cfcb75cb462179f648772c98cd78912ecd2a2062f7f977c606e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/ka/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/ka/firefox-105.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "5d435e6735e16f89fd1cd7ba7a27d96520252a532923f79d0d5a3b09c205b8b8";
+      sha256 = "99b41e63b573b62fde39daee0af1f7c0ec6b93b30cec594691634e27f70cbe49";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/kab/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/kab/firefox-105.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "dc35fab048224d5ca271c0c7cbee899d75443d18793729121a16ab6db9cf0269";
+      sha256 = "447df815475f83c3b9215758948292d9eb093cf417897f4904ff4253ac3cb818";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/kk/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/kk/firefox-105.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "514452b1ebba8d95a69f28f5a6c5c294f88400f2b6df86b457fac141e7392a90";
+      sha256 = "376a29caff8ab9382321487665b545ca97b9177551e368158176c9d50f5cf5e8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/km/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/km/firefox-105.0.1.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "7a2912cdaa060cdce14670abae2d7bc6bf651252bd946a6a1c54553597e2b066";
+      sha256 = "86b08e8922c907bd0358d91ab19a5b5ef84ac505c33b9126eb4c4ce034107aba";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/kn/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/kn/firefox-105.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "988d5eca50317aa2ea6e22c6c17525802c031de53d57994c6f5662c229fb4bbb";
+      sha256 = "d90f60352bf07cf3366f1a421c9dc7ae4c16b1ab7db3edc252eb884ee3f7035b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/ko/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/ko/firefox-105.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "7fbf4ae8548e2d807127728d0d2c677987f95ed4910479fa3e72bf1a6516e88f";
+      sha256 = "7e5144713519d0b29451047a0946215117791641142247c1f90d6e4c294ebef4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/lij/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/lij/firefox-105.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "ec0b3e7f2814ad7ff8d837c35f9f332459faeec13dfe538f35482f6914638968";
+      sha256 = "75165203c5ba0c382818214dddfeb2ab94a6948f4c5c7d142d31c36ca9422e2d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/lt/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/lt/firefox-105.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "d66813d963ee72207e22c73d9a977038b09695e7c438983766d4d442fb00f410";
+      sha256 = "6cb8920f924f8be2fdf6b8cef9113e4b539205beb24d5f5110712eef818ca279";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/lv/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/lv/firefox-105.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "fd7a156896aee98d88d5865dda0a66a4c3c4151e7c2a399dcd9e8aa0156fe1e3";
+      sha256 = "1e4e7622a97910462ba924109e8e0e6d35efcfbdc849ac3621d61ccd119a60e5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/mk/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/mk/firefox-105.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "327988768a64637a83ff57eeddf3db49bb1cd9cb562239e54d0e9eb342495db7";
+      sha256 = "88ab94691358f26a294da16f2fd51755bd873dcfa07c6ab3e5dbfefe4684315c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/mr/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/mr/firefox-105.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "0bf8b90fb7685c2436a54835cf06f0533d4ae07462e8b255fa88017ade226805";
+      sha256 = "034d14b22d0258499863487b4cb693be23fab6d710f920640ede7430a75b0c11";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/ms/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/ms/firefox-105.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "6f83c323134846ea7107aafc30485724dfc61760721ae3af86fb6abb5cf28251";
+      sha256 = "0b0162fcf05a7317f8f977b93b532f312460de0dab631376ee1b8f618c776ec1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/my/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/my/firefox-105.0.1.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "ef6e44ba942630c5a0a7fcd92146e750b61c0a3afa6a1f29fe9bc361e756a108";
+      sha256 = "d01e4b321b2193675ab28c689164ce13f83ab9d6b808419a82536d294a230d53";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/nb-NO/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/nb-NO/firefox-105.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "b7a8dedcf29158ec99b560d4214088ae679a959ebbe096c394c3e1035e21bdcb";
+      sha256 = "bdb9e0a86302a4af47c84342aec2c9987b2052e876f9b81a1df20165593ae30b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/ne-NP/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/ne-NP/firefox-105.0.1.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "1a4bb04550e3b8fc4497170444dc2ca3868de203c3cb9bb9d3b0cbc102b0fbb2";
+      sha256 = "5c79c03bcfb2f81fe3ad3bb530fb7181c86e8615a096fe30b4bd207a6da3e395";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/nl/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/nl/firefox-105.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "e9e6623628921b8df212883c878faad149499eb540436607e32654658704ac14";
+      sha256 = "63733782d97d22d00abd3f8ddf82da5ff5d9313e2c5c56d7f767d153fb9ff3ec";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/nn-NO/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/nn-NO/firefox-105.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "06b3514690d587a2e8b6d5843e9aa70ceabfe5884df4d18fa3f8e1746a67f78d";
+      sha256 = "6e7c22e2b4bb9edfeb9936dad41c686bc27b3dec0dbcbf779388fb0bafd33e7f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/oc/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/oc/firefox-105.0.1.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "6fd51196fd68f4dd07c4bdb442f74d47165983911f9b60657963d448507d09d8";
+      sha256 = "071afc449c6e9a2a2168c5ffb520a23970f95c8c1b9218ecbc36260d60d9690f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/pa-IN/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/pa-IN/firefox-105.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "f5162d14437ed6ee8f94b23c321461790f280925b3135ac1c16533beec2412bf";
+      sha256 = "accfda66ed9b56182a95459ee2e0dacfea2991d47899826eeb1df89c390ef837";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/pl/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/pl/firefox-105.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "d3eff65b8ee7530e3269181c921bef1cc08b1964b92e593aa55494636b8bf9d8";
+      sha256 = "de2fc27c76605ed73b4685debcf0b6673bb0654282437b88df60a4594ff069bf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/pt-BR/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/pt-BR/firefox-105.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "91bfc0eee2058b030310311dbda6d6040adf818822349c8d9b413f940f85c800";
+      sha256 = "cba9679f14dfef7fd092b38d2477a4f48ce23947798227ecdb7fc8d2750e014d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/pt-PT/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/pt-PT/firefox-105.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "61bd251f547488951d507c35089f04f58bb499d4af233ce1cdbefff26ebf594d";
+      sha256 = "b04db51038bcdfe8dd6cc7d237f12a933d671c4f591742f4825f03e6f5675222";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/rm/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/rm/firefox-105.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "9b82311d831b1fc108e2d0a912d40513b71cebdc07233cc6e3ec03b1cd770e3a";
+      sha256 = "967b15befae35083f0b1ded69fec4deb8250211a9b099df76a8e689df2ccb0b0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/ro/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/ro/firefox-105.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "fff1067b0222be7bfb029ea529b7aaf43713815518542a64fa3eb3c37634fdb9";
+      sha256 = "7aa8c11f8e0c2e54b7c25e3d71fbe3fa8f4e36714e42a3cc0cec8167cdfa3691";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/ru/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/ru/firefox-105.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "c65c6324f5ccae6ab82af144ce2e6ed4f3b6be64fbc102c4ecce502e78703709";
+      sha256 = "b934733462b2dad1ff962709b6597e7827cc2880041f20b9015f8f270ca8df42";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/sco/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/sco/firefox-105.0.1.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "42e3c9dbb1b238d35b1f9b8d76ded603e4c7f2b686de549b134120fac6c0c921";
+      sha256 = "49a09268d03a2d92649dcddf34b3d0ceb94899529da1c15249883e3ef8c30ffc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/si/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/si/firefox-105.0.1.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "04677fa9a80c129fa9f535964b86261904da2a45dd2ca713d48218710c6f89c0";
+      sha256 = "fbfe9ed75eb62b5c3404c99228ddd9341fb9a0ca873d03592061952b0a6d3864";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/sk/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/sk/firefox-105.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "50d7a2345ac26ce7ab2f8c91f5b6edcd4849d96714d2f6c7f9bc0ea00217b4d9";
+      sha256 = "372d7fb0cffa5f89e2a9e44651f7a07dbb29911a9d5806809bf5db7a21005b51";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/sl/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/sl/firefox-105.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "6a72e3d498064b7efb84c152659fd5d21ff4dd7d9006ca57b897caefe980cfb4";
+      sha256 = "f6859b6e603261a3db82b368400d46a76bb10b9c0b3ce5eb39d493e41b534e6d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/son/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/son/firefox-105.0.1.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "2cf113f1ad98d5a82f65d91f6a9b5d54765e409060b7fc5242ea4741411f606a";
+      sha256 = "0891be0acc6412889574416f09642ffd344579185a602384ae0bf1d82b43cd43";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/sq/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/sq/firefox-105.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "a1d230bcee00d6fe1e22dc95a87d430aae59807906163c490e1093d488a35661";
+      sha256 = "4f13416dc34f59a84043ab3dd018a4ce6d0f20a90458f637d836e4048dc9852a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/sr/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/sr/firefox-105.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "8e50e6338ef41a7597a5ae1393144fe722a73ae84b1e05c84c24e21213b28498";
+      sha256 = "47b49b18d3cf2f9cd1fe81b3e13386fcf188aff88eaea478e161f674e19d017e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/sv-SE/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/sv-SE/firefox-105.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "1d538b977fc776cdcdcadd4d7031ac1d301a85b75a4f0bd8fa3d708c57daf2b4";
+      sha256 = "af5052b8c4167b0f95dd0cd8b0265b67c4a3aba52c7b762424d6ee6462e783a1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/szl/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/szl/firefox-105.0.1.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "92b268a8133cb43e2d9999471f75928e1371fe7f1842dd685260df82111626cf";
+      sha256 = "51dba44f903035373235f8b1a997387832e0a67fa74e1fe6d14ea44b9a363744";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/ta/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/ta/firefox-105.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "67f5bdc5499dfcebd5243445ba4989a10bf6d34bdca4276c4dac906e7d3176ce";
+      sha256 = "0f6e7b5409bd90a7120577480188257d590996a75a6bf11dcffc1cef7c0df749";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/te/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/te/firefox-105.0.1.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "94cdbd7574e5e4e13785abddc027cf1ce829b68c30222b8c9b3913bf72f0c5df";
+      sha256 = "831e373a64e2bcc0f9b60f18ac8e3f5a747e1042579bfd03f5d76d3f04f890c2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/th/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/th/firefox-105.0.1.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "1fe1c121bc6f46cadc7fe47dc05a83371ceebb2927e09c72723799089e5653bd";
+      sha256 = "3e343b11ab2a93557c86daf5cf1a789154fb53fb7090e33225dd04ee30e9acd5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/tl/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/tl/firefox-105.0.1.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "07574319bbf1184da97729cc43697dda35aded21788a6edff15a980d91a3a3e9";
+      sha256 = "4005e0e9a6078bca9c134862335d0d677af0cbd834a8e04e4720f8c2b59a4dc1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/tr/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/tr/firefox-105.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "c9a03af5b06924032e0c6e42a1ac0c8d621baa225203faf1adecd69e6221f5e0";
+      sha256 = "2ef97fceb2fe522ac83dd7b4db509e248eac83e6a5f7fab20064d3ceb4612d6e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/trs/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/trs/firefox-105.0.1.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "3aeb75365a09eb854d1fdea47bd0d61ef18e0f67b96eab6b15d5368be133902d";
+      sha256 = "131ce0fabb180156f04854fd3a78cacd7a07b8c45b78d219261cf76ad51a2f42";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/uk/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/uk/firefox-105.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "8b6eed06d3d014c7ff39867921522c200b2bff6352ecd091cde5559b9f12f0fc";
+      sha256 = "a35637a2633969dea796cd374aa0cd684661ced36ce8cf118514072b08e4a325";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/ur/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/ur/firefox-105.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "01fdfb0f75f410cf0eac52c3e1b6831de8ff5f5d0db43b706ec4f6667527677b";
+      sha256 = "24cb5ca13af2b770b0ce64cc2244b86a57aa70df6ce3d6234bd03527f72beb93";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/uz/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/uz/firefox-105.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "b502d358be20b76cff44d1cb355d4ee3de07f122a47caba90ea73fec5c1d9e67";
+      sha256 = "73008ac9452f1dbfdafcfd233a4dbd3fc2212030bbea5f1bc1e3efe8c291a4a3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/vi/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/vi/firefox-105.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "1b10c1b24f3c63f61bbf23223d09c2a5c0c31ae2d82fe08c6dd39faf196bf205";
+      sha256 = "990bd18ca8bd08d65df488e728d434edccce43a93cc1253baa3bd8d67e9ede40";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/xh/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/xh/firefox-105.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "8f478016e78330551888fca58b52c32230f5e2b83e9960157d5b064582c2e1f6";
+      sha256 = "9efe95e531a2b42d4464d75bc2d54b1bed4830e548619aa23fe957bd372c663d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/zh-CN/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/zh-CN/firefox-105.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "07e3b4a6da70928b2b03a65cb9b45bd391459e7a6829f5ceaea8e168739451e8";
+      sha256 = "03c12d452a4bc63f299f02868d79be87ee0b04ca76cad724964e11bf20bfed90";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-x86_64/zh-TW/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-x86_64/zh-TW/firefox-105.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "0dbb6c6208747457663d8f9ebe2d4daa9f6e202c0875b77323a1e60a59a9ff1b";
+      sha256 = "32c5e7ef19452f315d25c853c9bd24c34e67bda934221e2fe5f958fa789fc0e4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/ach/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/ach/firefox-105.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "6f975c35dcedbdc4699c98571a6ac345063700fde1d78d1e38d685125f47ba2a";
+      sha256 = "c17485b51c8829882e8fb50bd4a0ccd6419ef2b4dc15fa7a15551ff45def53b1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/af/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/af/firefox-105.0.1.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "8e067a16fd1244bc99a634e54cd906be8abdbb19962aafa7bc33a3cdd94d5654";
+      sha256 = "d12603bb7925dad96760de5731c895d287af7b05b1762eaeabab69d5bad61837";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/an/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/an/firefox-105.0.1.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "66bc164c466035416256448da0f9263082aba553750e66cf24e93718caeda4c9";
+      sha256 = "1140e17d0775c8e6ba1fa485aec35b9b7ac8434179a3faebfcd1e1cead070d03";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/ar/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/ar/firefox-105.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "8137ba66a04ede1d0a6fc2c48c10007f62c352fce5d8c23dc65505a69a8f8da4";
+      sha256 = "89d1cc5e45444f7aeb35e5fb094a6be4efb80d523cd0209188c61f10012102a5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/ast/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/ast/firefox-105.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "03d443c86cf9268b7b03dab2c48b99e654a11a9f2d336d3a00a5c3b255a66f75";
+      sha256 = "6bca591e2edf525e20d125e0f3ace831ddd217135537d958c070d2e00b852c26";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/az/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/az/firefox-105.0.1.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "cc1f90248b6245f72d4aa736207d3bbbd54e9bf77f0404894e2348fa2d3e8571";
+      sha256 = "f9eec0db663469d85e4f665969143a37860bc1043a3c5d83cf330dcafb1682c0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/be/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/be/firefox-105.0.1.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "73e05ed2fb2c95555249bab045146fe092cbb4b81f6f87f5f26fec9271fd499d";
+      sha256 = "5f792f86c5fbb601ccb769818ee3755c01fa443e87ed8a1d7df7388bbfb1fa56";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/bg/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/bg/firefox-105.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "6f85215f336a19c6964b880daa417bdde8eeda82a37ccdaf74644b92df56d4ca";
+      sha256 = "32305448e9d4740eb64e41f073e498da9013b90559eecfc619d1476d455c2c44";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/bn/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/bn/firefox-105.0.1.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "2571c76a2340bff32ced9b2797c02a1b2a169f77f0adc59df823621a8e0a070e";
+      sha256 = "f3244f87fac769e054774e1ee6a5e72873fdfc08189f9e7d1fccba63cc75fa2e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/br/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/br/firefox-105.0.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "465b3fe01c677ce713d90034ccf75321c9fdb5094ce3b6d558147f80f1984750";
+      sha256 = "2cd2a1b5b46b52470e14105960593da5da9ece3ef7cba2aa0157691968820016";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/bs/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/bs/firefox-105.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "97d0b1d4e41580a3a868678ea4a9cc0b01bbf14ea2440e2f8fe76735001a8f10";
+      sha256 = "661d4dc2bc6e093e2c8221f626d7fce7a66bd1a427a3af6582959e0073db8dfe";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/ca-valencia/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/ca-valencia/firefox-105.0.1.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "331f99038d04fd0251d9d2df47c2048410fc8212b7a1451697429650ae635c5f";
+      sha256 = "09c9bc54fc0c5b3527d5e2325d6b9b34f6dfaffe1e795efebd4d353a512c4f84";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/ca/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/ca/firefox-105.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "cd2b226430c44d92a56ea9b6d339c6095ff17978d2676522aa658f394c2dada1";
+      sha256 = "930d3dfa38d78297eff4b49359016f9c3db05d05046333b39a63d22b87f38383";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/cak/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/cak/firefox-105.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "d2ac7b2d1a0c6fadb5c1e2b010c69a75049e4ce55054253eefc6dd41d17f2a6b";
+      sha256 = "c8b9108011123ffa9f67a10de3b70384b9f3d4a886e46f4779be8220acc33a68";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/cs/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/cs/firefox-105.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "04390226094982f1aff3f30052769253078078101a5d531628fea567c4870c7b";
+      sha256 = "5f1ff971482d5626a5e4f1e77140cffa508f033049eab5b5036590e6ae8a4f81";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/cy/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/cy/firefox-105.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "db177b41d25895530de7873129efa3e23c9dd322c354468ac9042e550dd63b89";
+      sha256 = "af3352a2fcddda67ba32130f61209fca0b40ff04e1b68dc285dfc55be913c704";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/da/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/da/firefox-105.0.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "f3ca4888285d5c7e77517db130a0a67320cb5ce78e6e2476a31dd3ffccd297c6";
+      sha256 = "498ff4a5713bc063d20b3cf8218e33c33599a7ea663f06d8404a6380cffefbae";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/de/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/de/firefox-105.0.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "10a9c477f387c0fdeabab15c30f2c14f4afa473c931c939e69ed091e75551820";
+      sha256 = "e870df16f1af88255ff245a1becdf801fc79da9e0b862677aace5033aafbf250";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/dsb/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/dsb/firefox-105.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "c51570c8bd68c93c788755e9f2fcdf5a4ce12c275be67b07c58205f857da7cd5";
+      sha256 = "31a1d0c69e7be52417d5ba9d65cb1289a93b950966646b4bc53bd1676db0af49";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/el/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/el/firefox-105.0.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "d4929cf863cca7173ecba9d2761642b377671d8a14f97b2c8a979bbf08c066c5";
+      sha256 = "7e75ccf8b0259e99e450efd6e05fe03ffe4be200b2d67ed1c095f5bf2db01bc7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/en-CA/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/en-CA/firefox-105.0.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "3793eda18688385188b5efae5fa1c5880b67447b6c1e37dedb783d0938bf6eca";
+      sha256 = "0536023b7b2b9d9bcae78edb72851043b0be972d06fb6fd3767e2b877f24fb91";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/en-GB/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/en-GB/firefox-105.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "377e5df96e99e3a33995fc850339ad526361065b90ee10a409f2ae68dd5a3e04";
+      sha256 = "85164c418b3e48b5c0f0d6203900c0ce8cc17a04eafeb862a24b0dc3a5bc587a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/en-US/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/en-US/firefox-105.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "1f0ade7170d0f7e6c7ff7047d9232eb787f9a96047bde605b8a4642ee26e9641";
+      sha256 = "69d823ec54825b1965280c454dbc7a63757080a4e5de72c6e567e72531ed895b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/eo/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/eo/firefox-105.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "72b7c13e2f03ab29cdc497f4830f3a2d225a716fbd31c36d8168a2feae439d96";
+      sha256 = "abb83c2758cac013bf0cf6fbbf7acf05386567f55c571054e1b6dea8c0c0e43f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/es-AR/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/es-AR/firefox-105.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "7595a447c680644bc9454ed4888d089e83877e6ce043ded81dccc5aa821b4eae";
+      sha256 = "ea93982ba143edaba06936c16284b5eb001c1e5424462e060699a3295119b75f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/es-CL/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/es-CL/firefox-105.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "8375092ebfb356ed45710d390a18dc90da68e1777292b2b5b2632bc797fedf34";
+      sha256 = "aa92a0970c62f9e7d1909d643453986e41ea81a321871f2c8128ef916a8e1fe8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/es-ES/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/es-ES/firefox-105.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "50175a9b6b450a3a187a73ad3f75a169bd10be33940dad9fbb5b46361dc7683b";
+      sha256 = "06bd1d53d60a276a22a840d7353bfa20c226ac58cd7c465fb06c9fe177eb420a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/es-MX/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/es-MX/firefox-105.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "078243f648814dbb3644471b598178d3d07958afc5bb75bcdee4022e5aedde68";
+      sha256 = "7e5ec5011643f3cfe8085c193b840fd1de8e369eb1bd67eb007f4341acac9487";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/et/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/et/firefox-105.0.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "421284900426ff0e18c510ad63f01e38d6ce578064441c35601bd838b845bfe1";
+      sha256 = "018f41bea6254ae1385897945bf751983e0dc817c9035f9079840f67f6af3ed4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/eu/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/eu/firefox-105.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "83959e754be9aa02710a333fc9f2679d25e2040744a1edd478fbc409525844c7";
+      sha256 = "34c3f772a5fa16f80922728f11a11f96c6b0b2f7c7bb95a6dd2396c70fb39562";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/fa/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/fa/firefox-105.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "cf8bdebe72d45f5479b24b65106ba3412b9e304dff793b277ff2e32ecd27abd8";
+      sha256 = "2b4021fcdf417558767f703505b4b1ad7e70293db27198def80c45988b3429f3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/ff/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/ff/firefox-105.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "06b0c5c932649dba971fd5f6a60fe9fa481f7cce416a9ee77b34445f53626f01";
+      sha256 = "9b1b52de7649d6852379e96324fa7e21426c73c6e1b8eeeb6cf18bf639b41c7f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/fi/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/fi/firefox-105.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "b439bf86d644ac50d6b787510637f9f07b838e32d1d3ddacff6f252edc7cf49a";
+      sha256 = "b7a225e82b76f4f16332463937303b1a3a8c22007033393659ab1daa02d27722";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/fr/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/fr/firefox-105.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "55ddef92476bb483eccb7c4e552c06564d4f6a15783cb7b52a8c9fc0d148ca23";
+      sha256 = "7fefa49faba7d92119f76d662d041428f883399aafb00331ffb97f060da2e32d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/fy-NL/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/fy-NL/firefox-105.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "c96bee61073ee624e60502276b4bd81bad2b8290714a87626bbc18d5fa20f782";
+      sha256 = "9550b148d724d2629fe3907c7d3eeba143a2c50d23ab14494f55da33e31454e1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/ga-IE/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/ga-IE/firefox-105.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "40e283152e013e56b8296f909d618606c77c92fac10cf9761a8cab0fc689260d";
+      sha256 = "5ec814aaeb6a430b794df8113d9481d96d97912b542f51950dd1c3c24a5cf220";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/gd/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/gd/firefox-105.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "eab6e230c6c712c740d9bec9f2029549f00ffca8cab2661ffaa1f90fcbf7f7ad";
+      sha256 = "227fddc59c3314ba62ac7d13e40f7c3112d99ae2a3d0676990329fc4d1874e1d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/gl/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/gl/firefox-105.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "2f3e990359b57b915287bd64745e942d99e5937186d1eaf10dd3a4ba3b207828";
+      sha256 = "5f0f25b7ad58772e4948ad1a72e01bc1f2f33a1b0512954291c0c63c891b950e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/gn/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/gn/firefox-105.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "ee4e7a869be7d958b0800f46b0d8859d690c2ca6006652a0bc09bb1ac703e992";
+      sha256 = "e5dd4e06fbd220f1a21c471ee38e6653d38a303b2f5564b1e00f8eb35a3cf303";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/gu-IN/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/gu-IN/firefox-105.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "a9acab24a53884c38688df642f540421fb0d840c91fdce8f6a50f951ceab2599";
+      sha256 = "181024bdfae07111738906baf996fe8faa4041b872804e725160d3b98b747fe9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/he/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/he/firefox-105.0.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "9060d7cfed49d9942e1569a29d418d73a41d9b33bbc3002ce5b1cabb1e199bd6";
+      sha256 = "8968e235b288da41c7896a2d73574c7f8f018f0b0348c1e1c20626a3e29d73e8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/hi-IN/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/hi-IN/firefox-105.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "7495441fd99984e0d5ebdf1296908c60a2d9e39f9d9a50fba38f8d2e02544afa";
+      sha256 = "4d57c54d40f965169cee2023afefad8dded92e2695e920031b95b28e98d04336";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/hr/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/hr/firefox-105.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "0f3536a95017251ed84d87eec7478f096dcc56b47792de029e5399bfaa9d7486";
+      sha256 = "f7d5493712185009393d83470488bb3f8610132a6166d13ee1eb33d992cdbeab";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/hsb/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/hsb/firefox-105.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "2b795aaee36e67a03746fc3beee9f38ec1ba3ca1cfd8aa4ff3723d5d0b4d3929";
+      sha256 = "39c333ede996d3d678a8673461072c5f25732fef4d39629df2a4b85912fd3b04";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/hu/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/hu/firefox-105.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "1e217747ba637af07a4331a406f1b26082acb4ec6377a43bfe141af79abbdaab";
+      sha256 = "1f30c7756933e397f8817dafcb0c3265cde450720d3915e01374918774cc626c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/hy-AM/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/hy-AM/firefox-105.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "324f6f6baf3ba07e85fe0abc794b7cf6a90d9aa0b7f0138c7fb4fc55ed0128c0";
+      sha256 = "481d7b3a31e3a95e12f1fd73e32da4ef7be1b1de5c24cf13779cd5b8de600216";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/ia/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/ia/firefox-105.0.1.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "77bf023597f2ffed7197d0f80f2f85ecc1dd6dd87817e3d65e9f88563b52d23d";
+      sha256 = "9472b0cab6807dd844aca41bb5e4cc041fdbc414e902418192271efe6c6051ac";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/id/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/id/firefox-105.0.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "bd6cbfc65ed6c958da7ba59f09526b6a9ff38c67f28e4b1503058a240d542602";
+      sha256 = "0d1573bad6adf59a8c738f5d841fa68800e24f41c1fdeffb2429e899df4e3ecb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/is/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/is/firefox-105.0.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "a34c7e27d4f25be058d8a1a83062123e5b488a2ae0e0040019b2a4bc281fa88d";
+      sha256 = "b420be8c79d1ec72e72d127c439a8828f5999c7d38e3781f99c68b1a64b8035f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/it/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/it/firefox-105.0.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "013bab88bf6943b498ac175c9ff1318717e8244d2ab25427ef8ea6d77472625a";
+      sha256 = "2bf3cc8b4ea09af4acf9ddc8aa0028ac0166c94ac12d8202e2db17b512e4fffb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/ja/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/ja/firefox-105.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "9d6f20d0e7f0d0af3de717c0d41b486614e8522bad78aeecc0ccd2464110d05b";
+      sha256 = "666b5370f9d37434fc43d02904a2f101571611f5a12ebe7ea90f689dcf8c8b81";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/ka/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/ka/firefox-105.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "3cf05ea413291434638a8f8f5be7ed7bbc66cee50fddbee78c8f4682bc7f3dc1";
+      sha256 = "f2b12e230c3ee6b3320508b192b4e3f427d562fe505abb99bed913218588bd74";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/kab/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/kab/firefox-105.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "913de6e134c3207b56bec63a38d8ee3effe4bd6223e7b2b0274f0b309c6d374a";
+      sha256 = "b0a6a1e4aff4f340c1fddf2bde03a0e56397bff5dabaeea862f57b007f14cdc0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/kk/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/kk/firefox-105.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "6e6bb45fa044d767deb35d23aa18c82d9ceb1df5ce138b3d0d75cc4197535b0d";
+      sha256 = "783865df2e7095fafbcd6edde3e1dc3470bb301d625c0315ff83b293534eb263";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/km/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/km/firefox-105.0.1.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "344f8ab2ebb353228916174e04b3da735464baa7b7f53aad782bdf0821464bbe";
+      sha256 = "06c25152dd3cf32e89f5adf526d1f9ad8ce5e798ad6265b98b227d400190c617";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/kn/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/kn/firefox-105.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "40292c7cf06ef3653b62e4aee226ba955a505ed447e123bff2ac3c237b6c435f";
+      sha256 = "7a5bf4c31b625c46ebd82a4db8347e68e031892d9c9126c711ca43df63fc2649";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/ko/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/ko/firefox-105.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "df63ff22448daa385e591ced272684a79dcfff3337885cbffafa849b787e43c1";
+      sha256 = "a0780299835f875bedd0fc1908959817d27ae9e8df0854d762c09da0fbbb70e6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/lij/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/lij/firefox-105.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "420d0175e27757ef2f4ebafb01542b4de5c3e6cc81fb868a552746f049eb7cb2";
+      sha256 = "636067354e25e0e88d2b5b679f4984a3cbee6a36ef360bcce77a4cea20993748";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/lt/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/lt/firefox-105.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "a2abdadcf3fa1e4186d9da63a80c0cb73237971a330118191e8ff46be0795cd1";
+      sha256 = "f8643f2956b44a9f4127867154ad4e6d1924269fdcfd21a8e74b329d96d4a706";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/lv/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/lv/firefox-105.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "eae4757f982ba3a1fe805dc9d70b2f23fde8b8e382d8b2637f4ff48ab66e2387";
+      sha256 = "e8dfb8b33801ae7445aa43b767a9f51cc220d59b07f1c1367457653ac738d272";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/mk/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/mk/firefox-105.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "884d108f753147fbe1214a04a56a05db9f843ac86aab124fa4011c28dd7c7636";
+      sha256 = "965030558d6bc43c8c07c32d7ac93d35d7d9962396c0e2b45d9a8499774a60a8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/mr/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/mr/firefox-105.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "549336d310858ca5884a925460560ae86b1fdd65965fbaf31515f29653400dd1";
+      sha256 = "2763857de9bc8fc41e01fbfbb63a479672fa38cadee59ddad514661bf345ce72";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/ms/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/ms/firefox-105.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "bc200e788cf05198c7f1e2ebe24b8ba85c9188d70c7c4ce4f5be945a2a3e7925";
+      sha256 = "0cbc063cff1ad5718028a81937280486feee3a63aba4fb13224a2a10fcddd561";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/my/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/my/firefox-105.0.1.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "d12843cb1f689fe380831ce0ffbef82586309b64b98fc84b26a30218e68ae22b";
+      sha256 = "d2adf75fc742fa205f1493a6b65d0646e83e942c348ebfafe385e528e721d71b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/nb-NO/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/nb-NO/firefox-105.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "2bd33cefa2c1c496ec15947c66ae1602b13ca6cad26dbae6ae3b131e65c6b443";
+      sha256 = "1464a6619f1cceb564c1e9f32ae8b5cc3e8a9ee62cbbffe181226698c5ded161";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/ne-NP/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/ne-NP/firefox-105.0.1.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "e041ab48c19fa0b8a0ca721879591e296ffc17f6b31268da34ffa342ec12d58b";
+      sha256 = "0ada42ddf96d8288bd325f99aaf91fac6779922dd2117fc74d9034112a1f985d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/nl/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/nl/firefox-105.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "3de23b3a23f7813805a8eea7c2cf28391dd5d7a54e11effb68735fd0bda2c7fd";
+      sha256 = "ebbfcdbab8ebc80dfb15eac0206efd68e559754fc1bafac3ab450c564ee1e8c6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/nn-NO/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/nn-NO/firefox-105.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "8119be56b65ff48a74a772f65e43b588322940836d26a1f446fd7834fc91d6ec";
+      sha256 = "fdaad5508051c682a6949daa0e36ec84bfea17f016d24b2d2b93461b6a85ca87";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/oc/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/oc/firefox-105.0.1.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "f1276ff978f8883d9ccf2876a4b91fe70a09614f2d78b83e09773deab83caa73";
+      sha256 = "eff46408202a97bbfa1885aa6a76835dfaeb33d1892f1294940d696d432c20c5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/pa-IN/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/pa-IN/firefox-105.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "9b5e0b495675c6312d424b6cef4613a1547a7118e04ece943eebcc3088340978";
+      sha256 = "840fbea8544d6baf81241c1b7a7d23560973ec3677214836a20137338cd41c33";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/pl/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/pl/firefox-105.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "fc8423ce907d76eef4d353d46234c832a10637e658f18d04e09956355189d0f7";
+      sha256 = "7238903aaed3625786dd315084238cfed31aace7a48dc19edfb40714b8ef8f0f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/pt-BR/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/pt-BR/firefox-105.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "0f23356433436ac0b7db77b81b26072d41b9d56726d8d6e59ff74512b6a4e859";
+      sha256 = "75d5374dce1e4a6e25317ea050ea8819e8b855affbf306df2213822eba743c1b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/pt-PT/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/pt-PT/firefox-105.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "17008210a1b3b26150c80c6e7bf8a579b8d274ca7c412c52af9c56fc8f6ba151";
+      sha256 = "1f1cdaf6f3909558a38a4716539166f7e237c54485f4e53b6adc2aa25fff7f5f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/rm/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/rm/firefox-105.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "0253ecc68c06a315a48b01e9cf48b7028d306e172a4f8e0f5c88d9fe597dfbed";
+      sha256 = "bf261fc9821f42901350982452e7ef69f0cf94fb4b4c3a8cc2e6a39611ccf4a7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/ro/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/ro/firefox-105.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "92edff6123781db29039b5568fb462687e3c945ca45c35c39fb9df6614298ca1";
+      sha256 = "9f6ea3fb9af5f0ae117129548a2c6f3bba28765c103558756f672ded6bac9e78";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/ru/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/ru/firefox-105.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "474f586e580449ee3520af63acf7fa6589a6ef315a5e7174d64d238d1f4f6552";
+      sha256 = "933893a72cc90061cb0bf0a4efce8a8e5694c648201728fe2749612fc1ec2a7f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/sco/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/sco/firefox-105.0.1.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "9126f7d5312e2f1c9f1895ccdb07a2e5a36fd39d300307602129331af8667ba0";
+      sha256 = "b67dde50849a7beb29bfdd57aea15dc78a1e53ebf511a1f96a7fb35c0e6532db";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/si/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/si/firefox-105.0.1.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "66c1b70a8d07e0f7eec534d57737eb432c01d4dc9ced2506c1244d6d878bf278";
+      sha256 = "6063bd9e5aee98e3f709127ebc2dba8c06b6089461983c3da621bce197f11d11";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/sk/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/sk/firefox-105.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "7d6a6681afcf9abcbf8780bdf98ff0524da87fcc83e7f6abb11bca67b936538e";
+      sha256 = "3fdf0d10003878d73a2f5d0e07f7dd63bd9e7e363c039e200c5b2628edbf5343";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/sl/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/sl/firefox-105.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "e9c06965ef63e904e4adb1ac2246bda08f011784a13aabe4fac7c8fb4fdb281a";
+      sha256 = "008c46056e4d03bd31216c818858dcde07adbf3a7b87c273196ff8ac22e5979b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/son/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/son/firefox-105.0.1.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "b69e348c54e56edc055a82287a8d699e9cfb0c8698512952c974444c7c8a204d";
+      sha256 = "3bfa44ec693f9bfb1813316bdd4f5e5be0c76dab938248fd4cdfb3259f22d98b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/sq/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/sq/firefox-105.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "e24279136fcc90861f69fd322890a29544fdf411b2eb93a3b2a3f95c387f6f64";
+      sha256 = "070e7162c2ed8daab7adab7d08d93adda8d411a56bc8ca9d32daba7a333b4873";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/sr/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/sr/firefox-105.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "3512aecdb7d3513d08866110884e6b297e82a01a0dad6398f6c05a550ce58f64";
+      sha256 = "df51f1310cf61c087c128999fe09c5cac56141a9ab7c0ed1faf9ca41992af756";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/sv-SE/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/sv-SE/firefox-105.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "cc793dfaf3bf642d779e1babdaf78c145d22403bb531a6c2ed1c9ca866e63e5a";
+      sha256 = "df05aec1c9a34bc8392717522535f9b83a5adda4e57dcbfd9421b4f71caa2928";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/szl/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/szl/firefox-105.0.1.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "f6baa5a1cac5588a8600af4b0d01d441f7740be238123667b2fc9f92eb14b58e";
+      sha256 = "c39fabf4ae4d38411a5054365a97440a2ce14dc0aabfd1dfeb4b32c70e5cc84d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/ta/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/ta/firefox-105.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "9b2038bb8f72b683859777629de29dba4a14b8af8f356fcd0cb2cd5dbfd8986b";
+      sha256 = "e3648edda3e89e46c69cbbfa64835d7d1eea0df3cb34c224d85b21b9bf2de0a9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/te/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/te/firefox-105.0.1.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "d02d0902c7001c0a4de094f049671b922db4dcc69caafca8e61eeb112b400d31";
+      sha256 = "60e808bd5cc3d7e95c5815bf0718c7dcfa469f114485636abcac8b9f6f4598bd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/th/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/th/firefox-105.0.1.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "4a48168d1509bbec72f969febd7c2d4816406994223f110571825707b9cd50bd";
+      sha256 = "5327332fa0fa7bb2b15553274f4867158723f7f778fe1b76e47e03b8286fe8c4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/tl/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/tl/firefox-105.0.1.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "64787eaae32aa3b59952311cceb35b440ead8ee2457fcd52316191451f48504c";
+      sha256 = "417ed820ec567617b79029cc56572f82d68a54a194e281c0046329d247cc8321";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/tr/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/tr/firefox-105.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "15e76f7e7be5b78467e10d1b8b705a10235f6d18b53bd94255487f854df9771a";
+      sha256 = "efadb1233f78517063d5ea01992a2e0b87e6bf0b7e059ab93cea9ec56b92fd5f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/trs/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/trs/firefox-105.0.1.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "6591b7ca111350c15823ae24dce3d66f5d2ffe6ccbc6fcb5ad29a28477cd008d";
+      sha256 = "d50741ee4a03767bc93f8c6fe6c3d4ae28d4279e491dc7f63a6d4d9c0b903636";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/uk/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/uk/firefox-105.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "590348a7ce29d0f5a6a6fd88f6d778ab979cc683436a139865f811888f92d4dd";
+      sha256 = "b793a691f4ba360110d8588d135fc9b6148114367cb511fa4109af9591031468";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/ur/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/ur/firefox-105.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "86d0e19459e75617ae9fcd3b14a3d1500c0d253703b533b78b493d73f359e3d3";
+      sha256 = "86779f16e1c6bd852a5bf2a6d3cf4d185318a0e8255f5e740320a0acdad7483b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/uz/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/uz/firefox-105.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "e3852d3c36f0cd31792cb39735bb311c4b98cd5180fe7a8324d939faf57079b2";
+      sha256 = "75923c30c7d2f4ae52cd85f08636d984c28413cd1e3c78d0c11dac5a217cb496";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/vi/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/vi/firefox-105.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "77464c6ec7f89a15db8b288ef2d29b1bf2b58292906a0c85fd05549f921274af";
+      sha256 = "28f263131e02353e593906a289f9e6b929a6bd84be54647b486c9477c09596ce";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/xh/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/xh/firefox-105.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "eb5603508a843e97a3046a4253e5a949ccf4fa55747579ca75dcc4ed88a82bff";
+      sha256 = "6c27086dc8136077ab1c18d134ba5d569675296e428f7eb06db12761a4a52d93";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/zh-CN/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/zh-CN/firefox-105.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "d19dc1ec39a1a81589973aa8ca3eb22af06ec6f937b1219d598d020f5f13e731";
+      sha256 = "04e98684a9aaeb75e8e5e70ace60593fe200705ab055ffe1556f71e23ca77424";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0/linux-i686/zh-TW/firefox-105.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/105.0.1/linux-i686/zh-TW/firefox-105.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "aeae64a02a7fa0ff21a4c34f41debb2132080caa9d9cb1c5fff09fc1e0fb7585";
+      sha256 = "55f58ba2ef1806f37493503aad5bffdaab69cfb31661933b01e8be5aeb963e64";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -3,10 +3,10 @@
 rec {
   firefox = buildMozillaMach rec {
     pname = "firefox";
-    version = "105.0";
+    version = "105.0.1";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "a48f323f874b538402630a9094daa83189b3ca319feddc80fd66d087eca13f21c8b2d85be9c29e948c18cb7c524adac44e135adcde4d4592738e104ae9c1a734";
+      sha512 = "66ef7cd5028953e7da9d55e127135739c9d85be68ec633b71c52d6c9427edb0bd8a38504148484cd322adcefb57bfefe6e57cb15855f195508fe438864f4322b";
     };
 
     meta = {

--- a/pkgs/applications/networking/browsers/firefox/update.nix
+++ b/pkgs/applications/networking/browsers/firefox/update.nix
@@ -9,7 +9,7 @@
 , gnupg
 , attrPath
 , runtimeShell
-, baseUrl ? "http://archive.mozilla.org/pub/firefox/releases/"
+, baseUrl ? "https://archive.mozilla.org/pub/firefox/releases/"
 , versionPrefix ? ""
 , versionSuffix ? ""
 , versionKey ? "version"


### PR DESCRIPTION
###### Description of changes

https://www.mozilla.org/en-US/firefox/105.0.1/releasenotes/

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
