### PR TITLE
python310Packages.pgpy: cryptography 38 fix

### DIFF
--- a/pkgs/development/python-modules/pgpy/default.nix
+++ b/pkgs/development/python-modules/pgpy/default.nix
@@ -1,6 +1,14 @@
-{ lib, pythonOlder, fetchFromGitHub, buildPythonPackage
-, six, enum34, pyasn1, cryptography
-, pytestCheckHook }:
+{ lib
+, pythonOlder
+, fetchFromGitHub
+, fetchpatch
+, buildPythonPackage
+, six
+, enum34
+, pyasn1
+, cryptography
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "pgpy";
@@ -10,8 +18,18 @@ buildPythonPackage rec {
     owner = "SecurityInnovation";
     repo = "PGPy";
     rev = "v${version}";
-    sha256 = "03pch39y3hi4ici6y6lvz0j0zram8dw2wvnmq1zyjy3vyvm1ms4a";
+    hash = "sha256-iuga6vZ7eOl/wNVuLnhDVeUPJPibGm8iiyTC4dOA7A4=";
   };
+
+  patches = [
+    # Fixes the issue in https://github.com/SecurityInnovation/PGPy/issues/402.
+    # by pulling in https://github.com/SecurityInnovation/PGPy/pull/403.
+    (fetchpatch {
+      name = "crytography-38-support.patch";
+      url = "https://github.com/SecurityInnovation/PGPy/commit/d84597eb8417a482433ff51dc6b13060d4b2e686.patch";
+      hash = "sha256-dviXCSGtPguROHVZ1bt/eEfpATjehm8jZ5BeVjxdb8U=";
+    })
+  ];
 
   propagatedBuildInputs = [
     six


### PR DESCRIPTION
###### Description of changes

Pull patch from upstream that fixes pgpy after the update to cryptography 38. Needed by https://github.com/NixOS/nixpkgs/pull/191339.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
