### PR TITLE
armv6 fixes

### DIFF
--- a/pkgs/development/libraries/libdrm/default.nix
+++ b/pkgs/development/libraries/libdrm/default.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
     "-Dinstall-test-programs=true"
     "-Domap=enabled"
     "-Dcairo-tests=disabled"
+    "-Dvalgrind=${if withValgrind then "enabled" else "disabled"}"
   ] ++ lib.optionals stdenv.hostPlatform.isAarch [
     "-Dtegra=enabled"
     "-Detnaviv=enabled"

--- a/pkgs/development/libraries/x265/default.nix
+++ b/pkgs/development/libraries/x265/default.nix
@@ -25,6 +25,8 @@
 let
   mkFlag = optSet: flag: if optSet then "-D${flag}=ON" else "-D${flag}=OFF";
 
+  isCross = stdenv.buildPlatform != stdenv.hostPlatform;
+
   cmakeCommonFlags = [
     "-Wno-dev"
     (mkFlag custatsSupport "DETAILED_CU_STATS")
@@ -81,6 +83,8 @@ stdenv.mkDerivation rec {
       url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-libs/x265/files/test-ns.patch?id=1d1de341e1404a46b15ae3e84bc400d474cf1a2c";
       sha256 = "0zg3g53l07yh7ar5c241x50y5zp7g8nh8rh63ad4bdpchpc2f52d";
     })
+    # Fix detection of NEON (and armv6 build) :
+    ./fix-neon-detection.patch
   ];
 
   postPatch = ''
@@ -107,7 +111,7 @@ stdenv.mkDerivation rec {
     "-DENABLE_SHARED=${if stdenv.hostPlatform.isStatic then "OFF" else "ON"}"
     "-DHIGH_BIT_DEPTH=OFF"
     "-DENABLE_HDR10_PLUS=ON"
-  ] ++ [
+    (mkFlag (isCross && stdenv.hostPlatform.isAarch) "CROSS_COMPILE_ARM")
     (mkFlag cliSupport "ENABLE_CLI")
     (mkFlag unittestsSupport "ENABLE_TESTS")
   ] ++ lib.optionals (multibitdepthSupport) [

--- a/pkgs/development/libraries/x265/fix-neon-detection.patch
+++ b/pkgs/development/libraries/x265/fix-neon-detection.patch
@@ -1,0 +1,28 @@
+commit 72489cd0a1c229258abe4f20e4fdfd414dfa88da
+Author: rnhmjoj <rnhmjoj@inventati.org>
+Date:   Sun Oct 2 00:15:24 2022 +0200
+
+    Fix NEON detection
+
+diff --git a/cmake/FindNeon.cmake b/cmake/FindNeon.cmake
+index 0062449..9c436d9 100644
+--- a/cmake/FindNeon.cmake
++++ b/cmake/FindNeon.cmake
+@@ -1,10 +1,11 @@
+ include(FindPackageHandleStandardArgs)
+ 
+ # Check the version of neon supported by the ARM CPU
+-execute_process(COMMAND cat /proc/cpuinfo | grep Features | grep neon
+-                OUTPUT_VARIABLE neon_version
+-                ERROR_QUIET
+-                OUTPUT_STRIP_TRAILING_WHITESPACE)
+-if(neon_version)
+-    set(CPU_HAS_NEON 1)
++message(STATUS "Detecting NEON support")
++execute_process(COMMAND sed -n "/Features.* neon/q 1" /proc/cpuinfo
++                RESULT_VARIABLE CPU_HAS_NEON)
++if(CPU_HAS_NEON)
++    message(STATUS "Detecting NEON support - supported")
++else()
++    message(STATUS "Detecting NEON support - not supported" )
+ endif()

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -83,7 +83,7 @@
 , withHostnamed ? true
 , withHwdb ? true
 , withImportd ? !stdenv.hostPlatform.isMusl
-, withLibBPF ? true
+, withLibBPF ? lib.versionAtLeast llvmPackages.clang.version "10.0"
 , withLocaled ? true
 , withLogind ? true
 , withMachined ? true

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14259,6 +14259,7 @@ with pkgs;
       /**/ if platform.isDarwin then 11
       else if platform.isFreeBSD then 7
       else if platform.isAndroid then 12
+      else if platform.system == "armv6l-linux" then 7  # This fixes armv6 cross-compilation
       else if platform.isLinux then 11
       else if platform.isWasm then 12
       else latest_version;


### PR DESCRIPTION
###### Description of changes

A couple of fixes for armv6

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
