### PR TITLE
nixos/direnv: init

### DIFF
--- a/nixos/modules/programs/direnv.nix
+++ b/nixos/modules/programs/direnv.nix
@@ -1,0 +1,44 @@
+{ lib, config, pkgs, ... }: {
+
+  options.programs.direnv.enable = lib.mkOption {
+    type = lib.types.bool;
+    default = false;
+    example = true;
+    description = ''
+      Whether to enable direnv integration. Takes care of both installation and
+      setting up the sourcing of the shell. Additionally enables nix-direnv
+      integration. Note that you need to logout and login for this change to apply.
+    '';
+  };
+
+  config = lib.mkIf config.programs.direnv.enable {
+
+    environment.systemPackages = with pkgs; [
+      direnv
+      nix-direnv
+    ];
+
+    environment.pathsToLink = [
+      "/share/direnv"
+    ];
+
+    environment.sessionVariables.DIRENV_CONFIG = "/run/current-system/sw/share/direnv";
+
+    programs.bash.interactiveShellInit = ''
+      eval "$(direnv hook bash)"
+    '';
+
+    programs.zsh.interactiveShellInit = ''
+      eval "$(direnv hook zsh)"
+    '';
+
+    programs.fish.interactiveShellInit = ''
+      direnv hook fish | source
+    '';
+
+    # nix options for derivations to persist garbage collection
+    nix.settings.keep-outputs = true;
+    nix.settings.keep-derivations = true;
+  };
+
+}

--- a/pkgs/tools/misc/nix-direnv/default.nix
+++ b/pkgs/tools/misc/nix-direnv/default.nix
@@ -26,6 +26,9 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
     install -m500 -D direnvrc $out/share/nix-direnv/direnvrc
+
+    # Allows NixOS to set DIRENV_CONFIG to /run/current-system/sw/share/direnv and have direnv load this
+    install -m500 -D direnvrc $out/share/direnv/lib/nix-direnv.sh
     runHook postInstall
   '';
 


### PR DESCRIPTION
###### Description of changes

[nix-direnv](https://github.com/nix-community/nix-direnv) is surprisingly annoying to configure correctly, due to it needing both system-wide adjustments (`nix.conf` changes), but also user-wide adjustments (telling direnv to load nix-direnv using ~/.config/direnv/direnvrc).

This module puts an end to that, allowing a [direnv](https://direnv.net/) + nix-direnv installation with just

```nix
{
  programs.direnv.enable = true;
}
```

Currently this module comes with nix-direnv enabled by default and there's no way to turn it off. If there ever is a need to only enable direnv without nix-direnv we can do that in another PR. I don't need that myself.

Ping @zimbatm @Mic92 @bbenne10 

###### Things done

- [x] Tested the module