### PR TITLE
python310Packages.etils: 0.7.1 -> 0.8.0

### DIFF
--- a/pkgs/development/python-modules/etils/default.nix
+++ b/pkgs/development/python-modules/etils/default.nix
@@ -28,14 +28,14 @@
 
 buildPythonPackage rec {
   pname = "etils";
-  version = "0.7.1";
+  version = "0.8.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-IHwJfdQYDV5asce37ni3v5Rx4SU03qziOx05LevSkvM=";
+    hash = "sha256-0dWve9nHhKJzxOHsz6qP6speBIGghxe1MT+iMdoiqQM=";
   };
 
   nativeBuildInputs = [
@@ -58,8 +58,6 @@ buildPythonPackage rec {
       ++ etree ++ etree-dm ++ etree-jax ++ etree-tf;
   };
 
-  doCheck = false; # disable tests until https://github.com/NixOS/nixpkgs/issues/185273 is resolved
-
   pythonImportsCheck = [
     "etils"
   ];
@@ -79,6 +77,8 @@ buildPythonPackage rec {
     "test_public_access" # requires network access
     "test_resource_path" # known to fail on Python 3.10, see https://github.com/google/etils/issues/143
   ];
+
+  doCheck = false; # error: infinite recursion encountered
 
   meta = with lib; {
     description = "Collection of eclectic utils for python";


### PR DESCRIPTION
python310Packages.etils: 0.7.1 -> 0.8.0

Downstream packages:
* `python310Packages.dm-sonnet` => broken in master
* `python310Packages.distrax` => broken in master
  ![image](https://user-images.githubusercontent.com/5861043/192040570-d1b13aa9-155b-4e0b-80ea-84b855a222d9.png)
  * log of python310Packages.distrax at master: https://termbin.com/czlr
* `python310Packages.rlax` => depends on python310Packages.distrax
* `python310Packages.elegy` => ERROR: Package 'elegy' requires a different Python: 3.10.6<3.10,>=3.7'

Fixes #186690