### PR TITLE
pysolfc: 2.6.4 -> 2.16.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9338,6 +9338,12 @@
     githubId = 772914;
     name = "Mikael Voss";
   };
+  mwolfe = {
+    email = "corp@m0rg.dev";
+    github = "m0rg-dev";
+    githubId = 38578268;
+    name = "Morgan Wolfe";
+  };
   maxwilson = {
     email = "nixpkgs@maxwilson.dev";
     github = "mwilsoncoding";

--- a/pkgs/development/python-modules/pycotap/default.nix
+++ b/pkgs/development/python-modules/pycotap/default.nix
@@ -1,0 +1,18 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "pycotap";
+  version = "1.2.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-+Tjs1JMczRnZWY+2M9Xqu3k48IuEcXMV5SUmqmJ3yew=";
+  };
+
+  meta = with lib; {
+    description = "Test runner for unittest that outputs TAP results to stdout";
+    homepage = "https://el-tramo.be/pycotap";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mwolfe ];
+  };
+}

--- a/pkgs/development/python-modules/pysol-cards/default.nix
+++ b/pkgs/development/python-modules/pysol-cards/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildPythonPackage, fetchPypi, six, random2 }:
+
+buildPythonPackage rec {
+  pname = "pysol-cards";
+  version = "0.14.2";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "pysol_cards";
+    sha256 = "sha256-wI3oV1d7w+7JcMOt08RbNlMWzChErNYIO7Vuox1A6vA=";
+  };
+
+  propagatedBuildInputs = [ six random2 ];
+
+  meta = with lib; {
+    description = "Generates Solitaire deals";
+    homepage = "https://github.com/shlomif/pysol_cards";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mwolfe ];
+  };
+}

--- a/pkgs/games/pysolfc/default.nix
+++ b/pkgs/games/pysolfc/default.nix
@@ -3,20 +3,21 @@
 
 buildPythonApplication rec {
   pname = "PySolFC";
-  version = "2.6.4";
+  version = "2.16.0";
 
   src = fetchzip {
     url = "https://versaweb.dl.sourceforge.net/project/pysolfc/PySolFC/PySolFC-${version}/PySolFC-${version}.tar.xz";
-    sha256 = "1bd84law5b1yga3pryggdvlfvm0l62gci2q8y3q79cysdk3z4w3z";
+    sha256 = "sha256-kklB16IrDicxqMee1kbxtoqgwcSrMjCV4HP6GtnZxo8=";
   };
 
   cardsets = fetchzip {
-    url = "https://versaweb.dl.sourceforge.net/project/pysolfc/PySolFC-Cardsets/PySolFC-Cardsets-2.0/PySolFC-Cardsets-2.0.tar.bz2";
-    sha256 = "0h0fibjv47j8lkc1bwnlbbvrx2nr3l2hzv717kcgagwhc7v2mrqh";
+    url = "https://versaweb.dl.sourceforge.net/project/pysolfc/PySolFC-Cardsets/PySolFC-Cardsets-2.1/PySolFC-Cardsets-2.1.tar.bz2";
+    sha256 = "sha256-0ji6jY7zJFaaaJdInaULKUou+u934RMzYjxVDGVHbE0=";
   };
 
   propagatedBuildInputs = with python3Packages; [
-    tkinter six random2
+    tkinter six random2 configobj
+    pysol-cards attrs pycotap
     # optional :
     pygame freecell-solver pillow
   ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8544,6 +8544,8 @@ in {
 
   pysocks = callPackage ../development/python-modules/pysocks { };
 
+  pysol-cards = callPackage ../development/python-modules/pysol-cards { };
+
   pysolr = callPackage ../development/python-modules/pysolr { };
 
   pysoma = callPackage ../development/python-modules/pysoma { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7565,6 +7565,8 @@ in {
 
   pycosat = callPackage ../development/python-modules/pycosat { };
 
+  pycotap = callPackage ../development/python-modules/pycotap { };
+
   pycountry = callPackage ../development/python-modules/pycountry { };
 
   pycparser = callPackage ../development/python-modules/pycparser { };


### PR DESCRIPTION
###### Description of changes

- Updates `pysolfc` from `2.6.4` to `2.16.0`. That's a good page and a half or so of release notes - see https://pysolfc.sourceforge.io/doc/news.html. The one really important part is that `2.16.0` builds on Python 3.8 and later whereas `2.6.4` does not (see #190799).
- Adds `python3Packages.pycotap` and `python3Packages.pysol_cards`, new dependencies of `pysolfc`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Notes

The current `pysolfc` source disables tests on the grounds that there are no tests present in `pysolfc`'s source; this is no longer true, but when I tried to enable them again I ran into a whole load of GTK related nonsense that just made my head spin. Would appreciate someone else having a crack at it.
