### PR TITLE
chkservice: pull fix for gcc-11

### DIFF
--- a/pkgs/tools/admin/chkservice/default.nix
+++ b/pkgs/tools/admin/chkservice/default.nix
@@ -1,4 +1,13 @@
-{ stdenv, fetchFromGitHub, cmake, ninja, pkg-config, systemd, ncurses, lib }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, ninja
+, pkg-config
+, systemd
+, ncurses
+}:
 
 stdenv.mkDerivation rec {
   pname = "chkservice";
@@ -8,8 +17,18 @@ stdenv.mkDerivation rec {
     owner = "linuxenko";
     repo = "chkservice";
     rev = version;
-    hash = "sha256:0dfvm62h6dwg18f17fn58nr09mfh6kylm8wy88j00fiy13l4wnb6";
+    hash = "sha256-ZllO6Ag+OgAkQp6jSv000NUEskXFuhMcCo83A4Wp2zU=";
   };
+
+  patches = [
+    # Pull fix pending upstream inclusion for gcc-11 support:
+    #   https://github.com/linuxenko/chkservice/pull/38
+    (fetchpatch {
+      name = "gcc-11.patch";
+      url = "https://github.com/linuxenko/chkservice/commit/26b12a7918c8a3bc449c92b458e6cd5c2d7b2e05.patch";
+      hash = "sha256-LaJLlqRyn1eoahbW2X+hDSt8iV4lhNRn0j0kLHB+RhM=";
+    })
+  ];
 
   # Tools needed during build time
   nativeBuildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -208,9 +208,7 @@ with pkgs;
       }
     '');
 
-  chkservice = callPackage ../tools/admin/chkservice {
-    stdenv = gcc10StdenvCompat;
-  };
+  chkservice = callPackage ../tools/admin/chkservice { };
 
   addOpenGLRunpath = callPackage ../build-support/add-opengl-runpath { };
 


### PR DESCRIPTION
Without the change build fails on gcc-11 as:

    src/chk-systemd.cpp: In member function 'const char* ChkBus::getState(const char*)':
    src/chk-systemd.cpp:120:15: error: ordered comparison of pointer with integer zero ('const char*' and 'int')
      120 |     if (state < 0) {
          |         ~~~~~~^~~

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
