### PR TITLE
openvino: mark broken for linux-x86_64

### DIFF
--- a/pkgs/development/libraries/openvino/default.nix
+++ b/pkgs/development/libraries/openvino/default.nix
@@ -130,7 +130,8 @@ stdenv.mkDerivation rec {
     homepage = "https://docs.openvinotoolkit.org/";
     license = with licenses; [ asl20 ];
     platforms = platforms.all;
-    broken = stdenv.isDarwin; # Cannot find macos sdk
+    broken = (stdenv.isLinux && stdenv.isx86_64) # at 2022-09-23
+             || stdenv.isDarwin; # Cannot find macos sdk
     maintainers = with maintainers; [ tfmoraes ];
   };
 }


### PR DESCRIPTION
openvino: mark broken for linux-x86_64

![image](https://user-images.githubusercontent.com/5861043/191963467-eac4ffb9-9df1-4848-8751-5e9b019a133f.png)

Logs: https://termbin.com/sxps