### PR TITLE
kubectl: add Krew plugins

### DIFF
--- a/pkgs/applications/networking/cluster/kubernetes/krew-plugins.nix
+++ b/pkgs/applications/networking/cluster/kubernetes/krew-plugins.nix
@@ -1,0 +1,124 @@
+# The Krew repository lists available plugin artifacts in YAML files. This
+# module consumes the Krew repository to automatically create a set of Nix
+# derivations. Most plugins are statically compiled binaries, but some are shell
+# scripts or may have external dependencies (which Krew plugin definitions do
+# not express), so YMMV.
+{ autoPatchelfHook
+, buildPackages
+, fetchFromGitHub
+, go
+, lib
+, stdenv
+, targetPlatform
+}:
+
+let
+  inherit (builtins) filter length elem any;
+  inherit (lib)
+    head nameValuePair assertMsg filesystem id listToAttrs concatStringsSep
+    replaceChars licenses;
+  pluginDerivations = listToAttrs (map
+    (yamlFile:
+      let
+        pluginDefinition = readYaml yamlFile;
+        pluginName = pluginDefinition.metadata.name;
+      in
+      nameValuePair pluginName (mkPlugin pluginDefinition))
+    allPluginDefinitions);
+  mkPlugin = pluginDefinition:
+    let
+      pluginName = pluginDefinition.metadata.name;
+      matchingPlatforms =
+        filter isPlatformMatch pluginDefinition.spec.platforms;
+      selectedPlatform =
+        assert (assertMsg (length matchingPlatforms > 0)
+          "target platform is not supported by plugin ${pluginName}");
+        head matchingPlatforms;
+      # Plugin files to be installed are sometimes listed as from/to-pairs (copy
+      # from foo to bar). The “from” value may be preceeded by a slash, so we
+      # need to force a relative path.
+      copyPluginFilesCommands =
+        if selectedPlatform ? files then
+          map (fromTo: "cp -a ./${fromTo.from} $out/lib/${fromTo.to}")
+            selectedPlatform.files
+        else
+          [ "cp -a * $out/lib" ];
+      # When plugin definitions contain dashes, such as “foo-bar”, Krew
+      # implicitly transforms dashes into underscores. This ensures that the
+      # plugin can be invoked as “kubectl foo-bar”, instead of “kubectl foo
+      # bar”.
+      pluginBinaryName = "kubectl-${replaceChars ["-"] ["_"] pluginName}";
+    in
+    stdenv.mkDerivation {
+      pname = "kubectl-krew-plugin-${pluginName}";
+      version = pluginDefinition.spec.version;
+      src = builtins.fetchurl {
+        url = selectedPlatform.uri;
+        sha256 = selectedPlatform.sha256;
+      };
+      sourceRoot = ".";
+      dontBuild = true;
+      nativeBuildInputs = [ autoPatchelfHook ];
+      installPhase = ''
+        runHook preInstall
+        mkdir -p $out/{bin,lib}
+        ${concatStringsSep "\n" copyPluginFilesCommands}
+        ln -s $out/lib/${selectedPlatform.bin} $out/bin/${pluginBinaryName}
+        runHook postInstall
+      '';
+      meta = {
+        description = pluginDefinition.spec.description or "Plugin for kubectl";
+        platforms =
+          if length matchingPlatforms > 0
+          then [ targetPlatform.system ]
+          else [ ];
+        license = licenses.unfree;
+      };
+    };
+  krewIndex = fetchFromGitHub {
+    owner = "kubernetes-sigs";
+    repo = "krew-index";
+    rev = "400c05bc0e4e64a287a8773435d5d4f45dd615d2";
+    sha256 = "sha256-fIgenKymQO9qD1GQRysB1GRWfdGiMVp88X/MVks8ClE=";
+  };
+  allPluginDefinitions = filesystem.listFilesRecursive "${krewIndex}/plugins";
+  # Krew is using Golang terminology when listing plugin artifacts by platform.
+  targetOs = go.GOOS;
+  targetArch = go.GOARCH;
+  # Krew plugin definitions list artifact URLs in conjunction with selectors to
+  # determine plugin artifacts to install.
+  isPlatformMatch = platform:
+    if platform.selector ? matchExpressions then
+      isPlatformMatchByExpressions platform
+    else
+      (if platform.selector ? matchLabels then
+        isPlatformMatchByLabels platform
+      else
+        abort "unhandled switch case");
+  isPlatformMatchByExpressions = platform:
+    let
+      matchesExpression = expression:
+        assert expression.operator == "In";
+        assert expression.key == "os";
+        elem targetOs expression.values;
+      matchResults = map matchesExpression platform.selector.matchExpressions;
+    in
+    any id matchResults;
+  isPlatformMatchByLabels = platform:
+    let
+      matchesOs = platform.selector.matchLabels.os or targetOs == targetOs;
+      matchesArch = platform.selector.matchLabels.arch or targetArch == targetArch;
+    in
+    matchesOs && matchesArch;
+  readYaml = yamlFile:
+    let
+      jsonFile = buildPackages.runCommand "read-yaml"
+        {
+          allowSubstitutes = false;
+          preferLocalBuild = true;
+        }
+        "${buildPackages.remarshal}/bin/remarshal -if yaml -i ${yamlFile} -of json -o $out";
+    in
+    builtins.fromJSON (builtins.readFile jsonFile);
+in
+pluginDerivations

--- a/pkgs/applications/networking/cluster/kubernetes/kubectl.nix
+++ b/pkgs/applications/networking/cluster/kubernetes/kubectl.nix
@@ -1,4 +1,11 @@
-{ lib, kubernetes }:
+{ buildEnv
+, callPackage
+, kubectl
+, kubernetes
+, lib
+, makeWrapper
+, runCommand
+}:
 
 kubernetes.overrideAttrs (_: rec {
   pname = "kubectl";
@@ -29,4 +36,27 @@ kubernetes.overrideAttrs (_: rec {
     homepage = "https://github.com/kubernetes/kubectl";
     platforms = lib.platforms.unix;
   };
+
+  passthru =
+    let krewPlugins = callPackage ./krew-plugins.nix { };
+    in
+    {
+      withKrewPlugins = selectPlugins:
+        let
+          selectedPlugins = selectPlugins krewPlugins;
+          kubectlWrapper = runCommand "kubectl-with-plugins-wrapper"
+            {
+              nativeBuildInputs = [ makeWrapper ];
+              meta.priority = kubectl.meta.priority or 0 + 1;
+            } ''
+            makeWrapper ${kubectl}/bin/kubectl $out/bin/kubectl \
+              --prefix PATH : ${lib.makeBinPath selectedPlugins}
+          '';
+        in
+        buildEnv {
+          name = "${kubectl.name}-with-plugins";
+          paths = [ kubectlWrapper kubectl ];
+        };
+      inherit krewPlugins;
+    };
 })


### PR DESCRIPTION
###### Description of changes

The Krew plug-in manager for kubectl tracks a set of available kubectl plug-ins. We automatically generate derivations based on plug-in manifests from the Krew plug-in repository. We can then make plug-ins available to kubectl using the “withKrewPlugins” attribute of the kubectl derivation, e.g.:

    kubectl.withKrewPlugins (k: [ k.node-shell ])

Most plug-ins are statically compiled binaries. Some may have additional requirements regarding commands available on the system path, which we cannot handle automatically.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
