### PR TITLE
kicad: mark broken

### DIFF
--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -235,5 +235,7 @@ stdenv.mkDerivation rec {
     # as long as the base and libraries (minus 3d) are build,
     # this wrapper does not need to get built
     # the kicad-*small "packages" cause this to happen
+
+    broken = true; # at 2022-11-23
   };
 }


### PR DESCRIPTION
kicad: mark broken

![image](https://user-images.githubusercontent.com/5861043/191961895-656c989b-087a-4b3c-9ee5-f309b4dce4be.png)

logs: https://termbin.com/xeru