### PR TITLE
zecwallet-lite: 1.7.13 -> 1.8.8

### DIFF
--- a/pkgs/applications/blockchains/zecwallet-lite/default.nix
+++ b/pkgs/applications/blockchains/zecwallet-lite/default.nix
@@ -2,11 +2,11 @@
 
 appimageTools.wrapType2 rec {
   pname = "zecwallet-lite";
-  version = "1.7.13";
+  version = "1.8.8";
 
   src = fetchurl {
     url = "https://github.com/adityapk00/zecwallet-lite/releases/download/v${version}/Zecwallet.Lite-${version}.AppImage";
-    hash = "sha256-uBiLGHBgm0vurfvOJjJ+RqVoGnVccEHTFO2T7LDqUzU=";
+    hash = "sha256-6jppP3V7R8tCR5Wv5UWfbWKkAdsgrCjSiO/bbpLNcw4=";
   };
 
   extraInstallCommands =
@@ -14,9 +14,9 @@ appimageTools.wrapType2 rec {
     in ''
       mv $out/bin/${pname}-${version} $out/bin/${pname}
 
-      install -m 444 -D ${contents}/${pname}.desktop -t $out/share/applications
-      substituteInPlace $out/share/applications/${pname}.desktop \
-        --replace 'Exec=AppRun' 'Exec=${pname}'
+      install -m 444 -D ${contents}/zecwallet-lite.desktop -t $out/share/applications
+      substituteInPlace $out/share/applications/zecwallet-lite.desktop \
+        --replace 'Exec=AppRun' "Exec=$out/bin/zecwallet-lite"
       cp -r ${contents}/usr/share/icons $out/share
     '';
 


### PR DESCRIPTION
###### Description of changes

also fix the .desktop file to reference zecwallet-lite by fully-qualified path.

abbreviated change-log:
- sync improvements (save sync progress; faster syncs)
- full support for Orchard transactions
- full support for Orchard pool
- experimental support for Zebra-backed LightwalletD
- add spam filtering options

complete release notes
[here](https://github.com/adityapk00/zecwallet-lite/releases)

verified by sending a couple (shielded) test transactions. didn't test the Orchard stuff because i don't know how that works yet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
