### PR TITLE
Revert "gnome.gnome-boxes: add qemu to path"

### DIFF
--- a/pkgs/desktops/gnome/apps/gnome-boxes/default.nix
+++ b/pkgs/desktops/gnome/apps/gnome-boxes/default.nix
@@ -49,7 +49,6 @@
 , vte
 , glib-networking
 , qemu-utils
-, qemu
 }:
 
 stdenv.mkDerivation rec {
@@ -126,7 +125,7 @@ stdenv.mkDerivation rec {
   ];
 
   preFixup = ''
-    gappsWrapperArgs+=(--prefix PATH : "${lib.makeBinPath [ mtools cdrkit libcdio qemu-utils qemu ]}")
+    gappsWrapperArgs+=(--prefix PATH : "${lib.makeBinPath [ mtools cdrkit libcdio qemu-utils ]}")
   '';
 
   postPatch = ''


### PR DESCRIPTION
Boxes insert the absolute path of `qemu-system-x86_64` program as found on `PATH` into the `<emulator>` element of the libvirt
config. But if we add qemu to `PATH` using a wrapper, the saved path will point directly to a store path, which will break when the store path is garbage collected.

Let’s drop it again so that qemu can be picked up from the environment using a more stable path such as `/run/libvirt/nix-emulators/qemu-system-x86_64` introduced by the `virtualisation.libvirtd.enable = true;` NixOS option.

This reverts commit ba1ecbea398cd28341c422f3a15e09a54fecfbd9, essentially re-applying 120337053f4d28b34dab9a07efa1cd2d85c6e869.

Fixes: https://github.com/NixOS/nixpkgs/issues/57931
