### PR TITLE
nimbus: init at 23.2.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -50,6 +50,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [networkd-dispatcher](https://gitlab.com/craftyguy/networkd-dispatcher), a dispatcher service for systemd-networkd connection status changes. Available as [services.networkd-dispatcher](#opt-services.networkd-dispatcher.enable).
 
+- [nimbus-beacon-node](https://nimbus.guide/), an Ethereum consensus layer client available as [services.nimbus-beacon-node](options.html#opt-services.nimbus-beacon-node.enable).
+
 - [mmsd](https://gitlab.com/kop316/mmsd), a lower level daemon that transmits and recieves MMSes. Available as [services.mmsd](#opt-services.mmsd.enable).
 
 - [QDMR](https://dm3mat.darc.de/qdmr/), a GUI application and command line tool for programming DMR radios [programs.qdmr](#opt-programs.qdmr.enable)

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -341,6 +341,7 @@
   ./services/blockchain/ethereum/erigon.nix
   ./services/blockchain/ethereum/geth.nix
   ./services/blockchain/ethereum/lighthouse.nix
+  ./services/blockchain/ethereum/nimbus/beacon-node.nix
   ./services/cluster/corosync/default.nix
   ./services/cluster/hadoop/default.nix
   ./services/cluster/k3s/default.nix

--- a/nixos/modules/services/blockchain/ethereum/nimbus/beacon-node.md
+++ b/nixos/modules/services/blockchain/ethereum/nimbus/beacon-node.md
@@ -1,0 +1,64 @@
+# Nimbus Beacon Node {#module-services-nimbus-beacon-node}
+
+## Quick Start {#module-services-nimbus-beacon-node-quick-start}
+Nimbus is an extremely efficient consensus layer client implementation.
+While it's optimised for embedded systems and resource-restricted devices --
+including Raspberry Pis, its low resource usage also makes it an excellent choice
+for any server or desktop (where it simply takes up fewer resources).
+
+In order for the [Consensus Layer(CL) client](https://ethereum.org/en/developers/docs/nodes-and-clients/#consensus-clients)
+to function it requires access to an [Execution Layer(EL) client](https://ethereum.org/en/developers/docs/nodes-and-clients/#execution-clients)
+listening for AuthRPC requests on `http://localhost:8551/`.
+An example configuration using Geth as the EL client would look like this:
+
+```nix
+# Execution layer client
+services.geth.mainnet = {
+  enable = true;
+  authrpc = {
+    enable = true;
+    port = 8551;
+    vhosts = ["localhost"];
+    jwtsecret = "/var/run/geth/jwtsecret";
+  };
+};
+
+# Consensus layer client
+services.nimbus-beacon-node = {
+  enable = true;
+  web3Urls = ["http://localhost:${toString config.services.geth.mainnet.authrpc.port}"];
+  jwtSecret = "/var/run/geth/jwtsecret";
+  rest.enable = true;
+};
+```
+::: {.warning}
+This assumes you have a `/var/run/geth/jwtsecret` containing a 64 byte secret.
+You can create such a secret using `openssl rand -hex 32 | tr -d "\n"`.
+:::
+
+This should allow the CL node to communicate with EL node via Auth RPC.
+
+Keep in mind that the JWT secret needs to be the same and readable for both nodes.
+If both services run on the same host and listen on `localhost` it's just a formality.
+
+You can check if the node is working using the REST API:
+
+{command}`curl -s localhost:5052/eth/v1/node/version`
+```json
+{"data":{"version":"Nimbus/v22.9.1-ad286b-stateofus"}}
+```
+{command}`curl -s localhost:5052/eth/v1/node/syncing`
+```json
+{"data":{"head_slot":"45102","sync_distance":"4744542","is_syncing":true,"is_optimistic":false}}
+```
+
+## Configuration {#module-services-nimbus-beacon-node-configuration}
+
+Other settings worth looking at include:
+
+* {option}`services.nimbus-beacon-node.suggestedFeeRecipient` - Your address for receiving [transaction fees](https://nimbus.guide/suggested-fee-recipient.html).
+* {option}`services.nimbus-beacon-node.doppelganger` - Miss two epochs to avoid [validator slashing](https://ethereum.org/en/developers/docs/consensus-mechanisms/pos/rewards-and-penalties/#slashing).
+* {option}`services.nimbus-beacon-node.metrics.enable` - Prometheus metrics endpoint listening on `9100` by default.
+* {option}`services.nimbus-beacon-node.extraArgs` - Ability to provide flags not defined in the service.
+
+For documentation see: <https://nimbus.guide/>

--- a/nixos/modules/services/blockchain/ethereum/nimbus/beacon-node.nix
+++ b/nixos/modules/services/blockchain/ethereum/nimbus/beacon-node.nix
@@ -1,0 +1,236 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib)
+    escapeShellArg mdDoc concatStringsSep mkMerge
+    toUpper boolToString length forEach optionals optionalAttrs
+    types mkEnableOption mkOption mkIf literalExpression;
+
+  cfg = config.services.nimbus-beacon-node;
+in {
+  options = {
+    services = {
+      nimbus-beacon-node = {
+        enable = mkEnableOption (mdDoc "Nimbus Beacon Node service");
+
+        package = mkOption {
+          type = types.package;
+          default = pkgs.nimbus;
+          defaultText = literalExpression "pkgs.nimbus";
+          description = mdDoc "Package to use as Go Ethereum node.";
+        };
+
+        service = {
+          user = mkOption {
+            type = types.str;
+            default = "nimbus";
+            description = mdDoc "Username for Nimbus beacon node service.";
+          };
+
+          group = mkOption {
+            type = types.str;
+            default = "nimbus";
+            description = mdDoc "Group name for Nimbus beacon node service.";
+          };
+        };
+
+        dataDir = mkOption {
+          type = types.path;
+          default = "/var/lib/nimbus-beacon-node";
+          description = mdDoc "Directory for Nimbus beacon node blockchain data.";
+        };
+
+        network = mkOption {
+          type = types.str;
+          default = "mainnet";
+          description = mdDoc "Name of beacon node network to connect to.";
+        };
+
+        log = {
+          level = mkOption {
+            type = types.enum ["trace" "debug" "info" "notice" "warn" "error" "fatal" "none"];
+            default = "info";
+            example = "debug";
+            description = mdDoc "Logging level.";
+          };
+
+          format = mkOption {
+            type = types.enum ["auto" "colors" "nocolors" "json"];
+            default = "auto";
+            example = "json";
+            description = mdDoc "Logging formatting.";
+          };
+        };
+
+        web3Urls = mkOption {
+          type = types.listOf types.str;
+          default = [];
+          example = ["http://localhost:8551/"];
+          description = mdDoc "Mandatory URL(s) for the Web3 RPC endpoints.";
+        };
+
+        jwtSecret = mkOption {
+          type = types.path;
+          default = null;
+          example = "/var/run/nimbus/jwtsecret";
+          description = mdDoc ''
+            Path of file with 32 bytes long JWT secret for Auth RPC endpoint.
+            Can be generated using 'openssl rand -hex 32'.
+          '';
+        };
+
+        subAllSubnets = mkOption {
+          type = types.bool;
+          default = false;
+          description = mdDoc "Subscribe to all attestation subnet topics.";
+        };
+
+        doppelganger = mkOption {
+          type = types.bool;
+          default = true;
+          description = mdDoc ''
+            Protection against slashing due to double-voting.
+            Means you will miss two attestations when restarting.
+          '';
+        };
+
+        suggestedFeeRecipient = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = mdDoc ''
+            Wallet address where transaction fee tips - priority fees,
+            unburnt portion of gas fees - will be sent.
+          '';
+        };
+
+        listenPort = mkOption {
+          type = types.port;
+          default = 9000;
+          description = mdDoc "Listen port for libp2p protocol.";
+        };
+
+        discoverPort = mkOption {
+          type = types.port;
+          default = 9000;
+          description = mdDoc "Listen port for libp2p protocol.";
+        };
+
+        nat = mkOption {
+          type = types.str;
+          default = "any";
+          example = "extip:12.34.56.78";
+          description = mdDoc ''
+            Method for determining public address. (any, none, upnp, pmp, extip:<IP>)
+          '';
+        };
+
+        metrics = {
+          enable = lib.mkEnableOption (mdDoc "Nimbus beacon node metrics endpoint");
+          address = mkOption {
+            type = types.str;
+            default = "127.0.0.1";
+            description = mdDoc "Metrics address for beacon node.";
+          };
+          port = mkOption {
+            type = types.port;
+            default = 9100;
+            description = mdDoc "Metrics port for beacon node.";
+          };
+        };
+
+        rest = {
+          enable = lib.mkEnableOption (mdDoc "Nimbus beacon node REST API");
+          address = mkOption {
+            type = types.str;
+            default = "127.0.0.1";
+            description = mdDoc "Listening address of the REST API server.";
+          };
+
+          port = mkOption {
+            type = types.port;
+            default = 5052;
+            description = mdDoc "Port for the REST API server.";
+          };
+        };
+
+        extraArgs = mkOption {
+          type = types.listOf types.str;
+          default = [];
+          example = ["--num-threads=1" "--graffiti=1337_h4x0r"];
+          description = mdDoc "Additional arguments passed to node.";
+        };
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      { assertion = length cfg.web3Urls > 0;
+        message = "Nimbus beacon node requires at least one Web3 URL in services.nimbus-beacon-node.web3Urls to work!"; }
+    ];
+
+    users.users = optionalAttrs (cfg.service.user == "nimbus") {
+      nimbus = {
+        group = cfg.service.group;
+        home = cfg.dataDir;
+        description = "Nimbus beacon node service user";
+        isSystemUser = true;
+      };
+    };
+
+    users.groups = optionalAttrs (cfg.service.user == "nimbus") {
+      nimbus = { };
+    };
+
+    systemd.services.nimbus-beacon-node = {
+      description = "Nimbus Beacon Node (Ethereum consensus client)";
+
+      serviceConfig = mkMerge [{
+        User = cfg.service.user;
+        Group = cfg.service.group;
+
+        ExecStart = concatStringsSep " \\\n  " ([
+          "${cfg.package}/bin/nimbus_beacon_node"
+          "--network=${cfg.network}"
+          "--data-dir=${cfg.dataDir}"
+          "--log-level=${toUpper cfg.log.level}"
+          "--log-format=${cfg.log.format}"
+          "--nat=${cfg.nat}"
+          "--tcp-port=${toString cfg.listenPort}"
+          "--udp-port=${toString cfg.discoverPort}"
+          "--subscribe-all-subnets=${boolToString cfg.subAllSubnets}"
+          "--doppelganger-detection=${boolToString cfg.doppelganger}"
+          "--rest=${boolToString cfg.rest.enable}"
+        ] ++ optionals cfg.rest.enable [
+          "--rest-address=${cfg.rest.address}"
+          "--rest-port=${toString cfg.rest.port}"
+        ] ++ [
+          "--metrics=${boolToString cfg.metrics.enable}"
+        ] ++ optionals cfg.metrics.enable [
+          "--metrics-address=${cfg.metrics.address}"
+          "--metrics-port=${toString cfg.metrics.port}"
+        ] ++ (forEach cfg.web3Urls (u: "--web3-url=${u}"))
+          ++ optionals (cfg.jwtSecret != null) ["--jwt-secret=${cfg.jwtSecret}"]
+          ++ optionals (cfg.suggestedFeeRecipient != null) ["--suggested-fee-recipient=${cfg.suggestedFeeRecipient}"]
+          ++ (forEach cfg.extraArgs escapeShellArg));
+
+        WorkingDirectory = cfg.dataDir;
+        TimeoutSec = 1200;
+        Restart = "on-failure";
+        # Don't restart when Doppelganger detection has been activated
+        RestartPreventExitStatus = 129;
+      }
+      (mkIf (cfg.dataDir == "/var/lib/nimbus-beacon-node") {
+        StateDirectory = "nimbus-beacon-node";
+        StateDirectoryMode = "0750";
+      })];
+      wantedBy = [ "multi-user.target" ];
+      requires = [ "network.target" ];
+    };
+  };
+
+  meta = {
+    doc = ./beacon-node.md;
+    maintainers = with lib.maintainers; [ jakubgs ];
+  };
+}

--- a/pkgs/applications/blockchains/nimbus/default.nix
+++ b/pkgs/applications/blockchains/nimbus/default.nix
@@ -1,0 +1,75 @@
+{ stdenv
+, fetchFromGitHub
+, lib
+, nim
+, which
+, writeScriptBin
+  # Options: nimbus_light_client, nimbus_validator_client, nimbus_signing_node
+, makeTargets ? [ "nimbus_beacon_node" ]
+  # These are the only platforms tested in CI and considered stable.
+, stablePlatforms ? [
+  "x86_64-linux" "aarch64-linux" "armv7a-linux"
+  "x86_64-darwin" "aarch64-darwin"
+  "x86_64-windows"
+]
+}:
+
+# Version 1.6.10 is known to be stable and overriden in top-level.
+assert nim.version == "1.6.10";
+
+stdenv.mkDerivation rec {
+  pname = "nimbus";
+  version = "23.2.0";
+  commit = "6b9381ef";
+  name = "${pname}-${version}-${commit}";
+
+  src = fetchFromGitHub {
+    owner = "status-im";
+    repo = "nimbus-eth2";
+    rev = "v${version}";
+    sha256 = "sha256-+QIimBo2a/4OPTZMvVPm/+f8c8QNfXo+oNKGpJKh0bI=";
+    fetchSubmodules = true;
+  };
+
+  # Fix for Nim compiler calling 'git rev-parse' and 'lsb_release'.
+  nativeBuildInputs = let
+    fakeGit = writeScriptBin "git" "echo $commit";
+    fakeLsbRelease = writeScriptBin "lsb_release" "echo nix";
+  in [ fakeGit fakeLsbRelease nim which ];
+
+  enableParallelBuilding = true;
+
+  # Disable CPU optmizations that make binary not portable.
+  NIMFLAGS = "-d:disableMarchNative";
+
+  makeFlags = makeTargets ++ [ "USE_SYSTEM_NIM=1" ];
+
+  # Generate the nimbus-build-system.paths file.
+  configurePhase = ''
+    patchShebangs scripts vendor/nimbus-build-system/scripts
+    make nimbus-build-system-paths
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    rm build/generate_makefile
+    cp build/* $out/bin
+  '';
+
+  meta = with lib; {
+    homepage = "https://nimbus.guide/";
+    downloadPage = "https://github.com/status-im/nimbus-eth2/releases";
+    changelog = "https://github.com/status-im/nimbus-eth2/blob/stable/CHANGELOG.md";
+    description = "Nimbus is a lightweight client for the Ethereum consensus layer";
+    longDescription = ''
+      Nimbus is an extremely efficient consensus layer client implementation.
+      While it's optimised for embedded systems and resource-restricted devices --
+      including Raspberry Pis, its low resource usage also makes it an excellent choice
+      for any server or desktop (where it simply takes up fewer resources).
+    '';
+    branch = "stable";
+    license = with licenses; [ asl20 mit ];
+    maintainers = with maintainers; [ jakubgs ];
+    platforms = stablePlatforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34896,6 +34896,16 @@ with pkgs;
 
   nbxplorer = callPackage ../applications/blockchains/nbxplorer { };
 
+  nimbus = callPackage ../applications/blockchains/nimbus {
+    nim = nim.overrideAttrs (_: rec {
+      version = "1.6.10";
+      src = fetchurl {
+        url = "https://nim-lang.org/download/nim-${version}.tar.xz";
+        hash = "sha256-E9dwL4tXCHur6M0FHBO8VqMXFBi6hntJxrvQmynST+o=";
+      };
+    });
+  };
+
   pivx = libsForQt5.callPackage ../applications/blockchains/pivx { withGui = true; };
   pivxd = callPackage ../applications/blockchains/pivx {
     withGui = false;


### PR DESCRIPTION
###### Description of changes
[Nimbus](https://nimbus.guide/) is a client for the [Ethereum](https://ethereum.org/) [consensus layer](https://geth.ethereum.org/docs/interface/consensus-clients) that is lightweight, secure and easy to use.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).