### PR TITLE
process-viewer: init at 0.5.5

### DIFF
--- a/pkgs/applications/misc/process-viewer/default.nix
+++ b/pkgs/applications/misc/process-viewer/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, rustPlatform
+, fetchCrate
+, pkg-config
+, gtk4
+, stdenv
+, DiskArbitration
+, Foundation
+, IOKit
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "process-viewer";
+  version = "0.5.5";
+
+  src = fetchCrate {
+    inherit pname version;
+    sha256 = "sha256-MHVKjbD1/h7G94x6dpyRT/BPWQVUFurW7EvAUJ2xZeU=";
+  };
+
+  cargoSha256 = "sha256-NkJjwB4rBV4hFRwYHILMET8o4x1+95sVsFqNaVN8tMg=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ gtk4 ] ++ lib.optionals stdenv.isDarwin [
+    DiskArbitration
+    Foundation
+    IOKit
+  ];
+
+  postInstall = ''
+    install -Dm644 assets/fr.guillaume_gomez.ProcessViewer.desktop -t $out/share/applications
+    install -Dm644 assets/fr.guillaume_gomez.ProcessViewer.svg -t $out/share/icons/hicolor/scalable/apps
+    install -Dm644 assets/fr.guillaume_gomez.ProcessViewer.metainfo.xml -t $out/share/metainfo
+  '';
+
+  meta = with lib; {
+    description = "A process viewer GUI in rust";
+    homepage = "https://github.com/guillaumegomez/process-viewer";
+    license = licenses.mit;
+    maintainers = with maintainers; [ figsoda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17104,6 +17104,10 @@ with pkgs;
 
   privacyidea = callPackage ../applications/misc/privacyidea { };
 
+  process-viewer = callPackage ../applications/misc/process-viewer {
+    inherit (darwin.apple_sdk.frameworks) DiskArbitration Foundation IOKit;
+  };
+
   procodile = callPackage ../tools/system/procodile { };
 
   pry = callPackage ../development/tools/pry { };


### PR DESCRIPTION
###### Description of changes

> process-viewer is a process viewer GUI in rust

https://github.com/guillaumegomez/process-viewer

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
