### PR TITLE
fetchNuGet: add support for sri hashes

### DIFF
--- a/pkgs/build-support/dotnet/fetchnuget/default.nix
+++ b/pkgs/build-support/dotnet/fetchnuget/default.nix
@@ -4,16 +4,19 @@ attrs @
 { pname
 , version
 , url ? "https://www.nuget.org/api/v2/package/${pname}/${version}"
+, hash ? ""
 , sha256 ? ""
 , md5 ? ""
 , ...
 }:
 if md5 != "" then
-  throw "fetchnuget does not support md5 anymore, please use sha256"
+  throw "fetchnuget does not support md5 anymore, please use sha256/hash"
+else if hash != "" && sha256 != "" then
+  throw "multiple hashes passed to fetchNuGet"
 else
   buildDotnetPackage ({
     src = fetchurl {
-      inherit url sha256;
+      inherit url sha256 hash;
       name = "${pname}.${version}.zip";
     };
 

--- a/pkgs/build-support/dotnet/make-nuget-deps/default.nix
+++ b/pkgs/build-support/dotnet/make-nuget-deps/default.nix
@@ -1,10 +1,10 @@
 { linkFarmFromDrvs, fetchurl }:
 { name, nugetDeps }:
 linkFarmFromDrvs "${name}-nuget-deps" (nugetDeps {
-  fetchNuGet = { pname, version, sha256
+  fetchNuGet = { pname, version, sha256 ? "", hash ? ""
     , url ? "https://www.nuget.org/api/v2/package/${pname}/${version}" }:
     fetchurl {
       name = "${pname}.${version}.nupkg";
-      inherit url sha256;
+      inherit url sha256 hash;
     };
 })


### PR DESCRIPTION
###### Description of changes
Adds extra inputs to the fetchNuGet function which are passed to fetchUrl. Did some testing on dotnet packages already in nixpkgs by converting their hashes from sha256 to sri, seemed to run fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
