### PR TITLE
cc-wrapper: generating compile_commands.json using cc-wrapper

### DIFF
--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -1426,7 +1426,7 @@ In nixpkgs standard environments, [compilers are wrapped](#cc-wrapper), and bear
 
 The mini-compile-commands package is a nixpkgs specific tool for generating a `compile_commands.json`. The package consists of two files: `mini_compile_commands_server.py` and `mini_compile_commands_client.py`.
 The basic idea is that we inject the `mini_compile_commands_client.py` into the compiler wrapper using a [post-wrapper-hook](#post-wrapper-hook).
-Whenever the wrapper is executed, it sends the unwrapped compile command to a running `mini_compile_commands_client.py`, which collects them and when shut down, writes a `compile_commands.json`.
+Whenever the wrapper is executed, it sends the unwrapped compile command to a running `mini_compile_commands_server.py`, which collects them and when shut down, writes a `compile_commands.json`.
 The client server architecture is required to handle parallel builds.
 
 

--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -1430,7 +1430,7 @@ Whenever the wrapper is executed, it sends the unwrapped compile command to a ru
 The client server architecture is required to handle parallel builds.
 
 
-The `mini-compile-commands.wrap` function takes a nixpkgs standard environment, and returns a new standard environment with the `mini_compile_commands_client.py` insert into the compiler wrapper as a post wrapper hook.
+The `mini-compile-commands.wrap` function takes a nixpkgs standard environment, and returns a new standard environment with the `mini_compile_commands_client.py` insert into the compiler wrapper as a post wrapper hook and `mini_compile_commands_server.py` in scope.
 
 For example, in the environment
 

--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -1418,15 +1418,16 @@ The post wrapper hook executes in the same environment as the compiler wrapper, 
 
 ### Generating compile_commands.json files {#compile-commands-json}
 
-A `compile_commands.json` file is a record of all the compiler invocations which occoured when building a C or C++ project.
+A `compile_commands.json` is a record of all the compiler invocations which occoured when building a C or C++ project.
 The specification can be found [here](https://clang.llvm.org/docs/JSONCompilationDatabase.html).
-A `compile_commands.json` file is used by lsp servers like `clangd` to provide IDE features to editors for C and C++.
+A `compile_commands.json` is used by lsp servers like `clangd` to provide IDE features to editors for C and C++.
 The most popular tool for generating a `compile_commands.json` is [bear](https://github.com/rizsotto/Bear).
 In nixpkgs standard environments, [compilers are wrapped](#cc-wrapper), and bear can have trouble distinguishing between invocations of the compiler wrapper and invocations of the unwrapped compiler.
 
-The mini-compile-commands package is a nixpkgs specific tool for generating a `compile_commands.json`. The package provides `mini_compile_commands_server.py` and `mini_compile_commands_client.py`.
+The mini-compile-commands package is a nixpkgs specific tool for generating a `compile_commands.json`. The package consists of two files: `mini_compile_commands_server.py` and `mini_compile_commands_client.py`.
 The basic idea is that we inject the `mini_compile_commands_client.py` into the compiler wrapper using a [post-wrapper-hook](#post-wrapper-hook).
 Whenever the wrapper is executed, it sends the unwrapped compile command to a running `mini_compile_commands_client.py`, which collects them and when shut down, writes a `compile_commands.json`.
+The client server architecture is required to handle parallel builds.
 
 
 The `mini-compile-commands.wrap` function takes a nixpkgs standard environment, and returns a new standard environment with the `mini_compile_commands_client.py` insert into the compiler wrapper as a post wrapper hook.

--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -219,6 +219,12 @@ fi
 PATH="$path_backup"
 # Old bash workaround, see above.
 
+# if a post-wrapper-hook exists, run it.
+if [[ -e @out@/nix-support/post-wrapper-hook.sh ]]; then
+    compiler=@prog@
+    source @out@/nix-support/post-wrapper-hook.sh
+fi
+
 if (( "${NIX_CC_USE_RESPONSE_FILE:-@use_response_file_by_default@}" >= 1 )); then
     exec @prog@ @<(printf "%q\n" \
        ${extraBefore+"${extraBefore[@]}"} \

--- a/pkgs/development/tools/mini-compile-commands/default.nix
+++ b/pkgs/development/tools/mini-compile-commands/default.nix
@@ -16,6 +16,7 @@ rec {
           installPhase = previous.installPhase or "" + hook;
         });
         extraBuildInputs = old.extraBuildInputs or [] ++ [ package ];
+        allowedRequisites = null;
       });
 
   # mini compile commands package. You probably don't want to use this directly.

--- a/pkgs/development/tools/mini-compile-commands/default.nix
+++ b/pkgs/development/tools/mini-compile-commands/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, python3
+}:
+
+rec {
+  # function for wrapping a standard environment to include the
+  # compile commands generation functionality
+  wrap = env:
+    let
+      hook = "ln -s ${package}/bin/post-wrapper-hook.sh $out/nix-support/post-wrapper-hook.sh\n";
+    in
+      env.override (old: {
+        cc = old.cc.overrideAttrs (final: previous: {
+          installPhase = previous.installPhase or "" + hook;
+        });
+        extraBuildInputs = old.extraBuildInputs or [] ++ [ package ];
+      });
+
+  # mini compile commands package. You probably don't want to use this directly.
+  # instead, wrap your standard environment: ( mini-compile-commands.wrap stdenv )
+  package = stdenv.mkDerivation rec {
+    pname = "mini_compile_commands";
+    version = "0.1";
+
+    src = fetchFromGitHub {
+      owner = "danielbarter";
+      repo = "mini_compile_commands";
+      rev = "v${version}";
+      sha256 = "0yDocHY4+DsakFXDnrCa/d4ZTGxjFCW68zB8F5GsRuo=";
+    };
+
+    # specifying python environment variable so that it gets substituted
+    # during install phase
+    python = python3;
+
+    installPhase = ''
+      mkdir -p $out/bin
+      export mini_compile_commands_client=$out/bin/mini_compile_commands_client.py
+      for file in $(ls $src); do
+        substituteAll $src/$file $out/bin/$file
+        chmod +x $out/bin/$file
+      done
+    '';
+
+    meta = with lib; {
+      homepage = "https://github.com/danielbarter/mini_compile_commands";
+      description = "Generate compile_commands.json using nixpkgs infrastructure";
+      license = licenses.gpl3;
+      maintainers = with maintainers; [ danielbarter ];
+      platforms = platforms.linux;
+    };
+  };
+}

--- a/pkgs/development/tools/mini-compile-commands/default.nix
+++ b/pkgs/development/tools/mini-compile-commands/default.nix
@@ -1,7 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, python3
+, python3Minimal
 }:
 
 rec {
@@ -33,7 +33,7 @@ rec {
 
     # specifying python environment variable so that it gets substituted
     # during install phase
-    python = python3;
+    python = python3Minimal;
 
     installPhase = ''
       mkdir -p $out/bin

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8381,6 +8381,8 @@ with pkgs;
 
   minica = callPackage ../tools/security/minica { };
 
+  mini-compile-commands = callPackage ../development/tools/mini-compile-commands { };
+
   minidlna = callPackage ../tools/networking/minidlna { };
 
   miniplayer = callPackage ../applications/audio/miniplayer { };


### PR DESCRIPTION
###### Description of changes

Modifying the cc-wrapper so that it can be used to generate `compile_commands.json` files. Here is the corresponding package:
https://github.com/danielbarter/mini_compile_commands

Inserts a `post-wrapper-hook` which the user can provide to insert a hook into the wrapper.

`mini-compile-commands` provides the function `mini-compile-commands.wrap` which can be used to add compile command generating functionality to a standard environment: 

```
with (import <nixpkgs> {});
let llvm = llvmPackages_latest;
in (mkShell.override {stdenv = ( mini-compile-commands.wrap llvm.stdenv );}) {
   buildInputs = [ cmake gtest ];
}
``` 


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
