### PR TITLE
spin-framework: init at 0.5.0

### DIFF
--- a/pkgs/development/web/spin-framework/build.patch
+++ b/pkgs/development/web/spin-framework/build.patch
@@ -1,0 +1,54 @@
+diff --git a/build.rs b/build.rs
+index b65cdc7..0fe012d 100644
+--- a/build.rs
++++ b/build.rs
+@@ -12,6 +12,15 @@ const RUST_HTTP_INTEGRATION_ENV_TEST: &str = "tests/http/headers-env-routes-test
+ fn main() {
+     println!("cargo:rerun-if-changed=build.rs");
+ 
++    let mut config = vergen::Config::default();
++    *config.git_mut().sha_kind_mut() = vergen::ShaKind::Short;
++    *config.git_mut().commit_timestamp_kind_mut() = vergen::TimestampKind::DateOnly;
++    vergen::vergen(config).expect("failed to extract build information");
++
++    if !has_rustup() {
++        process::exit(0);
++    }
++
+     if !has_wasm32_wasi_target() {
+         // Current toolchain: e.g. "stable-x86_64-pc-windows-msvc", "1.60-x86_64-pc-windows-msvc"
+         let current_toolchain = std::env::var("RUSTUP_TOOLCHAIN").unwrap();
+@@ -52,11 +61,6 @@ error: the `wasm32-wasi` target is not installed
+ 
+     cargo_build(RUST_HTTP_INTEGRATION_TEST);
+     cargo_build(RUST_HTTP_INTEGRATION_ENV_TEST);
+-
+-    let mut config = vergen::Config::default();
+-    *config.git_mut().sha_kind_mut() = vergen::ShaKind::Short;
+-    *config.git_mut().commit_timestamp_kind_mut() = vergen::TimestampKind::DateOnly;
+-    vergen::vergen(config).expect("failed to extract build information");
+ }
+ 
+ fn build_wasm_test_program(name: &'static str, root: &'static str) {
+@@ -66,6 +70,13 @@ fn build_wasm_test_program(name: &'static str, root: &'static str) {
+         .build();
+ }
+ 
++fn has_rustup() -> bool {
++    match Command::new("rustup").spawn() {
++        Ok(_) => true,
++        Err(_e) => false,
++    }
++}
++
+ fn has_wasm32_wasi_target() -> bool {
+     let output = run(vec!["rustup", "target", "list", "--installed"], None, None);
+     let output = std::str::from_utf8(&output.stdout).unwrap();
+@@ -129,6 +140,6 @@ fn get_os_process() -> String {
+     if cfg!(target_os = "windows") {
+         String::from("powershell.exe")
+     } else {
+-        String::from("/bin/bash")
++        String::from("bash")
+     }
+ }

--- a/pkgs/development/web/spin-framework/default.nix
+++ b/pkgs/development/web/spin-framework/default.nix
@@ -1,0 +1,37 @@
+{ lib, rustPlatform, fetchFromGitHub, pkgs, stdenv, Security }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "spin-framework";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "fermyon";
+    repo = "spin";
+    rev = "v${version}";
+    sha256 = "sha256-UJiUXzbdvntzsIZ6bB69tiLR++S4I37f1+lcK1jqWxA=";
+    leaveDotGit = true; # let vergen populate its various env vars
+  };
+
+  doCheck = false;
+
+  patches = [
+    # build.rs requires rustup by default as it validates your system has a wasm
+    # target installed and then does some rudimentary building as a test of the
+    # system. We can't do that in a nix build environment, so patch that out
+    # without breaking vergen.
+    ./build.patch
+  ];
+
+  nativeBuildInputs = with pkgs; [ pkg-config ] ++ lib.optional stdenv.isDarwin Security;
+  buildInputs = with pkgs; [ openssl_3 ];
+
+  cargoSha256 = "sha256-534zlEkea4wEwtcQ9N7dufyc738oKIWRlmxkz32K4S0=";
+
+  meta = with lib; {
+    description = "Spin is an open source framework for building and running fast, secure, and composable cloud microservices with WebAssembly";
+    homepage = "https://spin.fermyon.dev/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ endocrimes ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16970,6 +16970,10 @@ with pkgs;
 
   spin = callPackage ../development/tools/analysis/spin { };
 
+  spin-framework = callPackage ../development/web/spin-framework {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   spirv-headers = callPackage ../development/libraries/spirv-headers { };
   spirv-tools = callPackage ../development/tools/spirv-tools { };
 


### PR DESCRIPTION
###### Description of changes

Add [spin](https://github.com/fermyon/spin) for WASM development. Carry over from #173444 (cc @booklearner for testing assuming you're on darwin)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

