### PR TITLE
openblas: Enable & honour parallel building

### DIFF
--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -174,6 +174,8 @@ stdenv.mkDerivation rec {
     buildPackages.stdenv.cc
   ];
 
+  enableParallelBuilding = true;
+
   makeFlags = mkMakeFlagsFromConfig (config // {
     FC = "${stdenv.cc.targetPrefix}gfortran";
     CC = "${stdenv.cc.targetPrefix}${if stdenv.cc.isClang then "clang" else "cc"}";
@@ -191,6 +193,10 @@ stdenv.mkDerivation rec {
     NO_BINARY_MODE = if stdenv.isx86_64
         then toString (stdenv.hostPlatform != stdenv.buildPlatform)
         else stdenv.hostPlatform != stdenv.buildPlatform;
+    # This disables automatic build job count detection (which honours neither enableParallelBuilding nor NIX_BUILD_CORES)
+    # and uses the main make invocation's job count, falling back to 1 if no parallelism is used.
+    # https://github.com/xianyi/OpenBLAS/blob/v0.3.20/getarch.c#L1781-L1792
+    MAKE_NB_JOBS = 0;
   } // (lib.optionalAttrs singleThreaded {
     # As described on https://github.com/xianyi/OpenBLAS/wiki/Faq/4bded95e8dc8aadc70ce65267d1093ca7bdefc4c#multi-threaded
     USE_THREAD = false;


### PR DESCRIPTION
###### Description of changes

Currently, `openblas` doesn't set `enableParallelBuilding` (which means that it should build without any parallelism, which it obviously doesn't) and uses as many jobs as the build machine has cores due to some [custom detection code](https://github.com/xianyi/OpenBLAS/blob/v0.3.20/getarch.c#L1781-L1792).

![Bildschirmfoto von 2022-09-25 17-18-48](https://user-images.githubusercontent.com/23431373/192152942-f6bf57cb-9019-4957-bca8-6c10ef081f50.png)
This is a build with `--cores 6`. Note the lack of a `-j` setting in the main `make`, and a mysterious `-j 48` in a `make` subprocess.

This PR:

1. Sets `enableParallelBuilding` to properly enable build parallelism.
2. Sets the `MAKE_NB_JOBS` `makeFlag` to 0, which disables the custom job count detection and properly uses the main `make` invocation's `-j` count if set (which automatically acts like `-j1` if no parallelism is set).
The alternative is to keep dealing with the custom detection, setting `NO_PARALLEL_MAKE=1` in `buildFlags` / `checkFlags` when `enableParallelBuilding` / `enableParallelChecking` is enabled and `MAKE_NB_JOBS` to `$NIX_BUILD_CORES`, but there's really no benefit in doing so when we can just tell it to act "normal". :wink:

I've tested `--cores` values 1, 6, 9, 24 as well as unsetting `enableParallelBuilding`, all of which work & properly honour the desired core setting now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
