### PR TITLE
Revert "abi-dumper: fix cross compilation"

### DIFF
--- a/pkgs/development/tools/misc/abi-dumper/default.nix
+++ b/pkgs/development/tools/misc/abi-dumper/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
       --replace '"ctags"' '"${ctags}/bin/ctags"'
   '';
 
-  nativeBuildInputs = [ perl ];
+  buildInputs = [ elfutils ctags perl vtable-dumper ];
 
   preBuild = "mkdir -p $out";
   makeFlags = [ "prefix=$(out)" ];


### PR DESCRIPTION
Sorry.

On further tests, I'm not sure everything is alright.

![image](https://user-images.githubusercontent.com/5861043/192094126-5abf79bf-a232-4f89-b38b-4c0be9dd9088.png)

Reverts NixOS/nixpkgs#192708