### PR TITLE
Backport: onnxruntime and related packages

### DIFF
--- a/pkgs/development/libraries/onnxruntime/default.nix
+++ b/pkgs/development/libraries/onnxruntime/default.nix
@@ -13,7 +13,6 @@
 , howard-hinnant-date
 , nlohmann_json
 , boost
-, oneDNN
 , gtest
 , pythonSupport ? true
 , nsync
@@ -67,7 +66,6 @@ stdenv.mkDerivation rec {
     howard-hinnant-date
     nlohmann_json
     boost
-    oneDNN
   ] ++ lib.optionals pythonSupport ([
     flatbuffers
     nsync
@@ -91,7 +89,7 @@ stdenv.mkDerivation rec {
     "-Donnxruntime_USE_PREINSTALLED_EIGEN=ON"
     "-Donnxruntime_USE_MPI=ON"
     "-Deigen_SOURCE_PATH=${eigen.src}"
-    "-Donnxruntime_USE_DNNL=YES"
+    "-Donnxruntime_USE_DNNL=NO"
   ] ++ lib.optionals pythonSupport [
     "-Donnxruntime_ENABLE_PYTHON=ON"
   ];
@@ -133,6 +131,6 @@ stdenv.mkDerivation rec {
     # https://github.com/microsoft/onnxruntime/blob/master/BUILD.md#architectures
     platforms = platforms.unix;
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer puffnfresh ck3d ];
+    maintainers = with maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/libraries/onnxruntime/default.nix
+++ b/pkgs/development/libraries/onnxruntime/default.nix
@@ -2,74 +2,43 @@
 , lib
 , fetchFromGitHub
 , fetchpatch
-, runCommand
-, patchutils
+, fetchurl
 , pkg-config
-, glibcLocales
 , cmake
 , python3
 , libpng
 , zlib
 , eigen
 , protobuf
-, nsync
-, flatbuffers
 , howard-hinnant-date
-, re2
 , nlohmann_json
 , boost
 , oneDNN
+, gtest
 }:
 
 let
-  externals = {
-    pytorch_cpuinfo = fetchFromGitHub {
-      owner = "pytorch";
-      repo = "cpuinfo";
-      rev = "5916273f79a21551890fd3d56fc5375a78d1598d";
-      sha256 = "sha256-nXBnloVTuB+AVX59VDU/Wc+Dsx94o92YQuHp3jowx2A=";
-    };
-    onnx = fetchFromGitHub {
-      owner = "onnx";
-      repo = "onnx";
-      rev = "be76ca7148396176784ba8733133b9fb1186ea0d";
-      sha256 = "sha256-WwbfUijV67LL69RPgz+4m6EcwSyBNFweGUe0jkYRpbg=";
-    };
-    "SafeInt/safeint" = fetchFromGitHub {
-      owner = "dcleblanc";
-      repo = "SafeInt";
-      rev = "a104e0cf23be4fe848f7ef1f3e8996fe429b06bb";
-      sha256 = "sha256-LmQNIoHPqvl8asn86P33SDn+lCg8LpLfxUmoG9CGEdc=";
-    };
+  # prefetch abseil
+  # Note: keep URL in sync with `cmake/external/abseil-cpp.cmake`
+  abseil = fetchurl {
+    url = "https://github.com/abseil/abseil-cpp/archive/refs/tags/20211102.0.zip";
+    sha256 = "sha256-pFZ/8C+spnG5XjHTFbqxi0K2xvGmDpHG6oTlohQhEsI=";
   };
 in
 stdenv.mkDerivation rec {
   pname = "onnxruntime";
-  version = "1.10.0";
+  version = "1.12.1";
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "onnxruntime";
     rev = "v${version}";
-    sha256 = "sha256-kWl0xrbTQL2FBSvpiqTcaj8uZV+ZV8gJJvj4/I0jopw=";
+    sha256 = "sha256-wwllEemiHTp9aJcCd1gsTS4WUVMp5wW+4i/+6DzmAeM=";
+    fetchSubmodules = true;
   };
 
-  preConfigure = lib.concatStringsSep "\n" (lib.mapAttrsToList (name: path: ''
-    rmdir cmake/external/${name}
-    ln -s ${path} cmake/external/${name}
-  '') externals);
-
   patches = [
-    # Exclude the flatbuffers change which breaks things
-    (runCommand "filtered" {
-      AUR_PATCH = fetchpatch {
-        name = "aur-build-fixes.patch";
-        url = "https://aur.archlinux.org/cgit/aur.git/plain/build-fixes.patch?h=python-onnxruntime&id=0185531906bda3a9aba93bbb0f3dcfeb0ae671ad";
-        sha256 = "sha256-bAJWThTbECQaoqDdkjHLneg6I1BshGMyCWaj7nfACvA=";
-      };
-    } ''
-      ${patchutils}/bin/filterdiff --hunks 1,2 $AUR_PATCH > $out
-    '')
+    # Use dnnl from nixpkgs instead of submodules
     (fetchpatch {
       name = "system-dnnl.patch";
       url = "https://aur.archlinux.org/cgit/aur.git/plain/system-dnnl.diff?h=python-onnxruntime&id=0185531906bda3a9aba93bbb0f3dcfeb0ae671ad";
@@ -77,27 +46,27 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  # TODO: build server, and move .so's to lib output
-  outputs = [ "out" "dev" ];
-
   nativeBuildInputs = [
     cmake
     pkg-config
     python3
+    gtest
   ];
 
   buildInputs = [
     libpng
     zlib
     protobuf
-    nsync
-    flatbuffers
     howard-hinnant-date
-    re2
     nlohmann_json
     boost
     oneDNN
   ];
+
+  # TODO: build server, and move .so's to lib output
+  outputs = [ "out" "dev" ];
+
+  enableParallelBuilding = true;
 
   cmakeDir = "../cmake";
 
@@ -105,16 +74,29 @@ stdenv.mkDerivation rec {
     "-Donnxruntime_PREFER_SYSTEM_LIB=ON"
     "-Donnxruntime_BUILD_SHARED_LIB=ON"
     "-Donnxruntime_ENABLE_LTO=ON"
-    "-Donnxruntime_BUILD_UNIT_TESTS=OFF"
+    "-Donnxruntime_BUILD_UNIT_TESTS=ON"
     "-Donnxruntime_USE_PREINSTALLED_EIGEN=ON"
     "-Donnxruntime_USE_MPI=ON"
     "-Deigen_SOURCE_PATH=${eigen.src}"
     "-Donnxruntime_USE_DNNL=YES"
   ];
 
-  enableParallelBuilding = true;
+  doCheck = true;
 
-  meta = {
+  postPatch = ''
+    substituteInPlace cmake/external/abseil-cpp.cmake \
+      --replace "${abseil.url}" "${abseil}"
+  '';
+
+  postInstall = ''
+    # perform parts of `tools/ci_build/github/linux/copy_strip_binary.sh`
+    install -m644 -Dt $out/include \
+      ../include/onnxruntime/core/framework/provider_options.h \
+      ../include/onnxruntime/core/providers/cpu/cpu_provider_factory.h \
+      ../include/onnxruntime/core/session/onnxruntime_*.h
+  '';
+
+  meta = with lib; {
     description = "Cross-platform, high performance scoring engine for ML models";
     longDescription = ''
       ONNX Runtime is a performance-focused complete scoring engine
@@ -126,10 +108,10 @@ stdenv.mkDerivation rec {
       compatibility.
     '';
     homepage = "https://github.com/microsoft/onnxruntime";
-    changelog = "https://github.com/microsoft/onnxruntime/releases";
+    changelog = "https://github.com/microsoft/onnxruntime/releases/tag/v${version}";
     # https://github.com/microsoft/onnxruntime/blob/master/BUILD.md#architectures
-    platforms = lib.platforms.unix;
-    license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ jonringer puffnfresh ];
+    platforms = platforms.unix;
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer puffnfresh ck3d ];
   };
 }

--- a/pkgs/development/libraries/onnxruntime/default.nix
+++ b/pkgs/development/libraries/onnxruntime/default.nix
@@ -1,0 +1,135 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchpatch
+, runCommand
+, patchutils
+, pkg-config
+, glibcLocales
+, cmake
+, python3
+, libpng
+, zlib
+, eigen
+, protobuf
+, nsync
+, flatbuffers
+, howard-hinnant-date
+, re2
+, nlohmann_json
+, boost
+, oneDNN
+}:
+
+let
+  externals = {
+    pytorch_cpuinfo = fetchFromGitHub {
+      owner = "pytorch";
+      repo = "cpuinfo";
+      rev = "5916273f79a21551890fd3d56fc5375a78d1598d";
+      sha256 = "sha256-nXBnloVTuB+AVX59VDU/Wc+Dsx94o92YQuHp3jowx2A=";
+    };
+    onnx = fetchFromGitHub {
+      owner = "onnx";
+      repo = "onnx";
+      rev = "be76ca7148396176784ba8733133b9fb1186ea0d";
+      sha256 = "sha256-WwbfUijV67LL69RPgz+4m6EcwSyBNFweGUe0jkYRpbg=";
+    };
+    "SafeInt/safeint" = fetchFromGitHub {
+      owner = "dcleblanc";
+      repo = "SafeInt";
+      rev = "a104e0cf23be4fe848f7ef1f3e8996fe429b06bb";
+      sha256 = "sha256-LmQNIoHPqvl8asn86P33SDn+lCg8LpLfxUmoG9CGEdc=";
+    };
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "onnxruntime";
+  version = "1.10.0";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "onnxruntime";
+    rev = "v${version}";
+    sha256 = "sha256-kWl0xrbTQL2FBSvpiqTcaj8uZV+ZV8gJJvj4/I0jopw=";
+  };
+
+  preConfigure = lib.concatStringsSep "\n" (lib.mapAttrsToList (name: path: ''
+    rmdir cmake/external/${name}
+    ln -s ${path} cmake/external/${name}
+  '') externals);
+
+  patches = [
+    # Exclude the flatbuffers change which breaks things
+    (runCommand "filtered" {
+      AUR_PATCH = fetchpatch {
+        name = "aur-build-fixes.patch";
+        url = "https://aur.archlinux.org/cgit/aur.git/plain/build-fixes.patch?h=python-onnxruntime&id=0185531906bda3a9aba93bbb0f3dcfeb0ae671ad";
+        sha256 = "sha256-bAJWThTbECQaoqDdkjHLneg6I1BshGMyCWaj7nfACvA=";
+      };
+    } ''
+      ${patchutils}/bin/filterdiff --hunks 1,2 $AUR_PATCH > $out
+    '')
+    (fetchpatch {
+      name = "system-dnnl.patch";
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/system-dnnl.diff?h=python-onnxruntime&id=0185531906bda3a9aba93bbb0f3dcfeb0ae671ad";
+      sha256 = "sha256-58RBrQnAWNtc/1pmFs+PkZ6qCsL1LfMY3P0exMKzotA=";
+    })
+  ];
+
+  # TODO: build server, and move .so's to lib output
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    python3
+  ];
+
+  buildInputs = [
+    libpng
+    zlib
+    protobuf
+    nsync
+    flatbuffers
+    howard-hinnant-date
+    re2
+    nlohmann_json
+    boost
+    oneDNN
+  ];
+
+  cmakeDir = "../cmake";
+
+  cmakeFlags = [
+    "-Donnxruntime_PREFER_SYSTEM_LIB=ON"
+    "-Donnxruntime_BUILD_SHARED_LIB=ON"
+    "-Donnxruntime_ENABLE_LTO=ON"
+    "-Donnxruntime_BUILD_UNIT_TESTS=OFF"
+    "-Donnxruntime_USE_PREINSTALLED_EIGEN=ON"
+    "-Donnxruntime_USE_MPI=ON"
+    "-Deigen_SOURCE_PATH=${eigen.src}"
+    "-Donnxruntime_USE_DNNL=YES"
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "Cross-platform, high performance scoring engine for ML models";
+    longDescription = ''
+      ONNX Runtime is a performance-focused complete scoring engine
+      for Open Neural Network Exchange (ONNX) models, with an open
+      extensible architecture to continually address the latest developments
+      in AI and Deep Learning. ONNX Runtime stays up to date with the ONNX
+      standard with complete implementation of all ONNX operators, and
+      supports all ONNX releases (1.2+) with both future and backwards
+      compatibility.
+    '';
+    homepage = "https://github.com/microsoft/onnxruntime";
+    changelog = "https://github.com/microsoft/onnxruntime/releases";
+    # https://github.com/microsoft/onnxruntime/blob/master/BUILD.md#architectures
+    platforms = lib.platforms.unix;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jonringer puffnfresh ];
+  };
+}

--- a/pkgs/development/python-modules/onnxconverter-common/default.nix
+++ b/pkgs/development/python-modules/onnxconverter-common/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, numpy
+, packaging
+, protobuf
+, onnx
+, onnxruntime
+}:
+
+buildPythonPackage {
+  pname = "onnxconverter-common";
+  version = "1.12.2"; # Upstream no longer seems to push tags
+
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "onnxconverter-common";
+    rev = "814cdf494d987900d30b16971c0e8334aaca9ae6";
+    hash = "sha256-XA/kl8aT1wLthl1bMihtv/1ELOW1sGO/It5XfJtD+sY=";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+    packaging # undeclared dependency
+    protobuf
+    onnx
+  ];
+
+  checkInputs = [
+    onnxruntime
+  ];
+
+  # Failing tests
+  # https://github.com/microsoft/onnxconverter-common/issues/242
+  doCheck = false;
+
+  meta = {
+    description = "ONNX Converter and Optimization Tools";
+    maintainers = with lib.maintainers; [ fridh ];
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/pkgs/development/python-modules/skl2onnx/default.nix
+++ b/pkgs/development/python-modules/skl2onnx/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, numpy
+, scipy
+, protobuf
+, onnx
+, scikit-learn
+, onnxconverter-common
+, onnxruntime
+, pandas
+}:
+
+buildPythonPackage rec {
+  pname = "skl2onnx";
+  version = "1.13";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-XzUva5uFX/rGMFpwfwLH1Db0Nok47pBJCSqVo1ZcJz0=";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+    scipy
+    protobuf
+    onnx
+    scikit-learn
+    onnxconverter-common
+  ];
+
+  checkInputs = [
+    onnxruntime
+    pandas
+  ];
+
+  # Core dump
+  doCheck = false;
+
+  meta = {
+    description = "Convert scikit-learn models to ONNX";
+    maintainers = with lib.maintainers; [ fridh ];
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -936,7 +936,6 @@ mapAliases ({
   odpdown = throw "odpdown has been removed because it lacks python3 support"; # Added 2022-04-25
   ofp = throw "ofp is not compatible with odp-dpdk";
   olifant = throw "olifant has been removed from nixpkgs, as it was unmaintained"; # Added 2021-08-05
-  onnxruntime = throw "onnxruntime has been removed due to poor maintainability"; # Added 2020-12-04
   openbazaar = throw "openbazzar has been removed from nixpkgs as upstream has abandoned the project"; # Added 2022-01-06
   openbazaar-client = throw "openbazzar-client has been removed from nixpkgs as upstream has abandoned the project"; # Added 2022-01-06
   opencascade_oce = throw "'opencascade_oce' has been renamed to/replaced by 'opencascade'"; # Converted to throw 2022-02-22

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4060,6 +4060,8 @@ with pkgs;
 
   online-judge-tools = with python3.pkgs; toPythonApplication online-judge-tools;
 
+  onnxruntime = callPackage ../development/libraries/onnxruntime { };
+
   xkbd = callPackage ../applications/misc/xkbd { };
 
   libpsm2 = callPackage ../os-specific/linux/libpsm2 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5955,6 +5955,11 @@ in {
 
   onnx = callPackage ../development/python-modules/onnx { };
 
+  onnxruntime = (toPythonModule (pkgs.onnxruntime.override {
+    python3Packages = self;
+    pythonSupport = true;
+  })).python;
+
   onvif-zeep-async = callPackage ../development/python-modules/onvif-zeep-async { };
 
   oocsi = callPackage ../development/python-modules/oocsi { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5955,6 +5955,8 @@ in {
 
   onnx = callPackage ../development/python-modules/onnx { };
 
+  onnxconverter-common = callPackage ../development/python-modules/onnxconverter-common { };
+
   onnxruntime = (toPythonModule (pkgs.onnxruntime.override {
     python3Packages = self;
     pythonSupport = true;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9597,6 +9597,8 @@ in {
 
   skidl = callPackage ../development/python-modules/skidl { };
 
+  skl2onnx = callPackage ../development/python-modules/skl2onnx { };
+
   sklearn-deap = callPackage ../development/python-modules/sklearn-deap { };
 
   skodaconnect = callPackage ../development/python-modules/skodaconnect { };


### PR DESCRIPTION
###### Description of changes

Backport the reintroduction on onnxruntime to 22.05 and add related Python packages. None oneDNN is disabled because I think a newer version is needed.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
