### PR TITLE
[22.05] python3Packages.joblib: add patch for CVE-2022-21797

### DIFF
--- a/pkgs/development/python-modules/joblib/1.1.0-CVE-2022-21797.patch
+++ b/pkgs/development/python-modules/joblib/1.1.0-CVE-2022-21797.patch
@@ -1,0 +1,120 @@
+Combination of upstream b90f10efeb670a2cc877fb88ebb3f2019189e059 and
+54f4d21f098591c77b48c9acfffaa4cf0a45282b adjusted to apply to 1.1.0
+
+diff --git a/joblib/_utils.py b/joblib/_utils.py
+new file mode 100644
+index 0000000..2dbd4f6
+--- /dev/null
++++ b/joblib/_utils.py
+@@ -0,0 +1,44 @@
++# Adapted from https://stackoverflow.com/a/9558001/2536294
++
++import ast
++import operator as op
++
++# supported operators
++operators = {
++    ast.Add: op.add,
++    ast.Sub: op.sub,
++    ast.Mult: op.mul,
++    ast.Div: op.truediv,
++    ast.FloorDiv: op.floordiv,
++    ast.Mod: op.mod,
++    ast.Pow: op.pow,
++    ast.USub: op.neg,
++}
++
++
++def eval_expr(expr):
++    """
++    >>> eval_expr('2*6')
++    12
++    >>> eval_expr('2**6')
++    64
++    >>> eval_expr('1 + 2*3**(4) / (6 + -7)')
++    -161.0
++    """
++    try:
++        return eval_(ast.parse(expr, mode="eval").body)
++    except (TypeError, SyntaxError, KeyError) as e:
++        raise ValueError(
++            f"{expr!r} is not a valid or supported arithmetic expression."
++        ) from e
++
++
++def eval_(node):
++    if isinstance(node, ast.Num):  # <number>
++        return node.n
++    elif isinstance(node, ast.BinOp):  # <left> <operator> <right>
++        return operators[type(node.op)](eval_(node.left), eval_(node.right))
++    elif isinstance(node, ast.UnaryOp):  # <operator> <operand> e.g., -1
++        return operators[type(node.op)](eval_(node.operand))
++    else:
++        raise TypeError(node)
+diff --git a/joblib/parallel.py b/joblib/parallel.py
+index 687557e..6ef9fb3 100644
+--- a/joblib/parallel.py
++++ b/joblib/parallel.py
+@@ -28,6 +28,7 @@ from ._parallel_backends import (FallbackToBackend, MultiprocessingBackend,
+                                  LokyBackend)
+ from .externals.cloudpickle import dumps, loads
+ from .externals import loky
++from ._utils import eval_expr
+ 
+ # Make sure that those two classes are part of the public joblib.parallel API
+ # so that 3rd party backend implementers can import them from here.
+@@ -477,7 +478,9 @@ class Parallel(Logger):
+         pre_dispatch: {'all', integer, or expression, as in '3*n_jobs'}
+             The number of batches (of tasks) to be pre-dispatched.
+             Default is '2*n_jobs'. When batch_size="auto" this is reasonable
+-            default and the workers should never starve.
++            default and the workers should never starve. Note that only basic
++            arithmetics are allowed here and no modules can be used in this
++            expression.
+         batch_size: int or 'auto', default: 'auto'
+             The number of atomic tasks to dispatch at once to each
+             worker. When individual evaluations are very fast, dispatching
+@@ -1012,7 +1015,9 @@ class Parallel(Logger):
+         else:
+             self._original_iterator = iterator
+             if hasattr(pre_dispatch, 'endswith'):
+-                pre_dispatch = eval(pre_dispatch)
++                pre_dispatch = eval_expr(
++                    pre_dispatch.replace("n_jobs", str(n_jobs))
++                )
+             self._pre_dispatch_amount = pre_dispatch = int(pre_dispatch)
+ 
+             # The main thread will consume the first pre_dispatch items and
+diff --git a/joblib/test/test_utils.py b/joblib/test/test_utils.py
+new file mode 100644
+index 0000000..4999a21
+--- /dev/null
++++ b/joblib/test/test_utils.py
+@@ -0,0 +1,27 @@
++import pytest
++
++from joblib._utils import eval_expr
++
++
++@pytest.mark.parametrize(
++    "expr",
++    ["exec('import os')", "print(1)", "import os", "1+1; import os", "1^1"],
++)
++def test_eval_expr_invalid(expr):
++    with pytest.raises(
++        ValueError, match="is not a valid or supported arithmetic"
++    ):
++        eval_expr(expr)
++
++
++@pytest.mark.parametrize(
++    "expr, result",
++    [
++        ("2*6", 12),
++        ("2**6", 64),
++        ("1 + 2*3**(4) / (6 + -7)", -161.0),
++        ("(20 // 3) % 5", 1),
++    ],
++)
++def test_eval_expr_valid(expr, result):
++    assert eval_expr(expr) == result

--- a/pkgs/development/python-modules/joblib/default.nix
+++ b/pkgs/development/python-modules/joblib/default.nix
@@ -22,6 +22,10 @@ buildPythonPackage rec {
     sha256 = "4158fcecd13733f8be669be0683b96ebdbbd38d23559f54dca7205aea1bf1e35";
   };
 
+  patches = [
+    ./1.1.0-CVE-2022-21797.patch
+  ];
+
   checkInputs = [ sphinx numpydoc pytestCheckHook ];
   propagatedBuildInputs = [ lz4 setuptools ];
 


### PR DESCRIPTION
###### Description of changes
https://nvd.nist.gov/vuln/detail/CVE-2022-21797

Single line merge conflict in the imports necessitated bringing patch in-repo.

See #193095 for unstable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
