### PR TITLE
nixos/nats: loosen systemd syscall filter

### DIFF
--- a/nixos/modules/services/networking/nats.nix
+++ b/nixos/modules/services/networking/nats.nix
@@ -121,6 +121,7 @@ in {
           PrivateDevices = true;
           PrivateTmp = true;
           PrivateUsers = true;
+          PrivateIPC = true;
           ProcSubset = "pid";
           ProtectClock = true;
           ProtectControlGroups = true;
@@ -137,7 +138,7 @@ in {
           RestrictNamespaces = true;
           RestrictRealtime = true;
           RestrictSUIDSGID = true;
-          SystemCallFilter = [ "@system-service" "~@privileged" "~@resources" ];
+          SystemCallFilter = [ "@system-service" "~@privileged" ];
           UMask = "0077";
         }
       ];

--- a/nixos/modules/services/networking/nats.nix
+++ b/nixos/modules/services/networking/nats.nix
@@ -138,7 +138,7 @@ in {
           RestrictNamespaces = true;
           RestrictRealtime = true;
           RestrictSUIDSGID = true;
-          SystemCallFilter = [ "@system-service" "~@privileged" ];
+          SystemCallFilter = [ "@system-service" "~@privileged" "~@resources" ];
           UMask = "0077";
         }
       ];

--- a/nixos/tests/nats.nix
+++ b/nixos/tests/nats.nix
@@ -3,61 +3,89 @@ let
   port = 4222;
   username = "client";
   password = "password";
-  topic = "foo.bar";
 
-in import ./make-test-python.nix ({ pkgs, lib, ... }: {
+in
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
   name = "nats";
   meta = with pkgs.lib; { maintainers = with maintainers; [ c0deaddict ]; };
 
-  nodes = let
-    client = { pkgs, ... }: {
-      environment.systemPackages = with pkgs; [ natscli ];
-    };
-  in {
-    server = { pkgs, ... }: {
-      networking.firewall.allowedTCPPorts = [ port ];
-      services.nats = {
-        inherit port;
-        enable = true;
-        settings = {
-          authorization = {
-            users = [{
-              user = username;
-              inherit password;
-            }];
+  nodes =
+    let
+      client = { pkgs, ... }: {
+        environment.systemPackages = with pkgs; [ natscli ];
+      };
+    in
+    {
+      server = { pkgs, ... }: {
+        networking.firewall.allowedTCPPorts = [ port ];
+        services.nats = {
+          inherit port;
+          enable = true;
+          jetstream = true;
+          settings = {
+            jetstream = {
+              max_file = "32M";
+              max_mem = "32M";
+            };
+            authorization = {
+              users = [{
+                user = username;
+                inherit password;
+              }];
+            };
           };
         };
       };
+
+      client1 = client;
+      client2 = client;
     };
 
-    client1 = client;
-    client2 = client;
-  };
+  testScript =
+    let
+      stream = pkgs.writeText "stream.json" (builtins.toJSON {
+        name = "TEST";
+        subjects = [ "TEST.>" ];
+        retention = "limits";
+        storage = "file";
+        num_replicas = 1;
+      });
+      consumer = pkgs.writeText "consumer.json" (builtins.toJSON {
+        deliver_policy = "all";
+        deliver_subject = "consume";
+        filter_subject = "TEST.topic";
+      });
+    in
+    ''
+      def nats_cmd(*args):
+          return (
+              "nats "
+              "--server=nats://server:${toString port} "
+              "--user=${username} "
+              "--password=${password} "
+              "{}"
+          ).format(" ".join(args))
 
-  testScript = let file = "/tmp/msg";
-  in ''
-    def nats_cmd(*args):
-        return (
-            "nats "
-            "--server=nats://server:${toString port} "
-            "--user=${username} "
-            "--password=${password} "
-            "{}"
-        ).format(" ".join(args))
+      def parallel(*fns):
+          from threading import Thread
+          threads = [ Thread(target=fn) for fn in fns ]
+          for t in threads: t.start()
+          for t in threads: t.join()
 
-    def parallel(*fns):
-        from threading import Thread
-        threads = [ Thread(target=fn) for fn in fns ]
-        for t in threads: t.start()
-        for t in threads: t.join()
+      start_all()
+      server.wait_for_unit("nats.service")
 
-    start_all()
-    server.wait_for_unit("nats.service")
+      with subtest("pub sub"):
+          parallel(
+              lambda: client1.succeed(nats_cmd("sub", "--count", "1", "foo.bar")),
+              lambda: client2.succeed("sleep 2 && {}".format(nats_cmd("pub", "foo.bar", "hello"))),
+          )
 
-    with subtest("pub sub"):
-        parallel(
-            lambda: client1.succeed(nats_cmd("sub", "--count", "1", "${topic}")),
-            lambda: client2.succeed("sleep 2 && {}".format(nats_cmd("pub", "${topic}", "hello"))),
-        )
-  '';
+      with subtest("jetstream publish and consume"):
+          client1.succeed(nats_cmd("str", "add", "TEST", "--config", "${stream}"))
+          client1.succeed(nats_cmd("con", "add", "TEST", "CON", "--config", "${consumer}"))
+          client1.succeed(nats_cmd("pub", "TEST.topic", "hello"))
+          print(client1.succeed(nats_cmd("str", "info", "TEST")))
+          client2.succeed(nats_cmd("sub", "--count", "1", "--ack", "consume"))
+    '';
 })


### PR DESCRIPTION
###### Description of changes

Since nats 2.9.x it uses the setrlimit syscall. This is currently not allowed by the syscall filter, and thus nats crashes.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
