### PR TITLE
i3: 4.20.1 -> 4.21

### DIFF
--- a/pkgs/applications/window-managers/i3/default.nix
+++ b/pkgs/applications/window-managers/i3/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, lib, stdenv, pkg-config, makeWrapper, meson, ninja, installShellFiles, libxcb, xcbutilkeysyms
-, xcbutil, xcbutilwm, xcbutilxrm, libstartup_notification, libX11, pcre, libev
+, xcbutil, xcbutilwm, xcbutilxrm, libstartup_notification, libX11, pcre2, libev
 , yajl, xcb-util-cursor, perl, pango, perlPackages, libxkbcommon
 , xorgserver, xvfb-run
 , asciidoc, xmlto, docbook_xml_dtd_45, docbook_xsl, findXMLCatalogs
@@ -7,11 +7,11 @@
 
 stdenv.mkDerivation rec {
   pname = "i3";
-  version = "4.20.1";
+  version = "4.21";
 
   src = fetchurl {
     url = "https://i3wm.org/downloads/${pname}-${version}.tar.xz";
-    sha256 = "1rpwdgykcvmrmdz244f0wm7446ih1dcw8rlc1hm1c7cc42pyrq93";
+    sha256 = "sha256-jcUgXg80Q9WGYeMHg1If2cbUJtHn82Z6sS8qwbLTIHg=";
   };
 
   nativeBuildInputs = [
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     libxcb xcbutilkeysyms xcbutil xcbutilwm xcbutilxrm libxkbcommon
-    libstartup_notification libX11 pcre libev yajl xcb-util-cursor perl pango
+    libstartup_notification libX11 pcre2 libev yajl xcb-util-cursor perl pango
     perlPackages.AnyEventI3 perlPackages.X11XCB perlPackages.IPCRun
     perlPackages.ExtUtilsPkgConfig perlPackages.InlineC
     xorgserver xvfb-run

--- a/pkgs/applications/window-managers/i3/gaps.nix
+++ b/pkgs/applications/window-managers/i3/gaps.nix
@@ -2,13 +2,13 @@
 
 i3.overrideAttrs (oldAttrs : rec {
   pname = "i3-gaps";
-  version = "4.20.1";
+  version = "4.21";
 
   src = fetchFromGitHub {
     owner = "Airblader";
     repo = "i3";
     rev = version;
-    sha256 = "sha256-aS1dLs8KxoJaTf3RlQX+zRrtNmHEFZgkXDjt+8SuGDw=";
+    sha256 = "sha256-douSRvnyDbi2gDJfu9VZmmTyYfy+FrFWHgyAyPyBWdM=";
   };
 
   meta = with lib; {

--- a/pkgs/applications/window-managers/i3/rounded.nix
+++ b/pkgs/applications/window-managers/i3/rounded.nix
@@ -1,4 +1,4 @@
-{ fetchFromGitHub, lib, i3 }:
+{ fetchFromGitHub, lib, i3, pcre }:
 
 i3.overrideAttrs (oldAttrs: rec {
   pname = "i3-rounded";
@@ -10,6 +10,8 @@ i3.overrideAttrs (oldAttrs: rec {
     rev = "524c9f7b50f8c540b2ae3480b242c30d8775f98e";
     sha256 = "0y7m1s1y8f9vgkp7byi33js8n4rigiykd71s936i5d4rwlzrxiwm";
   };
+
+  buildInputs = oldAttrs.buildInputs ++ [ pcre ];
 
   meta = with lib; {
     description = "A fork of i3-gaps that adds rounding to window corners";


### PR DESCRIPTION
###### Description of changes

Update i3 to 4.21
Changelog: https://i3wm.org/downloads/RELEASE-NOTES-4.21.txt

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [x] [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).