### PR TITLE
nil: unstable-2022-09-19 -> 2022-09-26

### DIFF
--- a/pkgs/development/tools/nil/default.nix
+++ b/pkgs/development/tools/nil/default.nix
@@ -1,26 +1,31 @@
-{ lib, rustPlatform, fetchFromGitHub }:
-
-let
-  date = "2022-09-19";
-in
+{ lib, rustPlatform, fetchFromGitHub, nix, nix-update-script }:
 
 rustPlatform.buildRustPackage rec {
   pname = "nil";
-  version = "unstable-${date}";
+  version = "2022-09-26";
 
   src = fetchFromGitHub {
     owner = "oxalica";
     repo = pname;
-    rev = date;
-    sha256 = "sha256-WdBRfp0shz6Xhwx0fEUQwROK52XNDTkmhC2xkdT+INA=";
+    rev = version;
+    hash = "sha256-2bcAXcJiFV+xKSIy3oD2/TkijV4302jAtTF3xtHiOhU=";
   };
 
-  cargoSha256 = "sha256-J1CRe5xPl428mwOO4kDxLyPBc0mtzl3iU4mUqW5d4+E=";
+  cargoHash = "sha256-RL9n2kfWPpu17qudqSx5DkZbgxqVCf2IRBu/koCAqFA=";
 
-  CFG_DATE = date;
+  CFG_DATE = version;
+  CFG_REV = "release";
+
+  nativeBuildInputs = [
+    (lib.getBin nix)
+  ];
+
+  passthru.updateScript = nix-update-script {
+    attrPath = pname;
+  };
 
   meta = with lib; {
-    description = "A language server for Nix Expression Language";
+    description = "Yet another language server for Nix";
     homepage = "https://github.com/oxalica/nil";
     license = with licenses; [ mit asl20 ];
     maintainers = with maintainers; [ figsoda oxalica ];


### PR DESCRIPTION
###### Description of changes

https://github.com/oxalica/nil/releases/tag/2022-09-26

Note: The date string is the official release name. It does not satisfy "a package is not a release but a commit from a repository" from [nixpkgs manual](https://nixos.org/manual/nixpkgs/unstable/#sec-package-naming). We could remove the `unstable` prefix.

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>nil</li>
  </ul>
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
