### PR TITLE
dropbox-cli: mark broken

### DIFF
--- a/pkgs/applications/networking/dropbox/cli.nix
+++ b/pkgs/applications/networking/dropbox/cli.nix
@@ -66,5 +66,7 @@ stdenv.mkDerivation {
     license = lib.licenses.gpl3Plus;
     # NOTE: Dropbox itself only works on linux, so this is ok.
     platforms = lib.platforms.linux;
+    # Download 404 error + make: No targets specified and no makefile found.
+    broken = true; # at 2022-09-25
   };
 }


### PR DESCRIPTION
dropbox-cli: mark broken

![image](https://user-images.githubusercontent.com/5861043/192165754-64e70113-d981-41b1-996c-9df42287849c.png)
logs: https://termbin.com/ptay

I've tried release from GitHub:
![image](https://user-images.githubusercontent.com/5861043/192165800-d7821d41-414d-4d53-9b51-30c1ceca0942.png)

But errors as:
![image](https://user-images.githubusercontent.com/5861043/192165809-9a26977e-1025-48e1-b177-ccab318336fe.png)

I have no interest in digging further into this package.

---

All of a sudden this package is downloading again!!! And working!!! Flaky connection???