### PR TITLE
mailnag: mark broken

### DIFF
--- a/pkgs/applications/networking/mailreaders/mailnag/default.nix
+++ b/pkgs/applications/networking/mailreaders/mailnag/default.nix
@@ -103,5 +103,6 @@ python3Packages.buildPythonApplication rec {
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = with maintainers; [ doronbehar ];
+    broken = true; # at 2022-09-23
   };
 }


### PR DESCRIPTION
mailnag: mark broken

* linux-x86-64
  ![image](https://user-images.githubusercontent.com/5861043/192004018-0df0a97f-2715-40e0-a94d-5856cca6485c.png)
* linux-aarch64:
  ![image](https://user-images.githubusercontent.com/5861043/192004588-e907eeb2-93b4-4c58-b474-6fcea4e9da55.png)

I do not have the means to test Darwin.

logs: https://termbin.com/n6nc