### PR TITLE
nodePackages: fix builds on x86_64-darwin

### DIFF
--- a/pkgs/applications/video/epgstation/default.nix
+++ b/pkgs/applications/video/epgstation/default.nix
@@ -54,6 +54,9 @@ let
       # Workaround for https://github.com/svanderburg/node2nix/issues/275
       sed -i -e "s|#!/usr/bin/env node|#! ${nodejs}/bin/node|" node_modules/node-gyp-build/bin.js
 
+      # Optional typeorm dependency that does not build on aarch64-linux
+      rm -r node_modules/oracledb
+
       find . -name package-lock.json -delete
     '';
 

--- a/pkgs/development/node-packages/overrides.nix
+++ b/pkgs/development/node-packages/overrides.nix
@@ -93,8 +93,17 @@ final: prev: {
 
   bitwarden-cli = prev."@bitwarden/cli".override {
     name = "bitwarden-cli";
-    nativeBuildInputs = [ pkgs.pkg-config ];
-    buildInputs = with pkgs; [ pixman cairo pango ];
+    nativeBuildInputs = with pkgs; [
+      pkg-config
+    ] ++ lib.optionals stdenv.isDarwin [
+      xcbuild
+      darwin.apple_sdk.frameworks.CoreText
+    ];
+    buildInputs = with pkgs; [
+      pixman
+      cairo
+      pango
+    ];
   };
 
   bower2nix = prev.bower2nix.override {
@@ -138,13 +147,14 @@ final: prev: {
   # ../../applications/video/epgstation
   epgstation = prev."epgstation-../../applications/video/epgstation".override (oldAttrs: {
     buildInputs = [ pkgs.postgresql ];
-    nativeBuildInputs = [ final.node-pre-gyp final.node-gyp-build pkgs.which ];
+    nativeBuildInputs = [ final.node-pre-gyp final.node-gyp-build pkgs.which ] ++ lib.optionals stdenv.isDarwin [ pkgs.xcbuild ];
     meta = oldAttrs.meta // { platforms = lib.platforms.none; };
   });
 
   # NOTE: this is a stub package to fetch npm dependencies for
   # ../../applications/video/epgstation/client
   epgstation-client = prev."epgstation-client-../../applications/video/epgstation/client".override (oldAttrs: {
+    nativeBuildInputs = lib.optionals stdenv.isDarwin [ pkgs.xcbuild ];
     meta = oldAttrs.meta // { platforms = lib.platforms.none; };
   });
 
@@ -212,7 +222,11 @@ final: prev: {
   });
 
   joplin = prev.joplin.override {
-    nativeBuildInputs = [ pkgs.pkg-config ];
+    nativeBuildInputs = with pkgs; [
+      pkg-config
+    ] ++ lib.optionals stdenv.isDarwin [
+      xcbuild
+    ];
     buildInputs = with pkgs; [
       # required by sharp
       # https://sharp.pixelplumbing.com/install
@@ -276,6 +290,10 @@ final: prev: {
         installShellCompletion --cmd $cmd --bash <(./bin/$cmd --completion)
       done
     '';
+  };
+
+  mastodon-bot = prev.mastodon-bot.override {
+    nativeBuildInputs = lib.optionals stdenv.isDarwin [ pkgs.xcbuild ];
   };
 
   mermaid-cli = prev."@mermaid-js/mermaid-cli".override (
@@ -495,7 +513,11 @@ final: prev: {
   };
 
   thelounge-plugin-giphy = prev.thelounge-plugin-giphy.override {
-    nativeBuildInputs = [ final.node-pre-gyp ];
+    nativeBuildInputs = [
+      final.node-pre-gyp
+    ] ++ lib.optionals stdenv.isDarwin [
+      pkgs.xcbuild
+    ];
   };
 
   thelounge-theme-flat-blue = prev.thelounge-theme-flat-blue.override {


### PR DESCRIPTION
###### Description of changes

Follow-up to #193337 to fix several x86_64-darwin build failures due to missing `xcrun`/`xcodebuild` (see https://hydra.nixos.org/eval/1782541#tabs-now-fail)

I'm waiting on OfBorg to build these because I do not personally have access to any darwin systems. It probably also fixes aarch64-darwin errors, but those are additionally failing because the nodejs build had a [transient failure](https://hydra.nixos.org/build/192112047) (and the failure has been since cached - see #193331)

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).