### PR TITLE
nixos/testing: Fix release.nix tests evaluation

### DIFF
--- a/nixos/lib/testing-python.nix
+++ b/nixos/lib/testing-python.nix
@@ -49,7 +49,7 @@ rec {
     , extraPythonPackages ? (_ : [])
     , interactive ? {}
     } @ t:
-      runTest {
+      (evalTest {
         imports = [
           { _file = "makeTest parameters"; config = t; }
           {
@@ -59,7 +59,7 @@ rec {
             };
           }
         ];
-      };
+      }).config;
 
   simpleTest = as: (makeTest as).test;
 

--- a/nixos/lib/testing/call-test.nix
+++ b/nixos/lib/testing/call-test.nix
@@ -4,13 +4,9 @@ let
 in
 {
   options = {
-    callTest = mkOption {
-      internal = true;
-      type = types.functionTo types.raw;
-    };
     result = mkOption {
       internal = true;
-      default = config.test;
+      default = config;
     };
   };
 }

--- a/nixos/lib/testing/default.nix
+++ b/nixos/lib/testing/default.nix
@@ -2,7 +2,7 @@
 let
 
   evalTest = module: lib.evalModules { modules = testModules ++ [ module ]; };
-  runTest = module: (evalTest module).config.result;
+  runTest = module: (evalTest ({ config, ... }: { imports = [ module ]; result = config.test; })).config.result;
 
   testModules = [
     ./call-test.nix

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -45,9 +45,9 @@ let
 
   inherit
     (rec {
-      doRunTest = arg: (import ../lib/testing-python.nix { inherit system pkgs; }).runTest {
-        imports = [ arg { inherit callTest; } ];
-      };
+      doRunTest = arg: ((import ../lib/testing-python.nix { inherit system pkgs; }).evalTest {
+        imports = [ arg ];
+      }).config.result;
       findTests = tree:
         if tree?recurseForDerivations && tree.recurseForDerivations
         then

--- a/pkgs/build-support/testers/default.nix
+++ b/pkgs/build-support/testers/default.nix
@@ -67,6 +67,6 @@
             else test;
           calledTest = lib.toFunction loadedTest pkgs;
         in
-          nixosTesting.makeTest calledTest;
+          nixosTesting.simpleTest calledTest;
 
 }


### PR DESCRIPTION

###### Description of changes

Fixes the problem introduced by 12b3066aae46a8ccc3d21f54f668a3f4be344332 which caused nixos/release.nix to return the wrong attributes, while intending to only affect nixos/lib's runTest.
This also removes callTest from the test options, because callTest is only ever invoked by all-tests.nix.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Manually tested in nix repl, covering multiple "styles" of test invocation.

release.nix, nixosTests:
 - acme
 - agda
 - avahi
 - simple
 - proxy

pkgs.tests.testers.nixosTest-example
runTest { nodes = {}; name = "foo"; testScript = ""; hostPkgs = import ./. {}; }

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
