### PR TITLE
check-meta: Add isHydraChannel

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -285,6 +285,10 @@ let
     });
     timeout = int;
 
+    # Needed for Hydra to expose channel tarballs:
+    # https://github.com/NixOS/hydra/blob/53335323ae79ca1a42643f58e520b376898ce641/doc/manual/src/jobs.md#meta-fields
+    isHydraChannel = bool;
+
     # Weirder stuff that doesn't appear in the documentation?
     maxSilent = int;
     knownVulnerabilities = listOf str;


### PR DESCRIPTION
This is needed in order to mark a certain derivation containing a Nix expression tarball to Hydra so that it is recognised as a channel.

When I first got an evaluation error due to using this meta attribute, I was under the impression that nobody outside of Vuizvui[^1] is using this feature and that we don't have any occurrence of isHydraChannel in Nixpkgs.

However, when working around[^2] the issue I assumed that it's not something that should be included in Nixpkgs because we're not using it there.

It turned out that my assumption was wrong and we *do* use the attribute in Nixpkgs, namely via releaseTools.channel, which is similar to what we're doing in Vuizvui.

Since we already include a bunch of undocumented attributes in metaTypes, it only makes sense to add isHydraChannel as well since it's actually documented in the Hydra documentation[^3].

[^1]: https://github.com/openlab-aux/vuizvui
[^2]: https://github.com/openlab-aux/vuizvui/commit/e0685e81b3fdc43a272f0
[^3]: https://github.com/NixOS/hydra/blob/53335323ae79ca1a42643f58e520b376898ce641/doc/manual/src/jobs.md#meta-fields