### PR TITLE
[staging-next] protobuf3_{19,20,21}: Update to fix CVE-2022-1941

### DIFF
--- a/pkgs/development/libraries/protobuf/3.11.nix
+++ b/pkgs/development/libraries/protobuf/3.11.nix
@@ -1,6 +1,0 @@
-{ callPackage, ... }:
-
-callPackage ./generic-v3.nix {
-  version = "3.11.4";
-  sha256 = "00g61f1yd8z5l0z0svmr3hms38ph35lcx2y7hivw6fahslw0l8yw";
-}

--- a/pkgs/development/libraries/protobuf/3.19.nix
+++ b/pkgs/development/libraries/protobuf/3.19.nix
@@ -1,6 +1,6 @@
 { callPackage, ... }:
 
 callPackage ./generic-v3.nix {
-  version = "3.19.4";
-  sha256 = "sha256-mxQ8XonVgctfaNAyd3vqQHMLHVnkjBa9EObk47vxH24=";
+  version = "3.19.5";
+  sha256 = "sha256-C5ZfPXHtUtNjPGS4tbswCwVH1gjd6A64KtIR16DgHzQ=";
 }

--- a/pkgs/development/libraries/protobuf/3.20.nix
+++ b/pkgs/development/libraries/protobuf/3.20.nix
@@ -1,6 +1,6 @@
 { callPackage, abseil-cpp, ... }:
 
 callPackage ./generic-v3.nix {
-  version = "3.20.1";
-  sha256 = "sha256-pAMacD0UQetqysZHszu5slPqp0iREtDmHFv1cgcUBJA=";
+  version = "3.20.2";
+  sha256 = "sha256-7hLTIujvYIGRqBQgPHrCq0XOh0GJrePBszXJnBFaXVM=";
 }

--- a/pkgs/development/libraries/protobuf/3.21.nix
+++ b/pkgs/development/libraries/protobuf/3.21.nix
@@ -1,6 +1,6 @@
 { callPackage, abseil-cpp, ... }:
 
 callPackage ./generic-v3-cmake.nix {
-  version = "3.21.2";
-  sha256 = "sha256-DUv07pWiZV7jNeSA2ClDOz9DY0x/hiJynxkbSTeJOSs=";
+  version = "3.21.6";
+  sha256 = "sha256-6Omd2O/eIZIgod3YV+zIIv+GqT+trith6+eepFEJIWM=";
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -938,6 +938,7 @@ mapAliases ({
   prometheus-dmarc-exporter = dmarc-metrics-exporter; # added 2022-05-31
   prometheus-mesos-exporter = throw "prometheus-mesos-exporter is deprecated and archived by upstream"; # Added 2022-04-05
   prometheus-unifi-exporter = throw "prometheus-unifi-exporter is deprecated and archived by upstream, use unifi-poller instead"; # Added 2022-06-03
+  protobuf3_11 = throw "protobuf3_11 does not receive updates anymore and has been removed"; # Added 2022-09-28
   proxytunnel = throw "proxytunnel has been removed from nixpkgs, because it has not been update upstream since it was added to nixpkgs in 2008 and has therefore bitrotted."; # added 2021-12-15
   pulseaudio-hsphfpd = throw "pulseaudio-hsphfpd upstream has been abandoned"; # Added 2022-03-23
   pulseaudio-modules-bt = throw "pulseaudio-modules-bt has been abandoned, and is superseded by pulseaudio's native bt functionality"; # Added 2022-04-01

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21309,7 +21309,6 @@ with pkgs;
   protobuf3_20 = callPackage ../development/libraries/protobuf/3.20.nix { };
   protobuf3_19 = callPackage ../development/libraries/protobuf/3.19.nix { };
   protobuf3_17 = callPackage ../development/libraries/protobuf/3.17.nix { };
-  protobuf3_11 = callPackage ../development/libraries/protobuf/3.11.nix { };
   protobuf3_8 = callPackage ../development/libraries/protobuf/3.8.nix { };
   protobuf3_7 = callPackage ../development/libraries/protobuf/3.7.nix { };
 


### PR DESCRIPTION
GHSA-8gq9-2x98-w8hf

Fixes: CVE-2022-1941

###### Description of changes

We don't have 3.18 and anything before that looks unsupported. Which means we should get rid of 3.7, 3.8, 3.11 and 3.17 before 22.11.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
