### PR TITLE
corrscope: 0.8.0 -> 0.8.1

### DIFF
--- a/pkgs/applications/video/corrscope/default.nix
+++ b/pkgs/applications/video/corrscope/default.nix
@@ -9,23 +9,23 @@
 
 mkDerivationWith python3Packages.buildPythonApplication rec {
   pname = "corrscope";
-  version = "0.8.0";
+  version = "0.8.1";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "corrscope";
     repo = "corrscope";
     rev = version;
-    sha256 = "1wdla4ryif1ss37aqi61lcvzddvf568wyh5s3xv1lrryh4al9vpd";
+    sha256 = "sha256-pS7upOYZAjgR3lWxny8TNZEj3Rrbg+L90ANZWFO9UPQ=";
   };
 
   pythonRelaxDeps = [ "attrs" ];
 
   nativeBuildInputs = [
-    python3Packages.pythonRelaxDepsHook
     wrapQtAppsHook
   ] ++ (with python3Packages; [
     poetry-core
+    pythonRelaxDepsHook
   ]);
 
   buildInputs = [
@@ -35,6 +35,7 @@ mkDerivationWith python3Packages.buildPythonApplication rec {
 
   propagatedBuildInputs = with python3Packages; [
     appdirs
+    appnope
     atomicwrites
     attrs
     click

--- a/pkgs/applications/video/corrscope/default.nix
+++ b/pkgs/applications/video/corrscope/default.nix
@@ -5,6 +5,8 @@
 , wrapQtAppsHook
 , ffmpeg
 , qtbase
+, testers
+, corrscope
 }:
 
 mkDerivationWith python3Packages.buildPythonApplication rec {
@@ -57,6 +59,14 @@ mkDerivationWith python3Packages.buildPythonApplication rec {
     )
   '';
 
+  passthru.tests.version = testers.testVersion {
+    package = corrscope;
+    # Tries writing to
+    # - $HOME/.local/share/corrscope on Linux
+    # - $HOME/Library/Application Support/corrscope on Darwin
+    command = "env HOME=$TMPDIR ${lib.getExe corrscope} --version";
+  };
+
   meta = with lib; {
     description = "Render wave files into oscilloscope views, featuring advanced correlation-based triggering algorithm";
     longDescription = ''
@@ -70,5 +80,6 @@ mkDerivationWith python3Packages.buildPythonApplication rec {
     license = licenses.bsd2;
     maintainers = with maintainers; [ OPNA2608 ];
     platforms = platforms.all;
+    mainProgram = "corr";
   };
 }


### PR DESCRIPTION
###### Description of changes

https://github.com/corrscope/corrscope/releases/tag/0.8.1

Very minor update in corrscope itself, just fixes some performance stuff on Darwin by using [`appnope`](https://github.com/minrk/appnope).

appnope on non-Darwin was fixed by #208545, cutting this down to just the corrscope stuff now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
