### PR TITLE
cargo-depgraph: 1.2.5 -> 1.3.0

### DIFF
--- a/pkgs/development/tools/rust/cargo-depgraph/default.nix
+++ b/pkgs/development/tools/rust/cargo-depgraph/default.nix
@@ -1,17 +1,15 @@
-{ lib, rustPlatform, fetchFromSourcehut }:
+{ lib, rustPlatform, fetchCrate }:
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-depgraph";
-  version = "1.2.5";
+  version = "1.3.0";
 
-  src = fetchFromSourcehut {
-    owner = "~jplatte";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-ewlrxxHnsXBWSMPAlxTfrHj23jMiThkDSJhEsChO/sM=";
+  src = fetchCrate {
+    inherit pname version;
+    sha256 = "sha256-mlbS9EI/ltxnWfpci9hK9QwYpA/nII+wc2IRSHrmNGI=";
   };
 
-  cargoSha256 = "sha256-Ce13vJ5zE63hHVkg/WFdz3LrASj7Xw6nqOO64uALOeQ=";
+  cargoSha256 = "sha256-9CKFZmkFiip6iQVkBmy/XoMEoyMhlKNRyI8oDHaAILc=";
 
   meta = with lib; {
     description = "Create dependency graphs for cargo projects using `cargo metadata` and graphviz";


### PR DESCRIPTION
###### Description of changes

https://github.com/jplatte/cargo-depgraph/compare/v1.2.5...v1.3.0
https://git.sr.ht/~jplatte/cargo-depgraph/tree/v1.3.0/item/CHANGELOG.md

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
