### PR TITLE
update tree-sitter grammars and add tree-sitter-racket

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
@@ -70,6 +70,7 @@
   tree-sitter-ql-dbscheme = lib.importJSON ./tree-sitter-ql-dbscheme.json;
   tree-sitter-query = lib.importJSON ./tree-sitter-query.json;
   tree-sitter-r = lib.importJSON ./tree-sitter-r.json;
+  tree-sitter-racket = lib.importJSON ./tree-sitter-racket.json;
   tree-sitter-regex = lib.importJSON ./tree-sitter-regex.json;
   tree-sitter-rego = lib.importJSON ./tree-sitter-rego.json;
   tree-sitter-rst = lib.importJSON ./tree-sitter-rst.json;

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-c-sharp",
-  "rev": "ad8e6980e9bf1882a324196229692febf332c4dd",
-  "date": "2022-08-22T14:15:43+01:00",
-  "path": "/nix/store/wl7r0cp4s43ivzxkd9vpvwp08xsl1cb2-tree-sitter-c-sharp",
-  "sha256": "17vn2cy23k1ms8dizyw2gz8gwfghhgd92xfvp9n4vnav9qzah09w",
+  "rev": "7a47daeaf0d410dd1a91c97b274bb7276dd96605",
+  "date": "2022-09-15T09:14:12+01:00",
+  "path": "/nix/store/sscjjlp833rqqvfpgh84wsnq59jmy90c-tree-sitter-c-sharp",
+  "sha256": "0lijbi5q49g50ji00p2lb45rvd76h07sif3xjl9b31yyxwillr6l",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-cpp",
-  "rev": "f40125503642845492d87fa56ece3ed26a4ef4db",
-  "date": "2022-08-01T17:34:55-05:00",
-  "path": "/nix/store/cs7pplbqvrv3j30hl510c8qjgjx592pp-tree-sitter-cpp",
-  "sha256": "17kxbs87fqf87dh7rf56yqg1njhhmh2xw6f43bpkj7z1k2ryf5zk",
+  "rev": "45593f057894db133da3cd46ac954626e0abdaf0",
+  "date": "2022-09-28T04:04:12-05:00",
+  "path": "/nix/store/d4dfmjs39chn6l8ja5by4m1zk3k8bf5r-tree-sitter-cpp",
+  "sha256": "0gspar07m3xhcykdp8hgrf79l6pk8vq80v5f9plh5hfrfp94dqgc",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-css.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-css.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-css",
-  "rev": "a03f1d2d1dfbf6f8e0fdca5f9ff030228241eb57",
-  "date": "2021-09-15T14:32:51-07:00",
-  "path": "/nix/store/zamdl9ixsmgi7rdsb7mx2a1g0i8gfvdy-tree-sitter-css",
-  "sha256": "0i5xf97m6vxgcpa21h2gzlgj9n5rlv9mz3w738bwvcz5k6nbx6np",
+  "rev": "769203d0f9abe1a9a691ac2b9fe4bb4397a73c51",
+  "date": "2022-08-31T10:51:16-07:00",
+  "path": "/nix/store/a91kqixk4gmh40ak98jjnfrlzm3ngvax-tree-sitter-css",
+  "sha256": "05875jmkkklx0b5g1h4qc8cbgcj8mr1n8slw7hsn0wssn7yn42z5",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cuda.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cuda.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/thehamsta/tree-sitter-cuda",
-  "rev": "bc48d8eaf5a145922a1bed0a69dca1342a83c12c",
-  "date": "2022-07-24T11:22:15+02:00",
-  "path": "/nix/store/xjgyflwrn6k3slzjvpy0mi1769z657li-tree-sitter-cuda",
-  "sha256": "0nd1xi5w9wjj4jbwlvwacs6b4q0syb91q06p27nc2ygs3v9wx3l7",
+  "rev": "cb72fa0fb94fccf59de5ac94b42be3601cf63fb5",
+  "date": "2022-09-04T21:44:49+02:00",
+  "path": "/nix/store/pxa2yi7m606qy0jasd3f8r9wrkzrlf2s-tree-sitter-cuda",
+  "sha256": "02scwsmiiss6vfki2n1c19mlh7r6406csj2vwymw572hpcs0w8ja",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elm.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elm.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/elm-tooling/tree-sitter-elm",
-  "rev": "a9317711507b094b2049b42356646dd5764bca06",
-  "date": "2022-08-28T14:37:52+02:00",
-  "path": "/nix/store/cq018zk73bw5163ch7p52kkxiqd0yz0y-tree-sitter-elm",
-  "sha256": "1ml93yj9ns6pxzhk0l4hiwfp9h9s1ad3cpwdnpmbgyc0fgaqzjf9",
+  "rev": "cce0e5938e7779f86cf8bf445eadf7df4b88229d",
+  "date": "2022-09-03T13:02:26+02:00",
+  "path": "/nix/store/scick955z3qrbxmk1jr8cchwsnx4l814-tree-sitter-elm",
+  "sha256": "0b5jpj8bnil1ylisyc4w48j8a30dyf3zylhidj73mlrb8rf7xm2s",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-glsl.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-glsl.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/thehamsta/tree-sitter-glsl",
-  "rev": "e594c182d9d55170ba01678e1fc534166a38e171",
-  "date": "2022-08-07T23:31:50-07:00",
-  "path": "/nix/store/cnfwwpml52i755k3k52r9c5sgpw57bmp-tree-sitter-glsl",
-  "sha256": "0pjy6d3fx973qf4waj80lkv03ws0sbmy4vpa9a1s72ws6y6c72in",
+  "rev": "a743ada24fa17da9acc5665133f07d56e03530be",
+  "date": "2022-09-04T21:41:54+02:00",
+  "path": "/nix/store/z4bzmqy26xqwi4lysjicllf2jrk6pvvm-tree-sitter-glsl",
+  "sha256": "04naalz59mczi0dlnjg49z5ygl0f9v1byr2kfclw6q6rhx9pcswp",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-haskell",
-  "rev": "1c89468614883e951db7d4ac05a56ec864f80bc1",
-  "date": "2022-08-22T12:22:27+02:00",
-  "path": "/nix/store/20yq98my5vdv12f76hyly2cc6b1d2dz3-tree-sitter-haskell",
-  "sha256": "1m94qx0gdcv31mskjxs884153qrz1jicajxph2wlp4wdpchl7gsp",
+  "rev": "e30bdfd53eb28c73f26a68b77d436fd2140af167",
+  "date": "2022-09-03T03:49:46+02:00",
+  "path": "/nix/store/zspdb0h8lq10icpq7ia8567gffpkcnjq-tree-sitter-haskell",
+  "sha256": "1ylgs6lv1dyh3wxf756fii070r32hzbgddrfjbi2v369vmvg337p",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-heex.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-heex.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/connorlay/tree-sitter-heex",
-  "rev": "961bc4d2937cfd24ceb0a5a6b2da607809f8822e",
-  "date": "2022-06-13T09:15:37-07:00",
-  "path": "/nix/store/5qackjn309ls9qja23wkwhqiid9rc6l3-tree-sitter-heex",
-  "sha256": "1by6c4gcqxy9czvwabbmlfr1hlw8z2w7f623llbag956scp2b9al",
+  "rev": "881f1c805f51485a26ecd7865d15c9ef8d606a78",
+  "date": "2022-09-24T18:53:08-07:00",
+  "path": "/nix/store/vb6x1b9lc90ys55cwshdz5dxmwvzyjvv-tree-sitter-heex",
+  "sha256": "00330rgg67fq0d9gk1yswj78d9mn1jvvjmmy1k7cxpvm5993p3sw",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-json.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-json.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-json",
-  "rev": "368736a6137770f785e1e7479a6be29417eb13aa",
-  "date": "2022-05-22T14:37:14-07:00",
-  "path": "/nix/store/1hgawfjnlijb9vj0bl4ry05p9cnyhpqq-tree-sitter-json",
-  "sha256": "06gvjpg5z8l9vm8a5di5ziv4z1wx3cah1ng14wa9f8r6zi9gn6an",
+  "rev": "11e2cc12d9b267766fb11a06e52952792fd8e3f0",
+  "date": "2022-09-02T09:29:25-07:00",
+  "path": "/nix/store/z0iwsd829ibisjlq0371snwpq1jrb7gk-tree-sitter-json",
+  "sha256": "1g73p5jclqmfkmdyqk0wxgwb6m80mpm1xbhq3jbmihkqa9cblxm5",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-julia.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-julia.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-julia",
-  "rev": "fc60b7cce87da7a1b7f8cb0f9371c3dc8b684500",
-  "date": "2022-05-31T14:11:51-07:00",
-  "path": "/nix/store/mmcw5by2scxv3k085qbi0m5qfm7qldmz-tree-sitter-julia",
-  "sha256": "1mkbp0913xi0mccdp4lb3rvcf9h1xljr5mgavs2kmajcabygv46w",
+  "rev": "0572cebf7b8e8ef5990b4d1e7f44f0b36f62922c",
+  "date": "2022-09-01T18:19:12-07:00",
+  "path": "/nix/store/qh31867lp801xzb93n6jdmibp25zzli1-tree-sitter-julia",
+  "sha256": "1vxwwdl98n7ic739hl9mq43di10j6r53fpyjh4a738dvjrjg1pc4",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-lua.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-lua.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/MunifTanjim/tree-sitter-lua",
-  "rev": "c9ece5b2d348f917052db5a2da9bd4ecff07426c",
-  "date": "2022-07-16T17:09:45+06:00",
-  "path": "/nix/store/88rff0xq0hw7snlcf2kkvvrknnda6sgk-tree-sitter-lua",
-  "sha256": "11jhyll9w6ffd78nnr6d0y79x8r253wvxsflmq3nrhvwqvk2yarm",
+  "rev": "887dfd4e83c469300c279314ff1619b1d0b85b91",
+  "date": "2022-09-16T01:06:50+06:00",
+  "path": "/nix/store/nypzx0f8fdlamiycl1vqrj4ifx0bfgij-tree-sitter-lua",
+  "sha256": "1lv3mp0xm5ac9440gcskcxy0hzsnddvcysix1k5axy1cl4vr8bz6",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-norg.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-norg.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/nvim-neorg/tree-sitter-norg",
-  "rev": "17d61df817c1e0a9cdef8d915d4e4c556b7cf68c",
-  "date": "2022-03-16T16:23:43+01:00",
-  "path": "/nix/store/xjsyabq06584fnwjvqbyqf6yd19i4gn9-tree-sitter-norg",
-  "sha256": "161pmkpfyfhf4lcgkzcl1wdi4bsmmpwxcz7kjcb0jpjy7bamikch",
+  "rev": "5d9c76b5c9927955f7c5d5d946397584e307f69f",
+  "date": "2022-09-17T15:45:09+02:00",
+  "path": "/nix/store/hxz3dc9lw1lfv9kpci90x5skp8yvnbdw-tree-sitter-norg",
+  "sha256": "0vpp4fzfwdcrlyqrvjzfnckg620wpp0wix6qma6rq00mm9pl6py7",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-org-nvim.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-org-nvim.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/milisims/tree-sitter-org",
-  "rev": "698bb1a34331e68f83fc24bdd1b6f97016bb30de",
-  "date": "2022-08-16T11:52:06-04:00",
-  "path": "/nix/store/bixwb7s6ax1wygp2pmg1r4czgail0kq8-tree-sitter-org",
-  "sha256": "0adzb2kw8k3w75p5f3ax9lal64k8n2fwrmrqak2z2w8jl8cgagl6",
+  "rev": "eb1e080361ad885e3885d1037d9b57f81b579de8",
+  "date": "2022-09-12T12:12:18-04:00",
+  "path": "/nix/store/01n8d8yadgsbzj1fa9slfw9hssghp9aq-tree-sitter-org",
+  "sha256": "0bljj92fznjfw83hscbrgrfik3ggvk8589jzp7n7f525ibmn2g1g",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-php",
-  "rev": "670d1eb6822d8c7ade1c71232e0bef42757b9da7",
-  "date": "2022-07-16T12:25:05+02:00",
-  "path": "/nix/store/swkym10m39vwrhvknv5x2wsx2qml6w13-tree-sitter-php",
-  "sha256": "01kkds6nac4b8xb4y4qsndg2z9y2ikr4j7brrs28aw8rzw0qlqf0",
+  "rev": "ab2e72179ceb8bb0b249c8ac9162a148e911b3dc",
+  "date": "2022-09-24T09:03:15+02:00",
+  "path": "/nix/store/99jwdb92ng3xr6j881aja24dgwra4lvx-tree-sitter-php",
+  "sha256": "0gfjvpa5rfi1lgz30jhmdfr8f09vl34k3xjad8n8l2cv5q9203if",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ql-dbscheme.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ql-dbscheme.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-ql-dbscheme",
-  "rev": "ad0c1485aa1e61b727a986d82c7fab4cd21ca723",
-  "date": "2022-07-22T15:14:16+00:00",
-  "path": "/nix/store/13yzcd1k87sfxdac4cdj8pvqv06wal6i-tree-sitter-ql-dbscheme",
-  "sha256": "0glj3j9m4wsmfgahsjzhzp34scxrwpwjqkzgj0i72rn23869xjip",
+  "rev": "6b66b9e6e3d36a49ce4def7abee2a286ac9ca289",
+  "date": "2022-08-29T08:49:16+02:00",
+  "path": "/nix/store/k58fls33kiwgbf8vn4488x5l79c9a18x-tree-sitter-ql-dbscheme",
+  "sha256": "1kpkjg97s5j1dx79r3fk0i2bxhpm9sdawgb1drqnjgz4qsshp7f2",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-racket.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-racket.json
@@ -1,0 +1,11 @@
+{
+  "url": "https://github.com/6cdh/tree-sitter-racket",
+  "rev": "b9b2e7454d7098e44595dd8c1b471b9d1518b910",
+  "date": "2022-08-31T16:55:40+08:00",
+  "path": "/nix/store/pam35y7ib7xs8mv6cg3yn757q97qdg9m-tree-sitter-racket",
+  "sha256": "0cvmyy9lwgpnxqhw7khargk7mp3b840kvv9wj0sf3iw23hi1n70g",
+  "fetchLFS": false,
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ruby.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ruby.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-ruby",
-  "rev": "ad1043283b1f9daf4aad381b6a81f18a5a27fe7e",
-  "date": "2022-08-24T18:08:57+02:00",
-  "path": "/nix/store/mkg79bscx68yirm7avhlspfwqz3snqvl-tree-sitter-ruby",
-  "sha256": "0x4j2z18gf40snhyb416s9l5a2r9jjmki8v57wqldvkm39cvhm4z",
+  "rev": "30f9807df1f5015be5fade0b0e54948d2c5f8310",
+  "date": "2022-09-28T13:55:14+02:00",
+  "path": "/nix/store/4hpv69kwzg5372x1byzpvhss6lff7grg-tree-sitter-ruby",
+  "sha256": "1h1ai06sb5ip777y4rv6433hq2c0cpa4vcjkx36fd6gw31s45gn9",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scheme.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scheme.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/6cdh/tree-sitter-scheme",
-  "rev": "5bb5b2de83d548243fbcc77e76224882ffb4ce68",
-  "date": "2022-06-07T22:14:20+08:00",
-  "path": "/nix/store/jy8z2s9zmgxm8ziv39cqkkia52mq7mbx-tree-sitter-scheme",
-  "sha256": "1cdbzmgkz3f1zbhgps9q1zvy1hnwwj5rlr5fp4jbvbnwp13pd04a",
+  "rev": "2ae1dee116a7612b97dc2179be94ec06ebaaa0d6",
+  "date": "2022-09-03T11:01:28+08:00",
+  "path": "/nix/store/1jp6zsrfcqb50z1wkfpkh3rdh451kdsh-tree-sitter-scheme",
+  "sha256": "1lxclfrxa2nwzr1yp1kabqgc7kl1hanar0v047w9c2bbjvwy1iql",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-verilog.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-verilog.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-verilog",
-  "rev": "6fae7414fa854b5052bee9111b200e9137797f3d",
-  "date": "2021-10-04T10:25:49-07:00",
-  "path": "/nix/store/aklrgpy0si72r8vac5fqjbzvcpqiy5lk-tree-sitter-verilog",
-  "sha256": "0yjhb2rp7drwkwfp35fgwnp6d7qf6k1k6zlf0dfxygjywnjy0bfs",
+  "rev": "4457145e795b363f072463e697dfe2f6973c9a52",
+  "date": "2022-09-07T16:11:11-07:00",
+  "path": "/nix/store/z29mm9c88dd2iybsy648wh4m6z593kvk-tree-sitter-verilog",
+  "sha256": "0lfw8p04c85xyd85jfi3gajzrzsl5xcgc44nwxa43x4g3d7f104p",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-vim.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-vim.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/vigoux/tree-sitter-viml",
-  "rev": "d38ee3b8ea625591a0dc009d6691118517205685",
-  "date": "2022-08-27T12:10:49+02:00",
-  "path": "/nix/store/gl64rifl6x0c0g32fpzwk7kscwbzvxnk-tree-sitter-viml",
-  "sha256": "1mvmg0vssydmgkwgb4blgiwbiqiw5233l58hrqmcgfz4vg4yazr7",
+  "rev": "a078eb351837d2ceaddad5774cd0b6a141a18846",
+  "date": "2022-09-27T17:54:16+02:00",
+  "path": "/nix/store/r3bvc2zcw2jj20qa1c0y9rh6wggmapks-tree-sitter-viml",
+  "sha256": "0yr4h36brlsshcrsf9mjv91aaymzgj48zhigw9q41x17fk003dw1",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/update.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/update.nix
@@ -347,6 +347,10 @@ let
       orga = "indoorvivants";
       repo = "tree-sitter-smithy";
     };
+    "tree-sitter-racket" = {
+      orga = "6cdh";
+      repo = "tree-sitter-racket";
+    };
   };
 
   allGrammars =


### PR DESCRIPTION
Run `update.nix` and added `tree-sitter-racket`



- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
