### PR TITLE
stdenv/check-meta: fix support for `NIXPKGS_ALLOW_NONSOURCE=1`

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -16,8 +16,11 @@ let
   allowUnfree = config.allowUnfree
     || builtins.getEnv "NIXPKGS_ALLOW_UNFREE" == "1";
 
-  allowNonSource = config.allowNonSource or true
-    && builtins.getEnv "NIXPKGS_ALLOW_NONSOURCE" != "0";
+  allowNonSource = let
+    envVar = builtins.getEnv "NIXPKGS_ALLOW_NONSOURCE";
+  in if envVar != ""
+     then envVar != "0"
+     else config.allowNonSource or true;
 
   allowlist = config.allowlistedLicenses or config.whitelistedLicenses or [];
   blocklist = config.blocklistedLicenses or config.blacklistedLicenses or [];


### PR DESCRIPTION
###### Description of changes

Looks like we got it wrong in #177549. This restores support for `NIXPKGS_ALLOW_NONSOURCE=1` when you've got `allowNonSource` set `false`, while being a clearer expression (I think).

Checked it still supports `NIXPKGS_ALLOW_NONSOURCE=0` when you've got `allowNonSource` set `true`

cc @dotlambda 

###### Things done

- Tested on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
