### PR TITLE
inkscape-extensions.living_hinge: init at unstable-2020-01-21

### DIFF
--- a/pkgs/applications/graphics/inkscape/extensions.nix
+++ b/pkgs/applications/graphics/inkscape/extensions.nix
@@ -33,7 +33,7 @@
 
     meta = with lib; {
       description = "This is an extension for creating living hinges in Inkscape.";
-      homepage = "https://github.com/lifelike/hexmapextension";
+      homepage = "https://github.com/stogo/Inkscape_LivingHinge"
       license = licenses.gpl2Plus;
       maintainers = [ maintainers.raboof ];
       platforms = platforms.all;

--- a/pkgs/applications/graphics/inkscape/extensions.nix
+++ b/pkgs/applications/graphics/inkscape/extensions.nix
@@ -8,6 +8,38 @@
 {
   applytransforms = callPackage ./extensions/applytransforms { };
 
+  living_hinge = stdenv.mkDerivation {
+    pname = "living_hinge";
+    version = "unstable-2020-01-21";
+
+    src = fetchFromGitHub {
+      owner = "stogo";
+      repo = "Inkscape_LivingHinge";
+      rev = "67df66c14130dfc831a3ce5c53d8d3b59427858b";
+      sha256 = "sha256-rmq3QUqS0iZRWPqe5j/nsDOCE1ZokzT76ZWIVq1YIH0=";
+    };
+
+    preferLocalBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p "$out/share/inkscape/extensions"
+      cp -p *.inx *.py "$out/share/inkscape/extensions/"
+      find "$out/share/inkscape/extensions/" -name "*.py" -exec chmod +x {} \;
+
+      runHook postInstall
+    '';
+
+    meta = with lib; {
+      description = "This is an extension for creating living hinges in Inkscape.";
+      homepage = "https://github.com/lifelike/hexmapextension";
+      license = licenses.gpl2Plus;
+      maintainers = [ maintainers.raboof ];
+      platforms = platforms.all;
+    };
+  };
+
   hexmap = stdenv.mkDerivation {
     pname = "hexmap";
     version = "unstable-2020-06-06";


### PR DESCRIPTION
###### Description of changes

Adds an extension that allows the creation of so-called "living hinge" vector paths in inkscape, usually for laser cutting purposes. This only seems to work with Inkscape 1.1.2 and not 1.2, which is in master now. But I still think it's worth including.

You can test this out by doing:

`nix shell --impure --expr '(import (builtins.getFlake "github:nixos/nixpkgs/nixos-22.05") {}).inkscape-with-extensions.override { inkscapeExtensions = [(import (builtins.getFlake "github:matthewcroughan/nixpkgs/mc/inkscape-living-hinge") {}).inkscape-extensions.living_hinge]; }'`

And then running `inkscape`.

![image](https://user-images.githubusercontent.com/26458780/192908159-2b23cf2e-2893-42d8-90d7-5f822bcf3424.png)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
