### PR TITLE
listmonk: fix frontend build using Webpack due to OpenSSL 3.0 deprecations

### DIFF
--- a/pkgs/servers/mail/listmonk/frontend.nix
+++ b/pkgs/servers/mail/listmonk/frontend.nix
@@ -29,7 +29,7 @@ yarn2nix-moretea.mkYarnPackage rec {
 
     mv dist $out
 
-    run postInstall
+    runHook postInstall
   '';
 
   doDist = false;

--- a/pkgs/servers/mail/listmonk/frontend.nix
+++ b/pkgs/servers/mail/listmonk/frontend.nix
@@ -22,7 +22,7 @@ yarn2nix-moretea.mkYarnPackage rec {
   NODE_OPTIONS = "--openssl-legacy-provider";
 
   installPhase = ''
-    run preInstall
+    runHook preInstall
 
     cd deps/listmonk-frontend/frontend
     npm run build

--- a/pkgs/servers/mail/listmonk/frontend.nix
+++ b/pkgs/servers/mail/listmonk/frontend.nix
@@ -18,11 +18,18 @@ yarn2nix-moretea.mkYarnPackage rec {
   yarnLock = ./yarn.lock;
   yarnNix = ./yarn.nix;
 
+  # For Node.js v17+, this is necessary.
+  NODE_OPTIONS = "--openssl-legacy-provider";
+
   installPhase = ''
+    run preInstall
+
     cd deps/listmonk-frontend/frontend
     npm run build
 
     mv dist $out
+
+    run postInstall
   '';
 
   doDist = false;


### PR DESCRIPTION
###### Description of changes

See the OpenSSL 3.0 section here https://medium.com/the-node-js-collection/node-js-17-is-here-8dba1e14e382 for explanations.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).