### PR TITLE
python310Packages.dm-sonnet: mark broken

### DIFF
--- a/pkgs/development/python-modules/dm-sonnet/default.nix
+++ b/pkgs/development/python-modules/dm-sonnet/default.nix
@@ -50,5 +50,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/deepmind/sonnet";
     license = licenses.asl20;
     maintainers = with maintainers; [ onny ];
+    # ERROR: No matching distribution found for etils[epath]
+    broken = true; # at 2022-10-04
   };
 }


### PR DESCRIPTION
python310Packages.dm-sonnet: mark broken

  > ERROR: Could not find a version that satisfies the requirement etils[epath] (from versions: none)
  > ERROR: No matching distribution found for etils[epath]

   logs: https://termbin.com/ttvk


* Goal is to avoid **false positive** in upstream builds.
  - Please, feel free to propose a fix in a **new** PR.