### PR TITLE
vimUtils.buildVimPlugin: prevent building two times

### DIFF
--- a/pkgs/applications/editors/vim/plugins/build-vim-plugin.nix
+++ b/pkgs/applications/editors/vim/plugins/build-vim-plugin.nix
@@ -8,6 +8,12 @@
 }:
 
 rec {
+  addRtp = drv:
+    drv // {
+      rtp = "${drv}";
+      overrideAttrs = f: addRtp (drv.overrideAttrs f);
+    };
+
   buildVimPlugin = attrs@{
     name ? "${attrs.pname}-${attrs.version}",
     namePrefix ? "vimplugin-",
@@ -36,9 +42,7 @@ rec {
         runHook postInstall
       '';
     });
-    in toVimPlugin(drv.overrideAttrs(oa: {
-      rtp = "${drv}";
-    }));
+    in addRtp drv;
 
   buildVimPluginFrom2Nix = attrs: buildVimPlugin ({
     # vim plugins may override this

--- a/pkgs/applications/editors/vim/plugins/build-vim-plugin.nix
+++ b/pkgs/applications/editors/vim/plugins/build-vim-plugin.nix
@@ -10,7 +10,7 @@
 rec {
   addRtp = drv:
     drv // {
-      rtp = "${drv}";
+      rtp = lib.warn "`rtp` attribute is deprecated, use `outPath` instead." drv.outPath;
       overrideAttrs = f: addRtp (drv.overrideAttrs f);
     };
 
@@ -42,7 +42,7 @@ rec {
         runHook postInstall
       '';
     });
-    in addRtp drv;
+    in addRtp (toVimPlugin drv);
 
   buildVimPluginFrom2Nix = attrs: buildVimPlugin ({
     # vim plugins may override this

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -654,8 +654,6 @@ self: super: {
 
   inherit parinfer-rust;
 
-  # plenary-nvim = super.toVimPlugin(luaPackages.plenary-nvim);
-
   plenary-nvim = super.plenary-nvim.overrideAttrs (old: {
     postPatch = ''
       sed -Ei lua/plenary/curl.lua \

--- a/pkgs/applications/editors/vim/plugins/vim-utils.nix
+++ b/pkgs/applications/editors/vim/plugins/vim-utils.nix
@@ -251,10 +251,10 @@ let
       */
       plugImpl =
       ''
-        source ${vimPlugins.vim-plug.rtp}/plug.vim
+        source ${vimPlugins.vim-plug}/plug.vim
         silent! call plug#begin('/dev/null')
 
-        '' + (lib.concatMapStringsSep "\n" (pkg: "Plug '${pkg.rtp}'") plug.plugins) + ''
+        '' + (lib.concatMapStringsSep "\n" (pkg: "Plug '${pkg}'") plug.plugins) + ''
 
         call plug#end()
       '';

--- a/pkgs/applications/editors/vim/vimacs.nix
+++ b/pkgs/applications/editors/vim/vimacs.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
       --replace '-gvim}' '-@bin@/bin/vim -g}' \
       --replace '--cmd "let g:VM_Enabled = 1"' \
                 '--cmd "let g:VM_Enabled = 1" --cmd "set rtp^=@rtp@" ${vimacsExtraArgs}' \
-      --replace @rtp@ ${vimPlugins.vimacs.rtp} \
+      --replace @rtp@ ${vimPlugins.vimacs} \
       --replace @bin@ ${vimPackage}
     for prog in vm gvm gvimacs vmdiff vimacsdiff
     do

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -514,12 +514,6 @@ with prev;
     '';
   });
 
-  # TODO just while testing, remove afterwards
-  # toVimPlugin should do it instead
-  gitsigns-nvim = prev.gitsigns-nvim.overrideAttrs (oa: {
-    nativeBuildInputs = oa.nativeBuildInputs or [ ] ++ [ vimUtils.vimGenDocHook ];
-  });
-
   # aliases
   cjson = prev.lua-cjson;
 }


### PR DESCRIPTION
###### Description of changes
## some background
1. Vim plugins have an attribute named `rtp` that points to the runtime path of the plugin, similar to tmux one.
2. There is also `vimUtils.rtpPath` which is set to `"."`, as opposed to `"share/tmux-plugins"` for tmux. This is supposed to be the path common to all plugins.

2. 0dbca90d4129b6c4296b66899fd2750584b24c4f removes a function called `addRtp` which was being used to set `rtp` inside `buildVimPlugin`:
``` nix
  addRtp = path: attrs: derivation:
    derivation // { rtp = "${derivation}"; } // {
      overrideAttrs = f: buildVimPlugin (attrs // f attrs);
    };
```
and later sets `rtp` like this:
``` nix
    in  drv.overrideAttrs(oa: {
      rtp = "${drv}";
    })
```
This has the implication that `rtp` will be set to the derivation before the `overrideAttrs` (drv1) and building the final derivation (drv2) will actually build both derivation. The resulting derivations are the same but "drv2" having additional environment variable (`rtp`) in its build environment makes them different derivations. 

## this PR
1.  I added a function similar to the removed `addRtp` to set `rtp`. But there are two differences:
    1. Old `addRtp` sets `rtp` to derivation's `outPath` without referring to `rtpPath`. Ideally `rtpPath` should be used to resolve the runtime paths otherwise there is no point in setting these things. But since `rtpPath` is `"."`, it seems the old `addRtp` did not bother using `rtpPath`. I defined `rtp` attributes as `"${drv}/${rtpPath}"` instead. This results in `rtp` attributes such as `/nix/store/ms06g89q1qcjsjdaf9qnif6d85m09ia5-vimplugin-gruvbox-2020-07-03/.` as opposed to previous ones like `/nix/store/ms06g89q1qcjsjdaf9qnif6d85m09ia5-vimplugin-gruvbox-2020-07-03`.
    2. Old `addRtp` defined `overrideAttrs` as `f: buildVimPlugin (attrs // f attrs)`. Note that `addRtp` was only called from `buildVimPlugin` at the time of removal so this makes sure that the `rtp` attribute is kept upon an override. But this effectively makes overriding after `buildVimPlugin` impossible (e.g. `buildVimPlugin` sets `installPhase`, so it was not possible to override `installPhase` of vim plugins with the old behaviour.). I think `buildVimPlugin` should redefine its own `overrideAttrs` if such a behaviour is required by it. I defined `overrideAttrs` as `f: addRtp (drv.overrideAttrs f)` instead.

2. Before removal of `addRtp` with 0dbca90d4129b6c4296b66899fd2750584b24c4f, it was called only by `buildVimPlugin` and `buildNeovimPluginFrom2Nix` was calling `buildVimPlugin`. `buildNeovimPluginFrom2Nix` is redefined and doesn't call `buildVimPlugin` since then. So currently `rtp` attribute is not set for plugins created with `buildNeovimPluginFrom2Nix` and this PR doesn't do anything to change that.

## personal notes
- I don't think setting `rtp` attribute for each plugin is useful because I couldn't find a place where it is used. To be useful `rtp` should be set to `"${outPath}/${rtpPath}"` but this is done for the first time with this PR. Besides, none of the Vim infrastructure in Nixpkgs seem to be using the `rtp` attribute but rather `"${outPath}/${rtpPath}"` or `$out/$rtpPath`.
- Double building problem probably went unnoticed because of the substitution and the fact that rebuilding does not propagate to dependencies. It can be experienced most easily when trying to build a new or custom plugin.

notify @teto 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
