### PR TITLE
openjdk*: Make bootstrap headless

### DIFF
--- a/pkgs/top-level/java-packages.nix
+++ b/pkgs/top-level/java-packages.nix
@@ -45,7 +45,7 @@ in {
     mkBootstrap = adoptopenjdk: path: args:
       /* adoptopenjdk not available for i686, so fall back to our old builds for bootstrapping */
       if   adoptopenjdk.jdk-hotspot.meta.available
-      then adoptopenjdk.jdk-hotspot
+      then adoptopenjdk.jdk-hotspot.override { gtkSupport = false; }
       else callPackage path args;
 
     mkOpenjdk = path-linux: path-darwin: args:


### PR DESCRIPTION
This reduces the build closure size.
Reducing the build closure size reduces the number of rebuilds across time and it helps with such tasks as bisecting the staging branch.

 Specifically, for the default headless jdk, it removes the need to rebuild when any of ~200 derivations change, because they aren't dependencies anymore.

<details><summary>openjdk_headless build closure difference</summary>

```diff
< /nix/store/0734mdkys3vgr76qkf18xmi5x6hp630l-source.drv
< /nix/store/0jfnr50g41xxpghf1jfh3wa3kml705lh-e0fc4ce7e87ab9c4b47e5c8e693f070dfd0d2f7b.patch.drv
< /nix/store/0knf89xmwl1xhq4hbz0knr4r7gicyqxb-bash-completion-2.11.drv
< /nix/store/0qv1f0xsij2kpb8sqz7dlclkim5j257x-source.drv
< /nix/store/0rhjp08mvbdsksd2r38cc8gxgi98w3r1-ca8e276aacf63a752346a6a44ba673b0af993237.patch.drv
< /nix/store/0rhlmpsx8y1r6grm8dmrpmlp2bszs6zv-valgrind-3.19.0.tar.bz2.drv
< /nix/store/0yv9l4kb76ax2jdj90lyajgqm090mlvw-dav1d-1.0.0.drv
< /nix/store/1073ykc7vi20pimx73wi8brsabl7nccv-python3.10-smartypants-2.0.1.drv
< /nix/store/12r43lw2lj2qcvy4msyai0i0v9n81gnh-libgd-2.3.3.tar.xz.drv
< /nix/store/16qfv5s0k6ahi09sw5h0dnv72qk17frd-json-glib-1.6.6.tar.xz.drv
< /nix/store/1gfplip1k7cnivq2yiq9f9gnpv4jw9l8-dconf-0.40.0.tar.xz.drv
< /nix/store/1hvn6z7yhdcaqk4lkyg1gvq0jx05cv79-remove-robust-and-descriptive-statistics.patch.drv
< /nix/store/1nb870vi0pc1ng13c8la4iwpavcfjrfv-gi-docgen-2022.1.drv
< /nix/store/1pwgrga58hqznq90n5lgld09xnk7immq-fix_pc.patch
< /nix/store/1q3ignggw3kphnbqrmx0wsnkfnrh1a5s-tracker-3.3.2.tar.xz.drv
< /nix/store/1vv9m1ihjfhvdg741qwadf032ifkq0gk-sysprof-3.44.0.tar.xz.drv
< /nix/store/22rmk14xnij8ckdb2j89g16jvvqpwhr2-libvmaf-2.3.1.drv
< /nix/store/2aswrrxb7yf30xqgbdjy97flq8n1nb5b-at-spi2-atk-2.38.0.tar.xz.drv
< /nix/store/2caq32imq4b7146nrxwfc7r52nhzx285-gtk+3-3.24.34.drv
< /nix/store/2d8r0hb31c2hkp51mk8qbdz0qsg1rrfr-setup-hook.sh
< /nix/store/2gxf4y6460vw0vbkdrmh5ihfcv3p5vc2-python3.10-markdown-3.4.1.drv
< /nix/store/2lcq6gwfadipyc23m3b9k5698dcnfsxc-attachment.cgi?id=149172.drv
< /nix/store/38abjbngzcq52mwvv2vk0jzgggk7b0jm-libjxl-0.6.1.drv
< /nix/store/38gz76g4d7miw4nx22qqbgf1y1d3abrd-attachment.cgi?id=149174.drv
< /nix/store/3f190zfrdnrx15djm3dig29g6c8rrh9i-shared-mime-info-2.2.drv
< /nix/store/3gpfydy8hskc68rnk1dma3s0k0wm0y12-source.drv
< /nix/store/3kgrpplfk9316n62dpkh4krfdf3qbp6d-CVE-2021-45942.patch.drv
< /nix/store/3s26f4qnqmnxsp7bsgq4ckqszbyb6hbk-util-macros-1.19.3.tar.bz2.drv
< /nix/store/3san532qqibyyc9vvvph2ychwkr0xqi3-b8ec58c58c6281987f42ebec892f513824c0cc0e.patch.drv
< /nix/store/3v12r8my9zhga98kha0fz9j9kyj4ndn6-source-highlight-3.1.9.drv
< /nix/store/3w8zcpiba1cfqhh8d3mhkhl13jrjz6b0-atk-2.38.0.tar.xz.drv
< /nix/store/444rimafskll9nbczw4cybndifsk75hs-at-spi2-atk-2.38.0.drv
< /nix/store/44bc59k1kqlm1pda6487z3hfqykdmh58-openjdk-headless-17.0.4+8.drv
< /nix/store/4zfk07p8yxac4wf49q1cyslclsbrqks7-nss-3.80.tar.gz.drv
< /nix/store/52730jbrs1kblpmcmncdy3h9xsdfxw5r-ilmbase-2.5.8.drv
< /nix/store/545a81j57v1qsmfgbhrplgc8dlkw23z0-automake-1.15.1.drv
< /nix/store/559ajlir5yfj4rbs7165piq57h9ir5pd-installCheck-path.patch
< /nix/store/561cln0l21pjinjf8ssp72bizmkki67z-gd-2.3.3.drv
< /nix/store/573xkk1g3g08dadkggrk2vk0y3affqp7-fix-cmake-config-includedir.patch
< /nix/store/5757843nn2ipqqcczldqrwi65zh02b6g-restore-GD_FLIP.patch.drv
< /nix/store/58mh5asf29kl1kx92x26r45yxjqxgy1k-vala-0.56.2.drv
< /nix/store/5crhcbgrgki649xpaxdcc6ziwdc7x3ap-graphite2-1.3.14.tgz.drv
< /nix/store/5dbbcmx1g96ym5hyh9wbvpq5mjf076zz-source.drv
< /nix/store/5mxj7xzfpzihkmbv0rcdxqhx6rd2m8cb-python3.10-toml-0.10.2.drv
< /nix/store/634fsp4s5lh6a6m0xfzd2r4nzr2lkr64-source.drv
< /nix/store/6f12dci1nycf3gaffvhj4b0b8lrv86v0-wayland-1.21.0.drv
< /nix/store/6khzx5jzlfch7x1f5svk9rzaq8dsj8j9-git-2.37.2.tar.xz.drv
< /nix/store/71fvqmjm3m7myyphfa23427zb32z55q5-atk-2.38.0.drv
< /nix/store/71q014ihgfbvdqrhg17n1lgjzz8lmlxn-ftbfs-libpng15.patch
< /nix/store/72ir35v23g6pr8sjy6wykgllk4dnm9wc-gsettings-desktop-schemas-42.0.drv
< /nix/store/796dnsf95f3yi1sd4gcsl6ijcknvlxq0-libgl-path.patch
< /nix/store/79xhi5janz96l142mlkhjab1q7lclb8r-mpfr-4.1.0.tar.xz.drv
< /nix/store/7a7gm6v82yxvjq7f1bmyhfzhlvkjz4c6-libXcomposite-0.4.5.drv
< /nix/store/7i5jl3d9p5d6y4i5nqj6bh7kkgnnb8hn-attachment.cgi?id=149173.drv
< /nix/store/7mkb725jvvkx98is9b1jm782k91gy6b2-disable-graphviz-0.46.1.patch
< /nix/store/7vzp2zvd8c379byl9qf0i1kzw9kc49ww-libsoup-2.74.2.drv
< /nix/store/7w9dqpqxb2232a6ph1xngfb41xq27dfg-source.drv
< /nix/store/7whwdkw2fhxls7zigdrw7zxdwhpsihhv-libsoup-3.0.7.tar.xz.drv
< /nix/store/82w6mrj0cwc38zgjrvg1113vb363hxpg-03_CVE-2009-3994.diff.drv
< /nix/store/894r3j0i2cdqn5gkh7r2bk5m0pfd8nbp-gcc-12.patch.drv
< /nix/store/8aiivd633l08lmqk9d4yhlminrl5rxy9-automake-1.15.1.tar.xz.drv
< /nix/store/8dcmsvli2fb54pzxvhq20gz7wi4ccns5-source.drv
< /nix/store/8lpvq3qhfbwfcvblrf64b0nz9l6da0ci-source.drv
< /nix/store/8wri2mggj88sgbw43a8p4xnlshrw0p2a-source.drv
< /nix/store/9632qg7q0zpmyx5cj3xww4pi9j631hq7-libdatrie-2019-12-20.drv
< /nix/store/972h8jwy18kgvkf292fy70a4gyxnx8n1-?id=904949c9026cb772dc93fbe0947a252ef47127f4.drv
< /nix/store/9rbw3s6lhyglw3sdp7xgh4vdbdf3pbxs-bash-completion-2.11.tar.xz.drv
< /nix/store/9svql5n1r6cspfgq0pa6fwiakhfnshs3-gdb-12.1.tar.xz.drv
< /nix/store/a5y8hiy3d01axp7vzd627dnggb5cbizk-libavif-0.10.0.drv
< /nix/store/a98ca18ch9zf8g5f121bwc1c4in2fy48-json-glib-1.6.6.drv
< /nix/store/aa3v7r1rql4dg0srhiqa3px1blp46as7-cacert-extra-certificates-bundle.crt.drv
< /nix/store/agy7by93gzijns6mwrhkinxxl7l9456h-buildcatrust-0.1.3.tar.gz.drv
< /nix/store/ak5n2jac6lrkyhj19bdc6ma89y92blhx-nss-cacert-certdata-3.80.drv
< /nix/store/aq2pv5ijchrhhk07lhmcscdjw8babgph-3.0-immodules.cache.patch
< /nix/store/b5mdnhclana16wxcjhfv0wj1r9pvz66j-libsoup-2.74.2.tar.xz.drv
< /nix/store/b9wmf2pbfqjn771dcyjc01a72sm3iyjv-icu4c-71.1.drv
< /nix/store/bi91w0dq7xx37ms21lcnvl4vlsb5a3qr-help2man-SOURCE_DATE_EPOCH-support.patch
< /nix/store/bx0vqy6hyx8cc0ky0hqgsj9cbsjqqzsz-libsass-3.6.5.drv
< /nix/store/c6al426l7gphl7139mrxck4ly5q0qh9r-fonts.conf.drv
< /nix/store/cjmhd932akgvyh8bz7dhikpbag2bxmbz-libhwy-0.15.0.drv
< /nix/store/ck6z9xr8z25azz7rsvz61xmwg0yf31r6-drop-icon-theme-cache.sh
< /nix/store/cq2sma9c3igdx78cf0wiyj62pnf2wq2n-hook.drv
< /nix/store/cs0lbxl3ghswd2lds3lvh98gdf65mbsp-gtk+-3.24.34.tar.xz.drv
< /nix/store/cw265c4apqfvbjps86qr64pg8pfv6x2j-git-minimal-2.37.2.drv
< /nix/store/cylk00sm6dz7qlcmiqf88wdl43k42b47-gtest-1.12.1.drv
< /nix/store/d1jjmpqnpw1769azx9k7aipqi1id3jdi-gperftools-2.10.drv
< /nix/store/d22p4rsn49yxmgkf6iy9kj1kr5ij59wl-wayland-protocols-1.26.drv
< /nix/store/d2lsdig037fv8v4dyyz3g0hwphnykmh1-python3.10-buildcatrust-0.1.3.drv
< /nix/store/d4md5z48969labfd64lmwr9jzwdas7j5-adoptopenjdk-hotspot-bin-17.0.2.drv
< /nix/store/d8nly91nc3h5gs1rlhfkxdwxr4jvqd49-setup-hook.sh
< /nix/store/dhvc1cxzpm43fjdcjna1kl1rki2pvya4-libxkbcommon-1.4.1.drv
< /nix/store/dlzf6bg3gxzirrrdmnskmnmq1cl3nj1y-source.drv
< /nix/store/dw85gc8h4r0pda2431fd8mprq6r5v989-aarch64-test-narrowing.diff.drv
< /nix/store/dxi8mzc45776kxq97y22swbwk27ria97-libXft-2.3.4.tar.bz2.drv
< /nix/store/f16y4iaj8w3pnpbggcq7yc9bjq16rqpq-builder.sh
< /nix/store/f3274388mhmd3zrw651lm0d5s7ngzahs-pango-1.50.8.drv
< /nix/store/fa84a81ci8b1ra679rgfhzqbpsih7wq6-util-macros-1.19.3.drv
< /nix/store/figchm0r5nnz1yd8i19d3zmzi865nf6c-python3.10-typogrify-2.0.7.drv
< /nix/store/fm3ggjpiyjr2ibk0m2cv57wbi1s7g3in-libdevil-1.7.8.drv
< /nix/store/g5rq1lbbkjhyjb51sdr9gh7x4ynnipch-gts-0.7.6.tar.gz.drv
< /nix/store/g6spvfs5x4xk98b2alqvpvkaz802k54i-gperftools-2.7.90-disable-generic-dynamic-tls.patch.drv
< /nix/store/g6whz55drd921dnm1kg5ynhp75bdfcxb-graphviz-5.0.1.drv
< /nix/store/gkbcp4rfb1rfrz9kyv8mk2q5gslhjf00-python3-3.10.6-env.drv
< /nix/store/gx96vrvldmqhbp419xzlp3pjr52m7s5f-source.drv
< /nix/store/gyppxd2hyc3nkq3b2s19n71qd23cvzn0-clean-immodules-cache.sh
< /nix/store/h4jrijgrvg4ldq9w5cikrnicdq7w0hq0-libwebp-1.2.4.drv
< /nix/store/h875zca86f9c5k2x9s9wljx5c87prdi4-toml-0.10.2.tar.gz.drv
< /nix/store/h9wy5mkcyc09jpy188fqmklxyz2f4jhx-cve-2013-4276.patch
< /nix/store/hc83rsz21zxj3r7v68lxhybnmvwx80xh-source.drv
< /nix/store/hn0dv2hig49xy7r08b2ydrbjm5sifrv5-boost_1_79_0.tar.bz2.drv
< /nix/store/i64a25n95nllhqq08f1x3yf5sil72wwq-publicsuffix-list-2021-09-03.drv
< /nix/store/i7cnndj8bswqmdwvkxs7xzvinjw9k2s5-libaom-3.4.0.drv
< /nix/store/if3yc4xllf4wwsaj2xdn1r7hiv9dvi78-libXcomposite-0.4.5.tar.bz2.drv
< /nix/store/ii74ss6z3r34zqlpr8s1006zvr96vfp8-cross-file.conf.drv
< /nix/store/im44badi6hzp0cr5rdy9hzgpa55s2wyx-outputs.patch
< /nix/store/iwd03grs1i6rmqcz8caikig0gsypz42f-boost-1.79.0.drv
< /nix/store/j3icrn59cmh11r9rxpcxh4a0rb0yzal4-source.drv
< /nix/store/j6vpikcvv4ry0pwalvpz1m65k2wckavl-docbook2texi.patch
> /nix/store/jc4kd4fx7qkl90gv97l0nh5jcvi691hp-openjdk-headless-17.0.4+8.drv
< /nix/store/jf18z5cdbihdvgija8gi2bgfghh73h5j-fribidi-1.0.12.tar.xz.drv
< /nix/store/jjw6ganms2y6g30ghgrqpv1axalmss84-fix-link-lld-macho.patch.drv
< /nix/store/jlsb7h82sac13xbi3zvjg35kb2g9nf9j-nix-prefetch-git
< /nix/store/jmmprm90wnfkcpwpnl66qz0k914d7p95-graphite2-1.3.14.drv
< /nix/store/jpwyi8z9dl9pqflhxg2c8ibbql3aw83w-libxkbcommon-1.4.1.tar.xz.drv
< /nix/store/jz0smxr4yldpsv3y39jqlb2xxazyjp8c-libpsl-0.21.1.tar.lz.drv
< /nix/store/k4qd9wd7cmr7glgrf857b9xmd56jcd45-libunwind-1.6.2.drv
< /nix/store/khf1qm2gppz8lb45lx2kp91xknmrcrl1-git-send-email-honor-PATH.patch
< /nix/store/ki5wd9k414k6azghpn4p395zmcqkrnri-Markdown-3.4.1.tar.gz.drv
< /nix/store/kim0grrms2j81jpzc1bvg7ih5q823ayl-il_endian.h.patch
< /nix/store/kpldyvi3dhi000skip5ic39mmflg89fc-libthai-0.1.29.drv
< /nix/store/krxaymda39gqvllzwmbcxxh3v7w7qp9h-iso-codes-4.11.0.drv
< /nix/store/l142cd6fjkkav536pwd907pbhfh04nb4-at-spi2-core-2.44.1.drv
< /nix/store/l6g4rq1i554afc8gp93wr9xjb966mcmf-lcms-1.19.drv
< /nix/store/lmwcy7lparsw004dwby4d3r6hg3w1bdl-openexr-2.5.8.drv
< /nix/store/lrww10ywqjip34bnn5ns3v1zvmz2ck2y-debug-info-from-env.patch
< /nix/store/lv68v754qww9s5m4n0xnj0314s4gqphd-vala-0.56.2.tar.xz.drv
< /nix/store/lwg53x0jp7kzi39f8mbg6xvb6jv2dz71-gts-0.7.6.drv
< /nix/store/m0kipgjc4wj15sbbzr2xz2sigmqmrgym-clean-immodules-cache.sh.drv
< /nix/store/mrmq2wn103apnfxgys49bzgas0dvv75z-3.0-Xft-setting-fallback-compute-DPI-properly.patch
< /nix/store/mvnlb58ffgqavfpp98007sav6s2v1pbl-yasm-1.3.0.tar.gz.drv
< /nix/store/mvyj08a6wj7zzbdpkyjfrxz6l95yj06c-icu4c-71_1-src.tgz.drv
> /nix/store/mwn4mmsfnix8a95jng833awk8qjsqwkn-adoptopenjdk-hotspot-bin-17.0.2.drv
< /nix/store/mzfpf61jix5z31ncqspny48cqr0g7s6c-sassc-3.6.2.drv
< /nix/store/n000jsw8hy5x6f06m67cvq1s7ll7y32z-e85b65cec757ef589f28957d0c6c21c498a03bdf.patch.drv
< /nix/store/n8wdha51zady0j1lrp9sixsrlls70sxn-source.drv
< /nix/store/na2arncin8rkcjxfcqdhs288aisyqxjs-source.drv
< /nix/store/naaiq3znf7ffaw97iqqmnldxcs9skw65-tracker-3.3.2.drv
< /nix/store/nvw9jv49ca035l27gqn3wsx9g48gkq3y-attachment.cgi?id=148912.drv
< /nix/store/ny16wsxkm13ll8c1ihi01rbzxc0qmn1p-mpfr-4.1.0.drv
< /nix/store/p0p4j9fs8ghsjafh1w4krsywncbh1hmf-libipt-2.0.5.drv
< /nix/store/p625vxv9y8bza2zrx07s8jlvc2yms6mh-xkeyboard-config-2.33.drv
< /nix/store/p6s3984ywyab5kixd8jxly2hz0fcrni4-cacert-blocklist.txt.drv
< /nix/store/p6x07951ypdifl7y7jq8fnhkw1flnsy5-libthai-0.1.29.tar.xz.drv
< /nix/store/pfwy687jdjdj2nsik8zmy085chsidz3x-gdk-pixbuf-2.42.8.tar.xz.drv
< /nix/store/pm7ax6znv2v4prgficnf9vpymjriq2vv-iso-codes-v4.11.0.tar.gz.drv
< /nix/store/pv3r7pc48i29zypg23mxqz9aj64qzqpy-libmng-2.0.3.tar.xz.drv
< /nix/store/pxf8pr5hmsjdwpi4m7fw2kx5fs7qx7pr-wayland-1.21.0.tar.xz.drv
< /nix/store/r3qrhv424i84sa0766cwn319w6rny0nn-libepoxy-1.5.10.drv
< /nix/store/r6by79kaxgmq4py8wzcfjsc87c3q104a-gsettings-desktop-schemas-42.0.tar.xz.drv
< /nix/store/rskrk7xy7cymsk387i8gc9wshpbqbwf4-yasm-1.3.0.drv
< /nix/store/s36f0nslqg0k6vdznpc95v0bq5riwasn-valgrind-3.19.0.drv
< /nix/store/s3gslzcngy4s3xkvwi1g1c744n23rr7z-gdk-pixbuf-2.42.8.drv
< /nix/store/s74kqbjk4v5aihx7c2s1ykjgj662yxgg-wrap-gapps-hook.sh
< /nix/store/sdwlpdv2fzxq5ayryyxkm71pk67xnwjr-source.drv
< /nix/store/sjzcx28nkpi4jjgx19xf88z131nn2dvl-8d662734b6a34709d9475b120e7ce3de872339e2.diff.drv
< /nix/store/sq77glsr7lzq6f5vzyn9s0xcrhcmvf83-at-spi2-core-2.44.1.tar.xz.drv
< /nix/store/v55fx3lfb933ysnyd68rskfi9vrhi0qr-libpsl-0.21.1.drv
< /nix/store/v86m22kxwig1qdgca599x99lzfnd12y7-libstemmer-unstable-2017-03-02.drv
< /nix/store/vb3mhna9n0gky55kiy05y248912li4ny-dconf-0.40.0.drv
< /nix/store/vndnczm832vi8m6ihqn424aly9g63xmb-gvc-compat.patch
< /nix/store/vsfh506w77i87wxpv1p5459k3dlzrzvj-libsysprof-capture-3.44.0.drv
< /nix/store/vxmndsdqw7w3g6p9mfjb65lfndz36rnl-typogrify-2.0.7.tar.gz.drv
< /nix/store/w131qh7a25ran00haxjim64y09kdgfr2-source.drv
< /nix/store/w5w4cyz5m4dri3pvck9i8rx3ckjbw4yw-source.drv
< /nix/store/wgg3vdxhvkkbkm3q6qjml737mvxj3svd-setup-hook.sh.drv
< /nix/store/whaivj7150764ri5wg7hwjr9hmlg4blk-wayland-protocols-1.26.tar.xz.drv
< /nix/store/wiqar4mkbfcas7kcc3ll27s5l97mylzp-hwy-add-missing-includes.patch.drv
< /nix/store/wpbcp7kf7xcjaf7kd7nqx23y6n8h86lf-cmake-paths-173.patch
< /nix/store/wqyrnl7f2hcncs0g4x68x09lj5269zg4-source.drv
< /nix/store/ws6kqwjilas1jj8l7s82cjr6796831ag-libmng-2.0.3.drv
< /nix/store/wxzqazjvsfzn7sm06zbs0g6nni6wiarv-libXft-2.3.4.drv
< /nix/store/x0xzpk7b0ncdzbwa2vz17z4m29cy2c56-nss-cacert-3.80.drv
< /nix/store/x5lzg2mw1vvg3jkq03z8ypidv41rvpjj-source.drv
< /nix/store/x6j8mqndp4q58h0yjin3ackqkzqm1jvb-source.drv
< /nix/store/xabcd5d4c1ilr0iaxm5xhxnchzn5wbxk-source-highlight-3.1.9.tar.gz.drv
< /nix/store/xjiymql1y8q7jdgmw93h48xc1dg0b50x-723092ece088559f1af299236305911f4ee4d450.patch.drv
< /nix/store/xlgp931l3krihh0qn24a4ndd8hh8zigd-pango-1.50.8.tar.xz.drv
< /nix/store/xp2c99q4ckzm6vyw2lyk31irz36f4inw-DevIL-1.7.8.tar.gz.drv
< /nix/store/xprdd33cnqprwk19lxi57h907fz7xic2-git-sh-i18n.patch
< /nix/store/xs2gp1w8f3vhzydsvgg2wqq8g0myl0rw-gdb-12.1.drv
< /nix/store/xs8pd4sh99g588s2ifvj4gw3z8j5l8hl-d385aa3e5320d18918413df0e8aef3a713a47e0b.patch.drv
< /nix/store/xwkyhxn3xqr3c2llqcw1cac6bnlws656-libunwind-1.6.2.tar.gz.drv
< /nix/store/xy7dm7874qzfi3fn5lykir5frhszmhcf-harfbuzz-5.1.0.drv
< /nix/store/y7chiid0hl1phd1hw932cv5sb044is8h-meson-add-installed-tests-prefix-option.patch
< /nix/store/yax78cn98xn74i2cxviiwki4ylrh5ivq-lcms-1.19.tar.gz.drv
< /nix/store/yykbp1qm4p4871l83rkbiki3wsyb1fjb-source.drv
< /nix/store/z702z6y1707k3jdz1ymlfk6zn520phn9-fribidi-1.0.12.drv
< /nix/store/zh17l63j1fv98sg8n0pp6mzmvjrb1dsv-python3.10-pyyaml-6.0.drv
< /nix/store/zn71cplg6qffhn1r0rpd4spligprih10-xkeyboard-config-2.33.tar.bz2.drv
< /nix/store/znvl3v02hy8ffkhwc6m9z1q5pj8j6ppj-setup-hook.sh
< /nix/store/znxmbxq68l7agflcx869k3z1qdacs0y3-libsoup-3.0.7.drv
< /nix/store/znxr6xcwkdcqgdaknidfsrq3h2azz9mq-installed-tests-path.patch
< /nix/store/zxwf8a3f3nb435r4z0jy30kz201yisp9-boost-build-boost-1.79.0.drv
< /nix/store/zz2z03a4zzj62s8lqnm28pn544vsxk3j-freefont-ttf-20120503.drv
```


</details>

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
