### PR TITLE
[22.05] tinygltf: add patch for CVE-2022-3008

### DIFF
--- a/pkgs/development/libraries/tinygltf/CVE-2022-3008.patch
+++ b/pkgs/development/libraries/tinygltf/CVE-2022-3008.patch
@@ -1,0 +1,43 @@
+Simple backport of upstream 52ff00a38447f06a17eab1caa2cf0730a119c751
+to apply to 2.5.0. Most of the hunks in that commit are irrelevant
+reformatting. The fix simply needs to make ExpandFilePath return
+its first argument unchanged.
+
+--- a/tiny_gltf.h
++++ b/tiny_gltf.h
+@@ -1602,7 +1612,7 @@ class TinyGLTF {
+ #endif
+ 
+ #elif !defined(__ANDROID__)
+-#include <wordexp.h>
++//#include <wordexp.h>
+ #endif
+ 
+ #if defined(__sparcv9)
+@@ -2610,6 +2618,18 @@ bool FileExists(const std::string &abs_filename, void *) {
+ }
+ 
+ std::string ExpandFilePath(const std::string &filepath, void *) {
++  // https://github.com/syoyo/tinygltf/issues/368
++  //
++  // No file path expansion in built-in FS function anymore, since glTF URI
++  // should not contain tilde('~') and environment variables, and for security
++  // reason(`wordexp`).
++  //
++  // Users need to supply `base_dir`(in `LoadASCIIFromString`,
++  // `LoadBinaryFromMemory`) in expanded absolute path.
++
++  return filepath;
++
++#if 0
+ #ifdef _WIN32
+   // Assume input `filepath` is encoded in UTF-8
+   std::wstring wfilepath = UTF8ToWchar(filepath);
+@@ -2657,6 +2677,7 @@ std::string ExpandFilePath(const std::string &filepath, void *) {
+ 
+   return s;
+ #endif
++#endif
+ }
+ 
+ bool ReadWholeFile(std::vector<unsigned char> *out, std::string *err,

--- a/pkgs/development/libraries/tinygltf/default.nix
+++ b/pkgs/development/libraries/tinygltf/default.nix
@@ -16,6 +16,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-Pw4iNJs0bKALVPFBYUJe5/WjHxdffungCKfJFJEpDas=";
   };
 
+  patches = [
+    ./CVE-2022-3008.patch
+  ];
+
   nativeBuildInputs = [ cmake ];
 
   passthru.updateScript = nix-update-script {


### PR DESCRIPTION
###### Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2022-3008

Handled for unstable in #191868.

Very simple patch, making function `ExpandFilePath` do nothing as its operation was judged too dangerous.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
