### PR TITLE
haskell.packages.ghc942

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
@@ -11,6 +11,7 @@ in
 with haskellLib;
 self: super: let
   doctest_0_20_broken = p: checkAgainAfter self.doctest "0.20.0" "doctest broken on 9.4" (dontCheck p);
+  jailbreakForCurrentVersion = p: v: checkAgainAfter p v "bad bounds" (doJailbreak p);
 in {
   llvmPackages = lib.dontRecurseIntoAttrs self.ghc.llvmPackages;
 
@@ -81,6 +82,17 @@ in {
   http-types = doctest_0_20_broken super.http-types;
   iproute = doctest_0_20_broken super.iproute;
   foldl = doctest_0_20_broken super.foldl;
+  prettyprinter-ansi-terminal = doctest_0_20_broken super.prettyprinter-ansi-terminal;
+  pretty-simple = doctest_0_20_broken super.pretty-simple;
+  co-log-core = doctest_0_20_broken (doJailbreak super.co-log-core);
+
+  double-conversion = markBroken super.double-conversion;
+  blaze-textual = checkAgainAfter super.double-conversion "2.0.4.1" "double-conversion fails to build; required for testsuite" (dontCheck super.blaze-textual);
+  ghc-source-gen = checkAgainAfter super.ghc-source-gen "0.4.3.0" "fails to build" (markBroken super.ghc-source-gen);
+
+  lucid = jailbreakForCurrentVersion super.lucid "2.11.1";
+  invariant = jailbreakForCurrentVersion super.invariant "0.5.6";
+  implicit-hie-cradle = jailbreakForCurrentVersion super.implicit-hie-cradle "0.5.0.0";
 
   haskell-src-meta = doJailbreak super.haskell-src-meta;
 
@@ -92,6 +104,7 @@ in {
   aeson = self.aeson_2_1_0_0;
   # This `doJailbreak` can be removed once we have doctest v0.20
   aeson-diff = assert super.doctest.version == "0.18.2"; doJailbreak super.aeson-diff;
+  lens-aeson = self.lens-aeson_1_2_2;
 
   assoc = doJailbreak super.assoc;
   async = doJailbreak super.async;
@@ -185,6 +198,10 @@ in {
   vector = dontCheck super.vector;
   vector-binary-instances = doJailbreak super.vector-binary-instances;
 
+  # fixed in 1.16.x but it's not in hackage-packages yet.
+  rebase = jailbreakForCurrentVersion super.rebase "1.15.0.3";
+  rerebase = jailbreakForCurrentVersion super.rerebase "1.15.0.3";
+
   hpack = overrideCabal (drv: {
     # Cabal 3.6 seems to preserve comments when reading, which makes this test fail
     # 2021-10-10: 9.2.1 is not yet supported (also no issue)
@@ -228,7 +245,6 @@ in {
   hls-fourmolu-plugin = assert super.hls-fourmolu-plugin.version == "1.0.3.0"; doJailbreak super.hls-fourmolu-plugin;
 
   hls-ormolu-plugin = assert super.hls-ormolu-plugin.version == "1.0.2.1"; doJailbreak super.hls-ormolu-plugin;
-  implicit-hie-cradle = doJailbreak super.implicit-hie-cradle;
   # 1.3 introduced support for GHC 9.2.x, so when this assert fails, the jailbreak can be removed
   hashtables = assert super.hashtables.version == "1.2.4.2"; doJailbreak super.hashtables;
 

--- a/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
@@ -184,7 +184,17 @@ in {
   hspec-meta = dontCheck super.hspec-meta_2_9_3;
   hspec-expectations = dontCheck super.hspec-expectations;
   hspec-discover = super.hspec-discover_2_10_5;
-  hedgehog = super.hedgehog_1_2;
+  # the dontHaddock is due to a GHC panic. might be this bug, not sure.
+  # https://gitlab.haskell.org/ghc/ghc/-/issues/21619
+  #
+  # We need >= 1.1.2 for ghc-9.4 support, but we don't have 1.1.x in
+  # hackage-packages.nix
+  hedgehog = dontHaddock super.hedgehog_1_2;
+  # does not work with hedgehog 1.2 yet:
+  # https://github.com/qfpl/tasty-hedgehog/pull/63
+  tasty-hedgehog = markBroken super.tasty-hedgehog;
+  # due to tasty-hedgehog
+  retry = checkAgainAfter super.tasty-hedgehog "1.3.0.0" "tasty-hedgehog broken" (dontCheck super.retry);
 
   # https://github.com/dreixel/syb/issues/38
   syb = dontCheck super.syb;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
@@ -103,7 +103,7 @@ in {
 
   # Jailbreaks & Version Updates
 
-  aeson = self.aeson_2_1_0_0;
+  aeson = self.aeson_2_1_1_0;
   # This `doJailbreak` can be removed once we have doctest v0.20
   aeson-diff = assert super.doctest.version == "0.18.2"; doJailbreak super.aeson-diff;
   lens-aeson = self.lens-aeson_1_2_2;
@@ -178,12 +178,12 @@ in {
 
   # FIXME(lf-): some of these are pointlessly dontChecked; they are kinda
   # shotgun-dontChecked just to make them not infinite-recurse
-  hspec = dontCheck super.hspec_2_10_5;
+  hspec = dontCheck super.hspec_2_10_6;
   base-orphans = dontCheck super.base-orphans;
-  hspec-core = dontCheck super.hspec-core_2_10_5;
-  hspec-meta = dontCheck super.hspec-meta_2_9_3;
+  hspec-core = dontCheck super.hspec-core_2_10_6;
+  hspec-meta = dontCheck super.hspec-meta_2_10_5;
   hspec-expectations = dontCheck super.hspec-expectations;
-  hspec-discover = super.hspec-discover_2_10_5;
+  hspec-discover = super.hspec-discover_2_10_6;
   # the dontHaddock is due to a GHC panic. might be this bug, not sure.
   # https://gitlab.haskell.org/ghc/ghc/-/issues/21619
   #
@@ -250,13 +250,11 @@ in {
   jacinda = doDistribute super.jacinda;
   some = doJailbreak super.some;
 
-  # 2022-06-05: this is not the latest version of fourmolu because
-  # hls-fourmolu-plugin 1.0.3.0 doesn‘t support a newer one.
-  fourmolu = super.fourmolu_0_6_0_0;
+  fourmolu = super.fourmolu_0_8_2_0;
   # hls-fourmolu-plugin in this version has a to strict upper bound of fourmolu <= 0.5.0.0
-  hls-fourmolu-plugin = assert super.hls-fourmolu-plugin.version == "1.0.3.0"; doJailbreak super.hls-fourmolu-plugin;
+  # hls-fourmolu-plugin = assert super.hls-fourmolu-plugin.version == "1.0.3.0"; doJailbreak super.hls-fourmolu-plugin;
 
-  hls-ormolu-plugin = assert super.hls-ormolu-plugin.version == "1.0.2.1"; doJailbreak super.hls-ormolu-plugin;
+  # hls-ormolu-plugin = assert super.hls-ormolu-plugin.version == "1.0.2.1"; doJailbreak super.hls-ormolu-plugin;
   # 1.3 introduced support for GHC 9.2.x, so when this assert fails, the jailbreak can be removed
   hashtables = assert super.hashtables.version == "1.2.4.2"; doJailbreak super.hashtables;
 

--- a/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
@@ -2,10 +2,16 @@
 
 let
   inherit (pkgs) fetchpatch lib;
-  inherit (lib) throwIfNot versionOlder;
+  checkAgainAfter = pkg: ver: msg: act:
+    if builtins.compareVersions pkg.version ver <= 0 then act
+    else
+      builtins.throw "Check if '${msg}' was resolved in ${pkg.pname} ${pkg.version} and update or remove this";
 in
 
-self: super: {
+with haskellLib;
+self: super: let
+  doctest_0_20_broken = p: checkAgainAfter self.doctest "0.20.0" "doctest broken on 9.4" (dontCheck p);
+in {
   llvmPackages = lib.dontRecurseIntoAttrs self.ghc.llvmPackages;
 
   # Disable GHC core libraries.
@@ -48,4 +54,185 @@ self: super: {
   # GHC only bundles the xhtml library if haddock is enabled, check if this is
   # still the case when updating: https://gitlab.haskell.org/ghc/ghc/-/blob/0198841877f6f04269d6050892b98b5c3807ce4c/ghc.mk#L463
   xhtml = if self.ghc.hasHaddock or true then null else self.xhtml_3000_2_2_1;
+
+  # Tests fail because of typechecking changes
+  conduit = dontCheck super.conduit;
+
+  # 0.30 introduced support for GHC 9.2.
+  cryptonite = doDistribute self.cryptonite_0_30;
+
+  # cabal-install needs most recent versions of Cabal and Cabal-syntax
+  cabal-install = super.cabal-install.overrideScope (self: super: {
+    Cabal = self.Cabal_3_8_1_0;
+    Cabal-syntax = self.Cabal-syntax_3_8_1_0;
+    process = self.process_1_6_15_0;
+  });
+  cabal-install-solver = doJailbreak (super.cabal-install-solver.overrideScope (self: super: {
+    Cabal = self.Cabal_3_8_1_0;
+    Cabal-syntax = self.Cabal-syntax_3_8_1_0;
+    process = self.process_1_6_15_0;
+  }));
+
+  # build fails on due to ghc api changes
+  # unfinished PR that doesn't yet compile:
+  # https://github.com/sol/doctest/pull/375
+  doctest = markBroken super.doctest_0_20_0;
+  # consequences of doctest breakage follow:
+  http-types = doctest_0_20_broken super.http-types;
+  iproute = doctest_0_20_broken super.iproute;
+  foldl = doctest_0_20_broken super.foldl;
+
+  haskell-src-meta = doJailbreak super.haskell-src-meta;
+
+  # Tests fail in GHC 9.2
+  extra = dontCheck super.extra;
+
+  # Jailbreaks & Version Updates
+
+  aeson = self.aeson_2_1_0_0;
+  # This `doJailbreak` can be removed once we have doctest v0.20
+  aeson-diff = assert super.doctest.version == "0.18.2"; doJailbreak super.aeson-diff;
+
+  assoc = doJailbreak super.assoc;
+  async = doJailbreak super.async;
+  base64-bytestring = doJailbreak super.base64-bytestring;
+  base-compat = self.base-compat_0_12_2;
+  base-compat-batteries = self.base-compat-batteries_0_12_2;
+  binary-instances = doJailbreak super.binary-instances;
+  ChasingBottoms = doJailbreak super.ChasingBottoms;
+  constraints = doJailbreak super.constraints;
+  cpphs = overrideCabal (drv: { postPatch = "sed -i -e 's,time >=1.5 && <1.11,time >=1.5 \\&\\& <1.12,' cpphs.cabal";}) super.cpphs;
+  data-fix = doJailbreak super.data-fix;
+  dbus = self.dbus_1_2_26;
+  dec = doJailbreak super.dec;
+  ed25519 = doJailbreak super.ed25519;
+  ghc-byteorder = doJailbreak super.ghc-byteorder;
+  ghc-exactprint = overrideCabal (drv: {
+    # HACK: ghc-exactprint 1.4.1 is not buildable for GHC < 9.2,
+    # but hackage2nix evaluates the cabal file with GHC 8.10.*,
+    # causing the build-depends to be skipped. Since the dependency
+    # list hasn't changed much since 0.6.4, we can just reuse the
+    # normal expression.
+    inherit (self.ghc-exactprint_1_5_0) src version;
+    revision = null; editedCabalFile = null;
+    libraryHaskellDepends = [
+      self.fail
+      self.ordered-containers
+      self.data-default
+    ] ++ drv.libraryHaskellDepends or [];
+  }) super.ghc-exactprint;
+  ghc-lib = doDistribute self.ghc-lib_9_2_4_20220729;
+  ghc-lib-parser = doDistribute self.ghc-lib-parser_9_2_4_20220729;
+  ghc-lib-parser-ex = doDistribute self.ghc-lib-parser-ex_9_2_1_1;
+  hackage-security = doJailbreak super.hackage-security;
+  hashable = super.hashable_1_4_1_0;
+  hashable-time = doJailbreak super.hashable-time;
+  HTTP = overrideCabal (drv: { postPatch = "sed -i -e 's,! Socket,!Socket,' Network/TCP.hs"; }) (doJailbreak super.HTTP);
+  integer-logarithms = overrideCabal (drv: { postPatch = "sed -i -e 's, <1.1, <1.3,' integer-logarithms.cabal"; }) (doJailbreak super.integer-logarithms);
+  indexed-traversable = doJailbreak super.indexed-traversable;
+  indexed-traversable-instances = doJailbreak super.indexed-traversable-instances;
+  lifted-async = doJailbreak super.lifted-async;
+  lukko = doJailbreak super.lukko;
+  lzma-conduit = doJailbreak super.lzma-conduit;
+  ormolu = self.ormolu_0_5_0_1;
+  parallel = doJailbreak super.parallel;
+  path = doJailbreak super.path;
+  polyparse = overrideCabal (drv: { postPatch = "sed -i -e 's, <0.11, <0.12,' polyparse.cabal"; }) (doJailbreak super.polyparse);
+  primitive = dontCheck (doJailbreak self.primitive_0_7_4_0);
+  regex-posix = doJailbreak super.regex-posix;
+  resolv = doJailbreak super.resolv;
+  retrie = doDistribute (dontCheck self.retrie_1_2_0_1);
+  singleton-bool = doJailbreak super.singleton-bool;
+  servant = doJailbreak super.servant;
+  servant-swagger = doJailbreak super.servant-swagger;
+
+  # 2022-09-02: Too strict bounds on lens
+  # https://github.com/haskell-servant/servant/pull/1607/files
+  servant-docs = doJailbreak super.servant-docs;
+  servant-foreign = doJailbreak super.servant-foreign;
+  servant-auth = doJailbreak super.servant-auth;
+  servant-auth-docs = doJailbreak super.servant-auth-docs;
+  servant-auth-server = doJailbreak super.servant-auth-server;
+  servant-auth-swagger = doJailbreak super.servant-auth-swagger;
+  # 2022-09-02: Too strict bounds on lens
+  # https://github.com/haskell-servant/servant-multipart/pull/64
+  servant-multipart = doJailbreak super.servant-multipart;
+  # 2022-09-02: Too strict bounds on lens
+  # https://github.com/GetShopTV/swagger2/pull/242
+  swagger2 = doJailbreak super.swagger2;
+
+  # FIXME(lf-): some of these are pointlessly dontChecked; they are kinda
+  # shotgun-dontChecked just to make them not infinite-recurse
+  hspec = dontCheck super.hspec_2_10_5;
+  base-orphans = dontCheck super.base-orphans;
+  hspec-core = dontCheck super.hspec-core_2_10_5;
+  hspec-meta = dontCheck super.hspec-meta_2_9_3;
+  hspec-expectations = dontCheck super.hspec-expectations;
+  hspec-discover = super.hspec-discover_2_10_5;
+  hedgehog = super.hedgehog_1_2;
+
+  # https://github.com/dreixel/syb/issues/38
+  syb = dontCheck super.syb;
+
+  shelly = doJailbreak super.shelly;
+  splitmix = doJailbreak super.splitmix;
+  tasty-hspec = doJailbreak super.tasty-hspec;
+  th-desugar = self.th-desugar_1_14;
+  time-compat = doJailbreak super.time-compat;
+  tomland = doJailbreak super.tomland;
+  type-equality = doJailbreak super.type-equality;
+  unordered-containers = doJailbreak super.unordered-containers;
+  vector = dontCheck super.vector;
+  vector-binary-instances = doJailbreak super.vector-binary-instances;
+
+  hpack = overrideCabal (drv: {
+    # Cabal 3.6 seems to preserve comments when reading, which makes this test fail
+    # 2021-10-10: 9.2.1 is not yet supported (also no issue)
+    testFlags = [
+      "--skip=/Hpack/renderCabalFile/is inverse to readCabalFile/"
+    ] ++ drv.testFlags or [];
+  }) (doJailbreak super.hpack);
+
+  # lens >= 5.1 supports 9.2.1
+  lens = doDistribute self.lens_5_2;
+
+  # Syntax error in tests fixed in https://github.com/simonmar/alex/commit/84b29475e057ef744f32a94bc0d3954b84160760
+  alex = dontCheck super.alex;
+
+  # Apply patches from head.hackage.
+  language-haskell-extract = appendPatch (pkgs.fetchpatch {
+    url = "https://gitlab.haskell.org/ghc/head.hackage/-/raw/dfd024c9a336c752288ec35879017a43bd7e85a0/patches/language-haskell-extract-0.2.4.patch";
+    sha256 = "0w4y3v69nd3yafpml4gr23l94bdhbmx8xky48a59lckmz5x9fgxv";
+  }) (doJailbreak super.language-haskell-extract);
+
+  # Tests depend on `parseTime` which is no longer available
+  hourglass = dontCheck super.hourglass;
+
+  memory = super.memory_0_18_0;
+
+  # Use hlint from git for GHC 9.2.1 support
+  hlint = self.hlint_3_4_1;
+
+  # https://github.com/sjakobi/bsb-http-chunked/issues/38
+  bsb-http-chunked = dontCheck super.bsb-http-chunked;
+
+  # need bytestring >= 0.11 which is only bundled with GHC >= 9.2
+  regex-rure = doDistribute (markUnbroken super.regex-rure);
+  jacinda = doDistribute super.jacinda;
+  some = doJailbreak super.some;
+
+  # 2022-06-05: this is not the latest version of fourmolu because
+  # hls-fourmolu-plugin 1.0.3.0 doesn‘t support a newer one.
+  fourmolu = super.fourmolu_0_6_0_0;
+  # hls-fourmolu-plugin in this version has a to strict upper bound of fourmolu <= 0.5.0.0
+  hls-fourmolu-plugin = assert super.hls-fourmolu-plugin.version == "1.0.3.0"; doJailbreak super.hls-fourmolu-plugin;
+
+  hls-ormolu-plugin = assert super.hls-ormolu-plugin.version == "1.0.2.1"; doJailbreak super.hls-ormolu-plugin;
+  implicit-hie-cradle = doJailbreak super.implicit-hie-cradle;
+  # 1.3 introduced support for GHC 9.2.x, so when this assert fails, the jailbreak can be removed
+  hashtables = assert super.hashtables.version == "1.2.4.2"; doJailbreak super.hashtables;
+
+  # 2022-08-01: Tests are broken on ghc 9.2.4: https://github.com/wz1000/HieDb/issues/46
+  hiedb = doJailbreak (dontCheck super.hiedb);
+
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
@@ -84,6 +84,8 @@ in {
   foldl = doctest_0_20_broken super.foldl;
   prettyprinter-ansi-terminal = doctest_0_20_broken super.prettyprinter-ansi-terminal;
   pretty-simple = doctest_0_20_broken super.pretty-simple;
+  http-date = doctest_0_20_broken super.http-date;
+  network-byte-order = doctest_0_20_broken super.network-byte-order;
   co-log-core = doctest_0_20_broken (doJailbreak super.co-log-core);
 
   double-conversion = markBroken super.double-conversion;

--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -181,37 +181,9 @@ let
       };
     }) (self.callPackage src args);
 
-    # Creates a Haskell package from a source package by calling cabal2nix on the source.
-    callCabal2nixWithOptions' =
-      { name
-      , src
-      , extraCabal2nixOptions ? ""
-      , pathFilter ? path: type:
-          pkgs.lib.hasSuffix ".cabal" path || baseNameOf path == "package.yaml"
-      }: args:
-        let
-          expr = self.haskellSrc2nix {
-            inherit name extraCabal2nixOptions;
-            src = if pkgs.lib.canCleanSource src
-            then pkgs.lib.cleanSourceWith { inherit src; filter = pathFilter; }
-            else src;
-          };
-        in
-          overrideCabal (
-            orig: {
-              inherit src;
-            }
-          ) (callPackageKeepDeriver expr args);
-
-    callCabal2nixWithOptions = name: src: extraCabal2nixOptions: args:
-      callCabal2nixWithOptions' {
-        inherit name src extraCabal2nixOptions;
-      } args;
-
 in package-set { inherit pkgs lib callPackage; } self // {
 
-    inherit mkDerivation callPackage haskellSrc2nix hackage2nix buildHaskellPackages
-      callCabal2nixWithOptions callCabal2nixWithOptions';
+    inherit mkDerivation callPackage haskellSrc2nix hackage2nix buildHaskellPackages;
 
     inherit (haskellLib) packageSourceOverrides;
 
@@ -236,6 +208,22 @@ in package-set { inherit pkgs lib callPackage; } self // {
            url = "mirror://hackage/${pkgver}/${pkgver}.tar.gz";
            inherit sha256;
          });
+
+    # Creates a Haskell package from a source package by calling cabal2nix on the source.
+    callCabal2nixWithOptions = name: src: extraCabal2nixOptions: args:
+      let
+        filter = path: type:
+                   pkgs.lib.hasSuffix ".cabal" path ||
+                   baseNameOf path == "package.yaml";
+        expr = self.haskellSrc2nix {
+          inherit name extraCabal2nixOptions;
+          src = if pkgs.lib.canCleanSource src
+                  then pkgs.lib.cleanSourceWith { inherit src filter; }
+                else src;
+        };
+      in overrideCabal (orig: {
+           inherit src;
+         }) (callPackageKeepDeriver expr args);
 
     callCabal2nix = name: src: args: self.callCabal2nixWithOptions name src "" args;
 


### PR DESCRIPTION
Based on <https://github.com/NixOS/nixpkgs/pull/191618>

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
