### PR TITLE
xdg-ninja: init at 0.2.0.1

### DIFF
--- a/pkgs/tools/misc/xdg-ninja/default.nix
+++ b/pkgs/tools/misc/xdg-ninja/default.nix
@@ -1,0 +1,36 @@
+{ lib, stdenvNoCC, fetchFromGitHub, makeWrapper, jq, glow }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "xdg-ninja";
+  version = "0.2.0.1";
+
+  src = fetchFromGitHub {
+    owner = "b3nj5m1n";
+    repo = "xdg-ninja";
+    rev = "v${version}";
+    sha256 = "sha256-ZyqxMlyCB8gEsZTVrxgLdW/mQ/4xeTHTK+lDKIzYs6I=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 xdg-ninja.sh "$out/share/xdg-ninja/xdg-ninja.sh"
+    install -Dm644 programs/* -t "$out/share/xdg-ninja/programs"
+
+    mkdir -p "$out/bin"
+    ln -s "$out/share/xdg-ninja/xdg-ninja.sh" "$out/bin/xdg-ninja"
+
+    wrapProgram "$out/bin/xdg-ninja" \
+      --prefix PATH : "${lib.makeBinPath [ glow jq ]}"
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A shell script which checks your $HOME for unwanted files and directories";
+    homepage = "https://github.com/b3nj5m1n/xdg-ninja";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ patricksjackson ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12418,6 +12418,8 @@ with pkgs;
 
   xdummy = callPackage ../tools/misc/xdummy { };
 
+  xdg-ninja = callPackage ../tools/misc/xdg-ninja { };
+
   xdxf2slob = callPackage ../tools/misc/xdxf2slob { };
 
   xe-guest-utilities = callPackage ../tools/virtualization/xe-guest-utilities { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
xdg-ninja is a script that checks your $HOME directory for unwanted files and directories, and provides advice for how to force programs to respect the XDG Base Directory Specification. See https://github.com/b3nj5m1n/xdg-ninja

It is a POSIX script that expects the 'programs/' subdirectory to exist in the same directory as the script.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
