### PR TITLE
apache-directory-server: init at 2.0.0.AM26

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9555,6 +9555,13 @@
     githubId = 23743547;
     name = "Akshay Oppiliappan";
   };
+  ners = {
+    name = "ners";
+    email = "ners@gmx.ch";
+    matrix = "@ners:ners.ch";
+    github = "ners";
+    githubId = 50560955;
+  };
   nessdoor = {
     name = "Tomas Antonio Lopez";
     email = "entropy.overseer@protonmail.com";

--- a/pkgs/servers/apache-directory-server/default.nix
+++ b/pkgs/servers/apache-directory-server/default.nix
@@ -1,0 +1,29 @@
+{ lib, stdenv, fetchzip, jdk11, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  pname = "apache-directory-server";
+  version = "2.0.0.AM26";
+
+  src = fetchzip {
+    url = "https://dlcdn.apache.org//directory/apacheds/dist/${version}/apacheds-${version}.zip";
+    sha256 = "sha256-36kDvfSy5rt/3+nivEFTepnIKf6sX0NTgPRm28M+1v4=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/apacheds
+    install -D $src/lib/*.jar $out/share/apacheds
+    classpath=$(jars=($out/share/apacheds/*.jar); IFS=:; echo "''${jars[*]}")
+    makeWrapper ${jdk11}/bin/java $out/bin/apache-directory-server \
+      --add-flags "-classpath $classpath org.apache.directory.server.UberjarMain"
+  '';
+
+  meta = with lib; {
+    description = "An extensible and embeddable directory server";
+    homepage = "https://directory.apache.org/apacheds/";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.ners ];
+  };
+}

--- a/pkgs/servers/nosql/janusgraph/default.nix
+++ b/pkgs/servers/nosql/janusgraph/default.nix
@@ -1,0 +1,44 @@
+{ lib, stdenv, fetchzip, jdk11, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  pname = "janusgraph";
+  version = "0.6.2";
+
+  src = fetchzip {
+    url = "https://github.com/JanusGraph/janusgraph/releases/download/v${version}/janusgraph-${version}.zip";
+    sha256 = "sha256-8TMYk8gGyL71zcFk0Lgo7Isvm4k3eh/H6PjfVePpkI4=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/janusgraph
+    install -D $src/lib/*.jar $out/share/janusgraph
+    cd $src
+    find conf scripts -type f -exec install -D {} $out/share/janusgraph/{} \;
+
+    JANUSGRAPH_LIB=$out/share/janusgraph
+    classpath=""
+    # Add the slf4j-log4j12 binding
+    classpath="$classpath":$(find -L $JANUSGRAPH_LIB -name 'slf4j-log4j12*.jar' | sort | tr '\n' ':')
+    # Add the jars in $JANUSGRAPH_LIB that start with "janusgraph"
+    classpath="$classpath":$(find -L $JANUSGRAPH_LIB -name 'janusgraph*.jar' | sort | tr '\n' ':')
+    # Add the remaining jars in $JANUSGRAPH_LIB.
+    classpath="$classpath":$(find -L $JANUSGRAPH_LIB -name '*.jar' \
+                    \! -name 'janusgraph*' \
+                    \! -name 'slf4j-log4j12*.jar' | sort | tr '\n' ':')
+
+    makeWrapper ${jdk11}/bin/java $out/bin/janusgraph-server \
+      --add-flags "-classpath $classpath org.janusgraph.graphdb.server.JanusGraphServer"
+  '';
+
+  meta = with lib; {
+    description = "An open-source, distributed graph database";
+    homepage = "https://janusgraph.org/";
+    mainProgram = "janusgraph-server";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.ners ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26821,6 +26821,8 @@ with pkgs;
 
   ao = libfive;
 
+  apache-directory-server = callPackage ../servers/apache-directory-server {};
+
   apache-directory-studio = callPackage ../applications/networking/apache-directory-studio {};
 
   apkeep = callPackage ../tools/misc/apkeep {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23297,6 +23297,8 @@ with pkgs;
 
   janus-gateway = callPackage ../servers/janus-gateway { };
 
+  janusgraph = callPackage ../servers/nosql/janusgraph { };
+
   jboss = callPackage ../servers/http/jboss { };
 
   jboss_mysql_jdbc = callPackage ../servers/http/jboss/jdbc/mysql { };


### PR DESCRIPTION
###### Description of changes

Add the Apache Directory Server and JanusGraph packages, in a single PR to reduce PR load. 

Please don't squash when merging.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
