### PR TITLE
react-native-debugger: fix rpath

### DIFF
--- a/pkgs/development/tools/react-native-debugger/default.nix
+++ b/pkgs/development/tools/react-native-debugger/default.nix
@@ -1,5 +1,6 @@
-{ lib, stdenv, fetchurl, unzip, cairo, xorg, gdk-pixbuf, fontconfig, pango, gnome, atk, at-spi2-atk, at-spi2-core
-, gtk3, glib, freetype, dbus, nss, nspr, alsa-lib, cups, expat, udev, makeDesktopItem
+{ lib , stdenv , fetchurl , unzip , cairo , xorg , gdk-pixbuf , fontconfig , pango , gnome , atk , at-spi2-atk , at-spi2-core
+, gtk3 , glib , freetype , dbus , nss , nspr , alsa-lib , cups , expat , udev , makeDesktopItem , libdrm , libxkbcommon , mesa
+, makeWrapper
 }:
 
 let
@@ -22,6 +23,9 @@ let
     udev
     at-spi2-atk
     at-spi2-core
+    libdrm
+    libxkbcommon
+    mesa
 
     xorg.libX11
     xorg.libXcursor
@@ -44,6 +48,7 @@ in stdenv.mkDerivation rec {
     sha256 = "sha256-/uVXMVrVS7n4/mqz6IlKkk63hy67fn9KRjZ1wP5MHB0=";
   };
 
+  buildInputs = [ makeWrapper ];
   nativeBuildInputs = [ unzip ];
   buildCommand = ''
     shopt -s extglob
@@ -58,6 +63,8 @@ in stdenv.mkDerivation rec {
       --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
       --set-rpath ${rpath}:$out/lib \
       $out/share/react-native-debugger
+
+    wrapProgram $out/share/react-native-debugger --add-flags --no-sandbox
 
     ln -s $out/share/react-native-debugger $out/bin/react-native-debugger
 

--- a/pkgs/development/tools/react-native-debugger/default.nix
+++ b/pkgs/development/tools/react-native-debugger/default.nix
@@ -89,7 +89,8 @@ stdenv.mkDerivation rec {
       --set-rpath ${rpath}:$out/lib \
       $out/share/react-native-debugger
 
-    wrapProgram $out/share/react-native-debugger --add-flags --no-sandbox
+    wrapProgram $out/share/react-native-debugger \
+      --add-flags --no-sandbox
 
     ln -s $out/share/react-native-debugger $out/bin/react-native-debugger
 

--- a/pkgs/development/tools/react-native-debugger/default.nix
+++ b/pkgs/development/tools/react-native-debugger/default.nix
@@ -74,8 +74,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-/uVXMVrVS7n4/mqz6IlKkk63hy67fn9KRjZ1wP5MHB0=";
   };
 
-  buildInputs = [ makeWrapper ];
-  nativeBuildInputs = [ unzip ];
+  nativeBuildInputs = [ makeWrapper unzip ];
   buildCommand = ''
     shopt -s extglob
     mkdir -p $out

--- a/pkgs/development/tools/react-native-debugger/default.nix
+++ b/pkgs/development/tools/react-native-debugger/default.nix
@@ -1,5 +1,30 @@
-{ lib , stdenv , fetchurl , unzip , cairo , xorg , gdk-pixbuf , fontconfig , pango , gnome , atk , at-spi2-atk , at-spi2-core
-, gtk3 , glib , freetype , dbus , nss , nspr , alsa-lib , cups , expat , udev , makeDesktopItem , libdrm , libxkbcommon , mesa
+{ lib
+, stdenv
+, fetchurl
+, unzip
+, cairo
+, xorg
+, gdk-pixbuf
+, fontconfig
+, pango
+, gnome
+, atk
+, at-spi2-atk
+, at-spi2-core
+, gtk3
+, glib
+, freetype
+, dbus
+, nss
+, nspr
+, alsa-lib
+, cups
+, expat
+, udev
+, makeDesktopItem
+, libdrm
+, libxkbcommon
+, mesa
 , makeWrapper
 }:
 
@@ -40,7 +65,8 @@ let
     xorg.libXrender
     xorg.libXScrnSaver
   ];
-in stdenv.mkDerivation rec {
+in
+stdenv.mkDerivation rec {
   pname = "react-native-debugger";
   version = "0.13.0";
   src = fetchurl {


### PR DESCRIPTION
###### Description of changes
As described in #158478, `libdrm.so.2`, `libxkbcommon.so.0`, `libgbm.so.1` are missing from `LD_LIBRARY_PATH`, this PR adds them (as per this comment's suggested fix https://github.com/NixOS/nixpkgs/issues/158478#issuecomment-1108479170) as well as adds a `--no-sandbox` to the run command to prevent an electron exception.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
