### PR TITLE
plasma5Packages.kzones: init at 0.3

### DIFF
--- a/pkgs/desktops/plasma-5/3rdparty/kwin/scripts/kzones.nix
+++ b/pkgs/desktops/plasma-5/3rdparty/kwin/scripts/kzones.nix
@@ -1,0 +1,40 @@
+{ lib, mkDerivation, fetchFromGitHub
+, kcoreaddons, kwindowsystem, plasma-framework, systemsettings }:
+
+mkDerivation rec {
+  pname = "kzones";
+  version = "0.3";
+
+  src = fetchFromGitHub {
+    owner = "gerritdevriese";
+    repo = "kzones";
+    rev = "v${version}";
+    sha256 = "sha256-o7ItUHPayR0wnySssWvtVAaMRa9A1m778FY500hXHXQ=";
+  };
+
+  buildInputs = [
+    kcoreaddons kwindowsystem plasma-framework systemsettings
+  ];
+
+  dontBuild = true;
+
+  # 1. --global still installs to $HOME/.local/share so we use --packageroot
+  # 2. plasmapkg2 doesn't copy metadata.desktop into place, so we do that manually
+  installPhase = ''
+    runHook preInstall
+
+    plasmapkg2 --type kwinscript --install ${src} --packageroot $out/share/kwin/scripts
+    install -Dm644 ${src}/metadata.desktop $out/share/kservices5/kwin-script-kzones.desktop
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "KWin Script for snapping windows into zones";
+    maintainers = with maintainers; [ matthiasbeyer ];
+    license = licenses.gpl3Plus;
+    inherit (src.meta) homepage;
+    inherit (kwindowsystem.meta) platforms;
+  };
+}
+

--- a/pkgs/desktops/plasma-5/default.nix
+++ b/pkgs/desktops/plasma-5/default.nix
@@ -162,6 +162,7 @@ let
         krohnkite = callPackage ./3rdparty/kwin/scripts/krohnkite.nix { };
         krunner-ssh = callPackage ./3rdparty/addons/krunner-ssh.nix { };
         krunner-symbols = callPackage ./3rdparty/addons/krunner-symbols.nix { };
+        kzones = callPackage ./3rdparty/kwin/scripts/kzones.nix { };
         lightly = callPackage ./3rdparty/lightly { };
         parachute = callPackage ./3rdparty/kwin/scripts/parachute.nix { };
       };


### PR DESCRIPTION
Waiting for https://github.com/gerritdevriese/kzones/issues/3

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
