### PR TITLE
tidal-hifi: generate hicolor icon set and use it in .desktop file

### DIFF
--- a/pkgs/applications/audio/tidal-hifi/default.nix
+++ b/pkgs/applications/audio/tidal-hifi/default.nix
@@ -115,8 +115,7 @@ stdenv.mkDerivation rec {
     for size in 48 64 128 256 512; do
       mkdir -p $out/share/icons/hicolor/''${size}x''${size}/apps/
       convert $out/share/icons/hicolor/0x0/apps/tidal-hifi.png \
-        -resize ''${size}x''${size} \
-          $out/share/icons/hicolor/''${size}x''${size}/apps/tidal-hifi.png
+        -resize ''${size}x''${size} $out/share/icons/hicolor/''${size}x''${size}/apps/tidal-hifi.png
     done
   '';
 

--- a/pkgs/applications/audio/tidal-hifi/default.nix
+++ b/pkgs/applications/audio/tidal-hifi/default.nix
@@ -18,6 +18,7 @@
 , gdk-pixbuf
 , glib
 , gtk3
+, imagemagick
 , libappindicator-gtk3
 , libdbusmenu
 , libdrm
@@ -60,6 +61,7 @@ stdenv.mkDerivation rec {
     gdk-pixbuf
     glib
     gtk3
+    imagemagick
     pango
     systemd
     mesa # for libgbm
@@ -107,7 +109,15 @@ stdenv.mkDerivation rec {
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath buildInputs}" \
       "''${gappsWrapperArgs[@]}"
     substituteInPlace $out/share/applications/tidal-hifi.desktop --replace \
-      "/opt/tidal-hifi/tidal-hifi" "tidal-hifi"
+      "/opt/tidal-hifi/tidal-hifi" "tidal-hifi" \
+      --replace "/usr/share/icons/hicolor/0x0/apps/tidal-hifi.png" "tidal-hifi.png"
+
+    for size in 48 64 128 256 512; do
+      mkdir -p $out/share/icons/hicolor/''${size}x''${size}/apps/
+      convert $out/share/icons/hicolor/0x0/apps/tidal-hifi.png \
+        -resize ''${size}x''${size} \
+          $out/share/icons/hicolor/''${size}x''${size}/apps/tidal-hifi.png
+    done
   '';
 
   meta = with lib; {

--- a/pkgs/applications/audio/tidal-hifi/default.nix
+++ b/pkgs/applications/audio/tidal-hifi/default.nix
@@ -108,8 +108,8 @@ stdenv.mkDerivation rec {
     makeWrapper $out/opt/tidal-hifi/tidal-hifi $out/bin/tidal-hifi \
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath buildInputs}" \
       "''${gappsWrapperArgs[@]}"
-    substituteInPlace $out/share/applications/tidal-hifi.desktop --replace \
-      "/opt/tidal-hifi/tidal-hifi" "tidal-hifi" \
+    substituteInPlace $out/share/applications/tidal-hifi.desktop \
+      --replace \ "/opt/tidal-hifi/tidal-hifi" "tidal-hifi" \
       --replace "/usr/share/icons/hicolor/0x0/apps/tidal-hifi.png" "tidal-hifi.png"
 
     for size in 48 64 128 256 512; do


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
