### PR TITLE
python310Packages.edlib: init at 1.3.9

### DIFF
--- a/pkgs/development/libraries/science/biology/edlib/default.nix
+++ b/pkgs/development/libraries/science/biology/edlib/default.nix
@@ -1,0 +1,30 @@
+{ lib, stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "edlib";
+  version = "unstable-2021-08-20";
+
+  src = fetchFromGitHub {
+    owner = "Martinsos";
+    repo = pname;
+    rev = "f8afceb49ab0095c852e0b8b488ae2c88e566afd";
+    hash = "sha256-P/tFbvPBtA0MYCNDabW+Ypo3ltwP4S+6lRDxwAZ1JFo=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+    bin/runTests
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    homepage = "https://martinsos.github.io/edlib";
+    description = "Lightweight, fast C/C++ library for sequence alignment using edit distance";
+    maintainers = with maintainers; [ bcdarwin ];
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/python-modules/edlib/default.nix
+++ b/pkgs/development/python-modules/edlib/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, edlib
+, cython
+, python
+}:
+
+buildPythonPackage {
+  inherit (edlib) pname src meta;
+  version = "1.3.9";
+
+  disabled = pythonOlder "3.6";
+
+  sourceRoot = "source/bindings/python";
+
+  preBuild = ''
+    ln -s ${edlib.src}/edlib .
+  '';
+
+  EDLIB_OMIT_README_RST = 1;
+  EDLIB_USE_CYTHON = 1;
+
+  nativeBuildInputs = [ cython ];
+  buildInputs = [ edlib ];
+
+  checkPhase = ''
+    runHook preCheck
+    ${python.interpreter} test.py
+    runHook postCheck
+  '';
+
+  pythonImportsCheck = [ "edlib" ];
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6671,6 +6671,8 @@ with pkgs;
 
   edk2-uefi-shell = callPackage ../tools/misc/edk2-uefi-shell { };
 
+  edlib = callPackage ../development/libraries/science/biology/edlib { };
+
   eff = callPackage ../development/interpreters/eff { };
 
   eflite = callPackage ../applications/audio/eflite {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2935,6 +2935,10 @@ self: super: with self; {
 
   editorconfig = callPackage ../development/python-modules/editorconfig { };
 
+  edlib = callPackage ../development/python-modules/edlib {
+    inherit (pkgs) edlib;
+  };
+
   edward = callPackage ../development/python-modules/edward { };
 
   effect = callPackage ../development/python-modules/effect { };


### PR DESCRIPTION
edlib: init at unstable-2021-08-20

(Note that the C++ code and Python bindings are maintained in the same repo but with separate version numbers; hence the C++ code getting an `unstable-` version here corresponding to the commit introducing version `1.3.9` in the Python bindings even though the same `src` is used for both.)

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [NA] (Module updates) Added a release notes entry if the change is significant
  - [NA] (Module addition) Added a release notes entry if adding a new NixOS module
  - [NA] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
