### PR TITLE
fsv: 0.9-1 -> 3.0

### DIFF
--- a/pkgs/applications/misc/fsv/default.nix
+++ b/pkgs/applications/misc/fsv/default.nix
@@ -1,38 +1,47 @@
-{ lib, stdenv, fetchurl, fetchFromGitHub, autoreconfHook
-, libtool, pkg-config, gtk2, libGLU, file
+{ lib
+, stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, pkg-config
+, cglm
+, gtk3
+, libepoxy
+, libGLU
 }:
 
-let
-  gtkglarea = stdenv.mkDerivation rec {
-    pname    = "gtkglarea";
-    version = "2.1.0";
-    src = fetchurl {
-      url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-      sha256 = "1pl2vdj6l64j864ilhkq1bcggb3hrlxjwk5m029i7xfjfxc587lf";
-    };
-    nativeBuildInputs = [ pkg-config ];
-    buildInputs       = [ gtk2 libGLU ];
-    hardeningDisable  = [ "format" ];
-  };
-
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname   = "fsv";
-  version = "0.9-1";
+  version = "3.0";
 
   src = fetchFromGitHub {
-    owner  = "mcuelenaere";
-    repo   = "fsv";
-    rev    = "${pname}-${version}";
-    sha256 = "0n09jd7yqj18mx6zqbg7kab4idg5llr15g6avafj74fpg1h7iimj";
+    owner = "jabl";
+    repo  = "fsv";
+    rev   = "${pname}-${version}";
+    hash  = "sha256-fxsA3qcBPvK4H5P4juGTe6eg1lkygvzFpNW36B9lsE4=";
   };
 
-  postPatch = ''
-   # fix build with gettext 0.20
-   sed -i 's/AM_GNU_GETTEXT/AM_GNU_GETTEXT([external])/' configure.in
-  '';
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
 
-  nativeBuildInputs = [ autoreconfHook libtool pkg-config ];
-  buildInputs       = [ file gtk2 libGLU gtkglarea ];
+  buildInputs = [
+    cglm
+    gtk3
+    libepoxy
+    libGLU
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp src/fsv $out/bin/fsv
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description     = "File system visualizer in cyberspace";
@@ -44,7 +53,7 @@ in stdenv.mkDerivation rec {
       hard drive, or any arbitrarily large collection of files, limited only
       by the host computer's memory and graphics hardware.
     '';
-    homepage    = "https://github.com/mcuelenaere/fsv";
+    homepage    = "https://github.com/jabl/fsv";
     license     = licenses.lgpl2;
     platforms   = platforms.linux;
     maintainers = with maintainers; [ rnhmjoj ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27807,9 +27807,7 @@ with pkgs;
 
   fritzprofiles = with python3.pkgs; toPythonApplication fritzprofiles;
 
-  fsv = callPackage ../applications/misc/fsv {
-    autoreconfHook = buildPackages.autoreconfHook269;
-  };
+  fsv = callPackage ../applications/misc/fsv { };
 
   ft2-clone = callPackage ../applications/audio/ft2-clone {
     inherit (darwin.apple_sdk.frameworks) CoreAudio CoreMIDI CoreServices Cocoa;


### PR DESCRIPTION
###### Description of changes

The original 0.9-1 fork is unmaintained:
https://github.com/mcuelenaere/fsv/commit/4ef9040fcf14cddd52d79dad87a80355fc885602

The new 3.0 version uses a new fork https://github.com/jabl/fsv

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
