### PR TITLE
trealla: 1.20.31 -> 2.2.6

### DIFF
--- a/pkgs/development/interpreters/trealla/default.nix
+++ b/pkgs/development/interpreters/trealla/default.nix
@@ -1,14 +1,14 @@
-{ lib, stdenv, fetchFromGitHub, readline, openssl, withThread ? true, withSSL ? true, xxd }:
+{ lib, stdenv, fetchFromGitHub, readline, openssl, libffi, withThread ? true, withSSL ? true, xxd }:
 
 stdenv.mkDerivation rec {
   pname = "trealla";
-  version = "1.20.31";
+  version = "2.2.6";
 
   src = fetchFromGitHub {
-    owner = "infradig";
+    owner = "trealla-prolog";
     repo = "trealla";
     rev = "v${version}";
-    sha256 = "sha256-Yol+bbxC5cCtCIZxP5Sa8R3ev1LAopc/oQa6Zd1nS8A=";
+    sha256 = "sha256-DxlexijQPcNxlPjo/oIvsN//8nZ0injXFHc2t3n4yjg=";
   };
 
   postPatch = ''
@@ -26,7 +26,8 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ xxd ];
-  buildInputs = [ readline openssl ];
+  buildInputs = [ readline openssl libffi ];
+  enableParallelBuilding = true;
 
   installPhase = ''
     install -Dm755 -t $out/bin tpl
@@ -34,13 +35,16 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
   preCheck = ''
-    # Disable test 81 due to floating point error
-    rm tests/issues/test081.expected tests/issues/test081.pl
+    # Disable tests due to floating point error
+    rm tests/issues-OLD/test081.pl
+    rm tests/issues-OLD/test585.pl
+    # Disable test due to Unicode issues
+    rm tests/issues-OLD/test252.pl
   '';
 
   meta = with lib; {
     description = "A compact, efficient Prolog interpreter written in ANSI C";
-    homepage = "https://github.com/infradig/trealla";
+    homepage = "https://github.com/trealla-prolog/trealla";
     license = licenses.mit;
     maintainers = with maintainers; [ siraben ];
     mainProgram = "tpl";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
