### PR TITLE
orchis-theme: 2022-07-20 -> 2022-09-28

### DIFF
--- a/pkgs/data/themes/orchis-theme/default.nix
+++ b/pkgs/data/themes/orchis-theme/default.nix
@@ -21,13 +21,13 @@ assert lib.assertMsg (unknownTweaks == [ ]) ''
 stdenvNoCC.mkDerivation
 rec {
   pname = "orchis-theme";
-  version = "2022-07-20";
+  version = "2022-09-28";
 
   src = fetchFromGitHub {
     repo = "Orchis-theme";
     owner = "vinceliuice";
     rev = version;
-    sha256 = "sha256-0T9D42XwyvIb5XeXdqXbyahVHNcSeT469lSgWSisNvA=";
+    sha256 = "sha256-gabOn5ErJjDgqZCyIboMgFb1FqmDw8dljIskBENKTBg=";
   };
 
   nativeBuildInputs = [ gtk3 sassc ];

--- a/pkgs/data/themes/orchis-theme/default.nix
+++ b/pkgs/data/themes/orchis-theme/default.nix
@@ -5,6 +5,7 @@
 , gnome-themes-extra
 , gtk-engine-murrine
 , sassc
+, border-radius ? null # Suggested: 2 < value < 16
 , tweaks ? [ ] # can be "solid" "compact" "black" "primary"
 , withWallpapers ? false
 }:
@@ -42,7 +43,9 @@ rec {
 
   installPhase = ''
     runHook preInstall
-    bash install.sh -d $out/share/themes -t all ${lib.optionalString (tweaks != []) "--tweaks " + builtins.toString tweaks}
+    bash install.sh -d $out/share/themes -t all \
+      ${lib.optionalString (tweaks != []) "--tweaks " + builtins.toString tweaks} \
+      ${lib.optionalString (!isNull border-radius) ("--round " + builtins.toString border-radius + "px")}
     ${lib.optionalString withWallpapers ''
       mkdir -p $out/share/backgrounds
       cp src/wallpaper/{1080p,2k,4k}.jpg $out/share/backgrounds


### PR DESCRIPTION
###### Description of changes
https://github.com/vinceliuice/Orchis-theme/releases/tag/2022-09-28

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).