### PR TITLE
python310Packages.prance: update openapi-spec-validator

### DIFF
--- a/pkgs/development/python-modules/prance/default.nix
+++ b/pkgs/development/python-modules/prance/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
 , chardet
 , requests
 , ruamel-yaml
@@ -21,8 +22,28 @@ buildPythonPackage rec {
     repo = pname;
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "sha256-kGANMHfWwhW3ZBw2ZVCJZR/bV2EPhcydMKhDeDTVwcQ=";
+    hash = "sha256-kGANMHfWwhW3ZBw2ZVCJZR/bV2EPhcydMKhDeDTVwcQ=";
   };
+
+  patches = [
+    # Fix for openapi-spec-validator 0.5.0+:
+    # https://github.com/RonnyPfannschmidt/prance/pull/132
+    (fetchpatch {
+      name = "1-openapi-spec-validator-upgrade.patch";
+      url = "https://github.com/RonnyPfannschmidt/prance/commit/55503c9b12b685863c932ededac996369e7d288a.patch";
+      hash = "sha256-7SOgFsk2aaaaAYS8WJ9axqQFyEprurn6Zn12NcdQ9Bg=";
+    })
+    (fetchpatch {
+      name = "2-openapi-spec-validator-upgrade.patch";
+      url = "https://github.com/RonnyPfannschmidt/prance/commit/7e59cc69c6c62fd04875105773d9d220bb58fea6.patch";
+      hash = "sha256-j6vmY3NqDswp7v9682H+/MxMGtFObMxUeL9Wbiv9hYw=";
+    })
+    (fetchpatch {
+      name = "3-openapi-spec-validator-upgrade.patch";
+      url = "https://github.com/RonnyPfannschmidt/prance/commit/7e575781d83845d7ea0c2eff57644df9b465c7af.patch";
+      hash = "sha256-rexKoQ+TH3QmP20c3bA+7BLMLc+fkVhn7xsq+gle1Aw=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace setup.cfg \


### PR DESCRIPTION
###### Description of changes

Pulls in https://github.com/RonnyPfannschmidt/prance/pull/132. I see that one of the commits changes the validator to use "auto-detection", and I don't know the implication of this, but the tests pass. Needed by https://github.com/NixOS/nixpkgs/pull/191339.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
