### PR TITLE
google-cloud-sdk: Fix default component arches

### DIFF
--- a/pkgs/tools/admin/google-cloud-sdk/components.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/components.nix
@@ -11,7 +11,7 @@ let
   arches = {
     x86 = "i686";
     x86_64 = "x86_64";
-    # TODO arm
+    arm = "aarch64";
   };
 
   # Mapping from GCS component operating systems to Nix operating systems
@@ -30,8 +30,8 @@ let
     in
     "${arch'}-${os'}";
 
-  # All architectures that are supported
-  allArches = builtins.attrValues arches;
+  # All architectures that are supported by GCS
+  allArches = builtins.attrNames arches;
 
   # A description of all available google-cloud-sdk components.
   # It's a JSON file with a list of components, along with some metadata


### PR DESCRIPTION
When a google-cloud-sdk component does not specify architectures on components.json we should fallback to all supported arches.

Previously there was a bug where `allArches` were incorrectly taken from the `attrValues arches` (nixOS architectures) instead of the GCS ones using `attrNames arches`.

Also added arm to the list of supported architectures. No changes needed on components.json since it looks urls and hashes were already there.

Co-authored-by: Fabián Heredia Montiel <fabianhjr@>

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


Fixes #182856