### PR TITLE
lidarr: 0.8.1.2135 -> 1.0.2.2592

### DIFF
--- a/pkgs/servers/lidarr/default.nix
+++ b/pkgs/servers/lidarr/default.nix
@@ -1,35 +1,52 @@
-{ lib, stdenv, fetchurl, mono, libmediainfo, sqlite, curl, chromaprint, makeWrapper }:
+{ lib, stdenv, fetchurl, mono, libmediainfo, sqlite, curl, chromaprint, makeWrapper, icu, dotnet-runtime, openssl, nixosTests }:
 
-stdenv.mkDerivation rec {
+let
+  os = if stdenv.isDarwin then "osx" else "linux";
+  arch = {
+    x86_64-linux = "x64";
+    aarch64-linux = "arm64";
+    x86_64-darwin = "x64";
+  }."${stdenv.hostPlatform.system}" or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+  hash = {
+    x64-linux_hash = "sha256-iuI24gT7/RFZ9xc4csd+zWEzPSPsxqYY5F+78IWRjxQ=";
+    arm64-linux_hash = "sha256-yHAoZxLeKF6mlR/Av0EH0Lh2XquM9Vx6huNDTEs4wyU=";
+    x64-osx_hash = "sha256-ES6njZTSfd/36+RvibE1hlQlCT+hEEcOem8epBSsnXc=";
+  }."${arch}-${os}_hash";
+in stdenv.mkDerivation rec {
   pname = "lidarr";
-  version = "0.8.1.2135";
+  version = "1.0.2.2592";
 
   src = fetchurl {
-    url = "https://github.com/lidarr/Lidarr/releases/download/v${version}/Lidarr.master.${version}.linux.tar.gz";
-    sha256 = "sha256-eJX6t19D2slX68fXSMd/Vix3XSgCVylK+Wd8VH9jsuI=";
+    url = "https://github.com/lidarr/Lidarr/releases/download/v${version}/Lidarr.master.${version}.${os}-core-${arch}.tar.gz";
+    sha256 = hash;
   };
 
   nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
-    mkdir -p $out/bin
-    cp -r * $out/bin/
+    runHook preInstall
 
-    # Mark main executable as executable
-    chmod +x $out/bin/Lidarr.exe
-
-    makeWrapper "${mono}/bin/mono" $out/bin/Lidarr \
-      --add-flags "$out/bin/Lidarr.exe" \
-      --prefix PATH : ${lib.makeBinPath [ chromaprint ]} \
+    mkdir -p $out/{bin,share/${pname}-${version}}
+    cp -r * $out/share/${pname}-${version}/.
+    makeWrapper "${dotnet-runtime}/bin/dotnet" $out/bin/Lidarr \
+      --add-flags "$out/share/${pname}-${version}/Lidarr.dll" \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [
-          curl sqlite libmediainfo ]}
+        curl sqlite libmediainfo icu  openssl ]}
+
+    runHook postInstall
   '';
+
+
+  passthru = {
+    updateScript = ./update.sh;
+    tests.smoke-test = nixosTests.lidarr;
+  };
 
   meta = with lib; {
     description = "A Usenet/BitTorrent music downloader";
     homepage = "https://lidarr.audio/";
     license = licenses.gpl3;
     maintainers = [ maintainers.etu ];
-    platforms = platforms.all;
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
   };
 }

--- a/pkgs/servers/lidarr/update.sh
+++ b/pkgs/servers/lidarr/update.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnused nix-prefetch jq
+
+set -e
+
+dirname="$(dirname "$0")"
+
+updateHash()
+{
+    version=$1
+    arch=$2
+    os=$3
+
+    hashKey="${arch}-${os}_hash"
+
+    url="https://github.com/Lidarr/Lidarr/releases/download/v$version/Lidarr.master.$version.$os-core-$arch.tar.gz"
+    hash=$(nix-prefetch-url --type sha256 $url)
+    sriHash="$(nix hash to-sri --type sha256 $hash)"
+
+    sed -i "s|$hashKey = \"[a-zA-Z0-9\/+-=]*\";|$hashKey = \"$sriHash\";|g" "$dirname/default.nix"
+}
+
+updateVersion()
+{
+    sed -i "s/version = \"[0-9.]*\";/version = \"$1\";/g" "$dirname/default.nix"
+}
+
+currentVersion=$(cd $dirname && nix eval --raw -f ../../.. radarr.version)
+
+latestTag=$(curl https://api.github.com/repos/Lidarr/Lidarr/releases/latest | jq -r ".tag_name")
+latestVersion="$(expr $latestTag : 'v\(.*\)')"
+
+if [[ "$currentVersion" == "$latestVersion" ]]; then
+    echo "Lidarr is up-to-date: ${currentVersion}"
+    exit 0
+fi
+
+updateVersion $latestVersion
+
+updateHash $latestVersion x64 linux
+updateHash $latestVersion arm64 linux
+updateHash $latestVersion x64 osx


### PR DESCRIPTION
###### Description of changes

Changes: https://github.com/Lidarr/Lidarr/releases/tag/v1.0.2.2592 (and previous releases)
One major point is a **switch from Mono to the dotnet runtime**. I based it on https://github.com/NixOS/nixpkgs/blob/master/pkgs/servers/radarr/default.nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
