### PR TITLE
coreboot-configurator: init at 2022-08-22

### DIFF
--- a/pkgs/tools/misc/coreboot-configurator/default.nix
+++ b/pkgs/tools/misc/coreboot-configurator/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, inkscape
+, meson
+, ninja
+, pkg-config
+, libyamlcpp
+, nvramtool
+, qtbase
+, qtsvg
+, wrapQtAppsHook
+}:
+
+stdenv.mkDerivation {
+  pname = "coreboot-configurator";
+  version = "unstable-2022-08-22";
+
+  src = fetchFromGitHub {
+    owner = "StarLabsLtd";
+    repo = "coreboot-configurator";
+    rev = "37c93e7e101a20f85be309904177b9404875cfd8";
+    sha256 = "2pk+uJk1EnVNO2vO1zF9Q6TLpij69iRdr5DFiNcZlM0=";
+  };
+
+  nativeBuildInputs = [ inkscape meson ninja pkg-config wrapQtAppsHook ];
+  buildInputs = [ libyamlcpp qtbase qtsvg ];
+
+  postPatch = ''
+    substituteInPlace src/application/*.cpp \
+      --replace '/usr/bin/pkexec' 'sudo' \
+      --replace '/usr/bin/systemctl' 'systemctl' \
+      --replace '/usr/sbin/nvramtool' '${nvramtool}/bin/nvramtool'
+  '';
+
+  meta = with lib; {
+    description = "A simple GUI to change settings in Coreboot's CBFS";
+    homepage = "https://support.starlabs.systems/kb/guides/coreboot-configurator";
+    license = licenses.gpl2Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ danth ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3406,6 +3406,8 @@ with pkgs;
     acpidump-all
     coreboot-utils;
 
+  coreboot-configurator = libsForQt5.callPackage ../tools/misc/coreboot-configurator { };
+
   corosync = callPackage ../servers/corosync { };
 
   cowsay = callPackage ../tools/misc/cowsay { };


### PR DESCRIPTION
###### Description of changes

Packaged [Coreboot Configurator](https://support.starlabs.systems/kb/guides/coreboot-configurator).

> A simple GUI to change settings in coreboot's CBFS, via the nvramtool utility.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
