### PR TITLE
bash: fix android cross-compile

### DIFF
--- a/pkgs/shells/bash/5.1.nix
+++ b/pkgs/shells/bash/5.1.nix
@@ -36,6 +36,7 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "format" ]
   # bionic libc is super weird and has issues with fortify outside of its own libc, check this comment:
   # https://github.com/NixOS/nixpkgs/pull/192630#discussion_r978985593
+  # or you can check libc/include/sys/cdefs.h in bionic source code
   ++ optional (stdenv.hostPlatform.libc == "bionic") "fortify";
 
   outputs = [ "out" "dev" "man" "doc" "info" ];

--- a/pkgs/shells/bash/5.1.nix
+++ b/pkgs/shells/bash/5.1.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ]
   # https://android.googlesource.com/platform/bionic/+/1342527b5791a53bf441322ab9adf41c8e060a1e%5E2..1342527b5791a53bf441322ab9adf41c8e060a1e/
-  ++ optional (stdenv.hostPlatform.useAndroidPrebuilt or false) "fortify";
+  ++ optional (stdenv.hostPlatform.libc == "bionic") "fortify";
 
   outputs = [ "out" "dev" "man" "doc" "info" ];
 

--- a/pkgs/shells/bash/5.1.nix
+++ b/pkgs/shells/bash/5.1.nix
@@ -33,7 +33,9 @@ stdenv.mkDerivation rec {
     sha256 = "1alv68wplnfdm6mh39hm57060xgssb9vqca4yr1cyva0c342n0fc";
   };
 
-  hardeningDisable = [ "format" ];
+  hardeningDisable = [ "format" ]
+  # https://android.googlesource.com/platform/bionic/+/1342527b5791a53bf441322ab9adf41c8e060a1e%5E2..1342527b5791a53bf441322ab9adf41c8e060a1e/
+  ++ optional (stdenv.hostPlatform.useAndroidPrebuilt or false) "fortify";
 
   outputs = [ "out" "dev" "man" "doc" "info" ];
 

--- a/pkgs/shells/bash/5.1.nix
+++ b/pkgs/shells/bash/5.1.nix
@@ -34,7 +34,8 @@ stdenv.mkDerivation rec {
   };
 
   hardeningDisable = [ "format" ]
-  # https://android.googlesource.com/platform/bionic/+/1342527b5791a53bf441322ab9adf41c8e060a1e%5E2..1342527b5791a53bf441322ab9adf41c8e060a1e/
+  # bionic libc is super weird and has issues with fortify outside of its own libc, check this comment:
+  # https://github.com/NixOS/nixpkgs/pull/192630#discussion_r978985593
   ++ optional (stdenv.hostPlatform.libc == "bionic") "fortify";
 
   outputs = [ "out" "dev" "man" "doc" "info" ];


### PR DESCRIPTION
###### Description of changes
Fix bash compilation on android-prebuilt by disabling the "fortify" hardening
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
