### PR TITLE
fwupd: 1.8.4 -> 1.8.6

### DIFF
--- a/pkgs/os-specific/linux/firmware/fwupd/add-option-for-installation-sysconfdir.patch
+++ b/pkgs/os-specific/linux/firmware/fwupd/add-option-for-installation-sysconfdir.patch
@@ -94,7 +94,7 @@ index 1d1698a7e..5469d00a6 100644
 +  install_dir: join_paths(sysconfdir_install, 'fwupd', 'remotes.d'),
  )
 diff --git a/meson.build b/meson.build
-index e7980e965..2c66e2dc4 100644
+index 0ac74a510..8c0da2e19 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -195,6 +195,12 @@ endif
@@ -111,7 +111,7 @@ index e7980e965..2c66e2dc4 100644
  gio = dependency('gio-2.0', version: '>= 2.45.8')
  giounix = dependency('gio-unix-2.0', version: '>= 2.45.8', required: false)
 diff --git a/meson_options.txt b/meson_options.txt
-index 6cf92e72e..2e8568292 100644
+index cfa821d87..024d0da69 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
 @@ -1,3 +1,4 @@
@@ -145,7 +145,7 @@ index d626c3ad3..5a2f847d5 100644
  shared_module('fu_plugin_msr',
    fu_hash,
 diff --git a/plugins/redfish/meson.build b/plugins/redfish/meson.build
-index 95606e478..e5355e520 100644
+index 491246358..5831e4a6e 100644
 --- a/plugins/redfish/meson.build
 +++ b/plugins/redfish/meson.build
 @@ -43,7 +43,7 @@ shared_module('fu_plugin_redfish',
@@ -154,14 +154,14 @@ index 95606e478..e5355e520 100644
  install_data(['redfish.conf'],
 -  install_dir: join_paths(sysconfdir, 'fwupd'),
 +  install_dir: join_paths(sysconfdir_install, 'fwupd'),
+   install_mode: 'rw-r-----',
  )
  
- if get_option('tests')
 diff --git a/plugins/thunderbolt/meson.build b/plugins/thunderbolt/meson.build
-index 5f8ffbf90..9ba323e75 100644
+index a42a4d31c..1f70834a4 100644
 --- a/plugins/thunderbolt/meson.build
 +++ b/plugins/thunderbolt/meson.build
-@@ -32,7 +32,7 @@ fu_plugin_thunderbolt = shared_module('fu_plugin_thunderbolt',
+@@ -30,7 +30,7 @@ fu_plugin_thunderbolt = shared_module('fu_plugin_thunderbolt',
  )
  
  install_data(['thunderbolt.conf'],

--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -114,7 +114,7 @@ let
 
   self = stdenv.mkDerivation rec {
     pname = "fwupd";
-    version = "1.8.4";
+    version = "1.8.5";
 
     # libfwupd goes to lib
     # daemon, plug-ins and libfwupdplugin go to out
@@ -123,7 +123,7 @@ let
 
     src = fetchurl {
       url = "https://people.freedesktop.org/~hughsient/releases/fwupd-${version}.tar.xz";
-      sha256 = "sha256-rfoHQ0zcKexBxA/vRg6Nlwlj/gx+hJ3sfzkyrbFh+IY=";
+      sha256 = "sha256-M+nXiPZdGCWb5hm7N5cIUZo0kBTLfzRn9CxV+uNSJhI=";
     };
 
     patches = [
@@ -144,6 +144,9 @@ let
 
       # EFI capsule is located in fwupd-efi now.
       ./efi-app-path.patch
+
+      # gi-docgen dependencies are already covered by gi-docgen
+      ./drop-markdown-check.patch
     ];
 
     nativeBuildInputs = [
@@ -254,13 +257,7 @@ let
     postPatch = ''
       patchShebangs \
         contrib/generate-version-script.py \
-        meson_post_install.sh \
         po/test-deps
-
-      # This checks a version of a dependency of gi-docgen but gi-docgen is self-contained in Nixpkgs.
-      echo "Clearing docs/test-deps.py"
-      test -f docs/test-deps.py
-      echo > docs/test-deps.py
 
       substituteInPlace data/installed-tests/fwupdmgr-p2p.sh \
         --replace "gdbus" ${glib.bin}/bin/gdbus

--- a/pkgs/os-specific/linux/firmware/fwupd/drop-markdown-check.patch
+++ b/pkgs/os-specific/linux/firmware/fwupd/drop-markdown-check.patch
@@ -1,0 +1,34 @@
+diff --git a/docs/meson.build b/docs/meson.build
+index 92b9e6fc7..56bc189d9 100644
+--- a/docs/meson.build
++++ b/docs/meson.build
+@@ -1,4 +1,4 @@
+-if gidocgen_dep.found() and docs_python_deps.allowed() and gidocgen_app.found() and introspection.allowed()
++if gidocgen_dep.found() and gidocgen_app.found() and introspection.allowed()
+   toml_conf = configuration_data()
+   docgen_version = source_version
+   if git.found() and source_version != fwupd_version
+diff --git a/meson.build b/meson.build
+index 0ac74a510..a3b1ad5e8 100644
+--- a/meson.build
++++ b/meson.build
+@@ -539,18 +539,12 @@ fwupd_gir = []
+ gir_dep = dependency('gobject-introspection-1.0', required: get_option('introspection'))
+ introspection = get_option('introspection').disable_auto_if(host_machine.system() != 'linux').disable_auto_if(not gir_dep.found())
+ 
+-markdown_version = run_command(
+-  python3, '-c', 'import markdown; print(markdown.__version__)'
+-).stdout().strip()
+-docs_python_deps = get_option('docs').require(markdown_version.version_compare('>=3.2'),
+-						error_message: 'docs=enabled requires at least markdown >= 3.2')
+ gidocgen_dep = dependency('gi-docgen',
+   version: '>= 2021.1',
+   native: true,
+   fallback: ['gi-docgen', 'dummy_dep'],
+-  required: docs_python_deps,
+ )
+-gidocgen_app = find_program('gi-docgen', required: docs_python_deps)
++gidocgen_app = find_program('gi-docgen')
+ 
+ # using "meson configure -Db_sanitize=address,undefined" is super useful in finding corruption,
+ # but it does not work with our GMainContext-abuse tests...

--- a/pkgs/os-specific/linux/firmware/fwupd/efi-app-path.patch
+++ b/pkgs/os-specific/linux/firmware/fwupd/efi-app-path.patch
@@ -1,8 +1,8 @@
 diff --git a/meson.build b/meson.build
-index b91dd037..01d70a61 100644
+index 0ac74a510..a0be9713b 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -413,7 +413,7 @@ if build_standalone and efiboot.found() and efivar.found()
+@@ -415,7 +415,7 @@ if build_standalone and efiboot.found() and efivar.found()
      conf.set('HAVE_EFI_TIME_T', '1')
    endif
  

--- a/pkgs/os-specific/linux/firmware/fwupd/install-fwupdplugin-to-out.patch
+++ b/pkgs/os-specific/linux/firmware/fwupd/install-fwupdplugin-to-out.patch
@@ -1,8 +1,8 @@
 diff --git a/libfwupdplugin/meson.build b/libfwupdplugin/meson.build
-index 1afa28e1..3da81d30 100644
+index 9505104c5..6f00fb858 100644
 --- a/libfwupdplugin/meson.build
 +++ b/libfwupdplugin/meson.build
-@@ -220,7 +220,8 @@ fwupdplugin = library(
+@@ -268,7 +268,8 @@ fwupdplugin = library(
    ],
    link_args: cc.get_supported_link_arguments([vflag]),
    link_depends: fwupdplugin_mapfile,
@@ -12,7 +12,7 @@ index 1afa28e1..3da81d30 100644
  )
  
  fwupdplugin_pkgg = import('pkgconfig')
-@@ -280,7 +281,8 @@ if introspection.allowed()
+@@ -328,7 +329,8 @@ if introspection.allowed()
        girtargets,
        fwupd_gir[0],
      ],
@@ -23,10 +23,10 @@ index 1afa28e1..3da81d30 100644
  
    # Verify the map file is correct -- note we can't actually use the generated
 diff --git a/meson.build b/meson.build
-index b91dd037..f97b4c26 100644
+index 0ac74a510..c277fa07d 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -504,7 +504,7 @@ if build_standalone
+@@ -506,7 +506,7 @@ if build_standalone
  if host_machine.system() == 'windows'
    plugin_dir = 'fwupd-plugins-@0@'.format(libfwupdplugin_lt_current)
  else

--- a/pkgs/os-specific/linux/firmware/fwupd/installed-tests-path.patch
+++ b/pkgs/os-specific/linux/firmware/fwupd/installed-tests-path.patch
@@ -1,16 +1,16 @@
 diff --git a/data/installed-tests/meson.build b/data/installed-tests/meson.build
-index b8ec916f..38209b36 100644
+index be3d5c6d9..14d45dcaf 100644
 --- a/data/installed-tests/meson.build
 +++ b/data/installed-tests/meson.build
 @@ -83,5 +83,5 @@ configure_file(
-   output : 'fwupd-tests.conf',
-   configuration : con2,
+   output: 'fwupd-tests.conf',
+   configuration: con2,
    install: true,
 -  install_dir: join_paths(sysconfdir, 'fwupd', 'remotes.d'),
 +  install_dir: join_paths(get_option('installed_test_prefix'), 'etc', 'fwupd', 'remotes.d'),
  )
 diff --git a/meson.build b/meson.build
-index b91dd037..d7e20b18 100644
+index 0ac74a510..b3f572760 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -188,8 +188,8 @@ else
@@ -24,7 +24,7 @@ index b91dd037..d7e20b18 100644
    daemon_dir = join_paths(libexecdir, 'fwupd')
  endif
  mandir = join_paths(prefix, get_option('mandir'))
-@@ -492,6 +492,7 @@ gnome = import('gnome')
+@@ -494,6 +494,7 @@ gnome = import('gnome')
  i18n = import('i18n')
  
  conf.set_quoted('FWUPD_PREFIX', prefix)
@@ -33,10 +33,10 @@ index b91dd037..d7e20b18 100644
  conf.set_quoted('FWUPD_LIBDIR', libdir)
  conf.set_quoted('FWUPD_LIBEXECDIR', libexecdir)
 diff --git a/meson_options.txt b/meson_options.txt
-index d00038db..be1c45b4 100644
+index cfa821d87..042c30524 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -56,6 +56,7 @@ option('systemd', type : 'feature', description : 'systemd support', deprecated:
+@@ -57,6 +57,7 @@ option('systemd', type : 'feature', description : 'systemd support', deprecated:
  option('systemd_unit_user', type : 'string', description : 'User account to use for fwupd-refresh.service (empty for DynamicUser)')
  option('systemd_root_prefix', type: 'string', value: '', description: 'Directory to base systemd’s installation directories on')
  option('elogind', type : 'feature', description : 'elogind support', deprecated: {'true': 'enabled', 'false': 'disabled'})
@@ -45,7 +45,7 @@ index d00038db..be1c45b4 100644
  option('soup_session_compat', type : 'boolean', value : true, description : 'enable SoupSession runtime compatibility support')
  option('curl', type : 'feature', description : 'libcurl support', deprecated: {'true': 'enabled', 'false': 'disabled'})
 diff --git a/plugins/redfish/fu-self-test.c b/plugins/redfish/fu-self-test.c
-index 4d19e560..91cfaa61 100644
+index 31ffc3f3e..8fa6b6f8b 100644
 --- a/plugins/redfish/fu-self-test.c
 +++ b/plugins/redfish/fu-self-test.c
 @@ -27,7 +27,7 @@ fu_test_is_installed_test(void)


### PR DESCRIPTION
- https://github.com/fwupd/fwupd/releases/tag/1.8.5

###### Description of changes

I haven't had the chance to fully test it, just compile and check fwupd.tests. There's quite extensive meson changes that led to dropping some helper scripts, so something might have broken. I haven't fully reviewed the diff.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
