### PR TITLE
calamares: fix errors and update modules

### DIFF
--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-calamares.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-calamares.nix
@@ -16,5 +16,10 @@ in
     calamares-nixos-extensions
     # Needed for calamares QML module packagechooserq
     libsForQt5.full
+    # Get list of locales
+    glibcLocales
   ];
+
+  # Support choosing from any locale
+  i18n.supportedLocales = [ "all" ];
 }

--- a/pkgs/development/libraries/glibc/locales.nix
+++ b/pkgs/development/libraries/glibc/locales.nix
@@ -64,8 +64,9 @@ callPackage ./common.nix { inherit stdenv; } {
 
   installPhase =
     ''
-      mkdir -p "$out/lib/locale"
+      mkdir -p "$out/lib/locale" "$out/share/i18n"
       cp -v "$TMPDIR/$NIX_STORE/"*"/lib/locale/locale-archive" "$out/lib/locale"
+      cp -v ../glibc-2*/localedata/SUPPORTED "$out/share/i18n/SUPPORTED"
     '';
 
   setupHook = writeText "locales-setup-hook.sh"

--- a/pkgs/tools/misc/calamares-nixos-extensions/default.nix
+++ b/pkgs/tools/misc/calamares-nixos-extensions/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "calamares-nixos-extensions";
-  version = "0.3.10";
+  version = "0.3.11";
 
   src = fetchFromGitHub {
     owner = "NixOS";
     repo = "calamares-nixos-extensions";
     rev = version;
-    sha256 = "YJyK0rsrftrCwYD+aCAkPe/kAqUXsP/4WBAGtNKIGj8=";
+    sha256 = "NAHUU0tQLu8c2dke1V0aM3mHrNgM8ekHSB2Fo9dQUk8=";
   };
 
   installPhase = ''

--- a/pkgs/tools/misc/calamares/default.nix
+++ b/pkgs/tools/misc/calamares/default.nix
@@ -36,6 +36,8 @@ mkDerivation rec {
     # Fix setting the kayboard layout on GNOME wayland
     # By default the module uses the setxkbmap, which will not change the keyboard
     ./waylandkbd.patch
+    # Change default location where calamares searches for locales
+    ./supportedlocale.patch
   ];
 
   nativeBuildInputs = [ cmake extra-cmake-modules ];

--- a/pkgs/tools/misc/calamares/supportedlocale.patch
+++ b/pkgs/tools/misc/calamares/supportedlocale.patch
@@ -1,0 +1,13 @@
+diff --git a/src/modules/locale/Config.cpp b/src/modules/locale/Config.cpp
+index 2357019a7..75b547430 100644
+--- a/src/modules/locale/Config.cpp
++++ b/src/modules/locale/Config.cpp
+@@ -48,7 +48,7 @@ loadLocales( const QString& localeGenPath )
+     // supported locales. We first try that one, and if it doesn't exist, we fall back
+     // to parsing the lines from locale.gen
+     localeGenLines.clear();
+-    QFile supported( "/usr/share/i18n/SUPPORTED" );
++    QFile supported( "/run/current-system/sw/share/i18n/SUPPORTED" );
+     QByteArray ba;
+ 
+     if ( supported.exists() && supported.open( QIODevice::ReadOnly | QIODevice::Text ) )


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Same as #184061 without pinging everyone and targeting staging.

Changes that fix the calamares installer on unstable, update versions, and add more stability by adding a backup network check url.

###### Things done

- Update calamares to 0.3.59
- Add SUPPORTED file to glibcLocales
- Make calamares read that SUPPORTED files to find suitable locales
  - fixes #180935
  - Caused as a side effect of #177318
- Add https://cache.nixos.org connectivity check
  - fixes https://github.com/NixOS/calamares-nixos-extensions/issues/11

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
