### PR TITLE
picom-next: unstable-2022-08-23 -> unstable-2022-09-29

### DIFF
--- a/pkgs/applications/window-managers/picom/picom-next.nix
+++ b/pkgs/applications/window-managers/picom/picom-next.nix
@@ -2,12 +2,12 @@
 
 picom.overrideAttrs (oldAttrs: rec {
   pname = "picom-next";
-  version = "unstable-2022-08-23";
+  version = "unstable-2022-09-29";
   src = fetchFromGitHub {
     owner = "yshui";
     repo = "picom";
-    rev = "e0758eb5e572d5d7cf28f28e5e409f20e0bd2ded";
-    sha256 = "sha256-L0cFkKPFw92dx3P9jlkwgw7/otjUVkVZbOE0UT6gF+I=";
+    rev = "0fe4e0a1d4e2c77efac632b15f9a911e47fbadf3";
+    sha256 = "1slcmayja8cszapxzs83xl1i9n9q0dz79cn5gzzf4mfcwvnxp8km";
   };
   meta.maintainers = with lib.maintainers; oldAttrs.meta.maintainers ++ [ GKasparov ];
 })


### PR DESCRIPTION
Update to keep up with picom-next.

###### Description of changes

This PR is to update the package to keep up with picom-next upstream. No breaking changes as far as I'm aware but it includes fixes to rounded corners when blurring and shadows are enabled.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
