### PR TITLE
postgresqlPackages.pgroonga: also install the pgroonga_database extension

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pgroonga.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgroonga.nix
@@ -18,6 +18,10 @@ stdenv.mkDerivation rec {
     install -D pgroonga.so -t $out/lib/
     install -D pgroonga.control -t $out/share/postgresql/extension
     install -D data/pgroonga-*.sql -t $out/share/postgresql/extension
+
+    install -D pgroonga_database.so -t $out/lib/
+    install -D pgroonga_database.control -t $out/share/postgresql/extension
+    install -D data/pgroonga_database-*.sql -t $out/share/postgresql/extension
   '';
 
   meta = with lib; {
@@ -31,6 +35,6 @@ stdenv.mkDerivation rec {
     homepage = "https://pgroonga.github.io/";
     license = licenses.postgresql;
     platforms = postgresql.meta.platforms;
-    maintainers = with maintainers; [ DerTim1 ];
+    maintainers = with maintainers; [ DerTim1 ivan ];
   };
 }


### PR DESCRIPTION
###### Description of changes

This extension contains the `pgoronga_database_remove()` function, which can be used to actually remove all the `pgrn*` files, because `DROP INDEX` on a pgroonga index does not actually delete the index data.

https://pgroonga.github.io/reference/modules/pgroonga-database.html

https://pgroonga.github.io/reference/functions/pgroonga-database-remove.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc maintainer @DerTim1

I tested that I could create the extension, call the function, and that the files were actually removed from disk.

```
# psql -d archive
Timing is on.
Line style is unicode.
Border style is 2.
Unicode header line style is "double".
Unicode border line style is "single".
Unicode column line style is "single".
psql (14.5)
Type "help" for help.

postgres@[local]:5432/archive(14.5)(2446918) # CREATE EXTENSION pgroonga_database;
CREATE EXTENSION
Time: 112.625 ms
postgres@[local]:5432/archive(14.5)(2446918) # SELECT pgroonga_database_remove();
┌──────────────────────────┐
│ pgroonga_database_remove │
╞══════════════════════════╡
│ t                        │
└──────────────────────────┘
(1 row)

Time: 220.891 ms
postgres@[local]:5432/archive(14.5)(2446918) # SELECT pgroonga_database_remove();
┌──────────────────────────┐
│ pgroonga_database_remove │
╞══════════════════════════╡
│ t                        │
└──────────────────────────┘
(1 row)

Time: 0.388 ms
```