### PR TITLE
Unpin protobuf3_8 in multiple places

### DIFF
--- a/pkgs/development/python-modules/coqui-trainer/default.nix
+++ b/pkgs/development/python-modules/coqui-trainer/default.nix
@@ -30,6 +30,10 @@ buildPythonPackage {
     hash = "sha256-WBFsQuGnpqOiQW7VFfsk0t7qEBs1ScOChfQFpLmqTz4=";
   };
 
+  postPatch = ''
+    sed -i 's/^protobuf.*/protobuf/' requirements.txt
+  '';
+
   propagatedBuildInputs = [
     coqpit
     fsspec

--- a/pkgs/development/python-modules/tensorboardx/default.nix
+++ b/pkgs/development/python-modules/tensorboardx/default.nix
@@ -8,7 +8,7 @@
 , moto
 , numpy
 , pillow
-, protobuf3_8
+, protobuf
 , pytestCheckHook
 , torch
 , six
@@ -19,13 +19,14 @@
 
 buildPythonPackage rec {
   pname = "tensorboardx";
-  version = "2.5";
+  version = "2.5.1";
+  format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "lanpa";
     repo = "tensorboardX";
-    rev = "refs/tags/${version}";
-    sha256 = "sha256-g6x0yUpofeSNA4rKPidqOKC7/TrOICstcc98VnQcfDY=";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-Np0Ibn51qL0ORwq1IY8lUle05MQDdb5XkI1uzGOKJno=";
   };
 
   # apparently torch API changed a bit at 1.6
@@ -39,9 +40,10 @@ buildPythonPackage rec {
     sed -i -e "s/'protobuf[^']*'/'protobuf'/" setup.py
   '';
 
-  # Wanted protobuf version is mentioned here:
-  # https://github.com/lanpa/tensorboardX/blob/0d08112618a2bbda4c028a15a137fed3afe77401/compile.sh#L6
-  nativeBuildInputs = [ which protobuf3_8 ];
+  nativeBuildInputs = [
+    which
+    protobuf
+  ];
 
   # required to make tests deterministic
   PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION = "python";

--- a/pkgs/servers/rippled/default.nix
+++ b/pkgs/servers/rippled/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchgit, fetchurl, git, cmake, pkg-config
-, openssl, boost, grpc, abseil-cpp, protobuf3_8, libnsl }:
+, openssl, boost, grpc, abseil-cpp, protobuf, libnsl }:
 
 let
   sqlite3 = fetchurl rec {
@@ -130,7 +130,7 @@ in stdenv.mkDerivation rec {
   cmakeFlags = ["-Dstatic=OFF" "-DBoost_NO_BOOST_CMAKE=ON"];
 
   nativeBuildInputs = [ pkg-config cmake git ];
-  buildInputs = [ openssl openssl.dev boostSharedStatic grpc abseil-cpp protobuf3_8 libnsl ];
+  buildInputs = [ openssl openssl.dev boostSharedStatic grpc abseil-cpp protobuf libnsl ];
 
   preConfigure = ''
     export HOME=$PWD

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-mozc/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-mozc/default.nix
@@ -8,8 +8,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "google";
     repo = "mozc";
-    rev = "063c41f1d7c1a877f44c1f8caad6be1897350336";
-    sha256 = "sha256-sgsfJZALpPHFB5bXu4OkRssViRDaPcgLfEyGhbqvJbI=";
+    rev = "refs/tags/${version}";
+    hash = "sha256-sgsfJZALpPHFB5bXu4OkRssViRDaPcgLfEyGhbqvJbI=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5340,7 +5340,7 @@ with pkgs;
 
     mozc = callPackage ../tools/inputmethods/ibus-engines/ibus-mozc {
       stdenv = clangStdenv;
-      protobuf = pkgs.protobuf3_8.overrideDerivation (_: { stdenv = clangStdenv; });
+      protobuf = pkgs.protobuf.overrideDerivation (_: { stdenv = clangStdenv; });
     };
 
     rime = callPackage ../tools/inputmethods/ibus-engines/ibus-rime { };


### PR DESCRIPTION
Relates to #193370 

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
