### PR TITLE
pacman: add missing PATHs

### DIFF
--- a/pkgs/tools/package-management/pacman/default.nix
+++ b/pkgs/tools/package-management/pacman/default.nix
@@ -106,7 +106,7 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/makepkg \
       --prefix PATH : ${lib.makeBinPath [ binutils ]}
     wrapProgram $out/bin/pacman-key \
-      --prefix PATH : ${lib.makeBinPath [ gnupg ]}
+      --prefix PATH : ${lib.makeBinPath [ "${placeholder "out"}" gnupg ]}
   '';
 
   meta = with lib; {

--- a/pkgs/tools/package-management/pacman/default.nix
+++ b/pkgs/tools/package-management/pacman/default.nix
@@ -4,7 +4,6 @@
 , fetchurl
 , asciidoc
 , binutils
-, bzip2
 , coreutils
 , curl
 , gnupg
@@ -17,8 +16,18 @@
 , openssl
 , perl
 , pkg-config
-, xz
 , zlib
+
+# Compression tools in scripts/libmakepkg/util/compress.sh.in
+, gzip
+, bzip2
+, xz
+, zstd
+, lrzip
+, lzop
+, ncompress
+, lz4
+, lzip
 
 # Tells pacman where to find ALPM hooks provided by packages.
 # This path is very likely to be used in an Arch-like root.
@@ -44,13 +53,11 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    bzip2
     curl
     gpgme
     libarchive
     openssl
     perl
-    xz
     zlib
   ];
 
@@ -63,7 +70,18 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  postPatch = ''
+  postPatch = let compressionTools = [
+    gzip
+    bzip2
+    xz
+    zstd
+    lrzip
+    lzop
+    ncompress
+    lz4
+    lzip
+  ]; in ''
+    echo 'export PATH=${lib.makeBinPath compressionTools}:$PATH' >> scripts/libmakepkg/util/compress.sh.in
     substituteInPlace meson.build \
       --replace "install_dir : SYSCONFDIR" "install_dir : '$out/etc'" \
       --replace "join_paths(DATAROOTDIR, 'libalpm/hooks/')" "'${sysHookDir}'" \


### PR DESCRIPTION
###### Description of changes

Adding compression tools to `buildInputs` doesn't seem to affect `repo-add` script. Let's add them to the `PATH` of `compress.sh` instead. Now `repo-add` should work in a pure shell.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
