### PR TITLE
wasm3: add many knownVulnerabilities

### DIFF
--- a/pkgs/development/interpreters/wasm3/default.nix
+++ b/pkgs/development/interpreters/wasm3/default.nix
@@ -29,5 +29,18 @@ stdenv.mkDerivation rec {
     platforms = platforms.all;
     maintainers = with maintainers; [ malbarbo ];
     license = licenses.mit;
+    knownVulnerabilities = [
+      # wasm3 expects all wasm code to be pre-validated, any users
+      # should be aware that running unvalidated wasm will potentially
+      # lead to RCE until upstream have added a builtin validator
+      "CVE-2022-39974"
+      "CVE-2022-34529"
+      "CVE-2022-28990"
+      "CVE-2022-28966"
+      "CVE-2021-45947"
+      "CVE-2021-45946"
+      "CVE-2021-45929"
+      "CVE-2021-38592"
+    ];
   };
 }


### PR DESCRIPTION
###### Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2022-39974
https://nvd.nist.gov/vuln/detail/CVE-2022-34529
https://nvd.nist.gov/vuln/detail/CVE-2022-28990
https://nvd.nist.gov/vuln/detail/CVE-2022-28966
https://nvd.nist.gov/vuln/detail/CVE-2021-45947
https://nvd.nist.gov/vuln/detail/CVE-2021-45946
https://nvd.nist.gov/vuln/detail/CVE-2021-45929
https://nvd.nist.gov/vuln/detail/CVE-2021-38592

`wasm3` expects all wasm code to be pre-validated, any users should be aware that running unvalidated wasm will potentially lead to RCE until upstream have added a builtin validator.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
