### PR TITLE
qcad: fix executable path in .desktop file

### DIFF
--- a/pkgs/applications/misc/qcad/application-dir.patch
+++ b/pkgs/applications/misc/qcad/application-dir.patch
@@ -33,16 +33,3 @@ index c6c31cbf5..c51b59ce6 100644
  }
  
  int RSettings::getSnapRange() {
-diff --git a/qcad.desktop b/qcad.desktop
-index 93c5e9720..2d0e6bf32 100644
---- a/qcad.desktop
-+++ b/qcad.desktop
-@@ -48,7 +48,7 @@ Comment[sv]=2D CAD-system
- Comment[sl]=Sistem 2D CAD
- Comment[uk]=2D САПР
- Comment[tr]=2D CAD Sistemi
--Exec=qcad %F
-+Exec=qcad-bin %F
- X-MultipleArgs=true
- Icon=qcad_icon
- Terminal=false


### PR DESCRIPTION
###### Description of changes
the patch did specify qcad-bin but the binary is just named qcad

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
