### PR TITLE
buildBazelPackage: optionally run bazel tests in checkPhase

### DIFF
--- a/pkgs/build-support/build-bazel-package/default.nix
+++ b/pkgs/build-support/build-bazel-package/default.nix
@@ -13,35 +13,37 @@ args@{
 , bazel ? bazelPkg
 , bazelFlags ? []
 , bazelBuildFlags ? []
+, bazelTestFlags ? []
 , bazelFetchFlags ? []
 , bazelTarget
+, bazelTestTargets ? []
 , buildAttrs
 , fetchAttrs
 
-# Newer versions of Bazel are moving away from built-in rules_cc and instead
-# allow fetching it as an external dependency in a WORKSPACE file[1]. If
-# removed in the fixed-output fetch phase, building will fail to download it.
-# This can be seen e.g. in #73097
-#
-# This option allows configuring the removal of rules_cc in cases where a
-# project depends on it via an external dependency.
-#
-# [1]: https://github.com/bazelbuild/rules_cc
+  # Newer versions of Bazel are moving away from built-in rules_cc and instead
+  # allow fetching it as an external dependency in a WORKSPACE file[1]. If
+  # removed in the fixed-output fetch phase, building will fail to download it.
+  # This can be seen e.g. in #73097
+  #
+  # This option allows configuring the removal of rules_cc in cases where a
+  # project depends on it via an external dependency.
+  #
+  # [1]: https://github.com/bazelbuild/rules_cc
 , removeRulesCC ? true
 , removeLocalConfigCc ? true
 , removeLocal ? true
 
-# Use build --nobuild instead of fetch. This allows fetching the dependencies
-# required for the build as configured, rather than fetching all the dependencies
-# which may not work in some situations (e.g. Java code which ends up relying on
-# Debian-specific /usr/share/java paths, but doesn't in the configured build).
+  # Use build --nobuild instead of fetch. This allows fetching the dependencies
+  # required for the build as configured, rather than fetching all the dependencies
+  # which may not work in some situations (e.g. Java code which ends up relying on
+  # Debian-specific /usr/share/java paths, but doesn't in the configured build).
 , fetchConfigured ? true
 
-# Don’t add Bazel --copt and --linkopt from NIX_CFLAGS_COMPILE /
-# NIX_LDFLAGS. This is necessary when using a custom toolchain which
-# Bazel wants all headers / libraries to come from, like when using
-# CROSSTOOL. Weirdly, we can still get the flags through the wrapped
-# compiler.
+  # Don’t add Bazel --copt and --linkopt from NIX_CFLAGS_COMPILE /
+  # NIX_LDFLAGS. This is necessary when using a custom toolchain which
+  # Bazel wants all headers / libraries to come from, like when using
+  # CROSSTOOL. Weirdly, we can still get the flags through the wrapped
+  # compiler.
 , dontAddBazelOpts ? false
 , ...
 }:
@@ -50,13 +52,33 @@ let
   fArgs = removeAttrs args [ "buildAttrs" "fetchAttrs" "removeRulesCC" ];
   fBuildAttrs = fArgs // buildAttrs;
   fFetchAttrs = fArgs // removeAttrs fetchAttrs [ "sha256" ];
-
-in stdenv.mkDerivation (fBuildAttrs // {
-  inherit name bazelFlags bazelBuildFlags bazelFetchFlags bazelTarget;
+  bazelCmd = { cmd, additionalFlags, targets }:
+    lib.optionalString (targets != [ ]) ''
+      # See footnote called [USER and BAZEL_USE_CPP_ONLY_TOOLCHAIN variables]
+      BAZEL_USE_CPP_ONLY_TOOLCHAIN=1 \
+      USER=homeless-shelter \
+      bazel \
+        --batch \
+        --output_base="$bazelOut" \
+        --output_user_root="$bazelUserRoot" \
+        ${cmd} \
+        --curses=no \
+        -j $NIX_BUILD_CORES \
+        "''${copts[@]}" \
+        "''${host_copts[@]}" \
+        "''${linkopts[@]}" \
+        "''${host_linkopts[@]}" \
+        $bazelFlags \
+        ${lib.strings.concatStringsSep " " additionalFlags} \
+        ${lib.strings.concatStringsSep " " targets}
+    '';
+in
+stdenv.mkDerivation (fBuildAttrs // {
+  inherit name bazelFlags bazelBuildFlags bazelTestFlags bazelFetchFlags bazelTarget bazelTestTargets;
 
   deps = stdenv.mkDerivation (fFetchAttrs // {
     name = "${name}-deps.tar.gz";
-    inherit bazelFlags bazelBuildFlags bazelFetchFlags bazelTarget;
+    inherit bazelFlags bazelBuildFlags bazelTestFlags bazelFetchFlags bazelTarget bazelTestTargets;
 
     impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ fFetchAttrs.impureEnvVars or [];
 
@@ -77,14 +99,7 @@ in stdenv.mkDerivation (fBuildAttrs // {
     buildPhase = fFetchAttrs.buildPhase or ''
       runHook preBuild
 
-      # Bazel computes the default value of output_user_root before parsing the
-      # flag. The computation of the default value involves getting the $USER
-      # from the environment. I don't have that variable when building with
-      # sandbox enabled. Code here
-      # https://github.com/bazelbuild/bazel/blob/9323c57607d37f9c949b60e293b573584906da46/src/main/cpp/startup_options.cc#L123-L124
-      #
-      # On macOS Bazel will use the system installed Xcode or CLT toolchain instead of the one in the PATH unless we pass BAZEL_USE_CPP_ONLY_TOOLCHAIN
-
+      # See footnote called [USER and BAZEL_USE_CPP_ONLY_TOOLCHAIN variables].
       # We disable multithreading for the fetching phase since it can lead to timeouts with many dependencies/threads:
       # https://github.com/bazelbuild/bazel/issues/6502
       BAZEL_USE_CPP_ONLY_TOOLCHAIN=1 \
@@ -97,7 +112,8 @@ in stdenv.mkDerivation (fBuildAttrs // {
         --loading_phase_threads=1 \
         $bazelFlags \
         $bazelFetchFlags \
-        $bazelTarget
+        ${bazelTarget} \
+        ${lib.strings.concatStringsSep " " bazelTestTargets}
 
       runHook postBuild
     '';
@@ -189,7 +205,7 @@ in stdenv.mkDerivation (fBuildAttrs // {
     # the wrappers are expecting will not be set. So instead of relying on the
     # wrappers picking them up, pass them in explicitly via `--copt`, `--linkopt`
     # and related flags.
-    #
+
     copts=()
     host_copts=()
     linkopts=()
@@ -209,23 +225,29 @@ in stdenv.mkDerivation (fBuildAttrs // {
       done
     fi
 
-    BAZEL_USE_CPP_ONLY_TOOLCHAIN=1 \
-    USER=homeless-shelter \
-    bazel \
-      --batch \
-      --output_base="$bazelOut" \
-      --output_user_root="$bazelUserRoot" \
-      build \
-      --curses=no \
-      -j $NIX_BUILD_CORES \
-      "''${copts[@]}" \
-      "''${host_copts[@]}" \
-      "''${linkopts[@]}" \
-      "''${host_linkopts[@]}" \
-      $bazelFlags \
-      $bazelBuildFlags \
-      $bazelTarget
-
+    ${
+      bazelCmd {
+        cmd = "test";
+        additionalFlags =
+          ["--test_output=errors"] ++  bazelTestFlags;
+        targets = bazelTestTargets;
+      }
+    }
+    ${
+      bazelCmd {
+        cmd = "build";
+        additionalFlags = bazelBuildFlags;
+        targets = [bazelTarget];
+      }
+    }
     runHook postBuild
   '';
 })
+
+# [USER and BAZEL_USE_CPP_ONLY_TOOLCHAIN variables]:
+#   Bazel computes the default value of output_user_root before parsing the
+#   flag. The computation of the default value involves getting the $USER
+#   from the environment. Code here :
+#   https://github.com/bazelbuild/bazel/blob/9323c57607d37f9c949b60e293b573584906da46/src/main/cpp/startup_options.cc#L123-L124
+#
+#   On macOS Bazel will use the system installed Xcode or CLT toolchain instead of the one in the PATH unless we pass BAZEL_USE_CPP_ONLY_TOOLCHAIN.

--- a/pkgs/development/tools/verible/default.nix
+++ b/pkgs/development/tools/verible/default.nix
@@ -31,11 +31,15 @@ buildBazelPackage rec {
     ./remove-unused-deps.patch
   ];
 
-  bazelFlags = [ "--//bazel:use_local_flex_bison" ];
+  bazelFlags = [
+    "--//bazel:use_local_flex_bison"
+    "--javabase=@bazel_tools//tools/jdk:remote_jdk11"
+    "--host_javabase=@bazel_tools//tools/jdk:remote_jdk11"
+  ];
 
   fetchAttrs = {
     # Fixed output derivation hash after bazel fetch
-    sha256 = "sha256-XoLdlEeoDJlyWlnXZADHOKu06zKHgHJfgey8UhOt+LM=";
+    sha256 = "sha256-45PINJ7VtL5Jl/nAQNkiSCt8wUwtytNfgeNMZaz3Y9U=";
   };
 
   nativeBuildInputs = [
@@ -45,14 +49,23 @@ buildBazelPackage rec {
   ];
 
   postPatch = ''
-    patchShebangs bazel/build-version.py \
-      common/util/create_version_header.sh \
+    patchShebangs\
+      bazel/build-version.py \
+      bazel/sh_test_with_runfiles_lib.sh \
+      common/lsp/dummy-ls_test.sh \
       common/parser/move_yacc_stack_symbols.sh \
-      common/parser/record_syntax_error.sh
+      common/parser/record_syntax_error.sh \
+      common/tools/patch_tool_test.sh \
+      common/tools/verible-transform-interactive.sh \
+      common/tools/verible-transform-interactive-test.sh \
+      common/util/create_version_header.sh \
+      kythe-browse.sh \
+      verilog/tools
   '';
 
   removeRulesCC = false;
   bazelTarget = ":install-binaries";
+  bazelTestTargets = [ "//..." ];
   bazelBuildFlags = [
     "-c opt"
   ];


### PR DESCRIPTION
As suggested in issue #190095, this PR introduces a way to optionally run bazel tests in the `checkPhase` of `buildBazelPackage`.

- The `checkPhase` is disabled by default and activated using `doCheck` argument.
- If activated, targets from the `bazelTestTargets` list will be tested (`["//..."]` by default).
- The `bazelTestFlags` argument can be used to provide test-specific flags. 

In order to test this, the PR also enables the `checkPhase` in the `vertible` package which is mentioned on the issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
