### PR TITLE
python3Packages.ehtim: init at 1.2.4

### DIFF
--- a/pkgs/development/python-modules/ehtim/default.nix
+++ b/pkgs/development/python-modules/ehtim/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, numpy
+, scipy
+, astropy
+, matplotlib
+, ephem
+, h5py
+, pandas
+, requests
+, future
+}:
+
+buildPythonPackage rec {
+  pname = "ehtim";
+  version = "1.2.4";
+
+  src = fetchFromGitHub {
+    owner = "achael";
+    repo = "eht-imaging";
+    rev = "v${version}";
+    sha256 = "ZeacOUve1QHX4Ei61GHEMtbqyfOV7Cj9q7+sH/lQR+w=";
+  };
+
+  propagatedBuildInputs = [
+    numpy scipy astropy matplotlib ephem h5py pandas requests future
+  ];
+
+  doCheck = false;  # Tests require additional data
+  pythonImportsCheck = [ "ehtim" ];
+
+  meta = with lib; {
+    homepage = "https://achael.github.io/eht-imaging";
+    description = ''
+      Python modules for simulating and manipulating VLBI data and
+      producing images with regularized maximum likelihood methods
+    '';
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ parras ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2908,6 +2908,8 @@ in {
 
   eiswarnung = callPackage ../development/python-modules/eiswarnung { };
 
+  ehtim = callPackage ../development/python-modules/ehtim { };
+
   elgato = callPackage ../development/python-modules/elgato { };
 
   elkm1-lib = callPackage ../development/python-modules/elkm1-lib { };


### PR DESCRIPTION
Add the python package ehtim to nixpkgs. It is widely used in the Event Horizon Telescope community.