### PR TITLE
openjfx17: use ffmpeg_4

### DIFF
--- a/pkgs/development/compilers/openjdk/openjfx/17.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/17.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchFromGitHub, writeText, openjdk17_headless, gradle_7
 , pkg-config, perl, cmake, gperf, gtk2, gtk3, libXtst, libXxf86vm, glib, alsa-lib
-, ffmpeg, python3, ruby, icu68 }:
+, ffmpeg_4, python3, ruby, icu68 }:
 
 let
   major = "17";
@@ -21,7 +21,7 @@ let
       sha256 = "sha256-PSiE9KbF/4u9VyBl9PAMLGzKyGFB86/XByeh7vhL6Kw=";
     };
 
-    buildInputs = [ gtk2 gtk3 libXtst libXxf86vm glib alsa-lib ffmpeg icu68 ];
+    buildInputs = [ gtk2 gtk3 libXtst libXxf86vm glib alsa-lib ffmpeg_4 icu68 ];
     nativeBuildInputs = [ gradle_ perl pkg-config cmake gperf python3 ruby ];
 
     dontUseCmakeConfigure = true;


### PR DESCRIPTION
###### Description of changes

openjfx17's `plugins/av/mpegtsdemuxer.c` expects ffmpeg 4 and does not build with ffmpeg 5.1.1.

This change does not result in any rebuilds because nixpkgs `ffmpeg` still points to `ffmpeg_4`.

When all-packages.nix `ffmpeg` is set to `ffmpeg_5`, this fixes:

<details>
<summary>Details</summary>

```
<====---------> 31% EXECUTING [1m 29s]> :media:buildAVPlugin
> Task :media:buildAVPlugin FAILED
make: Entering directory '/build/source/modules/javafx.media/src/main/native/gstreamer/projects/linux/avplugin'
mkdir -p /build/source/modules/javafx.media/build/native/linux/Release/obj/plugins/avplugin/av
gcc -fPIC -Wformat -Wextra -Wformat-security -fstack-protector -Werror=implicit-function-declaration -Werror=trampolines -fbuiltin -DHAVE_STDINT_H -DLINUX -DGST_DISABLE_LOADSAVE -DGSTREAMER_LITE -ffunction-sections -fdata-sections -msse2 -Os -I../../../plugins -I../../../plugins/av -I../../../gstreamer-lite/gstreamer -I../../../gstreamer-lite/gstreamer/libs -I/nix/store/7smln0rxv9rbqc7891gzwpn4g520c6ni-glib-2.72.3-dev/include/glib-2.0 -I/nix/store/f2l7rq62cak2yz0f51mzfqwrdislgjba-glib-2.72.3/lib/glib-2.0/include -I/nix/store/dzb8y1w9c6pvr3qsrc9j0bdw9h53b612-ffmpeg-5.1.1-dev/include -c ../../../plugins/av/fxavcodecplugin.c -o /build/source/modules/javafx.media/build/native/linux/Release/obj/plugins/avplugin/av/fxavcodecplugin.o
gcc -fPIC -Wformat -Wextra -Wformat-security -fstack-protector -Werror=implicit-function-declaration -Werror=trampolines -fbuiltin -DHAVE_STDINT_H -DLINUX -DGST_DISABLE_LOADSAVE -DGSTREAMER_LITE -ffunction-sections -fdata-sections -msse2 -Os -I../../../plugins -I../../../plugins/av -I../../../gstreamer-lite/gstreamer -I../../../gstreamer-lite/gstreamer/libs -I/nix/store/7smln0rxv9rbqc7891gzwpn4g520c6ni-glib-2.72.3-dev/include/glib-2.0 -I/nix/store/f2l7rq62cak2yz0f51mzfqwrdislgjba-glib-2.72.3/lib/glib-2.0/include -I/nix/store/dzb8y1w9c6pvr3qsrc9j0bdw9h53b612-ffmpeg-5.1.1-dev/include -c ../../../plugins/av/avelement.c -o /build/source/modules/javafx.media/build/native/linux/Release/obj/plugins/avplugin/av/avelement.o
gcc -fPIC -Wformat -Wextra -Wformat-security -fstack-protector -Werror=implicit-function-declaration -Werror=trampolines -fbuiltin -DHAVE_STDINT_H -DLINUX -DGST_DISABLE_LOADSAVE -DGSTREAMER_LITE -ffunction-sections -fdata-sections -msse2 -Os -I../../../plugins -I../../../plugins/av -I../../../gstreamer-lite/gstreamer -I../../../gstreamer-lite/gstreamer/libs -I/nix/store/7smln0rxv9rbqc7891gzwpn4g520c6ni-glib-2.72.3-dev/include/glib-2.0 -I/nix/store/f2l7rq62cak2yz0f51mzfqwrdislgjba-glib-2.72.3/lib/glib-2.0/include -I/nix/store/dzb8y1w9c6pvr3qsrc9j0bdw9h53b612-ffmpeg-5.1.1-dev/include -c ../../../plugins/av/decoder.c -o /build/source/modules/javafx.media/build/native/linux/Release/obj/plugins/avplugin/av/decoder.o
gcc -fPIC -Wformat -Wextra -Wformat-security -fstack-protector -Werror=implicit-function-declaration -Werror=trampolines -fbuiltin -DHAVE_STDINT_H -DLINUX -DGST_DISABLE_LOADSAVE -DGSTREAMER_LITE -ffunction-sections -fdata-sections -msse2 -Os -I../../../plugins -I../../../plugins/av -I../../../gstreamer-lite/gstreamer -I../../../gstreamer-lite/gstreamer/libs -I/nix/store/7smln0rxv9rbqc7891gzwpn4g520c6ni-glib-2.72.3-dev/include/glib-2.0 -I/nix/store/f2l7rq62cak2yz0f51mzfqwrdislgjba-glib-2.72.3/lib/glib-2.0/include -I/nix/store/dzb8y1w9c6pvr3qsrc9j0bdw9h53b612-ffmpeg-5.1.1-dev/include -c ../../../plugins/av/audiodecoder.c -o /build/source/modules/javafx.media/build/native/linux/Release/obj/plugins/avplugin/av/audiodecoder.o
gcc -fPIC -Wformat -Wextra -Wformat-security -fstack-protector -Werror=implicit-function-declaration -Werror=trampolines -fbuiltin -DHAVE_STDINT_H -DLINUX -DGST_DISABLE_LOADSAVE -DGSTREAMER_LITE -ffunction-sections -fdata-sections -msse2 -Os -I../../../plugins -I../../../plugins/av -I../../../gstreamer-lite/gstreamer -I../../../gstreamer-lite/gstreamer/libs -I/nix/store/7smln0rxv9rbqc7891gzwpn4g520c6ni-glib-2.72.3-dev/include/glib-2.0 -I/nix/store/f2l7rq62cak2yz0f51mzfqwrdislgjba-glib-2.72.3/lib/glib-2.0/include -I/nix/store/dzb8y1w9c6pvr3qsrc9j0bdw9h53b612-ffmpeg-5.1.1-dev/include -c ../../../plugins/av/videodecoder.c -o /build/source/modules/javafx.media/build/native/linux/Release/obj/plugins/avplugin/av/videodecoder.o
In file included from /nix/store/7smln0rxv9rbqc7891gzwpn4g520c6ni-glib-2.72.3-dev/include/glib-2.0/glib/gthread.h:32,
                 from /nix/store/7smln0rxv9rbqc7891gzwpn4g520c6ni-glib-2.72.3-dev/include/glib-2.0/glib/gasyncqueue.h:32,
                 from /nix/store/7smln0rxv9rbqc7891gzwpn4g520c6ni-glib-2.72.3-dev/include/glib-2.0/glib.h:32,
                 from ../../../gstreamer-lite/gstreamer/gst/gst.h:27,
                 from ../../../plugins/av/decoder.h:29,
                 from ../../../plugins/av/decoder.c:26:
../../../plugins/av/decoder.c: In function 'basedecoder_get_type':
/nix/store/7smln0rxv9rbqc7891gzwpn4g520c6ni-glib-2.72.3-dev/include/glib-2.0/glib/gatomic.h:113:5: warning: argument 2 of '__atomic_load' discards 'volatile' qualifier [-Wincompatible-pointer-types]
  113 |     __atomic_load (gapg_temp_atomic, &gapg_temp_newval, __ATOMIC_SEQ_CST); \
      |     ^~~~~~~~~~~~~
/nix/store/7smln0rxv9rbqc7891gzwpn4g520c6ni-glib-2.72.3-dev/include/glib-2.0/glib/gthread.h:260:7: note: in expansion of macro 'g_atomic_pointer_get'
  260 |     (!g_atomic_pointer_get (location) &&                             \
      |       ^~~~~~~~~~~~~~~~~~~~
../../../plugins/av/decoder.c:58:9: note: in expansion of macro 'g_once_init_enter'
   58 |     if (g_once_init_enter (&gonce_data))
      |         ^~~~~~~~~~~~~~~~~
../../../plugins/av/decoder.c:64:16: warning: cast between incompatible function types from 'void (*)(void *)' to 'void (*)(void *, void *)' [-Wcast-function-type]
   64 |                (GClassInitFunc) basedecoder_class_intern_init,
      |                ^
../../../plugins/av/decoder.c:66:16: warning: cast between incompatible function types from 'void (*)(BaseDecoder *)' {aka 'void (*)(struct _BaseDecoder *)'} to 'void (*)(GTypeInstance *, void *)' {aka 'void (*)(struct _GTypeInstance *, void *)'} [-Wcast-function-type]
   66 |                (GInstanceInitFunc) basedecoder_init,
      |                ^
../../../plugins/av/fxavcodecplugin.c:58:1: warning: missing initializer for field '_gst_reserved' of 'GstPluginDesc' {aka 'struct _GstPluginDesc'} [-Wmissing-field-initializers]
   58 | };
      | ^
In file included from ../../../gstreamer-lite/gstreamer/gst/gstelementfactory.h:38,
                 from ../../../gstreamer-lite/gstreamer/gst/gstelement.h:90,
                 from ../../../gstreamer-lite/gstreamer/gst/gstbin.h:27,
                 from ../../../gstreamer-lite/gstreamer/gst/gst.h:35,
                 from ../../../plugins/av/fxavcodecplugin.c:26:
../../../gstreamer-lite/gstreamer/gst/gstplugin.h:184:12: note: '_gst_reserved' declared here
  184 |   gpointer _gst_reserved[GST_PADDING];
      |            ^~~~~~~~~~~~~
../../../plugins/av/decoder.c: In function 'basedecoder_class_init':
../../../plugins/av/decoder.c:79:5: error: implicit declaration of function 'avcodec_register_all' [-Werror=implicit-function-declaration]
   79 |     avcodec_register_all();
      |     ^~~~~~~~~~~~~~~~~~~~
../../../plugins/av/decoder.c: In function 'basedecoder_open_decoder':
../../../plugins/av/decoder.c:112:20: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  112 |     decoder->codec = avcodec_find_decoder(id);
      |                    ^
In file included from /nix/store/7smln0rxv9rbqc7891gzwpn4g520c6ni-glib-2.72.3-dev/include/glib-2.0/glib/gthread.h:32,
                 from /nix/store/7smln0rxv9rbqc7891gzwpn4g520c6ni-glib-2.72.3-dev/include/glib-2.0/glib/gasyncqueue.h:32,
                 from /nix/store/7smln0rxv9rbqc7891gzwpn4g520c6ni-glib-2.72.3-dev/include/glib-2.0/glib.h:32,
                 from ../../../gstreamer-lite/gstreamer/gst/gst.h:27,
                 from ../../../plugins/av/decoder.h:29,
                 from ../../../plugins/av/videodecoder.h:29,
                 from ../../../plugins/av/videodecoder.c:35:
../../../plugins/av/videodecoder.c: In function 'videodecoder_get_type':
/nix/store/7smln0rxv9rbqc7891gzwpn4g520c6ni-glib-2.72.3-dev/include/glib-2.0/glib/gatomic.h:113:5: warning: argument 2 of '__atomic_load' discards 'volatile' qualifier [-Wincompatible-pointer-types]
  113 |     __atomic_load (gapg_temp_atomic, &gapg_temp_newval, __ATOMIC_SEQ_CST); \
      |     ^~~~~~~~~~~~~
/nix/store/7smln0rxv9rbqc7891gzwpn4g520c6ni-glib-2.72.3-dev/include/glib-2.0/glib/gthread.h:260:7: note: in expansion of macro 'g_atomic_pointer_get'
  260 |     (!g_atomic_pointer_get (location) &&                             \
      |       ^~~~~~~~~~~~~~~~~~~~
../../../plugins/av/videodecoder.c:87:9: note: in expansion of macro 'g_once_init_enter'
   87 |     if (g_once_init_enter (&gonce_data))
      |         ^~~~~~~~~~~~~~~~~
../../../plugins/av/decoder.c: In function 'basedecoder_set_codec_data':
../../../plugins/av/videodecoder.c:93:16: warning: cast between incompatible function types from 'void (*)(void *)' to 'void (*)(void *, void *)' [-Wcast-function-type]
   93 |                (GClassInitFunc) videodecoder_class_intern_init,
      |                ^
../../../plugins/av/decoder.c:169:17: warning: 'g_memdup' is deprecated: Use 'g_memdup2' instead [-Wdeprecated-declarations]
  169 |                 decoder->codec_data = g_memdup(info.data, info.size);
      |                 ^~~~~~~
../../../plugins/av/videodecoder.c:95:16: warning: cast between incompatible function types from 'void (*)(VideoDecoder *)' {aka 'void (*)(struct _VideoDecoder *)'} to 'void (*)(GTypeInstance *, void *)' {aka 'void (*)(struct _GTypeInstance *, void *)'} [-Wcast-function-type]
   95 |                (GInstanceInitFunc) videodecoder_init,
      |                ^
In file included from /nix/store/7smln0rxv9rbqc7891gzwpn4g520c6ni-glib-2.72.3-dev/include/glib-2.0/glib.h:82,
                 from ../../../gstreamer-lite/gstreamer/gst/gst.h:27,
                 from ../../../plugins/av/decoder.h:29,
                 from ../../../plugins/av/decoder.c:26:
/nix/store/7smln0rxv9rbqc7891gzwpn4g520c6ni-glib-2.72.3-dev/include/glib-2.0/glib/gstrfuncs.h:257:23: note: declared here
  257 | gpointer              g_memdup         (gconstpointer mem,
      |                       ^~~~~~~~
gcc -fPIC -Wformat -Wextra -Wformat-security -fstack-protector -Werror=implicit-function-declaration -Werror=trampolines -fbuiltin -DHAVE_STDINT_H -DLINUX -DGST_DISABLE_LOADSAVE -DGSTREAMER_LITE -ffunction-sections -fdata-sections -msse2 -Os -I../../../plugins -I../../../plugins/av -I../../../gstreamer-lite/gstreamer -I../../../gstreamer-lite/gstreamer/libs -I/nix/store/7smln0rxv9rbqc7891gzwpn4g520c6ni-glib-2.72.3-dev/include/glib-2.0 -I/nix/store/f2l7rq62cak2yz0f51mzfqwrdislgjba-glib-2.72.3/lib/glib-2.0/include -I/nix/store/dzb8y1w9c6pvr3qsrc9j0bdw9h53b612-ffmpeg-5.1.1-dev/include -c ../../../plugins/av/mpegtsdemuxer.c -o /build/source/modules/javafx.media/build/native/linux/Release/obj/plugins/avplugin/av/mpegtsdemuxer.o
../../../plugins/av/videodecoder.c: In function 'videodecoder_chain':
../../../plugins/av/videodecoder.c:402:23: error: implicit declaration of function 'avcodec_decode_video2'; did you mean 'avcodec_decode_subtitle2'? [-Werror=implicit-function-declaration]
  402 |             num_dec = avcodec_decode_video2(base->context, base->frame, &decoder->frame_finished, &decoder->packet);
      |                       ^~~~~~~~~~~~~~~~~~~~~
      |                       avcodec_decode_subtitle2
../../../plugins/av/videodecoder.c:403:13: error: implicit declaration of function 'av_free_packet'; did you mean 'av_get_packet'? [-Werror=implicit-function-declaration]
  403 |             av_free_packet(&decoder->packet);
      |             ^~~~~~~~~~~~~~
      |             av_get_packet
../../../plugins/av/videodecoder.c:413:9: warning: 'av_init_packet' is deprecated [-Wdeprecated-declarations]
  413 |         av_init_packet(&decoder->packet);
      |         ^~~~~~~~~~~~~~
In file included from /nix/store/dzb8y1w9c6pvr3qsrc9j0bdw9h53b612-ffmpeg-5.1.1-dev/include/libavcodec/avcodec.h:45,
                 from ../../../plugins/av/decoder.h:30,
                 from ../../../plugins/av/videodecoder.h:29,
                 from ../../../plugins/av/videodecoder.c:35:
/nix/store/dzb8y1w9c6pvr3qsrc9j0bdw9h53b612-ffmpeg-5.1.1-dev/include/libavcodec/packet.h:512:6: note: declared here
  512 | void av_init_packet(AVPacket *pkt);
      |      ^~~~~~~~~~~~~~
cc1: some warnings being treated as errors
make: *** [Makefile:87: /build/source/modules/javafx.media/build/native/linux/Release/obj/plugins/avplugin/av/decoder.o] Error 1
make: *** Waiting for unfinished jobs....
In file included from /nix/store/7smln0rxv9rbqc7891gzwpn4g520c6ni-glib-2.72.3-dev/include/glib-2.0/glib/gthread.h:32,
                 from /nix/store/7smln0rxv9rbqc7891gzwpn4g520c6ni-glib-2.72.3-dev/include/glib-2.0/glib/gasyncqueue.h:32,
                 from /nix/store/7smln0rxv9rbqc7891gzwpn4g520c6ni-glib-2.72.3-dev/include/glib-2.0/glib.h:32,
                 from ../../../gstreamer-lite/gstreamer/gst/gst.h:27,
                 from ../../../plugins/av/avelement.h:29,
                 from ../../../plugins/av/avelement.c:26:
../../../plugins/av/avelement.c: In function 'avelement_get_type':
/nix/store/7smln0rxv9rbqc7891gzwpn4g520c6ni-glib-2.72.3-dev/include/glib-2.0/glib/gatomic.h:113:5: warning: argument 2 of '__atomic_load' discards 'volatile' qualifier [-Wincompatible-pointer-types]
  113 |     __atomic_load (gapg_temp_atomic, &gapg_temp_newval, __ATOMIC_SEQ_CST); \
      |     ^~~~~~~~~~~~~
/nix/store/7smln0rxv9rbqc7891gzwpn4g520c6ni-glib-2.72.3-dev/include/glib-2.0/glib/gthread.h:260:7: note: in expansion of macro 'g_atomic_pointer_get'
  260 |     (!g_atomic_pointer_get (location) &&                             \
      |       ^~~~~~~~~~~~~~~~~~~~
../../../plugins/av/avelement.c:48:9: note: in expansion of macro 'g_once_init_enter'
   48 |     if (g_once_init_enter (&gonce_data))
      |         ^~~~~~~~~~~~~~~~~
../../../plugins/av/avelement.c:54:16: warning: cast between incompatible function types from 'void (*)(void *)' to 'void (*)(void *, void *)' [-Wcast-function-type]
   54 |                (GClassInitFunc) avelement_class_intern_init,
      |                ^
../../../plugins/av/avelement.c:56:16: warning: cast between incompatible function types from 'void (*)(AVElement *)' {aka 'void (*)(struct _AVElement *)'} to 'void (*)(GTypeInstance *, void *)' {aka 'void (*)(struct _GTypeInstance *, void *)'} [-Wcast-function-type]
   56 |                (GInstanceInitFunc) avelement_init,
      |                ^
In file included from /nix/store/7smln0rxv9rbqc7891gzwpn4g520c6ni-glib-2.72.3-dev/include/glib-2.0/glib/gthread.h:32,
                 from /nix/store/7smln0rxv9rbqc7891gzwpn4g520c6ni-glib-2.72.3-dev/include/glib-2.0/glib/gasyncqueue.h:32,
                 from /nix/store/7smln0rxv9rbqc7891gzwpn4g520c6ni-glib-2.72.3-dev/include/glib-2.0/glib.h:32,
                 from ../../../gstreamer-lite/gstreamer/gst/gst.h:27,
                 from ../../../plugins/av/decoder.h:29,
                 from ../../../plugins/av/audiodecoder.h:29,
                 from ../../../plugins/av/audiodecoder.c:37:
../../../plugins/av/audiodecoder.c: In function 'audiodecoder_get_type':
/nix/store/7smln0rxv9rbqc7891gzwpn4g520c6ni-glib-2.72.3-dev/include/glib-2.0/glib/gatomic.h:113:5: warning: argument 2 of '__atomic_load' discards 'volatile' qualifier [-Wincompatible-pointer-types]
  113 |     __atomic_load (gapg_temp_atomic, &gapg_temp_newval, __ATOMIC_SEQ_CST); \
      |     ^~~~~~~~~~~~~
/nix/store/7smln0rxv9rbqc7891gzwpn4g520c6ni-glib-2.72.3-dev/include/glib-2.0/glib/gthread.h:260:7: note: in expansion of macro 'g_atomic_pointer_get'
  260 |     (!g_atomic_pointer_get (location) &&                             \
      |       ^~~~~~~~~~~~~~~~~~~~
../../../plugins/av/audiodecoder.c:100:9: note: in expansion of macro 'g_once_init_enter'
  100 |     if (g_once_init_enter (&gonce_data))
      |         ^~~~~~~~~~~~~~~~~
../../../plugins/av/audiodecoder.c:106:16: warning: cast between incompatible function types from 'void (*)(void *)' to 'void (*)(void *, void *)' [-Wcast-function-type]
  106 |                (GClassInitFunc) audiodecoder_class_intern_init,
      |                ^
../../../plugins/av/audiodecoder.c:108:16: warning: cast between incompatible function types from 'void (*)(AudioDecoder *)' {aka 'void (*)(struct _AudioDecoder *)'} to 'void (*)(GTypeInstance *, void *)' {aka 'void (*)(struct _GTypeInstance *, void *)'} [-Wcast-function-type]
  108 |                (GInstanceInitFunc) audiodecoder_init,
      |                ^
../../../plugins/av/audiodecoder.c: In function 'audiodecoder_chain':
../../../plugins/av/audiodecoder.c:707:5: warning: 'av_init_packet' is deprecated [-Wdeprecated-declarations]
  707 |     av_init_packet(&decoder->packet);
      |     ^~~~~~~~~~~~~~
In file included from /nix/store/dzb8y1w9c6pvr3qsrc9j0bdw9h53b612-ffmpeg-5.1.1-dev/include/libavcodec/avcodec.h:45,
                 from ../../../plugins/av/decoder.h:30,
                 from ../../../plugins/av/audiodecoder.h:29,
                 from ../../../plugins/av/audiodecoder.c:37:
/nix/store/dzb8y1w9c6pvr3qsrc9j0bdw9h53b612-ffmpeg-5.1.1-dev/include/libavcodec/packet.h:512:6: note: declared here
  512 | void av_init_packet(AVPacket *pkt);
      |      ^~~~~~~~~~~~~~
cc1: some warnings being treated as errors
../../../plugins/av/audiodecoder.c:719:15: error: implicit declaration of function 'avcodec_decode_audio4'; did you mean 'avcodec_decode_subtitle2'? [-Werror=implicit-function-declaration]
  719 |     num_dec = avcodec_decode_audio4(base->context, base->frame, &got_frame, &decoder->packet);
      |               ^~~~~~~~~~~~~~~~~~~~~
      |               avcodec_decode_subtitle2
make: *** [Makefile:87: /build/source/modules/javafx.media/build/native/linux/Release/obj/plugins/avplugin/av/videodecoder.o] Error 1
In file included from /nix/store/7smln0rxv9rbqc7891gzwpn4g520c6ni-glib-2.72.3-dev/include/glib-2.0/glib/gthread.h:32,
                 from /nix/store/7smln0rxv9rbqc7891gzwpn4g520c6ni-glib-2.72.3-dev/include/glib-2.0/glib/gasyncqueue.h:32,
                 from /nix/store/7smln0rxv9rbqc7891gzwpn4g520c6ni-glib-2.72.3-dev/include/glib-2.0/glib.h:32,
                 from ../../../gstreamer-lite/gstreamer/gst/gst.h:27,
                 from ../../../plugins/av/avelement.h:29,
                 from ../../../plugins/av/mpegtsdemuxer.h:29,
                 from ../../../plugins/av/mpegtsdemuxer.c:30:
../../../plugins/av/mpegtsdemuxer.c: In function 'mpegts_demuxer_get_type':
/nix/store/7smln0rxv9rbqc7891gzwpn4g520c6ni-glib-2.72.3-dev/include/glib-2.0/glib/gatomic.h:113:5: warning: argument 2 of '__atomic_load' discards 'volatile' qualifier [-Wincompatible-pointer-types]
  113 |     __atomic_load (gapg_temp_atomic, &gapg_temp_newval, __ATOMIC_SEQ_CST); \
      |     ^~~~~~~~~~~~~
/nix/store/7smln0rxv9rbqc7891gzwpn4g520c6ni-glib-2.72.3-dev/include/glib-2.0/glib/gthread.h:260:7: note: in expansion of macro 'g_atomic_pointer_get'
  260 |     (!g_atomic_pointer_get (location) &&                             \
      |       ^~~~~~~~~~~~~~~~~~~~
../../../plugins/av/mpegtsdemuxer.c:173:9: note: in expansion of macro 'g_once_init_enter'
  173 |     if (g_once_init_enter (&gonce_data))
      |         ^~~~~~~~~~~~~~~~~
../../../plugins/av/mpegtsdemuxer.c:179:16: warning: cast between incompatible function types from 'void (*)(void *)' to 'void (*)(void *, void *)' [-Wcast-function-type]
  179 |                (GClassInitFunc) mpegts_demuxer_class_intern_init,
      |                ^
../../../plugins/av/mpegtsdemuxer.c:181:16: warning: cast between incompatible function types from 'void (*)(MpegTSDemuxer *)' {aka 'void (*)(struct _MpegTSDemuxer *)'} to 'void (*)(GTypeInstance *, void *)' {aka 'void (*)(struct _GTypeInstance *, void *)'} [-Wcast-function-type]
  181 |                (GInstanceInitFunc) mpegts_demuxer_init,
      |                ^
../../../plugins/av/mpegtsdemuxer.c: In function 'mpegts_demuxer_class_init':
../../../plugins/av/mpegtsdemuxer.c:229:5: error: implicit declaration of function 'av_register_all' [-Werror=implicit-function-declaration]
  229 |     av_register_all();
      |     ^~~~~~~~~~~~~~~
../../../plugins/av/mpegtsdemuxer.c: In function 'mpegts_demuxer_chain':
../../../plugins/av/mpegtsdemuxer.c:351:94: warning: comparison of integer expressions of different signedness: 'long unsigned int' and 'gint64' {aka 'long int'} [-Wsign-compare]
  351 |     while (((gint64)gst_adapter_available(demuxer->sink_adapter) + gst_buffer_get_size(buf)) >= demuxer->adapter_limit_size &&
      |                                                                                              ^~
../../../plugins/av/mpegtsdemuxer.c: In function 'mpegts_demuxer_expect_more_pads':
../../../plugins/av/mpegtsdemuxer.c:503:29: warning: comparison of integer expressions of different signedness: 'gint' {aka 'int'} and 'unsigned int' [-Wsign-compare]
  503 |     return demuxer->numpads < demuxer->context->nb_streams;
      |                             ^
../../../plugins/av/mpegtsdemuxer.c: In function 'mpegts_demuxer_check_streams':
../../../plugins/av/mpegtsdemuxer.c:539:19: warning: comparison of integer expressions of different signedness: 'int' and 'unsigned int' [-Wsign-compare]
  539 |     for (i = 0; i < demuxer->context->nb_streams; i++)
      |                   ^
../../../plugins/av/mpegtsdemuxer.c:541:45: error: 'AVStream' has no member named 'codec'
  541 |         switch (demuxer->context->streams[i]->codec->codec_type)
      |                                             ^~
../../../plugins/av/mpegtsdemuxer.c:549:31: error: 'AVStream' has no member named 'codec'
  549 |                     if (stream->codec->codec_id == AV_CODEC_ID_H264)
      |                               ^~
../../../plugins/av/mpegtsdemuxer.c:555:57: error: 'AVStream' has no member named 'codec'
  555 |                         demuxer->video.codec_id = stream->codec->codec_id;
      |                                                         ^~
../../../plugins/av/mpegtsdemuxer.c:562:75: error: 'AVStream' has no member named 'codec'
  562 |                         GstBuffer *codec_data = get_codec_extradata(stream->codec);
      |                                                                           ^~
../../../plugins/av/mpegtsdemuxer.c:580:31: error: 'AVStream' has no member named 'codec'
  580 |                     if (stream->codec->codec_id == AV_CODEC_ID_AAC)
      |                               ^~
../../../plugins/av/mpegtsdemuxer.c:586:57: error: 'AVStream' has no member named 'codec'
  586 |                         demuxer->audio.codec_id = stream->codec->codec_id;
      |                                                         ^~
../../../plugins/av/mpegtsdemuxer.c:591:83: error: 'AVStream' has no member named 'codec'
  591 |                                                     "channels", G_TYPE_INT, stream->codec->channels,
      |                                                                                   ^~
../../../plugins/av/mpegtsdemuxer.c:592:79: error: 'AVStream' has no member named 'codec'
  592 |                                                     "rate", G_TYPE_INT, stream->codec->sample_rate,
      |                                                                               ^~
../../../plugins/av/mpegtsdemuxer.c:593:82: error: 'AVStream' has no member named 'codec'
  593 |                                                     "bitrate", G_TYPE_INT, stream->codec->bit_rate,
      |                                                                                  ^~
../../../plugins/av/mpegtsdemuxer.c:596:75: error: 'AVStream' has no member named 'codec'
  596 |                         GstBuffer *codec_data = get_codec_extradata(stream->codec);
      |                                                                           ^~
../../../plugins/av/mpegtsdemuxer.c: In function 'same_stream':
../../../plugins/av/mpegtsdemuxer.c:636:59: error: 'AVStream' has no member named 'codec'
  636 |     return demuxer->context->streams[packet->stream_index]->codec->codec_id == stream->codec_id;
      |                                                           ^~
cc1: some warnings being treated as errors
../../../plugins/av/mpegtsdemuxer.c: In function 'mpegts_demuxer_read_frame':
../../../plugins/av/mpegtsdemuxer.c:879:5: error: implicit declaration of function 'av_free_packet'; did you mean 'av_get_packet'? [-Werror=implicit-function-declaration]
  879 |     av_free_packet(&packet);
      |     ^~~~~~~~~~~~~~
      |     av_get_packet
../../../plugins/av/mpegtsdemuxer.c: In function 'mpegts_demuxer_process_input':
../../../plugins/av/mpegtsdemuxer.c:942:42: warning: initialization discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  942 |                 AVInputFormat* iformat = av_find_input_format("mpegts");
      |                                          ^~~~~~~~~~~~~~~~~~~~
../../../plugins/av/mpegtsdemuxer.c:954:68: warning: comparison of integer expressions of different signedness: 'gint' {aka 'int'} and 'guint' {aka 'unsigned int'} [-Wsign-compare]
  954 |                 gst_adapter_flush(demuxer->sink_adapter, available > demuxer->offset ? demuxer->offset : available);
      |                                                                    ^
../../../plugins/av/mpegtsdemuxer.c:954:106: warning: operand of '?:' changes signedness from 'gint' {aka 'int'} to 'guint' {aka 'unsigned int'} due to unsignedness of other operand [-Wsign-compare]
  954 |                 gst_adapter_flush(demuxer->sink_adapter, available > demuxer->offset ? demuxer->offset : available);
      |                                                                                                          ^~~~~~~~~
../../../plugins/av/mpegtsdemuxer.c: In function 'mpegts_demuxer_read_packet':
../../../plugins/av/mpegtsdemuxer.c:1003:22: warning: comparison of integer expressions of different signedness: 'gint' {aka 'int'} and 'guint' {aka 'unsigned int'} [-Wsign-compare]
 1003 |     while (available < demuxer->offset + size &&
      |                      ^
../../../plugins/av/mpegtsdemuxer.c: In function 'mpegts_demuxer_sink_query':
../../../plugins/av/mpegtsdemuxer.c:1127:38: warning: comparison of integer expressions of different signedness: 'gint64' {aka 'long int'} and 'long unsigned int' [-Wsign-compare]
 1127 |                         if (duration != GST_CLOCK_TIME_NONE)
      |                                      ^~
make: *** [Makefile:87: /build/source/modules/javafx.media/build/native/linux/Release/obj/plugins/avplugin/av/audiodecoder.o] Error 1
cc1: some warnings being treated as errors
make: *** [Makefile:87: /build/source/modules/javafx.media/build/native/linux/Release/obj/plugins/avplugin/av/mpegtsdemuxer.o] Error 1
make: Leaving directory '/build/source/modules/javafx.media/src/main/native/gstreamer/projects/linux/avplugin'

FAILURE: Build failed with an exception.

* Where:
Build file '/build/source/build.gradle' line: 3263

* What went wrong:
Execution failed for task ':media:buildAVPlugin'.
> Process 'command 'make'' finished with non-zero exit value 2

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.5/userguide/command_line_interface.html#sec:command_line_warnings

BUILD FAILED in 1m 31s
44 actionable tasks: 44 executed


<-------------> 0% WAITING> :media:buildAVPlugin
```

</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc maintainer @abbradar