### PR TITLE
slint-lsp: init 0.3.0

### DIFF
--- a/pkgs/development/tools/misc/slint-lsp/default.nix
+++ b/pkgs/development/tools/misc/slint-lsp/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, stdenv
+, rustPlatform
+, fetchCrate
+, pkg-config
+, cmake
+, fontconfig
+, libGL
+, libxcb
+, libX11
+, libXcursor
+, libXi
+, libXrandr
+, libxkbcommon
+, wayland
+  # Darwin Frameworks
+, AppKit
+, CoreGraphics
+, CoreServices
+, CoreText
+, Foundation
+, libiconv
+, OpenGL
+}:
+
+let
+  rpathLibs = [ fontconfig libGL libxcb libX11 libXcursor libXrandr libXi ]
+    ++ lib.optionals stdenv.isLinux [ libxkbcommon wayland ];
+in
+rustPlatform.buildRustPackage rec {
+  pname = "slint-lsp";
+  version = "0.3.0";
+
+  src = fetchCrate {
+    inherit pname version;
+    sha256 = "sha256-dZYkiYrotW8td5dxnPSvDzkWf+xV4ceISVLRZx2goXo=";
+  };
+
+  cargoSha256 = "sha256-9zbA9JXfLdosCU6gVsrsAyiyX8Qh6x5wMw1W4QKqbp4=";
+
+  nativeBuildInputs = [ cmake pkg-config fontconfig ];
+  buildInputs = rpathLibs ++ [ libxcb.dev ]
+    ++ lib.optionals stdenv.isDarwin [
+    AppKit
+    CoreGraphics
+    CoreServices
+    CoreText
+    Foundation
+    libiconv
+    OpenGL
+  ];
+
+  postInstall = lib.optionalString stdenv.isLinux  ''
+    patchelf --set-rpath ${lib.makeLibraryPath rpathLibs} $out/bin/slint-lsp
+  '';
+
+  dontPatchELF = true;
+
+  meta = with lib; {
+    description = "Language Server Protocol (LSP) for Slint UI language";
+    homepage = "https://slint-ui.com/";
+    changelog = "https://github.com/slint-ui/slint/blob/v${version}/CHANGELOG.md";
+    license = with licenses; [ gpl3Plus ];
+    maintainers = with maintainers; [ xgroleau ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17300,6 +17300,11 @@ with pkgs;
 
   slimerjs = callPackage ../development/tools/slimerjs {};
 
+  slint-lsp = callPackage ../development/tools/misc/slint-lsp {
+    inherit (xorg) libXcursor libXi;
+    inherit (darwin.apple_sdk.frameworks) AppKit CoreGraphics CoreServices CoreText Foundation OpenGL;
+  };
+
   sloccount = callPackage ../development/tools/misc/sloccount { };
 
   sloc = nodePackages.sloc;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Sint is a crossplatform UI library that can be used on embedded devices. It uses a custom markup language and this package provide an LSP server for it. See more [here](https://slint-ui.com/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Tested the LSP using the vs code extension and it's preview functionality with X11
