### PR TITLE
gap: 4.11.1 -> 4.12.1

### DIFF
--- a/pkgs/applications/science/math/gap/default.nix
+++ b/pkgs/applications/science/math/gap/default.nix
@@ -4,6 +4,7 @@
 , makeWrapper
 , readline
 , gmp
+, pari
 , zlib
 # one of
 # - "minimal" (~400M):
@@ -23,27 +24,31 @@ let
   # packages absolutely required for gap to start
   # `*` represents the version where applicable
   requiredPackages = [
-    "GAPDoc-*"
-    "primgrp-*"
-    "SmallGrp-*"
+    "gapdoc"
+    "primgrp"
+    "smallgrp"
     "transgrp"
   ];
-  # packages autoloaded by default if available
+  # packages autoloaded by default if available, and their dependencies
   autoloadedPackages = [
     "atlasrep"
-    "autpgrp-*"
-    "alnuth-*"
-    "crisp-*"
-    "ctbllib-*"
-    "FactInt-*"
+    "autpgrp"
+    "alnuth"
+    "crisp"
+    "ctbllib"
+    "factint"
     "fga"
-    "irredsol-*"
-    "laguna-*"
-    "polenta-*"
-    "polycyclic-*"
-    "resclasses-*"
-    "sophus-*"
-    "tomlib-*"
+    "irredsol"
+    "laguna"
+    "polenta"
+    "polycyclic"
+    "resclasses"
+    "sophus"
+    "tomlib"
+    "autodoc"  # dependency of atlasrep
+    "io"       # used by atlasrep to fetch data from online sources
+    "radiroot" # dependency of polenta
+    "utils"    # dependency of atlasrep
   ];
   keepAll = keepAllPackages || (packageSet == "full");
   packagesToKeep = requiredPackages ++ lib.optionals (packageSet == "standard") autoloadedPackages;
@@ -61,11 +66,11 @@ in
 stdenv.mkDerivation rec {
   pname = "gap";
   # https://www.gap-system.org/Releases/
-  version = "4.11.1";
+  version = "4.12.1";
 
   src = fetchurl {
     url = "https://github.com/gap-system/gap/releases/download/v${version}/gap-${version}.tar.gz";
-    sha256 = "sha256-ZjXF2n2CdV+DOUhrnKwzdm9YcS8pfoI0+6QIGJAuowQ=";
+    sha256 = "sha256-+evvEe4xshDONuPHCWB0K04lMoK71ScK3JMkJzySsBY=";
   };
 
   # remove all non-essential packages (which take up a lot of space)
@@ -83,9 +88,14 @@ stdenv.mkDerivation rec {
     makeWrapper
   ];
 
-  # "teststandard" is a superset of testinstall. It takes ~1h instead of ~1min.
-  # tests are run twice, once with all packages loaded and once without
-  # checkTarget = "teststandard";
+  propagatedBuildInputs = [
+    pari # used at runtime by the alnuth package
+  ];
+
+  # "teststandard" is a superset of the tests run by "check". it takes ~20min
+  # instead of ~1min. tests are run twice, once with all packages loaded and
+  # once without.
+  # installCheckTarget = "teststandard";
 
   doInstallCheck = true;
   installCheckTarget = "check";
@@ -104,34 +114,28 @@ stdenv.mkDerivation rec {
     # like the defaults the Makefile, but use gap from PATH instead of the
     # one from builddir
     installCheckFlagsArray+=(
-      "TESTGAP=gap --quitonbreak -b -m 100m -o 1g -q -x 80 -r -A"
-      "TESTGAPauto=gap --quitonbreak -b -m 100m -o 1g -q -x 80 -r"
+      "TESTGAPcore=gap --quitonbreak -b -q -r"
+      "TESTGAPauto=gap --quitonbreak -b -q -r -m 100m -o 1g -x 80"
+      "TESTGAP=gap --quitonbreak -b -q -r -m 100m -o 1g -x 80 -A"
     )
   '';
 
   postBuild = ''
     pushd pkg
-    bash ../bin/BuildPackages.sh
+    # failures are ignored unless --strict is set
+    bash ../bin/BuildPackages.sh ${lib.optionalString (!keepAll) "--strict"}
     popd
   '';
 
-  installTargets = [
-    "install-libgap"
-    "install-headers"
-  ];
-
-  # full `make install` is not yet implemented, just for libgap and headers
   postInstall = ''
-    # Install config.h, which is not currently handled by `make install-headers`
-    cp gen/config.h "$out/include/gap"
+    # make install creates an empty pkg dir. since we run "make check" on
+    # installCheckPhase to make sure the installed GAP finds its libraries, we
+    # also install the tst dir. this is probably excessively cautious, see
+    # https://github.com/NixOS/nixpkgs/pull/192548#discussion_r992824942
+    rm -r "$out/share/gap/pkg"
+    cp -ar pkg tst "$out/share/gap"
 
-    mkdir -p "$out/bin" "$out/share/gap/"
-
-    echo "Copying files to target directory"
-    cp -ar . "$out/share/gap/build-dir"
-
-    makeWrapper "$out/share/gap/build-dir/bin/gap.sh" "$out/bin/gap" \
-      --set GAP_DIR $out/share/gap/build-dir
+    makeWrapper "$out/lib/gap/gap" "$out/bin/gap" --add-flags "-l $out/share/gap"
   '';
 
   preFixup = ''
@@ -141,14 +145,11 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Computational discrete algebra system";
-    maintainers = with maintainers;
-    [
-      raskin
-      chrisjefferson
-      timokau
-    ];
+    # We are also grateful to ChrisJefferson for previous work on the package,
+    # and to ChrisJefferson and fingolfin for help with GAP-related questions
+    # from the upstream point of view.
+    maintainers = teams.sage.members;
     platforms = platforms.all;
-    broken = stdenv.isDarwin;
     # keeping all packages increases the package size considerably, which is
     # why a local build is preferable in that situation. The timeframe is
     # reasonable and that way the binary cache doesn't get overloaded.

--- a/pkgs/applications/science/math/sage/env-locations.nix
+++ b/pkgs/applications/science/math/sage/env-locations.nix
@@ -35,7 +35,7 @@ writeTextFile rec {
     export GRAPHS_DATA_DIR='${graphs}/share/graphs'
     export ELLCURVE_DATA_DIR='${elliptic_curves}/share/ellcurves'
     export POLYTOPE_DATA_DIR='${polytopes_db}/share/reflexive_polytopes'
-    export GAP_ROOT_DIR='${gap}/share/gap/build-dir'
+    export GAP_ROOT_DIR='${gap}/share/gap'
     export ECLDIR='${maxima.lisp-compiler}/lib/${maxima.lisp-compiler.pname}-${maxima.lisp-compiler.version}/'
     export COMBINATORIAL_DESIGN_DATA_DIR="${combinatorial_designs}/share/combinatorial_designs"
     export CREMONA_MINI_DATA_DIR="${elliptic_curves}/share/cremona"

--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -130,6 +130,14 @@ stdenv.mkDerivation rec {
       rev = "2816dbacb342398a23bb3099e20c92c8020ab0fa";
       sha256 = "sha256-tCOsMxXwPkRg3FJGVvTqDzlWdra78UfDY6nci0Nr9GI=";
     })
+
+    # https://trac.sagemath.org/ticket/34391
+    (fetchSageDiff {
+      name = "gap-4.12-upgrade.patch";
+      base = "9.8.beta2";
+      rev = "eb8cd42feb58963adba67599bf6e311e03424328";
+      sha256 = "sha256-0dKewOZe2n3PqSdxCJt18FkqwTdrD0VA5MXAMiTW8Tw=";
+    })
   ];
 
   patches = nixPatches ++ bugfixPatches ++ packageUpgradePatches;


### PR DESCRIPTION
###### Description of changes

aarch64 deadlocks on Sage tests no longer happen after this update and a few minor Sage tweaks (which will be done in a separate PR). Hooray!

This applies an unreviewed patch from https://trac.sagemath.org/ticket/34391 (https://git.sagemath.org/sage.git/patch?id2=9.8.beta2&id=eb8cd42feb58963adba67599bf6e311e03424328), but the test changes all look reasonable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
