### PR TITLE
rocm-smi: fix runtime

### DIFF
--- a/pkgs/tools/system/rocm-smi/default.nix
+++ b/pkgs/tools/system/rocm-smi/default.nix
@@ -32,14 +32,10 @@ stdenv.mkDerivation rec {
     substituteInPlace oam/CMakeLists.txt \
       --replace "DESTINATION oam/" "DESTINATION " \
       --replace 'DESTINATION ''${OAM_NAME}/' "DESTINATION "
-
-    # Update relative path to librocm_smi64 in the Python binding.
-    substituteInPlace python_smi_tools/rsmiBindings.py \
-      --replace "/../lib/librocm_smi64.so" "/../../librocm_smi64.so"
   '';
 
   postInstall = ''
-    wrapPythonProgramsIn $out/bin
+    wrapPythonProgramsIn $out
   '';
 
   passthru.updateScript = writeScript "update.sh" ''


### PR DESCRIPTION
###### Description of changes

seems like #187851 didn't test this
@lovesegfault considering you're listed as this package's maintainer, i'm surprised you didn't test it before merging that change

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).