### PR TITLE
monero-{cli,gui}: 0.18.1.0 -> 0.18.1.1 

### DIFF
--- a/pkgs/applications/blockchains/monero-cli/default.nix
+++ b/pkgs/applications/blockchains/monero-cli/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "monero-cli";
-  version = "0.18.1.0";
+  version = "0.18.1.1";
 
   src = fetchFromGitHub {
     owner = "monero-project";
     repo = "monero";
     rev = "v${version}";
-    sha256 = "sha256-xniGiGqZpL1b6alnCxa2MNzuDQxPgMdNjqifOC8h0qM=";
+    sha256 = "sha256-R3ajdsHVgvkUEwaShwMvhIrcbM4YjsXgBk2QGBhxGRQ=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/applications/blockchains/monero-gui/default.nix
+++ b/pkgs/applications/blockchains/monero-gui/default.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation rec {
   pname = "monero-gui";
-  version = "0.18.1.0";
+  version = "0.18.1.1";
 
   src = fetchFromGitHub {
     owner = "monero-project";
     repo = "monero-gui";
     rev = "v${version}";
-    sha256 = "sha256-XL7DV4YD/U6RiqgdYJf6zFfvJWlOx//4YVmnc51riiE=";
+    sha256 = "sha256-mxbr02Ba/BeUiAZujnBdXgJSaq6a/U4GM7rR7sZzTWc=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes

Backport of a bugfix release

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as usual, by running a full node and connecting to it with monero-wallet-gui.
- [x] Tested compilation of all packages that depend on this change
- [x] Tested basic functionality of all binary files
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
