### PR TITLE
invoiceplane: mark as broken (missing php8 support)

### DIFF
--- a/pkgs/servers/web-apps/invoiceplane/default.nix
+++ b/pkgs/servers/web-apps/invoiceplane/default.nix
@@ -1,48 +1,17 @@
-{ lib, stdenv, fetchurl, writeText, unzip, nixosTests, fetchpatch }:
+{ lib, stdenv, fetchFromGitHub, writeText, unzip, nixosTests, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "invoiceplane";
   version = "1.5.11";
 
-  src = fetchurl {
-    url = "https://github.com/InvoicePlane/InvoicePlane/releases/download/v${version}/v${version}.zip";
-    sha256 = "137g0xps4kb3j7f5gz84ql18iggbya6d9dnrfp05g2qcbbp8kqad";
+  src = fetchFromGitHub {
+    owner = "InvoicePlane";
+    repo = "InvoicePlane";
+    rev = "7402b3761614d2cdd09836022b195e247922d509";
+    sha256 = "sha256-iiJ1BUjWYD33zzG1vpo2LJ/Tks+MT2x+cR1+PIik46U=";
   };
 
-  patches = [
-
-    # Fix CVE-2021-29024, unauthenticated directory listing
-    # Should be included in a later release > 1.5.11
-    # https://github.com/NixOS/nixpkgs/issues/166655
-    # https://github.com/InvoicePlane/InvoicePlane/pull/754
-    (fetchpatch {
-      url = "https://patch-diff.githubusercontent.com/raw/InvoicePlane/InvoicePlane/pull/754.patch";
-      sha256 = "sha256-EHXw7Zqli/nA3tPIrhxpt8ueXvDtshz0XRzZT78sdQk=";
-    })
-
-    # Fix CVE-2021-29023, password reset rate-limiting
-    # Should be included in a later release > 1.5.11
-    # https://github.com/NixOS/nixpkgs/issues/166655
-    # https://github.com/InvoicePlane/InvoicePlane/pull/739
-    (fetchpatch {
-      url = "https://patch-diff.githubusercontent.com/raw/InvoicePlane/InvoicePlane/pull/739.patch";
-      sha256 = "sha256-6ksJjW6awr3lZsDRxa22pCcRGBVBYyV8+TbhOp6HBq0=";
-    })
-
-    # Fix CVE-2021-29022, full path disclosure
-    # Should be included in a later release > 1.5.11
-    # https://github.com/NixOS/nixpkgs/issues/166655
-    # https://github.com/InvoicePlane/InvoicePlane/pull/767
-    #(fetchpatch {
-    #  url = "https://patch-diff.githubusercontent.com/raw/InvoicePlane/InvoicePlane/pull/767.patch";
-    #  sha256 = "sha256-rSWDH8KeHSRWLyQEa7RSwv+8+ja9etTz+6Q9XThuwUo=";
-    #})
-
-  ];
-
   nativeBuildInputs = [ unzip ];
-
-  sourceRoot = ".";
 
   installPhase = ''
     mkdir -p $out/
@@ -59,5 +28,8 @@ stdenv.mkDerivation rec {
     homepage = "https://www.invoiceplane.com";
     platforms = platforms.all;
     maintainers = with maintainers; [ onny ];
+    # Not yet working with php >= 8
+    # https://github.com/InvoicePlane/InvoicePlane/issues/798
+    broken = true;
   };
 }


### PR DESCRIPTION
###### Description of changes

Mark as broken since we have already dropped php7 in nixpkgs. In hindsight perhaps this should have been done immediately in a69ba21a2973b17df7986a7b1bd5a376591edc35 .

###### Things done

This is a more minimal variation of #182557

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
