### PR TITLE
mac-fdisk & pdisk: init

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -78,6 +78,12 @@ in mkLicense lset) ({
     url = "https://aomedia.org/license/patent-license/";
   };
 
+  apsl10 = {
+    spdxId = "APSL-1.0";
+    fullName = "Apple Public Source License 1.0";
+    url = "https://web.archive.org/web/20040701000000*/http://www.opensource.apple.com/apsl/1.0.txt";
+  };
+
   apsl20 = {
     spdxId = "APSL-2.0";
     fullName = "Apple Public Source License 2.0";

--- a/pkgs/tools/system/mac-fdisk/default.nix
+++ b/pkgs/tools/system/mac-fdisk/default.nix
@@ -1,0 +1,112 @@
+{ stdenv
+, lib
+, fetchzip
+, fetchpatch
+, installShellFiles
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mac-fdisk";
+  version = "0.1.16";
+
+  src = fetchzip {
+    url = "https://deb.debian.org/debian/pool/main/m/mac-fdisk/mac-fdisk_0.1.orig.tar.gz";
+    sha256 = "sha256-pYNyhPvRKdIje0Rpay0OzmrkGcl+/JOhMv7r+2LZk/Q=";
+  };
+
+  patches = [
+    # Debian's changeset, extracted into a patch
+    (fetchpatch {
+      url = "https://git.adelielinux.org/adelie/packages/-/raw/1b708c8a90e3548c4954c6367a9376f76f3746bd/user/mac-fdisk/mac-fdisk-0.1-debian.patch";
+      sha256 = "sha256-a9pGF+UsFeZiXgracmT4anqgpmcGcS/W3jGtFzHZtt4=";
+    })
+    # Include a lot more headers and remove a bunch of braindead __linux__ checks
+    (fetchpatch {
+      url = "https://git.adelielinux.org/adelie/packages/-/raw/1fa4c88ee21866eeb0feae8f6b0bf609a04711cc/user/mac-fdisk/mac-fdisk-0.1-headers.patch";
+      sha256 = "sha256-FIk9K+lP+3e1pgmNfymTdpdSoTpBDv29kmwYgqYwWQw=";
+    })
+    # Add support for more architectures
+    (fetchpatch {
+      url = "https://git.adelielinux.org/adelie/packages/-/raw/1b708c8a90e3548c4954c6367a9376f76f3746bd/user/mac-fdisk/mac-fdisk-0.1-more-arches.patch";
+      sha256 = "sha256-HNRmzETUmKfZQFrjg6Y/HPwUnLk0vO5DokfU4umdOm0=";
+    })
+    # From p16 (source?), adjusts some types & fixes PPC64 support
+    (fetchpatch {
+      url = "https://git.adelielinux.org/adelie/packages/-/raw/1fa4c88ee21866eeb0feae8f6b0bf609a04711cc/user/mac-fdisk/mac-fdisk-0.1_p16-ppc64.patch";
+      sha256 = "sha256-GK0nfga59nOXotkbKI+2ejA9TtyZUwDIxuXWFGGbeFg=";
+    })
+    # From p16 (source?), makes some inlines static
+    (fetchpatch {
+      url = "https://git.adelielinux.org/adelie/packages/-/raw/1fa4c88ee21866eeb0feae8f6b0bf609a04711cc/user/mac-fdisk/mac-fdisk-0.1_p16-proper-inline.patch";
+      sha256 = "sha256-wr2teKpm0FyqNudKYlTD49pTFDis33Fo+0LULNYIJko=";
+    })
+    # Adds x86_64 support
+    (fetchpatch {
+      url = "https://git.adelielinux.org/adelie/packages/-/raw/1b708c8a90e3548c4954c6367a9376f76f3746bd/user/mac-fdisk/mac-fdisk-amd64.patch";
+      sha256 = "sha256-iO4/sY5sGKQyymMmAOb/TlCc9id2qgEDw7E8pFZpsHI=";
+    })
+    # Fix missing header in fdisk.c on musl
+    (fetchpatch {
+      url = "https://git.adelielinux.org/adelie/packages/-/raw/1fa4c88ee21866eeb0feae8f6b0bf609a04711cc/user/mac-fdisk/mac-fdisk-fdisk-header-musl.patch";
+      sha256 = "sha256-mKBVjvLKtxKPADeoPqp17YdJ1QWj2enAYhKKSqTnQ44=";
+    })
+    # Support disks >550GB
+    (fetchpatch {
+      url = "https://git.adelielinux.org/adelie/packages/-/raw/1fa4c88ee21866eeb0feae8f6b0bf609a04711cc/user/mac-fdisk/mac-fdisk-large-disk-support.patch";
+      sha256 = "sha256-IXZZdozqZKyZEz87ZzB8Jof22GgvHf4GaXBqSKn8su8=";
+    })
+    # Enable Large File Support (>2GiB)
+    (fetchpatch {
+      url = "https://git.adelielinux.org/adelie/packages/-/raw/1fa4c88ee21866eeb0feae8f6b0bf609a04711cc/user/mac-fdisk/mac-fdisk-largerthan2gb.patch";
+      sha256 = "sha256-ATK7QYXV7BOk8iIFeXY8g+ZHLuuhww9pcrqOMDn/oLM=";
+    })
+    # Fix compilation on non-glibc
+    (fetchpatch {
+      url = "https://git.adelielinux.org/adelie/packages/-/raw/1fa4c88ee21866eeb0feae8f6b0bf609a04711cc/user/mac-fdisk/mac-fdisk-non-glibc-support.patch";
+      sha256 = "sha256-CBZUKf7dPvvpuG5L+SI1FQ4W7/fDgeKXHUMFkJNu/MY=";
+    })
+    # Flush stdout after printing prompt for better UX
+    (fetchpatch {
+      url = "https://git.adelielinux.org/adelie/packages/-/raw/656ae6bf9f8a64aee95c4797b20bfe713627f1f4/user/mac-fdisk/flush-stdout.patch";
+      sha256 = "sha256-k7+UPiUf/oCQdDhxDcC+FRwkxS89WSsYzFw6fUB/10I=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  enableParallelBuilding = true;
+
+  NIX_CFLAGS_COMPILE = "-D_GNU_SOURCE";
+
+  hardeningDisable = [ "format" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 pdisk $out/sbin/mac-fdisk
+    install -Dm755 fdisk $out/sbin/pmac-fdisk
+
+    for manpage in {,p}mac-fdisk.8; do
+      mv "$manpage".in $manpage
+      installManPage $manpage
+    done
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "68K and PowerPC Mac disk partitioning utility, Adélie Linux version";
+    # http://ftp.mklinux.apple.com:/pub/Other_Tools/ but that one's looong dead, link goes to the patch compilation we're using
+    homepage = "https://git.adelielinux.org/adelie/packages/-/tree/master/user/mac-fdisk";
+    license = with licenses; [
+      hpnd # original license statements seems to match this (in files that are shared with pdisk)
+      gpl1Plus # fdisk.c
+    ];
+    maintainers = with maintainers; [ OPNA2608 ];
+    # the toolchain that's being expected for Mac support (SCSI.h from Universal Headers 2.0, SIOUX.h from Metrowerks CoreWarrior) is ancient, unsure about BSDs
+    platforms = platforms.linux;
+    badPlatforms = platforms.aarch64; # missing some platform definitions
+  };
+}

--- a/pkgs/tools/system/pdisk/default.nix
+++ b/pkgs/tools/system/pdisk/default.nix
@@ -1,0 +1,88 @@
+{ stdenv
+, lib
+, fetchzip
+, fetchpatch
+, installShellFiles
+, libbsd
+, CoreFoundation
+, IOKit
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pdisk";
+  version = "0.9";
+
+  src = fetchzip {
+    url = "https://opensource.apple.com/tarballs/pdisk/pdisk-${lib.versions.minor version}.tar.gz";
+    sha256 = "sha256-+gBgnk/1juEHE0nXaz7laUaH7sxrX5SzsLGr0PHsdHs=";
+  };
+
+  patches = [
+    # Fix makefile for Unix
+    (fetchpatch {
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/makefile.patch?h=pdisk&id=39dc371712d2f7dbd38f6e8ddc6ba661faa1a7a9";
+      sha256 = "sha256-mLFclu8IlDN/gxNTI7Kei6ARketlAhJRu8ForFUzFU0=";
+    })
+    # Fix lseek usage in file_media.c
+    (fetchpatch {
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/file_media.c.patch?h=pdisk&id=39dc371712d2f7dbd38f6e8ddc6ba661faa1a7a9";
+      sha256 = "sha256-CCq5fApwx6w1GKDrgP+0nUdQy/5z5ON7/fdp4M63nko=";
+    })
+    # Fix open_partition_map call in cvt_pt.c
+    (fetchpatch {
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/cvt_pt.c.patch?h=pdisk&id=39dc371712d2f7dbd38f6e8ddc6ba661faa1a7a9";
+      sha256 = "sha256-jScPfzt9/fQHkf2MfHLvYsh/Rw2NZZXkzZiiVo8F5Mc=";
+    })
+    # Replace removed sys_nerr and sys_errlist with strerror
+    (fetchpatch {
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/linux_strerror.patch?h=pdisk&id=&id=d0c930ea8bcac008bbd0ade1811133a625caea54";
+      sha256 = "sha256-HGJIS+vTn6456KtaETutIgTPPBm2C9OHf1anG8yaJPo=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace makefile \
+      --replace 'cc' '${stdenv.cc.targetPrefix}cc'
+  '' + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace makefile \
+      --replace '-lbsd' '-framework CoreFoundation -framework IOKit'
+  '';
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  buildInputs = lib.optionals (!stdenv.hostPlatform.isDarwin) [
+    libbsd
+  ] ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
+    CoreFoundation
+    IOKit
+  ];
+
+  NIX_CFLAGS_COMPILE = "-D_GNU_SOURCE";
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 cvt_pt $out/bin/cvt_pt
+    install -Dm755 pdisk $out/bin/pdisk
+
+    installManPage pdisk.8
+    install -Dm644 pdisk.html $out/share/doc/pdisk/pdisk.html
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A low-level Apple partition table editor for Linux, OSS Apple version";
+    homepage = "https://github.com/apple-oss-distributions/pdisk";
+    license = with licenses; [
+      hpnd # original license statements seems to match this (in files that are shared with mac-fdisk)
+      apsl10 # new files
+    ];
+    maintainers = with maintainers; [ OPNA2608 ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7413,6 +7413,8 @@ with pkgs;
 
   lucky-cli = callPackage ../development/web/lucky-cli { };
 
+  mac-fdisk = callPackage ../tools/system/mac-fdisk { };
+
   partclone = callPackage ../tools/backup/partclone { };
 
   partimage = callPackage ../tools/backup/partimage { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7419,6 +7419,10 @@ with pkgs;
 
   partimage = callPackage ../tools/backup/partimage { };
 
+  pdisk = callPackage ../tools/system/pdisk {
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation IOKit;
+  };
+
   pgf_graphics = callPackage ../tools/graphics/pgf { };
 
   pgformatter = callPackage ../development/tools/pgformatter { };


### PR DESCRIPTION
###### Description of changes

Init mac-fdisk & [pdisk](https://opensource.apple.com/source/pdisk/pdisk-9/pdisk.html), tools for handling the [Apple Partition Map (APM)](https://en.wikipedia.org/wiki/Apple_Partition_Map) disk partitioning format.

The original upstream for mac-fdisk seems lost to time. I think it was accessible on `ftp://ftp.mklinux.apple.com/pub/Other_Tools/` then prolly migrated / was mirrored on `ftp://ftp.mklinux.org/pub/Other_Tools/`, both of which seem dead (or at least inaccessible to me). Several other distributions are using a Debian mirror or their own mirrors / pre-modified copies. I've opted to also use the mostly-unmodified Debian mirror + a variety of patches from Adélie Linux that apply common patches, introduce wider platform support (for example x86_64), fix compilation on modern systems (missing includes, migrations to strerror). For this reason, I'm also using their CVS as that package's homepage.

`pdisk` is an Apple-maintained evolution of the original tool. It comes with a slightly different set of additions compared to mac-fdisk, does some of the same modernisations as all of the mac-fdisk patches and updates the platform support from Mac OS to OS X / macOS. Some new files are licensed under APSL-1.0, I can add an entry for it to `lib.licenses` if that would be better. I have currently marked it as free, but I'm not sure what our guidelines for this are though:
![Bildschirmfoto von 2022-09-29 19-13-30](https://user-images.githubusercontent.com/23431373/193097819-c92fb9b4-71cb-409f-a313-82b3320fc6d9.png)

Distributions seem to carry either mac-fdisk or pdisk. I haven't had to do any disk modifications with either of them so just to be safe, I've added both. I've built both cross & natively for ppc64 and they can both read my disk partitions.

![Bildschirmfoto von 2022-09-28 22-53-33](https://user-images.githubusercontent.com/23431373/193056605-8c7286c8-dbe7-49aa-a6aa-d38479ed465c.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
Just listing disk partitions, no modifications to them yet.
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
