### PR TITLE
k3s: 1.25.0+k3s1 -> 1.25.2+k3s1

### DIFF
--- a/nixos/tests/k3s/multi-node.nix
+++ b/nixos/tests/k3s/multi-node.nix
@@ -1,4 +1,4 @@
-import ../make-test-python.nix ({ pkgs, ... }:
+import ../make-test-python.nix ({ pkgs, lib, ... }:
   let
     imageEnv = pkgs.buildEnv {
       name = "k3s-pause-image-env";
@@ -54,7 +54,15 @@ import ../make-test-python.nix ({ pkgs, ... }:
           role = "server";
           package = pkgs.k3s;
           clusterInit = true;
-          extraFlags = "--no-deploy coredns,servicelb,traefik,local-storage,metrics-server --pause-image test.local/pause:local --node-ip 192.168.1.1";
+          extraFlags = ''
+            --disable coredns \
+            --disable local-storage \
+            --disable metrics-server \
+            --disable servicelb \
+            --disable traefik \
+            --node-ip 192.168.1.1 \
+            --pause-image test.local/pause:local
+          '';
         };
         networking.firewall.allowedTCPPorts = [ 2379 2380 6443 ];
         networking.firewall.allowedUDPPorts = [ 8472 ];
@@ -76,7 +84,15 @@ import ../make-test-python.nix ({ pkgs, ... }:
           enable = true;
           serverAddr = "https://192.168.1.1:6443";
           clusterInit = false;
-          extraFlags = "--no-deploy coredns,servicelb,traefik,local-storage,metrics-server --pause-image test.local/pause:local --node-ip 192.168.1.3";
+          extraFlags = ''
+            --disable coredns \
+            --disable local-storage \
+            --disable metrics-server \
+            --disable servicelb \
+            --disable traefik \
+            --node-ip 192.168.1.3 \
+            --pause-image test.local/pause:local
+          '';
         };
         networking.firewall.allowedTCPPorts = [ 2379 2380 6443 ];
         networking.firewall.allowedUDPPorts = [ 8472 ];
@@ -110,7 +126,7 @@ import ../make-test-python.nix ({ pkgs, ... }:
     };
 
     meta = with pkgs.lib.maintainers; {
-      maintainers = [ euank ];
+      maintainers = [ euank superherointj ];
     };
 
     testScript = ''
@@ -123,7 +139,8 @@ import ../make-test-python.nix ({ pkgs, ... }:
       server.wait_until_succeeds("k3s kubectl get node agent")
 
       for m in machines:
-          m.succeed("k3s check-config")
+      '' # Fix-Me: Tests fail for 'aarch64-linux' as: "CONFIG_CGROUP_FREEZER: missing (fail)"
+      + lib.optionalString (!pkgs.stdenv.isAarch64) ''m.succeed("k3s check-config")'' + ''
           m.succeed(
               "${pauseImage} | k3s ctr image import -"
           )

--- a/nixos/tests/k3s/single-node.nix
+++ b/nixos/tests/k3s/single-node.nix
@@ -1,4 +1,4 @@
-import ../make-test-python.nix ({ pkgs, ... }:
+import ../make-test-python.nix ({ pkgs, lib, ... }:
   let
     imageEnv = pkgs.buildEnv {
       name = "k3s-pause-image-env";
@@ -26,7 +26,7 @@ import ../make-test-python.nix ({ pkgs, ... }:
   {
     name = "k3s";
     meta = with pkgs.lib.maintainers; {
-      maintainers = [ euank ];
+      maintainers = [ euank superherointj ];
     };
 
     nodes.machine = { pkgs, ... }: {
@@ -40,7 +40,15 @@ import ../make-test-python.nix ({ pkgs, ... }:
       services.k3s.role = "server";
       services.k3s.package = pkgs.k3s;
       # Slightly reduce resource usage
-      services.k3s.extraFlags = "--no-deploy coredns,servicelb,traefik,local-storage,metrics-server --pause-image test.local/pause:local";
+      services.k3s.extraFlags = ''
+        --disable coredns \
+        --disable local-storage \
+        --disable metrics-server \
+        --disable servicelb \
+        --disable traefik \
+        --pause-image \
+        test.local/pause:local
+      '';
 
       users.users = {
         noprivs = {
@@ -57,7 +65,8 @@ import ../make-test-python.nix ({ pkgs, ... }:
       machine.wait_for_unit("k3s")
       machine.succeed("k3s kubectl cluster-info")
       machine.fail("sudo -u noprivs k3s kubectl cluster-info")
-      machine.succeed("k3s check-config")
+      '' # Fix-Me: Tests fail for 'aarch64-linux' as: "CONFIG_CGROUP_FREEZER: missing (fail)"
+      + lib.optionalString (!pkgs.stdenv.isAarch64) ''machine.succeed("k3s check-config")'' + ''
 
       machine.succeed(
           "${pauseImage} | k3s ctr image import -"

--- a/pkgs/applications/networking/cluster/k3s/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/default.nix
@@ -47,10 +47,10 @@ with lib;
 # Those pieces of software we entirely ignore upstream's handling of, and just
 # make sure they're in the path if desired.
 let
-  k3sVersion = "1.25.0+k3s1";     # k3s git tag
-  k3sCommit = "26e9405767263a2915723cb72b1ffd7f50687a8f"; # k3s git commit at the above version
-  k3sRepoSha256 = "0rk0svqx26rn6qlvvyj5rsqb87195h1qcf84qmmvf874qwszwpgh";
-  k3sVendorSha256 = "sha256-YX/yLOLtDxGhRB4tic6oTli/qeeSnpP+f+S+sVXXDSs=";
+  k3sVersion = "1.25.2+k3s1";     # k3s git tag
+  k3sCommit = "53c268d8eb90ceea5e1c7865f89db5c7fb8763bc"; # k3s git commit at the above version
+  k3sRepoSha256 = "1w040bsrf981k19rwaaxjsv52pgzc0k77x083fkhysmrca565z0y";
+  k3sVendorSha256 = "sha256-8Xti08sjFk1WKimH/GEb99oqBdFO79WVCvYyXIWMpgo=";
 
   # taken from ./manifests/traefik.yaml, extracted from '.spec.chart' https://github.com/k3s-io/k3s/blob/v1.23.3%2Bk3s1/scripts/download#L9
   # The 'patch' and 'minor' versions are currently hardcoded as single digits only, so ignore the trailing two digits. Weird, I know.


### PR DESCRIPTION
k3s: 1.25.0+k3s1 -> 1.25.2+k3s1
* nixos/tests/k3s
  - fix tests
  - skip check-config in aarch64
  - add superherointj as maintainer
* (minor) convenience change to update script