### PR TITLE
proycon-wayout: init at 0.1.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14312,6 +14312,12 @@
       fingerprint = "2145 955E 3F5E 0C95 3458  41B5 11F7 BAEA 8567 43FF";
     }];
   };
+  wentam = {
+    name = "Matt Egeler";
+    email = "wentam42@gmail.com";
+    github = "wentam";
+    githubId = 901583;
+  };
   wentasah = {
     name = "Michal Sojka";
     email = "wsh@2x.cz";

--- a/pkgs/tools/wayland/proycon-wayout/default.nix
+++ b/pkgs/tools/wayland/proycon-wayout/default.nix
@@ -1,0 +1,46 @@
+{ stdenv
+, lib
+, fetchFromSourcehut
+, meson
+, wayland-protocols
+, wayland
+, cairo
+, pango
+, scdoc
+, ninja
+, cmake
+, pkg-config
+, wayland-scanner
+}:
+
+stdenv.mkDerivation rec {
+  pname = "proycon-wayout";
+  version = "0.1.3";
+
+  src = fetchFromSourcehut {
+    owner = "~proycon";
+    repo = "wayout";
+    rev = version;
+    sha256 = "sha256-pxHz8y63xX9I425OG0jPvQVx4mAbTYHxVMMkfjZpURo=";
+  };
+
+  postPatch = ''
+    substituteInPlace meson.build --replace "'werror=true'," "" # Build fails with -Werror, remove
+  '';
+
+  postFixup = ''
+    mv $out/bin/wayout $out/bin/proycon-wayout # Avoid conflict with shinyzenith/wayout
+  '';
+
+  depsBuildBuild = [ pkg-config ];
+  nativeBuildInputs = [ scdoc ninja meson cmake pkg-config wayland-scanner ];
+  buildInputs = [ wayland-protocols wayland cairo pango ];
+
+  meta = with lib; {
+    description = "Takes text from standard input and outputs it to a desktop-widget on Wayland desktops.";
+    homepage = "https://git.sr.ht/~proycon/wayout";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ wentam ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1351,6 +1351,8 @@ with pkgs;
 
   pferd = callPackage ../tools/misc/pferd {};
 
+  proycon-wayout = callPackage ../tools/wayland/proycon-wayout {};
+
   q = callPackage ../tools/networking/q {};
 
   qFlipper = libsForQt515.callPackage ../tools/misc/qflipper { };


### PR DESCRIPTION
###### Description of changes

Adds [~proycon/wayout](https://git.sr.ht/~proycon/wayout). From [sxmo-nix](https://github.com/wentam/sxmo-nix). This is a dependency of [sxmo](https://sxmo.org/).

Note: the binary has been renamed from 'wayout' to 'proycon-wayout' to avoid a conflict with the [existing wayout package](https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/wayland/wayout/default.nix).

This shouldn't pose any issues for sxmo down the road as an sxmo package can [use an alias](https://github.com/wentam/sxmo-nix/blob/d62e1ab6733b7bb6d29edadb28676c34d51d0c2e/pkgs/sxmo-utils/004-aliases.patch#L17) to select the correct wayout.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (both native and x86_64->aarch64 cross-compile tested)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
