### PR TITLE
libbpf: add libbpf_1 for libbpf 1.0.1

### DIFF
--- a/pkgs/os-specific/linux/libbpf/0.x.nix
+++ b/pkgs/os-specific/linux/libbpf/0.x.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libbpf";
-  version = "1.0.1";
+  version = "0.8.1";
 
   src = fetchFromGitHub {
     owner = "libbpf";
     repo = "libbpf";
     rev = "v${version}";
-    sha256 = "sha256-2rzVah+CxCztKnlEWMIQrUS2JJTLiWscfIA1aOBtIzs=";
+    sha256 = "sha256-daVS+TErmDU8ksThOvcepg1A61iD8N8GIkC40cmc9/8=";
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16111,7 +16111,10 @@ with pkgs;
 
   bump = callPackage ../development/tools/github/bump { };
 
-  libbpf = callPackage ../os-specific/linux/libbpf { };
+  libbpf_1 = callPackage ../os-specific/linux/libbpf { };
+  libbpf_0 = callPackage ../os-specific/linux/libbpf/0.x.nix { };
+  # until more issues are fixed default to libbpf 0.x
+  libbpf = libbpf_0;
 
   bpftools = callPackage ../os-specific/linux/bpftools { };
 


### PR DESCRIPTION
libbpf 1.x breaks too many packages to do a hard transition: just keep both packages for a while longer.

See https://github.com/libbpf/libbpf/issues/590 for discussion with upstream

###### Description of changes

This is a try-over from #187978 : since we can't upgrade to libbpf 1.0 in a go, give it a try with a subpackage.

Are there problems other than systemd (PR in progress, taking time) and pahole (upgrade available which requires libbpf1, just splitting PRs)? I see @vcunat fixed knot already.
If not I'm tempted to make this default to libbpf 1.x right away, but it doesn't really matter imo.

cc @saschagrunert 