### PR TITLE
stm8flash: init at 2022-03-27

### DIFF
--- a/pkgs/development/embedded/stm8/stm8flash/default.nix
+++ b/pkgs/development/embedded/stm8/stm8flash/default.nix
@@ -1,0 +1,34 @@
+{ lib, stdenv, fetchFromGitHub, libusb1, pkg-config }:
+
+stdenv.mkDerivation rec {
+  pname = "stm8flash";
+  version = "2022-03-27";
+
+  src = fetchFromGitHub {
+    owner = "vdudouyt";
+    repo = "stm8flash";
+    rev = "23305ce5adbb509c5cb668df31b0fd6c8759639c";
+    sha256 = "sha256-fFoC2EKSmYyW2lqrdAh5A2WEtUMCenKse2ySJdNHu6w=";
+  };
+
+  strictDeps = true;
+  enableParallelBuilding = true;
+
+  # NOTE: _FORTIFY_SOURCE requires compiling with optimization (-O)
+  NIX_CFLAGS_COMPILE = "-O";
+
+  preBuild = ''
+    export DESTDIR=$out;
+  '';
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ libusb1 ];
+
+  meta = with lib; {
+    homepage = "https://github.com/vdudouyt/stm8flash";
+    description = "A tool for flashing STM8 MCUs via ST-LINK (V1 and V2)";
+    maintainers = with maintainers; [ pkharvey ];
+    license = licenses.gpl2;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17361,6 +17361,8 @@ with pkgs;
 
   stm32flash = callPackage ../development/embedded/stm32/stm32flash { };
 
+  stm8flash = callPackage ../development/embedded/stm8/stm8flash { };
+
   strace = callPackage ../development/tools/misc/strace { };
 
   stylua = callPackage ../development/tools/stylua { };


### PR DESCRIPTION
###### Description of changes
Added new package `stm8flash`, for flashing STM8 series of microcontrollers with ST-LINK V1 and V2.
Tested on physical ST-LINK V2 hardware with STM8S103 for read, write and verify.
https://github.com/vdudouyt/stm8flash
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
