### PR TITLE
protonup-ng: init at 0.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5631,6 +5631,12 @@
     githubId = 3661115;
     name = "Ingo Blechschmidt";
   };
+  icedborn = {
+    name = "IceDBorn";
+    email = "github.envenomed@dralias.com";
+    github = "IceDBorn";
+    githubId = 51162078;
+  };
   icy-thought = {
     name = "Icy-Thought";
     email = "gilganyx@pm.me";

--- a/pkgs/development/python-modules/protonup-ng/default.nix
+++ b/pkgs/development/python-modules/protonup-ng/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     homepage = "https://github.com/cloudishBenne/protonup-ng";
-    description = "ProtonUp-ng: CLI program and API to automate the installation and update of GloriousEggroll's Proton-GE";
+    description = "CLI program and API to automate the installation and update of GloriousEggroll's Proton-GE";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ icedborn ];
   };

--- a/pkgs/development/python-modules/protonup-ng/default.nix
+++ b/pkgs/development/python-modules/protonup-ng/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildPythonPackage, pythonOlder, fetchPypi, requests, configparser }:
+
+buildPythonPackage rec {
+  pname = "protonup-ng";
+  version = "0.2.1";
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "rys9Noa3+w4phttfcI1OGEDfHMy8s80bm8kM8TzssQA=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "argparse" ""
+  '';
+
+  propagatedBuildInputs = [ requests configparser ];
+
+  doCheck = false; # protonup does not have any tests
+  pythonImportsCheck = [ "protonup" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/cloudishBenne/protonup-ng";
+    description = "ProtonUp-ng: CLI program and API to automate the installation and update of GloriousEggroll's Proton-GE";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ icedborn ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34079,6 +34079,8 @@ with pkgs;
 
   protonup = with python3Packages; toPythonApplication protonup;
 
+  protonup-ng = with python3Packages; toPythonApplication protonup-ng;
+
   steam-rom-manager = callPackage ../tools/games/steam-rom-manager {};
 
   sdlpop = callPackage ../games/sdlpop { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7267,6 +7267,8 @@ in {
 
   protonup = callPackage ../development/python-modules/protonup { };
 
+  protonup-ng = callPackage ../development/python-modules/protonup-ng { };
+
   protonvpn-nm-lib = callPackage ../development/python-modules/protonvpn-nm-lib {
     pkgs-systemd = pkgs.systemd;
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This is a [fork](https://github.com/cloudishBenne/protonup-ng) of AUNaseef's awesome [ProtonUp](https://github.com/AUNaseef/protonup). [cloudishBenne](https://github.com/cloudishBenne) will maintain this fork until [AUNaseef](https://github.com/AUNaseef) pulls all needed changes for the new versioning scheme of GE-Proton into his codebase.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
