### PR TITLE
master_me: init at unstable-2022-09-28

### DIFF
--- a/pkgs/applications/audio/airwindows-lv2/default.nix
+++ b/pkgs/applications/audio/airwindows-lv2/default.nix
@@ -1,19 +1,17 @@
-{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, lv2 }:
+{ lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, lv2 }:
 
 stdenv.mkDerivation rec {
   pname = "airwindows-lv2";
-  version = "5.0";
+  version = "11.0";
   src = fetchFromGitHub {
     owner = "hannesbraun";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-sLkcEEYez0Z3pkhMCC7raiwe/m9Tk/lFmOuybZvFqSk=";
+    sha256 = "sha256-IMVcspdWotNbdIZ2IpsNhI0k3+ZdXHEHVxrgOMoROEQ=";
   };
 
-  nativeBuildInputs = [ cmake pkg-config ];
+  nativeBuildInputs = [ meson ninja pkg-config ];
   buildInputs = [ lv2 ];
-
-  cmakeFlags = [ "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}/lib/lv2" ];
 
   meta = with lib; {
     description = "Airwindows plugins (ported to LV2)";

--- a/pkgs/applications/audio/master_me/default.nix
+++ b/pkgs/applications/audio/master_me/default.nix
@@ -1,0 +1,40 @@
+{ lib, stdenv, fetchFromGitHub, libGL, libX11, libXext, libXrandr, pkg-config, python3 }:
+
+stdenv.mkDerivation rec {
+  pname = "master_me";
+  # see: https://github.com/trummerschlunk/master_me/issues/91#issuecomment-1260727551
+  version = "unstable-2022-09-28";
+
+  src = fetchFromGitHub {
+    owner = "trummerschlunk";
+    repo = "master_me";
+    rev = "be4b5f2f8c27735464def91121368f9167aee119";
+    sha256 = "sha256-/aMYi4Nt3k54GW2YdcautiY5sPnKdaQJcnWAv9loapI=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libGL libX11 libXext libXrandr
+  ];
+
+  postPatch = ''
+    patchShebangs ./dpf/utils/
+    substituteInPlace ./dpf/utils/res2c.py \
+    --replace '/usr/bin/env python3' ${python3.interpreter}
+
+  '';
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/trummerschlunk/master_me";
+    description = "automatic mastering plugin for live streaming, podcasts and internet radio.";
+    maintainers = [ maintainers.magnetophon ];
+    platforms = platforms.all;
+    license = licenses.gpl3Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26669,6 +26669,8 @@ with pkgs;
 
   masterpdfeditor4 = libsForQt5.callPackage ../applications/misc/masterpdfeditor4 { };
 
+  master_me = callPackage ../applications/audio/master_me { };
+
   foxitreader = libsForQt512.callPackage ../applications/misc/foxitreader { };
 
   pdfstudio = import ../applications/misc/pdfstudio {


### PR DESCRIPTION
There are releases out, but they require
https://github.com/jpcima/faustpp, which is not in nixpkgs yet.
See: https://github.com/trummerschlunk/master_me/issues/91#issuecomment-1260727551

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
