### PR TITLE
gitlab: 15.4.0 -> 15.4.1

### DIFF
--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -1,15 +1,15 @@
 {
-  "version": "15.4.0",
-  "repo_hash": "sha256-AONzkIZbrOJkxGUYAunoWTc9xuCykKr4YkYeQQxRW8A=",
+  "version": "15.4.1",
+  "repo_hash": "sha256-z4J0ia9WxL+tJnoYNBtb6ZMuqGHiyhQ0tc0L8kzj26w=",
   "yarn_hash": "1r33qrvwf2wmq5c1d2awk9qhk9nzvafqn3drdvnczfv43sda4lg8",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v15.4.0-ee",
+  "rev": "v15.4.1-ee",
   "passthru": {
-    "GITALY_SERVER_VERSION": "15.4.0",
+    "GITALY_SERVER_VERSION": "15.4.1",
     "GITLAB_PAGES_VERSION": "1.62.0",
     "GITLAB_SHELL_VERSION": "14.10.0",
-    "GITLAB_WORKHORSE_VERSION": "15.4.0"
+    "GITLAB_WORKHORSE_VERSION": "15.4.1"
   },
   "vendored_gems": [
     "bundler-checksum",

--- a/pkgs/applications/version-management/gitlab/gitaly/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/default.nix
@@ -11,7 +11,7 @@ let
     gemdir = ./.;
   };
 
-  version = "15.4.0";
+  version = "15.4.1";
   package_version = "v${lib.versions.major version}";
   gitaly_package = "gitlab.com/gitlab-org/gitaly/${package_version}";
 
@@ -22,7 +22,7 @@ let
       owner = "gitlab-org";
       repo = "gitaly";
       rev = "v${version}";
-      sha256 = "sha256-cESZfLlwyC6khUrvS0LGfkvzCLudjFmlGXculYLrcDM=";
+      sha256 = "sha256-7f4TxCI/k2yirQxYI8i/6PXGVDs4x4ncIou1qH0TKAc=";
     };
 
     vendorSha256 = "sha256-CUFYHjmOfosM3mfw0qEY+AQcR8U3J/1lU2Ml6wSZ/QM=";

--- a/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
@@ -5,7 +5,7 @@ in
 buildGoModule rec {
   pname = "gitlab-workhorse";
 
-  version = "15.4.0";
+  version = "15.4.1";
 
   src = fetchFromGitLab {
     owner = data.owner;


### PR DESCRIPTION
###### Description of changes
https://about.gitlab.com/releases/2022/09/29/security-release-gitlab-15-4-1-released/

Fixes [CVE-2022-3283](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3283)
Fixes [CVE-2022-3060](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3060)
Fixes [CVE-2022-2904](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-2904)
Fixes [CVE-2022-3018](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3018)
Fixes [CVE-2022-3291](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3291)
Fixes [CVE-2022-3067](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3067)
Fixes [CVE-2022-2882](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-2882)
Fixes [CVE-2022-3066](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3066)
Fixes [CVE-2022-3286](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3286)
Fixes [CVE-2022-3285](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3285)
Fixes [CVE-2022-3330](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3330)
Fixes [CVE-2022-3351](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3351)
Fixes [CVE-2022-3288](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3288)
Fixes [CVE-2022-3293](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3293)
Fixes [CVE-2022-3279](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3279)
Fixes [CVE-2022-3325](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3325)
Fixes [CVE-2022-31107](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-31107)


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
Will mark as ready once built and the test passed.