### PR TITLE
[22.05] cachix: 0.8.1 -> 1.0.1

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2562,15 +2562,30 @@ self: super: {
   shower = doJailbreak (dontCheck super.shower);
 
   cachix = overrideCabal (drv: {
-    version = "0.8.1";
+    version = "1.0.1";
     src = pkgs.fetchFromGitHub {
       owner = "cachix";
       repo = "cachix";
-      rev = "v0.8.1";
-      sha256 = "sha256-s9JoWsDUVGWhPWLNsvrYK7OlcPZhLO63fo4gN/r4uwU=";
+      rev = "v1.0.1";
+      sha256 = "sha256-ImI1EOZCJ9f6avS+0MY+ITYwrIzvy2B0hPfeKCdCZxo=";
     };
     postUnpack = "sourceRoot=$sourceRoot/cachix";
-  }) super.cachix;
+    postPatch = ''
+      sed -i 's/1.0.0/1.0.1/' cachix.cabal
+      sed -i '/import Protolude/a import Data.List (isSuffixOf)' src/Cachix/Client/WatchStore.hs
+      sed -ir 's/[(]toS)/(option, toS)/' src/Cachix/Client/OptionsParser.hs
+    '';
+  }) (addBuildDepends [super.extra super.lukko] super.cachix);
+  cachix-api = overrideCabal (drv: {
+    version = "1.0.1";
+    src = pkgs.fetchFromGitHub {
+      owner = "cachix";
+      repo = "cachix";
+      rev = "v1.0.1";
+      sha256 = "sha256-ImI1EOZCJ9f6avS+0MY+ITYwrIzvy2B0hPfeKCdCZxo=";
+    };
+    postUnpack = "sourceRoot=$sourceRoot/cachix-api";
+  }) (addBuildDepend super.deriving-aeson super.cachix-api);
 
   # The shipped Setup.hs file is broken.
   csv = overrideCabal (drv: { preCompileBuildDriver = "rm Setup.hs"; }) super.csv;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
