### PR TITLE
luabridge: init at 2.8

### DIFF
--- a/pkgs/development/libraries/luabridge/default.nix
+++ b/pkgs/development/libraries/luabridge/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "luabridge";
+  version = "2.8";
+
+  src = fetchFromGitHub {
+    owner = "vinniefalco";
+    repo = "LuaBridge";
+    rev = version;
+    sha256 = "sha256-gXrBNzE41SH98Xz480+uHQlxHjMHzs23AImxil5LZ0g=";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/include
+    cp -r Source/LuaBridge $out/include
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A lightweight, dependency-free library for binding Lua to C++";
+    homepage = "https://github.com/vinniefalco/LuaBridge";
+    changelog = "https://github.com/vinniefalco/LuaBridge/blob/${version}/CHANGES.md";
+    platforms = platforms.unix;
+    license = licenses.mit;
+    maintainers = with maintainers; [ ivar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20699,6 +20699,8 @@ with pkgs;
 
   luabind_luajit = luabind.override { lua = luajit; };
 
+  luabridge = callPackage ../development/libraries/luabridge { };
+
   luksmeta = callPackage ../development/libraries/luksmeta {
     asciidoc = asciidoc-full;
   };


### PR DESCRIPTION
###### Description of changes
This adds [luabridge](https://github.com/vinniefalco/LuaBridge), a lightweight, dependency-free library for binding Lua to C++.

Tested with a personal project of mine, works just as expected.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and “core” functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
