### PR TITLE
gmrender-resurrect: mark broken

### DIFF
--- a/pkgs/tools/networking/gmrender-resurrect/default.nix
+++ b/pkgs/tools/networking/gmrender-resurrect/default.nix
@@ -32,5 +32,7 @@ in
       license = licenses.gpl2Plus;
       platforms = platforms.linux;
       maintainers = with maintainers; [ koral hzeller ];
+      # fatal error: ithread.h: No such file or directory
+      broken = true; # at 2022-09-23
     };
   }


### PR DESCRIPTION
gmrender-resurrect: mark broken

* linux-x86-64:
  ![image](https://user-images.githubusercontent.com/5861043/192007570-a60d996c-e785-4c54-bdea-c7f56476f01a.png)
  logs: https://termbin.com/h2x2

* linux-aarch64:
  ![image](https://user-images.githubusercontent.com/5861043/192009078-78e8acee-e92a-44f6-b5ec-079e36b3ac31.png)
  logs: https://termbin.com/0ot1a

Maintainers: @k0ral @hzeller