### PR TITLE
Add muldefs to ldFlags, and fix GHC targetPrefix on android

### DIFF
--- a/pkgs/development/androidndk-pkgs/androidndk-pkgs.nix
+++ b/pkgs/development/androidndk-pkgs/androidndk-pkgs.nix
@@ -49,19 +49,18 @@ let
   # targetInfo.triple is what Google thinks the toolchain should be, this is a little
   # different from what we use. We make it four parts to conform with the existing
   # standard more properly.
-  targetConfig = lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform) (stdenv.targetPlatform.config);
-  prefix = lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform) (stdenv.targetPlatform.config + "-");
+  targetPrefix = lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform) (stdenv.targetPlatform.config + "-");
 in
 
 rec {
   # Misc tools
   binaries = stdenv.mkDerivation {
-    pname = "${targetConfig}-ndk-toolchain";
+    pname = "${targetPrefix}ndk-toolchain";
     inherit (androidndk) version;
     nativeBuildInputs = [ makeWrapper autoPatchelfHook ];
     propagatedBuildInputs = [ androidndk ];
     passthru = {
-      targetPrefix = prefix;
+      inherit targetPrefix;
       isClang = true; # clang based cc, but bintools ld
     };
     dontUnpack = true;
@@ -93,23 +92,23 @@ rec {
       ln -s $out/toolchain/bin $out/bin
       ln -s $out/toolchain/${targetInfo.triple}/bin/* $out/bin/
       for f in $out/bin/${targetInfo.triple}-*; do
-        ln -s $f ''${f/${targetInfo.triple}-/${targetConfig}-}
+        ln -s $f ''${f/${targetInfo.triple}-/${targetPrefix}}
       done
       for f in $(find $out/toolchain -type d -name ${targetInfo.triple}); do
-        ln -s $f ''${f/${targetInfo.triple}/${targetConfig}}
+        ln -s $f ''${f/${targetInfo.triple}/${targetPrefix}}
       done
 
-      rm -f $out/bin/${targetConfig}-ld
-      ln -s $out/bin/lld $out/bin/${targetConfig}-ld
+      rm -f $out/bin/${targetPrefix}ld
+      ln -s $out/bin/lld $out/bin/${targetPrefix}ld
 
       (cd $out/bin;
         for tool in llvm-*; do
-          ln -sf $tool ${targetConfig}-$(echo $tool | sed 's/llvm-//')
+          ln -sf $tool ${targetPrefix}$(echo $tool | sed 's/llvm-//')
           ln -sf $tool $(echo $tool | sed 's/llvm-//')
         done)
 
       # handle last, as llvm-as is for llvm bytecode
-      ln -sf $out/bin/${targetInfo.triple}-as $out/bin/${targetConfig}-as
+      ln -sf $out/bin/${targetInfo.triple}-as $out/bin/${targetPrefix}as
       ln -sf $out/bin/${targetInfo.triple}-as $out/bin/as
 
       patchShebangs $out/bin

--- a/pkgs/development/androidndk-pkgs/androidndk-pkgs.nix
+++ b/pkgs/development/androidndk-pkgs/androidndk-pkgs.nix
@@ -50,6 +50,7 @@ let
   # different from what we use. We make it four parts to conform with the existing
   # standard more properly.
   targetConfig = lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform) (stdenv.targetPlatform.config);
+  prefix = lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform) (stdenv.targetPlatform.config + "-");
 in
 
 rec {
@@ -60,6 +61,7 @@ rec {
     nativeBuildInputs = [ makeWrapper autoPatchelfHook ];
     propagatedBuildInputs = [ androidndk ];
     passthru = {
+      targetPrefix = prefix;
       isClang = true; # clang based cc, but bintools ld
     };
     dontUnpack = true;
@@ -131,7 +133,7 @@ rec {
       # Android needs executables linked with -pie since version 5.0
       # Use -fPIC for compilation, and link with -pie if no -shared flag used in ldflags
       echo "-target ${targetInfo.triple} -fPIC" >> $out/nix-support/cc-cflags
-      echo "-z,noexecstack -z,relro -z,now" >> $out/nix-support/cc-ldflags
+      echo "-z,noexecstack -z,relro -z,now -z,muldefs" >> $out/nix-support/cc-ldflags
       echo 'if [[ ! " $@ " =~ " -shared " ]]; then NIX_LDFLAGS_${suffixSalt}+=" -pie"; fi' >> $out/nix-support/add-flags.sh
       echo "-Xclang -mnoexecstack" >> $out/nix-support/cc-cxxflags
       if [ ${targetInfo.triple} == arm-linux-androideabi ]; then


### PR DESCRIPTION
###### Description of changes
Add muldefs to ldFlags, and fix GHC targetPrefix on android

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
