### PR TITLE
whalebird: 4.6.0 -> 4.6.5

### DIFF
--- a/pkgs/applications/misc/whalebird/default.nix
+++ b/pkgs/applications/misc/whalebird/default.nix
@@ -3,7 +3,7 @@
 
 stdenv.mkDerivation rec {
   pname = "whalebird";
-  version = "4.6.0";
+  version = "4.6.5";
 
   src = let
     downloads = "https://github.com/h3poteto/whalebird-desktop/releases/download/${version}";
@@ -11,12 +11,12 @@ stdenv.mkDerivation rec {
     if stdenv.system == "x86_64-linux" then
       fetchurl {
         url = downloads + "/Whalebird-${version}-linux-x64.tar.bz2";
-        sha256 = "02f2f4b7184494926ef58523174acfa23738d5f27b4956d094836a485047c2f8";
+        sha256 = "sha256-WeZnWEwRbZEnYkLwWf6EC3ZbwI+Cr59czdKxxG/Lhn0=";
       }
     else if stdenv.system == "aarch64-linux" then
       fetchurl {
         url = downloads + "/Whalebird-${version}-linux-arm64.tar.bz2";
-        sha256 = "de0cdf7cbd6f0305100a2440e2559ddce0a5e4ad73a341874d6774e23dc76974";
+        sha256 = "sha256-5iKVP7zOci5X+EhnfJx5cZ5RiqZKz1pFLDUwZncynUc=";
       }
     else
       throw "Whalebird is not supported for ${stdenv.system}";
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
     # Necessary steps to find the tray icon
     asar extract opt/Whalebird/resources/app.asar "$TMP/work"
     substituteInPlace $TMP/work/dist/electron/main.js \
-      --replace "Do,\"tray_icon.png\"" "\"$out/opt/Whalebird/resources/build/icons/tray_icon.png\""
+      --replace "Ao,\"tray_icon.png\"" "\"$out/opt/Whalebird/resources/build/icons/tray_icon.png\""
     asar pack --unpack='{*.node,*.ftz,rect-overlay}' "$TMP/work" opt/Whalebird/resources/app.asar
 
     runHook postBuild

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32339,7 +32339,9 @@ with pkgs;
 
   weston = callPackage ../applications/window-managers/weston { };
 
-  whalebird = callPackage ../applications/misc/whalebird { };
+  whalebird = callPackage ../applications/misc/whalebird {
+    electron = electron_19;
+  };
 
   wio = callPackage ../applications/window-managers/wio {
     wlroots = wlroots_0_14;


### PR DESCRIPTION
###### Description of changes

also pin the electron version to that specified upstream, otherwise certain basic features like the login prompt do not show.

changelog: <https://github.com/h3poteto/whalebird-desktop/releases>

notable changes:
- add Persian translations
- update electron 17.3.0 -> 19.0.5
- display emoji reaction notifications in notifications timeline
- enable shortcuts to reload timeline and change focus

bugfixes:
- fix deleting tag timeline
- fix clearing notification dot on mention
- fix loading of ListMembership modal
- fix focus of NewToot modal
- fix closing sideBar
- fix z-index for knob and image modal
- fix en translation for sensitive contents
- Fix i18next when application is loaded
- fix visibility of boosted status

and about a hundred dependency updates :^)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
