### PR TITLE
python3Packages.radio_beam: update to the latest upstream and fix depends

### DIFF
--- a/pkgs/development/python-modules/pytest-astropy-header/default.nix
+++ b/pkgs/development/python-modules/pytest-astropy-header/default.nix
@@ -6,11 +6,7 @@
 , pytest-cov
 , pytestCheckHook
 , numpy
-, astropy
-, scipy
 , setuptools-scm
-, h5py
-, scikitimage
 }:
 
 buildPythonPackage rec {

--- a/pkgs/development/python-modules/pytest-astropy-header/default.nix
+++ b/pkgs/development/python-modules/pytest-astropy-header/default.nix
@@ -8,27 +8,23 @@
 , numpy
 , astropy
 , scipy
+, setuptools-scm
 , h5py
 , scikitimage
 }:
 
 buildPythonPackage rec {
   pname = "pytest-astropy-header";
-  version = "0.1.2";
+  version = "0.2.2";
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1y87agr324p6x5gvhziymxjlw54pyn4gqnd49papbl941djpkp5g";
+    sha256 = "77891101c94b75a8ca305453b879b318ab6001b370df02be2c0b6d1bb322db10";
   };
-  patches = [ (fetchpatch {
-      url = "https://github.com/astropy/pytest-astropy-header/pull/16.patch";
-      sha256 = "11ln63zq0kgsdx1jw3prlzpcdbxmc99p9cwr18s0x6apy0k6df31";
-    })
-    (fetchpatch {
-      url = "https://github.com/astropy/pytest-astropy-header/pull/29.patch";
-      sha256 = "18l434c926r5z1iq3b6lpnp0lrssszars9y1y9hs6216r60jgjpl";
-    })
+
+  nativeBuildInputs = [
+    setuptools-scm
   ];
 
   buildInputs = [
@@ -37,12 +33,7 @@ buildPythonPackage rec {
 
   checkInputs = [
     pytestCheckHook
-    pytest-cov
     numpy
-    scipy
-    h5py
-    scikitimage
-    astropy
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pytest-astropy/default.nix
+++ b/pkgs/development/python-modules/pytest-astropy/default.nix
@@ -1,10 +1,12 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, attrs
 , hypothesis
 , pytest
 , pytest-arraydiff
 , pytest-astropy-header
+, pytest-cov
 , pytest-doctestplus
 , pytest-filter-subpackage
 , pytest-mock
@@ -33,9 +35,11 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    attrs
     hypothesis
     pytest-arraydiff
     pytest-astropy-header
+    pytest-cov
     pytest-doctestplus
     pytest-filter-subpackage
     pytest-mock

--- a/pkgs/development/python-modules/radio_beam/default.nix
+++ b/pkgs/development/python-modules/radio_beam/default.nix
@@ -4,21 +4,22 @@
 , setuptools-scm
 , astropy
 , numpy
+, matplotlib
 , scipy
 , six
 , pytestCheckHook
-, pytest-doctestplus
+, pytest-astropy
 }:
 
 buildPythonPackage rec {
   pname = "radio_beam";
-  version = "0.3.3";
+  version = "0.3.4";
   format = "pyproject";
 
   src = fetchPypi {
     inherit version;
     pname = "radio-beam";
-    sha256 = "e34902d91713ccab9f450b9d3e82317e292cf46a30bd42f9ad3c9a0519fcddcd";
+    sha256 = "e032257f1501303873f251c00c74b1188180785c79677fb4443098d517852309";
   };
 
   nativeBuildInputs = [
@@ -34,13 +35,9 @@ buildPythonPackage rec {
 
   checkInputs = [
     pytestCheckHook
-    pytest-doctestplus
+    matplotlib
+    pytest-astropy
   ];
-
-  # Tests must be run in the build directory
-  preCheck = ''
-    cd build/lib
-  '';
 
   meta = {
     description = "Tools for Beam IO and Manipulation";


### PR DESCRIPTION
###### Description of changes

Update python3Packages.radio_beam to the latest upstream, and update/fix dependencies on the way.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
