### PR TITLE
ruffle: nightly-2022-02-02 -> nightly-2022-09-26

### DIFF
--- a/pkgs/applications/emulators/ruffle/default.nix
+++ b/pkgs/applications/emulators/ruffle/default.nix
@@ -9,27 +9,39 @@
 , wayland
 , xorg
 , vulkan-loader
+, jre_minimal
+, cairo
+, gtk3
+, wrapGAppsHook
+, gsettings-desktop-schemas
+, glib
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "ruffle";
-  version = "nightly-2022-02-02";
+  version = "nightly-2022-09-26";
 
   src = fetchFromGitHub {
     owner = "ruffle-rs";
     repo = pname;
     rev = version;
-    sha256 = "sha256-AV3zGfWacYdkyxHED1nGwTqRHhXpybaCVnudmHqWvqw=";
+    sha256 = "sha256-o0geKXODFRPKN4JgW+Sg16uPhBS5rrlMCmFSc9AcNPQ=";
   };
 
   nativeBuildInputs = [
+    glib
+    gsettings-desktop-schemas
+    jre_minimal
     makeWrapper
     pkg-config
     python3
+    wrapGAppsHook
   ];
 
   buildInputs = [
     alsa-lib
+    cairo
+    gtk3
     openssl
     wayland
     xorg.libX11
@@ -41,14 +53,25 @@ rustPlatform.buildRustPackage rec {
     vulkan-loader
   ];
 
-  postInstall = ''
+  dontWrapGApps = true;
+
+  postFixup = ''
     # This name is too generic
     mv $out/bin/exporter $out/bin/ruffle_exporter
 
-    wrapProgram $out/bin/ruffle_desktop --prefix LD_LIBRARY_PATH ':' ${vulkan-loader}/lib
+    vulkanWrapperArgs+=(
+      --prefix LD_LIBRARY_PATH ':' ${vulkan-loader}/lib
+    )
+
+    wrapProgram $out/bin/ruffle_exporter \
+      "''${vulkanWrapperArgs[@]}"
+
+    wrapProgram $out/bin/ruffle_desktop \
+      "''${vulkanWrapperArgs[@]}" \
+      "''${gappsWrapperArgs[@]}"
   '';
 
-  cargoSha256 = "sha256-LP9aHcey+e3fqtWdOkqF5k8dwjdAOKpP+mKGxFhTte0=";
+  cargoSha256 = "sha256-erqBuU66k7SGG9ueyYEINjeXbyC7A2I/r1bBqdsJemY=";
 
   meta = with lib; {
     description = "An Adobe Flash Player emulator written in the Rust programming language.";


### PR DESCRIPTION
###### Description of changes

Although there isn't a changelog for Ruffle, quite a lot has improved since last nightly, including the beginnings of AVM3 support.

We now need a valid JRE (only during build, to run the ActionScript compiler) and for ruffle desktop, GTK+3. In order to avoid unnecessarily wrapping every binary, and also to avoid double-wrapping, `wrapGAppsHook` is used with `dontWrapGApps = true`, then we use `"''${gappsWrapperArgs[@]}"` in the existing call to `wrapProgram` for `ruffle_desktop`. We need the file dialog schemas, so `gsettings-desktop-schemas` is added to nativeBuildInputs. We need the `glib` hook that adds schemas to the `XDG_CONFIG_PATH`, so `glib` is added to `nativeBuildInputs`, and `postInstall` is changed to `postFixup` to ensure that `gappsWrapperArgs` is set for us.

I believe this is the minimal necessary changes to make sure that it will work properly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).