### PR TITLE
mmex: mark broken

### DIFF
--- a/pkgs/applications/office/mmex/default.nix
+++ b/pkgs/applications/office/mmex/default.nix
@@ -28,5 +28,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [viric];
     platforms = with lib.platforms; linux;
+    broken = true; # at 2022-11-23
   };
 }


### PR DESCRIPTION
mmex: mark broken

Initially with hash error:
![image](https://user-images.githubusercontent.com/5861043/191967836-e3048c19-fecb-41cf-8f8e-e210161e54b4.png)

Then, this:
![image](https://user-images.githubusercontent.com/5861043/191967943-e1bd2d31-f6df-4cc1-a08e-8752426874cc.png)

Logs: https://termbin.com/y2qx

Version v1.5.21 is available upstream. But failed as:

![image](https://user-images.githubusercontent.com/5861043/191968270-d3db6c6e-2289-4a56-b5d4-6a3878475c55.png)

Logs: https://termbin.com/cmk7

I don't want to dig any further. It is broken.