### PR TITLE
jitsi-videobridge: add openssl to LD_LIBRARY_PATH

### DIFF
--- a/pkgs/servers/jitsi-videobridge/default.nix
+++ b/pkgs/servers/jitsi-videobridge/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, makeWrapper, dpkg, jre_headless, nixosTests }:
+{ lib, stdenv, fetchurl, makeWrapper, dpkg, jre_headless, openssl, nixosTests }:
 
 let
   pname = "jitsi-videobridge2";
@@ -28,9 +28,11 @@ stdenv.mkDerivation {
     mv usr/share/jitsi-videobridge/* $out/share/jitsi-videobridge/
     ln -s $out/share/jitsi-videobridge/jvb.sh $out/bin/jitsi-videobridge
 
-    # work around https://github.com/jitsi/jitsi-videobridge/issues/1547
+    # - work around https://github.com/jitsi/jitsi-videobridge/issues/1547
+    # - make libcrypto.so available at runtime for hardware AES
     wrapProgram $out/bin/jitsi-videobridge \
-      --set VIDEOBRIDGE_GC_TYPE G1GC
+      --set VIDEOBRIDGE_GC_TYPE G1GC \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ openssl ]}
     runHook postInstall
   '';
 


### PR DESCRIPTION
Jitsi Videobridge tries to load `libcrypto.so` at runtime to use hardware-accelerated AES implementation provided by OpenSSL. It currently fails because the library is not available:

```
Sep 28 14:30:54 localhost jitsi-videobridge2-start[2989]: WARNING: [66] JitsiOpenSslProvider.<clinit>#66: Unable to load jitsisrtp
Sep 28 14:30:54 localhost jitsi-videobridge2-start[2989]: java.lang.UnsatisfiedLinkError: /tmp/jna5834499288245935676.tmp: libcrypto.so.3: cannot open shared object file: No such file or directory
Sep 28 14:30:54 localhost jitsi-videobridge2-start[2989]:         at java.base/jdk.internal.loader.NativeLibraries.load(Native Method)
Sep 28 14:30:54 localhost jitsi-videobridge2-start[2989]:         at java.base/jdk.internal.loader.NativeLibraries$NativeLibraryImpl.open(NativeLibraries.java:388)
Sep 28 14:30:54 localhost jitsi-videobridge2-start[2989]:         at java.base/jdk.internal.loader.NativeLibraries.loadLibrary(NativeLibraries.java:232)
Sep 28 14:30:54 localhost jitsi-videobridge2-start[2989]:         at java.base/jdk.internal.loader.NativeLibraries.loadLibrary(NativeLibraries.java:174)
Sep 28 14:30:54 localhost jitsi-videobridge2-start[2989]:         at java.base/java.lang.ClassLoader.loadLibrary(ClassLoader.java:2389)
Sep 28 14:30:54 localhost jitsi-videobridge2-start[2989]:         at java.base/java.lang.Runtime.load0(Runtime.java:755)
Sep 28 14:30:54 localhost jitsi-videobridge2-start[2989]:         at java.base/java.lang.System.load(System.java:1953)
Sep 28 14:30:54 localhost jitsi-videobridge2-start[2989]:         at org.jitsi.utils.JNIUtils.loadLibrary(JNIUtils.java:99)
Sep 28 14:30:54 localhost jitsi-videobridge2-start[2989]:         at org.jitsi.utils.JNIUtils.loadLibrary(JNIUtils.java:38)
Sep 28 14:30:54 localhost jitsi-videobridge2-start[2989]:         at org.jitsi.srtp.crypto.JitsiOpenSslProvider.<clinit>(JitsiOpenSslProvider.java:48)
Sep 28 14:30:54 localhost jitsi-videobridge2-start[2989]:         at org.jitsi.srtp.crypto.Aes$OpenSSLCipherFactory.<init>(Aes.java:751)
<...>
Sep 28 14:30:54 localhost jitsi-videobridge2-start[2989]: WARNING: [66] Aes.benchmark#358: Chosen factory class "OpenSSL" not working for AES/GCM/NoPadding: No such algorithm: AES/GCM/NoPadding
Sep 28 14:30:55 localhost jitsi-videobridge2-start[2989]: INFO: [66] Aes.benchmark#367: AES benchmark (of execution times expressed in nanoseconds): SunJCE 8610, BouncyCastle 18438 for AES/GCM/NoPadding
Sep 28 14:30:55 localhost jitsi-videobridge2-start[2989]: INFO: [66] Aes.createCipher#433: Will employ AES implemented by SunJCE for AES/GCM/NoPadding.

```

With this PR the library can be loaded successfully:

```
Sep 28 14:46:32 localhost jitsi-videobridge2-start[3680]: INFO: [67] JitsiOpenSslProvider.<clinit>#52: jitsisrtp successfully loaded for OpenSSL 3
Sep 28 14:46:32 localhost jitsi-videobridge2-start[3680]: INFO: [67] Aes.createCipher#433: Will employ AES implemented by OpenSSL for AES/GCM/NoPadding.
```

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
