### PR TITLE
xfce.xfce4-time-out-plugin: init at 1.1.2

### DIFF
--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -143,6 +143,8 @@ lib.makeScope pkgs.newScope (self: with self; {
   xfce4-sensors-plugin = callPackage ./panel-plugins/xfce4-sensors-plugin { };
 
   xfce4-systemload-plugin = callPackage ./panel-plugins/xfce4-systemload-plugin { };
+  
+  xfce4-time-out-plugin = callPackage ./panel-plugins/xfce4-time-out-plugin { };
 
   xfce4-timer-plugin = callPackage ./panel-plugins/xfce4-timer-plugin { };
 

--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -143,7 +143,7 @@ lib.makeScope pkgs.newScope (self: with self; {
   xfce4-sensors-plugin = callPackage ./panel-plugins/xfce4-sensors-plugin { };
 
   xfce4-systemload-plugin = callPackage ./panel-plugins/xfce4-systemload-plugin { };
-  
+
   xfce4-time-out-plugin = callPackage ./panel-plugins/xfce4-time-out-plugin { };
 
   xfce4-timer-plugin = callPackage ./panel-plugins/xfce4-timer-plugin { };

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-time-out-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-time-out-plugin/default.nix
@@ -1,0 +1,20 @@
+{ lib, mkXfceDerivation, gtk3, libxfce4ui, libxfce4util, xfce4-panel, xfconf }:
+
+mkXfceDerivation {
+  category = "panel-plugins";
+  pname = "xfce4-time-out-plugin";
+  version = "1.1.2";
+  rev-prefix = "xfce4-time-out-plugin-";
+  odd-unstable = false;
+  sha256 = "sha256-xfkQjlUfvm0YXs3bRJD4W/71VkaPq3Y+cDFVNiL/bjc=";
+
+  buildInputs = [
+    gtk3 libxfce4ui libxfce4util xfce4-panel xfconf
+  ];
+
+  meta = with lib; {
+    description = "Xfce panel plugin acts like pomodoro";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ ] ++ teams.xfce.members;
+  };
+}

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-time-out-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-time-out-plugin/default.nix
@@ -13,7 +13,7 @@ mkXfceDerivation {
   ];
 
   meta = with lib; {
-    description = "Xfce panel plugin acts like pomodoro";
+    description = "Panel plug-in to take periodical breaks from the computer";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ ] ++ teams.xfce.members;
   };


### PR DESCRIPTION
###### Description of changes
https://gitlab.xfce.org/panel-plugins/xfce4-time-out-plugin

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

@SuperSandro2000
