### PR TITLE
Gitlab tools

### DIFF
--- a/pkgs/development/python-modules/lcov_cobertura/default.nix
+++ b/pkgs/development/python-modules/lcov_cobertura/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "lcov_cobertura";
+  version = "2.0.2";
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-xs40e/PuZ/jV0CDNZiYmo1lM8r5yfMY0qg0R+j9/E3Q=";
+  };
+
+  doCheck = true;
+  pythonImportsCheck = [
+    "lcov_cobertura"
+  ];
+
+  meta = {
+    description = "Converts code coverage from lcov format to Cobertura's XML format";
+    homepage = "https://eriwen.github.io/lcov-to-cobertura-xml/";
+    license = lib.licenses.asl20;
+  };
+}

--- a/pkgs/development/tools/rust/cargo-llvm-cov/default.nix
+++ b/pkgs/development/tools/rust/cargo-llvm-cov/default.nix
@@ -1,0 +1,44 @@
+{ stdenv
+, lib
+, fetchzip
+, rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-llvm-cov";
+  version = "0.5.0";
+
+  src = fetchzip {
+    url = "https://crates.io/api/v1/crates/${pname}/${version}/download#${pname}-${version}.tar.gz";
+    sha256 = "sha256-ifnwiOuFnpryYxLgescpxN8CzgFzSZlY+RlbyW7ND6g=";
+  };
+  cargoSha256 = "sha256-11xNgiOw0qysTWpoKAXQ5gx1uJSAsp+aDDir0zpkpeQ=";
+
+  # skip tests which require llvm-tools-preview
+  checkFlags = [
+    "--skip bin_crate"
+    "--skip cargo_config"
+    "--skip clean_ws"
+    "--skip instantiations"
+    "--skip merge"
+    "--skip merge_failure_mode_all"
+    "--skip no_test"
+    "--skip open_report"
+    "--skip real1"
+    "--skip show_env"
+    "--skip virtual1"
+  ];
+
+  meta = rec {
+    homepage = "https://github.com/taiki-e/${pname}";
+    changelog = homepage + "/blob/v${version}/CHANGELOG.md";
+    description = "Cargo subcommand to easily use LLVM source-based code coverage";
+    longDescription = ''
+      In order for this to work, you either need to run `rustup component add llvm-
+      tools-preview` or install the `llvm-tools-preview` component using your Nix
+      library (e.g. nixpkgs-mozilla, or rust-overlay)
+    '';
+    license = with lib.licenses; [ asl20 /* or */ mit ];
+    maintainers = with lib.maintainers; [ wucke13 ];
+  };
+}

--- a/pkgs/development/tools/rust/gitlab-clippy/default.nix
+++ b/pkgs/development/tools/rust/gitlab-clippy/default.nix
@@ -1,0 +1,31 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "gitlab-clippy";
+  version = "1.0.3";
+
+  src = fetchFromGitLab {
+    owner = "dlalic";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-d7SmlAWIV4SngJhIvlud90ZUSF55FWIrzFpkfSXIy2Y=";
+  };
+  cargoSha256 = "sha256-ztPbI+ncMNMKnIxUksxgz8GHQpLZ7SVWdC4QJWh18Wk=";
+
+  # TODO re-add theses tests once they get fixed in upstream
+  checkFlags = [
+    "--skip cli::converts_error_from_pipe"
+    "--skip cli::converts_warnings_from_pipe"
+  ];
+
+  meta = {
+    homepage = "https://gitlab.com/dlalic/gitlab-clippy";
+    description = "Convert clippy warnings into GitLab Code Quality report";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ wucke13 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7181,6 +7181,8 @@ with pkgs;
     gitlabEnterprise = true;
   };
 
+  gitlab-clippy = callPackage ../development/tools/rust/gitlab-clippy { };
+
   gitlab-runner = callPackage ../development/tools/continuous-integration/gitlab-runner { };
 
   gitlab-shell = callPackage ../applications/version-management/gitlab/gitlab-shell { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14929,6 +14929,7 @@ with pkgs;
   cargo-graph = callPackage ../development/tools/rust/cargo-graph { };
   cargo-hack = callPackage ../development/tools/rust/cargo-hack { };
   cargo-license = callPackage ../development/tools/rust/cargo-license { };
+  cargo-llvm-cov = callPackage ../development/tools/rust/cargo-llvm-cov { };
   cargo-llvm-lines = callPackage ../development/tools/rust/cargo-llvm-lines { };
   cargo-lock = callPackage ../development/tools/rust/cargo-lock { };
   cargo-outdated = callPackage ../development/tools/rust/cargo-outdated {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5049,6 +5049,8 @@ self: super: with self; {
 
   lc7001 = callPackage ../development/python-modules/lc7001 { };
 
+  lcov_cobertura = callPackage ../development/python-modules/lcov_cobertura { };
+
   ldap3 = callPackage ../development/python-modules/ldap3 { };
 
   ldapdomaindump = callPackage ../development/python-modules/ldapdomaindump { };


### PR DESCRIPTION
###### Description of changes
This includes a set of tools required to thoroughly integrate rust projects into GitLab:

+ `gitlab-clippy`, which allows to create a gitlab code quality reports from clippy lints
+ `lcov_cobertura`, which allows to convert llvm lcov coverage reports to the cobertura format required by GitLab
+ `cargo-llvm-cov` to generate lcov coverage data

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
