### PR TITLE
Run `nixosTests` on darwin

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -71,7 +71,7 @@ let
       importJSON importTOML warn warnIf warnIfNot throwIf throwIfNot checkListOfEnum
       info showWarnings nixpkgsVersion version isInOldestRelease
       mod compare splitByAndCompare
-      functionArgs setFunctionArgs isFunction toFunction
+      functionArgs setFunctionArgs isFunction toFunction lazyFunction
       toHexString toBaseDigits inPureEvalMode;
     inherit (self.fixedPoints) fix fix' converge extends composeExtensions
       composeManyExtensions makeExtensible makeExtensibleWithCustomName;

--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -204,7 +204,7 @@ rec {
         emulator = pkgs:
           if (final.emulatorAvailable pkgs)
           then selectEmulator pkgs
-          else throw "Don't know how to run ${final.config} executables.";
+          else throw "Don't know how to run ${final.config} executables on ${pkgs.stdenv.hostPlatform.system}.";
 
     }) // mapAttrs (n: v: v final.parsed) inspect.predicates
       // mapAttrs (n: v: v final.gcc.arch or "default") architectures.predicates

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -1,5 +1,9 @@
 { lib }:
 
+let
+  inherit (lib) mapAttrs functionArgs setFunctionArgs;
+in
+
 rec {
 
   ## Simple (higher order) functions
@@ -466,6 +470,29 @@ rec {
     if isFunction v
     then v
     else k: v;
+
+  /*
+    Make an attribute-set matching function such as `{ a, b }: b` delay
+    its evaluation of the attribute set in the argument.
+
+    This is not compatible with ellipsis patterns, `{ ... }:`. It removes the
+    ability to do `args@{ a, ... }: args.b`, although this limitation should
+    not be relied on.
+
+    Example:
+
+        lib.fix (lib.lazyFunction ({ a, b }: { a = b; b = 1; }))
+  */
+  lazyFunction = f:
+    setFunctionArgs
+      (args:
+        f
+          (mapAttrs
+            (k: _: args.${k})
+            (functionArgs f)
+          )
+      )
+      (functionArgs f) ;
 
   /* Convert the given positive integer to a string of its hexadecimal
      representation. For example:

--- a/nixos/lib/testing-python.nix
+++ b/nixos/lib/testing-python.nix
@@ -1,5 +1,6 @@
 { system
 , pkgs ? import ../.. { inherit system config; }
+, hostPkgs ? pkgs
   # Use a minimal kernel?
 , minimal ? false
   # Ignored
@@ -25,7 +26,8 @@ rec {
 
   extraTestModule = {
     config = {
-      hostPkgs = pkgs;
+      _module.args.pkgs = pkgs;
+      inherit hostPkgs;
     };
   };
 

--- a/nixos/lib/testing/pkgs.nix
+++ b/nixos/lib/testing/pkgs.nix
@@ -2,7 +2,7 @@
 {
   config = {
     # default pkgs for use in VMs
-    _module.args.pkgs = hostPkgs;
+    _module.args.pkgs = lib.mkDefault hostPkgs;
 
     defaults = {
       # TODO: a module to set a shared pkgs, if options.nixpkgs.* is untouched by user (highestPrio) */

--- a/nixos/lib/testing/run.nix
+++ b/nixos/lib/testing/run.nix
@@ -1,6 +1,13 @@
 { config, hostPkgs, lib, ... }:
 let
   inherit (lib) types mkOption mdDoc;
+
+  vmHostPlatform = hostPkgs.stdenv.buildPlatform;
+
+  virtualisationFeature =
+    if vmHostPlatform.isLinux then [ "kvm" ]
+    else if vmHostPlatform.isDarwin then [ "hvf" ]
+    else throw "Don't know how to require virtualisation on platform ${vmHostPlatform.system}";
 in
 {
   options = {
@@ -33,7 +40,7 @@ in
       derivation = hostPkgs.stdenv.mkDerivation {
         name = "vm-test-run-${config.name}";
 
-        requiredSystemFeatures = [ "kvm" "nixos-test" ];
+        requiredSystemFeatures = virtualisationFeature ++ [ "nixos-test" ];
 
         buildCommand = ''
           mkdir -p $out

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1,5 +1,6 @@
 { system,
   pkgs,
+  hostPkgs ? pkgs,
 
   # Projects the test configuration into a the desired value; usually
   # the test runner: `config: config.test`.
@@ -28,10 +29,10 @@ let
         # in that file, which are then forwarded to the test definition
         # following the `import make-test-python.nix` expression
         # (if it is a function).
-        discoverTests (val { inherit system pkgs; })
+        discoverTests (val { inherit system pkgs hostPkgs; })
       else val;
   handleTest = path: args:
-    discoverTests (import path ({ inherit system pkgs; } // args));
+    discoverTests (lazyFunction (import path) ({ inherit system pkgs hostPkgs; } // args));
   handleTestOn = systems: path: args:
     if elem system systems then handleTest path args
     else {};
@@ -45,7 +46,7 @@ let
 
   inherit
     (rec {
-      doRunTest = arg: ((import ../lib/testing-python.nix { inherit system pkgs; }).evalTest {
+      doRunTest = arg: ((import ../lib/testing-python.nix { inherit system pkgs hostPkgs; }).evalTest {
         imports = [ arg ];
       }).config.result;
       findTests = tree:

--- a/nixos/tests/make-test-python.nix
+++ b/nixos/tests/make-test-python.nix
@@ -1,10 +1,11 @@
 f: {
   system ? builtins.currentSystem,
   pkgs ? import ../.. { inherit system; },
+  hostPkgs ? pkgs,
   ...
 } @ args:
 
-with import ../lib/testing-python.nix { inherit system pkgs; };
+with import ../lib/testing-python.nix { inherit system pkgs hostPkgs; };
 
 let testConfig = makeTest (if pkgs.lib.isFunction f then f (args // { inherit pkgs; inherit (pkgs) lib; }) else f);
 in testConfig.test   # For nix-build


### PR DESCRIPTION
###### Description of changes

Towards #108984

I had to add `lazyFunction` in order to half-support `make-test-python.nix` calls which don't pass `hostPkgs` along.
All tests should be migrated to use the simpler `runTest` IMO.

Draft because this needs testing and validation, but I don't have much time to spend on this. Figured I'd dump my knowledge in the form of a draft PR (and because I've changed things #191540).

TODO
 - [ ] Eval on hydra against eval regressions
   - [ ] in existing nixos.test.*
   - [ ] future breakage in the macos tests (but only `nixos.tests.simple` and test-framework testing tests?)
 - [ ] Docs
 - [ ] Add tests to (TBD) `nixosTests.nixos-test-runner` suite (categorize tests with `recurseIntoAttrs`)
 - [ ] Consider moving more of the logic into `nixos/lib/testing`. The `nixosTests` system logic is also useful there.
 - [ ] Get #194514 done and rebase
 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
