### PR TITLE
nginxModules.opentelemetry: Init at 1.0.1

### DIFF
--- a/pkgs/development/libraries/opentelemetry-cpp/default.nix
+++ b/pkgs/development/libraries/opentelemetry-cpp/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, lib, fetchFromGitHub, cmake, protobuf, grpc, pkg-config, openssl }: let
+
+  proto = fetchFromGitHub {
+    owner = "open-telemetry";
+    repo = "opentelemetry-proto";
+    rev = "v0.19.0";
+    sha256 = "sha256-QWjGY0yW1XcrnvwWJ3QPr/8NJgoyQV5gFIn/ZI1dTaQ=";
+    # needed for detection by cmake
+    postFetch = ''
+      touch $out/.git
+    '';
+  };
+
+in stdenv.mkDerivation rec {
+  pname = "opentelemetry-cpp";
+  version = "1.6.1";
+
+  src = fetchFromGitHub {
+    owner = "open-telemetry";
+    repo = "opentelemetry-cpp";
+    rev = "v${version}";
+    hash = "sha256-Jc3dZxr570exw5gvUX98PQzrxoTes1F0OCaQ9JCzx4c=";
+  };
+
+  prePatch = ''
+    rmdir third_party/opentelemetry-proto
+    ln -s ${proto} third_party/opentelemetry-proto
+  '';
+
+  nativeBuildInputs = [ cmake protobuf pkg-config ];
+  buildInputs = [ protobuf grpc openssl ];
+
+  cmakeFlags = [
+    "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
+    "-DWITH_OTLP=ON"
+    "-DBUILD_SHARED_LIBS=ON"
+  ];
+
+  meta = {
+    description = "The OpenTelemetry C++ Client";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ das_j ];
+  };
+}

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -303,6 +303,30 @@ in
     inputs = [ pkgs.opentracing-cpp ];
   };
 
+  opentelemetry = {
+    src = fetchFromGitHub {
+      owner = "open-telemetry";
+      repo = "opentelemetry-cpp-contrib";
+      rev = "webserver/v1.0.1";
+      hash = "sha256-mf823DYhGLqP7lBtF6vH0JyGiykCi10pEzRvVj+qBLA=";
+      # Adds a missing header and moves the module to the root of the store path
+      postFetch = ''
+        mv $out/instrumentation/nginx .
+        sed -i '1s/^/#include <grpcpp\/grpcpp.h>\n/' nginx/src/otel_ngx_module.cpp
+
+        rm -rf $out
+        mv nginx $out
+      '';
+    };
+
+    inputs = with pkgs; [ opentelemetry-cpp protobuf grpc curl ];
+
+    meta = {
+      description = "Adds OpenTelemetry distributed tracing support to nginx";
+      license = lib.licenses.asl20;
+    };
+  };
+
   pagespeed =
     let
       version = pkgs.psol.version;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21176,6 +21176,8 @@ with pkgs;
 
   openstackclient = with python3Packages; toPythonApplication python-openstackclient;
 
+  opentelemetry-cpp = callPackage ../development/libraries/opentelemetry-cpp { };
+
   openvdb = callPackage ../development/libraries/openvdb {};
 
   inherit (callPackages ../development/libraries/libressl { })


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
