### PR TITLE
pantheon.elementary-iconbrowser: init at 2.0.0

### DIFF
--- a/pkgs/desktops/pantheon/apps/elementary-iconbrowser/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-iconbrowser/default.nix
@@ -1,0 +1,75 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, nix-update-script
+, meson
+, ninja
+, pkg-config
+, python3
+, vala
+, wrapGAppsHook4
+, elementary-gtk-theme
+, elementary-icon-theme
+, glib
+, granite7
+, gtk4
+, gtksourceview5
+}:
+
+stdenv.mkDerivation rec {
+  pname = "elementary-iconbrowser";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "elementary";
+    repo = "iconbrowser";
+    rev = version;
+    sha256 = "sha256-aXFgL5l9jnOZJJgMOYwiE7W//1sq23CbLEDmhYFJT38=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    python3
+    vala
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    elementary-icon-theme
+    glib
+    granite7
+    gtk4
+    gtksourceview5
+  ];
+
+  postPatch = ''
+    chmod +x meson/post_install.py
+    patchShebangs meson/post_install.py
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      # The GTK theme is hardcoded.
+      --prefix XDG_DATA_DIRS : "${elementary-gtk-theme}/share"
+      # The icon theme is hardcoded.
+      --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS"
+    )
+  '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/elementary/iconbrowser";
+    description = "Browse and find system icons";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = teams.pantheon.members;
+    mainProgram = "io.elementary.iconbrowser";
+  };
+}

--- a/pkgs/desktops/pantheon/default.nix
+++ b/pkgs/desktops/pantheon/default.nix
@@ -67,6 +67,8 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   elementary-feedback = callPackage ./apps/elementary-feedback { };
 
+  elementary-iconbrowser = callPackage ./apps/elementary-iconbrowser { };
+
   elementary-mail = callPackage ./apps/elementary-mail { };
 
   elementary-music = callPackage ./apps/elementary-music { };


### PR DESCRIPTION
###### Description of changes

https://github.com/elementary/iconbrowser


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
