### PR TITLE
pdfstudio/pdfstudioviewer: improve package naming schemes and add/uprade to 2022.0.2

### DIFF
--- a/pkgs/applications/misc/pdfstudio/common.nix
+++ b/pkgs/applications/misc/pdfstudio/common.nix
@@ -1,11 +1,13 @@
 { pname
+, program
 , src
 , year
 , version
 , desktopName
 , longDescription
 , buildFHSUserEnv
-, extraBuildInputs ? []
+, extraBuildInputs ? [ ]
+, jdk
 , stdenv
 , lib
 , dpkg
@@ -14,7 +16,6 @@
 , autoPatchelfHook
 , sane-backends
 , cups
-, jdk11
 }:
 let
   thisPackage = stdenv.mkDerivation rec {
@@ -23,7 +24,6 @@ let
 
     buildInputs = [
       sane-backends #for libsane.so.1
-      jdk11
     ] ++ extraBuildInputs;
 
     nativeBuildInputs = [
@@ -34,33 +34,33 @@ let
 
     desktopItems = [
       (makeDesktopItem {
-        name = "${pname}${year}";
+        name = "${pname}";
         desktopName = desktopName;
         genericName = "View and edit PDF files";
         exec = "${pname} %f";
-        icon = "${pname}${year}";
+        icon = "${pname}";
         comment = "Views and edits PDF files";
         mimeTypes = [ "application/pdf" ];
         categories = [ "Office" ];
       })
     ];
 
-    unpackCmd = "dpkg-deb -x $src ./${pname}-${version}";
+    unpackCmd = "dpkg-deb -x $src ./${program}-${version}";
     dontBuild = true;
 
     postPatch = ''
-      substituteInPlace opt/${pname}${year}/${pname}${year} --replace "# INSTALL4J_JAVA_HOME_OVERRIDE=" "INSTALL4J_JAVA_HOME_OVERRIDE=${jdk11.out}"
-      substituteInPlace opt/${pname}${year}/updater --replace "# INSTALL4J_JAVA_HOME_OVERRIDE=" "INSTALL4J_JAVA_HOME_OVERRIDE=${jdk11.out}"
+      substituteInPlace opt/${program}${year}/${program}${year} --replace "# INSTALL4J_JAVA_HOME_OVERRIDE=" "INSTALL4J_JAVA_HOME_OVERRIDE=${jdk.out}"
+      substituteInPlace opt/${program}${year}/updater --replace "# INSTALL4J_JAVA_HOME_OVERRIDE=" "INSTALL4J_JAVA_HOME_OVERRIDE=${jdk.out}"
     '';
 
     installPhase = ''
       runHook preInstall
 
       mkdir -p $out/{bin,share/pixmaps}
-      rm -rf opt/${pname}${year}/jre
-      cp -r opt/${pname}${year} $out/share/
-      ln -s $out/share/${pname}${year}/.install4j/${pname}${year}.png  $out/share/pixmaps/
-      ln -s $out/share/${pname}${year}/${pname}${year} $out/bin/${pname}
+      rm -rf opt/${program}${year}/jre
+      cp -r opt/${program}${year} $out/share/
+      ln -s $out/share/${program}${year}/.install4j/${program}${year}.png  $out/share/pixmaps/${pname}.png
+      ln -s $out/share/${program}${year}/${program}${year} $out/bin/
 
       runHook postInstall
     '';
@@ -74,7 +74,7 @@ buildFHSUserEnv {
     cups
     thisPackage
   ];
-  runScript = pname;
+  runScript = "${program}${year}";
 
   # link desktop item and icon into FHS user environment
   extraInstallCommands = ''

--- a/pkgs/applications/misc/pdfstudio/default.nix
+++ b/pkgs/applications/misc/pdfstudio/default.nix
@@ -1,42 +1,69 @@
-{ program ? "pdfstudioviewer"
+# For upstream versions, download links, and change logs see https://www.qoppa.com/pdfstudio/versions
+#
+# PDF Studio license is for a specific year, so we need different packages for different years.
+# All versions of PDF Studio Viewer are free, so we package only the latest year.
+# Thus, packages are pdfstudioviewer, pdfstudio2021, pdfstudio2022, etc.
+# Variables:
+# - program is either "pdfstudio" or "pdfstudioviewer", defaults to "pdfstudio".
+# - year identifies the year portion of the version, defaults to most recent year.
+# - pname is either "pdfstudio${year}" or "pdfstudioviewer".
+
+{ program ? "pdfstudio"
+, year ? "2022"
 , fetchurl
 , libgccjit
 , callPackage
+, jdk11
+, jdk17
 }:
-
-let makeurl = { pname, year, version }: "https://download.qoppa.com/${pname}/v${year}/${
-    builtins.replaceStrings [ "pdfstudio" "viewer" "." ] [ "PDFStudio" "Viewer" "_" ] "${pname}_v${version}"
-  }_linux64.deb";
+let
+  longDescription = ''
+    PDF Studio is an easy to use, full-featured PDF editing software. This is the standard/pro edition, which requires a license. For the free PDF Studio Viewer see the package pdfstudioviewer.
+  '';
+  pname = if (program == "pdfstudio") then "${program}${year}" else program;
+  desktopName =
+    if (program == "pdfstudio")
+    then "PDF Studio ${year}"
+    else "PDF Studio Viewer";
+  dot2dash = str: builtins.replaceStrings [ "." ] [ "_" ] str;
 in
 {
-  pdfstudio = callPackage ./common.nix rec {
-    pname = program;
-    year = "2021";
-    version = "${year}.2.0";
-    desktopName = "PDF Studio";
-    longDescription = ''
-      PDF Studio is an easy to use, full-featured PDF editing software. This is the standard/pro edition, which requires a license. For the free PDF Studio Viewer see the package pdfstudioviewer.
-    '';
-    extraBuildInputs = [
-      libgccjit #for libstdc++.so.6 and libgomp.so.1
-    ];
-    src = fetchurl {
-      url = makeurl { inherit pname year version; };
-      sha256 = "sha256-wQgVWz2kS+XkrqvCAUishizfDrCwGyVDAAU4Yzj4uYU=";
-    };
-  };
-
   pdfstudioviewer = callPackage ./common.nix rec {
-    pname = program;
-    year = "2021";
-    version = "${year}.2.0";
-    desktopName = "PDF Studio Viewer";
+    inherit desktopName pname program year;
+    version = "${year}.0.2";
     longDescription = ''
       PDF Studio Viewer is an easy to use, full-featured PDF editing software. This is the free edition. For the standard/pro edition, see the package pdfstudio.
     '';
     src = fetchurl {
-      url = makeurl { inherit pname year version; };
-      sha256 = "sha256-RjVfl3wRK4bqNwSZr2R0CNx4urHTL0QLmKdogEnySWU=";
+      url = "https://web.archive.org/web/20220909093140/https://download.qoppa.com/pdfstudioviewer/PDFStudioViewer_linux64.deb";
+      sha256 = "sha256-za+a5vGkINLFvFoZdnB++4VGE9rfdfZf5HFNw/Af1AA=";
     };
+    jdk = jdk11;
   };
-}.${program}
+
+  pdfstudio2021 = callPackage ./common.nix rec {
+    inherit desktopName longDescription pname program year;
+    version = "${year}.2.0";
+    src = fetchurl {
+      url = "https://download.qoppa.com/pdfstudio/v${year}/PDFStudio_v${dot2dash version}_linux64.deb";
+      sha256 = "sha256-wQgVWz2kS+XkrqvCAUishizfDrCwGyVDAAU4Yzj4uYU=";
+    };
+    extraBuildInputs = [
+      libgccjit #for libstdc++.so.6 and libgomp.so.1
+    ];
+    jdk = jdk11;
+  };
+
+  pdfstudio2022 = callPackage ./common.nix rec {
+    inherit desktopName longDescription pname program year;
+    version = "${year}.0.2";
+    src = fetchurl {
+      url = "https://download.qoppa.com/pdfstudio/v${year}/PDFStudio_v${dot2dash version}_linux64_adoptium17.deb";
+      sha256 = "sha256-fWZXCyizP++pkmC+UpgCzGvb0QrNs4RI6iC4ZBL8hLE=";
+    };
+    extraBuildInputs = [
+      libgccjit #for libstdc++.so.6 and libgomp.so.1
+    ];
+    jdk = jdk17;
+  };
+}.${pname}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -842,6 +842,7 @@ mapAliases ({
   pbis-open = throw "pbis-open has been removed, because it is no longer maintained upstream"; # added 2021-12-15
   pdf-redact-tools = throw "pdf-redact-tools has been removed from nixpkgs because the upstream has abandoned the project"; # Added 2022-01-01
   pdfmod = throw "pdfmod has been removed"; # Added 2022-01-15
+  pdfstudio = throw "'pdfstudio' has been replaced with 'pdfstudio<year>', where '<year>' is the year from the PDF Studio version number, because each license is specific to a given year"; # Added 2022-09-04
   peach = asouldocs; # Added 2022-08-28
   pentablet-driver = xp-pen-g430-driver; # Added 2022-06-23
   perlXMLParser = throw "'perlXMLParser' has been renamed to/replaced by 'perlPackages.XMLParser'"; # Converted to throw 2022-02-22

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26593,14 +26593,16 @@ with pkgs;
 
   foxitreader = libsForQt512.callPackage ../applications/misc/foxitreader { };
 
-  pdfstudio = import ../applications/misc/pdfstudio {
-    program = "pdfstudio";
-    inherit callPackage fetchurl libgccjit;
+  pdfstudio2021 = callPackage ../applications/misc/pdfstudio {
+    year = "2021";
   };
 
-  pdfstudioviewer = import ../applications/misc/pdfstudio {
+  pdfstudio2022 = callPackage ../applications/misc/pdfstudio {
+    year = "2022";
+  };
+
+  pdfstudioviewer = callPackage ../applications/misc/pdfstudio {
     program = "pdfstudioviewer";
-    inherit callPackage fetchurl libgccjit;
   };
 
   aeolus = callPackage ../applications/audio/aeolus { };


### PR DESCRIPTION
###### Description of changes
- Replaces package `pdfstudio` with `pdfstudio2021` and adds `pdfstudio2022`. Reason: licenses for PDF Studio are specific to the major release indicated by the year in the version number, so we should keep packages for past major releases. This fixes https://github.com/NixOS/nixpkgs/issues/189626.
- Updates `pdfstudioviewer` to the latest version, 2022.0.2. (PDF Studio Viewer is free, so we can always use the latest version.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
