### PR TITLE
python3Packages.energyflow: init at 1.3.2

### DIFF
--- a/pkgs/development/python-modules/energyflow/default.nix
+++ b/pkgs/development/python-modules/energyflow/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, h5py
+, numpy
+, six
+, wasserstein
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "EnergyFlow";
+  version = "1.3.2";
+
+  src = fetchFromGitHub {
+    owner = "pkomiske";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-fjT8c0ZTjdufP334upPzRVdTJDIBs84I7PkFu4CMcQw=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "setup_requires=" "" \
+      --replace "pytest-runner" ""
+  '';
+
+  propagatedBuildInputs = [
+    h5py
+    numpy
+    six
+    wasserstein
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+  pytestFlagsArray = [
+    "energyflow/tests"
+  ];
+  disabledTestPaths = [
+    "energyflow/tests/test_archs.py" # requires tensorflow
+    "energyflow/tests/test_emd.py" # requires "ot"
+  ];
+
+  pythonImportsCheck = [ "energyflow" ];
+
+  meta = with lib; {
+    description = "Python package for the EnergyFlow suite of tools";
+    homepage = "https://energyflow.network/";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ veprbl ];
+  };
+}

--- a/pkgs/development/python-modules/wasserstein/default.nix
+++ b/pkgs/development/python-modules/wasserstein/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, numpy
+, llvmPackages
+, wurlitzer
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "Wasserstein";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "pkomiske";
+    repo = pname;
+    rev = "89c2d6279a7e0aa3b56bcc8fb7b6009420f2563e"; # https://github.com/pkomiske/Wasserstein/issues/1
+    hash = "sha256-s9en6XwvO/WPsF7/+SEmGePHZQgl7zLgu5sEn4nD9YE=";
+  };
+
+  buildInputs = [
+    llvmPackages.openmp
+  ];
+  propagatedBuildInputs = [
+    numpy
+    wurlitzer
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+  pytestFlagsArray = [
+    "wasserstein/tests"
+  ];
+  disabledTestPaths = [
+    "wasserstein/tests/test_emd.py" # requires "ot"
+    # cyclic dependency on energyflow
+    "wasserstein/tests/test_externalemdhandler.py"
+    "wasserstein/tests/test_pairwiseemd.py"
+  ];
+
+  pythonImportsCheck = [ "wasserstein" ];
+
+  meta = with lib; {
+    description = "Python/C++ library for computing Wasserstein distances efficiently";
+    homepage = "https://github.com/pkomiske/Wasserstein";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ veprbl ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11647,6 +11647,8 @@ in {
 
   wasabi = callPackage ../development/python-modules/wasabi { };
 
+  wasserstein = callPackage ../development/python-modules/wasserstein { };
+
   wasm = callPackage ../development/python-modules/wasm { };
 
   wasmerPackages = pkgs.recurseIntoAttrs (callPackage ../development/python-modules/wasmer { });

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2948,6 +2948,8 @@ in {
 
   enamlx = callPackage ../development/python-modules/enamlx { };
 
+  energyflow = callPackage ../development/python-modules/energyflow { };
+
   enhancements = callPackage ../development/python-modules/enhancements { };
 
   enlighten = callPackage ../development/python-modules/enlighten { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
