### PR TITLE
libtool: improve cross-compilation support

### DIFF
--- a/pkgs/development/tools/misc/libtool/libtool2.nix
+++ b/pkgs/development/tools/misc/libtool/libtool2.nix
@@ -1,5 +1,6 @@
 { lib, stdenv, fetchurl, fetchpatch, autoconf, automake, m4, perl, help2man
 , runtimeShell
+, pkgsHostTarget
 , file
 }:
 
@@ -8,7 +9,13 @@
 # cgit) that are needed here should be included directly in Nixpkgs as
 # files.
 
-stdenv.mkDerivation rec {
+# Using pkgsHostTarget.targetPackages.stdenv.mkDerivation here, because
+# libtool does not support build/host/target as we know it. We have to
+# configure libtool with --host=$target and make sure only the target C
+# compiler is available during the configure, because otherwise libtool will
+# attempt to call the x86 compiler when it is used to cross-compile something.
+
+pkgsHostTarget.targetPackages.stdenv.mkDerivation rec {
   pname = "libtool";
   version = "2.4.7";
 
@@ -74,5 +81,7 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     maintainers = [ ];
     platforms = platforms.unix;
+    # Actually cross-compiling libtool is broken
+    broken = stdenv.buildPlatform != stdenv.hostPlatform;
   };
 }

--- a/pkgs/tools/misc/ttmkfdir/default.nix
+++ b/pkgs/tools/misc/ttmkfdir/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, freetype, fontconfig, libunwind, libtool, flex, bison }:
+{ lib, stdenv, fetchurl, freetype, libtool, flex, bison, pkg-config }:
 
 stdenv.mkDerivation {
   pname = "ttf-mkfontdir";
@@ -20,11 +20,19 @@ stdenv.mkDerivation {
       ./cstring.patch # also fixes some other compilation issues (freetype includes)
     ];
 
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace "libtool " "libtool --tag=CXX " \
+      --replace "CXX=" "#CXX=" \
+      --replace "freetype-config" "${stdenv.cc.targetPrefix}pkg-config freetype2"
+  '';
+
   preInstall = ''
     mkdir -p $out; makeFlags="DESTDIR=$out BINDIR=/bin"
   '';
 
-  buildInputs = [freetype fontconfig libunwind libtool flex bison];
+  nativeBuildInputs = [ libtool flex bison pkg-config ];
+  buildInputs = [ freetype ];
 
   meta = {
     description = "Create fonts.dir for TTF font directory";


### PR DESCRIPTION
###### Description of changes

libtool does not support build/host/target as we know it. We have to configure libtool with `--host=$target` and make sure _only_ the target C compiler is available during the configure, because otherwise libtool will attempt to call the x86 compiler when it is used to cross-compile something.

Fixes `pkgsCross.armv7l-hf-multiplatform.libmpack`

Also included changes to make `pkgsCross.armv7l-hf-multiplatform.ttmkfdir` cross-compile, which depend on the libtool change.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
