### PR TITLE
GNOME/Cinnamon/Pantheon: Clean up GSettings overrides and make strict

### DIFF
--- a/pkgs/desktops/cinnamon/cinnamon-gsettings-overrides/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-gsettings-overrides/default.nix
@@ -20,6 +20,8 @@
 
 let
 
+  inherit (lib) concatMapStringsSep;
+
   gsettingsOverridePackages = [
     # from
     mint-artwork
@@ -38,22 +40,21 @@ let
 
 in
 
-with lib;
-
 # TODO: Having https://github.com/NixOS/nixpkgs/issues/54150 would supersede this
-runCommand "cinnamon-gsettings-overrides" { }
+runCommand "cinnamon-gsettings-overrides" { preferLocalBuild = true; }
   ''
-    schema_dir=$out/share/gsettings-schemas/nixos-gsettings-overrides/glib-2.0/schemas
+    data_dir="$out/share/gsettings-schemas/nixos-gsettings-overrides"
+    schema_dir="$data_dir/glib-2.0/schemas"
 
-    mkdir -p $schema_dir
+    mkdir -p "$schema_dir"
 
-    ${concatMapStrings (pkg: "cp -rf ${glib.getSchemaPath pkg}/*.xml ${glib.getSchemaPath pkg}/*.gschema.override $schema_dir\n") gsettingsOverridePackages}
+    ${concatMapStringsSep "\n" (pkg: "cp -rf \"${glib.getSchemaPath pkg}\"/*.xml \"${glib.getSchemaPath pkg}\"/*.gschema.override \"$schema_dir\"") gsettingsOverridePackages}
 
-    chmod -R a+w $out/share/gsettings-schemas/nixos-gsettings-overrides
+    chmod -R a+w "$data_dir"
 
-    cat - > $schema_dir/nixos-defaults.gschema.override <<- EOF
+    cat - > "$schema_dir/nixos-defaults.gschema.override" <<- EOF
     ${extraGSettingsOverrides}
     EOF
 
-    ${glib.dev}/bin/glib-compile-schemas $schema_dir
+    ${glib.dev}/bin/glib-compile-schemas "$schema_dir"
   ''

--- a/pkgs/desktops/cinnamon/cinnamon-gsettings-overrides/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-gsettings-overrides/default.nix
@@ -56,5 +56,5 @@ runCommand "cinnamon-gsettings-overrides" { preferLocalBuild = true; }
     ${extraGSettingsOverrides}
     EOF
 
-    ${glib.dev}/bin/glib-compile-schemas "$schema_dir"
+    ${glib.dev}/bin/glib-compile-schemas --strict "$schema_dir"
   ''

--- a/pkgs/desktops/gnome/default.nix
+++ b/pkgs/desktops/gnome/default.nix
@@ -123,6 +123,8 @@ lib.makeScope pkgs.newScope (self: with self; {
     withGnome = true;
   };
 
+  nixos-gsettings-overrides = callPackage ./nixos/gsettings-overrides { };
+
   rygel = callPackage ./core/rygel { };
 
   simple-scan = callPackage ./core/simple-scan { };

--- a/pkgs/desktops/gnome/nixos/gsettings-overrides/default.nix
+++ b/pkgs/desktops/gnome/nixos/gsettings-overrides/default.nix
@@ -51,5 +51,5 @@ runCommand "gnome-gsettings-overrides" { preferLocalBuild = true; } ''
   ${gsettingsOverrides}
   EOF
 
-  ${glib.dev}/bin/glib-compile-schemas "$schema_dir"
+  ${glib.dev}/bin/glib-compile-schemas --strict "$schema_dir"
 ''

--- a/pkgs/desktops/gnome/nixos/gsettings-overrides/default.nix
+++ b/pkgs/desktops/gnome/nixos/gsettings-overrides/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, runCommand
+, gsettings-desktop-schemas
+, gnome-shell
+, glib
+, gnome-flashback
+, nixos-artwork
+, nixos-background-light ? nixos-artwork.wallpapers.simple-blue
+, nixos-background-dark ? nixos-artwork.wallpapers.simple-dark-gray
+, extraGSettingsOverrides ? ""
+, extraGSettingsOverridePackages ? [ ]
+, favoriteAppsOverride ? ""
+, flashbackEnabled ? false
+}:
+
+let
+
+  inherit (lib) concatMapStringsSep;
+
+  gsettingsOverridePackages = [
+    gsettings-desktop-schemas
+    gnome-shell
+  ] ++ lib.optionals flashbackEnabled [
+    gnome-flashback
+  ] ++ extraGSettingsOverridePackages;
+
+  gsettingsOverrides = ''
+    [org.gnome.desktop.background]
+    picture-uri='file://${nixos-background-light.gnomeFilePath}'
+    picture-uri-dark='file://${nixos-background-dark.gnomeFilePath}'
+
+    [org.gnome.desktop.screensaver]
+    picture-uri='file://${nixos-background-dark.gnomeFilePath}'
+
+    ${favoriteAppsOverride}
+
+    ${extraGSettingsOverrides}
+  '';
+
+in
+
+runCommand "gnome-gsettings-overrides" { preferLocalBuild = true; } ''
+  data_dir="$out/share/gsettings-schemas/nixos-gsettings-overrides"
+  schema_dir="$data_dir/glib-2.0/schemas"
+  mkdir -p "$schema_dir"
+
+  ${concatMapStringsSep "\n" (pkg: "cp -rf \"${glib.getSchemaPath pkg}\"/*.xml \"${glib.getSchemaPath pkg}\"/*.gschema.override \"$schema_dir\"") gsettingsOverridePackages}
+
+  chmod -R a+w "$data_dir"
+  cat - > "$schema_dir/nixos-defaults.gschema.override" <<- EOF
+  ${gsettingsOverrides}
+  EOF
+
+  ${glib.dev}/bin/glib-compile-schemas "$schema_dir"
+''

--- a/pkgs/desktops/pantheon/desktop/elementary-gsettings-schemas/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-gsettings-schemas/default.nix
@@ -10,10 +10,12 @@
 , elementary-dock
 , gsettings-desktop-schemas
 , extraGSettingsOverrides ? ""
-, extraGSettingsOverridePackages ? []
+, extraGSettingsOverridePackages ? [ ]
 }:
 
 let
+
+  inherit (lib) concatMapStringsSep;
 
   gsettingsOverridePackages = [
     elementary-dock
@@ -27,25 +29,24 @@ let
 
 in
 
-with lib;
 
 # TODO: Having https://github.com/NixOS/nixpkgs/issues/54150 would supersede this
-runCommand "elementary-gsettings-desktop-schemas" {}
+runCommand "elementary-gsettings-desktop-schemas" { preferLocalBuild = true; }
   ''
-     schema_dir=$out/share/gsettings-schemas/nixos-gsettings-overrides/glib-2.0/schemas
+    data_dir="$out/share/gsettings-schemas/nixos-gsettings-overrides"
+    schema_dir="$data_dir/glib-2.0/schemas"
 
-     mkdir -p $schema_dir
+    mkdir -p "$schema_dir"
+    cp -rf "${glib.getSchemaPath gala}"/*.gschema.override "$schema_dir"
 
-     cp -rf ${glib.getSchemaPath gala}/*.gschema.override $schema_dir
+    ${concatMapStringsSep "\n" (pkg: "cp -rf \"${glib.getSchemaPath pkg}\"/*.xml \"$schema_dir\"") gsettingsOverridePackages}
 
-     ${concatMapStrings (pkg: "cp -rf ${glib.getSchemaPath pkg}/*.xml $schema_dir\n") gsettingsOverridePackages}
+    chmod -R a+w "$data_dir"
+    cp "${glib.getSchemaPath elementary-default-settings}"/* "$schema_dir"
 
-     chmod -R a+w $out/share/gsettings-schemas/nixos-gsettings-overrides
-     cp ${glib.getSchemaPath elementary-default-settings}/* $schema_dir
+    cat - > "$schema_dir/nixos-defaults.gschema.override" <<- EOF
+    ${extraGSettingsOverrides}
+    EOF
 
-     cat - > $schema_dir/nixos-defaults.gschema.override <<- EOF
-     ${extraGSettingsOverrides}
-     EOF
-
-     ${glib.dev}/bin/glib-compile-schemas $schema_dir
+    ${glib.dev}/bin/glib-compile-schemas $schema_dir
   ''


### PR DESCRIPTION
###### Description of changes

Otherwise people will just miss errors in their overrides and be confused why they do not work.

While at it, also bring it more in line with Pantheon & Cinnamon and vice versa, and clean up the modules.

Cannot enable strict mode in Pantheon since the defaults will fail:

> No such key “show-unicode-menu” in schema “org.gnome.desktop.interface:Pantheon” as specified in override file “/nix/store/di6j4l0fhkyz76nysxqzry65c0pk0h83-elementary-gsettings-desktop-schemas/share/gsettings-schemas/nixos-gsettings-overrides/glib-2.0/schemas/default-settings.gschema.override” and --strict was specified; exiting.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
