### PR TITLE
stdenv: reintroduce limiting by system load

### DIFF
--- a/pkgs/applications/emulators/np2kai/default.nix
+++ b/pkgs/applications/emulators/np2kai/default.nix
@@ -124,7 +124,7 @@ stdenv.mkDerivation rec {
 
   configurePhase = ''
     export GIT_VERSION=${builtins.substring 0 7 src.rev}
-    buildFlags="$buildFlags ''${enableParallelBuilding:+-j$NIX_BUILD_CORES"
+    buildFlags="$buildFlags ''${enableParallelBuilding:+-j$NIX_BUILD_CORES -l$NIX_LOAD_LIMIT}"
   '' + optionalString enableX11 ''
     cd x11
     substituteInPlace Makefile.am \

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -325,7 +325,7 @@ let
 
     buildPhase = let
       buildCommand = target: ''
-        ninja -C "${buildPath}" -j$NIX_BUILD_CORES "${target}"
+        ninja -C "${buildPath}" -j$NIX_BUILD_CORES -l$NIX_LOAD_LIMIT "${target}"
         (
           source chrome/installer/linux/common/installer.include
           PACKAGE=$packageName

--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -252,7 +252,7 @@ stdenv.mkDerivation (finalAttrs: {
       '')
 
    + lib.optionalString withManual ''# Install man pages
-       make -j $NIX_BUILD_CORES PERL_PATH="${buildPackages.perl}/bin/perl" cmd-list.made install install-html \
+       make -j $NIX_BUILD_CORES -l $NIX_LOAD_LIMIT PERL_PATH="${buildPackages.perl}/bin/perl" cmd-list.made install install-html \
          -C Documentation ''
 
    + (if guiSupport then ''

--- a/pkgs/development/embedded/blackmagic/helper.sh
+++ b/pkgs/development/embedded/blackmagic/helper.sh
@@ -11,7 +11,7 @@ out=${out:-/tmp}
 ################################################################################
 export CFLAGS=$NIX_CFLAGS_COMPILE
 export MAKEFLAGS="\
-  ${enableParallelBuilding:+-j${NIX_BUILD_CORES}}"
+  ${enableParallelBuilding:+-j${NIX_BUILD_CORES} -l${NIX_LOAD_LIMIT}}"
 
 ################################################################################
 PRODUCTS="blackmagic.bin blackmagic.hex blackmagic_dfu.bin blackmagic_dfu.hex"

--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -81,7 +81,7 @@ callPackage ./common.nix { inherit stdenv; } {
 
     postInstall = (if stdenv.hostPlatform == stdenv.buildPlatform then ''
       echo SUPPORTED-LOCALES=C.UTF-8/UTF-8 > ../glibc-2*/localedata/SUPPORTED
-      make -j''${NIX_BUILD_CORES:-1} localedata/install-locales
+      make -j''${NIX_BUILD_CORES:-1} -l''${NIX_LOAD_LIMIT:-1} localedata/install-locales
     '' else lib.optionalString stdenv.buildPlatform.isLinux ''
       # This is based on http://www.linuxfromscratch.org/lfs/view/development/chapter06/glibc.html
       # Instead of using their patch to build a build-native localedef,

--- a/pkgs/development/libraries/kerberos/krb5.nix
+++ b/pkgs/development/libraries/kerberos/krb5.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
   buildPhase = lib.optionalString libOnly ''
     runHook preBuild
 
-    MAKE="make -j $NIX_BUILD_CORES"
+    MAKE="make -j $NIX_BUILD_CORES -l $NIX_LOAD_LIMIT"
     for folder in $libFolders; do
       $MAKE -C $folder
     done

--- a/pkgs/development/python-modules/pybind11/default.nix
+++ b/pkgs/development/python-modules/pybind11/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
 
   postBuild = ''
     # build tests
-    make -j $NIX_BUILD_CORES
+    make -j $NIX_BUILD_CORES -l $NIX_LOAD_LIMIT
   '';
 
   postInstall = ''

--- a/pkgs/development/tools/build-managers/ninja/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/ninja/setup-hook.sh
@@ -9,7 +9,7 @@ ninjaBuildPhase() {
     fi
 
     local flagsArray=(
-        -j$buildCores
+        -j$buildCores -l$NIX_LOAD_LIMIT
         $ninjaFlags "${ninjaFlagsArray[@]}"
     )
 
@@ -61,7 +61,7 @@ ninjaCheckPhase() {
         fi
 
         local flagsArray=(
-            -j$buildCores
+            -j$buildCores -l$NIX_LOAD_LIMIT
             $ninjaFlags "${ninjaFlagsArray[@]}"
             $checkTarget
         )

--- a/pkgs/games/uhexen2/default.nix
+++ b/pkgs/games/uhexen2/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     runHook preBuild
     for makefile in "''${makeFiles[@]}"; do
           local flagsArray=(
-            -j$NIX_BUILD_CORES
+            -j$NIX_BUILD_CORES -l$NIX_LOAD_LIMIT
             SHELL=$SHELL
             $makeFlags "''${makeFlagsArray[@]}"
             $buildFlags "''${buildFlagsArray[@]}"

--- a/pkgs/games/xonotic/default.nix
+++ b/pkgs/games/xonotic/default.nix
@@ -83,14 +83,14 @@ let
     '';
 
     buildPhase = (lib.optionalString withDedicated ''
-      make -j $NIX_BUILD_CORES sv-${target}
+      make -j $NIX_BUILD_CORES -l $NIX_LOAD_LIMIT sv-${target}
     '' + lib.optionalString withGLX ''
-      make -j $NIX_BUILD_CORES cl-${target}
+      make -j $NIX_BUILD_CORES -l $NIX_LOAD_LIMIT cl-${target}
     '' + lib.optionalString withSDL ''
-      make -j $NIX_BUILD_CORES sdl-${target}
+      make -j $NIX_BUILD_CORES -l $NIX_LOAD_LIMIT sdl-${target}
     '') + ''
       pushd ../d0_blind_id
-      make -j $NIX_BUILD_CORES
+      make -j $NIX_BUILD_CORES -l $NIX_LOAD_LIMIT
       popd
     '';
 

--- a/pkgs/os-specific/linux/trace-cmd/default.nix
+++ b/pkgs/os-specific/linux/trace-cmd/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   # because the Makefile would not print warnings about too old
   # libraries (see "warning:" in the Makefile)
   postBuild = ''
-    make libs doc -j$NIX_BUILD_CORES
+    make libs doc -j$NIX_BUILD_CORES -l$NIX_LOAD_LIMIT
   '';
 
   installTargets = [

--- a/pkgs/tools/admin/tigervnc/default.nix
+++ b/pkgs/tools/admin/tigervnc/default.nix
@@ -92,7 +92,7 @@ stdenv.mkDerivation rec {
         --with-xkb-path=${xkeyboard_config}/share/X11/xkb \
         --with-xkb-bin-directory=${xorg.xkbcomp}/bin \
         --with-xkb-output=$out/share/X11/xkb/compiled
-    make TIGERVNC_SRC=$src TIGERVNC_BUILDDIR=`pwd`/../.. -j$NIX_BUILD_CORES
+    make TIGERVNC_SRC=$src TIGERVNC_BUILDDIR=`pwd`/../.. -j$NIX_BUILD_CORES -l$NIX_LOAD_LIMIT
     popd
   '' + lib.optionalString stdenv.isDarwin ''
     make dmg

--- a/pkgs/tools/security/tracee/default.nix
+++ b/pkgs/tools/security/tracee/default.nix
@@ -63,7 +63,7 @@ buildGoModule rec {
 
   buildPhase = ''
     runHook preBuild
-    make $makeFlags ''${enableParallelBuilding:+-j$NIX_BUILD_CORES
+    make $makeFlags ''${enableParallelBuilding:+-j$NIX_BUILD_CORES -l$NIX_LOAD_LIMIT}
     runHook postBuild
   '';
 

--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -202,7 +202,7 @@ core-big = stdenv.mkDerivation { #TODO: upmendex
         if [[ "$path" =~ "libs/pplib" ]]; then
           # TODO: revert for texlive 2022
           # ../../../texk/web2c/luatexdir/luamd5/md5lib.c:197:10: fatal error: 'utilsha.h' file not found
-          make ''${enableParallelBuilding:+-j''${NIX_BUILD_CORES}}
+          make ''${enableParallelBuilding:+-j''${NIX_BUILD_CORES} -l''${NIX_LOAD_LIMIT}}
         fi
       )
     done


### PR DESCRIPTION
Commit c2b898da762 removed the mechanism; now it's replaced by a different one with higher limit of $(nproc) * 2.

Unfortunately there's no good mechanism how to override it from outside like `--cores` or `--max-jobs`, but at least the new limit should be high enough to avoid the previous downsides.