### PR TITLE
gnome.mutter: fixup color-device: Don't create profiles from obvious g…

### DIFF
--- a/pkgs/desktops/gnome/core/mutter/default.nix
+++ b/pkgs/desktops/gnome/core/mutter/default.nix
@@ -65,6 +65,27 @@ let self = stdenv.mkDerivation rec {
       url = "https://gitlab.gnome.org/GNOME/mutter/-/commit/285a5a4d54ca83b136b787ce5ebf1d774f9499d5.patch";
       sha256 = "/npUE3idMSTVlFptsDpZmGWjZ/d2gqruVlJKq4eF4xU=";
     })
+
+    # color-device: Don't create profiles from obvious garbage data
+    # https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/2627
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/mutter/-/commit/d21cab4298116df4c6a8508ce4b1b0fb5ac43b8f.patch";
+      sha256 = "sha256-1tQKCHKEhNz2y8EWY5L1kK0/ELrl99xeaktkjJ3N5sA=";
+    })
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/mutter/-/commit/e986bf52ddaec6f07d21aec0cac3e24ba5dd1f96.patch";
+      sha256 = "sha256-Uh0l1crYo4fOYlVA67Ha0nzvzpPmfowy+mk5xtnNqw0=";
+    })
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/mutter/-/commit/91aac852f677701dead6c3eeb23f1ec6c201973c.patch";
+      sha256 = "sha256-+kMGLeocNJDkaW4dlA7nM6yPuKijOg7xwfs85MtG68I=";
+    })
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/mutter/-/commit/a94eb5b60f6577744a67d8b3d0ae7bde801d6957.patch";
+      sha256 = "sha256-+N+yBL3ofgAy8P0UXp9nH6kNKwvV8xlDKKEfqxpI8Ok=";
+    })
+
+
   ];
 
   mesonFlags = [


### PR DESCRIPTION


###### Description of changes

this is for gnome branch, latest 43 updates fails to boot due to 
https://gitlab.gnome.org/GNOME/gnome-shell/-/issues/5875
applying patches from 
https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/2627
fixes the issue for me.

I am not sure if we can rely on those commit hashes from upstream MR, what happens if author rebases the branch ?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
