### PR TITLE
samplebrain: init at 0.18.5

### DIFF
--- a/pkgs/applications/audio/samplebrain/default.nix
+++ b/pkgs/applications/audio/samplebrain/default.nix
@@ -1,0 +1,62 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, fftw
+, liblo
+, libsndfile
+, makeDesktopItem
+, portaudio
+, qmake
+, qtbase
+, wrapQtAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "samplebrain";
+  version = "0.18.5";
+
+  src = fetchFromGitLab {
+    owner = "then-try-this";
+    repo = "samplebrain";
+    rev = "v${version}_release";
+    hash = "sha256-/pMHmwly5Dar7w/ZawvR3cWQHw385GQv/Wsl1E2w5p4=";
+  };
+
+  nativeBuildInputs = [
+    qmake
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    fftw
+    liblo
+    libsndfile
+    portaudio
+    qtbase
+  ];
+
+  desktopItem = makeDesktopItem {
+    type = "Application";
+    desktopName = pname;
+    name = pname;
+    comment = "A sample masher designed by Aphex Twin";
+    exec = pname;
+    icon = pname;
+    categories = [ "Audio" ];
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp samplebrain $out/bin
+    install -m 444 -D desktop/samplebrain.svg $out/share/icons/hicolor/scalable/apps/samplebrain.svg
+  '';
+
+  meta = with lib; {
+    description = "A custom sample mashing app";
+    homepage = "https://thentrythis.org/projects/samplebrain";
+    changelog = "https://gitlab.com/then-try-this/samplebrain/-/releases/v${version}_release";
+    maintainers = with maintainers; [ mitchmindtree ];
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15579,6 +15579,8 @@ with pkgs;
 
   mruby = callPackage ../development/compilers/mruby { };
 
+  samplebrain = libsForQt5.callPackage ../applications/audio/samplebrain { };
+
   scsh = callPackage ../development/interpreters/scsh { };
 
   scheme48 = callPackage ../development/interpreters/scheme48 { };


### PR DESCRIPTION
A custom sample mashing app designed by Aphex Twin, created by Dave Griffiths!

Recently shared by Warp Records [on twitter](https://twitter.com/WarpRecords/status/1573716350794698756?s=20&t=AyXKHfpELQMkasnJup3DIw).

Can confirm, it's good fun :)

![Screenshot from 2022-09-25 22-06-25](https://user-images.githubusercontent.com/4587373/192142574-d1e4ce4b-1065-4032-97d8-c6af4ef0ab95.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


