### PR TITLE
tsm-client: 8.1.15.1 -> 8.1.15.2, pin openssl version

### DIFF
--- a/nixos/modules/programs/tsm-client.nix
+++ b/nixos/modules/programs/tsm-client.nix
@@ -223,7 +223,7 @@ let
       description = lib.mdDoc ''
         The TSM client derivation to be
         added to the system environment.
-        It will called with `.override`
+        It will be used with `.override`
         to add paths to the client system-options file.
       '';
     };

--- a/pkgs/tools/backup/tsm-client/default.nix
+++ b/pkgs/tools/backup/tsm-client/default.nix
@@ -52,17 +52,17 @@
 # going to the `downloadPage` (see `meta` below).
 # Find the "Backup-archive client" table on that page.
 # Look for "Download Documents" of the latest release.
-# Here, two links must be checked:
+# Here, two links must be checked if existing:
 # * "IBM Spectrum Protect Client ... Downloads and READMEs":
 #   In the table at the page's bottom,
 #   check the date of the "Linux x86_64 client"
 # * "IBM Spectrum Protect BA client ... interim fix downloads"
-# Look for the "Linux x86_64 client" rows
+# Look for the "Linux x86_64 client ..." rows
 # in the table at the bottom of each page.
 # Follow the "HTTPS" link of the row with the latest date stamp.
 # In the directory listing to show up, pick the big `.tar` file.
 #
-# (as of 2022-08-13)
+# (as of 2022-09-29)
 
 
 let
@@ -107,10 +107,10 @@ let
 
   unwrapped = stdenv.mkDerivation rec {
     name = "tsm-client-${version}-unwrapped";
-    version = "8.1.15.1";
+    version = "8.1.15.2";
     src = fetchurl {
       url = mkSrcUrl version;
-      hash = "sha512-DURIMlWlmu+l2UT3bAMaFPlwO+UlrfgaYCsm/JonvvC0K0WallhNKFd7sp0amPkU+4QHE2fkFrTGE3/lY+fghQ==";
+      hash = "sha512-ljygVoW7zR+LVHf4LSoBn3qEHISobsxheLxs9NyKWQiwPWpfhSgJO+bX4QRzAmrpSTNrETxHkuXqzGSHaaBlzg==";
     };
     inherit meta passthru;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6001,8 +6001,13 @@ with pkgs;
 
   timeline = callPackage ../applications/office/timeline { };
 
-  tsm-client = callPackage ../tools/backup/tsm-client { };
-  tsm-client-withGui = callPackage ../tools/backup/tsm-client { enableGui = true; };
+  tsm-client = callPackage ../tools/backup/tsm-client {
+    openssl = openssl_1_1;
+  };
+  tsm-client-withGui = callPackage ../tools/backup/tsm-client {
+    openssl = openssl_1_1;
+    enableGui = true;
+  };
 
   tracker = callPackage ../development/libraries/tracker { };
 


### PR DESCRIPTION
###### Description of changes                                                                                                    
                                                                                                                                 
* update package to newest version 8.1.15.2, published 2022-09-27                                                                
                                                                                                                                 
  IBM's "Authorized Program Analysis Report"s (something like release notes): https://www.ibm.com/support/pages/node/6590857#81152  (the commit message contains more info)
                                                                                                                                 
  **note that this is a security update**                                                                                        
                                                                                                                                 
* fix build by pinning openssl version to 1.1                                                                                    
                                                                                                                                 
* fix a tiny typo in NixOS module                                                                                                
                                                                                                                                 
Due to security relevance, it would be good to have this backported.  However, `tsm-client` on NixOS 22.05 is currently broken, and https://github.com/NixOS/nixpkgs/pull/180607 needs to be merged before the pull-request at hand can be backported.
                                                                                                                                 
                                                                                                                                 
###### Things done                                                                                                               
                                                                                                                                 
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->     
                                                                                                                                 
- Built on platform(s)                                                                                                           
  - [x] x86_64-linux                                                                                                             
  - [ ] aarch64-linux                                                                                                            
  - [ ] x86_64-darwin                                                                                                            
  - [ ] aarch64-darwin                                                                                                           
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:                                                                                                     
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)                                         
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`) ( *only dsmc* )                                
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking                                         
  - [ ] (Module updates) Added a release notes entry if the change is significant                                                
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module                                               
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes                             
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).                                      
                                                                                                                                 
                                                                                                                                 
###### Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)                               
                                                                                                                                 
<details>                                                                                                                        
  <summary>1 package blacklisted:</summary>                                                                                      
  <ul>                                                                                                                           
    <li>nixos-install-tools</li>                                                                                                 
  </ul>                                                                                                                          
</details>                                                                                                                       
<details>                                                                                                                        
  <summary>2 packages built:</summary>                                                                                           
  <ul>                                                                                                                           
    <li>tsm-client</li>                                                                                                          
    <li>tsm-client-withGui</li>                                                                                                  
  </ul>                                                                                                                          
</details>                                                                                                                       
