### PR TITLE
docker-credential-helpers: 0.6.3 -> 0.7.0

### DIFF
--- a/pkgs/tools/admin/docker-credential-helpers/default.nix
+++ b/pkgs/tools/admin/docker-credential-helpers/default.nix
@@ -1,50 +1,52 @@
-{ lib, stdenv, buildGoPackage, fetchFromGitHub, pkg-config, libsecret }:
+{ lib, stdenv, buildGoModule, fetchFromGitHub, pkg-config, libsecret, testers, docker-credential-helpers }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "docker-credential-helpers";
-  version = "0.6.3";
-
-  goPackagePath = "github.com/docker/docker-credential-helpers";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "docker";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0xgmwjva3j1s0cqkbajbamj13bgzh5jkf2ir54m9a7w8gjnsh6dx";
+    sha256 = "sha256-KtDWrtd88s4Al3iWxIYE+YlhZTzf8/YDVYE2AwxH8ho=";
   };
+
+  vendorSha256 = null;
 
   nativeBuildInputs = lib.optionals stdenv.isLinux [ pkg-config ];
 
   buildInputs = lib.optionals stdenv.isLinux [ libsecret ];
 
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/docker/docker-credential-helpers/credentials.Version=${version}"
+  ];
+
   buildPhase =
-    if stdenv.isDarwin
-    then ''
-      cd go/src/${goPackagePath}
-      go build -ldflags -s -o bin/docker-credential-osxkeychain osxkeychain/cmd/main_darwin.go
+    let
+      cmds = if stdenv.isDarwin then [ "osxkeychain" "pass" ] else [ "secretservice" "pass" ];
+    in
     ''
-    else ''
-      cd go/src/${goPackagePath}
-      go build -o bin/docker-credential-secretservice secretservice/cmd/main_linux.go
-      go build -o bin/docker-credential-pass pass/cmd/main_linux.go
+      for cmd in ${builtins.toString cmds}; do
+        go build -ldflags "${builtins.toString ldflags}" -trimpath -o bin/docker-credential-$cmd ./$cmd/cmd
+      done
     '';
 
-  installPhase =
-    if stdenv.isDarwin
-    then ''
-      install -Dm755 -t $out/bin bin/docker-credential-osxkeychain
-    ''
-    else ''
-      install -Dm755 -t $out/bin bin/docker-credential-pass
-      install -Dm755 -t $out/bin bin/docker-credential-secretservice
-    '';
+  installPhase = ''
+    install -Dm755 -t $out/bin bin/docker-credential-*
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = docker-credential-helpers;
+    command = "docker-credential-pass version";
+  };
 
   meta = with lib; {
     description = "Suite of programs to use native stores to keep Docker credentials safe";
     homepage = "https://github.com/docker/docker-credential-helpers";
     license = licenses.mit;
-    maintainers = [ maintainers.marsam ];
-    platforms = platforms.linux ++ platforms.darwin;
+    maintainers = with maintainers; [ marsam ];
   } // lib.optionalAttrs stdenv.isDarwin {
     mainProgram = "docker-credential-osxkeychain";
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
